### PR TITLE
Maybe fix intellisense errors

### DIFF
--- a/.nuspec/Xamarin.Forms.Debug.targets
+++ b/.nuspec/Xamarin.Forms.Debug.targets
@@ -14,10 +14,20 @@
 	<PropertyGroup>
 		<CompileDependsOn>
 			$(CompileDependsOn);
-			GenerateDebugCode;
 			XamlC;
 		</CompileDependsOn>
 	</PropertyGroup>
+
+	<PropertyGroup>
+		<CoreCompileDependsOn Condition="'$(BuildingInsideVisualStudio)' == 'true' ">
+			DesignTimeMarkupCompilation;
+			$(CoreCompileDependsOn);
+		</CoreCompileDependsOn>
+	</PropertyGroup>
+
+	<Target Name="DesignTimeMarkupCompilation">
+		<CallTarget Condition="'$(BuildingProject)' != 'true' Or $(DesignTimeBuild) == 'true'" Targets="XamlG" />
+	</Target>
 
 	<Target Name="UpdateDesignTimeXaml" Condition="'$(UseHostCompilerIfAvailable)' == 'true'" DependsOnTargets="PrepareResources; Compile"/>
 
@@ -26,7 +36,6 @@
 	<PropertyGroup>
 		<XamlGDependsOn>
 			_PreXamlG;
-			_CollectXamlFiles;
 			_CoreXamlG;
 		</XamlGDependsOn>
 	</PropertyGroup>
@@ -35,46 +44,41 @@
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 	</Target>
 
-	<Target Name="_CollectXamlFiles">
+	<PropertyGroup>
+		<CoreCompileDependsOn>
+			IncludeXamlResource;
+			$(CoreCompileDependsOn)
+		</CoreCompileDependsOn>
+	</PropertyGroup>
+
+	<Target Name="IncludeXamlResource">
 		<ItemGroup>
-			<_XamlResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.xaml'"/>
-		</ItemGroup>
-		<FixedCreateCSharpManifestResourceName ResourceFiles="@(_XamlResources)" RootNamespace="$(RootNamespace)">
-			<Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="XamlFiles" />
-		</FixedCreateCSharpManifestResourceName>
-		<ItemGroup>
-			<XamlGFiles Include="@(XamlFiles->'$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)')"/>
-			<Compile Include="@(XamlGFiles)"/>
-			<FileWrites Include="@(XamlGFiles)"/>
+			<XamlResource Include="@(EmbeddedResource)" Condition="'%(EmbeddedResource.Extension)' == '.xaml' AND '$(DefaultLanguageSourceExtension)' == '.cs'" />
+			<Compile Include="@(XamlResource->'$(IntermediateOutputPath)%(RelativeDir)%(FileName)%(Extension).g$(DefaultLanguageSourceExtension)')" />
 		</ItemGroup>
 	</Target>
 
 	<Target Name="_CoreXamlG"
-		Inputs = "@(XamlFiles)"
-		Outputs = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
+		Inputs = "@(XamlResource)"
+		Outputs = "$(IntermediateOutputPath)%(RelativeDir)%(FileName)%(Extension).g$(DefaultLanguageSourceExtension)">
+		<MakeDir Directories="$(IntermediateOutputPath)%(XamlResource.RelativeDir)" Condition="!Exists('$(IntermediateOutputPath)%(RelativeDir)')" />
 		<XamlGTask
-			Source="@(XamlFiles)"
+			Source="@(XamlResource)"
 			Language = "$(Language)"
 			AssemblyName = "$(AssemblyName)"
-			OutputFile = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
+			OutputFile = "$(IntermediateOutputPath)%(RelativeDir)%(FileName)%(Extension).g$(DefaultLanguageSourceExtension)">
 		</XamlGTask>
-	</Target>
-
-	<!-- duplicate legacy InitializeComponent, create a ctor with bool param -->
-	<Target Name="GenerateDebugCode">
-		<DebugXamlCTask 
-			Assembly = "$(IntermediateOutputPath)$(TargetFileName)" 
-			ReferencePath = "@(ReferencePath)"
-			DebugSymbols = "$(DebugSymbols)" />
+		<ItemGroup>
+			<FileWrites Include="@(XamlResource->'$(IntermediateOutputPath)%(RelativeDir)%(FileName)%(Extension).g$(DefaultLanguageSourceExtension)')" />
+		</ItemGroup>
 	</Target>
 
 	<Target Name="XamlC">
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
-			DebugSymbols = "$(DebugSymbols)"
-			Verbosity = "4"
-			KeepXamlResources = "true"
-			OptimizeIL = "true" />
+			Verbosity = "2"
+			OptimizeIL = "true"
+			DebugSymbols = "$(DebugSymbols)" />
 	</Target>
 </Project>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -24,6 +24,9 @@
         <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="[23.1.1.1]"/>
         <dependency id="Xamarin.GooglePlayServices.AppIndexing" version="[29.0.0.1]"/>
       </group>
+      <group targetFramework="uap10.0">
+        <dependencies id="Microsoft.NetCore.UniversalWindowsPlatform" version="5.0.0" />
+      </group>
     </dependencies>
     <references>
        <group targetFramework="portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10">

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -17,6 +17,17 @@
 		</CompileDependsOn>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<CoreCompileDependsOn Condition="'$(BuildingInsideVisualStudio)' == 'true' ">
+			DesignTimeMarkupCompilation;
+			$(CoreCompileDependsOn);
+		</CoreCompileDependsOn>
+	</PropertyGroup>
+
+	<Target Name="DesignTimeMarkupCompilation">
+		<CallTarget Condition="'$(BuildingProject)' != 'true' Or $(DesignTimeBuild) == 'true'" Targets="XamlG" />
+	</Target>
+
 	<Target Name="UpdateDesignTimeXaml" Condition="'$(UseHostCompilerIfAvailable)' == 'true'" DependsOnTargets="PrepareResources; Compile"/>
 
 	<Target Name="XamlG" DependsOnTargets="$(XamlGDependsOn)"/>
@@ -24,7 +35,6 @@
 	<PropertyGroup>
 		<XamlGDependsOn>
 			_PreXamlG;
-			_CollectXamlFiles;
 			_CoreXamlG;
 		</XamlGDependsOn>
 	</PropertyGroup>
@@ -33,29 +43,33 @@
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 	</Target>
 
-	<Target Name="_CollectXamlFiles">
+	<PropertyGroup>
+		<CoreCompileDependsOn>
+			IncludeXamlResource;
+			$(CoreCompileDependsOn)
+		</CoreCompileDependsOn>
+	</PropertyGroup>
+
+	<Target Name="IncludeXamlResource">
 		<ItemGroup>
-			<_XamlResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.xaml' AND '$(DefaultLanguageSourceExtension)' == '.cs'"/>
-		</ItemGroup>
-		<FixedCreateCSharpManifestResourceName ResourceFiles="@(_XamlResources)" RootNamespace="$(RootNamespace)">
-			<Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="XamlFiles" />
-		</FixedCreateCSharpManifestResourceName>
-		<ItemGroup>
-			<XamlGFiles Include="@(XamlFiles->'$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)')"/>
-			<Compile Include="@(XamlGFiles)"/>
-			<FileWrites Include="@(XamlGFiles)"/>
+			<XamlResource Include="@(EmbeddedResource)" Condition="'%(EmbeddedResource.Extension)' == '.xaml' AND '$(DefaultLanguageSourceExtension)' == '.cs'" />
+			<Compile Include="@(XamlResource->'$(IntermediateOutputPath)%(RelativeDir)%(FileName)%(Extension).g$(DefaultLanguageSourceExtension)')" />
 		</ItemGroup>
 	</Target>
 
 	<Target Name="_CoreXamlG"
-		Inputs = "@(XamlFiles)"
-		Outputs = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
+		Inputs = "@(XamlResource)"
+		Outputs = "$(IntermediateOutputPath)%(RelativeDir)%(FileName)%(Extension).g$(DefaultLanguageSourceExtension)">
+		<MakeDir Directories="$(IntermediateOutputPath)%(XamlResource.RelativeDir)" Condition="!Exists('$(IntermediateOutputPath)%(RelativeDir)')" />
 		<XamlGTask
-			Source="@(XamlFiles)"
+			Source="@(XamlResource)"
 			Language = "$(Language)"
 			AssemblyName = "$(AssemblyName)"
-			OutputFile = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
+			OutputFile = "$(IntermediateOutputPath)%(RelativeDir)%(FileName)%(Extension).g$(DefaultLanguageSourceExtension)">
 		</XamlGTask>
+		<ItemGroup>
+			<FileWrites Include="@(XamlResource->'$(IntermediateOutputPath)%(RelativeDir)%(FileName)%(Extension).g$(DefaultLanguageSourceExtension)')" />
+		</ItemGroup>
 	</Target>
 
 	<Target Name="XamlC">


### PR DESCRIPTION
### Description of Change

This changes the way that the targets file works in a couple key ways. First it ensures that it creates directories as needed. It also further ensures that files get stored into file relative paths. This allows intellisense to properly detect them.

No unit tests in this code because unit testing the packaging isn't really possible for us right now.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=33181
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
