### PR TITLE
[UWP] Fix resource key name PushPinTemplate

### DIFF
--- a/Xamarin.Forms.Maps.UWP/PushPin.cs
+++ b/Xamarin.Forms.Maps.UWP/PushPin.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Maps.WinRT
 			if (pin == null)
 				throw new ArgumentNullException();
 
-			ContentTemplate = Windows.UI.Xaml.Application.Current.Resources["pushPinTemplate"] as Windows.UI.Xaml.DataTemplate;
+			ContentTemplate = Windows.UI.Xaml.Application.Current.Resources["PushPinTemplate"] as Windows.UI.Xaml.DataTemplate;
 			DataContext = Content = _pin = pin;
 
 			UpdateLocation();


### PR DESCRIPTION
### Description of Change

Fix wrong resource key name for the pushpin ContentTemplate
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
