### PR TITLE
[A] Fix insights api key access for Legacy Android

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -188,7 +188,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 			base.OnCreate(bundle);
 
 			if (!Debugger.IsAttached)
-				Insights.Initialize(App.InsightsApiKey, this.ApplicationContext);
+				Insights.Initialize(App.Secrets["InsightsApiKey"], this.ApplicationContext);
 
 			Forms.Init(this, bundle);
 			FormsMaps.Init(this, bundle);


### PR DESCRIPTION
Allows Control Gallery to be run in non-AppCompat mode
