### PR TITLE
[W] ListView Cells will respect RowHeight

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39829.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39829.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39829, "RowHeight of ListView is not working for UWP", PlatformAffected.WinRT)]
+	public class Bugzilla39829 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Master";
+			var listView = new ListView
+			{
+				RowHeight = 150,
+				AutomationId = "listview",
+				ItemsSource = new string[] { "Test1", "Test2", "Test3", "Test4", "Test5", "Test6", }
+			};
+
+			Content = listView;
+		}
+
+#if UITEST
+		[Test]
+		[Category("ManualReview")]
+		public void Bugzilla39829Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("listview"));
+			RunningApp.Screenshot("If there isn't substantial space between the list items, this test has failed.");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -125,6 +125,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38112.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39499.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39668.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39829.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -175,7 +175,7 @@
 	</Style>
 
     <DataTemplate x:Key="CellTemplate">
-        <uwp:CellControl HorizontalContentAlignment="Stretch" />
+		<uwp:CellControl HorizontalContentAlignment="Stretch" Height="{Binding Cell.RenderHeight,RelativeSource={RelativeSource Mode=Self},Converter={StaticResource HeightConverter}}" />
 	</DataTemplate>
 
 	<DataTemplate x:Key="TableRoot">

--- a/Xamarin.Forms.Platform.WinRT/Resources.xaml
+++ b/Xamarin.Forms.Platform.WinRT/Resources.xaml
@@ -44,7 +44,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="CellTemplate">
-		<forms:CellControl HorizontalContentAlignment="Stretch" />
+		<forms:CellControl HorizontalContentAlignment="Stretch" Height="{Binding Cell.RenderHeight,RelativeSource={RelativeSource Mode=Self},Converter={StaticResource HeightConverter}}" />
 	</DataTemplate>
 
 	<DataTemplate x:Key="TableRoot">


### PR DESCRIPTION
### Description of Change

Restored RenderHeight binding on the CellControl in the CellTemplate for WinRT and UWP.
### Bugs Fixed
- [Bug 39829  - RowHeight of ListView is not working for UWP](https://bugzilla.xamarin.com/show_bug.cgi?id=3982)
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
