### PR TITLE
Fix setting for spaces after using and lock keywords

### DIFF
--- a/Xamarin.Forms.sln.DotSettings
+++ b/Xamarin.Forms.sln.DotSettings
@@ -16,13 +16,13 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CATCH_ON_NEW_LINE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FINALLY_ON_NEW_LINE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_LOCK_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_LOCK_PARENTHESES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_METHOD_CALL_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_EMPTY_METHOD_CALL_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_METHOD_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_EMPTY_METHOD_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_USING_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_USING_PARENTHESES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/STICK_COMMENT/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">None</s:String>

--- a/Xamarin.Forms.vssettings
+++ b/Xamarin.Forms.vssettings
@@ -56,11 +56,12 @@
                 <PropertyValue name="Space_WithinSquares">0</PropertyValue>
                 <PropertyValue name="Space_BeforeLambdaArrow">1</PropertyValue>
                 <PropertyValue name="NewLines_Braces_AnonymousTypeInitializer">0</PropertyValue>
+                <PropertyValue name="NewLines_Braces_Property">1</PropertyValue>
                 <PropertyValue name="Space_WithinCastParentheses">0</PropertyValue>
                 <PropertyValue name="Space_AfterSemicolonsInForStatement">1</PropertyValue>
-                <PropertyValue name="Indent_CaseContents">0</PropertyValue>
+                <PropertyValue name="Indent_CaseContents">1</PropertyValue>
                 <PropertyValue name="Indent_FlushLabelsLeft">1</PropertyValue>
-                <PropertyValue name="Wrapping_PreserveSingleLine">1</PropertyValue>
+                <PropertyValue name="Wrapping_PreserveSingleLine">0</PropertyValue>
                 <PropertyValue name="Space_BetweenEmptySquares">0</PropertyValue>
                 <PropertyValue name="Space_BeforeOpenSquare">0</PropertyValue>
                 <PropertyValue name="Space_BeforeDot">0</PropertyValue>


### PR DESCRIPTION
### Description of Change

Correct the shared Resharper settings for spaces after `using` and `lock`.
