### PR TITLE
[iOS] PageRenderer no longer swallows touches

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -10,45 +10,49 @@ using System.Drawing;
 #if __UNIFIED__
 using UIKit;
 using Foundation;
-using RectangleF=CoreGraphics.CGRect;
+using RectangleF = CoreGraphics.CGRect;
+
 #else
 using MonoTouch.UIKit;
 using MonoTouch.Foundation;
 #endif
 
-[assembly: ExportRenderer (typeof (Bugzilla31395.CustomContentView), typeof (CustomContentRenderer))]
-[assembly: ExportRenderer (typeof (NativeCell), typeof (NativeiOSCellRenderer))]
-[assembly: ExportRenderer (typeof (NativeListView2), typeof (NativeiOSListViewRenderer))]
-[assembly: ExportRenderer (typeof (NativeListView), typeof (NativeListViewRenderer))]
+[assembly: ExportRenderer(typeof(Bugzilla21177.CollectionView), typeof(CollectionViewRenderer))]
+[assembly: ExportRenderer(typeof(Bugzilla31395.CustomContentView), typeof(CustomContentRenderer))]
+[assembly: ExportRenderer(typeof(NativeCell), typeof(NativeiOSCellRenderer))]
+[assembly: ExportRenderer(typeof(NativeListView2), typeof(NativeiOSListViewRenderer))]
+[assembly: ExportRenderer(typeof(NativeListView), typeof(NativeListViewRenderer))]
 namespace Xamarin.Forms.ControlGallery.iOS
 {
 	public class NativeiOSCellRenderer : ViewCellRenderer
 	{
 		static NSString s_rid = new NSString("NativeCell");
 
-		public NativeiOSCellRenderer ()
+		public NativeiOSCellRenderer()
 		{
 		}
 
-		public override UITableViewCell GetCell (Xamarin.Forms.Cell item, UITableViewCell reusableCell, UITableView tv)
+		public override UITableViewCell GetCell(Xamarin.Forms.Cell item, UITableViewCell reusableCell, UITableView tv)
 		{
 			var x = (NativeCell)item;
-			Console.WriteLine (x);
+			Console.WriteLine(x);
 
-			NativeiOSCell c = reusableCell as NativeiOSCell; 
+			NativeiOSCell c = reusableCell as NativeiOSCell;
 
-			if (c == null) {
-				c = new NativeiOSCell (s_rid);
+			if (c == null)
+			{
+				c = new NativeiOSCell(s_rid);
 			}
 
 			UIImage i = null;
-			if (!string.IsNullOrWhiteSpace (x.ImageFilename)) {
-				i = UIImage.FromFile ("Images/" + x.ImageFilename + ".jpg");
+			if (!string.IsNullOrWhiteSpace(x.ImageFilename))
+			{
+				i = UIImage.FromFile("Images/" + x.ImageFilename + ".jpg");
 			}
 
-			base.WireUpForceUpdateSizeRequested (item, c, tv);
+			base.WireUpForceUpdateSizeRequested(item, c, tv);
 
-			c.UpdateCell (x.Name, x.Category, i);
+			c.UpdateCell(x.Name, x.Category, i);
 
 			return c;
 		}
@@ -59,47 +63,48 @@ namespace Xamarin.Forms.ControlGallery.iOS
 	/// Sample of a custom cell layout, taken from the iOS docs at
 	/// http://developer.xamarin.com/guides/ios/user_interface/tables/part_3_-_customizing_a_table's_appearance/
 	/// </summary>
-	public class NativeiOSCell : UITableViewCell  {
+	public class NativeiOSCell : UITableViewCell
+	{
 		UILabel _headingLabel;
 		UILabel _subheadingLabel;
 		UIImageView _imageView;
 
-		public NativeiOSCell (NSString cellId) : base (UITableViewCellStyle.Default, cellId)
+		public NativeiOSCell(NSString cellId) : base(UITableViewCellStyle.Default, cellId)
 		{
 			SelectionStyle = UITableViewCellSelectionStyle.Gray;
 
-			ContentView.BackgroundColor = UIColor.FromRGB (255,255,224);
+			ContentView.BackgroundColor = UIColor.FromRGB(255, 255, 224);
 
 			_imageView = new UIImageView();
 
-			_headingLabel = new UILabel () {
+			_headingLabel = new UILabel() {
 				Font = UIFont.FromName("Cochin-BoldItalic", 22f),
-				TextColor = UIColor.FromRGB (127, 51, 0),
+				TextColor = UIColor.FromRGB(127, 51, 0),
 				BackgroundColor = UIColor.Clear
 			};
 
-			_subheadingLabel = new UILabel () {
+			_subheadingLabel = new UILabel() {
 				Font = UIFont.FromName("AmericanTypewriter", 12f),
-				TextColor = UIColor.FromRGB (38, 127, 0),
+				TextColor = UIColor.FromRGB(38, 127, 0),
 				TextAlignment = UITextAlignment.Center,
 				BackgroundColor = UIColor.Clear
 			};
 
-			ContentView.Add (_headingLabel);
-			ContentView.Add (_subheadingLabel);
-			ContentView.Add (_imageView);
+			ContentView.Add(_headingLabel);
+			ContentView.Add(_subheadingLabel);
+			ContentView.Add(_imageView);
 		}
 
-		public void UpdateCell (string caption, string subtitle, UIImage image)
+		public void UpdateCell(string caption, string subtitle, UIImage image)
 		{
 			_imageView.Image = image;
 			_headingLabel.Text = caption;
 			_subheadingLabel.Text = subtitle;
 		}
 
-		public override void LayoutSubviews ()
+		public override void LayoutSubviews()
 		{
-			base.LayoutSubviews ();
+			base.LayoutSubviews();
 
 			_imageView.Frame = new RectangleF(ContentView.Bounds.Width - 63, 5, 33, 33);
 			_headingLabel.Frame = new RectangleF(5, 4, ContentView.Bounds.Width - 63, 25);
@@ -111,47 +116,48 @@ namespace Xamarin.Forms.ControlGallery.iOS
 	/// Sample of a custom cell layout, taken from the iOS docs at
 	/// http://developer.xamarin.com/guides/ios/user_interface/tables/part_3_-_customizing_a_table's_appearance/
 	/// </summary>
-	public class NativeiOSListViewCell : UITableViewCell  {
+	public class NativeiOSListViewCell : UITableViewCell
+	{
 		UILabel _headingLabel;
 		UILabel _subheadingLabel;
 		UIImageView _imageView;
 
-		public NativeiOSListViewCell (NSString cellId) : base (UITableViewCellStyle.Default, cellId)
+		public NativeiOSListViewCell(NSString cellId) : base(UITableViewCellStyle.Default, cellId)
 		{
 			SelectionStyle = UITableViewCellSelectionStyle.Gray;
 
-			ContentView.BackgroundColor = UIColor.FromRGB (218, 255, 127);
+			ContentView.BackgroundColor = UIColor.FromRGB(218, 255, 127);
 
 			_imageView = new UIImageView();
 
-			_headingLabel = new UILabel () {
+			_headingLabel = new UILabel() {
 				Font = UIFont.FromName("Cochin-BoldItalic", 22f),
-				TextColor = UIColor.FromRGB (127, 51, 0),
+				TextColor = UIColor.FromRGB(127, 51, 0),
 				BackgroundColor = UIColor.Clear
 			};
 
-			_subheadingLabel = new UILabel () {
+			_subheadingLabel = new UILabel() {
 				Font = UIFont.FromName("AmericanTypewriter", 12f),
-				TextColor = UIColor.FromRGB (38, 127, 0),
+				TextColor = UIColor.FromRGB(38, 127, 0),
 				TextAlignment = UITextAlignment.Center,
 				BackgroundColor = UIColor.Clear
 			};
 
-			ContentView.Add (_headingLabel);
-			ContentView.Add (_subheadingLabel);
-			ContentView.Add (_imageView);
+			ContentView.Add(_headingLabel);
+			ContentView.Add(_subheadingLabel);
+			ContentView.Add(_imageView);
 		}
 
-		public void UpdateCell (string caption, string subtitle, UIImage image)
+		public void UpdateCell(string caption, string subtitle, UIImage image)
 		{
 			_imageView.Image = image;
 			_headingLabel.Text = caption;
 			_subheadingLabel.Text = subtitle;
 		}
 
-		public override void LayoutSubviews ()
+		public override void LayoutSubviews()
 		{
-			base.LayoutSubviews ();
+			base.LayoutSubviews();
 
 			_imageView.Frame = new RectangleF(ContentView.Bounds.Width - 63, 5, 33, 33);
 			_headingLabel.Frame = new RectangleF(5, 4, ContentView.Bounds.Width - 63, 25);
@@ -161,84 +167,96 @@ namespace Xamarin.Forms.ControlGallery.iOS
 
 	public class NativeiOSListViewRenderer : ViewRenderer<NativeListView2, UITableView>
 	{
-		public NativeiOSListViewRenderer ()
+		public NativeiOSListViewRenderer()
 		{
 		}
 
-		protected override void OnElementChanged (ElementChangedEventArgs<NativeListView2> e)
+		protected override void OnElementChanged(ElementChangedEventArgs<NativeListView2> e)
 		{
-			base.OnElementChanged (e);
+			base.OnElementChanged(e);
 
-			if (Control == null) {
-				SetNativeControl (new UITableView ());
+			if (Control == null)
+			{
+				SetNativeControl(new UITableView());
 			}
 
-			if (e.OldElement != null) {
+			if (e.OldElement != null)
+			{
 				// unsubscribe
 			}
 
-			if (e.NewElement != null) {
+			if (e.NewElement != null)
+			{
 				// subscribe
 
-				var s = new NativeiOSListViewSource (e.NewElement);
+				var s = new NativeiOSListViewSource(e.NewElement);
 				Control.Source = s;
 			}
 		}
-		protected override void OnElementPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
-		{
-			base.OnElementPropertyChanged (sender, e);
 
-			if (e.PropertyName == NativeListView.ItemsProperty.PropertyName) {
+		protected override void OnElementPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == NativeListView.ItemsProperty.PropertyName)
+			{
 				// update the Items list in the UITableViewSource
-				var s = new NativeiOSListViewSource (Element);
+				var s = new NativeiOSListViewSource(Element);
 
 				Control.Source = s;
 			}
 		}
-		public override SizeRequest GetDesiredSize (double widthConstraint, double heightConstraint)
+
+		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			return Control.GetSizeRequest (widthConstraint, heightConstraint, 44, 44);
+			return Control.GetSizeRequest(widthConstraint, heightConstraint, 44, 44);
 		}
 	}
 
 	public class NativeListViewRenderer : ViewRenderer<NativeListView, UITableView>
 	{
-		public NativeListViewRenderer ()
+		public NativeListViewRenderer()
 		{
 		}
 
-		protected override void OnElementChanged (ElementChangedEventArgs<NativeListView> e)
+		protected override void OnElementChanged(ElementChangedEventArgs<NativeListView> e)
 		{
-			base.OnElementChanged (e);
+			base.OnElementChanged(e);
 
-			if (Control == null) {
-				SetNativeControl (new UITableView ());
+			if (Control == null)
+			{
+				SetNativeControl(new UITableView());
 			}
 
-			if (e.OldElement != null) {
+			if (e.OldElement != null)
+			{
 				// unsubscribe
 			}
 
-			if (e.NewElement != null) {
+			if (e.NewElement != null)
+			{
 				// subscribe
 
-				var s = new NativeListViewSource (e.NewElement);
+				var s = new NativeListViewSource(e.NewElement);
 				Control.Source = s;
 			}
 		}
-		protected override void OnElementPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
-		{
-			base.OnElementPropertyChanged (sender, e);
 
-			if (e.PropertyName == NativeListView.ItemsProperty.PropertyName) {
+		protected override void OnElementPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == NativeListView.ItemsProperty.PropertyName)
+			{
 				// update the Items list in the UITableViewSource
-				var s = new NativeListViewSource (Element);
+				var s = new NativeListViewSource(Element);
 				Control.Source = s;
 			}
 		}
-		public override SizeRequest GetDesiredSize (double widthConstraint, double heightConstraint)
+
+		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			return Control.GetSizeRequest (widthConstraint, heightConstraint, 44, 44);
+			return Control.GetSizeRequest(widthConstraint, heightConstraint, 44, 44);
 		}
 	}
 
@@ -249,14 +267,16 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		NativeListView2 _listView;
 		readonly NSString _cellIdentifier = new NSString("TableCell");
 
-		public IEnumerable<DataSource> Items {
+		public IEnumerable<DataSource> Items
+		{
 			//get{ }
-			set{
+			set
+			{
 				_tableItems = value.ToList();
 			}
 		}
 
-		public NativeiOSListViewSource (NativeListView2 view)
+		public NativeiOSListViewSource(NativeListView2 view)
 		{
 			_tableItems = view.Items.ToList();
 			_listView = view;
@@ -266,32 +286,32 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		/// Called by the TableView to determine how many cells to create for that particular section.
 		/// </summary>
 
-		#if __UNIFIED__
-		public override nint RowsInSection (UITableView tableview, nint section)
+#if __UNIFIED__
+		public override nint RowsInSection(UITableView tableview, nint section)
 		{
 			return _tableItems.Count;
 		}
-		#else
+#else
 		public override int RowsInSection (UITableView tableview, int section)
 		{
 			return _tableItems.Count;
 		}
 
-		#endif
-	
+#endif
+
 
 		#region user interaction methods
 
-		public override void RowSelected (UITableView tableView, NSIndexPath indexPath)
+		public override void RowSelected(UITableView tableView, NSIndexPath indexPath)
 		{
-			_listView.NotifyItemSelected (_tableItems [indexPath.Row]);
-			Console.WriteLine("Row " + indexPath.Row.ToString() + " selected");	
-			tableView.DeselectRow (indexPath, true);
+			_listView.NotifyItemSelected(_tableItems[indexPath.Row]);
+			Console.WriteLine("Row " + indexPath.Row.ToString() + " selected");
+			tableView.DeselectRow(indexPath, true);
 		}
 
-		public override void RowDeselected (UITableView tableView, NSIndexPath indexPath)
+		public override void RowDeselected(UITableView tableView, NSIndexPath indexPath)
 		{
-			Console.WriteLine("Row " + indexPath.Row.ToString() + " deselected");	
+			Console.WriteLine("Row " + indexPath.Row.ToString() + " deselected");
 		}
 
 		#endregion
@@ -299,24 +319,27 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		/// <summary>
 		/// Called by the TableView to get the actual UITableViewCell to render for the particular section and row
 		/// </summary>
-		public override UITableViewCell GetCell (UITableView tableView, NSIndexPath indexPath)
+		public override UITableViewCell GetCell(UITableView tableView, NSIndexPath indexPath)
 		{
 			// request a recycled cell to save memory
-			NativeiOSListViewCell cell = tableView.DequeueReusableCell (_cellIdentifier) as NativeiOSListViewCell;
+			NativeiOSListViewCell cell = tableView.DequeueReusableCell(_cellIdentifier) as NativeiOSListViewCell;
 
 			// if there are no cells to reuse, create a new one
-			if (cell == null) {
-				cell = new NativeiOSListViewCell (_cellIdentifier);
+			if (cell == null)
+			{
+				cell = new NativeiOSListViewCell(_cellIdentifier);
 			}
 
-			if (string.IsNullOrWhiteSpace (_tableItems [indexPath.Row].ImageFilename)) {
-				cell.UpdateCell (_tableItems [indexPath.Row].Name
-					, _tableItems [indexPath.Row].Category
-					, null);
-			} else {
-				cell.UpdateCell (_tableItems[indexPath.Row].Name
+			if (string.IsNullOrWhiteSpace(_tableItems[indexPath.Row].ImageFilename))
+			{
+				cell.UpdateCell(_tableItems[indexPath.Row].Name
 					, _tableItems[indexPath.Row].Category
-					, UIImage.FromFile ("Images/" +_tableItems[indexPath.Row].ImageFilename + ".jpg") );
+					, null);
+			}
+			else {
+				cell.UpdateCell(_tableItems[indexPath.Row].Name
+					, _tableItems[indexPath.Row].Category
+					, UIImage.FromFile("Images/" + _tableItems[indexPath.Row].ImageFilename + ".jpg"));
 			}
 
 			return cell;
@@ -330,43 +353,46 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		string _cellIdentifier = "TableCell";
 		NativeListView _listView;
 
-		public IEnumerable<string> Items {
-			set{
+		public IEnumerable<string> Items
+		{
+			set
+			{
 				_tableItems = value.ToList();
 			}
 		}
 
-		public NativeListViewSource (NativeListView view)
+		public NativeListViewSource(NativeListView view)
 		{
-			_tableItems = view.Items.ToList ();
+			_tableItems = view.Items.ToList();
 			_listView = view;
 		}
 
-		#if __UNIFIED__
-		public override nint RowsInSection (UITableView tableview, nint section)
+#if __UNIFIED__
+		public override nint RowsInSection(UITableView tableview, nint section)
 		{
 			return _tableItems.Count;
 		}
-		#else
+
+#else
 		public override int RowsInSection (UITableView tableview, int section)
 		{
 			return _tableItems.Count;
 		}
-		#endif
+#endif
 		#region user interaction methods
 
-		public override void RowSelected (UITableView tableView, NSIndexPath indexPath)
+		public override void RowSelected(UITableView tableView, NSIndexPath indexPath)
 		{
-			_listView.NotifyItemSelected (_tableItems [indexPath.Row]);
+			_listView.NotifyItemSelected(_tableItems[indexPath.Row]);
 
-			Console.WriteLine("Row " + indexPath.Row.ToString() + " selected");	
+			Console.WriteLine("Row " + indexPath.Row.ToString() + " selected");
 
-			tableView.DeselectRow (indexPath, true);
+			tableView.DeselectRow(indexPath, true);
 		}
 
-		public override void RowDeselected (UITableView tableView, NSIndexPath indexPath)
+		public override void RowDeselected(UITableView tableView, NSIndexPath indexPath)
 		{
-			Console.WriteLine("Row " + indexPath.Row.ToString() + " deselected");	
+			Console.WriteLine("Row " + indexPath.Row.ToString() + " deselected");
 		}
 
 		#endregion
@@ -374,18 +400,18 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		/// <summary>
 		/// Called by the TableView to get the actual UITableViewCell to render for the particular section and row
 		/// </summary>
-		public override UITableViewCell GetCell (UITableView tableView, NSIndexPath indexPath)
+		public override UITableViewCell GetCell(UITableView tableView, NSIndexPath indexPath)
 		{
 			// declare vars
-			UITableViewCell cell = tableView.DequeueReusableCell (_cellIdentifier);
+			UITableViewCell cell = tableView.DequeueReusableCell(_cellIdentifier);
 			//string item = tableItems [indexPath.Row]; //.Items[indexPath.Row];
 
 			// if there are no cells to reuse, create a new one
 			if (cell == null)
-				cell = new UITableViewCell (UITableViewCellStyle.Subtitle, _cellIdentifier);
+				cell = new UITableViewCell(UITableViewCellStyle.Subtitle, _cellIdentifier);
 
 			// set the item text
-			cell.TextLabel.Text = _tableItems [indexPath.Row];//.Items[indexPath.Row].Heading;
+			cell.TextLabel.Text = _tableItems[indexPath.Row];//.Items[indexPath.Row].Heading;
 
 			// if it's a cell style that supports a subheading, set it
 			//			if(item.CellStyle == UITableViewCellStyle.Subtitle 
@@ -411,5 +437,108 @@ namespace Xamarin.Forms.ControlGallery.iOS
 	public class CustomContentRenderer : ViewRenderer
 	{
 	}
+
+	public class CollectionViewRenderer : ViewRenderer<Bugzilla21177.CollectionView, UICollectionView>
+	{
+		public void ItemSelected(UICollectionView collectionViewView, NSIndexPath indexPath)
+		{
+			Element.InvokeItemSelected(indexPath.Row);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Bugzilla21177.CollectionView> e)
+		{
+			if (e.NewElement != null)
+			{
+				var flowLayout = new UICollectionViewFlowLayout {
+					SectionInset = new UIEdgeInsets(20, 20, 20, 20),
+					ScrollDirection = UICollectionViewScrollDirection.Vertical,
+					MinimumInteritemSpacing = 5, // minimum spacing between cells 
+					MinimumLineSpacing = 5 // minimum spacing between rows if ScrollDirection is Vertical or between columns if Horizontal 
+				};
+				var collectionView = new CollectionViewController(flowLayout, ItemSelected);
+				SetNativeControl(collectionView.CollectionView);
+			}
+
+			base.OnElementChanged(e);
+		}
+	}
+
+	public class CollectionViewController : UICollectionViewController
+	{
+		readonly OnItemSelected _onItemSelected;
+		static NSString cellId = new NSString("CollectionViewCell");
+		List<string> items;
+
+		public delegate void OnItemSelected(UICollectionView collectionView, NSIndexPath indexPath);
+
+		public CollectionViewController(UICollectionViewLayout layout, OnItemSelected onItemSelected) : base(layout)
+		{
+			items = Enumerable.Range(0, 20).Select(c => $"#{c}").ToList();
+			_onItemSelected = onItemSelected;
+		}
+
+		public override void ViewDidLoad()
+		{
+			base.ViewDidLoad();
+			CollectionView.RegisterClassForCell(typeof(CollectionViewCell), cellId);
+		}
+
+#if __UNIFIED__
+		public override nint NumberOfSections(UICollectionView collectionView)
+		{
+			return 1;
+		}
+
+		public override nint GetItemsCount(UICollectionView collectionView, nint section)
+		{
+			return items.Count;
+		}
+
+#else
+		public override int NumberOfSections (UICollectionView collectionView)
+		{
+			return 1;
+		}
+
+		public override int GetItemsCount (UICollectionView collectionView, int section)
+		{
+			return items.Count;
+		}
+#endif
+
+		public override UICollectionViewCell GetCell(UICollectionView collectionView, NSIndexPath indexPath)
+		{
+			var cell = (CollectionViewCell)collectionView.DequeueReusableCell(cellId, indexPath);
+			cell.Label.Text = items[indexPath.Row];
+			return cell;
+		}
+
+		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
+		{
+			_onItemSelected(collectionView, indexPath);
+		}
+	}
+
+	public class CollectionViewCell : UICollectionViewCell
+	{
+		public UILabel Label
+		{
+			get; private set;
+		}
+
+		[Export("initWithFrame:")]
+		public CollectionViewCell(RectangleF frame) : base(frame)
+		{
+			var rand = new Random();
+			BackgroundView = new UIView { BackgroundColor = UIColor.FromRGB(rand.Next(0, 256), rand.Next(0, 256), rand.Next(0, 256)) };
+			SelectedBackgroundView = new UIView { BackgroundColor = UIColor.Green };
+			ContentView.Layer.BorderColor = UIColor.LightGray.CGColor;
+			ContentView.Layer.BorderWidth = 2.0f;
+			Label = new UILabel(frame);
+			Label.Center = ContentView.Center;
+			ContentView.AddSubview(Label);
+		}
+	}
+
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla21177.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla21177.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using System.Collections;
+using System.Linq;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest.iOS;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 21177, "Using a UICollectionView in a ViewRenderer results in issues with selection")]
+	public class Bugzilla21177 : TestContentPage
+	{
+		public class CollectionView : View
+		{
+			public event EventHandler<int> ItemSelected;
+
+			public void InvokeItemSelected(int index)
+			{
+				if (ItemSelected != null)
+				{
+					ItemSelected.Invoke(this, index);
+				}
+			}
+		}
+
+		protected override void Init()
+		{
+			var view = new CollectionView() { AutomationId = "view" };
+			view.ItemSelected += View_ItemSelected;
+			Content = view;
+		}
+
+		private void View_ItemSelected(object sender, int e)
+		{
+			DisplayAlert("Success", "Success", "Cancel");
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla21177Test()
+		{
+			if (RunningApp is iOSApp)
+			{
+				RunningApp.WaitForElement(q => q.Marked("#1"));
+				RunningApp.Tap(q => q.Marked("#1"));
+				RunningApp.WaitForElement(q => q.Marked("Success"));
+			}
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -125,6 +125,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38112.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39499.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39668.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla21177.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39829.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			uiTapGestureRecognizer.ShouldRecognizeSimultaneously = (recognizer, gestureRecognizer) => true;
 			uiTapGestureRecognizer.ShouldReceiveTouch = OnShouldReceiveTouch;
-			uiTapGestureRecognizer.DelaysTouchesBegan = uiTapGestureRecognizer.DelaysTouchesEnded = false;
+			uiTapGestureRecognizer.DelaysTouchesBegan = uiTapGestureRecognizer.DelaysTouchesEnded = uiTapGestureRecognizer.CancelsTouchesInView = false;
 			View.AddGestureRecognizer(uiTapGestureRecognizer);
 
 			UpdateBackground();


### PR DESCRIPTION
### Description of Change

Set `PageRenderer`'s `TapGesture`'s `CancelsTouchesInView = false`. Will allow users to create custom renderers that have touch events.
### Bugs Fixed
- [21177 - Using a UICollectionView in a ViewRenderer results in issues with selection](https://bugzilla.xamarin.com/show_bug.cgi?id=21177)
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
