### PR TITLE
[A]Resolve issue where calling Focus in an unfocus event would fail

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39702.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39702.cs
@@ -1,0 +1,27 @@
+﻿using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39702, "Cannot enter text when Entry is focus()'d from an editor completed event")]
+	public class Bugzilla39702 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			Title = "focus test";
+			var editor = new Editor();
+			var entry = new Entry();
+
+			editor.Unfocused += (object sender, FocusEventArgs e) => entry.Focus();
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					editor,
+					entry
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -83,6 +83,7 @@
       <DependentUpon>Bugzilla39463.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39702.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -625,6 +625,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				});
 			}
 
+			Context.HideKeyboard(this);
+
 			// 200ms is how long the animations are, and they are "reversible" in the sense that starting another one slightly before it's done is fine
 
 			return tcs.Task;

--- a/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Platform.Android
 					break;
 
 				Context.HideKeyboard(currentView);
-				RequestFocus();
+				((Activity)Context).Window.DecorView.ClearFocus();
 			} while (false);
 
 			return result;

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using Android.App;
+using Android.OS;
 using Android.Views;
 using AView = Android.Views.View;
 
@@ -149,11 +150,20 @@ namespace Xamarin.Forms.Platform.Android
 			if (Control == null)
 				return;
 
+			e.Result = true;
+
 			if (e.Focus)
-				e.Result = Control.RequestFocus();
+			{
+				// use post being BeginInvokeOnMainThread will not delay on android
+				Looper looper = Context.MainLooper;
+				var handler = new Handler(looper);
+				handler.Post(() =>
+				{
+					Control?.RequestFocus();
+				});
+			}
 			else
 			{
-				e.Result = true;
 				Control.ClearFocus();
 			}
 


### PR DESCRIPTION
### Description of Change

Changes the way that focus requests are handled in the android backend. Rather than immediately request focus we process it at the end of the looper queue. This helps with the fact that android does not seem to act correctly if you call focus during something else getting unfocused.

Tests omitted because UITest enters data into android in a way that doesn't seem to trigger the bug.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=39702
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
