### PR TITLE
[C]Remove view from previous parent when added to new parent layout

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/GroupViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/GroupViewUnitTests.cs
@@ -288,5 +288,18 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.False (added);
 			Assert.False (removed);
 		}
+
+		[Test]
+		public void AddToSecondLayoutRemovesFromOriginal()
+		{
+			var child = new BoxView();
+			var layout1 = new NaiveLayout();
+			var layout2 = new NaiveLayout();
+
+			layout1.Children.Add(child);
+			layout2.Children.Add(child);
+
+			Assert.False(layout1.Children.Contains(child));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -395,6 +395,9 @@ namespace Xamarin.Forms
 
 		void OnInternalAdded(View view)
 		{
+			var parent = view.Parent as Layout;
+			parent?.InternalChildren.Remove(view);
+
 			OnChildAdded(view);
 			if (ShouldInvalidateOnChildAdded(view))
 				InvalidateLayout();


### PR DESCRIPTION
### Description of Change

Make it so that adding a child to a Layout will remove it from any other layout it is currently a child of.

Technically this could be considered a breaking change if someone was depending on the old behavior, however the old behavior resulted in layouts that were not predictable to the user. So while yes someone could have built something that works, it would have been via trial and error and generally breaking the rule of one parent to each view.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=39509
### API Changes

None
### Behavioral Changes

See description
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
