### PR TITLE
[WP8] CustomMessageBox dismissal no longer causes black SystemTray

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25234.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25234.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 25234, "Use of CustomMessageBox resets SystemTray BackgroundColor to black", PlatformAffected.WinPhone)]
+	public class Bugzilla25234 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Button
+					{
+						Text = "Click for Alert",
+						Command = new Command(() =>
+						{
+							DisplayAlert("Display Alert",
+								"If the theme is set to light on WP8, the status bar should return to the white color when closed", "OK");
+						})
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -19,6 +19,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla22401.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla24769.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla25234.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla25662.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla26501.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla26868.cs" />

--- a/Xamarin.Forms.Platform.WP8/Platform.cs
+++ b/Xamarin.Forms.Platform.WP8/Platform.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 			_renderer = new Canvas();
 			_renderer.SizeChanged += RendererSizeChanged;
+			_renderer.Loaded += (sender, args) => UpdateSystemTray();
 
 			_tracker.CollectionChanged += (sender, args) => UpdateToolbarItems();
 
@@ -480,6 +481,15 @@ namespace Xamarin.Forms.Platform.WinPhone
 					((FrameworkElement)pageRenderer.ContainerElement).Width = _renderer.ActualWidth;
 					((FrameworkElement)pageRenderer.ContainerElement).Height = _renderer.ActualHeight;
 				}
+			}
+		}
+
+		void UpdateSystemTray()
+		{
+			var lightThemeVisibility = (Visibility)System.Windows.Application.Current.Resources["PhoneLightThemeVisibility"];
+			if (lightThemeVisibility == Visibility.Visible && SystemTray.BackgroundColor == System.Windows.Media.Color.FromArgb(0, 0, 0, 0))
+			{
+				SystemTray.BackgroundColor = System.Windows.Media.Color.FromArgb(1, 255, 255, 255);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

When running WP8 with the system's light theme, using the `CustomMessageBox` would initially change the `SystemTray`'s background color from white, but when dismissed would subsequently make the background color black. It appears as if the way that [CustomMessageBox](http://phone.codeplex.com/sourcecontrol/latest#Microsoft.Phone.Controls.Toolkit/CustomMessageBox/CustomMessageBox.cs) works has it resetting the background color of `SystemTray` upon dismissal; it appears that the proper background color was never initially set, though (the value was black prior to the `CustomMessageBox` appearing).

Inside of `Platform.cs`, a method has been added that checks to see if the light theme is active and if the SystemTray is black (presumably as an individual could otherwise set the color manually), and if so, sets `SystemTray.BackgroundColor` color to white.

A controls issue page has been added but there is no explicit test.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=25234
### API Changes

Added:
- `void UpdateSystemTray()`
### Behavioral Changes

There should be none, as it is only setting the system tray color to white if it is expected.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
