### PR TITLE
[Android] SendAppearing on resuming fragment

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
@@ -107,5 +107,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Page?.SendDisappearing();
 			base.OnPause();
 		}
+		
+		public override void OnResume()
+		{
+			Page?.SendAppearing();
+			base.OnResume();
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Override Fragment OnResume to call SendAppearing, this will make sure to balance the call of OnPause where we call SendDisappearing.

Didn't provide UITest because it requires pausing the app.
### Bugs Fixed

[Bug 39742 - OnAppearing not triggered if coming back after leaving Android app via home button](https://bugzilla.xamarin.com/show_bug.cgi?id=39742)
### API Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
