### PR TITLE
Ignore hidden fields when reflecting for FieldInfo's.

### DIFF
--- a/Xamarin.Forms.Core/ReflectionExtensions.cs
+++ b/Xamarin.Forms.Core/ReflectionExtensions.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms
 	{
 		public static FieldInfo GetField(this Type type, Func<FieldInfo, bool> predicate)
 		{
-			return GetFields(type).SingleOrDefault(predicate);
+			return GetFields(type).FirstOrDefault(predicate);
 		}
 
 		public static FieldInfo GetField(this Type type, string name)


### PR DESCRIPTION
Resolving BindableProperty fields in the same way C# does; ignore fields hidden by similarly named fields on inherited classes.

Trivial fix, no test.
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=39566
### API Changes

None
### Behavioral Changes

Change will only prevent an exception from being thrown in the case where a BindableProperty backing field hides a similarly named field on an inherited class.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
