### PR TITLE
[iOS,Android,Win] Make sure we only cache images that return a succes…

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.WinRT/WindowsBasePlatformServices.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			using (var client = new HttpClient())
 			{
 				HttpResponseMessage streamResponse = await client.GetAsync(uri.AbsoluteUri).ConfigureAwait(false);
-				return await streamResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
+				return streamResponse.IsSuccessStatusCode ? await streamResponse.Content.ReadAsStreamAsync().ConfigureAwait(false) : null;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Make sure we don't cache a image that return a 404 status code, this was causing the stream to be cached even though a successful image wasn't returned.

UITest not possible because it needs the same url working and failing after.
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=39359
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
