### PR TITLE
[W] Button BG Color & BorderRadius are consistent

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39853.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39853.cs
@@ -1,0 +1,78 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39853, "BorderRadius ignored on UWP", PlatformAffected.WinRT)]
+	public class Bugzilla39853 : TestContentPage
+	{
+		public class RoundedButton : Xamarin.Forms.Button
+		{
+			public RoundedButton(int radius)
+			{
+				base.BorderRadius = radius;
+				base.WidthRequest = 2 * radius;
+				base.HeightRequest = 2 * radius;
+				HorizontalOptions = LayoutOptions.Center;
+				VerticalOptions = LayoutOptions.Center;
+				BackgroundColor = Color.Aqua;
+				BorderColor = Color.White;
+				TextColor = Color.Purple;
+				Text = "YAY";
+				Image = new FileImageSource { File = "crimson.jpg" };
+			}
+
+			public new int BorderRadius
+			{
+				get
+				{
+					return base.BorderRadius;
+				}
+
+				set
+				{
+					base.WidthRequest = 2 * value;
+					base.HeightRequest = 2 * value;
+					base.BorderRadius = value;
+				}
+			}
+
+			public new double WidthRequest
+			{
+				get
+				{
+					return base.WidthRequest;
+				}
+
+				set
+				{
+					base.WidthRequest = value;
+					base.HeightRequest = value;
+					base.BorderRadius = ((int)value) / 2;
+				}
+			}
+
+			public new double HeightRequest
+			{
+				get
+				{
+					return base.HeightRequest;
+				}
+
+				set
+				{
+					base.WidthRequest = value;
+					base.HeightRequest = value;
+					base.BorderRadius = ((int)value) / 2;
+				}
+			}
+
+		}
+		protected override void Init()
+		{
+			Content = new RoundedButton(100);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -126,6 +126,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39499.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39668.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39829.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
@@ -88,6 +88,14 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 		}
 
+		protected override void UpdateBackgroundColor()
+		{
+			// Button is a special case; we don't want to set the Control's background
+			// because it goes outside the bounds of the Border/ContentPresenter, 
+			// which is where we might change the BorderRadius to create a rounded shape.
+			return;
+		}
+
 		void OnButtonClick(object sender, RoutedEventArgs e)
 		{
 			Button buttonView = Element;
@@ -97,7 +105,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void UpdateBackground()
 		{
-			Control.Background = Element.BackgroundColor != Color.Default ? Element.BackgroundColor.ToBrush() : (Brush)Windows.UI.Xaml.Application.Current.Resources["ButtonBackgroundThemeBrush"];
+			Control.BackgroundColor = Element.BackgroundColor != Color.Default ? Element.BackgroundColor.ToBrush() : (Brush)Windows.UI.Xaml.Application.Current.Resources["ButtonBackgroundThemeBrush"];
 		}
 
 		void UpdateBorderColor()

--- a/Xamarin.Forms.Platform.WinRT/FormsButton.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsButton.cs
@@ -1,7 +1,9 @@
 ﻿using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 
 #if WINDOWS_UWP
+using WContentPresenter = Windows.UI.Xaml.Controls.ContentPresenter;
 
 namespace Xamarin.Forms.Platform.UWP
 #else
@@ -11,23 +13,58 @@ namespace Xamarin.Forms.Platform.WinRT
 {
 	public class FormsButton : Windows.UI.Xaml.Controls.Button
 	{
-		public static readonly DependencyProperty BorderRadiusProperty = DependencyProperty.Register("BorderRadius", typeof(int), typeof(FormsButton),
+		public static readonly DependencyProperty BorderRadiusProperty = DependencyProperty.Register(nameof(BorderRadius), typeof(int), typeof(FormsButton),
 			new PropertyMetadata(default(int), OnBorderRadiusChanged));
 
+		public static readonly DependencyProperty BackgroundColorProperty = DependencyProperty.Register(nameof(BackgroundColor), typeof(Brush), typeof(FormsButton),
+			new PropertyMetadata(default(Brush), OnBackgroundColorChanged));
+
+#if WINDOWS_UWP
+		WContentPresenter _contentPresenter;
+#else
 		Border _border;
+#endif
+
+		public Brush BackgroundColor
+		{
+			get
+			{
+				return (Brush)GetValue(BackgroundColorProperty);
+			}
+			set
+			{
+				SetValue(BackgroundColorProperty, value);
+			}
+		}
 
 		public int BorderRadius
 		{
-			get { return (int)GetValue(BorderRadiusProperty); }
-			set { SetValue(BorderRadiusProperty, value); }
+			get
+			{
+				return (int)GetValue(BorderRadiusProperty);
+			}
+			set
+			{
+				SetValue(BorderRadiusProperty, value);
+			}
 		}
 
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
 
+#if WINDOWS_UWP
+			_contentPresenter = GetTemplateChild("ContentPresenter") as WContentPresenter;	
+#else
 			_border = GetTemplateChild("Border") as Border;
+#endif
+			UpdateBackgroundColor();
 			UpdateBorderRadius();
+		}
+
+		static void OnBackgroundColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			((FormsButton)d).UpdateBackgroundColor();
 		}
 
 		static void OnBorderRadiusChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -35,12 +72,28 @@ namespace Xamarin.Forms.Platform.WinRT
 			((FormsButton)d).UpdateBorderRadius();
 		}
 
+		void UpdateBackgroundColor()
+		{
+			Background = Color.Transparent.ToBrush();
+#if WINDOWS_UWP
+			if (_contentPresenter != null)
+				_contentPresenter.Background = BackgroundColor;
+#else
+			if (_border != null)
+				_border.Background = BackgroundColor;
+#endif
+		}
+
 		void UpdateBorderRadius()
 		{
-			if (_border == null)
-				return;
 
-			_border.CornerRadius = new CornerRadius(BorderRadius);
+#if WINDOWS_UWP
+			if (_contentPresenter != null)
+				_contentPresenter.CornerRadius = new CornerRadius(BorderRadius);
+#else
+			if (_border != null)
+				_border.CornerRadius = new CornerRadius(BorderRadius);
+#endif
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Setting BackgroundColor & BorderRadius on the Border and ContentPresenter controls for WinRT and UWP, respectively, instead of on the Control itself. UWP Buttons now respect the BorderRadius.
UWP & WinRT BackgroundColor no longer extends past the Border.

Test is visual only, not automated.
### Bugs Fixed
- [Bug 31670  - On WinRT, BackgroundColor of Button is used to paint outside the border of Buttons with rounded corners](https://bugzilla.xamarin.com/show_bug.cgi?id=31670)
- [Bug 39464  - [UWP Forms] Rounded Button Corners do not render in Forms (but do in native UWP)](https://bugzilla.xamarin.com/show_bug.cgi?id=39464)
- [Bug 39853  - BorderRadius ignored on UWP](https://bugzilla.xamarin.com/show_bug.cgi?id=39853)
### API Changes

None
### Behavioral Changes

None 
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
