### PR TITLE
[Controls,Core]Allow well known type conversions on the binding system

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Controls.Issues.Bugzilla39378" xmlns:local="clr-namespace:Xamarin.Forms.Controls">
+    <local:TestContentPage.Content>
+        <Grid BackgroundColor="{Binding BackgroundColor}" Margin="20" Padding="20">
+            <Image AutomationId="image1">
+                <Image.Source>
+                    <UriImageSource Uri="{Binding HomeImage}" />
+                </Image.Source>
+            </Image>
+        </Grid>
+    </local:TestContentPage.Content>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39378, "Image binding with caching not operating as expected", PlatformAffected.All)]
+	public partial class Bugzilla39378 : TestContentPage
+	{
+#if APP
+		public Bugzilla39378()
+		{
+			InitializeComponent();
+		}
+#endif
+
+		protected override void Init()
+		{
+			BindingContext = new ImageController();
+		}
+
+		class ImageController : ViewModelBase
+		{
+			
+			public ImageController()
+			{
+				HomeImage = "http://xamarin.com/content/images/pages/forms/example-app.png";
+				LocalBackgroundImage = "Default-568h@2x.png";
+				BackgroundColor = "#00FF00";
+			}
+
+			public string BackgroundColor
+			{
+				get
+				{ 
+					return _backgroundColor;
+				}
+
+				set
+				{
+					_backgroundColor = value;
+					OnPropertyChanged();
+				}
+			}
+
+			public string HomeImage
+			{
+				get
+				{ 
+					return _homeImage;
+				}
+
+				set
+				{
+					_homeImage = value;
+					OnPropertyChanged();
+				}
+			}
+
+			public string LocalBackgroundImage
+			{
+				get
+				{ 
+					return _localBackgroundImage;
+				}
+
+				set
+				{
+					_localBackgroundImage = value;
+					OnPropertyChanged();
+				}
+			}
+
+
+			string _backgroundColor;
+			string _homeImage;
+			string _localBackgroundImage;
+		}
+
+#if UITEST
+		[Test]
+		public void ImageIsPresent()
+		{
+			RunningApp.WaitForElement(q => q.Marked("image1"));
+			Assert.Inconclusive("Please verify image is present");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -374,6 +374,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla27350.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla28709.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33578.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39378.xaml.cs">
+      <DependentUpon>Bugzilla39378.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -481,6 +484,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla39483.xaml">
       <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla39378.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Core/BindableProperty.cs
+++ b/Xamarin.Forms.Core/BindableProperty.cs
@@ -30,6 +30,12 @@ namespace Xamarin.Forms
 
 		public delegate bool ValidateValueDelegate<in TPropertyType>(BindableObject bindable, TPropertyType value);
 
+		static readonly Dictionary<Type, TypeConverter> WellKnownConvertTypes = new  Dictionary<Type,TypeConverter>
+		{
+			{ typeof(Uri), new UriTypeConverter() },
+			{ typeof(Color), new ColorTypeConverter() },
+		};
+
 		// more or less the encoding of this, without the need to reflect
 		// http://msdn.microsoft.com/en-us/library/y5b434w4.aspx
 		static readonly Dictionary<Type, Type[]> SimpleConvertTypes = new Dictionary<Type, Type[]>
@@ -303,9 +309,14 @@ namespace Xamarin.Forms
 
 			// Dont support arbitrary IConvertible by limiting which types can use this
 			Type[] convertableTo;
+			TypeConverter typeConverterTo;
 			if (SimpleConvertTypes.TryGetValue(valueType, out convertableTo) && Array.IndexOf(convertableTo, type) != -1)
 			{
 				value = Convert.ChangeType(value, type);
+			}
+			else if (WellKnownConvertTypes.TryGetValue(type, out typeConverterTo) && typeConverterTo.CanConvertFrom(valueType))
+			{
+				value = typeConverterTo.ConvertFromInvariantString(value.ToString());
 			}
 			else if (!ReturnTypeInfo.IsAssignableFrom(valueType.GetTypeInfo()))
 			{


### PR DESCRIPTION
### Description of Change

Adding a extra lookup when we are trying  to convert string to a type via a BindableProperty. 
The issue happens when we are applying bindings and we don't find a implicit operator for the type, at the same time if we don't use binding system the TypeConverter will kick in and make this work ok.
So we have  WellKnownTypesDictinary that knows how use a TypeConverter for strings.
### Bugs Fixed

Fixes [Bug 39378 - Image binding with caching not operating as expected](https://bugzilla.xamarin.com/show_bug.cgi?id=39378)

Bug talks on caching issue, but is not, just noticed when using a binding in UriImageSource in xaml.
### API Changes

None
### Behavioral Changes

Users will now be able to bind 
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
