### PR TITLE
Make spacing in lock statement consistent with code style

### DIFF
--- a/Xamarin.Forms.Core/ImageSource.cs
+++ b/Xamarin.Forms.Core/ImageSource.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Forms
 			if (tcs != null)
 				tcs.SetResult(cancelled);
 
-			lock(_synchandle)
+			lock (_synchandle)
 			{
 				CancellationTokenSource = null;
 			}
@@ -124,7 +124,7 @@ namespace Xamarin.Forms
 
 		protected void OnLoadingStarted()
 		{
-			lock(_synchandle)
+			lock (_synchandle)
 			{
 				CancellationTokenSource = new CancellationTokenSource();
 			}

--- a/Xamarin.Forms.Core/Interactivity/AttachedCollection.cs
+++ b/Xamarin.Forms.Core/Interactivity/AttachedCollection.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Forms
 
 		protected virtual void OnAttachedTo(BindableObject bindable)
 		{
-			lock(_associatedObjects)
+			lock (_associatedObjects)
 			{
 				_associatedObjects.Add(new WeakReference(bindable));
 			}
@@ -73,7 +73,7 @@ namespace Xamarin.Forms
 		{
 			foreach (T item in this)
 				item.DetachFrom(bindable);
-			lock(_associatedObjects)
+			lock (_associatedObjects)
 			{
 				for (var i = 0; i < _associatedObjects.Count; i++)
 				{

--- a/Xamarin.Forms.Core/LockingSemaphore.cs
+++ b/Xamarin.Forms.Core/LockingSemaphore.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms
 		public void Release()
 		{
 			TaskCompletionSource<bool> toRelease = null;
-			lock(_waiters)
+			lock (_waiters)
 			{
 				if (_waiters.Count > 0)
 					toRelease = _waiters.Dequeue();
@@ -34,7 +34,7 @@ namespace Xamarin.Forms
 
 		public Task WaitAsync(CancellationToken token)
 		{
-			lock(_waiters)
+			lock (_waiters)
 			{
 				if (_currentCount > 0)
 				{

--- a/Xamarin.Forms.Core/SynchronizedList.cs
+++ b/Xamarin.Forms.Core/SynchronizedList.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms
 
 		public void Add(T item)
 		{
-			lock(_list)
+			lock (_list)
 			{
 				_list.Add(item);
 				_snapshot = null;
@@ -21,7 +21,7 @@ namespace Xamarin.Forms
 
 		public void Clear()
 		{
-			lock(_list)
+			lock (_list)
 			{
 				_list.Clear();
 				_snapshot = null;
@@ -30,13 +30,13 @@ namespace Xamarin.Forms
 
 		public bool Contains(T item)
 		{
-			lock(_list)
+			lock (_list)
 				return _list.Contains(item);
 		}
 
 		public void CopyTo(T[] array, int arrayIndex)
 		{
-			lock(_list)
+			lock (_list)
 				_list.CopyTo(array, arrayIndex);
 		}
 
@@ -52,7 +52,7 @@ namespace Xamarin.Forms
 
 		public bool Remove(T item)
 		{
-			lock(_list)
+			lock (_list)
 			{
 				if (_list.Remove(item))
 				{
@@ -74,7 +74,7 @@ namespace Xamarin.Forms
 			ReadOnlyCollection<T> snap = _snapshot;
 			if (snap == null)
 			{
-				lock(_list)
+				lock (_list)
 					_snapshot = snap = new ReadOnlyCollection<T>(_list.ToList());
 			}
 
@@ -83,13 +83,13 @@ namespace Xamarin.Forms
 
 		public int IndexOf(T item)
 		{
-			lock(_list)
+			lock (_list)
 				return _list.IndexOf(item);
 		}
 
 		public void Insert(int index, T item)
 		{
-			lock(_list)
+			lock (_list)
 			{
 				_list.Insert(index, item);
 				_snapshot = null;
@@ -104,13 +104,13 @@ namespace Xamarin.Forms
 				if (snap != null)
 					return snap[index];
 
-				lock(_list)
+				lock (_list)
 					return _list[index];
 			}
 
 			set
 			{
-				lock(_list)
+				lock (_list)
 				{
 					_list[index] = value;
 					_snapshot = null;
@@ -120,7 +120,7 @@ namespace Xamarin.Forms
 
 		public void RemoveAt(int index)
 		{
-			lock(_list)
+			lock (_list)
 			{
 				_list.RemoveAt(index);
 				_snapshot = null;

--- a/Xamarin.Forms.Core/UriImageSource.cs
+++ b/Xamarin.Forms.Core/UriImageSource.cs
@@ -185,7 +185,7 @@ namespace Xamarin.Forms
 		{
 			string key = GetCacheKey(uri);
 			LockingSemaphore sem;
-			lock(s_syncHandle)
+			lock (s_syncHandle)
 			{
 				if (s_semaphores.ContainsKey(key))
 					sem = s_semaphores[key];

--- a/Xamarin.Forms.Platform.iOS/Renderers/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FontExtensions.cs
@@ -170,7 +170,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var key = new ToUIFontKey(family, size, attributes);
 
-			lock(ToUiFont)
+			lock (ToUiFont)
 			{
 				UIFont value;
 				if (ToUiFont.TryGetValue(key, out value))
@@ -179,7 +179,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var generatedValue = _ToUIFont(family, size, attributes);
 
-			lock(ToUiFont)
+			lock (ToUiFont)
 			{
 				UIFont value;
 				if (!ToUiFont.TryGetValue(key, out value))


### PR DESCRIPTION
### Description of Change

Make all uses of `lock ()` consistent with the code style for the project.
