### PR TITLE
[W] Setting CurrentPage in CarouselPage ctor works

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39458.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39458.cs
@@ -1,0 +1,84 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39458, "[UWP/WinRT] Cannot Set CarouselPage.CurrentPage Inside Constructor", PlatformAffected.WinRT)]
+	public class Bugzilla39458 : TestCarouselPage
+	{
+		public class ChildPage : ContentPage
+		{
+			public ChildPage(int pageNumber)
+			{
+				var layout = new StackLayout();
+				var MyLabel = new Label {
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					FontSize = 21,
+					TextColor = Color.White,
+					Text = $"This is page {pageNumber}"
+				};
+				var TestBtn = new Button {
+					Text = "Go to Page 2",
+					IsEnabled = false,
+					BackgroundColor = Color.White
+				};
+
+				if (pageNumber != 2)
+				{
+					TestBtn.IsEnabled = true;
+					TestBtn.Clicked += TestBtn_Clicked;
+				}
+
+				layout.Children.Add(MyLabel);
+				layout.Children.Add(TestBtn);
+				Content = layout;
+			}
+
+			private void TestBtn_Clicked(object sender, EventArgs e)
+			{
+				var carousel = Application.Current.MainPage as CarouselPage;
+				carousel.CurrentPage = carousel.Children[1];
+			}
+		}
+
+		public class DesiredPage : ChildPage
+		{
+			public DesiredPage(int pageNumber) : base(pageNumber)
+			{
+			}
+		}
+
+		protected override void Init()
+		{
+			var firstPage = new ChildPage(1);
+			firstPage.BackgroundColor = Color.Blue;
+			Children.Add(firstPage);
+
+			var secondPage = new DesiredPage(2);
+			secondPage.BackgroundColor = Color.Red;
+			Children.Add(secondPage);
+
+			var thirdPage = new ChildPage(3);
+			thirdPage.BackgroundColor = Color.Green;
+			Children.Add(thirdPage);
+
+			CurrentPage = secondPage;
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla39458Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("This is page 2"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -133,6 +133,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39499.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39668.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39829.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.WinRT/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/CarouselPageRenderer.cs
@@ -92,8 +92,12 @@ namespace Xamarin.Forms.Platform.WinRT
 
 				_tracker.Element = newPage;
 
+				// Adding Items triggers the SelectionChanged event,
+				// which will reset the CurrentPage unless we tell it to ignore.
+				_fromUpdate = true;
 				for (var i = 0; i < newPage.Children.Count; i++)
 					Items.Add(newPage.Children[i]);
+				_fromUpdate = false;
 
 				((INotifyCollectionChanged)newPage.Children).CollectionChanged += OnChildrenChanged;
 				newPage.PropertyChanged += OnElementPropertyChanged;


### PR DESCRIPTION
### Description of Change

WinRT/UWP CarouselPage will no longer revert to the first Page when it is first rendered.
### Bugs Fixed
- [Bug 39458  - [UWP/WinRT] Cannot Set CarouselPage.CurrentPage Inside Constructor](https://bugzilla.xamarin.com/show_bug.cgi?id=39458)
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
