### PR TITLE
[iOS] ViewCellRenderer did not set RealCellProperty

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36955.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36955.cs
@@ -1,0 +1,62 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.iOS;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 36955, "[iOS] ViewCellRenderer.UpdateIsEnabled referencing null object", PlatformAffected.iOS)]
+	public class Bugzilla36955 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var ts = new TableSection();
+			var tr = new TableRoot { ts };
+			var tv = new TableView(tr);
+
+			var sc = new SwitchCell
+			{
+				Text = "Toggle switch; nothing should crash"
+			};
+
+			var button = new Button();
+			button.SetBinding(Button.TextProperty, new Binding("On", source: sc));
+
+			var vc = new ViewCell
+			{
+				View = button
+			};
+			vc.SetBinding(IsEnabledProperty, new Binding("On", source: sc));
+
+			ts.Add(sc);
+			ts.Add(vc);
+
+			Content = tv;
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla36955Test()
+		{
+			if (RunningApp is iOSApp)
+			{
+				AppResult[] buttonFalse = RunningApp.Query(q => q.Button().Text("False"));
+				Assert.AreEqual(buttonFalse.Length == 1, true);
+				RunningApp.Tap(q => q.Class("Switch"));
+				AppResult[] buttonTrue = RunningApp.Query(q => q.Button().Text("True"));
+				Assert.AreEqual(buttonTrue.Length == 1, true);
+			}
+			else
+			{
+				Assert.Inconclusive("Test is only run on iOS.");
+			}
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -68,6 +68,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36559.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36171.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37462.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37841.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37863.cs" />

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -35,6 +35,8 @@ namespace Xamarin.Forms.Platform.iOS
 			viewCell.PropertyChanged += ViewCellPropertyChanged;
 			cell.ViewCell = viewCell;
 
+			SetRealCell(item, cell);
+
 			WireUpForceUpdateSizeRequested(item, cell, tv);
 
 			UpdateBackground(cell, item);


### PR DESCRIPTION
### Description of Change

In the iOS `ViewCellRenderer`, the `GetRealCell` call in `ViewCellPropertyChanged` was returning null and passing that value to `UpdateIsEnabled`, causing a crash whenever it was called. `SetRealCell` was never being called in `ViewCellRenderer` and the `RealCellProperty` was never being set (which then has a default value of null). The situation, related to something like the referenced bug below, where a person would use a custom `ViewCell` with a toggle setting its binding of the `IsEnabled` property on the switch source would just leave a null value, so the cell had no `RealCellProperty` to get at which it could change.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=36955
### API Changes

None.
### Behavioral Changes

Should be none.
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
