### PR TITLE
Force conversion to target type when Static Resource returns OnPlatform<T>

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39636.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39636.xaml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                  xmlns:local="clr-namespace:Xamarin.Forms.Controls"
+             x:Class="Xamarin.Forms.Controls.Issues.Bugzilla39636">
+
+  <local:TestContentPage.Resources>
+    <ResourceDictionary>
+
+      <OnPlatform
+          x:Key="SizeMedium"
+          x:TypeArguments="x:Double"
+          iOS="40"
+          Android="30"
+          WinPhone="60" />
+
+      <x:Double x:Key="SizeLarge">80</x:Double>
+
+    </ResourceDictionary>
+  </local:TestContentPage.Resources>
+
+  <local:TestContentPage.Content>
+    <StackLayout HorizontalOptions="Fill" VerticalOptions="Fill">
+      <Label Text="Success"></Label>
+      <Label Text="If there is a blue box and a red box below, this test has passed. If the application crashes, the test has not passed."></Label>
+      <BoxView HorizontalOptions="Center" VerticalOptions="Center" BackgroundColor="Blue" WidthRequest="{StaticResource SizeMedium}">
+        <BoxView.HeightRequest>
+          <OnPlatform
+                        x:TypeArguments="x:Double"
+                        iOS="40"
+                        Android="30"
+                        WinPhone="60" />
+        </BoxView.HeightRequest>
+      </BoxView>
+      <BoxView  HorizontalOptions="Center" VerticalOptions="Center" BackgroundColor="Red" WidthRequest="{StaticResource SizeLarge}">
+
+      </BoxView>
+    </StackLayout>
+  </local:TestContentPage.Content>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39636.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39636.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39636, "Cannot use XamlC with OnPlatform in resources, it throws System.InvalidCastException", PlatformAffected.All)]
+	#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	#endif
+	public partial class Bugzilla39636 : TestContentPage
+	{
+		public Bugzilla39636 ()
+		{
+#if APP
+			InitializeComponent ();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+
+#if UITEST
+		[Test]
+		public void DoesNotCrash()
+		{
+			RunningApp.WaitForElement(q => q.Text("Success"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -89,6 +89,10 @@
       <DependentUpon>Bugzilla39463.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39636.xaml.cs">
+      <DependentUpon>Bugzilla39636.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39702.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
@@ -500,6 +504,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla27417Xaml.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla39636.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -264,7 +264,7 @@
     <Compile Include="PlatformTests\DisplayAlertUITestsAndroid.cs" />
     <Compile Include="..\Xamarin.Forms.Core.iOS.UITests\Tests\AppearingUITests.cs">
       <Link>Tests\AppearingUITests.cs</Link>
-	</Compile>
+    </Compile>
     <Compile Include="..\Xamarin.Forms.Core.iOS.UITests\Tests\AutomationIDUITests.cs">
       <Link>Tests\AutomationIDUITests.cs</Link>
     </Compile>
@@ -288,6 +288,10 @@
     <ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj">
       <Project>{67f9d3a8-f71e-4428-913f-c37ae82cdb24}</Project>
       <Name>Xamarin.Forms.Platform</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj">
+      <Project>{9DB2F292-8034-4E06-89AD-98BBDA4306B9}</Project>
+      <Name>Xamarin.Forms.Xaml</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change

XamlC normally checks for an implicit operator when setting a property value, which allows it to add a call to the implicit operator for OnPlatform<T>. However, when OnPlatform<T> is accessed via a static resource, XamlC doesn't have enough type information to set up the implicit operator call. This change adds a check to the StaticResourceExtension for a return value of OnPlatform<T> and forces the implicit conversion. 
### Bugs Fixed
- [39636 - Cannot use XamlC with OnPlatform in resources](https://bugzilla.xamarin.com/show_bug.cgi?id=39636)
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

…rm<T>
