### PR TITLE
[C] Cast to ICommand instead of Command inside SearchBar

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/SearchBarUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/SearchBarUnitTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Windows.Input;
 using NUnit.Framework;
 
 namespace Xamarin.Forms.Core.UnitTests
@@ -108,5 +108,26 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.True (searchBar.IsEnabled);
 		}
+
+	    class MyCommand : ICommand
+	    {
+	        public bool CanExecute(object parameter)
+	        {
+	            return true;
+	        }
+
+	        public void Execute(object parameter)
+	        {
+	        }
+
+	        public event EventHandler CanExecuteChanged;
+	    }
+
+	    [Test]
+	    public void DoesNotCrashWithNonCommandICommand()
+	    {
+	        var searchBar = new SearchBar();
+            Assert.DoesNotThrow(() => searchBar.SearchCommand = new MyCommand());
+	    }
 	}
 }

--- a/Xamarin.Forms.Core/SearchBar.cs
+++ b/Xamarin.Forms.Core/SearchBar.cs
@@ -134,8 +134,8 @@ namespace Xamarin.Forms
 		static void OnCommandChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var self = (SearchBar)bindable;
-			var newCommand = (Command)newValue;
-			var oldCommand = (Command)oldValue;
+			var newCommand = (ICommand)newValue;
+			var oldCommand = (ICommand)oldValue;
 
 			if (oldCommand != null)
 			{


### PR DESCRIPTION
### Description of Change

Simple bug fix resulting from the fact that user can implement ICommand by hand and is not beholden to Xamarin.Forms.Command. We were simply too eagerly casting.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=40096
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
