### PR TITLE
[A] SwitchCell IsEnabled bit now affects the toggle

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25662.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25662.cs
@@ -1,24 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Xamarin.Forms.CustomAttributes;
+﻿using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 25662, "Setting IsEnabled does not disable SwitchCell")]
-    public class Bugzilla25662 : ContentPage
+    public class Bugzilla25662 : TestContentPage
     {
+		[Preserve(AllMembers = true)]
 		class MySwitch : SwitchCell
 		{
 			public MySwitch ()
 			{
 				IsEnabled = false;
+				SetBinding(SwitchCell.TextProperty, new Binding("."));
+				OnChanged += (sender, e) => Text = "FAIL";
 			}
 		}
 
-
-		public Bugzilla25662 ()
+		protected override void Init ()
 		{
 			var list = new ListView {
 				ItemsSource = new[] {
@@ -28,8 +32,16 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 
 			Content = list;
-			Title = "My page";
-
 		}
-    }
+
+#if UITEST
+		[Test]
+		public void Bugzilla25662Test ()
+		{
+            RunningApp.WaitForElement (q => q.Marked ("One"));
+			RunningApp.Tap(q => q.Marked("One"));
+			RunningApp.WaitForNoElement(q => q.Marked("FAIL"));
+		}
+#endif
+	}
 }

--- a/Xamarin.Forms.Platform.Android/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/SwitchCellRenderer.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateText();
 			UpdateChecked();
 			UpdateHeight();
+			UpdateIsEnabled(_view, cell);
 
 			return _view;
 		}
@@ -35,11 +36,21 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateChecked();
 			else if (args.PropertyName == "RenderHeight")
 				UpdateHeight();
+			else if (args.PropertyName == Cell.IsEnabledProperty.PropertyName)
+				UpdateIsEnabled(_view, (SwitchCell)sender);
 		}
 
 		void UpdateChecked()
 		{
 			((ASwitch)_view.AccessoryView).Checked = ((SwitchCell)Cell).On;
+		}
+
+		void UpdateIsEnabled(SwitchCellView cell, SwitchCell switchCell)
+		{
+			cell.Enabled = switchCell.IsEnabled;
+			var aSwitch = cell.AccessoryView as ASwitch;
+			if (aSwitch != null)
+				aSwitch.Enabled = switchCell.IsEnabled;
 		}
 
 		void UpdateHeight()


### PR DESCRIPTION
### Description of Change

Explicitly setting Enabled property of the Android SwitchView when the IsEnabled property of the SwitchCell is changed.
### Bugs Fixed
- [Bug 25662  - Setting IsEnabled does not disable SwitchCell in Forms listview](https://bugzilla.xamarin.com/show_bug.cgi?id=25662)
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
