### PR TITLE
Automatically marshal all AnimationExtensions calls onto UI thread

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39821.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39821.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39821, "ViewExtension.TranslateTo cannot be invoked on Main thread")]
+	public class Bugzilla39821 : TestContentPage 
+	{
+		protected override void Init()
+		{
+			var box = new BoxView { BackgroundColor = Color.Blue, WidthRequest = 50, HeightRequest = 50, HorizontalOptions = LayoutOptions.Center };
+
+			var instructions = new Label { Text = "Click the 'Animate' button to run animation on the box. If the animations complete without crashing, this test has passed." };
+
+			var success = new Label { Text = "Success", IsVisible = false };
+
+			var button = new Button() { Text = "Animate" };
+
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Fill,
+				HorizontalOptions = LayoutOptions.Fill,
+				Children =
+				{
+					instructions,
+					success,
+					button,
+					new AbsoluteLayout
+					{
+						Children = { box },
+						HorizontalOptions = LayoutOptions.Fill,
+						VerticalOptions = LayoutOptions.Fill
+					}
+				}
+			};
+
+			button.Clicked += async (sender, args) => {
+				// Run a bunch of animations from the thread pool 
+				await Task.WhenAll(
+					Task.Run(async () => await Translate(box)),
+					Task.Run(async () => await CheckTranslateRunning(box)),
+					Task.Run(async () => await AnimateScale(box)),
+					Task.Run(async () => await Rotate(box)),
+					Task.Run(async () => await Animate(box)),
+					Task.Run(async () => await Kinetic(box)),
+					Task.Run(async () => await Cancel(box))
+					);
+
+				success.IsVisible = true;
+			};
+		}
+
+		async Task CheckTranslateRunning(BoxView box)
+		{
+			Debug.WriteLine(box.AnimationIsRunning("TranslateTo") ? "Translate is running" : "Translate is not running");
+		}
+
+		static async Task Translate(BoxView box)
+		{
+			var currentX = box.X;
+			var currentY = box.Y;
+
+			await box.TranslateTo(currentX, currentY + 100);
+			await box.TranslateTo(currentX, currentY);
+		}
+
+		static async Task AnimateScale(BoxView box)
+		{
+			await box.ScaleTo(2);
+			await box.ScaleTo(0.5);
+		}
+
+		static async Task Rotate(BoxView box)
+		{
+			await box.RelRotateTo(360);
+		}
+
+		async Task Cancel(BoxView box)
+		{
+			box.AbortAnimation("animate");
+			box.AbortAnimation("kinetic");
+		}
+
+		async Task Animate(BoxView box)
+		{
+			box.Animate("animate", d => d, d => { }, 100, 1);
+		}
+
+		async Task Kinetic(BoxView box)
+		{
+			var resultList = new List<Tuple<double, double>>();
+
+			box.AnimateKinetic("kinetic", (distance, velocity) =>
+			{
+				resultList.Add(new Tuple<double, double>(distance, velocity));
+				return true;
+			}, 100, 1);
+		}
+
+#if UITEST
+		[Test]
+		public void DoesNotCrash()
+		{
+			RunningApp.Tap(q => q.Marked("Animate"));
+			RunningApp.WaitForElement(q => q.Marked("Success"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -96,6 +96,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39702.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40173.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39821.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using Xamarin.Forms.Controls.Issues;
 
 namespace Xamarin.Forms.Controls
 {
@@ -23,8 +24,9 @@ namespace Xamarin.Forms.Controls
 		{
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 			InitInsights();
-			// MainPage = new MainPageLifeCycleTests ();
-			MainPage = new MasterDetailPage {
+			//MainPage = new MainPageLifeCycleTests();
+			MainPage = new MasterDetailPage
+			{
 				Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
 				Detail = CoreGallery.GetMainPage()
 			};


### PR DESCRIPTION
### Description of Change

Automatically forces all calls to AnimationExtensions onto the UI thread (as opposed to throwing an exception if they weren't called on the UI thread, like it used to).
### Bugs Fixed
- Fixes at least part (if not all) of [39821 - ViewExtension.TranslateTo cannot be invoked on Main thread](https://bugzilla.xamarin.com/show_bug.cgi?id=39821)
### API Changes

None
### Behavioral Changes

Previously, the user had to explicitly check `Device.IsInvokeRequired` and, if true, use `Device.BeginInvokeOnMainThread`. Now even if they don't use `Device.BeginInvokeOnMainThread` the call will be marshaled to the main thread.
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
