### PR TITLE
Fix race condition in IsInvokeRequired on Android

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/IsInvokeRequiredRaceCondition.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/IsInvokeRequiredRaceCondition.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Device.IsInvokeRequired race condition causes crash")]
+	public class IsInvokeRequiredRaceCondition : TestContentPage
+	{
+		protected override void Init()
+		{
+			var button = new Button
+			{
+				AutomationId = "crashButton",
+				Text = "Start Test"
+			};
+
+			var success = new Label { Text = "Success", IsVisible = false, AutomationId = "successLabel" };
+
+			var instructions = new Label { Text = "Click the Start Test button. " };
+
+			Content = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+				Children = { instructions, success, button }
+			};
+
+			button.Clicked += async (sender, args) =>
+			{
+				await Task.WhenAll(GenerateTasks());
+				success.IsVisible = true;
+			};
+		}
+
+		List<Task> GenerateTasks()
+		{
+			var result = new List<Task>();
+
+			for (int n = 0; n < 1000; n++)
+			{
+				result.Add(Task.Run(() => { var t = Device.IsInvokeRequired; } ));
+			}
+
+			return result;
+		}
+
+#if UITEST
+		[Test]
+		public void ShouldNotCrash()
+		{
+			RunningApp.Tap(q => q.Marked("crashButton"));
+			RunningApp.WaitForElement(q => q.Marked("successLabel"));
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -99,6 +99,7 @@
       <DependentUpon>Bugzilla38416.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)InputTransparentIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IsInvokeRequiredRaceCondition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsPasswordToggleTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1025.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1026.cs" />

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -362,15 +362,7 @@ namespace Xamarin.Forms
 				return new _IsolatedStorageFile(IsolatedStorageFile.GetUserStoreForApplication());
 			}
 
-			public bool IsInvokeRequired
-			{
-				get
-				{
-					using (Looper my = Looper.MyLooper())
-					using (Looper main = Looper.MainLooper)
-						return my != main;
-				}
-			}
+			public bool IsInvokeRequired => !Looper.MainLooper.IsCurrentThread;
 
 			public void OpenUriAction(Uri uri)
 			{


### PR DESCRIPTION
### Description of Change

Fixes issue where accessing Device.IsInvokeRequired on Android resulted in a race condition and possible crash.
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
