### PR TITLE
Remove 0114 supression from Platform.WP8; fix warnings

### DIFF
--- a/Xamarin.Forms.Platform.WP8/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/NavigationPageRenderer.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			return stack;
 		}
 
-		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName != "Parent" || Element.RealParent != null)
 				return;

--- a/Xamarin.Forms.Platform.WP8/Xamarin.Forms.Platform.WP8.csproj
+++ b/Xamarin.Forms.Platform.WP8/Xamarin.Forms.Platform.WP8.csproj
@@ -32,7 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;4014;0618;0219;0067</NoWarn>
+    <NoWarn>4014;0618;0219;0067</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
### Description of Change

Remove suppression of [CS0114](https://msdn.microsoft.com/en-us/library/04xcc4t1.aspx) from WP8 platform project 
Fix warning [CS0114](https://msdn.microsoft.com/en-us/library/04xcc4t1.aspx) occurrences
