### PR TITLE
[UWP] Adjust bounds for ContentPage when by itself

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40185.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40185.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40185, "[UWP] ContentPage does not have proper right bounds in landscape", PlatformAffected.WinRT)]
+	public class Bugzilla40185 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Button
+					{
+						Text = "Switch Main Page",
+						Command = new Command(SwitchMainPage)
+					}
+				}
+			};
+		}
+
+		void SwitchMainPage()
+		{
+			Application.Current.MainPage = new ContentPage
+			{
+				BackgroundColor = Color.White,
+				Content = new Label
+				{
+					Text = "This text should be in bounds in landscape mode.",
+					HorizontalTextAlignment = TextAlignment.End,
+					VerticalTextAlignment = TextAlignment.Center,
+					TextColor = Color.Black
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -97,6 +97,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39702.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40173.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39821.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40185.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Windows.ApplicationModel.Core;
 using Windows.UI;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
@@ -421,9 +422,19 @@ namespace Xamarin.Forms.Platform.WinRT
 				StatusBar statusBar = StatusBar.GetForCurrentView();
 
 				bool landscape = Device.Info.CurrentOrientation.IsLandscape();
+				bool titleBar = CoreApplication.GetCurrentView().TitleBar.IsVisible;
 				double offset = landscape ? statusBar.OccludedRect.Width : statusBar.OccludedRect.Height;
 
 				_bounds = new Rectangle(0, 0, _page.ActualWidth - (landscape ? offset : 0), _page.ActualHeight - (landscape ? 0 : offset));
+
+				// Even if the MainPage is a ContentPage not inside of a NavigationPage, the calculated bounds
+				// assume the TitleBar is there even if it isn't visible. When UpdatePageSizes is called,
+				// _container.ActualWidth is correct because it's aware that the TitleBar isn't there, but the
+				// bounds aren't, and things can subsequently run under the StatusBar.
+				if (!titleBar)
+				{
+					_bounds.Width -= (_bounds.Width - _container.ActualWidth);
+				}
 			}
 #endif
 		}


### PR DESCRIPTION
### Description of Change

In UWP apps (on mobile devices), there was a scenario in which a `ContentPage` by itself was being treated as if it still had a `TitleBar`, and as such was causing things like labels to run out of bounds (beneath the StatusBar) when the device went into landscape mode. This is prevented by checking against the `IsVisible` property of the `TitleBar` and adjusting the bounds if it is in fact missing,

(No UITest, but visual repro added to Issues -- this issue for some reason was also only found when testing on a physical device)
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=40185
### API Changes

None.
### Behavioral Changes

None.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
