### PR TITLE
Fix warnings for error CS1998

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27350.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27350.cs
@@ -30,7 +30,9 @@ namespace Xamarin.Forms.Controls
 
 			public ObservableCollection<RecipeGroup> RecipeGroups { get; set; }
 
+#pragma warning disable 1998 // considered for removal
 			public async Task LoadRecipesAsync ()
+#pragma warning restore 1998
 			{
 				var groups = new  ObservableCollection<RecipeGroup> ();
 				groups.Add (new RecipeGroup { Title = "Teste 1" });

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
@@ -377,7 +377,9 @@ namespace Xamarin.Forms.Controls
 				}
 			}
 
+#pragma warning disable 1998 // considered for removal
 			async void FastCompleteForCmd(object sender)
+#pragma warning restore 1998
 			{
 				try
 				{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39821.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39821.cs
@@ -59,7 +59,9 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 		}
 
+#pragma warning disable 1998 // considered for removal
 		async Task CheckTranslateRunning(BoxView box)
+#pragma warning restore 1998
 		{
 			Debug.WriteLine(box.AnimationIsRunning("TranslateTo") ? "Translate is running" : "Translate is not running");
 		}
@@ -84,18 +86,24 @@ namespace Xamarin.Forms.Controls.Issues
 			await box.RelRotateTo(360);
 		}
 
+#pragma warning disable 1998 // considered for removal
 		async Task Cancel(BoxView box)
+#pragma warning restore 1998
 		{
 			box.AbortAnimation("animate");
 			box.AbortAnimation("kinetic");
 		}
 
+#pragma warning disable 1998 // considered for removal
 		async Task Animate(BoxView box)
+#pragma warning restore 1998
 		{
 			box.Animate("animate", d => d, d => { }, 100, 1);
 		}
 
+#pragma warning disable 1998 // considered for removal
 		async Task Kinetic(BoxView box)
+#pragma warning restore 1998
 		{
 			var resultList = new List<Tuple<double, double>>();
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1461.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1461.cs
@@ -278,7 +278,7 @@ namespace Xamarin.Forms.Controls
 			try {
 				IsPresented = !IsPresented;
 			} catch (InvalidOperationException ex) {
-				DisplayAlert ("Error", ex.Message, "ok");
+				await DisplayAlert ("Error", ex.Message, "ok");
 			}
 		
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1758.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1758.cs
@@ -63,7 +63,7 @@ namespace Xamarin.Forms.Controls
 			// Comment this delay out to see the bug
 			// await Task.Delay(500);
  
-			_button.LayoutTo(new Rectangle(100, 100, 100, 100), 1000);
+			await _button.LayoutTo(new Rectangle(100, 100, 100, 100), 1000);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1875.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1875.cs
@@ -92,7 +92,9 @@ namespace Xamarin.Forms.Controls
 				}
 			}
 
+#pragma warning disable 1998 // considered for removal
 			public async Task LoadData (int start, int numberOfRecords)
+#pragma warning restore 1998
 			{
 				IsLoading = true;
 				for (int counter = 0; counter < numberOfRecords; counter++)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2357.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2357.xaml.cs
@@ -210,7 +210,9 @@ namespace Xamarin.Forms.Controls
 			_mainMenuItems = new ObservableCollection<MainMenuItem> (Enumerable.Empty<MainMenuItem> ());
 		}
 
+#pragma warning disable 1998 // considered for removal
 		public async Task InitializeAsync ()
+#pragma warning restore 1998
 		{
 			var items = new List<MainMenuItem> ();
 			items.Add (new MainMenuItem {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3319.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3319.xaml.cs
@@ -56,7 +56,9 @@ namespace Xamarin.Forms.Controls
 	
 		}
 
+#pragma warning disable 1998 // considered for removal
 		public async void OnDelete (object sender, EventArgs e)
+#pragma warning restore 1998
 		{
 			var mi = ((MenuItem)sender);
 			if (mi.CommandParameter == null)
@@ -105,7 +107,9 @@ namespace Xamarin.Forms.Controls
 				}
 			}
 
+#pragma warning disable 1998 // considered for removal
 			public async Task ExecuteFavoritesCommand ()
+#pragma warning restore 1998
 			{
 				if (IsBusy)
 					return;

--- a/Xamarin.Forms.Controls/ControlGalleryPages/AutomationIDGallery.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/AutomationIDGallery.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Controls
 				var btn = new Button {
 					AutomationId = "popModal",
 					Text = "Pop",
-					Command = new Command (async () => Navigation.PopModalAsync ())
+					Command = new Command (async () => await Navigation.PopModalAsync ())
 				};
 				rootLayout.Children.Add (btn);
 				rootLayout.Children.Add (new ActivityIndicator { AutomationId = "actHello", IsRunning = true });
@@ -72,7 +72,7 @@ namespace Xamarin.Forms.Controls
 				var btn = new Button {
 					AutomationId = "popModal",
 					Text = "Pop",
-					Command = new Command (async () => Navigation.PopModalAsync ())
+					Command = new Command (async () => await Navigation.PopModalAsync ())
 				};
 				rootLayout.Children.Add (btn);
 				rootLayout.Children.Add (new Image { AutomationId = "imgHello", Source = "menuIcon" });

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -28,7 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;0109;4014;1998;0649;0169;0472;0414;0168;0219;0429</NoWarn>
+    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;0109;4014;1998;0649;0169;0472;0414;0168;0219;0429</NoWarn>
+    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -51,7 +51,7 @@
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;0109;4014;1998;0649;0169;0472;0414;0168;0219;0429</NoWarn>
+    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -23,7 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0168;0169;0219</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0168;0169;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0168;0169;0219</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0168;0169;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -44,7 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0168;0169;0219</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0168;0169;0219</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -21,7 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,7 +31,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -23,7 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -44,7 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -362,7 +362,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateToolbar();
 		}
 
-		void DeviceInfoPropertyChanged(object sender, PropertyChangedEventArgs e)
+#pragma warning disable 1998 // considered for removal
+		async void DeviceInfoPropertyChanged(object sender, PropertyChangedEventArgs e)
+#pragma warning restore 1998
 		{
 			if (nameof(Device.Info.CurrentOrientation) == e.PropertyName)
 				ResetToolbar();

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -28,8 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>
-    </NoWarn>
+    <NoWarn>0642;0114;0108;0672;0168;0169;0184;0649;0414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -39,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0642;0114;0108;0672;0168;0169;0184;0649;1998;0414</NoWarn>
+    <NoWarn>0642;0114;0108;0672;0168;0169;0184;0649;0414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -51,7 +50,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0642;0114;0108;0672;0168;0169;0184;0649;1998;0414</NoWarn>
+    <NoWarn>0642;0114;0108;0672;0168;0169;0184;0649;0414</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -27,7 +27,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998</NoWarn>
+    <NoWarn></NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,14 +38,14 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998</NoWarn>
+    <NoWarn></NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\ARM\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>1998;0649;0169;0067</NoWarn>
+    <NoWarn>0649;0169;0067</NoWarn>
     <DebugType>full</DebugType>
     <PlatformTarget>ARM</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -58,7 +58,7 @@
     <OutputPath>bin\ARM\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
-    <NoWarn>1998;0649;0169;0067</NoWarn>
+    <NoWarn>0649;0169;0067</NoWarn>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>ARM</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -71,7 +71,7 @@
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>1998;0649;0169;0067</NoWarn>
+    <NoWarn>0649;0169;0067</NoWarn>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -84,7 +84,7 @@
     <OutputPath>bin\x64\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
-    <NoWarn>1998;0649;0169;0067</NoWarn>
+    <NoWarn>0649;0169;0067</NoWarn>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -97,7 +97,7 @@
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>1998;0649;0169;0067</NoWarn>
+    <NoWarn>0649;0169;0067</NoWarn>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -110,7 +110,7 @@
     <OutputPath>bin\x86\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
-    <NoWarn>1998;0649;0169;0067</NoWarn>
+    <NoWarn>0649;0169;0067</NoWarn>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>

--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -278,7 +278,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			ScrollTo(til.ListProxy.ProxiedEnumerable, til.ListProxy[0], ScrollToPosition.Start, true, true);
 		}
 
+#pragma warning disable 1998 // considered for removal
 		async void ScrollTo(object group, object item, ScrollToPosition toPosition, bool shouldAnimate, bool includeGroup = false, bool previouslyFailed = false)
+#pragma warning restore 1998
 		{
 			ScrollViewer viewer = GetScrollViewer();
 			if (viewer == null)

--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -496,7 +496,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			(this as ITitleProvider).BarForegroundBrush = GetBarForegroundBrush();
 		}
 
+#pragma warning disable 1998 // considered for removal
 		async void UpdateTitleOnParents()
+#pragma warning restore 1998
 		{
 			if (Element == null)
 				return;

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -493,7 +493,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			return GetCommandBarAsync();
 		}
 
+#pragma warning disable 1998 // considered for removal
 		async Task<CommandBar> GetCommandBarAsync()
+#pragma warning restore 1998
 		{
 #if !WINDOWS_UWP
 			return _page.BottomAppBar as CommandBar;

--- a/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.csproj
+++ b/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.csproj
@@ -37,7 +37,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998</NoWarn>
+    <NoWarn></NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -47,7 +47,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998</NoWarn>
+    <NoWarn></NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/Xamarin.Forms.Xaml.UnitTests/EventsConnection.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/EventsConnection.xaml.cs
@@ -64,7 +64,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		int asyncPrivateClicked;
+#pragma warning disable 1998 // considered for removal
 		async void HandleClickedPrivateAsync (object sender, EventArgs e)
+#pragma warning restore 1998
 		{
 			asyncPrivateClicked++;
 		}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -21,7 +21,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0672;1998;0219;0414</NoWarn>
+    <NoWarn>0672;0219;0414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0672;1998;0219;0414</NoWarn>
+    <NoWarn>0672;0219;0414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -44,7 +44,7 @@
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0672;1998;0219;0414</NoWarn>
+    <NoWarn>0672;0219;0414</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">


### PR DESCRIPTION
### Description of Change

Disable CS1998 errors as needed.

CS1998: "This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread."
### Bugs Fixed

N/A
### API Changes

None.
### Behavioral Changes

None, aside from disabling.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
