### PR TITLE
Enable CS0618 warnings as errors

### DIFF
--- a/ICSharpCode.Decompiler/Ast/AstBuilder.cs
+++ b/ICSharpCode.Decompiler/Ast/AstBuilder.cs
@@ -1661,7 +1661,9 @@ namespace ICSharpCode.Decompiler.Ast
 			if (member.DeclaringType.BaseType != null) {
 				var baseTypeRef = member.DeclaringType.BaseType;
 				while (baseTypeRef != null) {
+#pragma warning disable 618
 					var baseType = baseTypeRef.ResolveOrThrow();
+#pragma warning restore 618
 					if (baseType.HasProperties && AnyIsHiddenBy(baseType.Properties, member, m => !m.IsIndexer()))
 						return true;
 					if (baseType.HasEvents && AnyIsHiddenBy(baseType.Events, member))

--- a/ICSharpCode.Decompiler/Ast/TypesHierarchyHelpers.cs
+++ b/ICSharpCode.Decompiler/Ast/TypesHierarchyHelpers.cs
@@ -370,10 +370,14 @@ namespace ICSharpCode.Decompiler.Ast
 				var baseType = type.Item.BaseType;
 				var genericBaseType = baseType as GenericInstanceType;
 				if (genericBaseType != null) {
+#pragma warning disable 618
 					type = new GenericContext<TypeDefinition>(genericBaseType.ResolveOrThrow(),
+#pragma warning restore 618
 						genericBaseType.GenericArguments.Select(t => type.ResolveWithContext(t)));
 				} else
+#pragma warning disable 618
 					type = new GenericContext<TypeDefinition>(baseType.ResolveOrThrow());
+#pragma warning restore 618
 				yield return type;
 			}
 		}
@@ -441,7 +445,9 @@ namespace ICSharpCode.Decompiler.Ast
 					var resolvedElementType = ResolveWithContext(typeSpecification.ElementType);
 					return ReplaceElementType(typeSpecification, resolvedElementType);
 				}
+#pragma warning disable 618
 				return type.ResolveOrThrow();
+#pragma warning restore 618
 			}
 
 			TypeReference ReplaceElementType(TypeSpecification ts, TypeReference newElementType)
@@ -460,7 +466,9 @@ namespace ICSharpCode.Decompiler.Ast
 					return new ByReferenceType(newElementType);
 			}
 				// TODO: should we throw an exception instead calling Resolve method?
+#pragma warning disable 618
 				return ts.ResolveOrThrow();
+#pragma warning restore 618
 			}
 
 			public GenericContext<T2> ApplyTo<T2>(T2 item) where T2 : class

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -44,11 +44,11 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618;0219;0414</NoWarn>
+    <NoWarn>0219;0414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618;0219;0414</NoWarn>
+    <NoWarn>0219;0414</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AddingMultipleItemsListView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AddingMultipleItemsListView.cs
@@ -363,7 +363,9 @@ namespace Xamarin.Forms.Controls
 			public CustomViewCell ()
 			{
 				var jobId = new Label {
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize(20),
+#pragma warning restore 618
 					WidthRequest = 105,
 					VerticalOptions = LayoutOptions.Center,
 
@@ -381,7 +383,9 @@ namespace Xamarin.Forms.Controls
 				var hours = new Label {
 					WidthRequest = 45,
 					VerticalOptions = LayoutOptions.Center,
+#pragma warning disable 618
 					XAlign = TextAlignment.End,
+#pragma warning restore 618
 					HorizontalOptions = LayoutOptions.EndAndExpand,
 
 				};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27581.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27581.cs
@@ -15,7 +15,9 @@ namespace Xamarin.Forms.Controls
 				VerticalOptions = LayoutOptions.FillAndExpand,
 				Children = {
 					new Label {
+#pragma warning disable 618
 						XAlign = TextAlignment.Center,
+#pragma warning restore 618
 						Text = "Tap input field, then try to scroll"
 					},
 					new WebView {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27642.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27642.cs
@@ -93,7 +93,9 @@ namespace Xamarin.Forms.Controls
 				for (var i = 0; i < 100; i++)
 					sb.Append ("View 1a with ScrollView +++ ");
 
+#pragma warning disable 618
 				var label = new Label { Text = sb.ToString (), HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center, XAlign = TextAlignment.Center, };
+#pragma warning restore 618
 
 				scrollView.Content = label;
 
@@ -118,7 +120,9 @@ namespace Xamarin.Forms.Controls
 				for (var i = 0; i < 50; i++)
 					sb.Append ("View 1b with ScrollView and recreation of content +++++ ");
 
+#pragma warning disable 618
 				var label = new Label { Text = sb.ToString (), HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center, XAlign = TextAlignment.Center, };
+#pragma warning restore 618
 
 				scrollView.Content = label;
 
@@ -132,7 +136,9 @@ namespace Xamarin.Forms.Controls
 			public View2 ()
 			{
 				BackgroundColor = Color.Teal;
+#pragma warning disable 618
 				Content = new Label { Text = "View 2", HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center, XAlign = TextAlignment.Center, };
+#pragma warning restore 618
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28575.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28575.cs
@@ -21,7 +21,9 @@ namespace Xamarin.Forms.Controls
 			listview.Header = new Label () {
 				Text = _header,
 				TextColor = Color.Red,
+#pragma warning disable 618
 				XAlign = TextAlignment.Center
+#pragma warning restore 618
 			};
 
 			var b = new Button () {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
@@ -19,7 +19,9 @@ namespace Xamarin.Forms.Controls
 				VerticalOptions = LayoutOptions.Center,
 				Children = {
 					new Label {
+#pragma warning disable 618
 						XAlign = TextAlignment.Center,
+#pragma warning restore 618
 						Text = "Welcome to Xamarin Forms!"
 					},
 					new Button {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29453.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29453.cs
@@ -18,7 +18,9 @@ namespace Xamarin.Forms.Controls
 			var page1Layout = new StackLayout {
 				Children = {
 					new Label {
+#pragma warning disable 618
 						XAlign = TextAlignment.Center,
+#pragma warning restore 618
 						Text = "Page 1"
 					}
 				}
@@ -27,7 +29,9 @@ namespace Xamarin.Forms.Controls
 			var page2Layout = new StackLayout {
 				Children = {
 					new Label {
+#pragma warning disable 618
 						XAlign = TextAlignment.Center,
+#pragma warning restore 618
 						Text = "Page 2"
 					}
 				}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31029.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31029.cs
@@ -29,7 +29,9 @@ namespace Xamarin.Forms.Controls
 			Content = new StackLayout {
 				Children = {
 						btn,
+#pragma warning disable 618
                     new Label {Text = "GeneratedImage", Font=Font.BoldSystemFontOfSize(NamedSize.Medium)},
+#pragma warning restore 618
                     generatedImage
                 },
 				Padding = new Thickness (0, 20, 0, 0),

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
@@ -240,7 +240,9 @@ namespace Xamarin.Forms.Controls
 				_secondaryLabel = new Label() { HeightRequest = 40, FontSize = 16, TranslationY = -5, LineBreakMode = LineBreakMode.TailTruncation };
 				_secondaryLabel.SetBinding(Label.TextProperty, "SecondaryLabelText");
 
+#pragma warning disable 618
 				_distanceLabel = new Label() { XAlign = TextAlignment.End, HorizontalOptions = LayoutOptions.EndAndExpand, FontSize = 11, LineBreakMode = LineBreakMode.NoWrap };
+#pragma warning restore 618
 				_distanceLabel.SetBinding(Label.TextProperty, "OtherLabelText");
 
 				_statusCircle = new Label()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31255.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31255.cs
@@ -19,7 +19,9 @@ namespace Xamarin.Forms.Controls
 			var stack = new StackLayout () { VerticalOptions = LayoutOptions.Center };
 
 			stack.Children.Add (new Label () { VerticalOptions =
+#pragma warning disable 618
 				LayoutOptions.Center, XAlign = TextAlignment.Center, Text = "Page 1"
+#pragma warning restore 618
 			});
 
 			Content = stack;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32040.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32040.cs
@@ -25,7 +25,9 @@ namespace Xamarin.Forms.Controls
 			};
 
 			var entryCell = new EntryCell { Text = "yaddayadda" };
+#pragma warning disable 618
 			entryCell.XAlign = TextAlignment.End;
+#pragma warning restore 618
 			entryCell.Label = "Click Here";
 			entryCell.Tapped += (s, e) =>
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32691.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32691.cs
@@ -22,7 +22,9 @@ namespace Xamarin.Forms.Controls
 
 		protected override void Init ()
 		{
+#pragma warning disable 618
 			var label = new Label () { XAlign = TextAlignment.Center };
+#pragma warning restore 618
 			var image = new Image ();
 
 			image.PropertyChanged += (sender, e) => {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32898.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32898.cs
@@ -23,7 +23,9 @@ namespace Xamarin.Forms.Controls
 
 			stack.Children.Add (new Label () {
 				VerticalOptions = LayoutOptions.Center,
+#pragma warning disable 618
 				XAlign = TextAlignment.Center,
+#pragma warning restore 618
 				Text = "Page 1"
 			});
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
@@ -62,7 +62,9 @@ namespace Xamarin.Forms.Controls
 
 			void NewMenuItem_Clicked (object sender, EventArgs e)
 			{
+#pragma warning disable 618
 				ParentView.Navigation.PushAsync (new NextPage (), false);
+#pragma warning restore 618
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35294.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35294.cs
@@ -19,7 +19,9 @@ namespace Xamarin.Forms.Controls
 			Label header = new Label
 			{
 				Text = "Should not see blue",
+#pragma warning disable 618
 				Font = Font.BoldSystemFontOfSize(40),
+#pragma warning restore 618
 				HorizontalOptions = LayoutOptions.Center,
 				TextColor = Color.Black
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ComplexListView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ComplexListView.cs
@@ -56,10 +56,14 @@ namespace Xamarin.Forms.Controls
 			if (s_mImgRenewal == null)
 				s_mImgRenewal = ImageSource.FromFile ("bank.png");
 
+#pragma warning disable 618
 			var label1 = new Label { Text = "Label 1", Font = Font.SystemFontOfSize (NamedSize.Small, FontAttributes.Bold) };
+#pragma warning restore 618
 			label1.SetBinding (Label.TextProperty, new Binding ("."));
 
+#pragma warning disable 618
 			var label2 = new Label { Text = "Label 2", Font = Font.SystemFontOfSize (NamedSize.Small) };
+#pragma warning restore 618
 
 			// was ListButton?
 			var button = new Button {
@@ -71,7 +75,9 @@ namespace Xamarin.Forms.Controls
 			button.Clicked += (sender, e) => {
 				var b = (Button) sender;
 				var t = b.CommandParameter;
+#pragma warning disable 618
 				((ContentPage) ((ListView) ((StackLayout) b.ParentView).ParentView).ParentView).DisplayAlert ("Clicked",
+#pragma warning restore 618
 					t + " button was clicked", "OK");
 				Debug.WriteLine ("clicked" + t);
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1026.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1026.cs
@@ -77,8 +77,13 @@ namespace Xamarin.Forms.Controls
 						new Label {
 							Text = "by subscribing, you accept the general conditions.",
 							TextColor = Color.White,
+#pragma warning disable 618
 							XAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 							Font = Font.SystemFontOfSize (NamedSize.Micro),
+#pragma warning restore 618
 							WidthRequest = 262,
 							HorizontalOptions = LayoutOptions.Center,
 						},

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1075.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1075.cs
@@ -16,7 +16,9 @@ namespace Xamarin.Forms.Controls
 			Label header = new Label
 			{
 				Text = "Picker",
+#pragma warning disable 618
 				Font = Font.BoldSystemFontOfSize(50),
+#pragma warning restore 618
 				HorizontalOptions = LayoutOptions.Center
 			};
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1267.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1267.cs
@@ -23,10 +23,14 @@ namespace Xamarin.Forms.Controls
 			grid.Children.Add (label = new Label (),0,1);
 			label.SetBinding (Label.TextProperty, "LastName");			
 
+#pragma warning disable 618
 			grid.Children.Add (label = new Label {XAlign = TextAlignment.End},1,0);
+#pragma warning restore 618
 			label.SetBinding (Label.TextProperty, "Zip");			
 
+#pragma warning disable 618
 			grid.Children.Add (label = new Label {XAlign = TextAlignment.End},1,1);
+#pragma warning restore 618
 			label.SetBinding (Label.TextProperty, "City");
 			View = grid;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1384.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1384.cs
@@ -14,10 +14,17 @@ namespace Xamarin.Forms.Controls
 			grid.Children.Add (new Image {Source = "photo.jpg", Aspect = Aspect.AspectFit});
 			grid.Children.Add (new Label { 
 				Opacity =.75,
+#pragma warning disable 618
 				YAlign = TextAlignment.Start,
+#pragma warning restore 618
+
+#pragma warning disable 618
 				XAlign = TextAlignment.End,
+#pragma warning restore 618
 				Text ="top and flush right",
+#pragma warning disable 618
 				Font = Font.SystemFontOfSize (NamedSize.Large),
+#pragma warning restore 618
 				VerticalOptions=LayoutOptions.Start,
 				HorizontalOptions=LayoutOptions.End,
 				HeightRequest=30,
@@ -25,9 +32,13 @@ namespace Xamarin.Forms.Controls
 			});
 			grid.Children.Add (new Label { 
 				Opacity =.75,
+#pragma warning disable 618
 				YAlign = TextAlignment.End,
+#pragma warning restore 618
 				Text ="bottom and flush left",
+#pragma warning disable 618
 				Font = Font.SystemFontOfSize (NamedSize.Large),
+#pragma warning restore 618
 				VerticalOptions=LayoutOptions.End,
 				HeightRequest=40,
 				TextColor = Color.White,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1590.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1590.cs
@@ -88,10 +88,14 @@ namespace Xamarin.Forms.Controls.TestCasesPages
 	{
 		public ModuleMediaListItemTemplate()
 		{
+#pragma warning disable 618
 			var title = new Label { YAlign = TextAlignment.Center };
+#pragma warning restore 618
 			title.SetBinding(Label.TextProperty, new Binding("Title", BindingMode.OneWay));
 
+#pragma warning disable 618
 			var description = new Label { YAlign = TextAlignment.Center };
+#pragma warning restore 618
 			description.SetBinding(Label.TextProperty, new Binding("Description", BindingMode.OneWay));
 
 			View = new StackLayout
@@ -108,7 +112,9 @@ namespace Xamarin.Forms.Controls.TestCasesPages
 	{
 		public ModuleMediaListHeaderTemplate()
 		{
+#pragma warning disable 618
 			var title = new Label { TextColor = Color.White, YAlign = TextAlignment.Center };
+#pragma warning restore 618
 			title.SetBinding(Label.TextProperty, new Binding("SectionName", BindingMode.OneWay));
 
 			View = new StackLayout

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1593.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1593.cs
@@ -14,7 +14,9 @@ namespace Xamarin.Forms.Controls
 		{
 			var title = new Label {
 				Text = "Select League",
+#pragma warning disable 618
 				Font = Font.SystemFontOfSize (NamedSize.Large),
+#pragma warning restore 618
 				TextColor = Color.White
 			};
 
@@ -22,7 +24,9 @@ namespace Xamarin.Forms.Controls
 
 			var seasonLabel = new Label {
 				Text = "Season",
+#pragma warning disable 618
 				Font = Font.SystemFontOfSize (NamedSize.Small),
+#pragma warning restore 618
 				TextColor = Color.White
 			};
 
@@ -45,7 +49,9 @@ namespace Xamarin.Forms.Controls
 
 			var sportLabel = new Label {
 				Text = "Sport",
+#pragma warning disable 618
 				Font = Font.SystemFontOfSize (NamedSize.Small),
+#pragma warning restore 618
 				TextColor = Color.White
 			};
 
@@ -96,8 +102,9 @@ namespace Xamarin.Forms.Controls
 				BackgroundColor = Color.Gray,
 				ItemTemplate = new DataTemplate (() => {
 					var leagueName = new Label {
-						Font =
-							Font.SystemFontOfSize (NamedSize.Large),
+#pragma warning disable 618
+						Font = Font.SystemFontOfSize (NamedSize.Large),
+#pragma warning restore 618
 						BackgroundColor = Color.Transparent,
 						TextColor = Color.White,
 						VerticalOptions = LayoutOptions.CenterAndExpand,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1598.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1598.cs
@@ -69,7 +69,9 @@ namespace Xamarin.Forms.Controls
 						new Label () {
 							Text = title,
 							VerticalOptions = LayoutOptions.CenterAndExpand,
+#pragma warning disable 618
 							Font = Font.SystemFontOfSize (NamedSize.Large,
+#pragma warning restore 618
 							                              FontAttributes.Bold)
 						}
 					}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1613.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1613.cs
@@ -28,9 +28,17 @@ namespace Xamarin.Forms.Controls.TestCasesPages
 
 			var name = new Label {
 				Text = "Foo",
+#pragma warning disable 618
 				XAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 				YAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 				Font = Font.SystemFontOfSize(30, FontAttributes.Bold),
+#pragma warning restore 618
 				TextColor = Color.White,
 			};
 
@@ -45,8 +53,13 @@ namespace Xamarin.Forms.Controls.TestCasesPages
 				
 			var addressLabel = new Label {
 				Text = "Loading address…",
+#pragma warning disable 618
 				XAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 				YAlign = TextAlignment.Center,
+#pragma warning restore 618
 			};
 										
 			var map = new Map {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1769.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1769.cs
@@ -38,7 +38,9 @@ namespace Xamarin.Forms.Controls
 				Label header = new Label
 				{
 					Text = "Switch",
+#pragma warning disable 618
 					Font = Font.BoldSystemFontOfSize(50),
+#pragma warning restore 618
 					HorizontalOptions = LayoutOptions.Center
 				};
 
@@ -52,7 +54,9 @@ namespace Xamarin.Forms.Controls
 				_label = new Label
 				{
 					Text = "Switch is now False",
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize(NamedSize.Large),
+#pragma warning restore 618
 					HorizontalOptions = LayoutOptions.Center,
 					VerticalOptions = LayoutOptions.CenterAndExpand
 				};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue181.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue181.cs
@@ -21,8 +21,13 @@ namespace Xamarin.Forms.Controls
 					Text = "I should have red text",
 					TextColor = Color.Red,
 					BackgroundColor = new Color (0.5, 0.5, 0.5),
+#pragma warning disable 618
 					XAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 					YAlign = TextAlignment.Center
+#pragma warning restore 618
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2259.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2259.cs
@@ -40,7 +40,9 @@ namespace Xamarin.Forms.Controls
 				new Person ("Abigail", new DateTime (1975, 1, 15), Color.Aqua),
 				new Person ("Bob", new DateTime (1976, 2, 20), Color.Black),
 				new Person ("Cathy", new DateTime (1977, 3, 10), Color.Blue),
+#pragma warning disable 618
 				new Person ("David", new DateTime (1978, 4, 25), Color.Fuschia),
+#pragma warning restore 618
 			};
 
 			var buttonAdd = new Button {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue229.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue229.cs
@@ -15,8 +15,13 @@ namespace Xamarin.Forms.Controls
 
 			var label = new Label {
 				Text = "I should have a toolbar item",
+#pragma warning disable 618
 				XAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 				YAlign = TextAlignment.Center
+#pragma warning restore 618
 			};
 
 			var refreshBtn = new ToolbarItem ("Refresh", null, () => label.Text = "Clicking it works");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2563.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2563.cs
@@ -24,8 +24,13 @@ namespace Xamarin.Forms.Controls
 						Title = "Page " + i,
 						Content = new Label {
 							Text = "Page " + i,
+#pragma warning disable 618
 							XAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 							YAlign = TextAlignment.Center
+#pragma warning restore 618
 						}
 					}, random.NextDouble () > 0.5);
 				}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2597.cs
@@ -31,7 +31,9 @@ namespace Xamarin.Forms.Controls
 			_label = new Label
 			{
 				Text = "Stepper value is 0",
+#pragma warning disable 618
 				Font = Font.SystemFontOfSize(NamedSize.Large),
+#pragma warning restore 618
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.CenterAndExpand
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2634.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2634.cs
@@ -81,7 +81,9 @@ namespace Xamarin.Forms.Controls
 				var slFirstName = new StackLayout { Orientation = StackOrientation.Vertical };
 				var lblFirstNameLabel = new Label {
 					Text = "First Name",
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold),
+#pragma warning restore 618
 					TextColor = textColor
 				};
 				_firstNameEntry = new Entry {
@@ -96,7 +98,9 @@ namespace Xamarin.Forms.Controls
 				var slMiddleName = new StackLayout { Orientation = StackOrientation.Vertical };
 				var lblMiddleNameLabel = new Label {
 					Text = "Middle Name",
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold),
+#pragma warning restore 618
 					TextColor = textColor
 				};
 				var entMiddleName = new Entry {
@@ -111,7 +115,9 @@ namespace Xamarin.Forms.Controls
 				var slLastName = new StackLayout { Orientation = StackOrientation.Vertical };
 				var lblLastNameLabel = new Label {
 					Text = "Last Name",
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold),
+#pragma warning restore 618
 					TextColor = textColor
 				};
 				var entLastName = new Entry {
@@ -126,9 +132,13 @@ namespace Xamarin.Forms.Controls
 				var slDob = new StackLayout { Orientation = StackOrientation.Vertical };
 				var lblDobLabel = new Label {
 					Text = "Date of Birth",
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold),
+#pragma warning restore 618
 					TextColor = textColor,
+#pragma warning disable 618
 					XAlign = TextAlignment.Start
+#pragma warning restore 618
 				};
 				var entDob = new Entry {
 					TextColor = dataColor,
@@ -142,9 +152,13 @@ namespace Xamarin.Forms.Controls
 				var slGender = new StackLayout { Orientation = StackOrientation.Vertical };
 				var lblGenderLabel = new Label {
 					Text = "Gender",
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold),
+#pragma warning restore 618
 					TextColor = textColor,
+#pragma warning disable 618
 					XAlign = TextAlignment.Start
+#pragma warning restore 618
 				};
 				slGender.Children.Add (lblGenderLabel);
 
@@ -154,9 +168,13 @@ namespace Xamarin.Forms.Controls
 				var slHomePhone = new StackLayout { Orientation = StackOrientation.Vertical };
 				var lblHomePhoneLabel = new Label {
 					Text = "Home Phone",
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold),
+#pragma warning restore 618
 					TextColor = textColor,
+#pragma warning disable 618
 					XAlign = TextAlignment.Start
+#pragma warning restore 618
 				};
 				var entHomePhone = new Entry {
 					TextColor = dataColor,
@@ -173,9 +191,13 @@ namespace Xamarin.Forms.Controls
 				var slMobilePhone = new StackLayout { Orientation = StackOrientation.Vertical };
 				var lblMobilePhoneLabel = new Label {
 					Text = "Mobile Phone",
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold),
+#pragma warning restore 618
 					TextColor = textColor,
+#pragma warning disable 618
 					XAlign = TextAlignment.Start
+#pragma warning restore 618
 				};
 				var entMobilePhone = new Entry {
 					TextColor = dataColor,
@@ -257,23 +279,44 @@ namespace Xamarin.Forms.Controls
 					Font dataFont = Font.SystemFontOfSize (NamedSize.Medium);
 					var nameData = new Label {
 						TextColor = txtColor,
+#pragma warning disable 618
 						Font = dataFont,
+#pragma warning restore 618
+
+#pragma warning disable 618
 						XAlign = TextAlignment.Start,
+#pragma warning restore 618
+
+#pragma warning disable 618
 						YAlign = TextAlignment.Center,
+#pragma warning restore 618
 						VerticalOptions = LayoutOptions.Center
 					};
 					nameData.SetBinding (Label.TextProperty, "Name");
 					var genderData = new Label {
 						TextColor = txtColor,
+#pragma warning disable 618
 						Font = dataFont,
+#pragma warning restore 618
+
+#pragma warning disable 618
 						XAlign = TextAlignment.Start,
+#pragma warning restore 618
+
+#pragma warning disable 618
 						YAlign = TextAlignment.Center,
+#pragma warning restore 618
 						VerticalOptions = LayoutOptions.Center
 					};
 					genderData.SetBinding (Label.TextProperty, "Gender");
 					var slNameGender = new StackLayout { Orientation = StackOrientation.Horizontal };
+#pragma warning disable 618
 					var lblGender1 = new Label { Text = " (", Font = dataFont };
+#pragma warning restore 618
+
+#pragma warning disable 618
 					var lblGender2 = new Label { Text = ")", Font = dataFont };
+#pragma warning restore 618
 					slNameGender.Children.Add (nameData);
 					slNameGender.Children.Add (lblGender1);
 					slNameGender.Children.Add (genderData);
@@ -283,13 +326,23 @@ namespace Xamarin.Forms.Controls
 					var lblDob = new Label {
 						TextColor = txtColor,
 						Text = "DOB: ",
+#pragma warning disable 618
 						Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold)
+#pragma warning restore 618
 					};
 					var dobData = new Label {
 						TextColor = txtColor,
+#pragma warning disable 618
 						Font = dataFont,
+#pragma warning restore 618
+
+#pragma warning disable 618
 						XAlign = TextAlignment.Start,
+#pragma warning restore 618
+
+#pragma warning disable 618
 						YAlign = TextAlignment.Center,
+#pragma warning restore 618
 						VerticalOptions = LayoutOptions.Center
 					};
 					dobData.SetBinding (Label.TextProperty, "DateOfBirth");
@@ -297,19 +350,31 @@ namespace Xamarin.Forms.Controls
 					slDobPhone.Children.Add (lblDob);
 					slDobPhone.Children.Add (dobData);
 
+#pragma warning disable 618
 					var lblSpacer = new Label { Text = "      ", Font = dataFont };
+#pragma warning restore 618
 					slDobPhone.Children.Add (lblSpacer);
 
 					var lblPhone = new Label {
 						TextColor = txtColor,
 						Text = "PHONE: ",
+#pragma warning disable 618
 						Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold)
+#pragma warning restore 618
 					};
 					var phoneData = new Label {
 						TextColor = txtColor,
+#pragma warning disable 618
 						Font = dataFont,
+#pragma warning restore 618
+
+#pragma warning disable 618
 						XAlign = TextAlignment.Start,
+#pragma warning restore 618
+
+#pragma warning disable 618
 						YAlign = TextAlignment.Center,
+#pragma warning restore 618
 						VerticalOptions = LayoutOptions.Center
 					};
 					phoneData.SetBinding (Label.TextProperty, "PrimaryPhone");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
@@ -118,7 +118,9 @@ namespace Xamarin.Forms.Controls
 	[Preserve (AllMembers = true)]
 	public class ButtonExtensions
 	{
+#pragma warning disable 618
 		public static readonly BindableProperty IsPrimaryProperty = BindableProperty.CreateAttached<ButtonExtensions, bool> (
+#pragma warning restore 618
 			                                                            bindable => GetIsPrimary (bindable),
 			                                                            false,
 			                                                            BindingMode.TwoWay,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2961.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2961.cs
@@ -192,8 +192,13 @@ namespace Xamarin.Forms.Controls
 						new Label {
 							AutomationId = "lblHome",
 							Text = "Sample Home page",
+#pragma warning disable 618
 							XAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 							YAlign = TextAlignment.Center
+#pragma warning restore 618
 						}
 					}
 				};
@@ -221,8 +226,13 @@ namespace Xamarin.Forms.Controls
 						new Label {
 							AutomationId = "lblAbout",
 							Text = "Sample About page",
+#pragma warning disable 618
 							XAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 							YAlign = TextAlignment.Center
+#pragma warning restore 618
 						}
 					}
 				};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2976.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2976.cs
@@ -75,7 +75,9 @@ namespace Xamarin.Forms.Controls
 				Padding = new Thickness (0, Device.OnPlatform(20,0,0), 0, 0),
 				Children = {
 					new Label {
+#pragma warning disable 618
 						XAlign = TextAlignment.Center,
+#pragma warning restore 618
 						Text = Device.OnPlatform("Custom renderer UITableView","Custom renderer ListView","Custom renderer todo")
 					},
 					fasterListView 
@@ -143,7 +145,9 @@ namespace Xamarin.Forms.Controls
 				Padding = new Thickness (5, Device.OnPlatform(20,0,0), 5, 0),
 				Children = {
 					new Label {
+#pragma warning disable 618
 						XAlign = TextAlignment.Center,
+#pragma warning restore 618
 						Text = "Xamarin.Forms built-in ListView"
 					},
 					listView
@@ -183,7 +187,9 @@ namespace Xamarin.Forms.Controls
 				Padding = new Thickness (0, Device.OnPlatform(20,0,0), 0, 0),
 				Children = {
 					new Label {
+#pragma warning disable 618
 						XAlign = TextAlignment.Center,
+#pragma warning restore 618
 						Text = "Xamarin.Forms native Cell" 
 					},
 					listView
@@ -285,7 +291,9 @@ namespace Xamarin.Forms.Controls
 				Padding = new Thickness (0, Device.OnPlatform(20,0,0), 0, 0),
 				Children = {
 					new Label {
+#pragma warning disable 618
 						XAlign = TextAlignment.Center,
+#pragma warning restore 618
 						Text = Device.OnPlatform("Custom UITableView+UICell","Custom ListView+Cell","Custom renderer todo")
 					},
 					nativeListView2

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewOutOfBounds.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewOutOfBounds.cs
@@ -10,7 +10,9 @@ namespace Xamarin.Forms.Controls
 		{
 			var header = new Label {
 				Text = "ScrollView",
+#pragma warning disable 618
 				Font = Font.SystemFontOfSize (50, FontAttributes.Bold),
+#pragma warning restore 618
 				HorizontalOptions = LayoutOptions.Center
 			};
 
@@ -43,7 +45,9 @@ namespace Xamarin.Forms.Controls
 					       "only at runtime, you should probably put it in " +
 					       "a StackLayout just to be sure your stuff doesn't " +
 					       "go running off the bottom of the screen.",
+#pragma warning disable 618
 					Font = Font.SystemFontOfSize (NamedSize.Large)
+#pragma warning restore 618
 				}
 			};
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/StackLayoutIssue.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/StackLayoutIssue.cs
@@ -23,12 +23,19 @@ namespace Xamarin.Forms.Controls
 
 			var winPrizeLabel = new Label {
 				Text = "Win a Xamarin Prize",
+#pragma warning disable 618
 				XAlign = TextAlignment.Center,
+#pragma warning restore 618
+
+#pragma warning disable 618
 				YAlign = TextAlignment.Center,
+#pragma warning restore 618
 				VerticalOptions = LayoutOptions.FillAndExpand
 			};
 
+#pragma warning disable 618
 			Device.OnPlatform (iOS: () => winPrizeLabel.Font = Font.OfSize ("HelveticaNeue-UltraLight", NamedSize.Large));
+#pragma warning restore 618
 
 			StackLayout form = MakeForm ();
 

--- a/Xamarin.Forms.Controls/CoreGalleryPages/LabelCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/LabelCoreGalleryPage.cs
@@ -18,12 +18,29 @@ namespace Xamarin.Forms.Controls
 		{
 			base.Build (stackLayout);
 
+#pragma warning disable 618
 			var namedSizeMediumBoldContainer = new ViewContainer<Label> (Test.Label.FontAttibutesBold, new Label { Text = "Medium Bold Font", Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold) });
+#pragma warning restore 618
+
+#pragma warning disable 618
 			var namedSizeMediumItalicContainer = new ViewContainer<Label> (Test.Label.FontAttributesItalic, new Label { Text = "Medium Italic Font", Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Italic) });
+#pragma warning restore 618
+
+#pragma warning disable 618
 			var namedSizeLargeContainer = new ViewContainer<Label> (Test.Label.FontNamedSizeLarge, new Label { Text = "Large Font", Font = Font.SystemFontOfSize (NamedSize.Large) });
+#pragma warning restore 618
+
+#pragma warning disable 618
 			var namedSizeMediumContainer = new ViewContainer<Label> (Test.Label.FontNamedSizeMedium, new Label { Text = "Medium Font", Font = Font.SystemFontOfSize (NamedSize.Medium) });
+#pragma warning restore 618
+
+#pragma warning disable 618
 			var namedSizeMicroContainer = new ViewContainer<Label> (Test.Label.FontNamedSizeMicro, new Label { Text = "Micro Font", Font = Font.SystemFontOfSize (NamedSize.Micro) });
+#pragma warning restore 618
+
+#pragma warning disable 618
 			var namedSizeSmallContainer = new ViewContainer<Label> (Test.Label.FontNamedSizeSmall, new Label { Text = "Small Font", Font = Font.SystemFontOfSize (NamedSize.Small) });
+#pragma warning restore 618
 
 			var formattedString = new FormattedString ();
 			formattedString.Spans.Add (new Span { BackgroundColor = Color.Red, ForegroundColor = Color.Olive, Text = "Span 1 " });

--- a/Xamarin.Forms.Controls/GalleryPages/GroupedListContactsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GroupedListContactsGallery.cs
@@ -41,7 +41,9 @@ namespace Xamarin.Forms.Controls
 				Label name = new Label();
 				name.SetBinding (Label.TextProperty, "FullName");
 
+#pragma warning disable 618
 				Label title = new Label { Font = Font.SystemFontOfSize (NamedSize.Micro) };
+#pragma warning restore 618
 				title.SetBinding (Label.TextProperty, "Title");
 
 				return new ViewCell { View = new StackLayout  {

--- a/Xamarin.Forms.Controls/GalleryPages/LabelGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/LabelGallery.cs
@@ -36,32 +36,68 @@ namespace Xamarin.Forms.Controls
 			};
 			var formatted = new Label { FormattedText = new FormattedString { 
 					Spans = { 
+#pragma warning disable 618
 						new Span {Text="FormattedStrings ", ForegroundColor=Color.Blue, BackgroundColor = Color.Yellow, Font = Font.BoldSystemFontOfSize (NamedSize.Large)},
+#pragma warning restore 618
 						new Span {Text="are ", ForegroundColor=Color.Red, BackgroundColor = Color.Gray},
 						new Span {Text="not pretty!", ForegroundColor = Color.Green,},
 					}
 				} };
 			var missingfont = new Label { Text = "Missing font: use default" };
 
+#pragma warning disable 618
 			micro.Font = Font.SystemFontOfSize (NamedSize.Micro);
-			small.Font = Font.SystemFontOfSize (NamedSize.Small);
-			medium.Font = Font.SystemFontOfSize (NamedSize.Medium);
-			large.Font = Font.SystemFontOfSize (NamedSize.Large);
+#pragma warning restore 618
 
+#pragma warning disable 618
+			small.Font = Font.SystemFontOfSize (NamedSize.Small);
+#pragma warning restore 618
+
+#pragma warning disable 618
+			medium.Font = Font.SystemFontOfSize (NamedSize.Medium);
+#pragma warning restore 618
+
+#pragma warning disable 618
+			large.Font = Font.SystemFontOfSize (NamedSize.Large);
+#pragma warning restore 618
+
+#pragma warning disable 618
 			bold.Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold);
+#pragma warning restore 618
+
+#pragma warning disable 618
 			italic.Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Italic);
+#pragma warning restore 618
+
+#pragma warning disable 618
 			bolditalic.Font = Font.SystemFontOfSize (NamedSize.Medium, FontAttributes.Bold | FontAttributes.Italic);
+#pragma warning restore 618
 
 			var fontName = Device.OnPlatform ("Georgia", "sans-serif-light", "Comic Sans MS");
 			var font = Font.OfSize (fontName, NamedSize.Medium);
+#pragma warning disable 618
 			customFont.Font = font;
+#pragma warning restore 618
+
+#pragma warning disable 618
 			italicfont.Font = font.WithAttributes (FontAttributes.Italic);
+#pragma warning restore 618
+
+#pragma warning disable 618
 			boldfont.Font = font.WithAttributes (FontAttributes.Bold);
+#pragma warning restore 618
+
+#pragma warning disable 618
 			bolditalicfont.Font = font.WithAttributes (FontAttributes.Bold | FontAttributes.Italic);
+#pragma warning restore 618
 
+#pragma warning disable 618
 			customFont.GestureRecognizers.Add (new TapGestureRecognizer{Command = new Command (o => customFont.Font = Font.Default)});
+#pragma warning restore 618
 
+#pragma warning disable 618
 			missingfont.Font = Font.OfSize ("FooBar", 20);
+#pragma warning restore 618
 			center.HorizontalTextAlignment = TextAlignment.Center;
 			right.HorizontalTextAlignment = TextAlignment.End;
 			int i = 1;

--- a/Xamarin.Forms.Controls/GalleryPages/ListViewDemoPage.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ListViewDemoPage.cs
@@ -125,7 +125,9 @@ namespace Xamarin.Forms.Controls
             Label header = new Label
             {
                 Text = "ListView",
+#pragma warning disable 618
                 Font = Font.BoldSystemFontOfSize(50),
+#pragma warning restore 618
                 HorizontalOptions = LayoutOptions.Center
             };
 
@@ -135,7 +137,9 @@ namespace Xamarin.Forms.Controls
                 new Person("Abigail", new DateTime(1975, 1, 15), Color.Aqua),
                 new Person("Bob", new DateTime(1976, 2, 20), Color.Black),
                 new Person("Cathy", new DateTime(1977, 3, 10), Color.Blue),
+#pragma warning disable 618
                 new Person("David", new DateTime(1978, 4, 25), Color.Fuschia),
+#pragma warning restore 618
                 new Person("Eugenie", new DateTime(1979, 5, 5), Color.Gray),
                 new Person("Freddie", new DateTime(1980, 6, 30), Color.Green),
                 new Person("Greta", new DateTime(1981, 7, 15), Color.Lime),
@@ -150,7 +154,9 @@ namespace Xamarin.Forms.Controls
                 new Person("Pendleton", new DateTime(1978, 4, 10), Color.Yellow),
                 new Person("Queenie", new DateTime(1979, 5, 15), Color.Aqua),
                 new Person("Rob", new DateTime(1980, 6, 30), Color.Blue),
+#pragma warning disable 618
                 new Person("Sally", new DateTime(1981, 7, 5), Color.Fuschia),
+#pragma warning restore 618
                 new Person("Timothy", new DateTime(1982, 8, 30), Color.Green),
                 new Person("Uma", new DateTime(1983, 9, 10), Color.Lime),
                 new Person("Victor", new DateTime(1984, 10, 20), Color.Maroon),
@@ -164,7 +170,9 @@ namespace Xamarin.Forms.Controls
                 new Person("Abigail", new DateTime(1975, 1, 15), Color.Aqua),
                 new Person("Bob", new DateTime(1976, 2, 20), Color.Black),
                 new Person("Cathy", new DateTime(1977, 3, 10), Color.Blue),
+#pragma warning disable 618
                 new Person("David", new DateTime(1978, 4, 25), Color.Fuschia),
+#pragma warning restore 618
                 new Person("Eugenie", new DateTime(1979, 5, 5), Color.Gray),
                 new Person("Freddie", new DateTime(1980, 6, 30), Color.Green),
                 new Person("Greta", new DateTime(1981, 7, 15), Color.Lime),
@@ -179,7 +187,9 @@ namespace Xamarin.Forms.Controls
                 new Person("Pendleton", new DateTime(1978, 4, 10), Color.Yellow),
                 new Person("Queenie", new DateTime(1979, 5, 15), Color.Aqua),
                 new Person("Rob", new DateTime(1980, 6, 30), Color.Blue),
+#pragma warning disable 618
                 new Person("Sally", new DateTime(1981, 7, 5), Color.Fuschia),
+#pragma warning restore 618
                 new Person("Timothy", new DateTime(1982, 8, 30), Color.Green),
                 new Person("Uma", new DateTime(1983, 9, 10), Color.Lime),
                 new Person("Victor", new DateTime(1984, 10, 20), Color.Maroon),

--- a/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
@@ -45,7 +45,9 @@ namespace Xamarin.Forms.Controls
 					new Button {
 						Text = "Make sure Tint still works", 
 						Command = new Command (() => {
+#pragma warning disable 618
 							rootNavPage.Tint = Color.Red;
+#pragma warning restore 618
 						})
 					},
 					new Button {

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -28,7 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;0109;4014;1998;0649;0618;0169;0472;0414;0168;0219;0429</NoWarn>
+    <NoWarn>0114;0108;0109;4014;1998;0649;0169;0472;0414;0168;0219;0429</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;0109;4014;1998;0649;0618;0169;0472;0414;0168;0219;0429</NoWarn>
+    <NoWarn>0114;0108;0109;4014;1998;0649;0169;0472;0414;0168;0219;0429</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -51,7 +51,7 @@
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;0109;4014;1998;0649;0618;0169;0472;0414;0168;0219;0429</NoWarn>
+    <NoWarn>0114;0108;0109;4014;1998;0649;0169;0472;0414;0168;0219;0429</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -23,7 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0618;0168;0169;0219</NoWarn>
+    <NoWarn>0114;0108;4014;1998;0649;0168;0169;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0618;0168;0169;0219</NoWarn>
+    <NoWarn>0114;0108;4014;1998;0649;0168;0169;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -44,7 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0618;0168;0169;0219</NoWarn>
+    <NoWarn>0114;0108;4014;1998;0649;0168;0169;0219</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -21,7 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618;0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,7 +31,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618;0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
@@ -27,7 +27,9 @@ namespace Xamarin.Forms.Core.UITests
 
 		protected abstract void NavigateToGallery ();
 
+#pragma warning disable 618
 		[TestFixtureSetUp]
+#pragma warning restore 618
 		protected virtual void FixtureSetup ()
 		{
 			if (ShouldResetPerFixture) {
@@ -35,7 +37,9 @@ namespace Xamarin.Forms.Core.UITests
 			}
 		}
 
+#pragma warning disable 618
 		[TestFixtureTearDown]
+#pragma warning restore 618
 		protected virtual void FixtureTeardown ()
 		{	
 		}

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -23,7 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0618;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0618;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -44,7 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;0108;4014;1998;0649;0618;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;1998;0649;0169;0168;0219</NoWarn>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Maps.Android/FormsMaps.cs
+++ b/Xamarin.Forms.Maps.Android/FormsMaps.cs
@@ -24,7 +24,9 @@ namespace Xamarin
 
 			MapRenderer.Bundle = bundle;
 
+#pragma warning disable 618
 			if (GooglePlayServicesUtil.IsGooglePlayServicesAvailable(Context) == ConnectionResult.Success)
+#pragma warning restore 618
 			{
 				try
 				{

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -30,7 +30,9 @@ namespace Xamarin.Forms.Maps.Android
 
 		const string MoveMessageName = "MapMoveToRegion";
 
+#pragma warning disable 618
 		protected GoogleMap NativeMap => ((MapView) Control).Map;
+#pragma warning restore 618
 
 		protected Map Map => (Map) Element;
 
@@ -56,8 +58,13 @@ namespace Xamarin.Forms.Maps.Android
 
 				MessagingCenter.Unsubscribe<Map, MapSpan> (this, MoveMessageName);
 
+#pragma warning disable 618
 				if (oldMapView.Map != null) {
+#pragma warning restore 618
+
+#pragma warning disable 618
 					oldMapView.Map.SetOnCameraChangeListener (null);
+#pragma warning restore 618
 					NativeMap.InfoWindowClick -= MapOnMarkerClick;
 				}
 

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -28,7 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618;0253</NoWarn>
+    <NoWarn>0253</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618;0253</NoWarn>
+    <NoWarn>0253</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -51,7 +51,7 @@
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618;0253</NoWarn>
+    <NoWarn>0253</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -127,7 +127,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 							{
 								Resources.Theme theme = context.Theme;
 								if (theme != null && theme.ResolveAttribute(id, value, true))
+#pragma warning disable 618
 									Control.SupportBackgroundTintList = Resources.GetColorStateList(value.Data);
+#pragma warning restore 618
 								else
 									Control.SupportBackgroundTintList = new ColorStateList(States, new[] { (int)0xffd7d6d6, 0x7fd7d6d6 });
 							}

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -303,7 +303,9 @@ namespace Xamarin.Forms.Platform.Android
 						if (value.Type >= DataType.FirstInt && value.Type <= DataType.LastInt)
 							return value.Data;
 						if (value.Type == DataType.String)
+#pragma warning disable 618
 							return context.Resources.GetColor(value.ResourceId);
+#pragma warning restore 618
 					}
 				}
 				catch (Exception ex)

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -245,7 +245,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				return;
 
 			Android.Platform.SetPageContext(page, _context);
+#pragma warning disable 618
 			IVisualElementRenderer renderView = RendererFactory.GetRenderer(page);
+#pragma warning restore 618
 			Android.Platform.SetRenderer(page, renderView);
 
 			if (layout)
@@ -330,7 +332,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				AddView(_backgroundView);
 
 				Android.Platform.SetPageContext(modal, context);
+#pragma warning disable 618
 				_renderer = RendererFactory.GetRenderer(modal);
+#pragma warning restore 618
 				Android.Platform.SetRenderer(modal, _renderer);
 
 				AddView(_renderer.ViewGroup);

--- a/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
@@ -39,7 +39,9 @@ namespace Xamarin.Forms.Platform.Android
 			SetPadding(padding, padding, padding, padding);
 
 			_imageView = new ImageView(context);
+#pragma warning disable 618
 			var imageParams = new LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.FillParent)
+#pragma warning restore 618
 			{
 				Width = (int)context.ToPixels(60),
 				Height = (int)context.ToPixels(60),
@@ -55,8 +57,13 @@ namespace Xamarin.Forms.Platform.Android
 			_mainText.SetSingleLine(true);
 			_mainText.Ellipsize = TextUtils.TruncateAt.End;
 			_mainText.SetPadding((int)context.ToPixels(15), padding, padding, padding);
+#pragma warning disable 618
 			_mainText.SetTextAppearance(context, global::Android.Resource.Attribute.TextAppearanceListItem);
+#pragma warning restore 618
+
+#pragma warning disable 618
 			using (var lp = new LayoutParams(ViewGroup.LayoutParams.FillParent, ViewGroup.LayoutParams.WrapContent))
+#pragma warning restore 618
 				textLayout.AddView(_mainText, lp);
 
 			_detailText = new TextView(context);
@@ -64,8 +71,13 @@ namespace Xamarin.Forms.Platform.Android
 			_detailText.Ellipsize = TextUtils.TruncateAt.End;
 			_detailText.SetPadding((int)context.ToPixels(15), padding, padding, padding);
 			_detailText.Visibility = ViewStates.Gone;
+#pragma warning disable 618
 			_detailText.SetTextAppearance(context, global::Android.Resource.Attribute.TextAppearanceListItemSmall);
+#pragma warning restore 618
+
+#pragma warning disable 618
 			using (var lp = new LayoutParams(ViewGroup.LayoutParams.FillParent, ViewGroup.LayoutParams.WrapContent))
+#pragma warning restore 618
 				textLayout.AddView(_detailText, lp);
 
 			var layoutParams = new LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent) { Width = 0, Weight = 1, Gravity = GravityFlags.Center };
@@ -118,7 +130,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (view != null)
 			{
+#pragma warning disable 618
 				using (var layout = new LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.FillParent))
+#pragma warning restore 618
 					AddView(view, layout);
 
 				AccessoryView = view;

--- a/Xamarin.Forms.Platform.Android/Cells/EntryCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/EntryCellView.cs
@@ -29,7 +29,9 @@ namespace Xamarin.Forms.Platform.Android
 			SetPadding((int)context.ToPixels(15), padding, padding, padding);
 
 			_label = new TextView(context);
+#pragma warning disable 618
 			_label.SetTextAppearance(context, global::Android.Resource.Attribute.TextAppearanceListItem);
+#pragma warning restore 618
 
 			var layoutParams = new LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent) { Gravity = GravityFlags.CenterVertical };
 			using (layoutParams)

--- a/Xamarin.Forms.Platform.Android/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ColorExtensions.cs
@@ -17,7 +17,9 @@ namespace Xamarin.Forms.Platform.Android
 			if (self == Color.Default)
 			{
 				using (Resources resources = Resources.System)
+#pragma warning disable 618
 					return resources.GetColor(defaultColorResourceId);
+#pragma warning restore 618
 			}
 
 			return ToAndroid(self);

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -144,7 +144,9 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+#pragma warning disable 618
 		ActionBarDrawerToggle MasterDetailPageToggle { get; set; }
+#pragma warning restore 618
 
 		void IDisposable.Dispose()
 		{
@@ -456,10 +458,10 @@ namespace Xamarin.Forms.Platform.Android
 			Color colorToUse = Color.Default;
 			if (CurrentNavigationPage != null)
 			{
-//#pragma warning disable 618
+#pragma warning disable 618
 				if (CurrentNavigationPage.Tint != Color.Default)
 					colorToUse = CurrentNavigationPage.Tint;
-//#pragma warning restore 618
+#pragma warning restore 618
 				else if (CurrentNavigationPage.BarBackgroundColor != Color.Default)
 					colorToUse = CurrentNavigationPage.BarBackgroundColor;
 			}
@@ -524,12 +526,16 @@ namespace Xamarin.Forms.Platform.Android
 			_renderer.AddView(renderView.ViewGroup);
 		}
 
+#pragma warning disable 618
 		ActionBar.Tab AddTab(Page page, int index)
+#pragma warning restore 618
 		{
 			ActionBar actionBar = ((Activity)_context).ActionBar;
 			TabbedPage currentTabs = CurrentTabbedPage;
 
+#pragma warning disable 618
 			ActionBar.Tab atab = actionBar.NewTab();
+#pragma warning restore 618
 			atab.SetText(page.Title);
 			atab.TabSelected += (sender, e) =>
 			{
@@ -588,7 +594,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void CurrentNavigationPageOnPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
+#pragma warning disable 618
 			if (e.PropertyName == NavigationPage.TintProperty.PropertyName)
+#pragma warning restore 618
 				UpdateActionBarBackgroundColor();
 			else if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName)
 				UpdateActionBarBackgroundColor();
@@ -680,7 +688,9 @@ namespace Xamarin.Forms.Platform.Android
 			var drawer = GetRenderer(CurrentMasterDetailPage) as MasterDetailRenderer;
 			if (drawer == null)
 				return;
+#pragma warning disable 618
 			MasterDetailPageToggle = new ActionBarDrawerToggle(_context as Activity, drawer, icon, 0, 0);
+#pragma warning restore 618
 			MasterDetailPageToggle.SyncState();
 		}
 
@@ -731,7 +741,9 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 
 				var page = sender as Page;
+#pragma warning disable 618
 				ActionBar.Tab atab = actionBar.GetTabAt(currentTabs.Children.IndexOf(page));
+#pragma warning restore 618
 				atab.SetText(page.Title);
 			}
 		}
@@ -815,7 +827,9 @@ namespace Xamarin.Forms.Platform.Android
 			var i = 0;
 			foreach (Page tab in CurrentTabbedPage.Children.OfType<Page>())
 			{
+#pragma warning disable 618
 				ActionBar.Tab realTab = AddTab(tab, i++);
+#pragma warning restore 618
 				if (tab == CurrentTabbedPage.CurrentPage)
 					realTab.Select();
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -195,7 +195,9 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 
 				if (_defaultDrawable != null)
+#pragma warning disable 618
 					Control.SetBackgroundDrawable(_defaultDrawable);
+#pragma warning restore 618
 
 				_drawableEnabled = false;
 			}
@@ -212,7 +214,9 @@ namespace Xamarin.Forms.Platform.Android
 				if (_defaultDrawable == null)
 					_defaultDrawable = Control.Background;
 
+#pragma warning disable 618
 				Control.SetBackgroundDrawable(_backgroundDrawable);
+#pragma warning restore 618
 				_drawableEnabled = true;
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CarouselPageRenderer.cs
@@ -30,7 +30,9 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnAttachedToWindow();
 			var adapter = new CarouselPageAdapter(_viewPager, Element, Context);
 			_viewPager.Adapter = adapter;
+#pragma warning disable 618
 			_viewPager.SetOnPageChangeListener(adapter);
+#pragma warning restore 618
 
 			adapter.UpdateCurrentItem();
 
@@ -50,7 +52,9 @@ namespace Xamarin.Forms.Platform.Android
 			if (_viewPager != null)
 			{
 				RemoveView(_viewPager);
+#pragma warning disable 618
 				_viewPager.SetOnPageChangeListener(null);
+#pragma warning restore 618
 				_viewPager.Dispose();
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormattedStringExtensions.cs
@@ -50,7 +50,9 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				if (!span.IsDefault())
+#pragma warning disable 618
 					spannable.SetSpan(new FontSpan(span.Font, view), start, end, SpanTypes.InclusiveInclusive);
+#pragma warning restore 618
 				else if (defaultFont != Font.Default)
 					spannable.SetSpan(new FontSpan(defaultFont, view), start, end, SpanTypes.InclusiveInclusive);
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -32,7 +32,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateBackground()
 		{
+#pragma warning disable 618
 			SetBackgroundDrawable(new FrameDrawable(Element));
+#pragma warning restore 618
 		}
 
 		class FrameDrawable : Drawable

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -125,7 +125,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateFont()
 		{
+#pragma warning disable 618
 			Font f = Element.Font;
+#pragma warning restore 618
 
 			Typeface newTypeface = f.ToTypeface();
 			if (newTypeface != _lastTypeface)
@@ -190,7 +192,9 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element.FormattedText != null)
 			{
 				FormattedString formattedText = Element.FormattedText ?? Element.Text;
+#pragma warning disable 618
 				_view.TextFormatted = formattedText.ToAttributed(Element.Font, Element.TextColor, _view);
+#pragma warning restore 618
 				_wasFormatted = true;
 			}
 			else

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -270,7 +270,9 @@ namespace Xamarin.Forms.Platform.Android
 			AView bline;
 			if (makeBline)
 			{
+#pragma warning disable 618
 				bline = new AView(_context) { LayoutParameters = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.FillParent, 1) };
+#pragma warning restore 618
 
 				layout.AddView(bline);
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
@@ -305,7 +305,9 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateBackgroundImage(Page view)
 		{
 			if (!string.IsNullOrEmpty(view.BackgroundImage))
+#pragma warning disable 618
 				SetBackgroundDrawable(Context.Resources.GetDrawable(view.BackgroundImage));
+#pragma warning restore 618
 		}
 
 		void UpdateDetail()

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
@@ -110,7 +110,9 @@ namespace Xamarin.Forms.Platform.Android
 			AView bline;
 			if (makeBline)
 			{
+#pragma warning disable 618
 				bline = new AView(Context) { LayoutParameters = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.FillParent, 1) };
+#pragma warning restore 618
 
 				layout.AddView(bline);
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -61,7 +61,9 @@ namespace Xamarin.Forms.Platform.Android
 			if (Control == null)
 			{
 				var webView = new AWebView(Context);
+#pragma warning disable 618
 				webView.LayoutParameters = new global::Android.Widget.AbsoluteLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, 0, 0);
+#pragma warning restore 618
 				webView.SetWebViewClient(new WebClient(this));
 
 				_webChromeClient = GetFormsWebChromeClient();
@@ -178,7 +180,9 @@ namespace Xamarin.Forms.Platform.Android
 				_navigationResult = WebNavigationResult.Failure;
 				if (errorCode == ClientError.Timeout)
 					_navigationResult = WebNavigationResult.Timeout;
+#pragma warning disable 618
 				base.OnReceivedError(view, errorCode, description, failingUrl);
+#pragma warning restore 618
 			}
 
 			public override bool ShouldOverrideUrlLoading(AWebView view, string url)

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -33,7 +33,9 @@ namespace Xamarin.Forms.Platform.Android
 				Log.Warning("Could not load image named: {0}", name);
 				return null;
 			}
+#pragma warning disable 618
 			return resource.GetDrawable(id);
+#pragma warning restore 618
 		}
 
 		public static int GetDrawableByName(string name)

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -27,9 +27,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (s_apiLevel < 16)
 			{
-//#pragma warning disable 618
+#pragma warning disable 618
 				view.SetBackgroundDrawable(drawable);
-//#pragma warning restore 618
+#pragma warning restore 618
 			}
 			else
 				view.Background = drawable;
@@ -46,12 +46,19 @@ namespace Xamarin.Forms.Platform.Android
 					switch (type)
 					{
 						case "color":
+#pragma warning disable 618
 							global::Android.Graphics.Color color = context.Resources.GetColor(background.ResourceId);
+#pragma warning restore 618
 							view.SetBackgroundColor(color);
 							break;
 						case "drawable":
+#pragma warning disable 618
 							using (Drawable drawable = context.Resources.GetDrawable(background.ResourceId))
+#pragma warning restore 618
+
+#pragma warning disable 618
 								view.SetBackgroundDrawable(drawable);
+#pragma warning restore 618
 							break;
 					}
 				}

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -28,7 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0642;0618;0114;0108;0672;0168;0169;0184;0649;1998;0414</NoWarn>
+    <NoWarn>0642;0114;0108;0672;0168;0169;0184;0649;1998;0414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0642;0618;0114;0108;0672;0168;0169;0184;0649;1998;0414</NoWarn>
+    <NoWarn>0642;0114;0108;0672;0168;0169;0184;0649;1998;0414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -50,7 +50,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0642;0618;0114;0108;0672;0168;0169;0184;0649;1998;0414</NoWarn>
+    <NoWarn>0642;0114;0108;0672;0168;0169;0184;0649;1998;0414</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -27,7 +27,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998;0649;0618;0169;0067</NoWarn>
+    <NoWarn>1998;0649;0169;0067</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,14 +38,14 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998;0649;0618;0169;0067</NoWarn>
+    <NoWarn>1998;0649;0169;0067</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\ARM\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>1998;0649;0618;0169;0067</NoWarn>
+    <NoWarn>1998;0649;0169;0067</NoWarn>
     <DebugType>full</DebugType>
     <PlatformTarget>ARM</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -58,7 +58,7 @@
     <OutputPath>bin\ARM\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
-    <NoWarn>1998;0649;0618;0169;0067</NoWarn>
+    <NoWarn>1998;0649;0169;0067</NoWarn>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>ARM</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -71,7 +71,7 @@
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>1998;0649;0618;0169;0067</NoWarn>
+    <NoWarn>1998;0649;0169;0067</NoWarn>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -84,7 +84,7 @@
     <OutputPath>bin\x64\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
-    <NoWarn>1998;0649;0618;0169;0067</NoWarn>
+    <NoWarn>1998;0649;0169;0067</NoWarn>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -97,7 +97,7 @@
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>1998;0649;0618;0169;0067</NoWarn>
+    <NoWarn>1998;0649;0169;0067</NoWarn>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -110,7 +110,7 @@
     <OutputPath>bin\x86\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
-    <NoWarn>1998;0649;0618;0169;0067</NoWarn>
+    <NoWarn>1998;0649;0169;0067</NoWarn>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>

--- a/Xamarin.Forms.Platform.WP8/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/LabelRenderer.cs
@@ -24,8 +24,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 				run.Foreground = span.ForegroundColor.ToBrush();
 
 			if (!span.IsDefault())
+#pragma warning disable 618
 				run.ApplyFont(span.Font);
-
+#pragma warning restore 618
 			return run;
 		}
 	}
@@ -121,7 +122,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 			if (label == null || (label.IsDefault() && !_fontApplied))
 				return;
 
+#pragma warning disable 618
 			Font fontToApply = label.IsDefault() ? Font.SystemFontOfSize(NamedSize.Medium) : label.Font;
+#pragma warning restore 618
 
 			textBlock.ApplyFont(fontToApply);
 			_fontApplied = true;

--- a/Xamarin.Forms.Platform.WP8/Platform.cs
+++ b/Xamarin.Forms.Platform.WP8/Platform.cs
@@ -475,7 +475,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 			foreach (Page f in _navModel.Roots)
 			{
 				f.Layout(new Rectangle(0, 0, _renderer.ActualWidth, _renderer.ActualHeight));
+#pragma warning disable 618
 				IVisualElementRenderer pageRenderer = f.GetRenderer();
+#pragma warning restore 618
 				if (pageRenderer != null)
 				{
 					((FrameworkElement)pageRenderer.ContainerElement).Width = _renderer.ActualWidth;
@@ -540,7 +542,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 				var button = new TaggedAppBarButton
 				{
 					IconUri = new Uri(item.Icon ?? "ApplicationIcon.jpg", UriKind.Relative),
+#pragma warning disable 618
 					Text = !string.IsNullOrWhiteSpace(item.Name) ? item.Text : (string)item.Icon ?? "ApplicationIcon.jpg",
+#pragma warning restore 618
 					IsEnabled = item.IsEnabled,
 					Tag = item
 				};
@@ -554,7 +558,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 				if (_page.ApplicationBar.MenuItems.OfType<TaggedAppBarMenuItem>().Any(b => b.Tag == item))
 					continue;
 
+#pragma warning disable 618
 				var button = new TaggedAppBarMenuItem { Text = !string.IsNullOrWhiteSpace(item.Name) ? item.Text : (string)item.Icon ?? "MenuItem", IsEnabled = true, Tag = item };
+#pragma warning restore 618
 				button.Click += (sender, args) => item.Activate();
 				menuItemsToAdd.Add(button);
 			}
@@ -624,7 +630,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 				if (e.PropertyName == MenuItem.IsEnabledProperty.PropertyName)
 					IsEnabled = item.IsEnabled;
 				else if (e.PropertyName == MenuItem.TextProperty.PropertyName)
+#pragma warning disable 618
 					Text = !string.IsNullOrWhiteSpace(item.Name) ? item.Text : (string)item.Icon ?? "ApplicationIcon.jpg";
+#pragma warning restore 618
 				else if (e.PropertyName == MenuItem.IconProperty.PropertyName)
 					IconUri = new Uri(item.Icon ?? "ApplicationIcon.jpg", UriKind.Relative);
 			}

--- a/Xamarin.Forms.Platform.WP8/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/VisualElementRenderer.cs
@@ -144,7 +144,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 				var child = Element.LogicalChildren[i] as VisualElement;
 				if (child == null)
 					continue;
+#pragma warning disable 618
 				IVisualElementRenderer renderer = child.GetRenderer();
+#pragma warning restore 618
 				if (renderer == null)
 					continue;
 				Rectangle bounds = child.Bounds;

--- a/Xamarin.Forms.Platform.WP8/Xamarin.Forms.Platform.WP8.csproj
+++ b/Xamarin.Forms.Platform.WP8/Xamarin.Forms.Platform.WP8.csproj
@@ -32,7 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618;0219</NoWarn>
+    <NoWarn>0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -44,7 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;4014;0618;0219;0067</NoWarn>
+    <NoWarn>0114;4014;0219;0067</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,7 +56,7 @@
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;4014;0618;0219;0067</NoWarn>
+    <NoWarn>0114;4014;0219;0067</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
@@ -68,7 +68,7 @@
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;4014;0618;0219;0067</NoWarn>
+    <NoWarn>0114;4014;0219;0067</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|ARM' ">
@@ -81,7 +81,7 @@
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;4014;0618;0219;0067</NoWarn>
+    <NoWarn>0114;4014;0219;0067</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|ARM' ">
@@ -93,7 +93,7 @@
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;4014;0618;0219;0067</NoWarn>
+    <NoWarn>0114;4014;0219;0067</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
@@ -106,7 +106,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0114;4014;0618;0219;0067</NoWarn>
+    <NoWarn>0114;4014;0219;0067</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -117,7 +117,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <NoWarn>0114;4014;0618;0219;0067</NoWarn>
+    <NoWarn>0114;4014;0219;0067</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|ARM'">
@@ -129,7 +129,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <NoWarn>0114;4014;0618;0219;0067</NoWarn>
+    <NoWarn>0114;4014;0219;0067</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
@@ -23,7 +23,9 @@ namespace Xamarin.Forms.Platform.WinRT
 				run.Foreground = span.ForegroundColor.ToBrush();
 
 			if (!span.IsDefault())
+#pragma warning disable 618
 				run.ApplyFont(span.Font);
+#pragma warning restore 618
 
 			return run;
 		}
@@ -131,7 +133,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (label == null || (label.IsDefault() && !_fontApplied))
 				return;
 
+#pragma warning disable 618
 			Font fontToApply = label.IsDefault() ? Font.SystemFontOfSize(NamedSize.Medium) : label.Font;
+#pragma warning restore 618
 
 			textBlock.ApplyFont(fontToApply);
 			_fontApplied = true;

--- a/Xamarin.Forms.Platform.WinRT/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementExtensions.cs
@@ -18,7 +18,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			IVisualElementRenderer renderer = Platform.GetRenderer(self);
 			if (renderer == null)
 			{
+#pragma warning disable 618
 				renderer = RendererFactory.CreateRenderer(self);
+#pragma warning restore 618
 				Platform.SetRenderer(self, renderer);
 			}
 

--- a/Xamarin.Forms.Platform.WinRT/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/WebViewRenderer.cs
@@ -96,7 +96,9 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		async void OnEvalRequested(object sender, EventArg<string> eventArg)
 		{
+#pragma warning disable 618
 			await Control.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => Control.InvokeScript("eval", new[] { eventArg.Data }));
+#pragma warning restore 618
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
@@ -16,7 +16,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (span == null)
 				return null;
 
+#pragma warning disable 618
 			var font = span.Font != Font.Default ? span.Font : defaultFont;
+#pragma warning restore 618
 
 			var fgcolor = span.ForegroundColor;
 			if (fgcolor.IsDefault)

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -435,7 +435,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
+#pragma warning disable 618
 			if (e.PropertyName == NavigationPage.TintProperty.PropertyName)
+#pragma warning restore 618
 				UpdateTint();
 			if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor();
@@ -643,7 +645,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateTint()
 		{
+#pragma warning disable 618
 			var tintColor = ((NavigationPage)Element).Tint;
+#pragma warning restore 618
 
 			if (Forms.IsiOS7OrNewer)
 			{

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.Classic.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.Classic.csproj
@@ -25,7 +25,7 @@
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0169;0114;0108;0105;0618;0414;0649</NoWarn>
+    <NoWarn>0169;0114;0108;0105;0414;0649</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -38,7 +38,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <DefineConstants>TRACE;__IOS__;__MOBILE__;</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0169;0114;0108;0105;0618;0414;0649</NoWarn>
+    <NoWarn>0169;0114;0108;0105;0414;0649</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -50,11 +50,11 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0169;0114;0108;0105;0618;0414;0649</NoWarn>
+    <NoWarn>0169;0114;0108;0105;0414;0649</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'AppStore|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0169;0114;0108;0105;0618;0414;0649</NoWarn>
+    <NoWarn>0169;0114;0108;0105;0414;0649</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs">

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -20,7 +20,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0108;0114;0618;0414;0649</NoWarn>
+    <NoWarn>0108;0114;0414;0649</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0108;0114;0618;0414;0649</NoWarn>
+    <NoWarn>0108;0114;0414;0649</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -42,11 +42,11 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0108;0114;0618;0414;0649</NoWarn>
+    <NoWarn>0108;0114;0414;0649</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'AppStore|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0108;0114;0618;0414;0649</NoWarn>
+    <NoWarn>0108;0114;0414;0649</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Xamarin.Forms.Xaml.UnitTests/FontConverterTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/FontConverterTests.cs
@@ -21,7 +21,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var label = new Label ().LoadFromXaml (xaml);
 
 			Assert.AreEqual (result, label.FontAttributes);
+#pragma warning disable 618
 			Assert.AreEqual (result, label.Font.FontAttributes);
+#pragma warning restore 618
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz24910.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz24910.xaml.cs
@@ -102,7 +102,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		public static readonly BindableProperty AttachedNullableIntProperty =
+#pragma warning disable 618
 			BindableProperty.CreateAttached<Bz24910Control, int?> (bindable => GetAttachedNullableInt (bindable), default(int?));
+#pragma warning restore 618
 
 		public static int? GetAttachedNullableInt (BindableObject bindable)
 		{

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz29300.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz29300.xaml.cs
@@ -10,10 +10,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 	public class Bz29300DummyView : StackLayout
 	{
 		public static readonly BindableProperty NumOfRepeatProperty =
+#pragma warning disable 618
 			BindableProperty.Create<Bz29300DummyView, int> (p => p.NumOfRepeat, 1, BindingMode.OneWay, null, UpdateTexts);
+#pragma warning restore 618
 
 		public static readonly BindableProperty TextProperty =
+#pragma warning disable 618
 			BindableProperty.Create<Bz29300DummyView, string> (p => p.Text, string.Empty, BindingMode.OneWay, null, UpdateTexts);
+#pragma warning restore 618
 
 		public int NumOfRepeat
 		{

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Issue2742.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Issue2742.xaml.cs
@@ -38,7 +38,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 				Assert.NotNull (layout.ToolbarItems);
 				Assert.AreEqual (2, layout.ToolbarItems.Count);
+#pragma warning disable 618
 				Assert.AreEqual ("One", layout.ToolbarItems [0].Name);
+#pragma warning restore 618
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/TestCases.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/TestCases.cs
@@ -27,7 +27,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		public static readonly BindableProperty InnerViewProperty = 
+#pragma warning disable 618
 			BindableProperty.CreateAttached<TestCases, View> (bindable => GetInnerView (bindable), default(View));
+#pragma warning restore 618
 
 		public static View GetInnerView (BindableObject bindable)
 		{

--- a/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
@@ -57,7 +57,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 	public class Catalog
 	{
 		public static readonly BindableProperty MessageProperty = 
+#pragma warning disable 618
 			BindableProperty.CreateAttached<Catalog, string> (bindable => GetMessage (bindable), default(string), 
+#pragma warning restore 618
 				propertyChanged: (bindable, oldvalue, newvalue) => {
 					var label = bindable as Label;
 					if (label != null)

--- a/Xamarin.Forms.Xaml.UnitTests/TypeConverterTestsLegacy.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/TypeConverterTestsLegacy.cs
@@ -63,7 +63,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public Foo Foo { get; set; }
 
 		public static readonly BindableProperty BarProperty = 
+#pragma warning disable 618
 			BindableProperty.Create<Bindable, Bar> (w => w.Bar, default(Bar));
+#pragma warning restore 618
 
 		[TypeConverter (typeof(BarConverter))]
 		public Bar Bar {
@@ -74,7 +76,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public Baz Baz { get; set; }
 
 		public static readonly BindableProperty QuxProperty = 
+#pragma warning disable 618
 			BindableProperty.CreateAttached<Bindable, Qux> (bindable => GetQux (bindable), default(Qux));
+#pragma warning restore 618
 
 		[TypeConverter (typeof(QuxConverter))]
 		public static Qux GetQux (BindableObject bindable)

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -21,7 +21,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0672;0618;1998;0219;0414</NoWarn>
+    <NoWarn>0672;1998;0219;0414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0672;0618;1998;0219;0414</NoWarn>
+    <NoWarn>0672;1998;0219;0414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -44,7 +44,7 @@
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0672;0618;1998;0219;0414</NoWarn>
+    <NoWarn>0672;1998;0219;0414</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">


### PR DESCRIPTION
### Description of Change

Enabled CS0618 warnings as errors -- they occur when obsolete properties or methods are used.

https://msdn.microsoft.com/en-us/library/x5ye6x1e.aspx

Tests N/A.
### Bugs Fixed

N/A
### API Changes

N/A
### Behavioral Changes

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
