### PR TITLE
Enable warnings 0649 and 0067 on UAP/WinRT

### DIFF
--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -98,7 +98,9 @@ namespace Xamarin.Forms.Platform.UWP
 			get { return Element; }
 		}
 
+#pragma warning disable 0067 // Revisit: Can't remove; required by interface
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+#pragma warning restore
 
 		public SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -27,7 +27,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998;0649;0169;0067</NoWarn>
+    <NoWarn>1998;0618;0169</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998;0649;0169;0067</NoWarn>
+    <NoWarn>1998;0618;0169</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>

--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -628,7 +628,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		}
 #endif
 
-		bool _deferSelection;
+		bool _deferSelection = false;
 		Tuple<object, SelectedItemChangedEventArgs> _deferredSelectedItemChangedEvent;
 	}
 }

--- a/Xamarin.Forms.Platform.WinRT/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/TextCellRenderer.cs
@@ -34,7 +34,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			return true;
 		}
 
+#pragma warning disable 0067 // Revisit: Can't remove; required by interface
 		public event EventHandler CanExecuteChanged;
+#pragma warning restore
 
 		public void Execute(object parameter)
 		{


### PR DESCRIPTION
### Description of Change

Enable warnings 0649 and 0067 on UAP/WinRT
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
