### PR TITLE
Mop up enabling warnings as errors

### DIFF
--- a/Xamarin.Forms.Core/Cells/EntryCell.cs
+++ b/Xamarin.Forms.Core/Cells/EntryCell.cs
@@ -74,7 +74,9 @@ namespace Xamarin.Forms
 		static void OnHorizontalTextAlignmentPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var label = (EntryCell)bindable;
+#pragma warning disable 0618 // retain until XAlign removed
 			label.OnPropertyChanged(nameof(XAlign));
+#pragma warning restore
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -176,11 +176,15 @@ namespace Xamarin.Forms
 			var family = (string)values[0];
 			if (family != null)
 			{
+#pragma warning disable 0618 // retain until Font removed
 				label.Font = Font.OfSize(family, (double)values[1]).WithAttributes(attributes);
+#pragma warning restore
 			}
 			else
 			{
+#pragma warning disable 0618 // retain until Font removed
 				label.Font = Font.SystemFontOfSize((double)values[1], attributes);
+#pragma warning restore
 			}
 
 			label._cancelEvents = false;
@@ -201,11 +205,15 @@ namespace Xamarin.Forms
 			var family = (string)newValue;
 			if (family != null)
 			{
+#pragma warning disable 0618 // retain until Font removed
 				label.Font = Font.OfSize(family, (double)values[0]).WithAttributes((FontAttributes)values[1]);
+#pragma warning restore
 			}
 			else
 			{
+#pragma warning disable 0618 // retain until Font removed
 				label.Font = Font.SystemFontOfSize((double)values[0], (FontAttributes)values[1]);
+#pragma warning restore
 			}
 
 			label._cancelEvents = false;
@@ -226,11 +234,15 @@ namespace Xamarin.Forms
 			var family = (string)values[0];
 			if (family != null)
 			{
+#pragma warning disable 0618 // retain until Font removed
 				label.Font = Font.OfSize(family, size).WithAttributes((FontAttributes)values[1]);
+#pragma warning restore
 			}
 			else
 			{
+#pragma warning disable 0618 // retain until Font removed
 				label.Font = Font.SystemFontOfSize(size, (FontAttributes)values[1]);
+#pragma warning restore
 			}
 
 			label._cancelEvents = false;
@@ -246,7 +258,9 @@ namespace Xamarin.Forms
 		static void OnHorizontalTextAlignmentPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var label = (Label)bindable;
+#pragma warning disable 0618 // retain until XAlign removed
 			label.OnPropertyChanged(nameof(XAlign));
+#pragma warning restore
 		}
 
 		static void OnTextPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
@@ -264,7 +278,9 @@ namespace Xamarin.Forms
 		static void OnVerticalTextAlignmentPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var label = (Label)bindable;
+#pragma warning disable 0618 // retain until YAlign removed
 			label.OnPropertyChanged(nameof(YAlign));
+#pragma warning restore
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -126,6 +126,7 @@ namespace Xamarin.Forms
 				handler(this, new PropertyChangedEventArgs(propertyName));
 		}
 
+#pragma warning disable 0618 // retain until Span.Font removed
 		void UpdateFontPropertiesFromStruct()
 		{
 			if (_inUpdate)
@@ -166,4 +167,5 @@ namespace Xamarin.Forms
 			_inUpdate = false;
 		}
 	}
+#pragma warning restore
 }

--- a/Xamarin.Forms.Core/TapGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/TapGestureRecognizer.cs
@@ -45,9 +45,11 @@ namespace Xamarin.Forms
 			if (handler != null)
 				handler(sender, new TappedEventArgs(CommandParameter));
 
+#pragma warning disable 0618 // retain until TappedCallback removed
 			Action<View, object> callback = TappedCallback;
 			if (callback != null)
 				callback(sender, TappedCallbackParameter);
+#pragma warning restore
 		}
 
 		#region obsolete cruft

--- a/Xamarin.Forms.Core/TypeConverter.cs
+++ b/Xamarin.Forms.Core/TypeConverter.cs
@@ -27,7 +27,9 @@ namespace Xamarin.Forms
 
 		public virtual object ConvertFromInvariantString(string value)
 		{
+#pragma warning disable 0618 // retain until ConvertFrom removed
 			return ConvertFrom(CultureInfo.InvariantCulture, value);
+#pragma warning restore
 		}
 	}
 }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -511,7 +511,9 @@ namespace Xamarin.Forms
 
 		public SizeRequest Measure(double widthConstraint, double heightConstraint, MeasureFlags flags = MeasureFlags.None)
 		{
+#pragma warning disable 0618 // retain until GetSizeRequest removed
 			SizeRequest result = GetSizeRequest(widthConstraint, heightConstraint);
+#pragma warning restore
 
 			if ((flags & MeasureFlags.IncludeMargins) != 0)
 			{
@@ -577,11 +579,14 @@ namespace Xamarin.Forms
 
 		protected virtual SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
 		{
+#pragma warning disable 0618 // retain until OnSizeRequest removed
 			return OnSizeRequest(widthConstraint, heightConstraint);
+#pragma warning restore
 		}
 
 		protected override void OnParentSet()
 		{
+#pragma warning disable 0618 // retain until ParentView removed
 			base.OnParentSet();
 
 			if (ParentView != null)
@@ -592,6 +597,7 @@ namespace Xamarin.Forms
 			{
 				NavigationProxy.Inner = null;
 			}
+#pragma warning restore
 		}
 
 		protected virtual void OnSizeAllocated(double width, double height)

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -22,7 +22,8 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -32,14 +33,16 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Turkey\</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0618</NoWarn>
+    <NoWarn>
+    </NoWarn>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -260,7 +260,7 @@ namespace Xamarin.Forms.Maps.Android
 				return;
 			
 			foreach (Pin p in pins) {
-				var marker = _markers.FirstOrDefault (m => m.Id == p.Id);
+				var marker = _markers.FirstOrDefault (m => (object)m.Id == p.Id);
 				if (marker == null)
 					continue;
 				marker.Remove ();

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -28,7 +28,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0253</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,7 +39,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0253</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -51,7 +53,8 @@
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0253</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/Xamarin.Forms.Maps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.UWP/MapRenderer.cs
@@ -133,7 +133,9 @@ namespace Xamarin.Forms.Maps.WinRT
 		void ClearPins()
 		{
 			Control.Children.Clear();
+#pragma warning disable 4014 // don't wanna block UI thread
 			UpdateIsShowingUser();
+#pragma warning restore
 		}
 
 		void RemovePin(Pin pinToRemove)

--- a/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
+++ b/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
@@ -27,7 +27,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>4014</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,7 +39,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>4014</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>

--- a/Xamarin.Forms.Maps.WinRT.Phone/Xamarin.Forms.Maps.WinRT.Phone.csproj
+++ b/Xamarin.Forms.Maps.WinRT.Phone/Xamarin.Forms.Maps.WinRT.Phone.csproj
@@ -26,7 +26,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>4014</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,7 +37,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>4014</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Maps.WinRT.Tablet/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.WinRT.Tablet/MapRenderer.cs
@@ -110,7 +110,9 @@ namespace Xamarin.Forms.Maps.WinRT
 		void ClearPins()
 		{
 			Control.Children.Clear();
+#pragma warning disable 4014 // don't wanna block UI thread
 			UpdateIsShowingUser();
+#pragma warning restore
 		}
 
 		void RemovePin(Pin pinToRemove)

--- a/Xamarin.Forms.Maps.WinRT.Tablet/Xamarin.Forms.Maps.WinRT.Tablet.csproj
+++ b/Xamarin.Forms.Maps.WinRT.Tablet/Xamarin.Forms.Maps.WinRT.Tablet.csproj
@@ -42,7 +42,8 @@
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\ARM\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_APP</DefineConstants>
-    <NoWarn>2008;4014</NoWarn>
+    <NoWarn>
+    </NoWarn>
     <DebugType>full</DebugType>
     <PlatformTarget>ARM</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -54,7 +55,8 @@
     <OutputPath>bin\ARM\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_APP</DefineConstants>
     <Optimize>true</Optimize>
-    <NoWarn>2008;4014</NoWarn>
+    <NoWarn>
+    </NoWarn>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>ARM</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>

--- a/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.Classic.csproj
+++ b/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.Classic.csproj
@@ -25,7 +25,8 @@
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0414</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -37,7 +38,8 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0414</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -49,11 +51,13 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0414</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'AppStore|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0414</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs">

--- a/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
+++ b/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
@@ -24,7 +24,8 @@
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0414</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -35,7 +36,8 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0414</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -47,11 +49,13 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0414</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'AppStore|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0414</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs">

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -27,7 +27,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998;0618;0169</NoWarn>
+    <NoWarn>1998</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998;0618;0169</NoWarn>
+    <NoWarn>1998</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>

--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -165,8 +165,6 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		sealed class BrushedElement
 		{
-			bool _isBound;
-
 			public BrushedElement(FrameworkElement element, WBinding brushBinding = null, Brush brush = null)
 			{
 				Element = element;

--- a/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.csproj
+++ b/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.csproj
@@ -37,7 +37,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998;0168;0169;0067;0618</NoWarn>
+    <NoWarn>1998</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -47,7 +47,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1998;0168;0169;0067;0618</NoWarn>
+    <NoWarn>1998</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->


### PR DESCRIPTION
### Description of Change

Mop up enabling warnings as errors in a few projects
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
