### PR TITLE
Maps.WP8 warning as error mop up

### DIFF
--- a/Xamarin.Forms.Maps.WP8/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.WP8/MapRenderer.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Forms.Maps.WP8
 
 		void RemovePin(Pin pin)
 		{
-			var child = _pushPinLayer.FirstOrDefault(p => ((Pushpin)p.Content).Tag == pin);
+			var child = _pushPinLayer.FirstOrDefault(p => ((Pushpin)p.Content).Tag == (object)pin);
 			if (child != null)
 				_pushPinLayer.Remove(child);
 		}

--- a/Xamarin.Forms.Maps.WP8/Xamarin.Forms.Maps.WP8.csproj
+++ b/Xamarin.Forms.Maps.WP8/Xamarin.Forms.Maps.WP8.csproj
@@ -32,7 +32,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0252</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -44,7 +45,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0252</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -106,7 +108,8 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>0252</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Turkey|x86'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
### Description of Change

Maps.WP8 warning as error mop up
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
