### PR TITLE
Fix relaunch template app hangs; Port fix from OnStateChange in Froms…

### DIFF
--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -287,7 +287,7 @@ namespace Xamarin.Forms.Platform.Android
 			_layout.AddView(_canvas.GetViewGroup());
 		}
 
-		void OnStateChanged()
+		async void OnStateChanged()
 		{
 			if (_application == null)
 				return;
@@ -297,7 +297,7 @@ namespace Xamarin.Forms.Platform.Android
 			else if (_previousState == AndroidApplicationLifecycleState.OnStop && _currentState == AndroidApplicationLifecycleState.OnRestart)
 				_application.SendResume();
 			else if (_previousState == AndroidApplicationLifecycleState.OnPause && _currentState == AndroidApplicationLifecycleState.OnStop)
-				_application.SendSleepAsync().Wait();
+				await _application.SendSleepAsync();
 		}
 
 		void SetMainPage()


### PR DESCRIPTION
### Description of Change

Relaunching the template app on android hangs. After this change, app no longer hangs. No tests as UITest cannot relaunch. Probably why we have the bug in the first place. 
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=40228
### API Changes

None
### Behavioral Changes

Android non-appCompat activity no longer hangs on relaunch. 
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

…AppCompatActivity to FormsApplicationActivity
