### PR TITLE
Windows.UI.Xaml.dll on X64 Windows.UI.Xaml.Setter.get_Value is NYI

### DIFF
--- a/Xamarin.Forms.Platform.WinRT.Tablet/WindowsResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/WindowsResourcesProvider.cs
@@ -58,6 +58,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				catch (NotImplementedException)
 				{
 					// see https://bugzilla.xamarin.com/show_bug.cgi?id=33135
+					// WinRT implementation of Windows.UI.Xaml.Setter.get_Value is not implemented.
 				}
 			}
 


### PR DESCRIPTION
### Description of Change

`Convert.ToUInt16(setter.Value)` implemented in the x64 Windows 10 WinRT layer is throwing\returning NYI! Have to follow up with the Windows.UI.Xaml.
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=33135
### Behavioral Changes

The actual line throwing is hooking up the 'FontWeightProperty'. Wrapping that logic in a try/catch prevents the crash but that property clearly we won't support on Win10 x64.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
