### PR TITLE
Enable CarouselView on UWP; add ItemTemplate to resources.xaml on UWP

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -56,6 +56,10 @@
 		</Setter>
 	</Style>
 
+    <DataTemplate x:Key="ItemTemplate">
+        <uwp:ItemControl HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" />
+    </DataTemplate>
+
 	<ControlTemplate TargetType="ContentDialog" x:Key="MyContentDialogControlTemplate">
 		<Border x:Name="Container">
 			<Grid x:Name="LayoutRoot">

--- a/Xamarin.Forms.Platform.WinRT/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/CarouselViewRenderer.cs
@@ -45,7 +45,11 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				if (_flipView == null)
 				{
-					_flipView = new FlipView { IsSynchronizedWithCurrentItem = false, ItemTemplate = (WDataTemplate)WApp.Current.Resources["ItemTemplate"] };
+					_flipView = new FlipView 
+					{
+						IsSynchronizedWithCurrentItem = false,
+						ItemTemplate = (WDataTemplate)WApp.Current.Resources["ItemTemplate"]
+					};
 				}
 
 				_flipView.ItemsSource = Element.ItemsSource;


### PR DESCRIPTION
### Description of Change

Enable CarouselView on UWP; add ItemTemplate to resources.xaml on UWP
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=40334
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
