### PR TITLE
[UWP] TabbedPage OnElementChanged is now virtual

### DIFF
--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -192,7 +192,7 @@ namespace Xamarin.Forms.Platform.UWP
 			Tracker = null;
 		}
 
-		protected void OnElementChanged(VisualElementChangedEventArgs e)
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
 		{
 			EventHandler<VisualElementChangedEventArgs> changed = ElementChanged;
 			if (changed != null)


### PR DESCRIPTION
### Description of Change

`OnElementChanged` for `TabbedPage` was not virtual. Now it is. No tests required, other than successful build!
### Bugs Fixed
- [Bug 36374  - Xamarin.Forms.Platform.UWP.TabbedPageRenderer.OnElementChanged is not virtual](https://bugzilla.xamarin.com/show_bug.cgi?id=36374)
### API Changes

Changed:
UWP TabbedPage
- `protected void OnElementChanged(VisualElementChangedEventArgs e)` => `protected virtual void OnElementChanged(VisualElementChangedEventArgs e)`
### Behavioral Changes

Custom renderers for the UWP `TabbedPage` can now override `OnElementChanged`.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
