### PR TITLE
Make sure StaticResources can be looked up in ResourceDictionaries di…

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/SharedResourceDictionary.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/SharedResourceDictionary.xaml
@@ -11,4 +11,6 @@
 	<Style TargetType="Label">
 		<Setter Property="TextColor" Value="Red" />
 	</Style>
+	<Color x:Key="TestingColor">#454545</Color>
+	<Label x:Key="label" BackgroundColor="{StaticResource TestingColor}" />
 </ResourceDictionary>

--- a/Xamarin.Forms.Xaml.UnitTests/SharedResourceDictionary.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/SharedResourceDictionary.xaml.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			public void ResourcesDirectoriesCanBeXamlRoots (bool useCompiledXaml)
 			{
 				var layout = new SharedResourceDictionary (useCompiledXaml);
-				Assert.AreEqual (3, layout.Count);
+				Assert.AreEqual (5, layout.Count);
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -27,12 +27,11 @@ namespace Xamarin.Forms.Xaml
 			foreach (var p in valueProvider.ParentObjects)
 			{
 				var ve = p as VisualElement;
-				if (ve == null)
-					continue;
-				if (ve.Resources == null)
+				var resDict = ve?.Resources ?? p as ResourceDictionary;
+				if (resDict == null)
 					continue;
 				object res;
-				if (ve.Resources.TryGetValue(Key, out res))
+				if (resDict.TryGetValue(Key, out res))
 				{
 					return ConvertCompiledOnPlatform(res);
 				}


### PR DESCRIPTION
### Description of Change

Changes StaticResource extension to handle ResourceDictionary root elements properly
### Bugs Fixed

None
### API Changes

None
### Behavioral Changes

None minus description
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
