### PR TITLE
Use style resources when calling SetTextAppearance 

### DIFF
--- a/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Platform.Android
 			_mainText.SetSingleLine(true);
 			_mainText.Ellipsize = TextUtils.TruncateAt.End;
 			_mainText.SetPadding((int)context.ToPixels(15), padding, padding, padding);
-			_mainText.SetTextAppearanceCompat(context, global::Android.Resource.Style.TextAppearance);
+			_mainText.SetTextAppearanceCompat(context, global::Android.Resource.Style.TextAppearanceSmall);
 
 			using (var lp = new LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent))
 				textLayout.AddView(_mainText, lp);

--- a/Xamarin.Forms.Platform.Android/Cells/EntryCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/EntryCellView.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Platform.Android
 			SetPadding((int)context.ToPixels(15), padding, padding, padding);
 
 			_label = new TextView(context);
-			_label.SetTextAppearanceCompat(context, global::Android.Resource.Style.TextAppearance);
+			_label.SetTextAppearanceCompat(context, global::Android.Resource.Style.TextAppearanceSmall);
 
 			var layoutParams = new LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent) { Gravity = GravityFlags.CenterVertical };
 			using (layoutParams)


### PR DESCRIPTION
### Description of Change

Use correct parameter "type" for calls to SetTextAppearance (style resources instead of style attributes).
### Bugs Fixed
- Fixes potential crash when styling application
