### PR TITLE
[Android] Allow designer to disable asynchronicity in image loading.

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FileImageSourceHandler.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FileImageSourceHandler.cs
@@ -8,10 +8,19 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public sealed class FileImageSourceHandler : IImageSourceHandler
 	{
+		// This is set to true when run under designer context
+		internal static bool DecodeSynchronously {
+			get;
+			set;
+		}
+
 		public async Task<Bitmap> LoadImageAsync(ImageSource imagesource, Context context, CancellationToken cancelationToken = default(CancellationToken))
 		{
 			string file = ((FileImageSource)imagesource).File;
-			return await (File.Exists(file) ? BitmapFactory.DecodeFileAsync(file) : context.Resources.GetBitmapAsync(file)).ConfigureAwait(false);
+			if (File.Exists (file))
+				return !DecodeSynchronously ? (await BitmapFactory.DecodeFileAsync (file).ConfigureAwait (false)) : BitmapFactory.DecodeFile (file);
+			else
+				return !DecodeSynchronously ? (await context.Resources.GetBitmapAsync (file).ConfigureAwait (false)) : context.Resources.GetBitmap (file);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The XF Previewer doesn't support async operations as it loads a layout and immediately tries to snapshot it.

This commit adds a new property to let designer reflect onto so that the behavior can be specifically made synchronous and image will appear in the final preview.

Not sure if needing tests?
### Bugs Fixed

None
### API Changes

None public
### Behavioral Changes

Can make `FileImageSourceHandler` load image synchronously when run under a designer.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
