### PR TITLE
[Android] Fix registering of default AppCompact renderers

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -402,8 +402,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void RegisterHandlerForDefaultRenderer(Type target, Type handler, Type filter)
 		{
-			Type current = Registrar.Registered.GetHandlerType(filter);
-			if (current == target)
+			Type current = Registrar.Registered.GetHandlerType(target);
+			if (current != filter)
 				return;
 
 			Registrar.Registered.Register(target, handler);


### PR DESCRIPTION
### Description of Change

The default register of AppCompact was replacing renderers that already existed (for example from the user) at the same time the filter property wasn't correct as the handler's key is the Forms view and not a renderer.
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=39847
### API Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
