### PR TITLE
[Android] Don't set TabbedPage BarTextColor to nothing

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -359,14 +359,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 
-		private void UpdateBarTextColor()
+		void UpdateBarTextColor()
 		{
 			if (_disposed || _tabLayout == null)
 				return;
 
-			var textColor = Element.BarTextColor.ToAndroid().ToArgb();
-
-			_tabLayout.SetTabTextColors(textColor, textColor);
+			Color textColor = Element.BarTextColor;
+			if (!textColor.IsDefault)
+				_tabLayout.SetTabTextColors(textColor.ToAndroid().ToArgb(), textColor.ToAndroid().ToArgb());
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Don't set the BarTextColor to nothing when it is not set on Android.
### Bugs Fixed

Bar text was missing altogether when the BarTextColor was default.
### API Changes

None
### Behavioral Changes

Text!
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
