### PR TITLE
[UWP] Unhook Entry and Editor event handlers during Dispose

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/EditorRenderer.cs
@@ -22,10 +22,10 @@ namespace Xamarin.Forms.Platform.WinRT
 				{
 					var textBox = new TextBox { AcceptsReturn = true, TextWrapping = TextWrapping.Wrap };
 
+					SetNativeControl(textBox);
+
 					textBox.TextChanged += OnNativeTextChanged;
 					textBox.LostFocus += OnLostFocus;
-					
-					SetNativeControl(textBox);
 				}
 
 				UpdateText();

--- a/Xamarin.Forms.Platform.WinRT/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/EntryRenderer.cs
@@ -27,10 +27,11 @@ namespace Xamarin.Forms.Platform.WinRT
 				if (Control == null)
 				{
 					var textBox = new FormsTextBox { Style = Windows.UI.Xaml.Application.Current.Resources["FormsTextBoxStyle"] as Windows.UI.Xaml.Style };
+					
+					SetNativeControl(textBox);
 
 					textBox.TextChanged += OnNativeTextChanged;
 					textBox.KeyUp += TextBoxOnKeyUp;
-					SetNativeControl(textBox);
 				}
 
 				UpdateIsPassword();


### PR DESCRIPTION
### Description of Change

Unhook event handlers during Dispose to prevent handlers firing after Element is set to null

It's a race condition; not sure how to write a consistent UI test.
### Bugs Fixed
- [40435 Entry on UWP crashing with nullreference exception Xamarin.Forms V2.2.0-pre2](https://bugzilla.xamarin.com/show_bug.cgi?id=40435)
### API Changes

None
### Behavioral Changes

None 
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
