### PR TITLE
[Android] Add constructor to MasterDetailContainer

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailContainer.cs
@@ -1,5 +1,7 @@
+using System;
 using Android.Content;
 using Android.Content.Res;
+using Android.Runtime;
 using Android.Views;
 
 namespace Xamarin.Forms.Platform.Android
@@ -17,6 +19,8 @@ namespace Xamarin.Forms.Platform.Android
 			_parent = parent;
 			_isMaster = isMaster;
 		}
+
+		public MasterDetailContainer(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer) { }
 
 		public VisualElement ChildView
 		{


### PR DESCRIPTION
### Description of Change

Add constructor to MasterDetailContainer.
### Bugs Fixed
- Prevents `System.NotSupportedException: Unable to activate instance of type Xamarin.Forms.Platform.Android.MasterDetailContainer from native handle 0x48900019 (key_handle 0x3b7dc33f).`
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
