### PR TITLE
[iOS] Fix issue with WebView dispose and  resizing

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -47,7 +47,6 @@ namespace Xamarin.Forms.Platform.iOS
 			BackgroundColor = UIColor.Clear;
 
 			AutosizesSubviews = true;
-			AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
 
 			_tracker = new VisualElementTracker(this);
 
@@ -103,6 +102,9 @@ namespace Xamarin.Forms.Platform.iOS
 				((WebView)Element).EvalRequested -= OnEvalRequested;
 				((WebView)Element).GoBackRequested -= OnGoBackRequested;
 				((WebView)Element).GoForwardRequested -= OnGoForwardRequested;
+
+				_tracker?.Dispose();
+				_packager?.Dispose();
 			}
 
 			base.Dispose(disposing);


### PR DESCRIPTION
### Description of Change

Fix a issue when the WebView was reused we and we weren't disposing the tracker and packager. 
Remove a old fix for tabbed page resize, but  that doesn't appear now in iOS 9.3, maybe fix in the iOS site
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
