### PR TITLE
Allow renderers to specify whether native controls should be eagerly disposed

### DIFF
--- a/Xamarin.Forms.Platform.Android/NativeViewWrapperRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/NativeViewWrapperRenderer.cs
@@ -57,5 +57,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (!handled)
 				base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
 		}
+
+		protected override bool ManageNativeControlLifetime => false;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (disposing && !_disposed)
 			{
-				if (Control != null)
+				if (Control != null && ManageNativeControlLifetime)
 				{
 					Control.RemoveFromParent();
 					Control.Dispose();

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -212,6 +212,12 @@ namespace Xamarin.Forms.Platform.Android
 			Performance.Stop();
 		}
 
+		/// <summary>
+		/// Determines whether the native control is disposed of when this renderer is disposed
+		/// Can be overridden in deriving classes 
+		/// </summary>
+		protected virtual bool ManageNativeControlLifetime => true;
+
 		protected override void Dispose(bool disposing)
 		{
 			if ((_flags & VisualElementRendererFlags.Disposed) != 0)
@@ -244,11 +250,14 @@ namespace Xamarin.Forms.Platform.Android
 					_gestureListener = null;
 				}
 
-				int count = ChildCount;
-				for (var i = 0; i < count; i++)
+				if (ManageNativeControlLifetime)
 				{
-					AView child = GetChildAt(i);
-					child.Dispose();
+					int count = ChildCount;
+					for (var i = 0; i < count; i++)
+					{
+						AView child = GetChildAt(i);
+						child.Dispose();
+					}
 				}
 
 				RemoveAllViews();

--- a/Xamarin.Forms.Platform.iOS/NativeViewWrapperRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/NativeViewWrapperRenderer.cs
@@ -68,5 +68,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (e.OldElement == null)
 				SetNativeControl(Element.NativeView);
 		}
+
+		/// <summary>
+		/// The native control we're wrapping isn't ours to dispose of
+		/// </summary>
+		protected override bool ManageNativeControlLifetime => false;
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -41,11 +41,17 @@ namespace Xamarin.Forms.Platform.iOS
 			return Control.SizeThatFits(size);
 		}
 
+		/// <summary>
+		/// Determines whether the native control is disposed of when this renderer is disposed
+		/// Can be overridden in deriving classes 
+		/// </summary>
+		protected virtual bool ManageNativeControlLifetime => true;
+
 		protected override void Dispose(bool disposing)
 		{
 			base.Dispose(disposing);
 
-			if (disposing && Control != null)
+			if (disposing && Control != null && ManageNativeControlLifetime)
 			{
 				Control.Dispose();
 				Control = null;


### PR DESCRIPTION
### Description of Change

When using the native wrappers, XF should not be responsible for the lifetime of the wrapped controls. This change adds a flag (default `true`) which allows renderers to opt-out of eager disposal of native controls during cleanup. It also overrides that flag with `false` in the Android and iOS versions of `NativeViewWrapperRenderer`.

Since this has to interact with the native code portions of the app, I haven't figure out how to automate a test of this just yet.
### Bugs Fixed
- Crash when leaving and re-entering a page on iOS or Android which contains wrapped native controls.
### API Changes

None
### Behavioral Changes

None.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
