### PR TITLE
Removed hard reference to StatusBar, changed to type name to prevent …

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -76,8 +76,9 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			UpdateBounds();
 
+
 #if WINDOWS_UWP
-			if (ApiInformation.IsTypePresent(typeof(StatusBar).ToString()))
+			if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
 			{
 				StatusBar statusBar = StatusBar.GetForCurrentView();
 				statusBar.Showing += (sender, args) => UpdateBounds();
@@ -417,7 +418,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			_bounds = new Rectangle(0, 0, _page.ActualWidth, _page.ActualHeight);
 #if WINDOWS_UWP
-			if (ApiInformation.IsTypePresent(typeof(StatusBar).ToString()))
+			if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
 			{
 				StatusBar statusBar = StatusBar.GetForCurrentView();
 


### PR DESCRIPTION
### Description of Change ###

Modified calls to `ApiInformation.IsTypePresent()` in WinRT Platform.cs to compile and run when the `StatusBar` type is not present.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40740

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (Omitted -- can't run tests since my machine is missing the required type.  Did verify that my application starts up with change)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

…crash when StatusBar type is not present