### PR TITLE
Forward Orientation Methods in PlatformRenderer and ModalWrapper

### DIFF
--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -23,12 +23,46 @@ namespace Xamarin.Forms.Platform.iOS
 			modal.ViewController.DidMoveToParentViewController(this);
 		}
 
-		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
-		{
-			return UIInterfaceOrientationMask.All;
-		}
+        public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
+        {
+            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+            {
+                return ChildViewControllers[0].GetSupportedInterfaceOrientations();
+            }
 
-		public override void ViewDidLayoutSubviews()
+            return base.GetSupportedInterfaceOrientations();
+        }
+
+        public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
+        {
+            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+            {
+                return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
+            }
+            return base.PreferredInterfaceOrientationForPresentation();
+        }
+
+        public override bool ShouldAutorotate()
+        {
+            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+            {
+                return ChildViewControllers[0].ShouldAutorotate();
+            }
+            return base.ShouldAutorotate();
+        }
+
+        public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
+        {
+            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+            {
+                return ChildViewControllers[0].ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+            }
+            return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+        }
+
+        public override bool ShouldAutomaticallyForwardRotationMethods => true;
+
+        public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
 			if (_modal != null)
@@ -58,12 +92,45 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public Platform Platform { get; set; }
 
-		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
-		{
-			return UIInterfaceOrientationMask.All;
-		}
+        public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
+        {
+            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+            {
+                return ChildViewControllers[0].GetSupportedInterfaceOrientations();
+            }
+            return base.GetSupportedInterfaceOrientations();
+        }
 
-		public override void ViewDidAppear(bool animated)
+        public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
+        {
+            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+            {
+                return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
+            }
+            return base.PreferredInterfaceOrientationForPresentation();
+        }
+
+        public override bool ShouldAutorotate()
+        {
+            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+            {
+                return ChildViewControllers[0].ShouldAutorotate();
+            }
+            return base.ShouldAutorotate();
+        }
+
+        public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
+        {
+            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+            {
+                return ChildViewControllers[0].ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+            }
+            return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+        }
+
+        public override bool ShouldAutomaticallyForwardRotationMethods => true;
+
+        public override void ViewDidAppear(bool animated)
 		{
 			Platform.DidAppear();
 			base.ViewDidAppear(animated);

--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -23,46 +23,46 @@ namespace Xamarin.Forms.Platform.iOS
 			modal.ViewController.DidMoveToParentViewController(this);
 		}
 
-        public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].GetSupportedInterfaceOrientations();
-            }
+		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].GetSupportedInterfaceOrientations();
+			}
 
-            return base.GetSupportedInterfaceOrientations();
-        }
+			return base.GetSupportedInterfaceOrientations();
+		}
 
-        public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
-            }
-            return base.PreferredInterfaceOrientationForPresentation();
-        }
+		public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
+			}
+			return base.PreferredInterfaceOrientationForPresentation();
+		}
 
-        public override bool ShouldAutorotate()
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].ShouldAutorotate();
-            }
-            return base.ShouldAutorotate();
-        }
+		public override bool ShouldAutorotate()
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].ShouldAutorotate();
+			}
+			return base.ShouldAutorotate();
+		}
 
-        public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
-            }
-            return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
-        }
+		public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+			}
+			return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+		}
 
-        public override bool ShouldAutomaticallyForwardRotationMethods => true;
+		public override bool ShouldAutomaticallyForwardRotationMethods => true;
 
-        public override void ViewDidLayoutSubviews()
+		public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
 			if (_modal != null)
@@ -92,45 +92,45 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public Platform Platform { get; set; }
 
-        public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].GetSupportedInterfaceOrientations();
-            }
-            return base.GetSupportedInterfaceOrientations();
-        }
+		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].GetSupportedInterfaceOrientations();
+			}
+			return base.GetSupportedInterfaceOrientations();
+		}
 
-        public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
-            }
-            return base.PreferredInterfaceOrientationForPresentation();
-        }
+		public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
+			}
+			return base.PreferredInterfaceOrientationForPresentation();
+		}
 
-        public override bool ShouldAutorotate()
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].ShouldAutorotate();
-            }
-            return base.ShouldAutorotate();
-        }
+		public override bool ShouldAutorotate()
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].ShouldAutorotate();
+			}
+			return base.ShouldAutorotate();
+		}
 
-        public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
-            }
-            return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
-        }
+		public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+			}
+			return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+		}
 
-        public override bool ShouldAutomaticallyForwardRotationMethods => true;
+		public override bool ShouldAutomaticallyForwardRotationMethods => true;
 
-        public override void ViewDidAppear(bool animated)
+		public override void ViewDidAppear(bool animated)
 		{
 			Platform.DidAppear();
 			base.ViewDidAppear(animated);


### PR DESCRIPTION
### Description of Change ###

PlatformRenderer and ModalWrapper are Wrappers around the real UIViewController, rotation and orientations methods are not correctly forwarded in IOS. Per example, you cannot programatically lock the rotation of the IOS screen. This changes will fix that.

No Unit test was made. Will do if you need checking, but the code is pretty straightforward.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

PlataformRender and ModalWrapper will forward orientation methods from their first child (The Actual Controller).


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

