### PR TITLE
Enable warning as error on pages project

### DIFF
--- a/Xamarin.Forms.Pages.Azure/Xamarin.Forms.Pages.Azure.csproj
+++ b/Xamarin.Forms.Pages.Azure/Xamarin.Forms.Pages.Azure.csproj
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
+++ b/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
@@ -26,6 +26,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>4014</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +36,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>4014</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->


### PR DESCRIPTION
### Description of Change ###

Enable warning as error on pages project. 

### Bugs Fixed ###

None. But we had to disable a warning here https://github.com/xamarin/Xamarin.Forms/blob/35b63e158df8d2537ad7cca9f930c44a593e02e7/Xamarin.Forms.Pages/BaseDataSource.cs#L20-L20. Just below the warning is explicitly disabled even though wae was not enabled. Must have gotten flipped at some point. I'll leave it to @jassmith to take a look at the remaining case.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

