### PR TITLE
Add Plain Keyboard from KeyboardFlags.None

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/KeyboardCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/KeyboardCoreGalleryPage.cs
@@ -27,6 +27,7 @@ namespace Xamarin.Forms.Controls
 			}
 
 			var customKeyboards = new [] {
+				Tuple.Create ("None", Keyboard.Create (KeyboardFlags.None)),
 				Tuple.Create ("Suggestions", Keyboard.Create (KeyboardFlags.Suggestions)),
 				Tuple.Create ("Spellcheck", Keyboard.Create (KeyboardFlags.Spellcheck)),
 				Tuple.Create ("SpellcheckSuggestions", Keyboard.Create (KeyboardFlags.Spellcheck | KeyboardFlags.Suggestions)),

--- a/Xamarin.Forms.Controls/CoreGalleryPages/KeyboardCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/KeyboardCoreGalleryPage.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Controls
 				Keyboard.Default,
 				Keyboard.Email,
 				Keyboard.Numeric,
+				Keyboard.Plain,
 				Keyboard.Telephone,
 				Keyboard.Text,
 				Keyboard.Url

--- a/Xamarin.Forms.Core/Keyboard.cs
+++ b/Xamarin.Forms.Core/Keyboard.cs
@@ -3,6 +3,8 @@ namespace Xamarin.Forms
 	[TypeConverter(typeof(KeyboardTypeConverter))]
 	public class Keyboard
 	{
+		static Keyboard s_plain;
+
 		static Keyboard s_def;
 
 		static Keyboard s_email;
@@ -21,8 +23,12 @@ namespace Xamarin.Forms
 		{
 		}
 
-		public static Keyboard Chat
+		public static Keyboard Plain
 		{
+			get { return s_plain ?? (s_plain = new CustomKeyboard(KeyboardFlags.None)); }
+		}
+
+		public static Keyboard Chat {
 			get { return s_chat ?? (s_chat = new ChatKeyboard()); }
 		}
 

--- a/Xamarin.Forms.Core/KeyboardFlags.cs
+++ b/Xamarin.Forms.Core/KeyboardFlags.cs
@@ -5,6 +5,7 @@ namespace Xamarin.Forms
 	[Flags]
 	public enum KeyboardFlags
 	{
+		None = 0,
 		CapitalizeSentence = 1,
 		Spellcheck = 1 << 1,
 		Suggestions = 1 << 2,

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Keyboard.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Keyboard.xml
@@ -139,6 +139,22 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Plain">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.Keyboard Plain { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property class Xamarin.Forms.Keyboard Plain" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Keyboard</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Returns a new keyboard with None <see cref="T:Xamarin.Forms.KeyboardFlags" /> ".</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Telephone">
       <MemberSignature Language="C#" Value="public static Xamarin.Forms.Keyboard Telephone { get; }" />
       <MemberSignature Language="ILAsm" Value=".property class Xamarin.Forms.Keyboard Telephone" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/KeyboardFlags.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/KeyboardFlags.xml
@@ -64,6 +64,20 @@
         <summary>Capitalize the first words of sentences.</summary>
       </Docs>
     </Member>
+    <Member MemberName="None">
+      <MemberSignature Language="C#" Value="None" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.KeyboardFlags None = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.KeyboardFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>No special features provided by the keyboard.</summary>
+      </Docs>
+    </Member>
     <Member MemberName="Spellcheck">
       <MemberSignature Language="C#" Value="Spellcheck" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.KeyboardFlags Spellcheck = int32(2)" />


### PR DESCRIPTION
### Description of Change ###

When creating an Entry for a username, for example, there should be NO possible Keyboard interference with the typing performed by the user.  No autocaps, spellcheck, suggestions, etc.  usernames are typically not english words so we don't want any chance of the Keyboard itself messing up what the user types.  Therefore, there should be a keyboard that has none of these features.  Currently, there is no obvious way of doing this except for creating a custom keyboard with KeyboardFlags.  However, KeyboardFlags has no option to choose None of the features.  There is NO 0 value in the KeyboardFlags enum.  Therefore, the developer must hardcode a 0 and then cast it to KeyboardFlags like this:

Keyboard.Create((KeyboardFlags)0)

This is not very appealing.  This pull request allows a developer to do this better in two ways:

Keyboard.Plain
Keyboard.Create(KeyboardFlags.None)

Also, the MSDN docs for a [Flags] based enum lists a best practice to include a None value assigned to 0.

### API Changes ###

Added KeyboardFlags.None enum value
Added Keyboard.Plain which uses KeyboardFlags.None for its implementation

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

