### PR TITLE
Bug #39399: Ensure UI Thread before loading xaml

### DIFF
--- a/Xamarin.Forms.Xaml/ViewExtensions.cs
+++ b/Xamarin.Forms.Xaml/ViewExtensions.cs
@@ -26,21 +26,28 @@
 // THE SOFTWARE.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Xaml
 {
 	public static class Extensions
 	{
-		public static TXaml LoadFromXaml<TXaml>(this TXaml view, Type callingType) 
+		public static TXaml LoadFromXaml<TXaml>(this TXaml view, Type callingType)
 		{
-			XamlLoader.Load(view, callingType);
-			return view;
+			return Device.BeginInvokeOnMainThreadWait(() =>
+			{
+				XamlLoader.Load(view, callingType);
+				return view;
+			});
 		}
 
 		internal static TXaml LoadFromXaml<TXaml>(this TXaml view, string xaml)
 		{
-			XamlLoader.Load(view, xaml);
-			return view;
+			return Device.BeginInvokeOnMainThreadWait(() =>
+			{
+				XamlLoader.Load(view, xaml);
+				return view;
+			});
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Ensures that the LoadXaml call is always called on the UI Thread.

Existing unit test coverage.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=39399
Calling Application.Current.Resources in UWP/WInRT on a non-UI thread will result in application crash.

### API Changes ###

Added:
Xamarin.Forms.Device
 - internal static T BeginInvokeOnMainThreadWait<T>(Func<T> action)

### Behavioral Changes ###

If the xaml page constructor is called on a non-UI Thread, it will invoke on the UI Thread. 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

