### PR TITLE
[Android] TabbedPage text can be set back to Default

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -69,6 +69,17 @@ namespace Xamarin.Forms.Controls
 		public CoreNavigationPage ()
 		{
 			AutomationId = "NavigationPageRoot";
+
+			BarBackgroundColor = Color.Maroon;
+			BarTextColor = Color.Yellow;
+
+			Device.StartTimer(TimeSpan.FromSeconds(2), () => {
+				BarBackgroundColor = Color.Default;
+				BarTextColor = Color.Default;
+
+				return false;
+			});
+
 			Navigation.PushAsync (new CoreRootPage (this));
 		}
 	}
@@ -86,7 +97,14 @@ namespace Xamarin.Forms.Controls
 			AutomationId = "TabbedPageRoot";
 
 			BarBackgroundColor = Color.Maroon;
-			BarTextColor = Color.White;
+			BarTextColor = Color.Yellow;
+
+			Device.StartTimer(TimeSpan.FromSeconds(2), () => {
+				BarBackgroundColor = Color.Default;
+				BarTextColor = Color.Default;
+
+				return false;
+			});
 
 			Children.Add(new CoreRootPage(this, NavigationBehavior.PushModalAsync) { Title = "Tab 1" });
 			Children.Add(new CoreRootPage(this, NavigationBehavior.PushModalAsync) { Title = "Tab 2" });

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 	public class TabbedPageRenderer : VisualElementRenderer<TabbedPage>, TabLayout.IOnTabSelectedListener, ViewPager.IOnPageChangeListener, IManageFragments
 	{
 		Drawable _backgroundDrawable;
+		int? _defaultColor;
 		bool _disposed;
 		FragmentManager _fragmentManager;
 		TabLayout _tabLayout;
@@ -153,7 +154,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 						tabs = _tabLayout = new TabLayout(activity) { TabMode = TabLayout.ModeFixed, TabGravity = TabLayout.GravityFill };
 					FormsViewPager pager =
 						_viewPager =
-						new FormsViewPager(activity) 
+						new FormsViewPager(activity)
 						{
 							OverScrollMode = OverScrollMode.Never,
 							EnableGesture = UseAnimations,
@@ -364,9 +365,18 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (_disposed || _tabLayout == null)
 				return;
 
-			Color textColor = Element.BarTextColor;
-			if (!textColor.IsDefault)
-				_tabLayout.SetTabTextColors(textColor.ToAndroid().ToArgb(), textColor.ToAndroid().ToArgb());
+			int currentColor = _tabLayout.TabTextColors.DefaultColor;
+
+			if (!_defaultColor.HasValue)
+				_defaultColor = currentColor;
+
+			Color newTextColor = Element.BarTextColor;
+			int newTextColorArgb = newTextColor.ToAndroid().ToArgb();
+
+			if (!newTextColor.IsDefault && currentColor != newTextColorArgb)
+				_tabLayout.SetTabTextColors(newTextColorArgb, newTextColorArgb);
+			else if (newTextColor.IsDefault && _defaultColor.HasValue && currentColor != _defaultColor)
+				_tabLayout.SetTabTextColors(_defaultColor.Value, _defaultColor.Value);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Storing default color for TabbedPage bar text on Android so we can reset it if necessary.

### Bugs Fixed ###

- [Android] Can't reset BarTextColor to default on TabbedPage

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

