### PR TITLE
[Android/iOS] Entries should use explicitly set TextColor values when enabled/disabled

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40485.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40485.cs
@@ -1,0 +1,79 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 40485, "Entries with a set/custom text color are not the same color when disabled")]
+    public class Bugzilla40485 : TestContentPage
+    {
+        protected override void Init()
+        {
+			var entrySwitch = new Switch();
+			var boundEntry = new Entry
+			{
+				BindingContext = entrySwitch,
+				Text = "Default Color Entry - Bound"
+			};
+			boundEntry.SetBinding(Entry.IsEnabledProperty, new Binding("IsToggled"));
+			var boundEntrySetColor = new Entry
+			{
+				BindingContext = entrySwitch,
+				Text = "Set Color Entry - Bound",
+				TextColor = Color.Blue
+			};
+			boundEntrySetColor.SetBinding(Entry.IsEnabledProperty, new Binding("IsToggled"));
+			Content = new StackLayout
+			{ 
+				Children =
+				{
+					new Entry
+					{
+						Text = "Default Color Entry - Enabled"
+					},
+					new Entry
+					{
+						IsEnabled = false,
+						Text = "Default Color Entry - Disabled"
+					},
+					new Entry
+					{
+						Text = "Red Entry - Enabled",
+						TextColor = Color.Red
+					},
+					new Entry
+					{
+						IsEnabled = false,
+						Text = "Red Entry - Disabled",
+						TextColor = Color.Red
+					},
+					new Entry
+					{
+						Text = "Green Entry - Disabled",
+						TextColor = Color.Green
+					},
+					new Entry
+					{
+						IsEnabled = false,
+						Text = "Green Entry - Disabled",
+						TextColor = Color.Green
+					},
+					boundEntry,
+					boundEntrySetColor,
+					new Label
+					{
+						Text = "Toggle to enable/disable bound entries"
+					},
+					entrySwitch
+				}
+            };
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -101,6 +101,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40173.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39821.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40185.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40485.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ColorExtensions.cs
@@ -31,6 +31,11 @@ namespace Xamarin.Forms.Platform.Android
 			return ToAndroid(self);
 		}
 
+		public static ColorStateList ToAndroidOverrideDisabled(this Color color, ColorStateList defaults)
+		{
+			return new ColorStateList(States, new[] { color.ToAndroid().ToArgb(), color.ToAndroid().ToArgb() });
+		}
+
 		public static ColorStateList ToAndroidPreserveDisabled(this Color color, ColorStateList defaults)
 		{
 			int disabled = defaults.GetColorForState(States[1], color.ToAndroid());

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -137,8 +137,7 @@ namespace Xamarin.Forms.Platform.Android
 					// and so we can preserve the default disabled color
 					_textColorDefault = Control.TextColors;
 				}
-
-				Control.SetTextColor(Element.TextColor.ToAndroidPreserveDisabled(_textColorDefault));
+				Control.SetTextColor(Element.TextColor.ToAndroidOverrideDisabled(_textColorDefault));
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -128,7 +128,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var textColor = Element.TextColor;
 
-			if (textColor.IsDefault || !Element.IsEnabled)
+			if (textColor.IsDefault)
 				Control.TextColor = _defaultTextColor;
 			else
 				Control.TextColor = textColor.ToUIColor();


### PR DESCRIPTION
### Description of Change ###

Both Android and iOS applications which have explicitly set `TextColor` values for `Entry` were both setting the color of their text to a different color when disabled; this is different from the behavior which would be exhibited when developing for those platforms without Forms. The changes here would bring that behavior in line.

A reproduction has been added to the issues, sans an explicit UI test.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40485

### API Changes ###

Added:
- public static ColorStateList ToAndroidOverrideDisabled(this Color color, ColorStateList defaults)

Note: This is very similar to the method `ToAndroidPreserveDisabled` but it instead sets the same color value for both the enabled and disabled states. This could perhaps be tweaked.

### Behavioral Changes ###

The changes should bring the behavior in line with Android/iOS applications developed without Forms and leave the set text color the same.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense