### PR TITLE
Set InternalsVisibleTo for CarouselView

### DIFF
--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -54,4 +54,5 @@ using Xamarin.Forms.Internals;
 [assembly: InternalsVisibleTo("Xamarin.Forms.Platform")]
 [assembly: InternalsVisibleTo("Xamarin.Forms.Pages")]
 [assembly: InternalsVisibleTo("Xamarin.Forms.Pages.UnitTests")]
+[assembly: InternalsVisibleTo("Xamarin.Forms.CarouselView")]
 [assembly: Preserve]


### PR DESCRIPTION
### Description of Change ###

Allow Xamarin.Forms.CarouselView to access internal api from Xamarin.Forms
No need for tests

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

