### PR TITLE
[Win] Fixed known issues with BarTextColor

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -86,7 +86,15 @@ namespace Xamarin.Forms.Controls
 			AutomationId = "TabbedPageRoot";
 
 			BarBackgroundColor = Color.Maroon;
-			BarTextColor = Color.White;
+			BarTextColor = Color.Yellow;
+
+			Device.StartTimer(TimeSpan.FromSeconds(2), () =>
+			{
+				BarBackgroundColor = Color.Default;
+				BarTextColor = Color.Default;
+
+				return false;
+			});
 
 			Children.Add(new CoreRootPage(this, NavigationBehavior.PushModalAsync) { Title = "Tab 1" });
 			Children.Add(new CoreRootPage(this, NavigationBehavior.PushModalAsync) { Title = "Tab 2" });
@@ -94,7 +102,8 @@ namespace Xamarin.Forms.Controls
 				{
 					Title = "Rubriques",
 					Icon = "coffee.png",
-					BarBackgroundColor = Color.Blue
+					BarBackgroundColor = Color.Blue,
+					BarTextColor = Color.Aqua
 				});
 
 			Children.Add(new NavigationPage(new Page())
@@ -358,8 +367,16 @@ namespace Xamarin.Forms.Controls
 		}
 	}
 
-	internal class CoreRootPage : ContentPage
+	internal class CoreRootPage : ContentPage, IBarTextColorController
 	{
+		public static readonly BindableProperty BarTextColorProperty = BindableProperty.Create(nameof(BarTextColor), typeof(Color), typeof(CoreRootPage), Color.Default);
+
+		public Color BarTextColor
+		{
+			get { return (Color)GetValue(BarTextColorProperty); }
+			set { SetValue(BarTextColorProperty, value); }
+		}
+
 		public CoreRootPage (Page rootPage, NavigationBehavior navigationBehavior = NavigationBehavior.PushAsync)
 		{
 			IStringProvider stringProvider = DependencyService.Get<IStringProvider> ();

--- a/Xamarin.Forms.Core/IBarBackgroundColorController.cs
+++ b/Xamarin.Forms.Core/IBarBackgroundColorController.cs
@@ -1,0 +1,7 @@
+namespace Xamarin.Forms
+{
+	public interface IBarBackgroundColorController
+	{
+		Color BarBackgroundColor { get; set; }
+	}
+}

--- a/Xamarin.Forms.Core/IBarTextColorController.cs
+++ b/Xamarin.Forms.Core/IBarTextColorController.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms
+{
+	public interface IBarTextColorController
+	{
+		Color BarTextColor { get; set; }
+	}
+}

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -8,7 +8,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_NavigationPageRenderer))]
-	public class NavigationPage : Page, IPageContainer<Page>, INavigationPageController
+	public class NavigationPage : Page, IPageContainer<Page>, INavigationPageController, IBarTextColorController, IBarBackgroundColorController
 	{
 		public static readonly BindableProperty BackButtonTitleProperty = BindableProperty.CreateAttached("BackButtonTitle", typeof(string), typeof(Page), null);
 

--- a/Xamarin.Forms.Core/TabbedPage.cs
+++ b/Xamarin.Forms.Core/TabbedPage.cs
@@ -3,7 +3,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_TabbedPageRenderer))]
-	public class TabbedPage : MultiPage<Page>
+	public class TabbedPage : MultiPage<Page>, IBarTextColorController, IBarBackgroundColorController
 	{
 		public static readonly BindableProperty BarBackgroundColorProperty = BindableProperty.Create(nameof(BarBackgroundColor), typeof(Color), typeof(TabbedPage), Color.Default);
 

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -92,6 +92,8 @@
     <Compile Include="ElementEventArgs.cs" />
     <Compile Include="ElementTemplate.cs" />
     <Compile Include="EmailKeyboard.cs" />
+    <Compile Include="IBarBackgroundColorController.cs" />
+    <Compile Include="IBarTextColorController.cs" />
     <Compile Include="IEntryController.cs" />
     <Compile Include="IImageController.cs" />
     <Compile Include="INavigationPageController.cs" />

--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -463,7 +463,7 @@
         <uwp:EntryCellTextBox IsEnabled="{Binding IsEnabled}" Header="{Binding}" Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextAlignment="{Binding HorizontalTextAlignment,Converter={StaticResource HorizontalTextAlignmentConverter}}" PlaceholderText="{Binding Placeholder}"  InputScope="{Binding Keyboard,Converter={StaticResource KeyboardConverter}}" HorizontalAlignment="Stretch">
 			<uwp:EntryCellTextBox.HeaderTemplate>
 				<DataTemplate>
-					<TextBlock Text="{Binding Label}" Style="{ThemeResource BaseTextBlockStyle}" Foreground="{Binding LabelColor, Converter={StaticResource ColorConverter}, ConverterParameter=DefaultTextForegroundThemeBrush}" />
+					<TextBlock Text="{Binding Label}" Style="{ThemeResource BaseTextBlockStyle}" Foreground="{Binding LabelColor, Converter={StaticResource ColorConverter}, ConverterParameter=SystemControlBackgroundChromeMediumLowBrush}" />
 				</DataTemplate>
 			</uwp:EntryCellTextBox.HeaderTemplate>
 		</uwp:EntryCellTextBox>
@@ -473,7 +473,7 @@
 		<Setter Property="HeaderTemplate">
 			<Setter.Value>
 				<DataTemplate>
-					<TextBlock Text="{Binding Title}" Foreground="{Binding ToolbarForeground}" Style="{ThemeResource BodyTextBlockStyle}" />
+					<TextBlock Text="{Binding Title}" Foreground="{Binding BarTextColor, Converter={StaticResource ColorConverter}, ConverterParameter=DefaultTextForegroundThemeBrush}" Style="{ThemeResource BodyTextBlockStyle}" />
 				</DataTemplate>
 			</Setter.Value>
 		</Setter>

--- a/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
@@ -12,12 +12,12 @@ namespace Xamarin.Forms.Platform.WinRT
 {
 	public class FormsPivot : Pivot, IToolbarProvider
 	{
-		public static readonly DependencyProperty ToolbarVisibilityProperty = DependencyProperty.Register("ToolbarVisibility", typeof(Visibility), typeof(FormsPivot),
+		public static readonly DependencyProperty ToolbarVisibilityProperty = DependencyProperty.Register(nameof(ToolbarVisibility), typeof(Visibility), typeof(FormsPivot),
 			new PropertyMetadata(Visibility.Collapsed));
 
-		public static readonly DependencyProperty ToolbarForegroundProperty = DependencyProperty.Register("ToolbarForeground", typeof(Brush), typeof(FormsPivot), new PropertyMetadata(default(Brush)));
+		public static readonly DependencyProperty ToolbarForegroundProperty = DependencyProperty.Register(nameof(ToolbarForeground), typeof(Brush), typeof(FormsPivot), new PropertyMetadata(default(Brush)));
 
-		public static readonly DependencyProperty ToolbarBackgroundProperty = DependencyProperty.Register("ToolbarBackground", typeof(Brush), typeof(FormsPivot), new PropertyMetadata(default(Brush)));
+		public static readonly DependencyProperty ToolbarBackgroundProperty = DependencyProperty.Register(nameof(ToolbarBackground), typeof(Brush), typeof(FormsPivot), new PropertyMetadata(default(Brush)));
 
 		CommandBar _commandBar;
 

--- a/Xamarin.Forms.Platform.WinRT.Phone/PhoneResources.xaml
+++ b/Xamarin.Forms.Platform.WinRT.Phone/PhoneResources.xaml
@@ -242,7 +242,7 @@
         <Setter Property="HeaderTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <TextBlock Text="{Binding Title}" Foreground="{TemplateBinding ToolbarForeground}" />
+					<TextBlock Text="{Binding Title}" Foreground="{Binding BarTextColor, Converter={StaticResource ColorConverter}, ConverterParameter=DefaultTextForegroundThemeBrush}" />
                 </DataTemplate>
             </Setter.Value>
         </Setter>
@@ -453,7 +453,7 @@
 	</DataTemplate>
 
 	<DataTemplate x:Key="TabbedPageHeader">
-		<TextBlock Text="{Binding Title}" />
+		<TextBlock Text="{Binding Title}" Foreground="{Binding BarTextColor, Converter={StaticResource ColorConverter}, ConverterParameter=DefaultTextForegroundThemeBrush}" />
 	</DataTemplate>
 
 	<Style x:Key="JumpListGrid" TargetType="GridView">

--- a/Xamarin.Forms.Platform.WinRT.Tablet/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/TabbedPageRenderer.cs
@@ -11,6 +11,8 @@ namespace Xamarin.Forms.Platform.WinRT
 	public class TabbedPageRenderer
 		: IVisualElementRenderer
 	{
+		Color _barBackgroundColor;
+		Color _barTextColor;
 		Canvas _canvas;
 
 		bool _disposed;
@@ -109,7 +111,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		Brush GetBarForegroundBrush()
 		{
 			object defaultColor = Windows.UI.Xaml.Application.Current.Resources["ApplicationForegroundThemeBrush"];
-			if (Page.BarTextColor.IsDefault)
+			if (Page.BarTextColor.IsDefault && defaultColor != null)
 				return (Brush)defaultColor;
 			return Page.BarTextColor.ToBrush();
 		}
@@ -182,12 +184,48 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void UpdateBarBackgroundColor()
 		{
-			_tabs.Background = GetBarBackgroundBrush();
+			TabbedPage tabbedPage = Element as TabbedPage;
+			if (tabbedPage == null) return;
+			var barBackgroundColor = tabbedPage.BarBackgroundColor;
+
+			if (barBackgroundColor == _barBackgroundColor) return;
+			_barBackgroundColor = barBackgroundColor;
+
+			if (_tabs.ToolbarBackground == null && barBackgroundColor.IsDefault) return;
+
+			var brush = GetBarBackgroundBrush();
+			if (brush == _tabs.ToolbarBackground) return;
+
+			_tabs.ToolbarBackground = brush;
+			foreach (var item in _tabs.Items)
+			{
+				var colorController = item as IBarBackgroundColorController;
+				if (colorController != null)
+					colorController.BarBackgroundColor = barBackgroundColor;
+			}
 		}
 
 		void UpdateBarTextColor()
 		{
-			_tabs.Foreground = GetBarForegroundBrush();
+			TabbedPage tabbedPage = Element as TabbedPage;
+			if (tabbedPage == null) return;
+			var barTextColor = tabbedPage.BarTextColor;
+
+			if (barTextColor == _barTextColor) return;
+			_barTextColor = barTextColor;
+
+			if (_tabs.ToolbarForeground == null && barTextColor.IsDefault) return;
+
+			var brush = GetBarForegroundBrush();
+			if (brush == _tabs.ToolbarForeground) return;
+
+			_tabs.ToolbarForeground = brush;
+			foreach (var item in _tabs.Items)
+			{
+				var colorController = item as IBarTextColorController;
+				if (colorController != null)
+					colorController.BarTextColor = barTextColor;
+			}
 		}
 
 		void UpdateCurrentPage()

--- a/Xamarin.Forms.Platform.WinRT.Tablet/TabletResources.xaml
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/TabletResources.xaml
@@ -250,7 +250,7 @@
 		<Setter Property="ItemsPanel">
 			<Setter.Value>
 				<ItemsPanelTemplate>
-					<StackPanel Orientation="Horizontal" Margin="0,11,0,0" Background="{TemplateBinding ToolbarBackground}" />
+					<StackPanel Orientation="Horizontal" Margin="0,11,0,0" Background="{Binding BarBackgroundColor, Converter={StaticResource ColorConverter}, ConverterParameter=TabButtonBackgroundBrush}" />
 				</ItemsPanelTemplate>
 			</Setter.Value>
 		</Setter>
@@ -261,7 +261,7 @@
 						<StackPanel VerticalAlignment="Bottom">
 							<Image DataContext="{Binding Icon, Converter={StaticResource ImageConverter}}" Source="{Binding Value}" HorizontalAlignment="Left" />
 							<TextBlock Margin="0,15,0,15" Text="{Binding Title, Converter={StaticResource UpperConverter}}"
-									   Style="{ThemeResource CaptionTextBlockStyle}" FontWeight="SemiBold" Foreground="{TemplateBinding ToolbarForeground}"  HorizontalAlignment="Left" />
+									   Style="{ThemeResource CaptionTextBlockStyle}" FontWeight="SemiBold" Foreground="{Binding BarTextColor, Converter={StaticResource ColorConverter}, ConverterParameter=DefaultTextForegroundThemeBrush}"  HorizontalAlignment="Left" />
 						</StackPanel>
 					</local:TabButton>
 				</DataTemplate>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/IBarBackgroundColorController.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/IBarBackgroundColorController.xml
@@ -1,0 +1,31 @@
+<Type Name="IBarBackgroundColorController" FullName="Xamarin.Forms.IBarBackgroundColorController">
+  <TypeSignature Language="C#" Value="public interface IBarBackgroundColorController" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IBarBackgroundColorController" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="BarBackgroundColor">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Color BarBackgroundColor { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Color BarBackgroundColor" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/IBarTextColorController.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/IBarTextColorController.xml
@@ -1,0 +1,31 @@
+<Type Name="IBarTextColorController" FullName="Xamarin.Forms.IBarTextColorController">
+  <TypeSignature Language="C#" Value="public interface IBarTextColorController" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IBarTextColorController" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="BarTextColor">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Color BarTextColor { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Color BarTextColor" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/INavigationPageController.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/INavigationPageController.xml
@@ -12,14 +12,14 @@
   </Docs>
   <Members>
     <Member MemberName="InsertPageBeforeRequested">
-      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt; InsertPageBeforeRequested;" />
-      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.NavigationRequestedEventArgs&gt; InsertPageBeforeRequested" />
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; InsertPageBeforeRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; InsertPageBeforeRequested" />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt;</ReturnType>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>To be added.</summary>
@@ -49,14 +49,14 @@
       </Docs>
     </Member>
     <Member MemberName="PopRequested">
-      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt; PopRequested;" />
-      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.NavigationRequestedEventArgs&gt; PopRequested" />
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PopRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PopRequested" />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt;</ReturnType>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>To be added.</summary>
@@ -64,14 +64,14 @@
       </Docs>
     </Member>
     <Member MemberName="PopToRootRequested">
-      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt; PopToRootRequested;" />
-      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.NavigationRequestedEventArgs&gt; PopToRootRequested" />
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PopToRootRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PopToRootRequested" />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt;</ReturnType>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>To be added.</summary>
@@ -79,14 +79,14 @@
       </Docs>
     </Member>
     <Member MemberName="PushRequested">
-      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt; PushRequested;" />
-      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.NavigationRequestedEventArgs&gt; PushRequested" />
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PushRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PushRequested" />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt;</ReturnType>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>To be added.</summary>
@@ -94,14 +94,14 @@
       </Docs>
     </Member>
     <Member MemberName="RemovePageRequested">
-      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt; RemovePageRequested;" />
-      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.NavigationRequestedEventArgs&gt; RemovePageRequested" />
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; RemovePageRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; RemovePageRequested" />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.EventHandler&lt;Xamarin.Forms.NavigationRequestedEventArgs&gt;</ReturnType>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>To be added.</summary>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/NavigationPage.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/NavigationPage.xml
@@ -1,6 +1,6 @@
 <Type Name="NavigationPage" FullName="Xamarin.Forms.NavigationPage">
-  <TypeSignature Language="C#" Value="public class NavigationPage : Xamarin.Forms.Page, Xamarin.Forms.INavigationPageController, Xamarin.Forms.IPageContainer&lt;Xamarin.Forms.Page&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit NavigationPage extends Xamarin.Forms.Page implements class Xamarin.Forms.INavigationPageController, class Xamarin.Forms.IPageContainer`1&lt;class Xamarin.Forms.Page&gt;" />
+  <TypeSignature Language="C#" Value="public class NavigationPage : Xamarin.Forms.Page, Xamarin.Forms.IBarBackgroundColorController, Xamarin.Forms.IBarTextColorController, Xamarin.Forms.INavigationPageController, Xamarin.Forms.IPageContainer&lt;Xamarin.Forms.Page&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit NavigationPage extends Xamarin.Forms.Page implements class Xamarin.Forms.IBarBackgroundColorController, class Xamarin.Forms.IBarTextColorController, class Xamarin.Forms.INavigationPageController, class Xamarin.Forms.IPageContainer`1&lt;class Xamarin.Forms.Page&gt;" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -15,6 +15,12 @@
     <BaseTypeName>Xamarin.Forms.Page</BaseTypeName>
   </Base>
   <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IBarBackgroundColorController</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IBarTextColorController</InterfaceName>
+    </Interface>
     <Interface>
       <InterfaceName>Xamarin.Forms.INavigationPageController</InterfaceName>
     </Interface>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/TabbedPage.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/TabbedPage.xml
@@ -1,6 +1,6 @@
 <Type Name="TabbedPage" FullName="Xamarin.Forms.TabbedPage">
-  <TypeSignature Language="C#" Value="public class TabbedPage : Xamarin.Forms.MultiPage&lt;Xamarin.Forms.Page&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit TabbedPage extends Xamarin.Forms.MultiPage`1&lt;class Xamarin.Forms.Page&gt;" />
+  <TypeSignature Language="C#" Value="public class TabbedPage : Xamarin.Forms.MultiPage&lt;Xamarin.Forms.Page&gt;, Xamarin.Forms.IBarBackgroundColorController, Xamarin.Forms.IBarTextColorController" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit TabbedPage extends Xamarin.Forms.MultiPage`1&lt;class Xamarin.Forms.Page&gt; implements class Xamarin.Forms.IBarBackgroundColorController, class Xamarin.Forms.IBarTextColorController" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -17,7 +17,14 @@
       <BaseTypeArgument TypeParamName="T">Xamarin.Forms.Page</BaseTypeArgument>
     </BaseTypeArguments>
   </Base>
-  <Interfaces />
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IBarBackgroundColorController</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IBarTextColorController</InterfaceName>
+    </Interface>
+  </Interfaces>
   <Attributes>
     <Attribute>
       <AttributeName>Xamarin.Forms.RenderWith(typeof(Xamarin.Forms.Platform._TabbedPageRenderer))</AttributeName>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -12,7 +12,7 @@
           <AttributeName>System.Reflection.AssemblyConfiguration("")</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Reflection.AssemblyCopyright("Copyright © Xamarin Inc. 2013-2015")</AttributeName>
+          <AttributeName>System.Reflection.AssemblyCopyright("Copyright © Xamarin Inc. 2013-2016")</AttributeName>
         </Attribute>
         <Attribute>
           <AttributeName>System.Reflection.AssemblyDescription("")</AttributeName>
@@ -102,6 +102,9 @@
           <AttributeName>System.Runtime.CompilerServices.InternalsVisibleTo("Xamarin.Forms.Core.Android.UITests")</AttributeName>
         </Attribute>
         <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.InternalsVisibleTo("Xamarin.Forms.Core.Windows.UITests")</AttributeName>
+        </Attribute>
+        <Attribute>
           <AttributeName>System.Runtime.CompilerServices.InternalsVisibleTo("Xamarin.Forms.iOS.UITests")</AttributeName>
         </Attribute>
         <Attribute>
@@ -120,10 +123,19 @@
           <AttributeName>System.Runtime.CompilerServices.InternalsVisibleTo("Xamarin.Forms.Platform")</AttributeName>
         </Attribute>
         <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.InternalsVisibleTo("Xamarin.Forms.Pages")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.InternalsVisibleTo("Xamarin.Forms.Pages.UnitTests")</AttributeName>
+        </Attribute>
+        <Attribute>
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
         <Attribute>
           <AttributeName>System.Runtime.Versioning.TargetFramework(".NETPortable,Version=v4.5,Profile=Profile259", FrameworkDisplayName=".NET Portable Subset")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>Xamarin.Forms.Internals.Preserve</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
@@ -169,6 +181,9 @@
       <Type Name="BoundsTypeConverter" Kind="Class" />
       <Type Name="BoxView" Kind="Class" />
       <Type Name="Button" Kind="Class" />
+      <Type Name="Button+ButtonContentLayout" Kind="Class" />
+      <Type Name="Button+ButtonContentLayout+ImagePosition" Kind="Enumeration" />
+      <Type Name="Button+ButtonContentTypeConverter" Kind="Class" />
       <Type Name="CarouselPage" Kind="Class" />
       <Type Name="Cell" Kind="Class" />
       <Type Name="CollectionSynchronizationCallback" Kind="Delegate" />
@@ -233,11 +248,16 @@
       <Type Name="IApplicationController" Kind="Interface" />
       <Type Name="IAppLinkEntry" Kind="Interface" />
       <Type Name="IAppLinks" Kind="Interface" />
+      <Type Name="IBarBackgroundColorController" Kind="Interface" />
+      <Type Name="IBarTextColorController" Kind="Interface" />
+      <Type Name="IButtonController" Kind="Interface" />
       <Type Name="IDefinition" Kind="Interface" />
       <Type Name="IEffectControlProvider" Kind="Interface" />
       <Type Name="IElementController" Kind="Interface" />
+      <Type Name="IEntryController" Kind="Interface" />
       <Type Name="IExtendedTypeConverter" Kind="Interface" />
       <Type Name="IGestureRecognizer" Kind="Interface" />
+      <Type Name="IImageController" Kind="Interface" />
       <Type Name="IItemViewController" Kind="Interface" />
       <Type Name="ILayout" Kind="Interface" />
       <Type Name="ILayoutController" Kind="Interface" />
@@ -245,16 +265,20 @@
       <Type Name="ImageCell" Kind="Class" />
       <Type Name="ImageSource" Kind="Class" />
       <Type Name="ImageSourceConverter" Kind="Class" />
+      <Type Name="IMasterDetailPageController" Kind="Interface" />
       <Type Name="INativeElementView" Kind="Interface" />
       <Type Name="INavigation" Kind="Interface" />
+      <Type Name="INavigationPageController" Kind="Interface" />
       <Type Name="InputView" Kind="Class" />
+      <Type Name="IOpenGlViewController" Kind="Interface" />
       <Type Name="IOpenGLViewController" Kind="Interface" />
       <Type Name="IPageContainer`1" DisplayName="IPageContainer&lt;T&gt;" Kind="Interface" />
       <Type Name="IPlatform" Kind="Interface" />
       <Type Name="IPlatformEngine" Kind="Interface" />
       <Type Name="IRegisterable" Kind="Interface" />
       <Type Name="IScrollViewController" Kind="Interface" />
-      <Type Name="ItemsView" Kind="Class" />
+      <Type Name="ISearchBarController" Kind="Interface" />
+      <Type Name="IStreamImageSource" Kind="Interface" />
       <Type Name="ItemsView`1" DisplayName="ItemsView&lt;TVisual&gt;" Kind="Class" />
       <Type Name="ItemTappedEventArgs" Kind="Class" />
       <Type Name="ItemVisibilityEventArgs" Kind="Class" />
@@ -262,6 +286,7 @@
       <Type Name="IViewContainer`1" DisplayName="IViewContainer&lt;T&gt;" Kind="Interface" />
       <Type Name="IViewController" Kind="Interface" />
       <Type Name="IVisualElementController" Kind="Interface" />
+      <Type Name="IWebViewDelegate" Kind="Interface" />
       <Type Name="Keyboard" Kind="Class" />
       <Type Name="KeyboardFlags" Kind="Enumeration" />
       <Type Name="KeyboardTypeConverter" Kind="Class" />
@@ -394,10 +419,15 @@
     </Namespace>
     <Namespace Name="Xamarin.Forms.Internals">
       <Type Name="DynamicResource" Kind="Class" />
+      <Type Name="EvalRequested" Kind="Class" />
       <Type Name="IDataTemplate" Kind="Interface" />
       <Type Name="IDynamicResourceHandler" Kind="Interface" />
       <Type Name="INameScope" Kind="Interface" />
+      <Type Name="InvalidationTrigger" Kind="Enumeration" />
       <Type Name="NameScope" Kind="Class" />
+      <Type Name="NavigationRequestedEventArgs" Kind="Class" />
+      <Type Name="PreserveAttribute" Kind="Class" />
+      <Type Name="Ticker" Kind="Class" />
     </Namespace>
     <Namespace Name="Xamarin.Forms.Xaml">
       <Type Name="IMarkupExtension" Kind="Interface" />


### PR DESCRIPTION
### Description of Change ###

Resolved known issues with the new `BarTextColor` feature for `TabbedPage`s on Windows platforms.

### Bugs Fixed ###

 - [WinRT, WinPhone 8.1, UWP] Setting `BarTextColor` does not currently work. 
 - [WinPhone 8.1, UWP] If the `TabbedPage` contains a `NavigationPage`, the `BarBackgroundColor` and `BarTextColor` for the `NavigationPage` takes precedence
 - [WinPhone 8.1] If the `TabbedPage` contains a `NavigationPage`, switching between tabs may cause the background color to be lost.

### API Changes ###

- pubic interface IBarBackgroundColorController;
- pubic interface IBarTextColorController;

### Behavioral Changes ###

- [Win] In order for the `BarTextColor` to take effect on `TabbedPage`s on all Windows platforms, the child page(s) must implement a `BindableProperty` named `BarTextColor`. `NavigationPage`s will implicitly have this property, but any other `Page` type will need to include this property.

- [Win] Explicitly setting the `BarTextColor` and `BarBackgroundColor` to `Color.Default` will take precedence over the `BarTextColor` and `BarBackgroundColor` on `NavigationPage`s. However, if the `BarTextColor` and `BarBackgroundColor` for the `TabbedPage` are never set, the `NavigationPage`s may supply individual `BarTextColor`s and `BarBackgroundColor`s. This should preserve existing behavior while still allowing the `TabbedPage` to be the ultimate authority of bar color.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

