### PR TITLE
[Android] Implement the AppIndexProvider on non-AppCompact, fix KeyValues on AppLinkEntry

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/AppLinkEntryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AppLinkEntryTests.cs
@@ -1,0 +1,42 @@
+using System;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class AppLinkEntryTests : BaseTestFixture
+	{
+
+		[Test]
+		public void KeyValuesTest()
+		{
+			var entry = new AppLinkEntry();
+
+			entry.KeyValues.Add("contentType", "GalleryPage");
+			entry.KeyValues.Add("companyName", "Xamarin");
+			Assert.AreEqual(entry.KeyValues.Count, 2);
+		}
+
+
+		[Test]
+		public void FromUriTest()
+		{
+			var uri = new Uri("http://foo.com");
+
+			var entry = AppLinkEntry.FromUri(uri);
+
+			Assert.AreEqual(uri, entry.AppLinkUri);
+		}
+
+		[Test]
+		public void ToStringTest()
+		{
+			var str = "http://foo.com";
+			var uri = new Uri(str);
+
+			var entry = new AppLinkEntry { AppLinkUri = uri };
+
+			Assert.AreEqual(uri.ToString(), entry.ToString());
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -175,6 +175,7 @@
     <Compile Include="MultiTriggerTests.cs" />
     <Compile Include="TriggerTests.cs" />
     <Compile Include="PinchGestureRecognizerTests.cs" />
+    <Compile Include="AppLinkEntryTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/Xamarin.Forms.Core/AppLinkEntry.cs
+++ b/Xamarin.Forms.Core/AppLinkEntry.cs
@@ -5,6 +5,13 @@ namespace Xamarin.Forms
 {
 	public class AppLinkEntry : Element, IAppLinkEntry
 	{
+		readonly Dictionary<string, string> keyValues;
+
+		public AppLinkEntry()
+		{
+			keyValues = new Dictionary<string, string>();
+		}
+
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(AppLinkEntry), default(string));
 
 		public static readonly BindableProperty DescriptionProperty = BindableProperty.Create(nameof(Description), typeof(string), typeof(AppLinkEntry), default(string));
@@ -33,7 +40,10 @@ namespace Xamarin.Forms
 			set { SetValue(IsLinkActiveProperty, value); }
 		}
 
-		public IDictionary<string, string> KeyValues => new Dictionary<string, string>();
+		public IDictionary<string, string> KeyValues
+		{
+			get { return keyValues; }
+		}
 
 		public ImageSource Thumbnail
 		{

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -100,6 +100,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (application == null)
 				throw new ArgumentNullException("application");
 
+			(application as IApplicationController)?.SetAppIndexingProvider(new AndroidAppIndexProvider(this));
+
 			_application = application;
 			Xamarin.Forms.Application.Current = application;
 


### PR DESCRIPTION
### Description of Change ###

Implement the AppIndexProvider on non-AppCompact backend.
Fix bug on KeyValues on AppLinkEntry

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=40866
- https://bugzilla.xamarin.com/show_bug.cgi?id=40830

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense