### PR TITLE
Add convenience GridLength.Star

### DIFF
--- a/Xamarin.Forms.Core/GridLength.cs
+++ b/Xamarin.Forms.Core/GridLength.cs
@@ -12,6 +12,11 @@ namespace Xamarin.Forms
 			get { return new GridLength(1, GridUnitType.Auto); }
 		}
 
+		public static GridLength Star
+		{
+			get { return new GridLength(1, GridUnitType.Star); }
+		}
+
 		public double Value { get; }
 
 		public GridUnitType GridUnitType { get; }

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/GridLength.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/GridLength.xml
@@ -270,6 +270,22 @@
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="Star">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.GridLength Star { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property valuetype Xamarin.Forms.GridLength Star" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.GridLength</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>A ready to reuse GridLength of GridUnitType.Star with a Value of 1.</summary>
+        <value></value>
+        <remarks>If a Value other than 1 is needed with GridUnitType.Star, then use the constructor GridLength (value, GridUnitType.Star).</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="ToString">
       <MemberSignature Language="C#" Value="public override string ToString ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance string ToString() cil managed" />


### PR DESCRIPTION
### Description of Change ###

When writing UI in code, it should be as convenient as possible, like XAML.  When configuring Row and Column Definitions in a Grid, the majority of the time only (1,Auto) and (1,Star) are needed.  There is already a convenience value for (1,Auto) with GridLength.Auto, but there is not one for (1,Star) with GridLength.Star.  This adds that allowing this:

				RowDefinitions = {
					new RowDefinition { Height = GridLength.Auto },
					new RowDefinition { Height = new GridLength (1, GridUnitType.Star) },
					new RowDefinition { Height = new GridLength (1, GridUnitType.Star) }
				}

to become this:

				RowDefinitions = {
					new RowDefinition { Height = GridLength.Auto },
					new RowDefinition { Height = GridLength.Star },
					new RowDefinition { Height = GridLength.Star }
				}


### API Changes ###

Added convenience static value GridLength.Star

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

