### PR TITLE
Make RunningApp.Screenshot do nothing unless SCREENSHOTS symbol defined

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla21177.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla21177.cs
@@ -42,16 +42,13 @@ namespace Xamarin.Forms.Controls
 			DisplayAlert("Success", "Success", "Cancel");
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		public void Bugzilla21177Test()
 		{
-			if (RunningApp is iOSApp)
-			{
-				RunningApp.WaitForElement(q => q.Marked("#1"));
-				RunningApp.Tap(q => q.Marked("#1"));
-				RunningApp.WaitForElement(q => q.Marked("Success"));
-			}
+			RunningApp.WaitForElement(q => q.Marked("#1"));
+			RunningApp.Tap(q => q.Marked("#1"));
+			RunningApp.WaitForElement(q => q.Marked("Success"));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28570.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28570.cs
@@ -105,13 +105,13 @@ namespace Xamarin.Forms.Controls
 		[Ignore("Fails intermittently on TestCloud")]
 		public void Bugzilla28570Test ()
 		{
-			if (RunningApp is AndroidApp) {
-				RunningApp.WaitForElement (q => q.Marked ("Tap"));
-				RunningApp.Screenshot ("At test page");
-				RunningApp.Tap (q => q.Marked ("Tap"));
+#if __ANDROID__
+			RunningApp.WaitForElement (q => q.Marked ("Tap"));
+			RunningApp.Screenshot ("At test page");
+			RunningApp.Tap (q => q.Marked ("Tap"));
 
-				RunningApp.WaitForElement (q => q.Marked ("28570Target"));
-			}
+			RunningApp.WaitForElement (q => q.Marked ("28570Target"));
+#endif
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30317.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30317.cs
@@ -173,87 +173,75 @@ namespace Xamarin.Forms.Controls
 			Navigation.PushAsync (new Bugzilla30317Page1 ());
 		}
 
-#if UITEST
+#if UITEST && __ANDROID__
 		[Test]
 		public void Bugzilla30317ItemSourceOnAppearingContentPage ()
 		{
-			if (RunningApp is AndroidApp) {
-				RunningApp.Screenshot ("I am at Bugzilla30317");
-				RunningApp.WaitForElement (q => q.Marked ("PageOne"));
-				RunningApp.Screenshot ("I see Page 1");
+			RunningApp.Screenshot ("I am at Bugzilla30317");
+			RunningApp.WaitForElement (q => q.Marked ("PageOne"));
+			RunningApp.Screenshot ("I see Page 1");
 	
-				RunningApp.WaitForElement (q => q.Marked ("PageOneItem1"));
-				RunningApp.TouchAndHold (q => q.Marked ("PageOneItem1"));
+			RunningApp.WaitForElement (q => q.Marked ("PageOneItem1"));
+			RunningApp.TouchAndHold (q => q.Marked ("PageOneItem1"));
 		
-				RunningApp.WaitForElement (q => q.Marked ("PageOneItem5"));
-				RunningApp.TouchAndHold (q => q.Marked ("PageOneItem5"));
+			RunningApp.WaitForElement (q => q.Marked ("PageOneItem5"));
+			RunningApp.TouchAndHold (q => q.Marked ("PageOneItem5"));
 
-				RunningApp.Screenshot ("I did not crash");
-			} else {
-				Assert.Inconclusive ("Not run on iOS");	
-			}
+			RunningApp.Screenshot ("I did not crash");
 		}
 
 		[Test]
 		public void Bugzilla30317ItemSourceCtorContentPage ()
 		{
-			if (RunningApp is AndroidApp) {
-				RunningApp.WaitForElement (q => q.Marked ("GoToPageTwoButton"));
-				RunningApp.Tap (q => q.Marked ("GoToPageTwoButton"));
+			RunningApp.WaitForElement (q => q.Marked ("GoToPageTwoButton"));
+			RunningApp.Tap (q => q.Marked ("GoToPageTwoButton"));
 
-				RunningApp.WaitForElement (q => q.Marked ("PageTwo"));
-				RunningApp.Screenshot ("I see Page 2");
+			RunningApp.WaitForElement (q => q.Marked ("PageTwo"));
+			RunningApp.Screenshot ("I see Page 2");
 				
-				RunningApp.WaitForElement (q => q.Marked ("PageTwoItem1"));
-				RunningApp.TouchAndHold (q => q.Marked ("PageTwoItem1"));
+			RunningApp.WaitForElement (q => q.Marked ("PageTwoItem1"));
+			RunningApp.TouchAndHold (q => q.Marked ("PageTwoItem1"));
 				
-				RunningApp.WaitForElement (q => q.Marked ("PageTwoItem5"));
-				RunningApp.TouchAndHold (q => q.Marked ("PageTwoItem5"));
+			RunningApp.WaitForElement (q => q.Marked ("PageTwoItem5"));
+			RunningApp.TouchAndHold (q => q.Marked ("PageTwoItem5"));
 				
-				RunningApp.Screenshot ("I did not crash");
-			} else {
-				Assert.Inconclusive ("Not run on iOS");	
-			}
+			RunningApp.Screenshot ("I did not crash");
 		}
 
 		[Test]
 		public void Bugzilla30317ItemSourceTabbedPage ()
 		{
-			if (RunningApp is AndroidApp) {
-				RunningApp.WaitForElement (q => q.Marked ("GoToPageTwoButton"));
-				RunningApp.Tap (q => q.Marked ("GoToPageTwoButton"));
+			RunningApp.WaitForElement (q => q.Marked ("GoToPageTwoButton"));
+			RunningApp.Tap (q => q.Marked ("GoToPageTwoButton"));
 
-				RunningApp.Screenshot ("I see Page 2");
-				RunningApp.WaitForElement (q => q.Marked ("PageTwo"));
+			RunningApp.Screenshot ("I see Page 2");
+			RunningApp.WaitForElement (q => q.Marked ("PageTwo"));
 
-				RunningApp.WaitForElement (q => q.Marked ("GoToPageThreeButton"));
-				RunningApp.Tap (q => q.Marked ("GoToPageThreeButton"));
+			RunningApp.WaitForElement (q => q.Marked ("GoToPageThreeButton"));
+			RunningApp.Tap (q => q.Marked ("GoToPageThreeButton"));
 
-				RunningApp.Screenshot ("I see TabbedPage One");
-				RunningApp.WaitForElement (q => q.Marked ("TabOneCtor"));
+			RunningApp.Screenshot ("I see TabbedPage One");
+			RunningApp.WaitForElement (q => q.Marked ("TabOneCtor"));
 
-				RunningApp.WaitForElement (q => q.Marked ("PageThreeTabOneItem1"));
-				RunningApp.TouchAndHold (q => q.Marked ("PageThreeTabOneItem1"));
-				RunningApp.WaitForElement (q => q.Marked ("PageThreeTabOneItem1"));
+			RunningApp.WaitForElement (q => q.Marked ("PageThreeTabOneItem1"));
+			RunningApp.TouchAndHold (q => q.Marked ("PageThreeTabOneItem1"));
+			RunningApp.WaitForElement (q => q.Marked ("PageThreeTabOneItem1"));
 
-				RunningApp.WaitForElement (q => q.Marked ("PageThreeTabOneItem5"));
-				RunningApp.TouchAndHold (q => q.Marked ("PageThreeTabOneItem5"));
-				RunningApp.WaitForElement (q => q.Marked ("PageThreeTabOneItem5"));
+			RunningApp.WaitForElement (q => q.Marked ("PageThreeTabOneItem5"));
+			RunningApp.TouchAndHold (q => q.Marked ("PageThreeTabOneItem5"));
+			RunningApp.WaitForElement (q => q.Marked ("PageThreeTabOneItem5"));
 
-				RunningApp.Screenshot ("I see TabbedPage Two");
-				RunningApp.WaitForElement (q => q.Marked ("TabTwoOnAppearing"));
-				RunningApp.Tap (q => q.Marked ("TabTwoOnAppearing"));
+			RunningApp.Screenshot ("I see TabbedPage Two");
+			RunningApp.WaitForElement (q => q.Marked ("TabTwoOnAppearing"));
+			RunningApp.Tap (q => q.Marked ("TabTwoOnAppearing"));
 
-				RunningApp.WaitForElement (q => q.Marked ("PageThreeTabTwoItem1"));
-				RunningApp.TouchAndHold (q => q.Marked ("PageThreeTabTwoItem1"));
-				RunningApp.WaitForElement (q => q.Marked ("PageThreeTabTwoItem1"));
+			RunningApp.WaitForElement (q => q.Marked ("PageThreeTabTwoItem1"));
+			RunningApp.TouchAndHold (q => q.Marked ("PageThreeTabTwoItem1"));
+			RunningApp.WaitForElement (q => q.Marked ("PageThreeTabTwoItem1"));
 
-				RunningApp.WaitForElement (q => q.Marked ("PageThreeTabTwoItem5"));
-				RunningApp.TouchAndHold (q => q.Marked ("PageThreeTabTwoItem5"));
-				RunningApp.WaitForElement (q => q.Marked ("PageThreeTabTwoItem5"));
-			} else {
-				Assert.Inconclusive ("Not run on iOS");	
-			}
+			RunningApp.WaitForElement (q => q.Marked ("PageThreeTabTwoItem5"));
+			RunningApp.TouchAndHold (q => q.Marked ("PageThreeTabTwoItem5"));
+			RunningApp.WaitForElement (q => q.Marked ("PageThreeTabTwoItem5"));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
@@ -79,10 +79,7 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Tap (q => q.Marked ("Toggle"));
 			RunningApp.Screenshot ("Portrait Visible");
 			RunningApp.WaitForElement (q => q.Marked ("The Master is now visible"));
-			if (RunningApp is iOSApp)
-				RunningApp.Tap (q => q.Marked ("Toggle"));
-			else
-				RunningApp.Back ();
+			Back();
 			RunningApp.Screenshot ("Portrait Invisible");
 			RunningApp.WaitForElement (q => q.Marked ("The Master is now invisible"));
 			RunningApp.SetOrientationLandscape ();
@@ -91,23 +88,26 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Tap (q => q.Marked ("Toggle"));
 			RunningApp.Screenshot ("Landscape Visible");
 			RunningApp.WaitForElement (q => q.Marked ("The Master is now visible"));
-			if (RunningApp is iOSApp)
-				RunningApp.Tap (q => q.Marked ("Toggle"));
-			else
-				RunningApp.Back ();
+			Back();
 			RunningApp.Screenshot ("Landscape InVisible");
 			RunningApp.WaitForElement (q => q.Marked ("The Master is now invisible"));
 			RunningApp.SetOrientationPortrait ();
 			RunningApp.Tap (q => q.Marked ("Toggle"));
 			RunningApp.Screenshot ("Portrait Visible");
 			RunningApp.WaitForElement (q => q.Marked ("The Master is now visible"));
-			if (RunningApp is iOSApp)
-				RunningApp.Tap (q => q.Marked ("Toggle"));
-			else
-				RunningApp.Back ();
+			Back();
 			RunningApp.Screenshot ("Portrait Invisible");
 			RunningApp.WaitForElement (q => q.Marked ("The Master is now invisible"));
 			RunningApp.SetOrientationLandscape ();
+		}
+
+		void Back()
+		{
+#if __IOS__
+			RunningApp.Tap (q => q.Marked ("Toggle"));
+#else
+			RunningApp.Back();
+#endif
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
@@ -399,26 +399,24 @@ namespace Xamarin.Forms.Controls
 
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		[Ignore("Fails sometimes - needs a better test")]
 		public void Bugzilla31114Test ()
 		{
-			if (RunningApp is iOSApp) {
-				for (int i = 0; i < 5; i++) {
-					RunningApp.DragCoordinates (10, 300, 10, 10);
-				}
-				RunningApp.Tap (q => q.Marked ("btnLoad"));
+			for (int i = 0; i < 5; i++) {
 				RunningApp.DragCoordinates (10, 300, 10, 10);
-				RunningApp.WaitForElement (q => q.Marked ("PIPE #1007"));
-				RunningApp.WaitForElement (q => q.Marked ("PIPE #1008"));
-				RunningApp.WaitForElement (q => q.Marked ("PIPE #1009"));
-				RunningApp.DragCoordinates (10, 300, 10, 10);
-				RunningApp.WaitForElement (q => q.Marked ("PIPE #1010"));
-				RunningApp.WaitForElement (q => q.Marked ("PIPE #1011"));
-				RunningApp.WaitForElement (q => q.Marked ("PIPE #1012"));
-				RunningApp.WaitForElement (q => q.Marked ("PIPE #1013"));
 			}
+			RunningApp.Tap (q => q.Marked ("btnLoad"));
+			RunningApp.DragCoordinates (10, 300, 10, 10);
+			RunningApp.WaitForElement (q => q.Marked ("PIPE #1007"));
+			RunningApp.WaitForElement (q => q.Marked ("PIPE #1008"));
+			RunningApp.WaitForElement (q => q.Marked ("PIPE #1009"));
+			RunningApp.DragCoordinates (10, 300, 10, 10);
+			RunningApp.WaitForElement (q => q.Marked ("PIPE #1010"));
+			RunningApp.WaitForElement (q => q.Marked ("PIPE #1011"));
+			RunningApp.WaitForElement (q => q.Marked ("PIPE #1012"));
+			RunningApp.WaitForElement (q => q.Marked ("PIPE #1013"));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31330.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31330.cs
@@ -135,28 +135,26 @@ namespace Xamarin.Forms.Controls
 
 			var cell = RunningApp.Query (c => c.Marked ("Something 1")) [0];
 			var cell2 = RunningApp.Query (c => c.Marked ("Something 2")) [0];
-			if (RunningApp is iOSApp) {
-				RunningApp.DragCoordinates (screenBounds.Width - 10, cell.Rect.CenterY, 0, cell.Rect.CenterY);
-				RunningApp.WaitForElement (c => c.Marked ("Delete"));
-				RunningApp.Tap (c => c.Marked ("Delete"));
-				RunningApp.WaitForElement (c => c.Marked ("Something 1"));
-				RunningApp.Tap (c => c.Marked ("Something 2"));
-				RunningApp.DragCoordinates (screenBounds.Width - 10, cell2.Rect.CenterY, 0, cell2.Rect.CenterY);
-				RunningApp.Tap (c => c.Marked ("Delete"));
-				RunningApp.WaitForNoElement (c => c.Marked ("Something 2"));
-			}
-			else {
-				RunningApp.TouchAndHoldCoordinates (cell.Rect.CenterX, cell.Rect.CenterY);
-				RunningApp.WaitForElement (c => c.Marked ("Delete"));
-				RunningApp.Tap (c => c.Marked ("Delete"));
-				RunningApp.Back ();
-				RunningApp.WaitForElement (c => c.Marked ("Something 1"));
-				RunningApp.Tap (c => c.Marked ("Something 2"));
-				RunningApp.TouchAndHoldCoordinates (cell2.Rect.CenterX, cell2.Rect.CenterY);
-				RunningApp.Tap (c => c.Marked ("Delete"));
-				RunningApp.WaitForNoElement (c => c.Marked ("Something 2"));
-			}
-
+#if __IOS__
+			RunningApp.DragCoordinates (screenBounds.Width - 10, cell.Rect.CenterY, 0, cell.Rect.CenterY);
+			RunningApp.WaitForElement (c => c.Marked ("Delete"));
+			RunningApp.Tap (c => c.Marked ("Delete"));
+			RunningApp.WaitForElement (c => c.Marked ("Something 1"));
+			RunningApp.Tap (c => c.Marked ("Something 2"));
+			RunningApp.DragCoordinates (screenBounds.Width - 10, cell2.Rect.CenterY, 0, cell2.Rect.CenterY);
+			RunningApp.Tap (c => c.Marked ("Delete"));
+			RunningApp.WaitForNoElement (c => c.Marked ("Something 2"));
+#else
+			RunningApp.TouchAndHoldCoordinates (cell.Rect.CenterX, cell.Rect.CenterY);
+			RunningApp.WaitForElement (c => c.Marked ("Delete"));
+			RunningApp.Tap (c => c.Marked ("Delete"));
+			RunningApp.Back ();
+			RunningApp.WaitForElement (c => c.Marked ("Something 1"));
+			RunningApp.Tap (c => c.Marked ("Something 2"));
+			RunningApp.TouchAndHoldCoordinates (cell2.Rect.CenterX, cell2.Rect.CenterY);
+			RunningApp.Tap (c => c.Marked ("Delete"));
+			RunningApp.WaitForNoElement (c => c.Marked ("Something 2"));
+#endif
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32801.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32801.cs
@@ -73,19 +73,17 @@ namespace Xamarin.Forms.Controls
 			}
 		}
 
-		#if UITEST
+		#if UITEST && __IOS__
 		[Test]
 		public void Bugzilla32801Test ()
 		{
-			if (RunningApp is iOSApp) {
-				RunningApp.Tap (c => c.Marked ("btnAdd"));
-				RunningApp.Tap (c => c.Marked ("btnAdd"));
-				RunningApp.Tap (c => c.Marked ("btnStack"));
-				RunningApp.WaitForElement (c => c.Marked ("Stack 3"));
-				RunningApp.Tap (c => c.Marked ("Tab"));
-				RunningApp.Tap (c => c.Marked ("btnStack"));
-				RunningApp.WaitForElement (c => c.Marked ("Stack 1"));
-			}
+			RunningApp.Tap (c => c.Marked ("btnAdd"));
+			RunningApp.Tap (c => c.Marked ("btnAdd"));
+			RunningApp.Tap (c => c.Marked ("btnStack"));
+			RunningApp.WaitForElement (c => c.Marked ("Stack 3"));
+			RunningApp.Tap (c => c.Marked ("Tab"));
+			RunningApp.Tap (c => c.Marked ("btnStack"));
+			RunningApp.WaitForElement (c => c.Marked ("Stack 1"));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33578.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33578.cs
@@ -74,26 +74,24 @@ namespace Xamarin.Forms.Controls
 			};
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		[Ignore("Needs Xamarin.UITest 0.18")]
 		public void Bugzilla33578Test ()
 		{
-			if (RunningApp is iOSApp) {
-				RunningApp.ScrollDown ();
-				RunningApp.ScrollDown ();
-				RunningApp.Tap (x => x.Marked ("0"));
-				var e = RunningApp.Query (c => c.Marked ("0").Parent ("UITextField").Index (0).Invoke ("keyboardType")) [0];
-				//8 DecimalPad
-				Assert.AreEqual (8, e);
-				RunningApp.DismissKeyboard ();
-				RunningApp.Tap (x => x.Marked ("Enter text here").Index (0).Parent ());
-				RunningApp.ScrollUp ();
-				RunningApp.Tap (x => x.Marked ("Enter text here 1"));
-				RunningApp.Tap (x => x.Marked ("Enter text here 2").Index (0).Parent ());
-				var e1 = RunningApp.Query (c => c.Marked ("Enter text here 2").Parent ("UITextField").Index (0).Invoke ("keyboardType")) [0];
-				Assert.AreEqual (0, e1);		
-			}
+			RunningApp.ScrollDown ();
+			RunningApp.ScrollDown ();
+			RunningApp.Tap (x => x.Marked ("0"));
+			var e = RunningApp.Query (c => c.Marked ("0").Parent ("UITextField").Index (0).Invoke ("keyboardType")) [0];
+			//8 DecimalPad
+			Assert.AreEqual (8, e);
+			RunningApp.DismissKeyboard ();
+			RunningApp.Tap (x => x.Marked ("Enter text here").Index (0).Parent ());
+			RunningApp.ScrollUp ();
+			RunningApp.Tap (x => x.Marked ("Enter text here 1"));
+			RunningApp.Tap (x => x.Marked ("Enter text here 2").Index (0).Parent ());
+			var e1 = RunningApp.Query (c => c.Marked ("Enter text here 2").Parent ("UITextField").Index (0).Invoke ("keyboardType")) [0];
+			Assert.AreEqual (0, e1);		
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
@@ -74,12 +74,12 @@ namespace Xamarin.Forms.Controls
 		{
 			RunningApp.WaitForElement (q => q.Marked ("ListViewItem"));
 
-			if(RunningApp is iOSApp) {
-				var listItem = RunningApp.Query (q => q.Marked ("ListViewItem"))[0].Rect;
-				RunningApp.DragCoordinates(listItem.CenterX, listItem.CenterY, 0, listItem.CenterY);
-			} else {
-				RunningApp.TouchAndHold (q => q.Marked ("ListViewItem"));
-			}
+#if __IOS__
+			var listItem = RunningApp.Query (q => q.Marked ("ListViewItem"))[0].Rect;
+			RunningApp.DragCoordinates(listItem.CenterX, listItem.CenterY, 0, listItem.CenterY);
+#else 
+			RunningApp.TouchAndHold (q => q.Marked ("ListViewItem"));
+#endif
 
 			RunningApp.WaitForElement (q => q.Marked ("Click"));
 			RunningApp.Tap (q => q.Marked ("Click"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36955.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36955.cs
@@ -42,23 +42,16 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = tv;
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Ignore("Test failing due to unrelated issue, disable for moment")]
 		[Test]
 		public void Bugzilla36955Test()
 		{
-			if (RunningApp is iOSApp)
-			{
-				AppResult[] buttonFalse = RunningApp.Query(q => q.Button().Text("False"));
-				Assert.AreEqual(buttonFalse.Length == 1, true);
-				RunningApp.Tap(q => q.Class("Switch"));
-				AppResult[] buttonTrue = RunningApp.Query(q => q.Button().Text("True"));
-				Assert.AreEqual(buttonTrue.Length == 1, true);
-			}
-			else
-			{
-				Assert.Inconclusive("Test is only run on iOS.");
-			}
+			AppResult[] buttonFalse = RunningApp.Query(q => q.Button().Text("False"));
+			Assert.AreEqual(buttonFalse.Length == 1, true);
+			RunningApp.Tap(q => q.Class("Switch"));
+			AppResult[] buttonTrue = RunningApp.Query(q => q.Button().Text("True"));
+			Assert.AreEqual(buttonTrue.Length == 1, true);
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2241.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2241.cs
@@ -37,7 +37,11 @@ namespace Xamarin.Forms.Controls
 		[Ignore("Fails intermittently on TestCloud")]
 		public void ChangeOrientationCheckScroll ()
 		{
-			var isAndroid = RunningApp is AndroidApp;
+#if __ANDROID__
+			var isAndroid = true;
+#else
+			var isAndroid = false;
+#endif
 			var className = "Xamarin_Forms_Platform_iOS_BoxRenderer";
 			if (isAndroid) {
 				className = "BoxRenderer";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2289.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2289.xaml.cs
@@ -43,75 +43,56 @@ namespace Xamarin.Forms.Controls
 
 		public ICommand DeleteCommand { get; protected set; }
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		[Ignore("Fails sometimes on XTC")]
 		public void TestIsEnabledFalse ()
 		{
-			if (RunningApp is iOSApp) {
-				var disable1 = RunningApp.Query (c => c.Marked ("txtCellDisable1")) [0];
-				Assert.IsFalse (disable1.Enabled);
-				var disable2 = RunningApp.Query (c => c.Marked ("txtCellDisable2")) [0];
-				Assert.IsFalse (disable2.Enabled);
-			}
+			var disable1 = RunningApp.Query (c => c.Marked ("txtCellDisable1")) [0];
+			Assert.IsFalse (disable1.Enabled);
+			var disable2 = RunningApp.Query (c => c.Marked ("txtCellDisable2")) [0];
+			Assert.IsFalse (disable2.Enabled);
 		}
 
 		[Test]
 		[Ignore("Fails sometimes on XTC")]
 		public void TestIsEnabledFalseContextActions ()
 		{
-			if (RunningApp is iOSApp) {
-				var disable1 = RunningApp.Query (c => c.Marked ("txtCellDisableContextActions1")) [0];
-				Assert.IsFalse (disable1.Enabled);
+			var disable1 = RunningApp.Query (c => c.Marked ("txtCellDisableContextActions1")) [0];
+			Assert.IsFalse (disable1.Enabled);
 
-				var screenBounds = RunningApp.Query (q => q.Raw ("* index:0")) [0].Rect;
+			var screenBounds = RunningApp.Query (q => q.Raw ("* index:0")) [0].Rect;
 
-				if (RunningApp is iOSApp) {
-					RunningApp.DragCoordinates (screenBounds.Width - 10, disable1.Rect.CenterY, 10, disable1.Rect.CenterY);
-				} else {
-					disable1 = RunningApp.Query (c => c.Marked ("txtCellDisableContextActions1")) [0];
-					RunningApp.TouchAndHoldCoordinates (disable1.Rect.CenterX, disable1.Rect.CenterY);
-				}
-				RunningApp.Screenshot ("Not showing context menu");
-				RunningApp.WaitForNoElement (c => c.Marked ("More"));
-				RunningApp.TapCoordinates (screenBounds.CenterX, screenBounds.CenterY);
-			}
+			RunningApp.DragCoordinates (screenBounds.Width - 10, disable1.Rect.CenterY, 10, disable1.Rect.CenterY);
+
+			RunningApp.Screenshot ("Not showing context menu");
+			RunningApp.WaitForNoElement (c => c.Marked ("More"));
+			RunningApp.TapCoordinates (screenBounds.CenterX, screenBounds.CenterY);
 		}
 
 		[Test]
 		[Ignore("Fails sometimes on XTC")]
 		public void TestIsEnabledTrue ()
 		{
-			if (RunningApp is iOSApp) {
-				var disable1 = RunningApp.Query (c => c.Marked ("txtCellEnable1")) [0];
-				Assert.IsTrue (disable1.Enabled);
-				var disable2 = RunningApp.Query (c => c.Marked ("txtCellEnable2")) [0];
-				Assert.IsTrue (disable2.Enabled);
-			}
-
+			var disable1 = RunningApp.Query (c => c.Marked ("txtCellEnable1")) [0];
+			Assert.IsTrue (disable1.Enabled);
+			var disable2 = RunningApp.Query (c => c.Marked ("txtCellEnable2")) [0];
+			Assert.IsTrue (disable2.Enabled);
 		}
 
 		[Test]
 		[Ignore("Fails sometimes on XTC")]
 		public void TestIsEnabledTrueContextActions ()
 		{
-			if (RunningApp is iOSApp) {
-				var disable1 = RunningApp.Query (c => c.Marked ("txtCellEnabledContextActions1")) [0];
-				Assert.IsTrue (disable1.Enabled);
+			var disable1 = RunningApp.Query (c => c.Marked ("txtCellEnabledContextActions1")) [0];
+			Assert.IsTrue (disable1.Enabled);
 
-				var screenBounds = RunningApp.Query (q => q.Raw ("* index:0")) [0].Rect;
+			var screenBounds = RunningApp.Query (q => q.Raw ("* index:0")) [0].Rect;
 
-				if (RunningApp is iOSApp) {
-					RunningApp.DragCoordinates (screenBounds.Width - 10, disable1.Rect.CenterY, 10, disable1.Rect.CenterY);
-				} else {
-					disable1 = RunningApp.Query (c => c.Marked ("txtCellEnabledContextActions1")) [0];
-					RunningApp.TouchAndHoldCoordinates (disable1.Rect.CenterX, disable1.Rect.CenterY);
-				}
+			RunningApp.DragCoordinates (screenBounds.Width - 10, disable1.Rect.CenterY, 10, disable1.Rect.CenterY);
 
-				RunningApp.Screenshot ("Showing context menu");
-				RunningApp.WaitForElement (c => c.Marked ("More"));
-			}
-
+			RunningApp.Screenshot ("Showing context menu");
+			RunningApp.WaitForElement (c => c.Marked ("More"));
 		}
 #endif
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2414.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2414.cs
@@ -63,15 +63,14 @@ namespace Xamarin.Forms.Controls
 			var screenBounds = RunningApp.Query (q => q.Raw ("* index:0"))[0].Rect;
 
 			var cell = RunningApp.Query (c => c.Marked ("Swipe ME")) [0];
-			if (RunningApp is iOSApp) {
-				RunningApp.DragCoordinates (screenBounds.Width - 10, cell.Rect.CenterY, 0, cell.Rect.CenterY);
-				//TODO: fix this when context menu bug is fixed
-				RunningApp.WaitForElement (c => c.Marked ("Text4"));
-			}
-			else {
-				RunningApp.TouchAndHoldCoordinates (cell.Rect.CenterX, cell.Rect.CenterY);
-				RunningApp.WaitForElement (c => c.Marked ("Text0"));
-			}
+#if __IOS__
+			RunningApp.DragCoordinates (screenBounds.Width - 10, cell.Rect.CenterY, 0, cell.Rect.CenterY);
+			//TODO: fix this when context menu bug is fixed
+			RunningApp.WaitForElement (c => c.Marked ("Text4"));
+#else
+			RunningApp.TouchAndHoldCoordinates (cell.Rect.CenterX, cell.Rect.CenterY);
+			RunningApp.WaitForElement (c => c.Marked ("Text0"));
+#endif
 			RunningApp.Screenshot ("Didn't crash");
 			RunningApp.TapCoordinates (screenBounds.CenterX, screenBounds.CenterY);
 		}
@@ -82,17 +81,18 @@ namespace Xamarin.Forms.Controls
 			var screenBounds = RunningApp.Query (q => q.Raw ("* index:0"))[0].Rect;
 
 			var cell = RunningApp.Query (c => c.Marked ("Swipe ME")) [0];
-			if (RunningApp is iOSApp)
-				RunningApp.DragCoordinates (screenBounds.Width -10, cell.Rect.CenterY, 0, cell.Rect.CenterY);
-			else
-				RunningApp.TouchAndHoldCoordinates (cell.Rect.CenterX, cell.Rect.CenterY);
+#if __IOS__
+			RunningApp.DragCoordinates (screenBounds.Width -10, cell.Rect.CenterY, 0, cell.Rect.CenterY);
+#else
+			RunningApp.TouchAndHoldCoordinates (cell.Rect.CenterX, cell.Rect.CenterY);
+#endif
 			RunningApp.WaitForElement (c => c.Marked ("Text0"));
 			RunningApp.Screenshot ("Are the menuitems in the right order?");
 
 		}
 #endif
 
-	}
+		}
 }
 
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2809.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2809.cs
@@ -38,14 +38,14 @@ namespace Xamarin.Forms.Controls
 
 		void ShouldShowMenu ()
 		{
-			if (RunningApp is AndroidApp) {
-				//show secondary menu
-				RunningApp.Tap (c => c.Class ("android.support.v7.widget.ActionMenuPresenter$OverflowMenuButton"));
-			}
+#if __ANDROID__
+			//show secondary menu
+			RunningApp.Tap (c => c.Class ("android.support.v7.widget.ActionMenuPresenter$OverflowMenuButton"));
+#endif
 		}
 
 #endif
 
-	}
+		}
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2948.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2948.cs
@@ -222,11 +222,11 @@ namespace Xamarin.Forms.Controls
 			return !isMasterVisible;
 		}
 		public void OpenMDP() {
-			if (RunningApp is iOSApp) {
-				RunningApp.Tap (q => q.Marked ("Menu"));
-			} else {
-				RunningApp.Tap ("ShowMasterBtn");
-			}				
+#if __IOS__
+			RunningApp.Tap (q => q.Marked ("Menu"));
+#else
+			RunningApp.Tap ("ShowMasterBtn");
+#endif
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2961.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2961.cs
@@ -279,22 +279,23 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Tap (c => c.Marked ("About"));
 			RunningApp.WaitForElement (c => c.Marked ("lblAbout"));
 			OpenMDP ("ShowMasterBtnAbout");
-			if(RunningApp is iOSApp)
-				return;
+#if __IOS__
+			return;
+#else
 			RunningApp.DoubleTap (c => c.Marked ("Home"));
 			RunningApp.WaitForElement (c => c.Marked ("lblHome"));
 			RunningApp.Tap (c => c.Marked ("About"));
 			RunningApp.WaitForNoElement (c => c.Marked ("Home"));
-		
+#endif
 		}
 
 		public void OpenMDP(string masterBtnId) {
-			if(RunningApp is iOSApp) {
-				RunningApp.Tap (q => q.Marked("Menu"));
-			} else {
-				RunningApp.Tap (masterBtnId);
-			}	
+#if __IOS__
+			RunningApp.Tap (q => q.Marked("Menu"));
+#else
+			RunningApp.Tap (masterBtnId);
+#endif
 		}
-		#endif
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2965.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2965.cs
@@ -131,22 +131,22 @@ namespace Xamarin.Forms.Controls
 			var element = RunningApp.WaitForElement (q => q.Marked ("lblCount"))[0];
 			Assert.That (element.Text, Is.EqualTo ("1"));
 
-			if(RunningApp is iOSApp)
-				RunningApp.Tap (q => q.Marked("Menu"));
-			else
-				RunningApp.Tap ("ShowMasterBtnPage1");
-
+#if __IOS__
+			RunningApp.Tap (q => q.Marked("Menu"));
+#else
+			RunningApp.Tap ("ShowMasterBtnPage1");
+#endif
 			RunningApp.Tap (q => q.Marked("btnDetail2"));
 
-			if(RunningApp is iOSApp)
-				RunningApp.Tap (q => q.Marked("Menu"));
-			else
-				RunningApp.Tap ("ShowMasterBtnPage2");
-			
+#if __IOS__
+			RunningApp.Tap (q => q.Marked("Menu"));
+#else
+			RunningApp.Tap ("ShowMasterBtnPage2");
+#endif
 			RunningApp.Tap (q => q.Marked("btnDetail1"));
 			element = RunningApp.WaitForElement (q => q.Marked ("lblCount"))[0];
 			Assert.That (element.Text, Is.EqualTo ("1"));
 		}
 #endif
+		}
 	}
-}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/SwipeBackNavCrash.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/SwipeBackNavCrash.cs
@@ -39,23 +39,23 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Screenshot ("At Second Page");
 		}
 
+#if __IOS__
 		[Test]
 		public void SwipeBackNavCrashTestsSwipeBackDoesNotCrash ()
 		{
-			if (RunningApp is iOSApp) {
-				RunningApp.WaitForElement (q => q.Marked ("Page One"));
-				RunningApp.Tap (q => q.Button ("Go to second page"));
-				RunningApp.WaitForElement (q => q.Marked ("Swipe lightly left and right to crash this page"));
-				System.Threading.Thread.Sleep (3);
+			RunningApp.WaitForElement (q => q.Marked ("Page One"));
+			RunningApp.Tap (q => q.Button ("Go to second page"));
+			RunningApp.WaitForElement (q => q.Marked ("Swipe lightly left and right to crash this page"));
+			System.Threading.Thread.Sleep (3);
 
-				var mainBounds = RunningApp.Query (q => q.Raw ("* index:0")) [0].Rect;
+			var mainBounds = RunningApp.Query (q => q.Raw ("* index:0")) [0].Rect;
 
-				Xamarin.Forms.Core.UITests.Gestures.Pan (RunningApp, new Xamarin.Forms.Core.UITests.Drag (mainBounds, 0, 125, 75, 125, Xamarin.Forms.Core.UITests.Drag.Direction.LeftToRight));
-				System.Threading.Thread.Sleep (3);
-				RunningApp.Screenshot ("Crash?");
-				RunningApp.WaitForElement (q => q.Marked ("Swipe lightly left and right to crash this page"));
-			}
+			Xamarin.Forms.Core.UITests.Gestures.Pan (RunningApp, new Xamarin.Forms.Core.UITests.Drag (mainBounds, 0, 125, 75, 125, Xamarin.Forms.Core.UITests.Drag.Direction.LeftToRight));
+			System.Threading.Thread.Sleep (3);
+			RunningApp.Screenshot ("Crash?");
+			RunningApp.WaitForElement (q => q.Marked ("Swipe lightly left and right to crash this page"));
 		}
+#endif
 #endif
 
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -1,0 +1,435 @@
+#if UITEST
+using System;
+using System.IO;
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+
+namespace Xamarin.Forms.Controls
+{
+	/// <summary>
+	/// Decorator for IApp which only takes screenshots if the SCREENSHOTS symbol  is specified
+	/// </summary>
+	internal class ScreenshotConditionalApp : IApp
+	{
+		readonly IApp _app;
+
+		public ScreenshotConditionalApp(IApp app)
+		{
+			_app = app;
+		}
+
+		public AppResult[] Query(Func<AppQuery, AppQuery> query = null)
+		{
+			return _app.Query(query);
+		}
+
+		public AppResult[] Query(string marked)
+		{
+			return _app.Query(marked);
+		}
+
+		public AppWebResult[] Query(Func<AppQuery, AppWebQuery> query)
+		{
+			return _app.Query(query);
+		}
+
+		public T[] Query<T>(Func<AppQuery, AppTypedSelector<T>> query)
+		{
+			return _app.Query(query);
+		}
+
+		public string[] Query(Func<AppQuery, InvokeJSAppQuery> query)
+		{
+			return _app.Query(query);
+		}
+
+		public AppResult[] Flash(Func<AppQuery, AppQuery> query = null)
+		{
+			return _app.Flash(query);
+		}
+
+		public AppResult[] Flash(string marked)
+		{
+			return _app.Flash(marked);
+		}
+
+		public void EnterText(string text)
+		{
+			_app.EnterText(text);
+		}
+
+		public void EnterText(Func<AppQuery, AppQuery> query, string text)
+		{
+			_app.EnterText(query, text);
+		}
+
+		public void EnterText(string marked, string text)
+		{
+			_app.EnterText(marked, text);
+		}
+
+		public void EnterText(Func<AppQuery, AppWebQuery> query, string text)
+		{
+			_app.EnterText(query, text);
+		}
+
+		public void ClearText(Func<AppQuery, AppQuery> query)
+		{
+			_app.ClearText(query);
+		}
+
+		public void ClearText(string marked)
+		{
+			_app.ClearText(marked);
+		}
+
+		public void ClearText()
+		{
+			_app.ClearText();
+		}
+
+		public void PressEnter()
+		{
+			_app.PressEnter();
+		}
+
+		public void DismissKeyboard()
+		{
+			_app.DismissKeyboard();
+		}
+
+		public void Tap(Func<AppQuery, AppQuery> query)
+		{
+			_app.Tap(query);
+		}
+
+		public void Tap(string marked)
+		{
+			_app.Tap(marked);
+		}
+
+		public void Tap(Func<AppQuery, AppWebQuery> query)
+		{
+			_app.Tap(query);
+		}
+
+		public void TapCoordinates(float x, float y)
+		{
+			_app.TapCoordinates(x, y);
+		}
+
+		public void TouchAndHold(Func<AppQuery, AppQuery> query)
+		{
+			_app.TouchAndHold(query);
+		}
+
+		public void TouchAndHold(string marked)
+		{
+			_app.TouchAndHold(marked);
+		}
+
+		public void TouchAndHoldCoordinates(float x, float y)
+		{
+			_app.TouchAndHoldCoordinates(x, y);
+		}
+
+		public void DoubleTap(Func<AppQuery, AppQuery> query)
+		{
+			_app.DoubleTap(query);
+		}
+
+		public void DoubleTap(string marked)
+		{
+			_app.DoubleTap(marked);
+		}
+
+		public void DoubleTapCoordinates(float x, float y)
+		{
+			_app.DoubleTapCoordinates(x, y);
+		}
+
+		public void PinchToZoomIn(Func<AppQuery, AppQuery> query, TimeSpan? duration = null)
+		{
+			_app.PinchToZoomIn(query, duration);
+		}
+
+		public void PinchToZoomIn(string marked, TimeSpan? duration = null)
+		{
+			_app.PinchToZoomIn(marked, duration);
+		}
+
+		public void PinchToZoomInCoordinates(float x, float y, TimeSpan? duration)
+		{
+			_app.PinchToZoomInCoordinates(x, y, duration);
+		}
+
+		public void PinchToZoomOut(Func<AppQuery, AppQuery> query, TimeSpan? duration = null)
+		{
+			_app.PinchToZoomOut(query, duration);
+		}
+
+		public void PinchToZoomOut(string marked, TimeSpan? duration = null)
+		{
+			_app.PinchToZoomOut(marked, duration);
+		}
+
+		public void PinchToZoomOutCoordinates(float x, float y, TimeSpan? duration)
+		{
+			_app.PinchToZoomOutCoordinates(x, y, duration);
+		}
+
+		public void WaitFor(Func<bool> predicate, string timeoutMessage = "Timed out waiting...", TimeSpan? timeout = null,
+			TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
+		{
+			_app.WaitFor(predicate, timeoutMessage, timeout, retryFrequency, postTimeout);
+		}
+
+		public AppResult[] WaitForElement(Func<AppQuery, AppQuery> query, string timeoutMessage = "Timed out waiting for element...",
+			TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
+		{
+			return _app.WaitForElement(query, timeoutMessage, timeout, retryFrequency, postTimeout);
+		}
+
+		public AppResult[] WaitForElement(string marked, string timeoutMessage = "Timed out waiting for element...",
+			TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
+		{
+			return _app.WaitForElement(marked, timeoutMessage, timeout, retryFrequency, postTimeout);
+		}
+
+		public AppWebResult[] WaitForElement(Func<AppQuery, AppWebQuery> query, string timeoutMessage = "Timed out waiting for element...",
+			TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
+		{
+			return _app.WaitForElement(query, timeoutMessage, timeout, retryFrequency, postTimeout);
+		}
+
+		public void WaitForNoElement(Func<AppQuery, AppQuery> query, string timeoutMessage = "Timed out waiting for no element...",
+			TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
+		{
+			_app.WaitForNoElement(query, timeoutMessage, timeout, retryFrequency, postTimeout);
+		}
+
+		public void WaitForNoElement(string marked, string timeoutMessage = "Timed out waiting for no element...",
+			TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
+		{
+			_app.WaitForNoElement(marked, timeoutMessage, timeout, retryFrequency, postTimeout);
+		}
+
+		public void WaitForNoElement(Func<AppQuery, AppWebQuery> query, string timeoutMessage = "Timed out waiting for no element...",
+			TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
+		{
+			_app.WaitForNoElement(query, timeoutMessage, timeout, retryFrequency, postTimeout);
+		}
+
+		public FileInfo Screenshot(string title)
+		{
+#if SCREENSHOTS
+			return _app.Screenshot(title);
+#else
+			return null;
+#endif
+		}
+
+		public void SwipeRight()
+		{
+#pragma warning disable 618
+			_app.SwipeRight();
+#pragma warning restore 618
+		}
+
+		public void SwipeLeftToRight(double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			_app.SwipeLeftToRight(swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void SwipeLeftToRight(string marked, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			_app.SwipeLeftToRight(marked, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void SwipeLeft()
+		{
+#pragma warning disable 618
+			_app.SwipeLeft();
+#pragma warning restore 618
+		}
+
+		public void SwipeRightToLeft(double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			_app.SwipeRightToLeft(swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void SwipeRightToLeft(string marked, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			_app.SwipeRightToLeft(marked, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void SwipeLeftToRight(Func<AppQuery, AppQuery> query, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			_app.SwipeLeftToRight(query, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void SwipeRightToLeft(Func<AppQuery, AppQuery> query, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			_app.SwipeRightToLeft(query, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void ScrollUp(Func<AppQuery, AppQuery> query = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500,
+			bool withInertia = true)
+		{
+			_app.ScrollUp(query, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void ScrollUp(string withinMarked, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500,
+			bool withInertia = true)
+		{
+			_app.ScrollUp(withinMarked, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void ScrollDown(Func<AppQuery, AppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67,
+			int swipeSpeed = 500, bool withInertia = true)
+		{
+			_app.ScrollDown(withinQuery, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void ScrollDown(string withinMarked, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500,
+			bool withInertia = true)
+		{
+			_app.ScrollDown(withinMarked, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public void ScrollTo(string toMarked, string withinMarked = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67,
+			int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
+		{
+			_app.ScrollTo(toMarked, withinMarked, strategy, swipePercentage, swipeSpeed, withInertia, timeout);
+		}
+
+		public void ScrollUpTo(string toMarked, string withinMarked = null, ScrollStrategy strategy = ScrollStrategy.Auto,
+			double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
+		{
+			_app.ScrollUpTo(toMarked, withinMarked, strategy, swipePercentage, swipeSpeed, withInertia, timeout);
+		}
+
+		public void ScrollUpTo(Func<AppQuery, AppWebQuery> toQuery, string withinMarked, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67,
+			int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
+		{
+			_app.ScrollUpTo(toQuery, withinMarked, strategy, swipePercentage, swipeSpeed, withInertia, timeout);
+		}
+
+		public void ScrollDownTo(string toMarked, string withinMarked = null, ScrollStrategy strategy = ScrollStrategy.Auto,
+			double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
+		{
+			_app.ScrollDownTo(toMarked, withinMarked, strategy, swipePercentage, swipeSpeed, withInertia, timeout);
+		}
+
+		public void ScrollDownTo(Func<AppQuery, AppWebQuery> toQuery, string withinMarked, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67,
+			int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
+		{
+			_app.ScrollDownTo(toQuery, withinMarked, strategy, swipePercentage, swipeSpeed, withInertia, timeout);
+		}
+
+		public void ScrollUpTo(Func<AppQuery, AppQuery> toQuery, Func<AppQuery, AppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67,
+			int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
+		{
+			_app.ScrollUpTo(toQuery, withinQuery, strategy, swipePercentage, swipeSpeed, withInertia, timeout);
+		}
+
+		public void ScrollUpTo(Func<AppQuery, AppWebQuery> toQuery, Func<AppQuery, AppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67,
+			int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
+		{
+			_app.ScrollUpTo(toQuery, withinQuery, strategy, swipePercentage, swipeSpeed, withInertia, timeout);
+		}
+
+		public void ScrollDownTo(Func<AppQuery, AppQuery> toQuery, Func<AppQuery, AppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67,
+			int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
+		{
+			_app.ScrollDownTo(toQuery, withinQuery, strategy, swipePercentage, swipeSpeed, withInertia, timeout);
+		}
+
+		public void ScrollDownTo(Func<AppQuery, AppWebQuery> toQuery, Func<AppQuery, AppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67,
+			int swipeSpeed = 500, bool withInertia = true, TimeSpan? timeout = null)
+		{
+			_app.ScrollDownTo(toQuery, withinQuery, strategy, swipePercentage, swipeSpeed, withInertia, timeout);
+		}
+
+		public void SetOrientationPortrait()
+		{
+			_app.SetOrientationPortrait();
+		}
+
+		public void SetOrientationLandscape()
+		{
+			_app.SetOrientationLandscape();
+		}
+
+		public void Repl()
+		{
+			_app.Repl();
+		}
+
+		public void Back()
+		{
+			_app.Back();
+		}
+
+		public void PressVolumeUp()
+		{
+			_app.PressVolumeUp();
+		}
+
+		public void PressVolumeDown()
+		{
+			_app.PressVolumeDown();
+		}
+
+		public object Invoke(string methodName, object argument = null)
+		{
+			return _app.Invoke(methodName, argument);
+		}
+
+		public object Invoke(string methodName, object[] arguments)
+		{
+			return _app.Invoke(methodName, arguments);
+		}
+
+		public void DragCoordinates(float fromX, float fromY, float toX, float toY)
+		{
+			_app.DragCoordinates(fromX, fromY, toX, toY);
+		}
+
+		public void DragAndDrop(Func<AppQuery, AppQuery> @from, Func<AppQuery, AppQuery> to)
+		{
+			_app.DragAndDrop(@from, to);
+		}
+
+		public void DragAndDrop(string @from, string to)
+		{
+			_app.DragAndDrop(@from, to);
+		}
+
+		public void SetSliderValue(string marked, double value)
+		{
+			_app.SetSliderValue(marked, value);
+		}
+
+		public void SetSliderValue(Func<AppQuery, AppQuery> query, double value)
+		{
+			_app.SetSliderValue(query, value);
+		}
+
+		public AppPrintHelper Print
+		{
+			get { return _app.Print; }
+		}
+
+		public IDevice Device
+		{
+			get { return _app.Device; }
+		}
+
+		public ITestServer TestServer
+		{
+			get { return _app.TestServer; }
+		}
+	}
+}
+#endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Controls
 		{
 			IApp app = null;
 #if __ANDROID__
-			app = ConfigureApp.Android.ApkFile (AppPaths.ApkPath).Debug ().EnableLocalScreenshots().StartApp ();
+			app = ConfigureApp.Android.ApkFile (AppPaths.ApkPath).Debug ().StartApp ();
 #elif __IOS__ 
 			app = ConfigureApp.iOS.InstalledApp (AppPaths.BundleId).Debug ()
 				//Uncomment to run from a specific iOS SIM, get the ID from XCode -> Devices

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -8,12 +8,12 @@ using Xamarin.Forms.CustomAttributes;
 #if UITEST
 using NUnit.Framework;
 using Xamarin.UITest;
-using Xamarin.UITest.Queries;
+
 #endif
 
 namespace Xamarin.Forms.Controls
 {
-    internal static class AppPaths
+	internal static class AppPaths
     {
         public static string ApkPath = "../../../Xamarin.Forms.ControlGallery.Android/bin/Debug/AndroidControlGallery.AndroidControlGallery-Signed.apk";
 
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Controls
 		{
 			IApp app = null;
 #if __ANDROID__
-			app = ConfigureApp.Android.ApkFile (AppPaths.ApkPath).Debug ().StartApp ();
+			app = ConfigureApp.Android.ApkFile (AppPaths.ApkPath).Debug ().EnableLocalScreenshots().StartApp ();
 #elif __IOS__ 
 			app = ConfigureApp.iOS.InstalledApp (AppPaths.BundleId).Debug ()
 				//Uncomment to run from a specific iOS SIM, get the ID from XCode -> Devices
@@ -39,7 +39,8 @@ namespace Xamarin.Forms.Controls
 			if (app == null)
 				throw new NullReferenceException ("App was not initialized.");
 
-			return app;
+			// Wrap the app in ScreenshotConditional so it only takes screenshots if the SCREENSHOTS symbol is specified
+			return new ScreenshotConditionalApp(app);
 		}
 
 		static void NavigateToIssue (Type type, IApp app)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -147,6 +147,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39829.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestPages\ScreenshotConditionalApp.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
-
+using Xamarin.Forms.Controls;
 using Xamarin.UITest;
 using Xamarin.UITest.Queries;
 
@@ -70,7 +70,9 @@ namespace Xamarin.Forms.Core.UITests
 				// if at first you dont succeed
 				RunningApp.Restart ();
 			}
-			App = RunningApp.App;
+
+			// Wrap the app in ScreenshotConditional so it only takes screenshots if the SCREENSHOTS symbol is specified
+			App = new ScreenshotConditionalApp(RunningApp.App);
 
 			App.SetOrientationPortrait ();
 			ScreenBounds = App.RootViewRect ();

--- a/Xamarin.Forms.Core.iOS.UITests/Remotes/BaseViewContainerRemote.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Remotes/BaseViewContainerRemote.cs
@@ -136,9 +136,9 @@ namespace Xamarin.Forms.Core.UITests
 			bool found = false;
 
 			bool isEdgeCase = false;
-			if (App is AndroidApp && formProperty == View.ScaleProperty)
-				isEdgeCase = true;
-		
+#if __ANDROID__
+			isEdgeCase = (formProperty == View.ScaleProperty);
+#endif
 		    if (!isEdgeCase) {
 			    found =
 					MaybeGetProperty<string> (App, query, propertyPath, out prop) ||
@@ -147,8 +147,8 @@ namespace Xamarin.Forms.Core.UITests
 					MaybeGetProperty<object> (App, query, propertyPath, out prop);
 		    }
 
-			
-			if (App is AndroidApp && formProperty == View.ScaleProperty) {
+#if __ANDROID__
+			if (formProperty == View.ScaleProperty) {
 				var matrix = new Matrix ();
 				matrix.M00 = App.Query (q => q.Raw (query).Invoke (propertyPath[0]).Value<float> ()).First ();
 				matrix.M11 = App.Query (q => q.Raw (query).Invoke (propertyPath[1]).Value<float> ()).First ();
@@ -156,6 +156,7 @@ namespace Xamarin.Forms.Core.UITests
 				matrix.M33 = 1.0f;
 				return (T)((object)matrix);
 			}
+#endif
 
 			if (!found || prop == null) {
 				throw new NullReferenceException ("null property");
@@ -170,24 +171,22 @@ namespace Xamarin.Forms.Core.UITests
 			}
 
 			if (typeof(T) == typeof(Color)) {
-				if (App is iOSApp) {
-					Color color = ParsingUtils.ParseUIColor ((string)prop);
-					return (T)((object)color);
-				} else {
-					uint intColor = (uint)((float)prop);
-					Color color = Color.FromUint (intColor);
-					return (T)((object)color);
-				}
+#if __IOS__
+				Color color = ParsingUtils.ParseUIColor ((string)prop);
+				return (T)((object)color);
+#else
+				uint intColor = (uint)((float)prop);
+				Color color = Color.FromUint (intColor);
+				return (T)((object)color);
+#endif
 			}
 
+#if __IOS__
 			if (prop.GetType () == typeof (string) && typeof(T) == typeof(Font)) {
-				if (App is iOSApp) {
-					Font font = ParsingUtils.ParseUIFont ((string)prop);
-					return (T)((object)font);
-				} else {
-					
-				}
+				Font font = ParsingUtils.ParseUIFont ((string)prop);
+				return (T)((object)font);
 			}
+#endif
 
 			T result = default(T);
 

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/ButtonUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/ButtonUITests.cs
@@ -64,11 +64,11 @@ namespace Xamarin.Forms.Core.UITests
 			var remote = new ViewContainerRemote (App, Test.Button.BorderRadius, PlatformViewType);
 			remote.GoTo ();
 
-			if (App is iOSApp) {
-				var borderRadius = remote.GetProperty<float> (Button.BorderRadiusProperty);
-				Assert.AreEqual (20.0f, borderRadius);
-			}
-			
+#if __IOS__
+			var borderRadius = remote.GetProperty<float> (Button.BorderRadiusProperty);
+			Assert.AreEqual (20.0f, borderRadius);
+#endif
+
 		}
 
 		[Test]
@@ -79,10 +79,10 @@ namespace Xamarin.Forms.Core.UITests
 			var remote = new ViewContainerRemote (App, Test.Button.BorderWidth, PlatformViewType);
 			remote.GoTo ();
 
-			if (App is iOSApp) {
-				var borderWidth = remote.GetProperty<float> (Button.BorderWidthProperty);
+#if __IOS__
+			var borderWidth = remote.GetProperty<float> (Button.BorderWidthProperty);
 				Assert.AreEqual (15.0f, borderWidth);
-			}
+#endif
 
 		}
 
@@ -124,14 +124,13 @@ namespace Xamarin.Forms.Core.UITests
 			var remote = new ViewContainerRemote (App, Test.Button.Font, PlatformViewType);
 			remote.GoTo ();
 
-			if (App is AndroidApp) {
-				var isBold = remote.GetProperty<bool> (Button.FontProperty);
-				Assert.True (isBold);
-			} else {
-				var font = remote.GetProperty<Font> (Button.FontProperty);
-				Assert.True (font.FontAttributes.HasFlag (FontAttributes.Bold));
-			}
-
+#if __ANDROID__
+			var isBold = remote.GetProperty<bool> (Button.FontProperty);
+			Assert.True (isBold);
+#else
+			var font = remote.GetProperty<Font> (Button.FontProperty);
+			Assert.True (font.FontAttributes.HasFlag (FontAttributes.Bold));
+#endif
 		}
 
 		[Test]
@@ -155,19 +154,20 @@ namespace Xamarin.Forms.Core.UITests
 			Assert.AreEqual ("Text", buttonText);
 		}
 
+		//TODO iOS
+
+#if __ANDROID__
 		[Test]
 		[UiTest (typeof (Button), "TextColor")]
 		public void TextColor ()
 		{
-			//TODO iOS
-			if (App is AndroidApp) {
-				var remote = new ViewContainerRemote (App, Test.Button.TextColor, PlatformViewType);
-				remote.GoTo ();
+			var remote = new ViewContainerRemote (App, Test.Button.TextColor, PlatformViewType);
+			remote.GoTo ();
 
-				var buttonTextColor = remote.GetProperty<Color> (Button.TextColorProperty);
-				Assert.AreEqual (Color.Pink, buttonTextColor);
-			}
+			var buttonTextColor = remote.GetProperty<Color> (Button.TextColorProperty);
+			Assert.AreEqual (Color.Pink, buttonTextColor);
 		}
+#endif
 
 		protected override void FixtureTeardown ()
 		{

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/ContextActionsUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/ContextActionsUITests.cs
@@ -31,58 +31,56 @@ namespace Xamarin.Forms.Core.UITests
 		const string clear = "Clear Items";
 		const string mark = "Mark";
 
+
+#if __ANDROID__
 		[Test]
 		public void ContextActionsShow ()
 		{
-			if (App is AndroidApp) {
-				// mark is an icon on android
-				App.TouchAndHold (q => q.Marked (cell0));
-				App.WaitForElement (q => q.Marked (delete));
-				App.Screenshot ("I have actions!");
-			} else if (App is iOSApp) {
-				Assert.Inconclusive ("Not tested on iOS yet");
-			}
+			// mark is an icon on android
+			App.TouchAndHold (q => q.Marked (cell0));
+			App.WaitForElement (q => q.Marked (delete));
+			App.Screenshot ("I have actions!");
 		}
 
 		[Test]
 		public void ContextActionsDelete ()
 		{
-			if (App is AndroidApp) {
-				// mark is an icon on android
-				App.TouchAndHold (q => q.Marked (cell0));
-				App.WaitForElement (q => q.Marked (delete));
-				App.Screenshot ("I have actions!");
+			// mark is an icon on android
+			App.TouchAndHold (q => q.Marked (cell0));
+			App.WaitForElement (q => q.Marked (delete));
+			App.Screenshot ("I have actions!");
 
-				App.Tap (q => q.Marked (delete));
-				App.WaitForNoElement (q => q.Marked (cell0));
-				App.Screenshot ("Deleted cell 0");
-
-			} else if (App is iOSApp) {
-				Assert.Inconclusive ("Not tested on iOS yet");
-			}
+			App.Tap (q => q.Marked (delete));
+			App.WaitForNoElement (q => q.Marked (cell0));
+			App.Screenshot ("Deleted cell 0");
 		}
+#endif
 
+#if __IOS__
 		[Test]
 		public void PopoverDismiss()
 		{
-			if (App is iOSApp) {
-				var app = ((iOSApp)App);
-				if (app.Device.IsTablet) {
-					var screenBounds = App.Query (PlatformQueries.Root)[0].Rect;
-					var cellBounds = App.Query (q => q.Marked (cell0))[0].Rect;
-					App.DragCoordinates (screenBounds.Width - 10, cellBounds.CenterY, 10, cellBounds.CenterY);
-					App.Screenshot("I see context actions");
-					App.Tap (q => q.Marked ("More"));
-					App.Screenshot ("Should see Popover");
-					App.TapCoordinates (50, 50);
-					App.Screenshot ("I should not crash");
-				} else {
-					Assert.Inconclusive("Not testing iOS Phone");
-				}
+			var device = App.Device as iOSDevice;
+
+			if (device == null)
+			{
+				return;
+			}
+
+			if (device.IsTablet) {
+				var screenBounds = App.Query (PlatformQueries.Root)[0].Rect;
+				var cellBounds = App.Query (q => q.Marked (cell0))[0].Rect;
+				App.DragCoordinates (screenBounds.Width - 10, cellBounds.CenterY, 10, cellBounds.CenterY);
+				App.Screenshot("I see context actions");
+				App.Tap (q => q.Marked ("More"));
+				App.Screenshot ("Should see Popover");
+				App.TapCoordinates (50, 50);
+				App.Screenshot ("I should not crash");
 			} else {
-				Assert.Inconclusive ("Not testing on Android");
+				Assert.Inconclusive("Not testing iOS Phone");
 			}
 		}
+#endif
 	}
 
 	[TestFixture]
@@ -107,23 +105,20 @@ namespace Xamarin.Forms.Core.UITests
 		const string mark = "Mark";
 		const string cellWithNoContextActions = "I have no ContextActions";
 
+#if __ANDROID__
 		[Test]
 		public void ContextActionsShowAndReset ()
 		{
-			if (App is AndroidApp) {
-				// mark is an icon on android
-				App.TouchAndHold (q => q.Marked (cell0));
-				App.WaitForElement (q => q.Marked (delete));
-				App.Screenshot ("I have actions!");
+			// mark is an icon on android
+			App.TouchAndHold (q => q.Marked (cell0));
+			App.WaitForElement (q => q.Marked (delete));
+			App.Screenshot ("I have actions!");
 				
-				App.Tap (q => q.Marked (cellWithNoContextActions));
-				App.WaitForNoElement (q => q.Marked (delete));
-				App.Screenshot ("Actions should be gone");
-
-			} else if (App is iOSApp) {
-				Assert.Inconclusive ("Not tested on iOS yet");
-			}
+			App.Tap (q => q.Marked (cellWithNoContextActions));
+			App.WaitForNoElement (q => q.Marked (delete));
+			App.Screenshot ("Actions should be gone");
 		}
+#endif
 	}
 }
 

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/EntryUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/EntryUITests.cs
@@ -53,11 +53,7 @@ namespace Xamarin.Forms.Core.UITests
 
 			App.EnterText (q=> q.Raw (remote.ViewQuery), "Test");
 
-			if (App is AndroidApp) {
-				((AndroidApp)App).PressUserAction (UserAction.Done);
-			} else {
-				App.PressEnter ();
-			}
+			App.PressEnter ();
 
 			var eventLabelText = remote.GetEventLabel ().Text;
 			Assert.AreEqual (eventLabelText, "Event: Completed (fired 1)");

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/Legacy-CellsUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/Legacy-CellsUITests.cs
@@ -248,11 +248,8 @@ namespace Xamarin.Forms.Core.UITests
 			App.Tap (PlatformQueries.EntryCellWithPlaceholder ("I am a placeholder"));
 			App.EnterText (PlatformQueries.EntryCellWithPlaceholder ("I am a placeholder"), "Hi");
 			App.Screenshot ("Entered Text");
-			if (App is AndroidApp) {
-				((AndroidApp)App).PressUserAction (UserAction.Done);
-			} else {
-				App.PressEnter ();
-			}
+			App.PressEnter ();
+			
 			App.WaitForElement (q => q.Marked ("Entered: 1"));
 			App.Screenshot ("Completed should have changed label's text");
 		}

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/RootGalleryUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/RootGalleryUITests.cs
@@ -78,8 +78,15 @@ namespace Xamarin.Forms.Core.UITests
 				var scrollViewArea = App.Query (q => q.Marked ("ChoosePageScrollView")).First ().Rect;
 				App.ScrollForElement (string.Format("* marked:'{0}'", page.ButtonId), new Drag (scrollViewArea, Drag.Direction.BottomToTop, Drag.DragLength.Long));
 				App.Tap (q => q.Marked (page.ButtonId));
-				if(!page.IsModal || App is iOSApp)
+
+				var ios = false;
+#if __IOS__
+				ios = true;	
+#endif
+
+				if (!page.IsModal || ios)
 					App.WaitForElement (q => q.Marked (page.PageId));
+
 				App.Screenshot ("Page: " + page.PageId);
 			}
 		}

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/ToolbarItemTests.cs
@@ -12,8 +12,9 @@ namespace Xamarin.Forms.Core.UITests
 	{
 		string btn1Id = "tb1";
 		string btn4Id = "tb4";
-
+#if __ANDROID__
 		static bool isSecondaryMenuOpen = false;
+#endif
 		static void ShouldShowMenu ()
 		{
 #if __ANDROID__

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/ToolbarItemTests.cs
@@ -16,28 +16,30 @@ namespace Xamarin.Forms.Core.UITests
 		static bool isSecondaryMenuOpen = false;
 		static void ShouldShowMenu ()
 		{
-			if (App is AndroidApp) {
-				isSecondaryMenuOpen = true;
-				//show secondary menu
-				App.Tap (c => c.Class ("android.support.v7.widget.ActionMenuPresenter$OverflowMenuButton"));
-			}
+#if __ANDROID__
+			isSecondaryMenuOpen = true;
+			//show secondary menu
+			App.Tap (c => c.Class ("android.support.v7.widget.ActionMenuPresenter$OverflowMenuButton"));
+#endif
 		}
 
 		static void ShouldHideMenu ()
 		{
-			if (App is AndroidApp && isSecondaryMenuOpen) {
+#if __ANDROID__
+			if (isSecondaryMenuOpen) {
 				isSecondaryMenuOpen = false;
 				App.Back ();	
 			}
+#endif
 		}
 
 		protected override void NavigateToGallery ()
 		{
 			App.NavigateToGallery (GalleryQueries.ToolbarItemGallery);
-			if (App is iOSApp) {
-				btn1Id = "menuIcon";
-				btn4Id = "tb4";
-			}
+#if __IOS__
+			btn1Id = "menuIcon";
+			btn4Id = "tb4";
+#endif
 		}
 
 		[Test]
@@ -51,12 +53,11 @@ namespace Xamarin.Forms.Core.UITests
 		public void ToolbarButtonsCommand ()
 		{
 			ShouldShowMenu ();
-			if (App is AndroidApp) {
-				//App.Query (c => c.Marked (btn4Id))[0];
-			}
-			else {
-				App.Tap (c => c.Marked (btn4Id));
-			}
+#if __ANDROID__
+			//App.Query (c => c.Marked (btn4Id))[0];
+#else
+			App.Tap (c => c.Marked (btn4Id));
+#endif
 		}
 
 		[Test]
@@ -93,8 +94,9 @@ namespace Xamarin.Forms.Core.UITests
 			var btn1 = App.Query (c => c.Marked (btn1Id)) [0];
 			ShouldShowMenu ();
 			var btn2 = App.Query (c => c.Marked ("tb4")) [0];
-			if(App is iOSApp)
-				Assert.True (btn1.Rect.CenterY < btn2.Rect.CenterY);
+#if __IOS__
+			Assert.True (btn1.Rect.CenterY < btn2.Rect.CenterY);
+#endif
 		}
 
 	}

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/ViewUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/ViewUITests.cs
@@ -20,20 +20,7 @@ namespace Xamarin.Forms.Core.UITests
 		//[UiTest (Test.VisualElement.AnchorX)]
 		public virtual void _AnchorX ()
 		{
-			//var remote = RemoteFactory.CreateRemote<StateViewContainerRemote> (App, "AnchorX", PlatformViewType);
-			//remote.GoTo ();
-
-			////App.LogPropertiesForView (remote.ViewQuery, true);
-
-			//if (App is AndroidApp) {
-			//	var anchorX = remote.GetProperty<float> (View.AnchorXProperty);
-			//	var viewWidth = remote.GetView ().Rect.Width;
-			//	Assert.AreEqual (anchorX, 0.25 * viewWidth);
-			//} else if (App is iOSApp) {
-			//	var anchorXMatrix = remote.GetProperty<Matrix> (View.AnchorXProperty);
-			//	var viewWidth = remote.GetView ().Rect.Width;
-			//	Assert.AreEqual (anchorXMatrix.M30, 0 - (viewWidth * 0.25f));
-			//} 
+			
 		}
 
 		// [Test]
@@ -41,18 +28,7 @@ namespace Xamarin.Forms.Core.UITests
 		// TODO: working on some views, others not
 		public virtual void _AnchorY ()
 		{
-			//var remote = RemoteFactory.CreateRemote<StateViewContainerRemote> (App, "AnchorY", PlatformViewType);
-			//remote.GoTo ();
-
-			//if (App is AndroidApp) {
-			//	var anchorY = remote.GetProperty<float> (View.AnchorYProperty);
-			//	var viewHeight = remote.GetView ().Rect.Height;
-			//	Assert.AreEqual (anchorY, viewHeight);
-			//} else if (App is iOSApp) {
-			//	var anchorYMatrix = remote.GetProperty<Matrix> (View.AnchorYProperty);
-			//	var viewHeight = remote.GetView ().Rect.Height;
-			//	Assert.AreEqual (anchorYMatrix.M31, viewHeight / 2.0f);
-			//} 
+			
 		}
 
 		// [Test]
@@ -175,16 +151,17 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			var remote = new ViewContainerRemote (App, Test.VisualElement.Rotation, PlatformViewType);
 			remote.GoTo ();
-			
-			if (App is AndroidApp) {
-				var rotation = remote.GetProperty<float> (View.RotationProperty);
-				Assert.AreEqual (10.0f, rotation);
-			} else if (App is iOSApp) {
-				var rotationMatrix = remote.GetProperty<Matrix> (View.RotationProperty);
-				Matrix generatedMatrix = NumericExtensions.CalculateRotationMatrixForDegrees (10, Axis.Z);
-				Assert.AreEqual (generatedMatrix, rotationMatrix);
-			}
-		}
+
+#if __ANDROID__
+			var rotation = remote.GetProperty<float> (View.RotationProperty);
+			Assert.AreEqual (10.0f, rotation);
+#endif
+#if __IOS__
+			var rotationMatrix = remote.GetProperty<Matrix> (View.RotationProperty);
+			Matrix generatedMatrix = NumericExtensions.CalculateRotationMatrixForDegrees (10, Axis.Z);
+			Assert.AreEqual (generatedMatrix, rotationMatrix);
+#endif
+}
 
 		[Test]
 		[UiTest (typeof (VisualElement), "RotationX")]
@@ -193,14 +170,15 @@ namespace Xamarin.Forms.Core.UITests
 			var remote = new ViewContainerRemote (App, Test.VisualElement.RotationX, PlatformViewType);
 			remote.GoTo ();
 
-			if (App is AndroidApp) {
-				var rotationX = remote.GetProperty<float> (View.RotationXProperty);
-				Assert.AreEqual (33.0f, rotationX);
-			} else if (App is iOSApp) {
-				var rotationXMatrix = remote.GetProperty<Matrix> (View.RotationXProperty);
-				Matrix matrix = NumericExtensions.CalculateRotationMatrixForDegrees (33.0f, Axis.X);
-				Assert.AreEqual (matrix, rotationXMatrix);
-			}
+#if __ANDROID__
+			var rotationX = remote.GetProperty<float> (View.RotationXProperty);
+			Assert.AreEqual (33.0f, rotationX);
+#endif
+#if __IOS__
+			var rotationXMatrix = remote.GetProperty<Matrix> (View.RotationXProperty);
+			Matrix matrix = NumericExtensions.CalculateRotationMatrixForDegrees (33.0f, Axis.X);
+			Assert.AreEqual (matrix, rotationXMatrix);
+#endif
 		}
 
 		[Test]
@@ -210,14 +188,15 @@ namespace Xamarin.Forms.Core.UITests
 			var remote = new ViewContainerRemote (App, Test.VisualElement.RotationY, PlatformViewType);
 			remote.GoTo ();
 
-			if (App is AndroidApp) {
-				var rotationY = remote.GetProperty<float> (View.RotationYProperty);
-				Assert.AreEqual (10.0f, rotationY);
-			} else if (App is iOSApp) {
-				var rotationYMatrix = remote.GetProperty<Matrix> (View.RotationYProperty);
-				Matrix matrix = NumericExtensions.CalculateRotationMatrixForDegrees (10.0f, Axis.Y);
-				Assert.AreEqual (matrix, rotationYMatrix);
-			}
+#if __ANDROID__
+			var rotationY = remote.GetProperty<float> (View.RotationYProperty);
+			Assert.AreEqual (10.0f, rotationY);
+#endif
+#if __IOS__
+			var rotationYMatrix = remote.GetProperty<Matrix> (View.RotationYProperty);
+			Matrix matrix = NumericExtensions.CalculateRotationMatrixForDegrees (10.0f, Axis.Y);
+			Assert.AreEqual (matrix, rotationYMatrix);
+#endif
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/WebViewUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/WebViewUITests.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[Category ("ManualReview")]
+		[Ignore("Keep empty test from failing in Test Cloud")]
 		public override void _IsVisible () {}
 
 		[UiTestExempt (ExemptReason.CannotTest, "Invalid interaction with Label")]
@@ -51,31 +52,38 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[Category ("ManualReview")]
+		[Ignore("Keep empty test from failing in Test Cloud")]
 		public override void _Opacity () {}
 
 		[Test]
 		[Category ("ManualReview")]
+		[Ignore("Keep empty test from failing in Test Cloud")]
 		public override void _Rotation () {}
 
 		[Test]
 		[Category ("ManualReview")]
+		[Ignore("Keep empty test from failing in Test Cloud")]
 		public override void _RotationX () {}
 
 		[Test]
 		[Category ("ManualReview")]
+		[Ignore("Keep empty test from failing in Test Cloud")]
 		public override void _RotationY () {}
 
 
 		[Test]
 		[Category ("ManualReview")]
+		[Ignore("Keep empty test from failing in Test Cloud")]
 		public override void _TranslationX () {}
 
 		[Test]
 		[Category ("ManualReview")]
+		[Ignore("Keep empty test from failing in Test Cloud")]
 		public override void _TranslationY () {}
 
 		[Test]
 		[Category ("ManualReview")]
+		[Ignore("Keep empty test from failing in Test Cloud")]
 		public override void _Scale () {}
 
 		[UiTestExempt (ExemptReason.CannotTest, "Invalid interaction with Label")]

--- a/Xamarin.Forms.Core.iOS.UITests/Utilities/ViewInspector.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Utilities/ViewInspector.cs
@@ -12,15 +12,17 @@ namespace Xamarin.Forms.Core.UITests
 	{
 	    public static void LogPropertiesForView (this IApp app, string query, bool isOnParent = false)
 	    {
-	        if (app is AndroidApp) {
-	            LogPropertiesForAndroidView ((AndroidApp)app, query, isOnParent);
-	        } else {
-	            LogPropertiesForUIView ((iOSApp)app, query, isOnParent);
-                LogPropertiesForCALayer ((iOSApp)app, query, isOnParent);
-	        }
-	    }
+#if __ANDROID__
+			LogPropertiesForAndroidView (app, query, isOnParent);
+#endif
+#if __IOS__
 
-		static void LogPropertiesForUIView (this iOSApp app, string query, bool isOnParent = false) {
+			LogPropertiesForUIView(app, query, isOnParent);
+			LogPropertiesForCALayer (app, query, isOnParent);
+#endif
+		}
+
+		static void LogPropertiesForUIView (this IApp app, string query, bool isOnParent = false) {
 
             //Logger.LogLine ("--- UIView Properties ---");
 
@@ -75,7 +77,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		}
 
-		static void LogPropertiesForCALayer(this iOSApp app, string query, bool isOnParent = false)
+		static void LogPropertiesForCALayer(this IApp app, string query, bool isOnParent = false)
         {
            // Logger.LogLine ("--- UIView.Layer Properties ---");
 
@@ -150,7 +152,7 @@ namespace Xamarin.Forms.Core.UITests
 
         }
 
-		static void LogPropertiesForAndroidView (this AndroidApp app, string query, bool isOnParent = false)
+		static void LogPropertiesForAndroidView (this IApp app, string query, bool isOnParent = false)
 		{
            // Logger.LogLine( "--- Android View Properties ---");
 
@@ -317,7 +319,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		}
 
-		static bool MaybeGetLayerProperty<T> (iOSApp app, string query, string property, out object result)
+		static bool MaybeGetLayerProperty<T> (IApp app, string query, string property, out object result)
 		{
 
 			try {


### PR DESCRIPTION
### Description of Change ###

Wraps the usual IApp used in UI tests with a version which will only take screenshots if the SCREENSHOTS symbol is defined during build. 

The goal is to reduce the number of screenshots we ask Test Cloud to take during each run, since screenshots are an expensive operation. If a screenshot is required to debug a specific test, the SCREENSHOTS symbol can be defined in a build and uploaded to test cloud; otherwise it can remain off. 

This is a proof-of-concept at the moment; I'm running it through the UI test process to get some actual performance data. 

