### PR TITLE
[UWP/8.1] Buttons not respecting a BorderWidth of 0

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40943.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40943.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40943, "[UWP/8.1] Buttons are not respecting a BorderWidth of 0")]
+	public class Bugzilla40943 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = "An explicit BorderWidth of 0 should be respected on UWP and 8.1"
+					},
+					new Button
+					{
+						Text = "Button with BorderWidth of 0 and Lime BorderColor",
+						FontSize = 10,
+						BackgroundColor = Color.Gray,
+						BorderColor = Color.Lime,
+						BorderWidth = 0
+					},
+					new Button
+					{
+						Text = "Button without explicit BorderWidth and Default BorderColor",
+						FontSize = 10
+					},
+					new Button
+					{
+						Text = "Button with BorderWidth of 5 and Blue BorderColor",
+						FontSize = 10,
+						BorderColor = Color.Blue,
+						BorderWidth = 5
+					}
+				},
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -101,6 +101,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40173.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39821.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40185.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40943.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(Button), FontAttributes.None,
 			propertyChanged: SpecificFontPropertyChanged);
 
-		public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create("BorderWidth", typeof(double), typeof(Button), 0d);
+		public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create("BorderWidth", typeof(double), typeof(Button), DefaultBorderWidth);
 
 		public static readonly BindableProperty BorderColorProperty = BindableProperty.Create("BorderColor", typeof(Color), typeof(Button), Color.Default);
 
@@ -237,6 +237,28 @@ namespace Xamarin.Forms
 		{
 			if (oldvalue != null)
 				oldvalue.SourceChanged -= OnSourceChanged;
+		}
+
+		// Windows 8.1/WP 8.1 have a different default behavior where if the BorderThickness is not explicitly set, it
+		// uses a BorderThickness of 2.5 on all sides on phone devices, and 2 otherwise. Because the BorderWidthProperty
+		// was otherwise set to 0d, it was not accounting for scenarios where a user did in fact want the button's border
+		// to be 0. If it is already 0 by default, the 8.1 Control's BorderThickness couldn't be properly compared. This
+		// private property to allow BorderWidthProperty to bind to for its correct default value and still uses 0 for
+		// the other platforms.
+		static double DefaultBorderWidth
+		{
+			get
+			{
+				double _value = 0d;
+				Device.OnPlatform(WinPhone: () =>
+				{
+					if (Device.Idiom == TargetIdiom.Phone)
+						_value = 2.5d;
+					else
+						_value = 2d;
+				});
+				return _value;
+			}
 		}
 
 		static void SpecificFontPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
@@ -44,12 +44,10 @@ namespace Xamarin.Forms.Platform.WinRT
 				if (Element.BorderColor != Color.Default)
 					UpdateBorderColor();
 
-				if (Element.BorderWidth != 0)
-					UpdateBorderWidth();
-
 				if (Element.BorderRadius != (int)Button.BorderRadiusProperty.DefaultValue)
 					UpdateBorderRadius();
 
+				UpdateBorderWidth();
 				UpdateFont();
 			}
 		}
@@ -120,7 +118,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void UpdateBorderWidth()
 		{
-			Control.BorderThickness = Element.BorderWidth == 0d ? new WThickness(3) : new WThickness(Element.BorderWidth);
+			Control.BorderThickness = new WThickness(Element.BorderWidth);
 		}
 
 		void UpdateContent()


### PR DESCRIPTION
### Description of Change ###

On UWP and 8.1, an issue existed where if the `BorderWidth` of a Button (in the PCL) was set to 0, the border of the Button would still remain.

When developing non-Forms applications in UWP and 8.1, there is a difference in behavior with regards to the button, as follows:

In UWP:
- If a Button is created with no `BorderThickness` and `BorderBrush` values set, there will be no border around the resulting Button whatsoever.
- If a Button is created with a `BorderThickness` value set, but no `BorderBrush` value set, the border around the resulting Button will have a border in the same color as its background.
- If a Button is created with no `BorderThickness` value set, but a `BorderBrush` value is set, a border around the resulting Button will appear in that color.

In 8.1:
- If a Button is created with no `BorderThickness` or `BorderBrush` values set, there will still be a default colored border around the resulting button (assuming a black system theme, it will be white).
- If a Button is created with a `BorderThickness` value set, but no `BorderBrush` value set, the border around the resulting Button will be of the provided thickness in the aforementioned default color.
- If a Button is created with no `BorderThickness` value set, but a `BorderBrush` value is set, a border around the resulting Button will appear in that color.

As it stands, UWP's handling of this 0 value could be more simply adjusted in the WinRT `ButtonRenderer`. However, assume a scenario where a user would create a button as follows:

    var button = new Button { Text = "Hey, I'm a button!" };

The resulting button on UWP would function as normal, as it would on 8.1, as the user is sticking with default behavior. But now, another button is created:

    var buttonExplicitWidth = new Button { Text = "Hey, I'm also a button!", BorderWidth = 0 };

The user is explicitly setting the value of the Button's `BorderWidth` to 0, but this is already the default value as provided by the `Button` class in Xamarin.Forms.Core. As such, there is no concept of truly wanting a 0 `BorderWidth` versus what is provided by default. The default behavior of both UWP and 8.1 both appear to use a default `BorderThickness` value of 2.5 on phone devices and 2 on tablet/desktop form factors. 

By adding a private `DefaultBorderWidth` property in the `Button` class in Core and allowing the `BorderWidthProperty` to use it as its default, we can use those as the standard values instead of 0 in order to respect what the platform normally does, while retaining the previously used 0 value as normal for the other platforms. In the WinRT `ButtonRenderer` we are also making sure to explicitly update the width via `UpdateBorderWidth()`, which can now simply use the Element's `BorderWidth` to set the correct `BorderThickness` on the Control.

A reproduction has been added to the control gallery's shared issues.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40943

### API Changes ###

Added:
- static double DefaultBorderWidth

### Behavioral Changes ###

This should only theoretically correct any incorrect behavior users may have been experiencing with a `BorderWidth` of 0.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense