### PR TITLE
[IOS] Update the current region of the MKMapView when visible

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38284.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38284.cs
@@ -1,0 +1,77 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Maps;
+
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 38284, "when creating a map in iOS, if the map is not visible when the page is created the zoom level is offn")]
+	public class Bugzilla38284 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		Map map1;
+		Map map2;
+		double Latitude = 28.032005;
+		double Longitude = -81.948931;
+		string LocationTitle = "Someplace Cool";
+		string StreetAddress = "";
+
+		protected override void Init()
+		{
+			var stack = new StackLayout();
+
+			map1 = new Maps.Map
+			{
+				IsShowingUser = false,
+				WidthRequest = 320,
+				HeightRequest = 200
+			};
+
+			map2 = new Maps.Map
+			{
+				IsShowingUser = false,
+				WidthRequest = 320,
+				HeightRequest = 200
+			};
+
+
+			var btn = new Button { Text = "Show" };
+			btn.Clicked += (sender, e) =>
+			{
+				map2.IsVisible = !map2.IsVisible;
+			};
+
+			stack.Children.Add(map1);
+			stack.Children.Add(map2);
+			stack.Children.Add(btn);
+			DisplayMaps();
+			Content = stack;
+		}
+
+		public void DisplayMaps()
+		{
+			map2.IsVisible = false;
+			var mapPinPosition = new Position(Latitude, Longitude);
+
+			var type = MapType.Satellite;
+			map1.MapType = type;
+			map2.MapType = type;
+			var pin = new Pin
+			{
+				Type = PinType.Place,
+				Position = mapPinPosition,
+				Label = LocationTitle,
+				Address = StreetAddress
+			};
+			map1.Pins.Add(pin);
+			map2.Pins.Add(pin);
+
+			// Move the map to center on the map location with the proper zoom level
+			var lldegrees = 360 / (Math.Pow(2, 16));
+			map1.MoveToRegion(new MapSpan(map1.Pins[0].Position, lldegrees, lldegrees));
+			map2.MoveToRegion(new MapSpan(map2.Pins[0].Position, lldegrees, lldegrees));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -406,6 +406,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39987.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40704.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41038.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38284.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -134,6 +134,7 @@ namespace Xamarin.Forms.Maps.iOS
 	public class MapRenderer : ViewRenderer
 	{
 	    CLLocationManager _locationManager;
+		bool _shouldUpdateRegion;
 
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
@@ -215,6 +216,19 @@ namespace Xamarin.Forms.Maps.iOS
 				UpdateHasScrollEnabled();
 			else if (e.PropertyName == Map.HasZoomEnabledProperty.PropertyName)
 				UpdateHasZoomEnabled();
+			else if (e.PropertyName == VisualElement.IsVisibleProperty.PropertyName && ((Map)Element).LastMoveToRegion != null)
+				_shouldUpdateRegion = true;
+		}
+
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+			if (_shouldUpdateRegion)
+			{
+				MoveToRegion(((Map)Element).LastMoveToRegion, false);
+				_shouldUpdateRegion = false;
+			}
+
 		}
 
 		void AddPins(IList pins)


### PR DESCRIPTION
### Description of Change ###

If the iOS MKMapView is invisible it will update it's region because there's no Frame/Bounds for calculation. We need to make sure we update the current region when the map is visible again.
Couldn't find a way to add a UITest to it.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=38284

### API Changes ###

None

### Behavioral Changes ###

None
### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
