### PR TITLE
[Win 8.1] Initial ListView selection not shown

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41078.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41078.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41078, "[Win 8.1] ListView not visually setting the initial SelectedItem upon creation", PlatformAffected.WinRT)]
+	public class Bugzilla41078 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var list = new List<int> { 1, 2, 3 };
+			var listView = new ListView
+			{
+				ItemsSource = list,
+				SelectedItem = list[1]
+			};
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label { Text = "The '2' cell should have a background color indicating it is selected" },
+					listView
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -104,6 +104,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40185.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40333.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31806.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -83,6 +83,12 @@ namespace Xamarin.Forms.Platform.WinRT
 				// WinRT throws an exception if you set ItemsSource directly to a CVS, so bind it.
 				List.DataContext = new CollectionViewSource { Source = Element.ItemsSource, IsSourceGrouped = Element.IsGroupingEnabled };
 
+#if !WINDOWS_UWP
+				var selected = Element.SelectedItem;
+				if (selected != null)
+					OnElementItemSelected(null, new SelectedItemChangedEventArgs(selected));
+#endif
+
 				UpdateGrouping();
 				UpdateHeader();
 				UpdateFooter();


### PR DESCRIPTION
### Description of Change ###

On Windows 8.1, when the `SelectedItem` property on a `ListView` was set prior to the page it was contained in displaying, there was no indication of that item being selected (although the value was set) when the page eventually displayed. This is normally indicated via a background color on the cell. Subsequent selections of other items would cause the visual indication to work as expected. Explicitly calling `OnElementItemSelected` in `OnElementChanged` if the `SelectedItem` value has been set resolves this.

A visual reproduction has been added to the Control Gallery's issues.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41078

### API Changes ###

None

### Behavioral Changes ###

None expected.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense