### PR TITLE
[Android] UpdateToolbar when page is added before on non AppCompact

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -81,12 +81,15 @@
     <!--PCL-->
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\Xamarin.Forms.Core.dll" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\Xamarin.Forms.Core.*pdb" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\Xamarin.Forms.Core.*mdb" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
     <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\Xamarin.Forms.Xaml.dll" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\Xamarin.Forms.Xaml.*pdb" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\Xamarin.Forms.Xaml.*mdb" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
     <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\Xamarin.Forms.Platform.*pdb" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\Xamarin.Forms.Platform.*mdb" target="lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
 
     <!--Xaml PCL Stuff-->
     <file src="Xamarin.Forms.targets" target="build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms$IdAppend$.targets" />
@@ -146,22 +149,28 @@
     <!--iPhone Unified-->
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.dll" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*pdb" target="lib\Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*mdb" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\Xamarin.Forms.Core.dll" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\Xamarin.Forms.Core.*pdb" target="lib\Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\Xamarin.Forms.Core.*mdb" target="lib\Xamarin.iOS10" />
     <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\Xamarin.Forms.Xaml.dll" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\Xamarin.Forms.Xaml.*pdb" target="lib\Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\Xamarin.Forms.Xaml.*mdb" target="lib\Xamarin.iOS10" />
     <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\Xamarin.iOS10" />
     <file src="..\Stubs\Xamarin.Forms.Platform.iOS\bin\iPhone\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\Xamarin.iOS10" />
 
     <!--iPhone Classic-->
     <file src="..\Xamarin.Forms.Platform.iOS\classic_bin\iPhoneSimulator\$Configuration$\Xamarin.Forms.Platform.iOS.Classic.dll" target="lib\MonoTouch10" />
     <file src="..\Xamarin.Forms.Platform.iOS\classic_bin\iPhoneSimulator\$Configuration$\Xamarin.Forms.Platform.iOS.Classic.*pdb" target="lib\MonoTouch10" />
+    <file src="..\Xamarin.Forms.Platform.iOS\classic_bin\iPhoneSimulator\$Configuration$\Xamarin.Forms.Platform.iOS.Classic.*mdb" target="lib\MonoTouch10" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\Xamarin.Forms.Core.dll" target="lib\MonoTouch10" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\Xamarin.Forms.Core.*pdb" target="lib\MonoTouch10" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\Xamarin.Forms.Core.*mdb" target="lib\MonoTouch10" />
     <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\MonoTouch10" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\Xamarin.Forms.Xaml.dll" target="lib\MonoTouch10" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\Xamarin.Forms.Xaml.*pdb" target="lib\MonoTouch10" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\Xamarin.Forms.Xaml.*mdb" target="lib\MonoTouch10" />
     <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoTouch10" />
     <file src="..\Stubs\Xamarin.Forms.Platform.iOS.Classic\bin\iPhone\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\MonoTouch10" />
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40005.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40005.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40005, "Navigation Bar back button does not show when using InsertPageBefore")]
+	public class Bugzilla40005 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		public Bugzilla40005()
+		{
+			Application.Current.MainPage = new NavigationPage(new Page1());
+		}
+
+		protected override void Init()
+		{
+		}
+
+		public class Page1 : ContentPage
+		{
+			bool pageInserted;
+
+			public Page1()
+			{
+				Button btn = new Button() {
+					Text = "Go to Page 2"
+				};
+				btn.Clicked += async (sender, e) => {
+					await Navigation.PushAsync(new Page2());
+				};
+
+				Content = new StackLayout {
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+					new Label {
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "Page 1"
+					},
+					btn
+				}
+				};
+			}
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+				if(!pageInserted) {
+					Navigation.InsertPageBefore(new InsertedPage(), this);
+					pageInserted = true;
+				}
+			}
+
+			protected override bool OnBackButtonPressed()
+			{
+				Debug.WriteLine("Hardware BackButton Pressed on Page1");
+				return base.OnBackButtonPressed();
+			}
+		}
+
+
+		public class InsertedPage : ContentPage
+		{
+			public InsertedPage()
+			{
+				Content = new StackLayout {
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+					new Label {
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "Inserted page"
+					}
+				}
+				};
+			}
+
+			protected override bool OnBackButtonPressed()
+			{
+				Debug.WriteLine("Hardware BackButton Pressed on InsertedPage");
+				return base.OnBackButtonPressed();
+			}
+		}
+
+		public class Page2 : ContentPage
+		{
+			public Page2()
+			{
+				Content = new StackLayout {
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+					new Label {
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "Page 2"
+					}
+				}
+				};
+			}
+
+			protected override bool OnBackButtonPressed()
+			{
+				Debug.WriteLine("Hardware BackButton Pressed on Page2");
+				return base.OnBackButtonPressed();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40333.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40333.cs
@@ -46,14 +46,14 @@ namespace Xamarin.Forms.Controls
 
 			protected override void Init()
 			{
-				Master = new NavigationPage(new _40333NavPusher("Root")) { Title = "MasterNav" };
-
 				if (_showTabVersion)
 				{
+					Master = new NavigationPage(new _40333TabPusher("Root")) { Title = "MasterNav" };
 					Detail = new TabbedPage() { Title = "DetailNav", Children = { new _40333DetailPage("T1") } };
 				}
 				else
 				{
+					Master = new NavigationPage(new _40333NavPusher("Root")) { Title = "MasterNav" };
 					Detail = new NavigationPage(new _40333DetailPage("Detail") { Title = "DetailPage" }) { Title = "DetailNav" };
 				}
 			}
@@ -195,6 +195,9 @@ namespace Xamarin.Forms.Controls
 		}
 
 #if UITEST
+
+#if __ANDROID__ // This test doesn't work in iOS for unrelated reasons
+
 		[Test]
 		public void ClickingOnMenuItemInMasterDoesNotCrash_NavPageVersion()
 		{
@@ -207,6 +210,8 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Tap(q => q.Marked(ClickThisId));
 			RunningApp.WaitForElement(q => q.Marked(StillHereId)); // If the bug isn't fixed, the app will have crashed by now
 		}
+
+#endif
 
 		[Test]
 		public void ClickingOnMenuItemInMasterDoesNotCrash_TabPageVersion()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -98,6 +98,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39702.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40005.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40173.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39821.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40185.cs" />

--- a/Xamarin.Forms.Core.UnitTests/AppLinkEntryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AppLinkEntryTests.cs
@@ -1,0 +1,42 @@
+using System;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class AppLinkEntryTests : BaseTestFixture
+	{
+
+		[Test]
+		public void KeyValuesTest()
+		{
+			var entry = new AppLinkEntry();
+
+			entry.KeyValues.Add("contentType", "GalleryPage");
+			entry.KeyValues.Add("companyName", "Xamarin");
+			Assert.AreEqual(entry.KeyValues.Count, 2);
+		}
+
+
+		[Test]
+		public void FromUriTest()
+		{
+			var uri = new Uri("http://foo.com");
+
+			var entry = AppLinkEntry.FromUri(uri);
+
+			Assert.AreEqual(uri, entry.AppLinkUri);
+		}
+
+		[Test]
+		public void ToStringTest()
+		{
+			var str = "http://foo.com";
+			var uri = new Uri(str);
+
+			var entry = new AppLinkEntry { AppLinkUri = uri };
+
+			Assert.AreEqual(uri.ToString(), entry.ToString());
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -175,6 +175,7 @@
     <Compile Include="MultiTriggerTests.cs" />
     <Compile Include="TriggerTests.cs" />
     <Compile Include="PinchGestureRecognizerTests.cs" />
+    <Compile Include="AppLinkEntryTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/Xamarin.Forms.Core/AppLinkEntry.cs
+++ b/Xamarin.Forms.Core/AppLinkEntry.cs
@@ -5,6 +5,13 @@ namespace Xamarin.Forms
 {
 	public class AppLinkEntry : Element, IAppLinkEntry
 	{
+		readonly Dictionary<string, string> keyValues;
+
+		public AppLinkEntry()
+		{
+			keyValues = new Dictionary<string, string>();
+		}
+
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(AppLinkEntry), default(string));
 
 		public static readonly BindableProperty DescriptionProperty = BindableProperty.Create(nameof(Description), typeof(string), typeof(AppLinkEntry), default(string));
@@ -33,7 +40,10 @@ namespace Xamarin.Forms
 			set { SetValue(IsLinkActiveProperty, value); }
 		}
 
-		public IDictionary<string, string> KeyValues => new Dictionary<string, string>();
+		public IDictionary<string, string> KeyValues
+		{
+			get { return keyValues; }
+		}
 
 		public ImageSource Thumbnail
 		{

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -100,6 +100,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (application == null)
 				throw new ArgumentNullException("application");
 
+			(application as IApplicationController)?.SetAppIndexingProvider(new AndroidAppIndexProvider(this));
+
 			_application = application;
 			Xamarin.Forms.Application.Current = application;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
@@ -131,6 +131,15 @@ namespace Xamarin.Forms.Platform.Android
 
 		void InsertPageBefore(Page page, Page before)
 		{
+
+			int index = Element.InternalChildren.IndexOf(before);
+			if (index == -1)
+				throw new InvalidOperationException("This should never happen, please file a bug");
+
+			Device.StartTimer(TimeSpan.FromMilliseconds(0), () => {
+				((Platform)Element.Platform).UpdateNavigationTitleBar();
+				return false;
+			});
 		}
 
 		void OnInsertPageBeforeRequested(object sender, NavigationRequestedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -59,6 +59,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
+			if (Control == null)
+				return (base.GetDesiredSize(widthConstraint, heightConstraint));
+				        
 			AView view = _container == this ? (AView)Control : _container;
 			view.Measure(widthConstraint, heightConstraint);
 

--- a/Xamarin.Forms.Platform.WP8/FormsApplicationPage.cs
+++ b/Xamarin.Forms.Platform.WP8/FormsApplicationPage.cs
@@ -47,18 +47,18 @@ namespace Xamarin.Forms.Platform.WinPhone
 		}
 
 		// when app gets tombstoned, user press back past first page
-		void OnClosing(object sender, ClosingEventArgs e)
+		async void OnClosing(object sender, ClosingEventArgs e)
 		{
 			// populate isolated storage.
 			//SerializePropertyStore ();
-			_application.SendSleepAsync().Wait();
+			await _application.SendSleepAsync();
 		}
 
-		void OnDeactivated(object sender, DeactivatedEventArgs e)
+		async void OnDeactivated(object sender, DeactivatedEventArgs e)
 		{
 			// populate state dictionaries, properties
 			//SerializePropertyStore ();
-			_application.SendSleepAsync().Wait();
+			await _application.SendSleepAsync();
 		}
 
 		void OnLaunching(object sender, LaunchingEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -38,6 +38,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override SizeF SizeThatFits(SizeF size)
 		{
+			if (Control == null)
+				return (base.SizeThatFits(size));
+
 			return Control.SizeThatFits(size);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Make sure to call update toolbar method when not using non app compact NavigationPageRenderer

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40005


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
