### PR TITLE
Turn off iOS version of 40333 UI test 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40333.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40333.cs
@@ -46,14 +46,14 @@ namespace Xamarin.Forms.Controls
 
 			protected override void Init()
 			{
-				Master = new NavigationPage(new _40333NavPusher("Root")) { Title = "MasterNav" };
-
 				if (_showTabVersion)
 				{
+					Master = new NavigationPage(new _40333TabPusher("Root")) { Title = "MasterNav" };
 					Detail = new TabbedPage() { Title = "DetailNav", Children = { new _40333DetailPage("T1") } };
 				}
 				else
 				{
+					Master = new NavigationPage(new _40333NavPusher("Root")) { Title = "MasterNav" };
 					Detail = new NavigationPage(new _40333DetailPage("Detail") { Title = "DetailPage" }) { Title = "DetailNav" };
 				}
 			}
@@ -195,6 +195,9 @@ namespace Xamarin.Forms.Controls
 		}
 
 #if UITEST
+
+#if __ANDROID__ // This test doesn't work in iOS for unrelated reasons
+
 		[Test]
 		public void ClickingOnMenuItemInMasterDoesNotCrash_NavPageVersion()
 		{
@@ -207,6 +210,8 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Tap(q => q.Marked(ClickThisId));
 			RunningApp.WaitForElement(q => q.Marked(StillHereId)); // If the bug isn't fixed, the app will have crashed by now
 		}
+
+#endif
 
 		[Test]
 		public void ClickingOnMenuItemInMasterDoesNotCrash_TabPageVersion()


### PR DESCRIPTION
### Description of Change ###

Disabling the UI test `ClickingOnMenuItemInMasterDoesNotCrash_NavPageVersion` on iOS; what it's testing was never broken on iOS (just on Android), and the test is broken because of an unrelated bug (see: [41085 Detail page contents disappear on iOS](https://bugzilla.xamarin.com/show_bug.cgi?id=41085))


