### PR TITLE
Make the Effect constructor protected

### DIFF
--- a/Xamarin.Forms.Core/Effect.cs
+++ b/Xamarin.Forms.Core/Effect.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Forms
 {
 	public abstract class Effect
 	{
-		internal Effect()
+		protected Effect()
 		{
 		}
 


### PR DESCRIPTION
### Description of Change ###

This simply changes the constructor for `Effect` from `internal` to `protected`. This enables directly subclassing `Effect` to create cross-platform effects -- e.g. effects that don't depend on platform-specific functionality.

### Bugs Fixed ###

None that I know of.

### API Changes ###

Changed:
 - internal Effect() => protected Effect()

### Behavioral Changes ###

None intended.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

