### PR TITLE
[Xaml] Resolve BindableProperties declared as public static properties

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
@@ -76,6 +76,22 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			bindable.SetValue (MessageProperty, value);
 		}
 	}
+
+	public static class AttachedBPStaticProperty
+	{
+		public static BindableProperty AttachedProperty { get; } =
+			BindableProperty.CreateAttached("Attached", typeof(string), typeof(AttachedBPStaticProperty), null);
+
+		public static string GetAttached (BindableObject bindable)
+		{
+			return (string)bindable.GetValue (AttachedProperty);
+		}
+
+		public static void SetAttached (BindableObject bindable, string value)
+		{
+			bindable.SetValue (AttachedProperty, value);
+		}
+	}
 	
 	[Flags]
 	public enum MockFlags
@@ -583,6 +599,20 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var label = new Label ().LoadFromXaml (xaml);
 			label.BindingContext = "foobar";
 			Assert.AreEqual ("raboof", label.Text);
+		}
+
+		[Test]
+		public void TestAttachedBPStaticProperty ()
+		{
+			var xaml = @"
+				<View
+				xmlns=""http://xamarin.com/schemas/2014/forms""
+				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+				xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests""
+				local:AttachedBPStaticProperty.Attached=""hello world!"">
+				</View>";
+			var view = new View ().LoadFromXaml (xaml);
+			Assert.AreEqual ("hello world!", AttachedBPStaticProperty.GetAttached (view));
 		}
 
 		[Test]

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -273,11 +273,17 @@ namespace Xamarin.Forms.Xaml
 		static BindableProperty GetBindableProperty(Type elementType, string localName, IXmlLineInfo lineInfo,
 			bool throwOnError = false)
 		{
+			PropertyInfo bindablePropertyInfo = null;
 			var bindableFieldInfo =
 				elementType.GetFields().FirstOrDefault(fi => fi.Name == localName + "Property" && fi.IsStatic && fi.IsPublic);
+			if (bindableFieldInfo == null)
+			{
+				bindablePropertyInfo =
+					elementType.GetProperties().FirstOrDefault(pi => pi.Name == localName + "Property" && pi.GetMethod.IsStatic && pi.GetMethod.IsPublic);
+			}
 
 			Exception exception = null;
-			if (exception == null && bindableFieldInfo == null)
+			if (exception == null && bindableFieldInfo == null && bindablePropertyInfo == null)
 			{
 				exception =
 					new XamlParseException(
@@ -285,7 +291,12 @@ namespace Xamarin.Forms.Xaml
 			}
 
 			if (exception == null)
-				return bindableFieldInfo.GetValue(null) as BindableProperty;
+			{
+				if (bindableFieldInfo != null)
+					return bindableFieldInfo.GetValue(null) as BindableProperty;
+				if (bindablePropertyInfo != null)
+					return bindablePropertyInfo.GetValue(null) as BindableProperty;
+			}
 			if (throwOnError)
 				throw exception;
 			return null;


### PR DESCRIPTION
### Description of Change ###

This enables the XAML loader to resolve `BindableProperties` that are declared as public static *properties*, as opposed to fields. The F# language does not support declaring public static fields.

### Bugs Fixed ###

None that I know of.

### API Changes ###

None.

### Behavioral Changes ###

With this change, the XAML loader will also set `BindableProperties` that are declared as public static properties.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
