### PR TITLE
Add workaround for bugzilla 37792

### DIFF
--- a/Xamarin.Forms.Core/Image.cs
+++ b/Xamarin.Forms.Core/Image.cs
@@ -140,7 +140,14 @@ namespace Xamarin.Forms
 				return;
 
 			oldvalue.SourceChanged -= OnSourceChanged;
-			await oldvalue.Cancel();
+			try
+			{
+				await oldvalue.Cancel();
+			}
+			catch(ObjectDisposedException)
+			{ 
+				// Workaround bugzilla 37792 https://bugzilla.xamarin.com/show_bug.cgi?id=37792
+			}
 		}
 
 		void IImageController.SetIsLoading(bool isLoading)


### PR DESCRIPTION
### Description of Change ###

Catch an ObjectDisposedException in Image.cs. This is causing lots of crashes in production for us, but we are not able to reproduce the bug reliably.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=37792

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

