### PR TITLE
[UWP/8.1] ListView respects keyboard selection

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -79,11 +79,8 @@ namespace Xamarin.Forms.Platform.WinRT
 
 					// We also want to watch for the Enter key being pressed for selection
 					List.KeyUp += OnKeyPressed;
-
-					if (ShouldCustomHighlight)
-					{
-						List.SelectionChanged += OnControlSelectionChanged;
-					}
+					
+					List.SelectionChanged += OnControlSelectionChanged;
 
 					List.SetBinding(ItemsControl.ItemsSourceProperty, "");
 				}
@@ -146,10 +143,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				List.Tapped -= ListOnTapped;
 				List.KeyUp -= OnKeyPressed;
 
-				if (ShouldCustomHighlight)
-				{
-					List.SelectionChanged -= OnControlSelectionChanged;
-				}
+				List.SelectionChanged -= OnControlSelectionChanged;
 
 				List.DataContext = null;
 				List = null;
@@ -203,18 +197,6 @@ namespace Xamarin.Forms.Platform.WinRT
 		ScrollViewer _scrollViewer;
 		ContentControl _headerControl;
 		readonly List<BrushedElement> _highlightedElements = new List<BrushedElement>();
-
-		bool ShouldCustomHighlight
-		{
-			get
-			{
-#if WINDOWS_UWP
-				return false;
-#else
-				return Device.Idiom == TargetIdiom.Phone;
-#endif
-			}
-		}
 
 		void ClearSizeEstimate()
 		{
@@ -543,13 +525,22 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (cell == null)
 				return;
 
-			if (ShouldCustomHighlight)
+#if !WINDOWS_UWP
+			if (Device.Idiom == TargetIdiom.Phone)
 			{
 				FrameworkElement element = FindElement(cell);
 				if (element != null)
 				{
 					SetSelectedVisual(element);
 				}
+			}
+#endif
+
+			// This is used for respecting ListView selection changes via keyboard, as the SelectedItem
+			// value is otherwise not set.
+			if (Element.SelectedItem != List.SelectedItem)
+			{
+				((IElementController)Element).SetValueFromRenderer(ListView.SelectedItemProperty, List.SelectedItem);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

In both UWP/Win 8.1, if a keyboard was being used to make a selection out of a list of items, the `SelectedItem` value on the `Element` was not being updated due to its not being changed via tap/click, although `OnControlSelectionChanged` would still fire and update the `SelectedIndex` value on the `ListView`.

In this change, the `ShouldCustomHighlight` bool property is removed, but its general behavior in checking that the platform isn't UWP and is the Phone idiom are shifted into the `OnControlSelectionChanged` method itself. `OnControlSelectionChanged` is then always hooked and unhooked so that it may be called when the selection changes, and if the `Element.SelectedItem` value hasn't changed, we can reasonably assume that this selection change was made via keyboard and not tap or click, then update that value accordingly.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41072

### API Changes ###

Removed:
- (private) bool ShouldCustomHighlight

### Behavioral Changes ###

None expected.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense