### PR TITLE
[Xaml] Fix MarkupExtension not found in default namespace

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz41296.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz41296.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<forms:ContentPage xmlns="clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:forms="http://xamarin.com/schemas/2014/forms"
+			 x:Class="Xamarin.Forms.Xaml.UnitTests.Bz41296">
+	<forms:Label x:Name="TestLabel" Text="{AppendMarkupExtension Value0=Foo, Value1=Bar}" />
+</forms:ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz41296.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz41296.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz41296 : ContentPage
+	{
+		public Bz41296()
+		{
+			InitializeComponent ();
+		}
+
+		public Bz41296(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true)]
+			[TestCase(false)]
+			public void MarkupExtensionInDefaultNamespace(bool useCompiledXaml)
+			{
+				var layout = new Bz41296 (useCompiledXaml);
+				Assert.AreEqual("FooBar", layout.TestLabel.Text.ToString());
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/MarkupExtensionTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MarkupExtensionTests.cs
@@ -157,7 +157,23 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.AreEqual ("FooBar", label.Text.ToString ());
 		}
 
-		[Test]
+        [Test]
+        public void TestMarkupExtensionInDefaultNamespace ()
+        {            
+            var xaml = @"
+			<forms:Label 
+				xmlns=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests""
+				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+				xmlns:forms=""http://xamarin.com/schemas/2014/forms""
+				Text=""{AppendMarkupExtension Value0=Foo, Value1=Bar}""
+			/>";
+
+            var label = new Label();
+            label.LoadFromXaml(xaml);
+            Assert.AreEqual("FooBar", label.Text.ToString());
+        }
+
+        [Test]
 		public void TestDocumentationCode ()
 		{
 			var xaml =@"

--- a/Xamarin.Forms.Xaml.UnitTests/MarkupExtensionTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MarkupExtensionTests.cs
@@ -157,10 +157,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.AreEqual ("FooBar", label.Text.ToString ());
 		}
 
-        [Test]
-        public void TestMarkupExtensionInDefaultNamespace ()
-        {            
-            var xaml = @"
+		[Test]
+		public void TestMarkupExtensionInDefaultNamespace ()
+		{
+			var xaml = @"
 			<forms:Label 
 				xmlns=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests""
 				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
@@ -168,12 +168,12 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Text=""{AppendMarkupExtension Value0=Foo, Value1=Bar}""
 			/>";
 
-            var label = new Label();
-            label.LoadFromXaml(xaml);
-            Assert.AreEqual("FooBar", label.Text.ToString());
-        }
+			var label = new Label();
+			label.LoadFromXaml(xaml);
+			Assert.AreEqual("FooBar", label.Text.ToString());
+		}
 
-        [Test]
+		[Test]
 		public void TestDocumentationCode ()
 		{
 			var xaml =@"

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -81,6 +81,9 @@
       <Link>MockPlatformServices.cs</Link>
     </Compile>
     <Compile Include="FontConverterTests.cs" />
+    <Compile Include="Issues\Bz41296.xaml.cs">
+      <DependentUpon>Bz41296.xaml</DependentUpon>
+    </Compile>
     <Compile Include="LoaderTests.cs" />
     <Compile Include="ViewExtensionsTest.cs" />
     <Compile Include="MarkupExpressionParserTests.cs" />
@@ -629,5 +632,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <ItemGroup />
+  <ItemGroup>
+    <EmbeddedResource Include="Issues\Bz41296.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Xaml/XamlServiceProvider.cs
+++ b/Xamarin.Forms.Xaml/XamlServiceProvider.cs
@@ -235,7 +235,7 @@ namespace Xamarin.Forms.Xaml.Internals
 					xmlLineInfo = lineInfoProvider.XmlLineInfo;
 			}
 
-			var namespaceuri = string.IsNullOrEmpty(prefix) ? "" : namespaceResolver.LookupNamespace(prefix);
+			var namespaceuri = prefix == null ? "" : namespaceResolver.LookupNamespace(prefix);
 			if (namespaceuri == null)
 			{
 				exception = new XamlParseException(string.Format("No xmlns declaration for prefix \"{0}\"", prefix), xmlLineInfo);


### PR DESCRIPTION
### Description of Change ###

Fixed loading MarkupExtension from default namespace if default namespace is not http://xamarin.com/schemas/2014/forms. See added unit test.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41296

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

