### PR TITLE
Fixed wp silverlight on resume bug - bugzilla 41076

### DIFF
--- a/Xamarin.Forms.Platform.WP8/FormsApplicationPage.cs
+++ b/Xamarin.Forms.Platform.WP8/FormsApplicationPage.cs
@@ -47,18 +47,18 @@ namespace Xamarin.Forms.Platform.WinPhone
 		}
 
 		// when app gets tombstoned, user press back past first page
-		void OnClosing(object sender, ClosingEventArgs e)
+		async void OnClosing(object sender, ClosingEventArgs e)
 		{
 			// populate isolated storage.
 			//SerializePropertyStore ();
-			_application.SendSleepAsync().Wait();
+			await _application.SendSleepAsync();
 		}
 
-		void OnDeactivated(object sender, DeactivatedEventArgs e)
+		async void OnDeactivated(object sender, DeactivatedEventArgs e)
 		{
 			// populate state dictionaries, properties
 			//SerializePropertyStore ();
-			_application.SendSleepAsync().Wait();
+			await _application.SendSleepAsync();
 		}
 
 		void OnLaunching(object sender, LaunchingEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Fixed bug for WP8 silverlight so it will not hang when resuming app.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41076

### API Changes ###

None


### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense