### PR TITLE
[8.1/UWP] Fix PopToRootAsync functioning incorrectly

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31806.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31806.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 31806, "[8.1/UWP] PopToRootAsync crashes due to not setting the current page correctly", PlatformAffected.WinRT)]
+	public class Bugzilla31806 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Button
+					{
+						Text = "Navigate to a new page",
+						Command = new Command(() =>
+						{
+							Navigation.PushAsync(new ContentPage
+							{
+								Content = new StackLayout
+								{
+									Children =
+									{
+										new Label
+										{
+											Text = "Pressing this button should let the navigation return to the repro list"
+										},
+										new Button
+										{
+											Text = "Call PopToRootAsync()",
+											Command = new Command(() =>
+											{
+												Navigation.PopToRootAsync();
+											})
+										}
+									}
+								}
+							});
+						})
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -102,6 +102,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39821.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40185.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40333.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31806.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -157,6 +157,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				((INavigationPageController)oldElement).PushRequested -= OnPushRequested;
 				((INavigationPageController)oldElement).PopRequested -= OnPopRequested;
+				((INavigationPageController)oldElement).PopToRootRequested -= OnPopToRootRequested;
 				oldElement.InternalChildren.CollectionChanged -= OnChildrenChanged;
 				oldElement.PropertyChanged -= OnElementPropertyChanged;
 			}
@@ -187,6 +188,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				Element.PropertyChanged += OnElementPropertyChanged;
 				((INavigationPageController)Element).PushRequested += OnPushRequested;
 				((INavigationPageController)Element).PopRequested += OnPopRequested;
+				((INavigationPageController)Element).PopToRootRequested += OnPopToRootRequested;
 				Element.InternalChildren.CollectionChanged += OnChildrenChanged;
 
 				if (!string.IsNullOrEmpty(Element.AutomationId))
@@ -375,6 +377,11 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			var newCurrent = (Page)Element.InternalChildren[Element.InternalChildren.Count - 2];
 			SetPage(newCurrent, e.Animated, true);
+		}
+
+		void OnPopToRootRequested(object sender, NavigationRequestedEventArgs e)
+		{
+			SetPage(e.Page, e.Animated, true);
 		}
 
 		void OnPushRequested(object sender, NavigationRequestedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

When calling` PopToRootAsync` on 8.1/UWP, the navigation stack was being cleared, but the current page wasn't actually being set, so a crash would subsequently occur if attempting to call it again, for example. This was due to a missing event handler on the `NavigationPageRenderer` which sets the page to the expected root.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=31809

### API Changes ###

Added:
- (private) void OnPopToRootRequested(object sender, NavigationRequestedEventArgs e)

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
