### PR TITLE
WinRT/UWP center crop image on AspectFill

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
@@ -97,6 +97,16 @@ namespace Xamarin.Forms.Platform.WinRT
 		void UpdateAspect()
 		{
 			Control.Stretch = GetStretch(Element.Aspect);
+			if (Element.Aspect == Aspect.AspectFill) // Then Center Crop
+			{
+				Control.HorizontalAlignment = HorizontalAlignment.Center;
+				Control.VerticalAlignment = VerticalAlignment.Center;
+			}
+			else // Default
+			{
+				Control.HorizontalAlignment = HorizontalAlignment.Left;
+				Control.VerticalAlignment = VerticalAlignment.Top;
+			}
 		}
 
 		async void UpdateSource()


### PR DESCRIPTION
### Description of Change ###

Images on WinRT and UWP will be center cropped when in AspectFill to provide the same experience that Android and iOS currently provide. Change was discussed in forms-devel Digest, Vol 1, Issue 9.

### Bugs Fixed ###


### API Changes ###

None

### Behavioral Changes ###

Images on WinRT and UWP will be center cropped when in AspectFill.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

