### PR TITLE
ViewRenderer unsubscribe from FocusChangeRequested on dispose

### DIFF
--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -86,6 +86,12 @@ namespace Xamarin.Forms.Platform.Android
 					_container = null;
 				}
 
+				if (Element != null && _focusChangeHandler != null)
+				{
+					Element.FocusChangeRequested -= _focusChangeHandler;
+					_focusChangeHandler = null;
+				}
+
 				_disposed = true;
 			}
 


### PR DESCRIPTION
### Description of Change ###

ViewRenderer failed to unsubscribe from FocusChangeRequested on disposed and so attempted to dispatch a focus change request to a disposed renderer.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=33507

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

