### PR TITLE
[Android] UpdateToolbar when page is added before on non AppCompact

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40005.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40005.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40005, "Navigation Bar back button does not show when using InsertPageBefore")]
+	public class Bugzilla40005 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		public Bugzilla40005()
+		{
+			Application.Current.MainPage = new NavigationPage(new Page1());
+		}
+
+		protected override void Init()
+		{
+		}
+
+		public class Page1 : ContentPage
+		{
+			bool pageInserted;
+
+			public Page1()
+			{
+				Button btn = new Button() {
+					Text = "Go to Page 2"
+				};
+				btn.Clicked += async (sender, e) => {
+					await Navigation.PushAsync(new Page2());
+				};
+
+				Content = new StackLayout {
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+					new Label {
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "Page 1"
+					},
+					btn
+				}
+				};
+			}
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+				if(!pageInserted) {
+					Navigation.InsertPageBefore(new InsertedPage(), this);
+					pageInserted = true;
+				}
+			}
+
+			protected override bool OnBackButtonPressed()
+			{
+				Debug.WriteLine("Hardware BackButton Pressed on Page1");
+				return base.OnBackButtonPressed();
+			}
+		}
+
+
+		public class InsertedPage : ContentPage
+		{
+			public InsertedPage()
+			{
+				Content = new StackLayout {
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+					new Label {
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "Inserted page"
+					}
+				}
+				};
+			}
+
+			protected override bool OnBackButtonPressed()
+			{
+				Debug.WriteLine("Hardware BackButton Pressed on InsertedPage");
+				return base.OnBackButtonPressed();
+			}
+		}
+
+		public class Page2 : ContentPage
+		{
+			public Page2()
+			{
+				Content = new StackLayout {
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+					new Label {
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "Page 2"
+					}
+				}
+				};
+			}
+
+			protected override bool OnBackButtonPressed()
+			{
+				Debug.WriteLine("Hardware BackButton Pressed on Page2");
+				return base.OnBackButtonPressed();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -98,6 +98,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39702.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40005.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40173.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39821.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40185.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
@@ -131,6 +131,15 @@ namespace Xamarin.Forms.Platform.Android
 
 		void InsertPageBefore(Page page, Page before)
 		{
+
+			int index = Element.InternalChildren.IndexOf(before);
+			if (index == -1)
+				throw new InvalidOperationException("This should never happen, please file a bug");
+
+			Device.StartTimer(TimeSpan.FromMilliseconds(0), () => {
+				((Platform)Element.Platform).UpdateNavigationTitleBar();
+				return false;
+			});
 		}
 
 		void OnInsertPageBeforeRequested(object sender, NavigationRequestedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Make sure to call update toolbar method when not using non app compact NavigationPageRenderer

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40005


### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
