### PR TITLE
Fix android StartTimer race condition

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -361,13 +361,20 @@ namespace Xamarin.Forms
 			public void StartTimer(TimeSpan interval, Func<bool> callback)
 			{
 				Timer timer = null;
-				TimerCallback onTimeout = o => BeginInvokeOnMainThread(() =>
+				bool invoking = false;
+				TimerCallback onTimeout = o =>
 				{
-					if (callback())
-						return;
-
-					timer.Dispose();
-				});
+					if (!invoking)
+					{
+						invoking = true;
+						BeginInvokeOnMainThread(() =>
+						{
+							if (!callback())
+								timer.Dispose();
+							invoking = false;
+						});
+					}
+				};
 				timer = new Timer(onTimeout, null, interval, interval);
 			}
 


### PR DESCRIPTION
### Description of Change ###

Timer comes back on a thread at the interval requested. In the event that our callback has no finished processing by the time this happens a second time, we will double fire the callback. Rather than attempt to "catch up" we skip frames that the callback misses.

### Bugs Fixed ###

This fixes the GREF issue reported by the Android team against Cycle 7, this report was not handled on the public bug tracker, so no link.

### API Changes ###

None

### Behavioral Changes ###

None other than described bug fix.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

