### PR TITLE
WinRT: Set BindingContext on default cell

### DIFF
--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -338,11 +338,6 @@ namespace Xamarin.Forms
 			content.Parent = null;
 		}
 
-		internal Cell CreateDefaultCell(object item)
-		{
-			return CreateDefault(item);
-		}
-
 		internal void NotifyRowTapped(int groupIndex, int inGroupIndex, Cell cell = null)
 		{
 			TemplatedItemsList<ItemsView<Cell>, Cell> group = TemplatedItems.GetGroup(groupIndex);

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -249,15 +249,17 @@ namespace Xamarin.Forms.Platform.WinRT
 				}
 				else
 				{
-					string textContent = newContext.ToString();
-
+					IItemsView<Cell> controller = lv;
 					if (isGroupHeader)
 					{
 						TemplatedItemsList<ItemsView<Cell>, Cell> group = GetGroup(newContext, lv);
-						textContent = GetDisplayTextFromGroup(lv, group);
+						cell = controller.CreateDefault(GetDisplayTextFromGroup(lv, group));
 					}
-
-					cell = lv.CreateDefaultCell(textContent);
+					else
+					{
+						cell = controller.CreateDefault(newContext);
+						cell.BindingContext = newContext;
+					}
 				}
 
 				// A TableView cell should already have its parent,


### PR DESCRIPTION
### Description of Change ###

In ListView, when a DataTemplate is not supplied `ListView.CreateDefault` is called which, when not overridden, creates a `TextCell { Text = item.ToString() }`. However if the customer overrides CreateDefault and creates an item which has bindings then on windows we we're not setting the `BindingContext` in the `ListView.CreateDefault` case so none of the bindings worked as expected. This change simply sets the `BindingContext` in the `CreateDefault` case.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41138

### API Changes ###

None

### Behavioral Changes ###

Enable bindings on windows ListView items created via CreateDefault.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

