### PR TITLE
Fix iOS clean build

### DIFF
--- a/Xamarin.Forms.UITest.Validator/Xamarin.Forms.UITest.Validator.csproj
+++ b/Xamarin.Forms.UITest.Validator/Xamarin.Forms.UITest.Validator.csproj
@@ -62,9 +62,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.UITest, Version=1.3.7.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xamarin.UITest.1.3.7\lib\Xamarin.UITest.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Fix one of the iOS `git clean -fxd` build errors by removing extra XF.UITest.Validator nunit reference.