### PR TITLE
[XAML] fix Thickness.IsDefault. Bottom was ignored

### DIFF
--- a/Xamarin.Forms.Core/Thickness.cs
+++ b/Xamarin.Forms.Core/Thickness.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms
 
 		internal bool IsDefault
 		{
-			get { return Left == 0 && Top == 0 && Right == 0 && Left == 0; }
+			get { return Left == 0 && Top == 0 && Right == 0 && Bottom == 0; }
 		}
 
 		public Thickness(double uniformSize) : this(uniformSize, uniformSize, uniformSize, uniformSize)


### PR DESCRIPTION
### Description of Change ###

Thickness.IsDefault was ignoring Bottom value

### Bugs Fixed ###

None raised so far.  

### API Changes ###

None.

### Behavioral Changes ###

Thickness.IsDefault ignore Bottom value.  This PR resolves this small issue.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense