### PR TITLE
Remove hard-coded image sizes for button images

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27417Xaml.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27417Xaml.xaml
@@ -2,14 +2,14 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xamarin.Forms.Controls.Issues.Bugzilla27417Xaml">
-  <StackLayout Spacing="10">
+	<StackLayout Spacing="10" HorizontalOptions="Center" >
 
-    <Button BackgroundColor="Color.Gray" Text="Click Me"></Button>
-    <Button BackgroundColor="Color.Gray" Image="coffee.png"></Button>
-    <Button BackgroundColor="Color.Gray" Image="coffee.png" Text="Click Me"></Button>
-    <Button BackgroundColor="Color.Gray" Image="coffee.png" Text="Click Me" ContentLayout="Top,10"></Button>
-    <Button BackgroundColor="Color.Gray" Image="coffee.png" Text="Click Me" ContentLayout="Bottom,10"></Button>
-    <Button BackgroundColor="Color.Gray" Image="coffee.png" Text="Click Me" ContentLayout="Right"></Button>
-    
-  </StackLayout>
+		<Button BackgroundColor="Color.Gray" Text="Click Me"></Button>
+		<Button BackgroundColor="Color.Gray" Image="coffee.png"></Button>
+		<Button BackgroundColor="Color.Gray" Image="coffee.png" Text="Click Me"></Button>
+		<Button BackgroundColor="Color.Gray" Image="coffee.png" Text="Click Me" ContentLayout="Top,10"></Button>
+		<Button BackgroundColor="Color.Gray" Image="coffee.png" Text="Click Me" ContentLayout="Bottom,10"></Button>
+		<Button BackgroundColor="Color.Gray" Image="coffee.png" Text="Click Me" ContentLayout="Right"></Button>
+
+	</StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
@@ -4,6 +4,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
+using Xamarin.Forms.Internals;
 using WThickness = Windows.UI.Xaml.Thickness;
 using WButton = Windows.UI.Xaml.Controls.Button;
 using WImage = Windows.UI.Xaml.Controls.Image;
@@ -135,13 +136,20 @@ namespace Xamarin.Forms.Platform.WinRT
 				return;
 			}
 
+			var bmp = new BitmapImage(new Uri("ms-appx:///" + elementImage.File));
+
 			var image = new WImage
 			{
-				Source = new BitmapImage(new Uri("ms-appx:///" + elementImage.File)),
-				Width = 30,
-				Height = 30,
+				Source = bmp,
 				VerticalAlignment = VerticalAlignment.Center,
-				HorizontalAlignment = HorizontalAlignment.Center
+				HorizontalAlignment = HorizontalAlignment.Center,
+				Stretch = Stretch.Uniform
+			};
+
+			bmp.ImageOpened += (sender, args) => {
+				image.Width = bmp.PixelWidth;
+				image.Height = bmp.PixelHeight;
+				Element.InvalidateMeasureInternal(InvalidationTrigger.RendererReady);
 			};
 
 			// No text, just the image
@@ -152,10 +160,13 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 
 			// Both image and text, so we need to build a container for them
-			var layout = Element.ContentLayout;
+			Control.Content = CreateContentContainer(Element.ContentLayout, image, text);
+		}
+
+		static StackPanel CreateContentContainer(Button.ButtonContentLayout layout, WImage image, string text)
+		{
 			var container = new StackPanel();
-			var textBlock = new TextBlock
-			{
+			var textBlock = new TextBlock {
 				Text = text,
 				VerticalAlignment = VerticalAlignment.Center,
 				HorizontalAlignment = HorizontalAlignment.Center
@@ -195,8 +206,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					break;
 			}
 
-			Control.Content = container;
-
+			return container;
 		}
 
 		void UpdateFont()


### PR DESCRIPTION
### Description of Change ###

Previously, the Windows platforms hard-coded the size of button images to 30x30; this meant that larger images on buttons could not be displayed and smaller images were scaled up.

This change removes the hard-coded size and uses the actual size of the image when laying out the button.

Currently no way to automate tests for this.

### Bugs Fixed ###

- [41241 – Custom Button Image Missized in Xamarin Forms Cross-platform in the WinPhone App](https://bugzilla.xamarin.com/show_bug.cgi?id=41241)

### API Changes ###

None

### Behavioral Changes ###

Anyone who relied on the button images of sizes other than 30x30 resizing to 30x30 on Windows platforms will need to resize their Windows image assets to that specific size.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

