### PR TITLE
[Android] DatePicker unfocuses on cancel

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41424.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41424.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41424, "[Android] Clicking cancel on a DatePicker does not cause it to unfocus", PlatformAffected.Android)]
+	public class Bugzilla41424 : TestContentPage
+	{
+		const string DatePicker = "DatePicker";
+
+		protected override void Init()
+		{
+			var datePicker = new DatePicker
+			{
+				AutomationId = DatePicker
+			};
+			var datePickerFocusButton = new Button
+			{
+				Text = "Click to focus DatePicker",
+				Command = new Command(() => datePicker.Focus())
+			};
+			Content = new StackLayout
+			{
+				Children =
+				{
+					datePicker,
+					datePickerFocusButton
+				}
+			};
+		}
+
+#if UITEST
+
+#if __ANDROID__
+		[Test]
+		public void DatePickerCancelShouldUnfocus()
+		{
+			RunningApp.Tap(q => q.Marked(DatePicker));
+			RunningApp.WaitForElement(q => q.Marked("Cancel"));
+
+			RunningApp.Tap(q => q.Marked("Cancel"));
+			RunningApp.WaitForElement(q => q.Marked("Click to focus DatePicker"));
+
+			RunningApp.Tap(q => q.Marked("Click to focus DatePicker"));
+			RunningApp.WaitForElement(q => q.Marked("Cancel"));
+
+			RunningApp.Tap(q => q.Marked("Cancel"));
+		}
+#endif
+		
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -106,6 +106,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31806.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -31,6 +31,7 @@ namespace Xamarin.Forms.Platform.Android
 				_disposed = true;
 				if (_dialog != null)
 				{
+					_dialog.CancelEvent -= OnCancelButtonClicked;
 					_dialog.Hide();
 					_dialog.Dispose();
 					_dialog = null;
@@ -84,6 +85,7 @@ namespace Xamarin.Forms.Platform.Android
 				_dialog.Hide();
 				((IElementController)Element).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 				Control.ClearFocus();
+				_dialog.CancelEvent -= OnCancelButtonClicked;
 				_dialog = null;
 			}
 		}
@@ -96,6 +98,8 @@ namespace Xamarin.Forms.Platform.Android
 				view.Date = e.Date;
 				((IElementController)view).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 				Control.ClearFocus();
+
+				_dialog.CancelEvent -= OnCancelButtonClicked;
 				_dialog = null;
 			}, year, month, day);
 		}
@@ -123,7 +127,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			UpdateMinimumDate();
 			UpdateMaximumDate();
+
+			_dialog.CancelEvent += OnCancelButtonClicked;
 			_dialog.Show();
+		}
+
+		void OnCancelButtonClicked(object sender, EventArgs e)
+		{
+			Element.Unfocus();
 		}
 
 		void SetDate(DateTime date)


### PR DESCRIPTION
### Description of Change ###

When using the DatePicker in Android, closing it via the cancel button would not unfocus the Element, causing a Focus() call via something such as a button to not function as otherwise expected.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41424

### API Changes ###

None

### Behavioral Changes ###

None expected

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense