### PR TITLE
[Android,IOS] Measure when ViewCell binding context is updated

### DIFF
--- a/Xamarin.Forms.Core/Cells/ViewCell.cs
+++ b/Xamarin.Forms.Core/Cells/ViewCell.cs
@@ -43,6 +43,15 @@ namespace Xamarin.Forms
 			}
 		}
 
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+
+			var listView = (this.Parent as ListView);
+			if(View != null && listView != null && listView.HasUnevenRows && listView.CachingStrategy == ListViewCachingStrategy.RecycleElement)
+				View.InvalidateMeasureInternal(Xamarin.Forms.Internals.InvalidationTrigger.RendererReady);
+		}
+
 		internal override ReadOnlyCollection<Element> LogicalChildren => _logicalChildren ?? base.LogicalChildren;
 	}
 }


### PR DESCRIPTION
### Description of Change ###

When we are reusing the cel with the new caching strategy, the renderer is still referring the old cell and doesn't show the correct size.
#206 repo case shows the issue when you scroll up and down, the cell size doesn't get updated.


### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=37862

### API Changes ###

List all API changes here (or just put None), example:

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
