### PR TITLE
[UWP] Escape key returns ActionSheet result

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40998.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40998.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40998, "[UWP] Pressing escape with an awaited DisplayActionSheet doesn't return a result", PlatformAffected.WinRT)]
+	public class Bugzilla40998 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var resultLabel = new Label
+			{
+				Text = "ActionSheet Result - use the ActionSheet to show the result"
+			};
+			Content = new StackLayout
+			{
+				Children =
+				{
+					resultLabel,
+					new Button
+					{
+						Text = "Click to display ActionSheet",
+						Command = new Command(async () =>
+						{
+							var result = await DisplayActionSheet("Test ActionSheet", "Cancel", "Destroy", new string[] { "Test Button" });
+							resultLabel.Text = result;
+						})
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -105,6 +105,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40333.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31806.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -13,7 +13,9 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 
 #if WINDOWS_UWP
+using Windows.Foundation;
 using Windows.Foundation.Metadata;
+using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 #endif
 
@@ -591,6 +593,17 @@ namespace Xamarin.Forms.Platform.WinRT
 				options.SetResult((string)e.ClickedItem);
 			};
 
+			TypedEventHandler<CoreWindow, CharacterReceivedEventArgs> onEscapeButtonPressed = delegate(CoreWindow window, CharacterReceivedEventArgs args)
+			{
+				if (args.KeyCode == 27)
+				{
+					dialog.Hide();
+					options.SetResult(ContentDialogResult.None.ToString());
+				}
+			};
+
+			Window.Current.CoreWindow.CharacterReceived += onEscapeButtonPressed;
+
 			_actionSheetOptions = options;
 
 			if (options.Cancel != null)
@@ -604,6 +617,8 @@ namespace Xamarin.Forms.Platform.WinRT
 				options.SetResult(options.Cancel);
 			else if (result == ContentDialogResult.Primary)
 				options.SetResult(options.Destruction);
+
+			Window.Current.CoreWindow.CharacterReceived -= onEscapeButtonPressed;
 		}
 #else
 		void OnPageActionSheet(Page sender, ActionSheetArguments options)


### PR DESCRIPTION
### Description of Change ###

On UWP, when DisplayActionSheet is being awaited, pressing escape while the ActionSheet is visible would cause it to disappear but not actually return any result. Checking for an escape keypress in the window and setting the result to `ContentDialogResult.None` (as no button was tapped) returns a result as expected.

A reproduction has been added to the issues gallery.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40998

### API Changes ###

None

### Behavioral Changes ###

Presumably none.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense