### PR TITLE
[iOS] Call UpdateLeftBarButtonItem when page is removed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41038.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41038.cs
@@ -1,0 +1,94 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41038, "MasterDetailPage loses menu icon on iOS after reusing NavigationPage as Detail")]
+	public class Bugzilla41038 : TestMasterDetailPage // or TestMasterDetailPage, etc ...
+	{
+		NavigationPage _navPage;
+
+		protected override void Init()
+		{
+			Title = "Main";
+
+			var btnViewA = new Button() { Text = "ViewA" };
+			btnViewA.Clicked += Button_Clicked;
+
+			var btnViewB = new Button() { Text = "ViewB" };
+			btnViewB.Clicked += Button_Clicked;
+
+			var stack = new StackLayout();
+			stack.Children.Add(btnViewA);
+			stack.Children.Add(btnViewB);
+
+			var master = new ContentPage() { Title = "Master", Content = stack };
+
+			_navPage = new NavigationPage(new ViewA());
+
+			Master = master;
+			Detail = _navPage;
+	
+		}
+
+		private async void Button_Clicked(object sender, EventArgs e)
+		{
+			Page root = _navPage.Navigation.NavigationStack[0];
+
+			await _navPage.Navigation.PopToRootAsync(false);
+
+			Page newRoot = null;
+
+			var btn = (Button)sender;
+			if (btn.Text == "ViewA")
+				newRoot = new ViewA();
+			else
+				newRoot = new ViewB();
+
+				
+			await _navPage.Navigation.PushAsync(newRoot);
+			_navPage.Navigation.RemovePage(root);
+			IsPresented = false;
+
+		}
+
+		public class ViewA : ContentPage
+		{
+			public ViewA()
+			{
+				Title = "ViewA";
+				Content = new Label() { Text = "View A" };
+			}
+		}
+
+		public class ViewB : ContentPage
+		{
+			public ViewB()
+			{
+				Title = "ViewB";
+				Content = new Label() { Text = "View B" };
+			}
+		}
+
+		#if UITEST &&  __IOS__
+		[Test]
+		public void Bugzilla41038Test()
+		{
+			RunningApp.WaitForElement("Master");
+			RunningApp.Tap("Master");
+			RunningApp.WaitForElement("ViewB");
+			RunningApp.Tap("ViewB");
+			RunningApp.WaitForElement("Master");
+			RunningApp.Screenshot("I see the master toogle");
+		}
+		#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -404,6 +404,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39987.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40704.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41038.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -523,6 +523,8 @@ namespace Xamarin.Forms.Platform.iOS
 				_removeControllers = _removeControllers.Remove(target);
 				ViewControllers = _removeControllers;
 			}
+			var parentingViewController = ViewControllers.Last() as ParentingViewController;
+			UpdateLeftBarButtonItem(parentingViewController, page);
 		}
 
 		void RemoveViewControllers(bool animated)
@@ -627,11 +629,13 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		void UpdateLeftBarButtonItem(ParentingViewController containerController)
+		void UpdateLeftBarButtonItem(ParentingViewController containerController, Page pageBeingRemoved = null)
 		{
+			if (containerController == null)
+				return;
 			var currentChild = containerController.Child;
 			var firstPage = ((INavigationPageController)Element).StackCopy.LastOrDefault();
-			if ((currentChild != firstPage && NavigationPage.GetHasBackButton(currentChild)) || _parentMasterDetailPage == null)
+			if ((firstPage != pageBeingRemoved && currentChild != firstPage && NavigationPage.GetHasBackButton(currentChild)) || _parentMasterDetailPage == null)
 				return;
 
 			if (!_parentMasterDetailPage.ShouldShowToolbarButton())


### PR DESCRIPTION
### Description of Change ###

When a page is being removed we need to make sure we update the left toolbar item to show the master icon or text. We need to pas a reference of the remove page, because the NavigationPage still has that page in the navigation stack, the event fires on the renderer before it's removed from the internal children. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41038

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense