### PR TITLE
[iOS] Changed how UIImages are created to allow use of Asset Catalog Image Sets

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
@@ -136,7 +136,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			void UpdateIcon()
 			{
-				((SecondaryToolbarItemContent)CustomView).Image = string.IsNullOrEmpty(_item.Icon) ? null : new UIImage(_item.Icon);
+				((SecondaryToolbarItemContent)CustomView).Image = string.IsNullOrEmpty(_item.Icon) ? null : UIImage.FromBundle(_item.Icon);
 			}
 
 			void UpdateIsEnabled()

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationMenuRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationMenuRenderer.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Forms.Platform.iOS
 				set
 				{
 					_icon = value;
-					_image.SetImage(new UIImage(_icon), UIControlState.Normal);
+					_image.SetImage(UIImage.FromBundle(_icon), UIControlState.Normal);
 				}
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -380,7 +380,7 @@ namespace Xamarin.Forms.Platform.iOS
 				try
 				{
 					//UIImage ctor throws on file not found if MonoTouch.ObjCRuntime.Class.ThrowOnInitFailure is true;
-					pack.NavigationItem.TitleView = new UIImageView(new UIImage(titleIcon));
+					pack.NavigationItem.TitleView = new UIImageView(UIImage.FromBundle(titleIcon));
 				}
 				catch
 				{
@@ -646,7 +646,7 @@ namespace Xamarin.Forms.Platform.iOS
 				try
 				{
 					containerController.NavigationItem.LeftBarButtonItem =
-						new UIBarButtonItem(new UIImage(_parentMasterDetailPage.Master.Icon), UIBarButtonItemStyle.Plain,
+						new UIBarButtonItem(UIImage.FromBundle(_parentMasterDetailPage.Master.Icon), UIBarButtonItemStyle.Plain,
 						(o, e) => _parentMasterDetailPage.IsPresented = !_parentMasterDetailPage.IsPresented);
 				}
 				catch (Exception)

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -205,7 +205,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				UIImage image = null;
 				if (!string.IsNullOrEmpty(page.Icon))
-					image = new UIImage(page.Icon);
+					image = UIImage.FromBundle(page.Icon);
 
 				// the new UITabBarItem forces redraw, setting the UITabBarItem.Image does not
 				renderer.ViewController.TabBarItem = new UITabBarItem(page.Title, image, 0);


### PR DESCRIPTION
### Description of Change ###

Switched from using `new UIImage()` to `UIImage.FromBundle()` to support image sets. Currently on iOS the Tabbed Page throws an exception if you try to use a image set as the icon for the tab. I went ahead and changed it in a few places were it might also cause issues.

### Bugs Fixed ###

Unable to use Image Assets in certain places.

### API Changes ###

List all API changes here (or just put None), example:

Changed:
 - new UIImage() => UIImage.FromBundle()

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense