### PR TITLE
[Core] Don't use the fixed LayoutConstraint when using uneven rows

### DIFF
--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -329,7 +329,11 @@ namespace Xamarin.Forms
 		protected override void SetupContent(Cell content, int index)
 		{
 			base.SetupContent(content, index);
+			var viewCell = content as ViewCell;
+			if (viewCell != null && viewCell.View != null && HasUnevenRows)
+				viewCell.View.ComputedConstraint = LayoutConstraint.None;
 			content.Parent = this;
+
 		}
 
 		protected override void UnhookContent(Cell content)


### PR DESCRIPTION
### Description of Change ###

We were using a fixed LayoutConstraint for the viewcell view, this caused Grid't using '*' (star) to skip computing the size of it's children and returning the cached value. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=37862

### API Changes ###

List all API changes here (or just put None), example:

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense