### PR TITLE
[WinRT] Add base platform as inner proxy navigation to Application, Fix back button issue

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -220,6 +220,13 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			if (_parentMasterDetailPage != null)
 				_parentMasterDetailPage.PropertyChanged -= MultiPagePropertyChanged;
+
+#if WINDOWS_UWP
+			if (_navManager != null)
+			{
+				_navManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+			}
+#endif
 		}
 
 		protected void OnElementChanged(VisualElementChangedEventArgs e)

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -97,6 +97,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			_navModel.Push(newRoot, null);
 			newRoot.NavigationProxy.Inner = this;
 			SetCurrent(newRoot, false, true);
+			((Application)newRoot.RealParent).NavigationProxy.Inner = this;
 		}
 
 		public IReadOnlyList<Page> NavigationStack


### PR DESCRIPTION
### Description of Change ###

In order to push a modal on app load the NavigationProxy needs a inner reference to the Platform itself. 
Also a small fix to remove the back button on UWP when the NavigationPageRenderer is removed. 

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=39187
- https://bugzilla.xamarin.com/show_bug.cgi?id=41854


List all API changes here (or just put None), example:

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense