### PR TITLE
[Core] Allow Registrar.RegisterAll to be run multiple times

### DIFF
--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Forms
 					foreach (Attribute attribute in effectAttributes)
 					{
 						var effect = (ExportEffectAttribute)attribute;
-						Effects.Add(resolutionName + "." + effect.Id, effect.Type);
+						Effects [resolutionName + "." + effect.Id] = effect.Type;
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Change ###

Allow Registrar.RegisterAll to be invoked multiple times.

### API Changes ###

None

### Behavioral Changes ###

There are cases where we run RegisterAll manually to ensure all
assemblies have actually been registered. The `Registrar<T>` class
does not use the `Dictionary<K, V>.Add` method so it does not
throw if there's a clash/duplicate.

If we change the `Effect` registration to use the same pattern we
can remove errors like this:

```
System.ArgumentException: An item with the same key has already been added.
	at ThrowArgumentException at offset 0 in file:line:column /Users/builder/data/lanes/2922/977921b7/source/maccore/_build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/src/mono/external/referencesource/mscorlib/system/throwhelper.cs:72:0
	at Insert at offset 142 in file:line:column /Users/builder/data/lanes/2922/977921b7/source/maccore/_build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/src/mono/external/referencesource/mscorlib/system/collections/generic/dictionary.cs:336:0
	at Add at offset 0 in file:line:column /Users/builder/data/lanes/2922/977921b7/source/maccore/_build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/src/mono/external/referencesource/mscorlib/system/collections/generic/dictionary.cs:192:0
	at RegisterAll at <unknown offset> in file:line:column <filename unknown>:0:0
	at <unknown method> at <unknown offset> in file:line:column <filename unknown>:0:0
	at Invoke at offset 56 in file:line:column /Users/builder/data/lanes/2922/977921b7/source/maccore/_build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/src/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:295:0
```