### PR TITLE
Fix bugzilla41209

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41029.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41029.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Controls
 	{
 		protected override void Init()
 		{
-			var layout = new StackLayout { VerticalOptions = LayoutOptions.Center, BackgroundColor = Color.Red };
+			var layout = new StackLayout { VerticalOptions = LayoutOptions.Center };
 			var lbl = new Label();
 			var slider = new Slider();
 			slider.HeightRequest = 50;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41029.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41029.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41029, "Slider default hitbox is larger than the control")]
+	public class Bugzilla41029 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var layout = new StackLayout { VerticalOptions = LayoutOptions.Center, BackgroundColor = Color.Red };
+			var lbl = new Label();
+			var slider = new Slider();
+			slider.HeightRequest = 50;
+			slider.ValueChanged += (object sender, ValueChangedEventArgs e) =>
+			{
+
+				lbl.Text = e.NewValue.ToString();
+			};
+			layout.Children.Add(lbl);
+			layout.Children.Add(slider);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -423,6 +423,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38284.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39486.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue55555.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41029.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsSeekBar.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsSeekBar.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Android.Widget;
+using Android.Content;
+using Android.Views;
+
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal class FormsSeekBar : SeekBar
+	{
+		public FormsSeekBar(Context context) : base(context)
+		{
+			//this should work, but it doesn't.
+			DuplicateParentStateEnabled = false;
+		}
+
+		public override bool OnTouchEvent(MotionEvent e)
+		{
+			switch (e.Action)
+			{
+				case MotionEventActions.Down:
+					isTouching = true;
+					break;
+				case MotionEventActions.Up:
+					Pressed = false;
+					break;
+			}
+				
+			return base.OnTouchEvent(e);
+		}
+
+		public override bool Pressed
+		{
+			get
+			{
+				return base.Pressed;
+			}
+			set
+			{
+				if (isTouching)
+				{
+					base.Pressed = value;
+					isTouching = value;
+				}
+					
+			}
+		}
+
+		bool isTouching = false;
+	}
+}
+

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (e.OldElement == null)
 			{
-				var seekBar = new SeekBar(Context);
+				var seekBar = new FormsSeekBar(Context);
 				SetNativeControl(seekBar);
 
 				seekBar.Max = 1000;

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -239,6 +239,7 @@
     <Compile Include="AppCompat\CarouselPageRenderer.cs" />
     <Compile Include="AppCompat\FormsFragmentPagerAdapter.cs" />
     <Compile Include="AndroidAppIndexProvider.cs" />
+    <Compile Include="Renderers\FormsSeekBar.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
### Description of Change ###

This issue seems to be a bug on android, for some reason the SeekBar gets the pressed state if we have a GestureDetector above on the hierarchy and the background ins transparent, i have checked and even with the correct Clickable = false; or DuplicateParentStateEnabled set to false this behaviour still occurs. 

My change is to override when android is trying to set the SeekBar as pressed state and check if we are or not touching the Slider itself before setting the pressed state.

The testing has to be with visual inspection . 


### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41029

### API Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense