### PR TITLE
Fix 39802

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -89,6 +89,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (contextCell != null)
 			{
 				contextCell.Update(tableView, cell, nativeCell);
+				var viewTableCell = contextCell.ContentCell as ViewCellRenderer.ViewTableCell;
+				if (viewTableCell != null)
+					viewTableCell.SupressSeparator = true;
 				nativeCell = contextCell;
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -86,10 +86,18 @@ namespace Xamarin.Forms.Platform.iOS
 				get { return ViewCell; }
 			}
 
+			internal bool SupressSeparator { get; set; }
+
 			public override void LayoutSubviews()
 			{
 				//This sets the content views frame.
 				base.LayoutSubviews();
+
+				if (SupressSeparator)
+				{
+					var oldFrame = Frame;
+					ContentView.Bounds = Frame = new RectangleF(oldFrame.Location, new SizeF(oldFrame.Width, oldFrame.Height + 0.5f));
+				}
 
 				var contentFrame = ContentView.Frame;
 				var view = ViewCell.View;
@@ -114,8 +122,9 @@ namespace Xamarin.Forms.Platform.iOS
 				var height = size.Height > 0 ? size.Height : double.PositiveInfinity;
 				var result = renderer.Element.Measure(width, height);
 
-				// make sure to add in the separator
-				return new SizeF(size.Width, (float)result.Request.Height + 1f / UIScreen.MainScreen.Scale);
+				// make sure to add in the separator if needed
+				var finalheight = ((float)result.Request.Height + (SupressSeparator ? 0f : 1f)) / UIScreen.MainScreen.Scale;
+				return new SizeF(size.Width, finalheight);
 			}
 
 			protected override void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change ###

When setting separator to None we sill had some issues when using RecycleElement, where a line would be seen. 
In iOS this was because we are using a ContextActionCell by default and we add as a child another UITableCell (ViewCellRenderer) for example, this 2 nd cell gets the separator since it was never attach to a UITableVIew to get the right parameter. 
Since there's no way to tell to that 2nd cell to remove it's separator, we hide when we are on LayoutSubviews.
On Android  our implementation only made the line get transparent, but it was always draw. So we changed so it only draws the line for group headers of if we have a separator.

This just needs visual inspection , can't write a uitest for it. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=39802

### API Changes ###

None

### Behavioral Changes ###

No Gap will be seen when using RecycleElement and Separator to None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense