### PR TITLE
[Android] Fix Api18 usage on PinchGesture

### DIFF
--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -41,9 +41,9 @@ namespace Xamarin.Forms.Platform.Android
 						_gestureListener =
 						new InnerGestureListener(_tapGestureHandler.OnTap, _tapGestureHandler.TapGestureRecognizers, _panGestureHandler.OnPan, _panGestureHandler.OnPanStarted, _panGestureHandler.OnPanComplete)));
 
-			_scaleDetector =
-				new Lazy<ScaleGestureDetector>(
-					() => new ScaleGestureDetector(Context, new InnerScaleListener(_pinchGestureHandler.OnPinch, _pinchGestureHandler.OnPinchStarted, _pinchGestureHandler.OnPinchEnded), Handler));
+			_scaleDetector = new Lazy<ScaleGestureDetector>(
+					() => new ScaleGestureDetector(Context, new InnerScaleListener(_pinchGestureHandler.OnPinch, _pinchGestureHandler.OnPinchStarted, _pinchGestureHandler.OnPinchEnded))
+					);
 		}
 
 		public TElement Element { get; private set; }


### PR DESCRIPTION
### Description of Change ###

Fix usage of a API18 only constructor on ScaleGestureDetector

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=36447

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
