### PR TITLE
[Android] Fix padding on master MDP when using split view

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -118,6 +118,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 					_masterLayout = new MasterDetailContainer(newElement, true, Context)
 					{
+						TopPadding = ((IMasterDetailPageController)newElement).ShouldShowSplitMode ? statusBarHeight : 0,
 						LayoutParameters = new LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent) { Gravity = (int)GravityFlags.Start }
 					};
 

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailContainer.cs
@@ -120,6 +120,7 @@ namespace Xamarin.Forms.Platform.Android
 			double width = Context.FromPixels(right - left);
 			double height = Context.FromPixels(bottom - top);
 			double xPos = 0;
+			bool supressPadding = false;
 
 			//splitview
 			if (MasterDetailPageController.ShouldShowSplitMode)
@@ -131,11 +132,13 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else
 			{
+				//if we are showing the normal popover master doesn't have padding
+				supressPadding = isMasterPage;
 				//popover make the master smaller
 				width = isMasterPage && (Device.Info.CurrentOrientation.IsLandscape() || Device.Idiom == TargetIdiom.Tablet) ? DefaultWidthMaster : width;
 			}
 
-			double padding = Context.FromPixels(TopPadding);
+			double padding = supressPadding ? 0 : Context.FromPixels(TopPadding);
 			return new Rectangle(xPos, padding, width, height - padding);
 		}
 


### PR DESCRIPTION
### Description of Change ###

On Android when using the split behaviour we need to add a extra padding to the master page.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41404

### API Changes ###

None

### Behavioral Changes ###

Master page of MDP when in split on a tablet android will show correctly bellow the status bar

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense