### PR TITLE
[UWP] MasterDetailControl will no longer null out the TCS before it is used. 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41842.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41842.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41842, "Set MasterDetailPage.Detail = New Page() twice will crash the application when set MasterBehavior = MasterBehavior.Split", PlatformAffected.WinRT)]
+	public class Bugzilla41842 : TestMasterDetailPage
+	{
+		protected override void Init()
+		{
+			MasterBehavior = MasterBehavior.Split;
+
+			Master = new Page() { Title = "Master" };
+
+			Detail = new NavigationPage(new Page());
+			Detail = new NavigationPage(new ContentPage { Content = new Label { Text = "Success" } });
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla41842Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Success"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -152,6 +152,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPages\ScreenshotConditionalApp.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41842.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -167,7 +167,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_commandBarTcs = new TaskCompletionSource<CommandBar>();
 			ApplyTemplate();
-			return _commandBarTcs.Task;
+
+			var commandBarFromTemplate = _commandBarTcs.Task;
+			_commandBarTcs = null;
+
+			return commandBarFromTemplate;
 		}
 
 		protected override void OnApplyTemplate()
@@ -193,12 +197,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			UpdateMode();
 
-			TaskCompletionSource<CommandBar> tcs = _commandBarTcs;
-			if (tcs != null)
-			{
-				_commandBarTcs = null;
-				tcs.SetResult(_commandBar);
-			}
+			if (_commandBarTcs != null)
+				_commandBarTcs.SetResult(_commandBar);
 		}
 
 		static void OnShouldShowSplitModeChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

MasterDetailControl will no longer null out the TCS before it is used. 

Failure only occurs when the MainPage is swapped out and the Detail page is changed twice. UI test doesn't cover this scenario.

### Bugs Fixed ###

- [Bug 41842  - Set MasterDetailPage.Detail = New Page() twice will crash the application when set MasterBehavior = MasterBehavior.Split] (https://bugzilla.xamarin.com/show_bug.cgi?id=41842)

### API Changes ###

None

### Behavioral Changes ###

Resolves NRE crash

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
