### PR TITLE
[Android] Set parent to the new group header cell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40704.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40704.cs
@@ -102,7 +102,7 @@ namespace Xamarin.Forms.Controls
 				tapGesture = new TapGestureRecognizer();
 				tapGesture.Tapped += HeaderCell_OnTapped;
 				grd.GestureRecognizers.Add(tapGesture);
-				var lbl = new Label { HorizontalOptions = LayoutOptions.FillAndExpand, TextColor = Color.Black, FontSize = 16 };
+				var lbl = new Label { VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.FillAndExpand, TextColor = Color.Black, FontSize = 16 };
 				lbl.SetBinding(Label.TextProperty, new Binding("Title"));
 
 				grd.Children.Add(lbl);
@@ -212,7 +212,12 @@ namespace Xamarin.Forms.Controls
 		}
 
 
-		#if UITEST
+#if UITEST
+		[Test]
+		public void Bugzilla40704HeaderPresentTest()
+		{
+			RunningApp.WaitForElement("Menu - 0");
+		}
 		[Test]
 		public void Bugzilla40704Test()
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -408,6 +408,7 @@ namespace Xamarin.Forms.Platform.Android
 						var groupContent = _listView.TemplatedItems.GroupHeaderTemplate.CreateContent(group.ItemsSource, _listView) as Cell;
 						if (groupContent != null)
 						{
+							groupContent.Parent = _listView;
 							groupContent.BindingContext = group.ItemsSource;
 							cells.Add(groupContent);
 						}


### PR DESCRIPTION
### Description of Change ###

When we have to create a GroupHeader cell since we aren't using TIL methods we need to make sure we add a parent to the cell so it can measure the content. The issue wasn't visible at first because of missing the LayoutOptions on the label. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40704

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
