### PR TITLE
[Android] Support override back button press event inside navigation bar with FormsAppCompatActivity

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 {
 	public class NavigationPageRenderer : VisualElementRenderer<NavigationPage>, IManageFragments
 	{
-        public delegate bool BackButtonPressedEventHandler(object sender, EventArgs e);
+		public delegate bool BackButtonPressedEventHandler(object sender, EventArgs e);
 
         readonly List<Fragment> _fragmentStack = new List<Fragment>();
 
@@ -359,16 +359,16 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			valueAnim.Start();
 		}
 
-        public static event BackButtonPressedEventHandler BackPressed;
+		public static event BackButtonPressedEventHandler BackPressed;
 
-        void BarOnNavigationClick(object sender, AToolbar.NavigationClickEventArgs navigationClickEventArgs)
+		void BarOnNavigationClick(object sender, AToolbar.NavigationClickEventArgs navigationClickEventArgs)
 		{
-            if (BackPressed != null && BackPressed(this, EventArgs.Empty))
-                return;
-            Element?.PopAsync();
+			if (BackPressed != null && BackPressed(this, EventArgs.Empty))
+				return;
+			Element?.PopAsync();
 		}
 
-        void CurrentOnPropertyChanged(object sender, PropertyChangedEventArgs e)
+		void CurrentOnPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == NavigationPage.HasNavigationBarProperty.PropertyName)
 				ToolbarVisible = NavigationPage.GetHasNavigationBar(Current);

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -28,7 +28,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 {
 	public class NavigationPageRenderer : VisualElementRenderer<NavigationPage>, IManageFragments
 	{
-		readonly List<Fragment> _fragmentStack = new List<Fragment>();
+        public delegate bool BackButtonPressedEventHandler(object sender, EventArgs e);
+
+        readonly List<Fragment> _fragmentStack = new List<Fragment>();
 
 		Drawable _backgroundDrawable;
 		Page _current;
@@ -357,12 +359,16 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			valueAnim.Start();
 		}
 
-		void BarOnNavigationClick(object sender, AToolbar.NavigationClickEventArgs navigationClickEventArgs)
+        public static event BackButtonPressedEventHandler BackPressed;
+
+        void BarOnNavigationClick(object sender, AToolbar.NavigationClickEventArgs navigationClickEventArgs)
 		{
-			Element?.PopAsync();
+            if (BackPressed != null && BackPressed(this, EventArgs.Empty))
+                return;
+            Element?.PopAsync();
 		}
 
-		void CurrentOnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        void CurrentOnPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == NavigationPage.HasNavigationBarProperty.PropertyName)
 				ToolbarVisible = NavigationPage.GetHasNavigationBar(Current);

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 	{
 		public delegate bool BackButtonPressedEventHandler(object sender, EventArgs e);
 
-        readonly List<Fragment> _fragmentStack = new List<Fragment>();
+		readonly List<Fragment> _fragmentStack = new List<Fragment>();
 
 		Drawable _backgroundDrawable;
 		Page _current;


### PR DESCRIPTION
### Description of Change ###

Support override back button press event inside navigation bar material design with FormsAppCompatActivity

### Bugs Fixed ###

- Fail to migrate to android material design

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - public delegate bool BackButtonPressedEventHandler(object sender, EventArgs e);
 - public static event BackButtonPressedEventHandler BackPressed;

Changed:
 - BarOnNavigationClick method
