### PR TITLE
Picker: bindable SelectedItem & ItemsSource props, Entry: IsFocused prop not only ReadOnly

### DIFF
--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -25,6 +25,9 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(Entry), FontAttributes.None);
 
+		public static new readonly BindableProperty IsFocusedProperty =
+				BindableProperty.Create (nameof (IsFocused), typeof (bool), typeof (Entry), false, BindingMode.TwoWay, propertyChanged: OnIsFocusedChanged);
+
 		public TextAlignment HorizontalTextAlignment
 		{
 			get { return (TextAlignment)GetValue(HorizontalTextAlignmentProperty); }
@@ -80,6 +83,11 @@ namespace Xamarin.Forms
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public new bool IsFocused {
+			get { return (bool)GetValue (IsFocusedProperty); }
+			set { SetValue (IsFocusedProperty, value); }
+		}
+
 		public event EventHandler Completed;
 
 		public event EventHandler<TextChangedEventArgs> TextChanged;
@@ -94,6 +102,18 @@ namespace Xamarin.Forms
 			var entry = (Entry)bindable;
 
 			entry.TextChanged?.Invoke(entry, new TextChangedEventArgs((string)oldValue, (string)newValue));
+		}
+
+		public static void OnIsFocusedChanged (object sender, object oldValue, object newvalue)
+		{
+			OnIsFocusedChanged ((VisualElement)sender, (bool)oldValue, (bool)newvalue);
+		}
+
+		public static void OnIsFocusedChanged (VisualElement sender, bool oldValue, bool newValue)
+		{
+			if (newValue)
+				sender.Focus ();
+			sender.SetValue (IsFocusedProperty, false);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
Picker.cs:
- A Collection can be bound to the ItemsSource property.
- We can easily get the current selected item with the SelectedItem property.

Entry.cs:
- An Entry can now be focused (call to the Focus(); method in the propertyChanged delegate) with the 'IsFocused' property. In order to do that, I have hidden 'IsFocused' that is inherited from VisualElement (new keyword).

### Bugs Fixed ###
None

### API Changes ###
None

Added:
Picker.cs:
- public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create (nameof (ItemsSource), typeof (IEnumerable), typeof (Picker), null, propertyChanged: OnItemsSourcePropertyChanged);

- public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create (nameof (SelectedItem), typeof (object), typeof (Picker), null, BindingMode.TwoWay, propertyChanged: OnSelectedItemPropertyChanged);

- static void OnItemsSourcePropertyChanged (BindableObject bindable, object value, object newValue);

- static void OnSelectedItemPropertyChanged (BindableObject bindable, object value, object newValue);

Entry.cs:
- public static new readonly BindableProperty IsFocusedProperty = BindableProperty.Create (nameof (IsFocused), typeof (bool), typeof (Entry), false, BindingMode.TwoWay, propertyChanged: OnIsFocusedChanged);

- public new bool IsFocused;

- public static void OnIsFocusedChanged (object sender, object oldValue, object newvalue);
- public static void OnIsFocusedChanged (VisualElement sender, bool oldValue, bool newValue);

Changed:
 - public Picker(); => public Picker(); (added : SelectedIndexChanged += (o, e) => ...)

### Behavioral Changes ###

Picker.cs:
- Two bindable properties added.

Entry.cs:
- One bindable property added.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense