### PR TITLE
[iOS] Default BarTextColor/BarBackgroundColor will no longer override values set in custom renderers

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -27,7 +27,7 @@ using MonoTouch.CoreLocation;
 [assembly: ExportRenderer(typeof(NativeListView2), typeof(NativeiOSListViewRenderer))]
 [assembly: ExportRenderer(typeof(NativeListView), typeof(NativeListViewRenderer))]
 [assembly: ExportRenderer(typeof(CustomMapView), typeof(CustomIOSMapRenderer))]
-
+[assembly: ExportRenderer(typeof(TabbedPage), typeof(TabbedPageWithCustomBarColorRenderer))]
 namespace Xamarin.Forms.ControlGallery.iOS
 {
 	public class CustomIOSMapRenderer : ViewRenderer<CustomMapView, MKMapView>
@@ -588,5 +588,16 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		}
 	}
 
+	public class TabbedPageWithCustomBarColorRenderer : TabbedRenderer
+	{
+		public TabbedPageWithCustomBarColorRenderer()
+		{
+			TabBar.TintColor = UIColor.White;
+			TabBar.BarTintColor = UIColor.Purple;
+
+			//UITabBar.Appearance.TintColor = UIColor.White;
+			//UITabBar.Appearance.BarTintColor = UIColor.Purple;
+		}
+	}
 }
 

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -96,12 +96,17 @@ namespace Xamarin.Forms.Controls
 		{
 			AutomationId = "TabbedPageRoot";
 
-			BarBackgroundColor = Color.Maroon;
-			BarTextColor = Color.Yellow;
 
-			Device.StartTimer(TimeSpan.FromSeconds(2), () => {
-				BarBackgroundColor = Color.Default;
-				BarTextColor = Color.Default;
+			Device.StartTimer(TimeSpan.FromSeconds(6), () => {
+				BarBackgroundColor = Color.Maroon;
+				BarTextColor = Color.Yellow;
+
+				Device.StartTimer(TimeSpan.FromSeconds(6), () => {
+					BarBackgroundColor = Color.Default;
+					BarTextColor = Color.Default;
+
+					return false;
+				});
 
 				return false;
 			});

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -24,6 +24,12 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class TabbedRenderer : UITabBarController, IVisualElementRenderer, IEffectControlProvider
 	{
+		bool _barBackgroundColorWasSet;
+		bool _barTextColorWasSet;
+		UIColor _defaultBarTextColor;
+		bool _defaultBarTextColorSet;
+		UIColor _defaultBarColor;
+		bool _defaultBarColorSet;
 		bool _loaded;
 		Size _queuedSize;
 
@@ -309,14 +315,31 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			var barBackgroundColor = Tabbed.BarBackgroundColor;
+			var isDefaultColor = barBackgroundColor.IsDefault;
+
+			if (isDefaultColor && !_barBackgroundColorWasSet)
+				return;
+
+			if (!_defaultBarColorSet)
+			{
+				if (Forms.IsiOS7OrNewer)
+					_defaultBarColor = TabBar.BarTintColor;
+				else
+					_defaultBarColor = TabBar.TintColor;
+
+				_defaultBarColorSet = true;
+			}
+
+			if (!isDefaultColor)
+				_barBackgroundColorWasSet = true;
 
 			if (Forms.IsiOS7OrNewer)
 			{
-				TabBar.BarTintColor = barBackgroundColor == Color.Default ? UINavigationBar.Appearance.BarTintColor : barBackgroundColor.ToUIColor();
+				TabBar.BarTintColor = isDefaultColor ? _defaultBarColor : barBackgroundColor.ToUIColor();
 			}
 			else
 			{
-				TabBar.TintColor = barBackgroundColor == Color.Default ? UINavigationBar.Appearance.TintColor : barBackgroundColor.ToUIColor();
+				TabBar.TintColor = isDefaultColor ? _defaultBarColor : barBackgroundColor.ToUIColor();
 			}
 		}
 
@@ -326,13 +349,24 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			var barTextColor = Tabbed.BarTextColor;
+			var isDefaultColor = barTextColor.IsDefault;
 
-			var globalAttributes = UINavigationBar.Appearance.GetTitleTextAttributes();
+			if (isDefaultColor && !_barTextColorWasSet)
+				return;
 
-			var attributes = new UITextAttributes { Font = globalAttributes.Font };
+			if (!_defaultBarTextColorSet)
+			{
+				_defaultBarTextColor = TabBar.TintColor; 
+				_defaultBarTextColorSet = true;
+			}
 
-			if (barTextColor == Color.Default)
-				attributes.TextColor = globalAttributes.TextColor;
+			if (!isDefaultColor)
+				_barTextColorWasSet = true;
+
+			var attributes = new UITextAttributes();
+
+			if (isDefaultColor)
+				attributes.TextColor = _defaultBarTextColor;
 			else
 				attributes.TextColor = barTextColor.ToUIColor();
 
@@ -345,7 +379,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// setting the unselected icon tint is not supported by iOS
 			if (Forms.IsiOS7OrNewer)
 			{
-				TabBar.TintColor = barTextColor == Color.Default ? UINavigationBar.Appearance.TintColor : barTextColor.ToUIColor();
+				TabBar.TintColor = isDefaultColor ? _defaultBarTextColor : barTextColor.ToUIColor();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

[iOS] Not setting the BarTextColor/BarBackgroundColor (i.e., leaving set to Default) will no longer override values set in custom renderers,

Visually test this by viewing the TabbedPage on the gallery. The tab bar should be purple/white, then maroon/yellow, then purple/white again.

### Bugs Fixed ###

- [Reported on forums] (https://forums.xamarin.com/discussion/comment/204166/#Comment_204166)
- [Bug 41980 - TabBar BarTintColor no longer working in 2.3.0.49] (https://bugzilla.xamarin.com/show_bug.cgi?id=41980)
- [Bug 42032 - UINavigationBar.Appearance.BarTintColor changes Tab bar color] (https://bugzilla.xamarin.com/show_bug.cgi?id=42032)

### API Changes ###

None

### Behavioral Changes ###

TabbedPage BarTextColor/BarBackgroundColor defaults are drawn from values set by a renderer, falling back to global defaults.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
