### PR TITLE
[Android] Don't force the SetSingleLine() to true

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -155,32 +155,31 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateLineBreakMode()
 		{
+            _view.SetSingleLine(false);
 			switch (Element.LineBreakMode)
 			{
 				case LineBreakMode.NoWrap:
-					_view.SetSingleLine(true);
+					_view.SetMaxLines(1);
 					_view.Ellipsize = null;
 					break;
 				case LineBreakMode.WordWrap:
-					_view.SetSingleLine(false);
 					_view.Ellipsize = null;
 					_view.SetMaxLines(100);
 					break;
 				case LineBreakMode.CharacterWrap:
-					_view.SetSingleLine(false);
 					_view.Ellipsize = null;
 					_view.SetMaxLines(100);
 					break;
 				case LineBreakMode.HeadTruncation:
-					_view.SetSingleLine(true);
+					_view.SetMaxLines(1);
 					_view.Ellipsize = TextUtils.TruncateAt.Start;
 					break;
 				case LineBreakMode.TailTruncation:
-					_view.SetSingleLine(true);
+					_view.SetMaxLines(1);
 					_view.Ellipsize = TextUtils.TruncateAt.End;
 					break;
 				case LineBreakMode.MiddleTruncation:
-					_view.SetSingleLine(true);
+					_view.SetMaxLines(1);
 					_view.Ellipsize = TextUtils.TruncateAt.Middle;
 					break;
 			}


### PR DESCRIPTION
### Description of Change ###

When using the SetSingleLine(true) in the base LabelRenderer on Android, developers won't be able to use the SetMaxLines() in their own Custom Renderers
later on.
So we force a single line by using the SetMaxLines(1) in the
base LabelRenderer and SetSingleLine(false)