### PR TITLE
[Android] Fix AppCompat not calling OnOptionsItemSelected

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -694,6 +694,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			bool isNavigated = ((INavigationPageController)Element).StackDepth > 1;
 			bar.NavigationIcon = null;
 
+			activity.SetSupportActionBar(bar);
+			activity.SupportActionBar.SetHomeButtonEnabled(true);
+			activity.SupportActionBar.SetDisplayHomeAsUpEnabled(true);
+
 			if (isNavigated)
 			{
 				if (toggle != null)


### PR DESCRIPTION
### Description of Change ###

The `NavigationPageRenderer` for AppCompat needed to correctly set the `SupportActionBar` and
call `SetHomeButtonEnabled(true)` and `SetDisplayHomeAsUpEnabled(true)` in order to get `OnOptionsItemSelected` to fire correctly.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=38189

### API Changes ###

None

### Behavioral Changes ###

At the moment, I don't expect anything other than `OnOptionsItemSelected` actually being able to fire off as it would were `FormsApplicationActivity` being used instead.

To note, I'm not entirely certain if we can or need to make any changes in `FormsAppCompatActivity` since `SetSupportActionBar` is being called there as well. However, the `activity` value being used in `NavigationPageRenderer` is what needed to be adjusted for the `OnOptionsItemSelected` to actually work.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense