### PR TITLE
[Android] TimePicker unfocuses on cancel

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42074.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42074.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 42074, "[Android] Clicking cancel on a TimePicker does not cause it to unfocus", PlatformAffected.Android)]
+    public class Bugzilla42074 : TestContentPage
+    {
+        const string TimePicker = "TimePicker";
+
+        protected override void Init()
+        {
+            var timePicker = new TimePicker
+            {
+                AutomationId = TimePicker
+            };
+            var timePickerFocusButton = new Button
+            {
+                Text = "Click to focus TimePicker",
+                Command = new Command(() => timePicker.Focus())
+            };
+            Content = new StackLayout
+            {
+                Children =
+                {
+                    timePicker,
+                    timePickerFocusButton
+                }
+            };
+        }
+
+#if UITEST
+
+#if __ANDROID__
+        [Test]
+        public void TimePickerCancelShouldUnfocus()
+        {
+            RunningApp.Tap(q => q.Marked(TimePicker));
+            RunningApp.WaitForElement(q => q.Marked("Cancel"));
+
+            RunningApp.Tap(q => q.Marked("Cancel"));
+            RunningApp.WaitForElement(q => q.Marked("Click to focus TimePicker"));
+
+            RunningApp.Tap(q => q.Marked("Click to focus TimePicker"));
+            RunningApp.WaitForElement(q => q.Marked("Cancel"));
+
+            RunningApp.Tap(q => q.Marked("Cancel"));
+        }
+#endif
+
+#endif
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -107,6 +107,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42074.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -27,6 +27,10 @@ namespace Xamarin.Forms.Platform.Android
 
 			ElementController.SetValueFromRenderer(TimePicker.TimeProperty, new TimeSpan(hourOfDay, minute, 0));
 			Control.ClearFocus();
+
+			if (Forms.IsLollipopOrNewer)
+				_dialog.CancelEvent -= OnCancelButtonClicked;
+
 			_dialog = null;
 		}
 
@@ -70,6 +74,10 @@ namespace Xamarin.Forms.Platform.Android
 				_dialog.Hide();
 				ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 				Control.ClearFocus();
+
+				if (Forms.IsLollipopOrNewer)
+					_dialog.CancelEvent -= OnCancelButtonClicked;
+
 				_dialog = null;
 			}
 		}
@@ -80,7 +88,16 @@ namespace Xamarin.Forms.Platform.Android
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 
 			_dialog = new TimePickerDialog(Context, this, view.Time.Hours, view.Time.Minutes, false);
+
+			if (Forms.IsLollipopOrNewer)
+				_dialog.CancelEvent += OnCancelButtonClicked;
+
 			_dialog.Show();
+		}
+
+		void OnCancelButtonClicked(object sender, EventArgs e)
+		{
+			Element.Unfocus();
 		}
 
 		void SetTime(TimeSpan time)


### PR DESCRIPTION
### Description of Change ###

This is a similar fix to #204 which needed to be adjusted to respect the cancel button being pressed on the `TimePicker` dialog, as well. The control gallery reproduction and test for that issue has been duplicated and modified to check against the `TimePicker`.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=42074

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
