### PR TITLE
[8.1/UWP] ListView allows selection with enter key

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.Foundation;
+using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
@@ -76,6 +77,9 @@ namespace Xamarin.Forms.Platform.WinRT
 					// and prevented from bubbling up) rather than ListView.ItemClick
 					List.Tapped += ListOnTapped;
 
+					// We also want to watch for the Enter key being pressed for selection
+					List.KeyUp += OnKeyPressed;
+
 					if (ShouldCustomHighlight)
 					{
 						List.SelectionChanged += OnControlSelectionChanged;
@@ -140,6 +144,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (List != null)
 			{
 				List.Tapped -= ListOnTapped;
+				List.KeyUp -= OnKeyPressed;
 
 				if (ShouldCustomHighlight)
 				{
@@ -519,6 +524,12 @@ namespace Xamarin.Forms.Platform.WinRT
 				List.SelectedItem = selectedItem;
 			}
 #endif
+		}
+
+		void OnKeyPressed(object sender, KeyRoutedEventArgs e)
+		{
+			if (e.Key == VirtualKey.Enter)
+				OnListItemClicked(List.SelectedIndex);
 		}
 
 		void OnControlSelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Putting ListView in line with standard behavior where `ItemClick` would normally fire off when pressing the enter key to select a ListView item.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=42188

### API Changes ###

None

### Behavioral Changes ###

If a user had a custom renderer with behavior linked to `KeyUp` for the enter key, something unintentional could potentially occur, though perhaps unlikely.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

