### PR TITLE
[Win] Setting TabbedPage.BarTextColor works

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -117,7 +117,8 @@ namespace Xamarin.Forms.Controls
 				{
 					Title = "Rubriques",
 					Icon = "coffee.png",
-					BarBackgroundColor = Color.Blue
+					BarBackgroundColor = Color.Blue,
+					BarTextColor = Color.Aqua
 				});
 
 			Children.Add(new NavigationPage(new Page())

--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -463,7 +463,7 @@
         <uwp:EntryCellTextBox IsEnabled="{Binding IsEnabled}" Header="{Binding}" Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextAlignment="{Binding HorizontalTextAlignment,Converter={StaticResource HorizontalTextAlignmentConverter}}" PlaceholderText="{Binding Placeholder}"  InputScope="{Binding Keyboard,Converter={StaticResource KeyboardConverter}}" HorizontalAlignment="Stretch">
 			<uwp:EntryCellTextBox.HeaderTemplate>
 				<DataTemplate>
-					<TextBlock Text="{Binding Label}" Style="{ThemeResource BaseTextBlockStyle}" Foreground="{Binding LabelColor, Converter={StaticResource ColorConverter}, ConverterParameter=DefaultTextForegroundThemeBrush}" />
+					<TextBlock Text="{Binding Label}" Style="{ThemeResource BaseTextBlockStyle}" Foreground="{Binding LabelColor, Converter={StaticResource ColorConverter}, ConverterParameter=SystemControlBackgroundChromeMediumLowBrush}" />
 				</DataTemplate>
 			</uwp:EntryCellTextBox.HeaderTemplate>
 		</uwp:EntryCellTextBox>
@@ -473,7 +473,7 @@
 		<Setter Property="HeaderTemplate">
 			<Setter.Value>
 				<DataTemplate>
-					<TextBlock Text="{Binding Title}" Foreground="{Binding ToolbarForeground}" Style="{ThemeResource BodyTextBlockStyle}" />
+					<TextBlock Name="TabbedPageHeaderTextBlock" Text="{Binding Title}" Style="{ThemeResource BodyTextBlockStyle}" />
 				</DataTemplate>
 			</Setter.Value>
 		</Setter>
@@ -618,7 +618,7 @@
                                             <ContentControl.Clip>
                                                 <RectangleGeometry x:Name="HeaderClipperGeometry"/>
                                             </ContentControl.Clip>
-                                            <Grid Background="{TemplateBinding ToolbarBackground}">
+											<Grid Name="TabbedPageHeaderGrid" Background="{TemplateBinding ToolbarBackground}">
                                                 <PivotHeaderPanel x:Name="StaticHeader" Visibility="Collapsed"/>
                                                 <PivotHeaderPanel x:Name="Header">
                                                     <PivotHeaderPanel.RenderTransform>

--- a/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
@@ -12,12 +12,12 @@ namespace Xamarin.Forms.Platform.WinRT
 {
 	public class FormsPivot : Pivot, IToolbarProvider
 	{
-		public static readonly DependencyProperty ToolbarVisibilityProperty = DependencyProperty.Register("ToolbarVisibility", typeof(Visibility), typeof(FormsPivot),
+		public static readonly DependencyProperty ToolbarVisibilityProperty = DependencyProperty.Register(nameof(ToolbarVisibility), typeof(Visibility), typeof(FormsPivot),
 			new PropertyMetadata(Visibility.Collapsed));
 
-		public static readonly DependencyProperty ToolbarForegroundProperty = DependencyProperty.Register("ToolbarForeground", typeof(Brush), typeof(FormsPivot), new PropertyMetadata(default(Brush)));
+		public static readonly DependencyProperty ToolbarForegroundProperty = DependencyProperty.Register(nameof(ToolbarForeground), typeof(Brush), typeof(FormsPivot), new PropertyMetadata(default(Brush)));
 
-		public static readonly DependencyProperty ToolbarBackgroundProperty = DependencyProperty.Register("ToolbarBackground", typeof(Brush), typeof(FormsPivot), new PropertyMetadata(default(Brush)));
+		public static readonly DependencyProperty ToolbarBackgroundProperty = DependencyProperty.Register(nameof(ToolbarBackground), typeof(Brush), typeof(FormsPivot), new PropertyMetadata(default(Brush)));
 
 		CommandBar _commandBar;
 

--- a/Xamarin.Forms.Platform.WinRT.Phone/PhoneResources.xaml
+++ b/Xamarin.Forms.Platform.WinRT.Phone/PhoneResources.xaml
@@ -242,7 +242,7 @@
         <Setter Property="HeaderTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <TextBlock Text="{Binding Title}" Foreground="{TemplateBinding ToolbarForeground}" />
+					<TextBlock Text="{Binding Title}" Name="TabbedPageHeaderTextBlock" />
                 </DataTemplate>
             </Setter.Value>
         </Setter>
@@ -450,10 +450,6 @@
 	
 	<DataTemplate x:Key="TabbedPage">
 		<local:TabbedPagePresenter Content="{Binding Converter={StaticResource PageToRenderer}}" />
-	</DataTemplate>
-
-	<DataTemplate x:Key="TabbedPageHeader">
-		<TextBlock Text="{Binding Title}" />
 	</DataTemplate>
 
 	<Style x:Key="JumpListGrid" TargetType="GridView">

--- a/Xamarin.Forms.Platform.WinRT.Tablet/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/TabbedPageRenderer.cs
@@ -12,8 +12,12 @@ namespace Xamarin.Forms.Platform.WinRT
 	public class TabbedPageRenderer
 		: IVisualElementRenderer
 	{
-		Canvas _canvas;
+		const string TabBarHeaderTextBlockName = "TabbedPageHeaderTextBlock";
+		const string TabbedPageHeaderStackPanelName = "TabbedPageHeaderStackPanel";
 
+		Color _barBackgroundColor;
+		Color _barTextColor;
+		Canvas _canvas;
 		bool _disposed;
 		TabsControl _tabs;
 		VisualElementTracker<Page, Canvas> _tracker;
@@ -83,16 +87,16 @@ namespace Xamarin.Forms.Platform.WinRT
 						Container = _canvas
 					};
 
-					_canvas.Loaded += OnLoaded;
-					_canvas.Unloaded += OnUnloaded;
+					_canvas.Loaded += canvas_OnLoaded;
+					_canvas.Unloaded += canvas_OnUnloaded;
+
+					_tabs.Loaded += tabs_OnLoaded;
 				}
 
 				_tabs.DataContext = element;
 
 				OnPagesChanged(Page.Children, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 				UpdateCurrentPage();
-				UpdateBarTextColor();
-				UpdateBarBackgroundColor();
 
 				((INotifyCollectionChanged)Page.Children).CollectionChanged += OnPagesChanged;
 				element.PropertyChanged += OnElementPropertyChanged;
@@ -112,7 +116,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		Brush GetBarForegroundBrush()
 		{
 			object defaultColor = Windows.UI.Xaml.Application.Current.Resources["ApplicationForegroundThemeBrush"];
-			if (Page.BarTextColor.IsDefault)
+			if (Page.BarTextColor.IsDefault && defaultColor != null)
 				return (Brush)defaultColor;
 			return Page.BarTextColor.ToBrush();
 		}
@@ -176,7 +180,11 @@ namespace Xamarin.Forms.Platform.WinRT
 		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(TabbedPage.CurrentPage))
+			{
 				UpdateCurrentPage();
+				UpdateBarTextColor();
+				UpdateBarBackgroundColor();
+			}
 			else if (e.PropertyName == TabbedPage.BarTextColorProperty.PropertyName)
 				UpdateBarTextColor();
 			else if (e.PropertyName == TabbedPage.BarBackgroundColorProperty.PropertyName)
@@ -185,12 +193,48 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void UpdateBarBackgroundColor()
 		{
-			_tabs.Background = GetBarBackgroundBrush();
+			TabbedPage tabbedPage = Element as TabbedPage;
+			if (tabbedPage == null) return;
+			var barBackgroundColor = tabbedPage.BarBackgroundColor;
+
+			if (barBackgroundColor == _barBackgroundColor) return;
+			_barBackgroundColor = barBackgroundColor;
+
+			var controlToolbarBackground = _tabs.ToolbarBackground;
+			if (controlToolbarBackground == null && barBackgroundColor.IsDefault) return;
+
+			var brush = GetBarBackgroundBrush();
+			if (brush == controlToolbarBackground) return;
+
+			_tabs.ToolbarBackground = brush;
+
+			foreach (StackPanel tabBarGrid in _tabs.GetDescendantsByName<StackPanel>(TabbedPageHeaderStackPanelName))
+			{
+				tabBarGrid.Background = brush;
+			}
 		}
 
 		void UpdateBarTextColor()
 		{
-			_tabs.Foreground = GetBarForegroundBrush();
+			TabbedPage tabbedPage = Element as TabbedPage;
+			if (tabbedPage == null) return;
+			var barTextColor = tabbedPage.BarTextColor;
+
+			if (barTextColor == _barTextColor) return;
+			_barTextColor = barTextColor;
+
+			var controlToolbarForeground = _tabs.ToolbarForeground;
+			if (controlToolbarForeground == null && barTextColor.IsDefault) return;
+
+			var brush = GetBarForegroundBrush();
+			if (brush == controlToolbarForeground) return;
+
+			_tabs.ToolbarForeground = brush;
+
+			foreach (TextBlock tabBarTextBlock in _tabs.GetDescendantsByName<TextBlock>(TabBarHeaderTextBlockName))
+			{
+				tabBarTextBlock.Foreground = brush;
+			}
 		}
 
 		void UpdateCurrentPage()
@@ -202,13 +246,19 @@ namespace Xamarin.Forms.Platform.WinRT
 				_canvas.Children.Add(renderer.ContainerElement);
 		}
 
-		void OnLoaded(object sender, RoutedEventArgs args)
+		void canvas_OnLoaded(object sender, RoutedEventArgs args)
 		{
 			if (Page == null)
 				return;
 
 			ShowTabs();
 			PageController.SendAppearing();
+		}
+
+		void tabs_OnLoaded(object sender, RoutedEventArgs e)
+		{
+			UpdateBarTextColor();
+			UpdateBarBackgroundColor();
 		}
 
 		Windows.UI.Xaml.Controls.Page GetTopPage()
@@ -262,7 +312,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			page.TopAppBar = null;
 		}
 
-		void OnUnloaded(object sender, RoutedEventArgs args)
+		void canvas_OnUnloaded(object sender, RoutedEventArgs args)
 		{
 			RemoveTabs();
 			PageController?.SendDisappearing();

--- a/Xamarin.Forms.Platform.WinRT.Tablet/TabletResources.xaml
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/TabletResources.xaml
@@ -250,7 +250,7 @@
 		<Setter Property="ItemsPanel">
 			<Setter.Value>
 				<ItemsPanelTemplate>
-					<StackPanel Orientation="Horizontal" Margin="0,11,0,0" Background="{TemplateBinding ToolbarBackground}" />
+					<StackPanel Orientation="Horizontal" Margin="0,11,0,0" Background="{Binding BarBackgroundColor, Converter={StaticResource ColorConverter}, ConverterParameter=TabButtonBackgroundBrush}" Name="TabbedPageHeaderStackPanel" />
 				</ItemsPanelTemplate>
 			</Setter.Value>
 		</Setter>
@@ -261,7 +261,7 @@
 						<StackPanel VerticalAlignment="Bottom">
 							<Image DataContext="{Binding Icon, Converter={StaticResource ImageConverter}}" Source="{Binding Value}" HorizontalAlignment="Left" />
 							<TextBlock Margin="0,15,0,15" Text="{Binding Title, Converter={StaticResource UpperConverter}}"
-									   Style="{ThemeResource CaptionTextBlockStyle}" FontWeight="SemiBold" Foreground="{TemplateBinding ToolbarForeground}"  HorizontalAlignment="Left" />
+									   Style="{ThemeResource CaptionTextBlockStyle}" FontWeight="SemiBold" Name="TabbedPageHeaderTextBlock"  HorizontalAlignment="Left" />
 						</StackPanel>
 					</local:TabButton>
 				</DataTemplate>

--- a/Xamarin.Forms.Platform.WinRT/FrameworkElementExtensions.cs
+++ b/Xamarin.Forms.Platform.WinRT/FrameworkElementExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Windows.UI.Xaml;
@@ -69,6 +70,23 @@ namespace Xamarin.Forms.Platform.WinRT
 				throw new ArgumentNullException("element");
 
 			element.SetBinding(GetForegroundProperty(element), binding);
+		}
+
+		internal static IEnumerable<T> GetDescendantsByName<T>(this DependencyObject parent, string elementName) where T : DependencyObject
+		{
+			int myChildrenCount = VisualTreeHelper.GetChildrenCount(parent);
+			for (int i = 0; i < myChildrenCount; i++)
+			{
+				var child = VisualTreeHelper.GetChild(parent, i);
+				var controlName = child.GetValue(FrameworkElement.NameProperty) as string;
+				if (controlName == elementName && child is T)
+					yield return child as T;
+				else
+				{
+					foreach (var subChild in child.GetDescendantsByName<T>(elementName))
+						yield return subChild;
+				}
+			}
 		}
 
 		internal static T GetFirstDescendant<T>(this DependencyObject element) where T : FrameworkElement


### PR DESCRIPTION
### Description of Change ###

Resolved known issues with the new `BarTextColor` feature for `TabbedPage`s on Windows platforms.

### Bugs Fixed ###

 - [WinRT, WinPhone 8.1, UWP] Setting `BarTextColor` does not currently work. 
 - [WinPhone 8.1, UWP] If the `TabbedPage` contains a `NavigationPage`, the `BarBackgroundColor` and `BarTextColor` for the `NavigationPage` takes precedence
 - [WinPhone 8.1] If the `TabbedPage` contains a `NavigationPage`, switching between tabs may cause the background color to be lost.

### API Changes ###

None

### Behavioral Changes ###

- [Win] Explicitly setting the `BarTextColor` and `BarBackgroundColor` to `Color.Default` will take precedence over the `BarTextColor` and `BarBackgroundColor` on `NavigationPage`s. However, if the `BarTextColor` and `BarBackgroundColor` for the `TabbedPage` are never set, the `NavigationPage`s may supply individual `BarTextColor`s and `BarBackgroundColor`s. This should preserve existing behavior while still allowing the `TabbedPage` to be the ultimate authority of bar color. 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense