### PR TITLE
Prevent FormsAppCompatActivity from loading fragments we don't use on restart

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42075.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42075.cs
@@ -1,0 +1,39 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve (AllMembers = true)]
+	[Issue (IssueTracker.Bugzilla, 42075, "IllegalStateException - Fragment does not have a view", PlatformAffected.Android)]
+	public class Bugzilla42075 : TestTabbedPage
+	{
+		protected override void Init()
+		{
+			Title = "Outer";
+
+			const string text = @"To run this test, you'll need to have an emulator or device in Developer mode, with the ""Don't Keep Activities"" setting turned on.
+Hit the Home button to dismiss the application. Then bring up the Overview (recent apps) screen and select the Control Gallery.
+If the application crashes with ""Java.Lang.IllegalStateException: Fragment does not have a view"", this test has failed. If the application does not crash or crashes with a different exception, this test has passed.";
+
+			var directions = new ContentPage
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = text
+						}
+					}
+				}
+			};
+
+			var tabbedPage = new TabbedPage() {Title = "Inner"};
+			tabbedPage.Children.Add(new ContentPage());
+
+			Children.Add(directions);
+			Children.Add(tabbedPage);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -109,7 +109,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41205.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42074.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -109,6 +109,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41205.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42074.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42075.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -44,6 +44,9 @@ namespace Xamarin.Forms.Platform.Android
 		int _statusBarHeight = -1;
 		global::Android.Views.View _statusBarUnderlay;
 
+		// Override this if you want to handle the default Android behavior of restoring fragments on an application restart
+		protected virtual bool AllowFragmentRestore => false;
+
 		protected FormsAppCompatActivity()
 		{
 			_previousState = AndroidApplicationLifecycleState.Uninitialized;
@@ -139,8 +142,17 @@ namespace Xamarin.Forms.Platform.Android
 				callback(resultCode, data);
 		}
 
+
 		protected override void OnCreate(Bundle savedInstanceState)
 		{
+			if (!AllowFragmentRestore)
+			{
+				// Remove the automatically persisted fragment structure; we don't need them
+				// because we're rebuilding everything from scratch. This saves a bit of memory
+				// and prevents loading errors from child fragment managers
+				savedInstanceState?.Remove("android:support:fragments");
+			}
+
 			base.OnCreate(savedInstanceState);
 
 			AToolbar bar;


### PR DESCRIPTION
### Description of Change ###

Prevent the `FormsAppCompatActivity` from attempting to restore fragments when being restored after being killed because of limited memory. Previously, the fragments were restored and then ignored by XF; in the case of nested fragments (e.g., a `TabbedPage` or `MasterDetailPage` containing another `TabbedPage`), this caused an `IllegalStateException` (followed by a crash) because a view could not be associated with the nested fragment. Now the `FormsAppCompatActivity` won't attempt to restore the fragments we weren't going to use anyway. (Bonus: slight memory improvement!)

### Bugs Fixed ###

- [42075 – IllegalStateException - Fragment does not have a view](https://bugzilla.xamarin.com/show_bug.cgi?id=42075)

### API Changes ###

None

### Behavioral Changes ###

If a user is deliberately matching up and restoring fragments by tag when the application is restored, that user will have to derive from FormsAppCompatActivity and override the `AllowFragmentRestore` property to return `true`.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

… restart