### PR TITLE
[Android] Handle creating a default GroupHeader if no GroupHeaderTemplate is provided

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue55555.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue55555.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 55555, "Header problem")]
+	public class Issue55555 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var lstView = new ListView(ListViewCachingStrategy.RecycleElement);
+			ObservableCollection<GroupedVeggieModel> grouped = CreateData();
+
+			lstView.ItemsSource = grouped;
+			lstView.HasUnevenRows = true;
+			lstView.IsGroupingEnabled = true;
+			lstView.GroupDisplayBinding = new Binding("LongName");
+			lstView.GroupShortNameBinding = new Binding("ShortName");
+
+			lstView.ItemTemplate = new DataTemplate(typeof(DemoTextCell));
+			lstView.ItemTemplate.SetBinding(DemoTextCell.TextProperty, "Name");
+
+			Content = lstView;
+		}
+
+		static ObservableCollection<GroupedVeggieModel> CreateData()
+		{
+			var grouped = new ObservableCollection<GroupedVeggieModel>();
+
+			var veggieGroup = new GroupedVeggieModel() { LongName = "vegetables", ShortName = "v" };
+			veggieGroup.Add(new VeggieModel() { Name = "celery", IsReallyAVeggie = true, Comment = "try ants on a log" });
+			veggieGroup.Add(new VeggieModel() { Name = "tomato", IsReallyAVeggie = false, Comment = "pairs well with basil" });
+			veggieGroup.Add(new VeggieModel() { Name = "zucchini", IsReallyAVeggie = true, Comment = "zucchini bread > bannana bread" });
+			veggieGroup.Add(new VeggieModel() { Name = "peas", IsReallyAVeggie = true, Comment = "like peas in a pod" });
+
+			var fruitGroup = new GroupedVeggieModel() { LongName = "fruit", ShortName = "f" };
+			fruitGroup.Add(new VeggieModel() { Name = "banana", IsReallyAVeggie = false, Comment = "available in chip form factor" });
+			fruitGroup.Add(new VeggieModel() { Name = "strawberry", IsReallyAVeggie = false, Comment = "spring plant" });
+			fruitGroup.Add(new VeggieModel() { Name = "cherry", IsReallyAVeggie = false, Comment = "topper for icecream" });
+
+			grouped.Add(veggieGroup);
+			grouped.Add(fruitGroup);
+
+			return grouped;
+		}
+
+		[Preserve(AllMembers = true)]
+		public class VeggieModel
+		{
+			public string Name { get; set; }
+			public string Comment { get; set; }
+			public bool IsReallyAVeggie { get; set; }
+			public string Image { get; set; }
+		}
+
+		[Preserve(AllMembers = true)]
+		public class GroupedVeggieModel : ObservableCollection<VeggieModel>
+		{
+			public string LongName { get; set; }
+			public string ShortName { get; set; }
+		}
+
+		[Preserve(AllMembers = true)]
+		public class DemoTextCell : TextCell
+		{
+			public DemoTextCell()
+			{
+				Height = 150;
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void TGroupDisplayBindingPresentRecycleElementTest()
+		{
+			RunningApp.WaitForElement(q => q.Marked("vegetables"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -409,6 +409,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41038.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38284.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39486.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue55555.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">


### PR DESCRIPTION
### Description of Change ###

When the user is using the RecycleElement strategy we don't really on the TIL cells, so we handle creating the group header cell on the platform side.
We weren't handling the case where no template was provided, (user provided the GroupDisplayPath).
This change makes sure we create the default group header and set the attached property so we know is a groupheader.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [x] Consolidate commits as makes sense