### PR TITLE
Fix DatePicker dialog regression

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -31,7 +31,9 @@ namespace Xamarin.Forms.Platform.Android
 				_disposed = true;
 				if (_dialog != null)
 				{
-					_dialog.CancelEvent -= OnCancelButtonClicked;
+					if (Forms.IsLollipopOrNewer)
+						_dialog.CancelEvent -= OnCancelButtonClicked;
+
 					_dialog.Hide();
 					_dialog.Dispose();
 					_dialog = null;
@@ -85,7 +87,10 @@ namespace Xamarin.Forms.Platform.Android
 				_dialog.Hide();
 				((IElementController)Element).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 				Control.ClearFocus();
-				_dialog.CancelEvent -= OnCancelButtonClicked;
+
+				if (Forms.IsLollipopOrNewer)
+					_dialog.CancelEvent -= OnCancelButtonClicked;
+
 				_dialog = null;
 			}
 		}
@@ -99,7 +104,9 @@ namespace Xamarin.Forms.Platform.Android
 				((IElementController)view).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 				Control.ClearFocus();
 
-				_dialog.CancelEvent -= OnCancelButtonClicked;
+				if (Forms.IsLollipopOrNewer)
+					_dialog.CancelEvent -= OnCancelButtonClicked;
+
 				_dialog = null;
 			}, year, month, day);
 		}
@@ -128,7 +135,9 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateMinimumDate();
 			UpdateMaximumDate();
 
-			_dialog.CancelEvent += OnCancelButtonClicked;
+			if (Forms.IsLollipopOrNewer)
+				_dialog.CancelEvent += OnCancelButtonClicked;
+
 			_dialog.Show();
 		}
 


### PR DESCRIPTION
### Description of Change ###

KitKat and older don't use a cancel button on the DatePicker dialog which was causing an NRE due to changes made in #204, so we have to account for it.

### Bugs Fixed ###

Fixes regression on #204
- https://bugzilla.xamarin.com/show_bug.cgi?id=42361

### API Changes ###

N/A

### Behavioral Changes ###

Should no longer crash.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense