### PR TITLE
Restore incorrectly renamed InvalidateMeasure method

### DIFF
--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -560,7 +560,7 @@ namespace Xamarin.Forms
 
 		public event EventHandler<FocusEventArgs> Unfocused;
 
-		protected virtual void InvalidateMeasureInternal()
+		protected virtual void InvalidateMeasure()
 		{
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
@@ -512,21 +512,6 @@
         <AssemblyVersion>1.3.0.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>Method that is called to invalidate the layout of this <see cref="T:Xamarin.Forms.VisualElement" />. Raises the <see cref="E:Xamarin.Forms.VisualElement.MeasureInvalidated" /> event.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="InvalidateMeasureInternal">
-      <MemberSignature Language="C#" Value="protected virtual void InvalidateMeasureInternal ();" />
-      <MemberSignature Language="ILAsm" Value=".method familyhidebysig newslot virtual instance void InvalidateMeasureInternal() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -534,7 +519,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Method that is called to invalidate the layout of this <see cref="T:Xamarin.Forms.VisualElement" />. Raises the <see cref="E:Xamarin.Forms.VisualElement.MeasureInvalidated" /> event.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
### Description of Change ###

When making the VisualElement.cs changes to allow for InternalsVisibleTo to be disabled, the `protected virtual void InvalidateMeasure()` method was incorrectly refactored into an overload of `InvalidateMeasureInternal()`. This change restores the original method name.

### Bugs Fixed ###

- http://forums.xamarin.com/discussion/comment/208593/#Comment_208593
- [42352 – [iOS] Xamarin.Forms 2.3.1.111-pre2 does not work with linker](https://bugzilla.xamarin.com/show_bug.cgi?id=42352)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

