### PR TITLE
Fixed issues where you could not force rotation with a NavigationPage

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -946,6 +946,40 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_navigation.TryGetTarget(out n))
 					n.UpdateToolBarVisible();
 			}
+
+			public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
+			{
+				IVisualElementRenderer childRenderer;
+				if (Child != null && (childRenderer = Platform.GetRenderer(Child)) != null)
+					return childRenderer.ViewController.GetSupportedInterfaceOrientations();
+				return base.GetSupportedInterfaceOrientations();
+			}
+
+			public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
+			{
+				IVisualElementRenderer childRenderer;
+				if (Child != null && (childRenderer = Platform.GetRenderer(Child)) != null)
+					return childRenderer.ViewController.PreferredInterfaceOrientationForPresentation();
+				return base.PreferredInterfaceOrientationForPresentation();
+			}
+
+			public override bool ShouldAutorotate()
+			{
+				IVisualElementRenderer childRenderer;
+				if (Child != null && (childRenderer = Platform.GetRenderer(Child)) != null)
+					return childRenderer.ViewController.ShouldAutorotate();				
+				return base.ShouldAutorotate();
+			}
+
+			public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
+			{
+				IVisualElementRenderer childRenderer;
+				if (Child != null && (childRenderer = Platform.GetRenderer(Child)) != null)
+					return childRenderer.ViewController.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+				return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+			}
+
+			public override bool ShouldAutomaticallyForwardRotationMethods => true;
 		}
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)


### PR DESCRIPTION
Resubmission of https://github.com/xamarin/Xamarin.Forms/pull/245

### Description of Change ###

Forwarded orientation events from ParentingViewController to the child ViewController.

### Bugs Fixed ###

Did not find any specific bugs relating to the exact problem. The fixes however (and general issue altogether) is very similar to this, https://github.com/xamarin/Xamarin.Forms/pull/147, but is more to do with NavigationPage.

May also be related to this bug, https://bugzilla.xamarin.com/show_bug.cgi?id=26169

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

… on iOS.