### PR TITLE
[Xaml/Previewer] add XamlLoader.Create overload with currentAssembly …

### DIFF
--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -262,7 +262,7 @@ namespace Xamarin.Forms.Xaml
 				localname = localname.Substring(dotIdx + 1);
 				XamlParseException xpe;
 				elementType = XamlParser.GetElementType(new XmlType(namespaceURI, typename, null), lineInfo,
-					context.RootElement.GetType().GetTypeInfo().Assembly, out xpe);
+					context.CurrentAssembly ?? context.RootElement.GetType().GetTypeInfo().Assembly, out xpe);
 				if (xpe != null)
 					throw xpe;
 				return true;

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Xaml
 				return;
 
 			XamlParseException xpe;
-			var type = XamlParser.GetElementType(node.XmlType, node, Context.RootElement?.GetType().GetTypeInfo().Assembly,
+			var type = XamlParser.GetElementType(node.XmlType, node, Context.CurrentAssembly ?? Context.RootElement?.GetType().GetTypeInfo().Assembly,
 				out xpe);
 			if (xpe != null)
 				throw xpe;

--- a/Xamarin.Forms.Xaml/HydratationContext.cs
+++ b/Xamarin.Forms.Xaml/HydratationContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Xamarin.Forms.Xaml
 {
@@ -20,5 +21,7 @@ namespace Xamarin.Forms.Xaml
 		public bool DoNotThrowOnExceptions { get; set; }
 
 		public object RootElement { get; set; }
+
+		public Assembly CurrentAssembly { get; set; }
 	}
 }

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Forms.Xaml
 		}
 
 		[Obsolete ("Use the XamlFileProvider to provide xaml files. We will remove this when Cycle 8 hits Stable.")]
-		public static object Create (string xaml, bool doNotThrow = false)
+		public static object Create(string xaml, bool doNotThrow = false, Assembly currentAssembly = null)
 		{
 			object inflatedView = null;
 			using (var reader = XmlReader.Create (new StringReader (xaml))) {
@@ -100,6 +100,7 @@ namespace Xamarin.Forms.Xaml
 					XamlParser.ParseXaml (rootnode, reader);
 					var visitorContext = new HydratationContext {
 						DoNotThrowOnExceptions = doNotThrow,
+						CurrentAssembly = currentAssembly
 					};
 					var cvv = new CreateValuesVisitor (visitorContext);
 					cvv.Visit ((ElementNode)rootnode, null);

--- a/Xamarin.Forms.Xaml/XamlServiceProvider.cs
+++ b/Xamarin.Forms.Xaml/XamlServiceProvider.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Xaml.Internals
 			if (node != null)
 			{
 				IXamlTypeResolver = new XamlTypeResolver(node.NamespaceResolver, XamlParser.GetElementType,
-					context.RootElement.GetType().GetTypeInfo().Assembly);
+					context.CurrentAssembly ?? context.RootElement.GetType().GetTypeInfo().Assembly);
 
 				var enode = node;
 				while (enode != null && !(enode is IElementNode))


### PR DESCRIPTION
### Description of Change ###

Add XamlLoader.Create overload with currentAssembly parameter

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=42254

### API Changes ###

Added:
 - `public static object XamlLoader.Create(string xaml, bool doNotThrow = false, Assembly currentAssembly = null)`

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

