### PR TITLE
Fixes issue when setting NavigationPage.SetHasBackButton after page has navigated (Android/AppCompat)

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -382,6 +382,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				ToolbarVisible = NavigationPage.GetHasNavigationBar(Current);
 			else if (e.PropertyName == Page.TitleProperty.PropertyName)
 				UpdateToolbar();
+			else if (e.PropertyName == NavigationPage.HasBackButtonProperty.PropertyName)
+				UpdateToolbar();
 		}
 
 #pragma warning disable 1998 // considered for removal


### PR DESCRIPTION
### Description of Change ###

When a page was already navigated, and you used NavigationPage.SetHasBackButton(this, false) to switch of the Back Button in Android AppCompat, the toolbar was not updated.
 
### Bugs Fixed ###
[https://bugzilla.xamarin.com/show_bug.cgi?id=42557](https://bugzilla.xamarin.com/show_bug.cgi?id=42557)

### API Changes ###

None

### Behavioral Changes ###

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
