### PR TITLE
[Android] Add dialog null check for AppCompat Picker OnClick

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -93,25 +93,27 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void OnClick()
 		{
 			Picker model = Element;
-			using (var builder = new AlertDialog.Builder(Context))
+			if (_dialog == null)
 			{
-				builder.SetTitle(model.Title ?? "");
-				string[] items = model.Items.ToArray();
-				builder.SetItems(items, (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
+				using (var builder = new AlertDialog.Builder(Context))
+				{
+					builder.SetTitle(model.Title ?? "");
+					string[] items = model.Items.ToArray();
+					builder.SetItems(items, (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
 
-				builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) => { });
+					builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) => { });
 
-				_dialog = builder.Create();
+					_dialog = builder.Create();
+				}
+				_dialog.SetCanceledOnTouchOutside(true);
+				_dialog.DismissEvent += (sender, args) =>
+				{
+					_dialog.Dispose();
+					_dialog = null;
+				};
+
+				_dialog.Show();
 			}
-
-			_dialog.SetCanceledOnTouchOutside(true);
-			_dialog.DismissEvent += (sender, args) =>
-			{
-				_dialog.Dispose();
-				_dialog = null;
-			};
-
-			_dialog.Show();
 		}
 
 		void RowsCollectionChanged(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

Multiple, rapid taps on the Picker in AppCompat could potentially open more than one dialog, causing a crash upon their being closed. Adding a null check for the dialog prevents more than one from being created. 

This was more easily producible on an actual device opposed to an emulator.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=41717

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense