### PR TITLE
Fix for NullReferenceException when ItemSource has item removed and a…

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -118,10 +118,10 @@ namespace Xamarin.Forms.Platform.iOS
 				if (!_rendererRef.TryGetTarget(out renderer))
 					return base.SizeThatFits(size);
 
-                if (renderer.Element == null)
-                    return SizeF.Empty;
-
-                double width = size.Width;
+                		if (renderer.Element == null)
+                			return SizeF.Empty;
+                			
+                		double width = size.Width;
 				var height = size.Height > 0 ? size.Height : double.PositiveInfinity;
 				var result = renderer.Element.Measure(width, height);
 

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -118,7 +118,10 @@ namespace Xamarin.Forms.Platform.iOS
 				if (!_rendererRef.TryGetTarget(out renderer))
 					return base.SizeThatFits(size);
 
-				double width = size.Width;
+                if (renderer.Element == null)
+                    return SizeF.Empty;
+
+                double width = size.Width;
 				var height = size.Height > 0 ? size.Height : double.PositiveInfinity;
 				var result = renderer.Element.Measure(width, height);
 


### PR DESCRIPTION
### Description of Change ###

In the SizeThatFits method of classViewTableCell added renderer.Element null check and return SizeF.Empty when the Element is null, so that it does not throw NullReferenceException when removing and re-adding another item to ListView

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=42580

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

…nother inserted on iOS