### PR TITLE
Ensure BindingContext is properly passed to CreateDefault in UWP ListView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41205.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41205.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41205, "UWP CreateDefault passes string instead of object")]
+	public class Bugzilla41205 : ContentPage
+	{
+		public class CustomListView : ListView
+		{
+			protected override Cell CreateDefault(object item)
+			{
+				if (item is ViewModel)
+					return base.CreateDefault("Pass");
+				return base.CreateDefault("Fail");
+			}
+		}
+
+		public Bugzilla41205()
+		{
+			var listView = new CustomListView
+			{
+				ItemsSource = new []
+				{
+					new ViewModel(), 
+					new ViewModel(),
+				}
+			};
+
+			Content = listView;
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -107,6 +107,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41205.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42074.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -228,14 +228,13 @@ namespace Xamarin.Forms.Platform.WinRT
 				}
 				else
 				{
-					string textContent = newContext.ToString();
-
 					IListViewController listViewController = lv;
+					var defaultContext = newContext;
 
 					if (isGroupHeader)
-						textContent = listViewController.GetDisplayTextFromGroup(newContext);
+						defaultContext = listViewController.GetDisplayTextFromGroup(newContext);
 
-					cell = listViewController.CreateDefaultCell(textContent);
+					cell = listViewController.CreateDefaultCell(defaultContext);
 				}
 
 				// A TableView cell should already have its parent,


### PR DESCRIPTION
### Description of Change ###

Fix regression where CreateDefault would be passed a ToString variant of the ViewModel in the ItemsSource instead of the ViewModel directly.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=41205

### API Changes ###

None

### Behavioral Changes ###

On UWP/WinRT CreateDefault now gets passed the item from your ItemsSource and not the item.ToString () result. This is in line with iOS/Android and the previous UWP behavior of 2.0.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense