### PR TITLE
[Android] Remove API check in ActivityIndicatorRenderer's UpdateColor method

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ActivityIndicatorRenderer.cs
@@ -40,9 +40,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateColor()
 		{
-			if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
-				return;
-
 			Color color = Element.Color;
 
 			if (!color.IsDefault)


### PR DESCRIPTION
### Description of Change ###

The API check does not need to be used as it was preventing a color from being applied to the ActivityIndicator when running on pre-Lollipop.

I set up an API 15 emulator to run the gallery with a reproduction to confirm it looks as expected when setting the color. It isn't included as a part of the commit.

![api15](https://cloud.githubusercontent.com/assets/1251024/16888249/79639d68-4aa4-11e6-9f93-61557d5a803d.PNG)

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=42326

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense