### PR TITLE
[Android] Fix focus/unfocus behavior on both Picker renderers

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -102,12 +102,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					builder.SetItems(items, (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
 
 					builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) => { });
+					
+					((IElementController)Element).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 
 					_dialog = builder.Create();
 				}
 				_dialog.SetCanceledOnTouchOutside(true);
 				_dialog.DismissEvent += (sender, args) =>
 				{
+					((IElementController)Element).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 					_dialog.Dispose();
 					_dialog = null;
 				};

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -133,7 +133,12 @@ namespace Xamarin.Forms.Platform.Android
 				_dialog = null;
 			});
 
-			(_dialog = builder.Create()).Show();
+			_dialog = builder.Create();
+			_dialog.DismissEvent += (sender, args) =>
+			{
+				ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
+			};
+			_dialog.Show();
 		}
 
 		void RowsCollectionChanged(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

On AppCompat, focus and unfocus would not trigger when using the Picker. On pre-Lollipop, unfocus would not trigger, but only when tapping outside of the dialog.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=42687

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense