### PR TITLE
Dispose of child renderers in FrameRenderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42329.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42329.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve (AllMembers = true)]
+	[Issue (IssueTracker.Bugzilla, 42329, "ListView in Frame and FormsAppCompatActivity Memory Leak")]
+	public class Bugzilla42329 : TestMasterDetailPage 
+	{
+		const string DestructorMessage = "ContentPageEx Destructor called";
+		const string Page1Title = "Page1";
+		const string Page2Title = "Page2";
+		const string Page3Title = "Page3";
+
+		protected override void Init ()
+		{
+			var masterPage = new MasterPage();
+			Master = masterPage;
+			masterPage.ListView.ItemSelected += (sender, e) =>
+			{
+				var item = e.SelectedItem as MasterPageItem;
+				if (item != null)
+				{
+					Detail = new NavigationPage((Page)Activator.CreateInstance(item.TargetType));
+					masterPage.ListView.SelectedItem = null;
+					IsPresented = false;
+				}
+			};
+
+			Detail = new NavigationPage(new _42329_FrameWithListView());
+		}
+
+		[Preserve(AllMembers = true)]
+		public class MasterPage : ContentPage
+		{
+			public MasterPage()
+			{
+				Title = "Menu";
+				ListView = new ListView { VerticalOptions = LayoutOptions.FillAndExpand, SeparatorVisibility = SeparatorVisibility.None };
+
+				ListView.ItemTemplate = new DataTemplate(() =>
+				{
+					var ic = new ImageCell();
+					ic.SetBinding(TextCell.TextProperty, "Title");
+					return ic;
+				});
+
+				Content = new StackLayout
+				{
+					Children = { ListView }
+				};
+
+				var masterPageItems = new List<MasterPageItem>();
+				masterPageItems.Add(new MasterPageItem
+				{
+					Title = Page1Title,
+					TargetType = typeof(Bugzilla42329._42329_FrameWithListView)
+				});
+				masterPageItems.Add(new MasterPageItem
+				{
+					Title = Page2Title,
+					TargetType = typeof(Bugzilla42329._42329_Page2)
+				});
+				masterPageItems.Add(new MasterPageItem
+				{
+					Title = Page3Title,
+					TargetType = typeof(Bugzilla42329._42329_Page3)
+				});
+
+				ListView.ItemsSource = masterPageItems;
+			}
+
+			public ListView ListView { get; }
+		}
+
+		[Preserve(AllMembers = true)]
+		public class MasterPageItem
+		{
+			public string IconSource { get; set; }
+
+			public Type TargetType { get; set; }
+
+			public string Title { get; set; }
+		}
+
+		[Preserve(AllMembers = true)]
+		public class ContentPageEx : ContentPage
+		{
+			~ContentPageEx()
+			{
+				Log.Warning("Bugzilla42329", DestructorMessage);
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class _42329_FrameWithListView : ContentPageEx
+		{
+			public _42329_FrameWithListView()
+			{
+				var lv = new ListView();
+				var label = new Label();
+				var frame = new Frame { Content = lv };
+
+				Title = Page1Title;
+				Content = new StackLayout
+				{
+					Children = { new Label { Text = "Open the drawer menu and select Page2" }, frame }
+				};
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class _42329_Page2 : ContentPage
+		{
+			public _42329_Page2()
+			{
+				Title = Page2Title;
+				Content = new StackLayout { Children = { new Label { Text = "Open the drawer menu and select Page3" } } };
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class _42329_Page3 : ContentPage
+		{
+			public _42329_Page3()
+			{
+				Title = Page3Title;
+				Content = new StackLayout { Children = { new Label { Text = $"The console should have displayed the text '{DestructorMessage}' at least once. If not, this test has failed." } } };
+			}
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+				GC.Collect();
+				GC.Collect();
+				GC.Collect();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -111,6 +111,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42074.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42075.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42329.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
@@ -227,7 +227,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				_collectionChangeHandler = HandleGestureRecognizerCollectionChanged;
 
 			var observableCollection = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
-			observableCollection.CollectionChanged += _collectionChangeHandler;
+			if (observableCollection != null)
+			{
+				observableCollection.CollectionChanged += _collectionChangeHandler;
+			}
 		}
 
 		void UnsubscribeGestureRecognizers(VisualElement element)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
@@ -138,9 +138,20 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					_visualElementPackager.Dispose();
 					_visualElementPackager = null;
 				}
+			
+				int count = ChildCount;
+				for (var i = 0; i < count; i++)
+				{
+					AView child = GetChildAt(i);
+					child.Dispose();
+				}
 
 				if (Element != null)
+				{
 					Element.PropertyChanged -= OnElementPropertyChanged;
+					UnsubscribeGestureRecognizers(Element);
+				}
+				
 			}
 
 			base.Dispose(disposing);
@@ -226,7 +237,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				return;
 
 			var observableCollection = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
-			observableCollection.CollectionChanged -= _collectionChangeHandler;
+			if (observableCollection != null)
+			{
+				observableCollection.CollectionChanged -= _collectionChangeHandler;
+			}
 		}
 
 		void UpdateBackgroundColor()


### PR DESCRIPTION
### Description of Change ###

The AppCompat version of `FrameRenderer` was not disposing of its child renderers, which prevented pages with some combinations of controls from being collected. Most renderers inherit this behavior from `VisualElementRenderer`, but `FrameRenderer` is not a subclass of `VisualElementRenderer`. This change duplicates the disposal behavior from `VisualElementRenderer`.

### Bugs Fixed ###

- [42329 – ListView in Frame and FormsAppCompatActivity Memory Leak](https://bugzilla.xamarin.com/show_bug.cgi?id=42329)

### API Changes ###

None

### Behavioral Changes ###

None 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

