### PR TITLE
[Android] Color.Accent is hardcoded

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -96,19 +96,7 @@ namespace Xamarin.Forms
 
 			ResourceManager.Init(resourceAssembly);
 
-			// Detect if legacy device and use appropriate accent color
-			// Hardcoded because could not get color from the theme drawable
-			var sdkVersion = (int)Build.VERSION.SdkInt;
-			if (sdkVersion <= 10)
-			{
-				// legacy theme button pressed color
-				Color.Accent = Color.FromHex("#fffeaa0c");
-			}
-			else
-			{
-				// Holo dark light blue
-				Color.Accent = Color.FromHex("#ff33b5e5");
-			}
+			Color.Accent = GetAccentColor();
 
 			if (!IsInitialized)
 				Log.Listeners.Add(new DelegateLogListener((c, m) => Trace.WriteLine(m, c)));
@@ -146,6 +134,39 @@ namespace Xamarin.Forms
 				ExpressionSearch.Default = new AndroidExpressionSearch();
 
 			IsInitialized = true;
+		}
+
+		static Color GetAccentColor()
+		{
+			Color rc;
+			using (var value = new TypedValue())
+			{
+				if (Context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorAccent, value, true))	// Android 5.0+
+				{
+					rc = Color.FromUint((uint)value.Data);
+				}
+				else if(Context.Theme.ResolveAttribute(Context.Resources.GetIdentifier("colorAccent", "attr", Context.PackageName), value, true))	// < Android 5.0
+				{
+					rc = Color.FromUint((uint)value.Data);
+				}
+				else                    // fallback to old code if nothing works (don't know if that ever happens)
+				{
+					// Detect if legacy device and use appropriate accent color
+					// Hardcoded because could not get color from the theme drawable
+					var sdkVersion = (int)Build.VERSION.SdkInt;
+					if (sdkVersion <= 10)
+					{
+						// legacy theme button pressed color
+						rc = Color.FromHex("#fffeaa0c");
+					}
+					else
+					{
+						// Holo dark light blue
+						rc = Color.FromHex("#ff33b5e5");
+					}
+				}
+			}
+			return rc;
 		}
 
 		class AndroidDeviceInfo : DeviceInfo


### PR DESCRIPTION
### Description of Change ###

On Android Color.Accent is set to a hardcoded value in Xamarin.Forms.Forms.SetupInit (in the Platform.Android project) and it cannot be changed by the user.

This color is then used as text and separator color for TableSections. The user cannot override the color.

As the hardcoded color may not fit to the users app theme, this should be changed.

Jason Smith said on forms-devel that the code should read from the current Android theme. This change does that.

I wouldn't know how to unit test this.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=42812

### API Changes ###

None

### Behavioral Changes ###

Color.Accent will be set to the accentColor of the current Android theme instead of the hardcoded values.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

