### PR TITLE
[Android] Add null check to prevent crashes when long clicking a text entry in ListView header/footer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40858.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40858.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40858, "Long clicking a text entry in a ListView header/footer cause a crash", PlatformAffected.Android)]
+	public class Bugzilla40858 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new ListView
+					{
+						Header = new Editor
+						{
+							AutomationId = "Header",
+							HeightRequest = 50,
+							Text = "ListView Header -- Editor"
+						},
+						Footer = new Entry
+						{
+							AutomationId = "Footer",
+							HeightRequest = 50,
+							Text = "ListView Footer -- Entry"
+						}
+					}
+				}
+			};
+		}
+
+#if UITEST
+
+#if __ANDROID__
+		[Test]
+		public void ListViewDoesNotCrashOnTextEntryHeaderOrFooterLongClick()
+		{
+			RunningApp.TouchAndHold(x => x.Marked("Header"));
+			RunningApp.TouchAndHold(x => x.Marked("Footer"));
+		}
+#endif
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -104,6 +104,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40185.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40333.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31806.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40858.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -211,6 +211,9 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Cell cell = GetCellForPosition(position);
 
+			if (cell == null)
+				return false;
+
 			if (_actionMode != null || _supportActionMode != null)
 			{
 				if (!cell.HasContextActions)


### PR DESCRIPTION
### Description of Change ###

When a text entry control (Entry, Editor, SearchBar, etc.) was being used in the header or footer of a `ListView` on Android, a long click/press would cause a crash. This was occurring in the `HandleContextMode` method because it expected to be a cell. Adding a null check and breaking out of the method if the value from `GetCellForPosition` is null prevents this crash from occurring.

### Bugs Fixed ###
https://bugzilla.xamarin.com/show_bug.cgi?id=40858

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense