### PR TITLE
[Android] Fix ListView contextual actions not closing in AppCompat's NavigationPage/TabbedPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40824.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40824.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40824, "ListView item's contextual action menu not being closed upon navigation in AppCompat")]
+	public class Bugzilla40824 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var list = new ListView
+			{
+				ItemsSource = new List<string>
+				{
+					"Cat",
+					"Dog",
+					"Rat"
+				},
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var cell = new TextCell();
+					cell.SetBinding(TextCell.TextProperty, ".");
+					cell.ContextActions.Add(new MenuItem
+					{
+						Text = "Action",
+						Icon = "icon",
+						IsDestructive = true,
+						Command = new Command(() => DisplayAlert("TITLE", "Context action invoked", "Ok")),
+					});
+					return cell;
+				}),
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Button
+					{
+						Text = "Go to next page",
+						Command = new Command(() => Navigation.PushAsync(new ContentPage { Title = "Next Page", Content = new Label { Text = "Here" } }))
+					},
+					list
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42364.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42364.cs
@@ -1,0 +1,63 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 42364, "ListView item's contextual action menu not being closed upon swiping a TabbedPage in AppCompat")]
+    public class Bugzilla42354 : TestTabbedPage
+    {
+        protected override void Init()
+        {
+            var list = new ListView
+            {
+                ItemsSource = new List<string>
+                {
+                    "Cat",
+                    "Dog",
+                    "Rat"
+                },
+                ItemTemplate = new DataTemplate(() =>
+                {
+                    var cell = new TextCell();
+                    cell.SetBinding(TextCell.TextProperty, ".");
+                    cell.ContextActions.Add(new MenuItem
+                    {
+                        Text = "Action",
+                        Icon = "icon",
+                        IsDestructive = true,
+                        Command = new Command(() => DisplayAlert("TITLE", "Context action invoked", "Ok")),
+                    });
+                    return cell;
+                }),
+            };
+
+            Children.Add(new ContentPage
+            {
+                Title = "Page One",
+                Content = new StackLayout
+                {
+                    Children =
+                    {
+                        new Button
+                        {
+                            Text = "Go to next page",
+                            Command = new Command(() => Navigation.PushAsync(new ContentPage { Title = "Next Page", Content = new Label { Text = "Here" } }))
+                        },
+                        list
+                    }
+                }
+            });
+
+            Children.Add(new ContentPage { Title = "Page Two" });
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -119,6 +119,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42074.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42075.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42329.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42364.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -105,6 +105,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40333.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31806.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40858.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40824.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -573,6 +573,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			Current = view;
 
+			((Platform)Element.Platform).NavAnimationInProgress = true;
 			FragmentTransaction transaction = fm.BeginTransaction();
 
 			if (animated)
@@ -606,6 +607,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 						transaction.Show(toShow);
 					else
 						transaction.Add(Id, toShow);
+
+					((Platform)Element.Platform).NavAnimationInProgress = false;
 				}
 				else
 				{
@@ -614,13 +617,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					transaction.Hide(currentToHide);
 					transaction.Add(Id, fragment);
 					fragments.Add(fragment);
+					((Platform)Element.Platform).NavAnimationInProgress = false;
 				}
 			}
 			transaction.Commit();
 
 			// The fragment transitions don't really SUPPORT telling you when they end
 			// There are some hacks you can do, but they actually are worse than just doing this:
-
+			
 			if (animated)
 			{
 				if (!removed)

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -264,7 +264,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void ScrollToCurrentPage()
 		{
+			((Platform)Element.Platform).NavAnimationInProgress = true;
 			_viewPager.SetCurrentItem(Element.Children.IndexOf(Element.CurrentPage), UseAnimations);
+			((Platform)Element.Platform).NavAnimationInProgress = false;
 		}
 
 		void UpdateIgnoreContainerAreas()

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -52,7 +52,11 @@ namespace Xamarin.Forms.Platform.Android
 			realListView.OnItemClickListener = this;
 			realListView.OnItemLongClickListener = this;
 
-			MessagingCenter.Subscribe<Platform>(this, Platform.CloseContextActionsSignalName, p => CloseContextAction());
+			var platform = _listView.Platform;
+			if (platform.GetType() == typeof(AppCompat.Platform))
+				MessagingCenter.Subscribe<AppCompat.Platform>(this, AppCompat.Platform.CloseContextActionsSignalName, p => CloseContextAction());
+			else
+				MessagingCenter.Subscribe<Platform>(this, Platform.CloseContextActionsSignalName, p => CloseContextAction());
 		}
 
 		public override int Count
@@ -325,7 +329,13 @@ namespace Xamarin.Forms.Platform.Android
 			if (disposing)
 			{
 				CloseContextAction();
-				MessagingCenter.Unsubscribe<Platform>(this, Platform.CloseContextActionsSignalName);
+
+				var platform = _listView.Platform;
+				if (platform.GetType() == typeof(AppCompat.Platform))
+					MessagingCenter.Unsubscribe<AppCompat.Platform>(this, Platform.CloseContextActionsSignalName);
+				else
+					MessagingCenter.Unsubscribe<Platform>(this, Platform.CloseContextActionsSignalName);
+
 				_realListView.OnItemClickListener = null;
 				_realListView.OnItemLongClickListener = null;
 


### PR DESCRIPTION
### Description of Change ###

When a `ListView` on a navigated page had a contextual actions menu open for one of its items and something caused a navigation to a new page (such as a button press), the menu would stay open. This was apparently caused by two things: the `Platform` type in the `ListViewAdapter` was being treated as the non-AppCompat type, thereby causing its use of the `MessagingCenter` to be non-functional, and the lack of the `NavAnimationInProgress` being set as necessary in the `NavigationPageRenderer` under AppCompat, whereas it was being set in the `NavigationRenderer` in non-AppCompat.

**Update**: A similar fix for TabbedPage which relies upon the initial commit has been added.

ControlGallery reproductions have been added for visual confirmation.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40824
https://bugzilla.xamarin.com/show_bug.cgi?id=42364

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense