### PR TITLE
[A, iOS] ListView Pull-To-Refresh indicator animates when navigating back to it

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33561.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33561.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 33561, "ListView Pull-to-Refresh ActivityIndicator animation stuck when navigating away and then back again")]
+	public class Bugzilla33561 : TestTabbedPage
+	{
+		public class ListPage : ContentPage
+		{
+			ListView _listView;
+			bool _isRefreshing;
+
+			public ListPage()
+			{
+				var template = new DataTemplate(typeof(TextCell));
+				template.SetBinding(TextCell.TextProperty, ".");
+
+				_listView = new ListView()
+				{
+					IsPullToRefreshEnabled = true,
+					ItemsSource = Enumerable.Range(0, 10).Select(no => $"FAIL {no}"),
+					ItemTemplate = template,
+					IsRefreshing = true
+				};
+
+				_listView.Refreshing += async (object sender, EventArgs e) =>
+				{
+					if (_isRefreshing)
+						return;
+
+					_isRefreshing = true;
+					await Task.Delay(10000);
+					_listView.EndRefresh();
+					_listView.ItemsSource = Enumerable.Range(0, 10).Select(no => $"SUCCESS {no}");
+					_isRefreshing = false;
+				};
+
+				Content = _listView;
+
+				Device.StartTimer(TimeSpan.FromSeconds(5), () => { _listView.IsRefreshing = false; return false; });
+			}
+		}
+
+		protected override void Init()
+		{
+			Children.Add(new NavigationPage(new ListPage()) { Title = "page 1" });
+			Children.Add(new ContentPage() { Title = "page 2" });
+			Children.Add(new ContentPage() { Title = "page 3" });
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -162,6 +162,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41842.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42277.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ImageLoadingErrorHandling.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -300,7 +300,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (_refresh != null)
 			{
-				if (Element.IsRefreshing && isInitialValue)
+				var isRefreshing = Element.IsRefreshing;
+				if (isRefreshing && isInitialValue)
 				{
 					_refresh.Refreshing = false;
 					_refresh.Post(() =>
@@ -309,7 +310,7 @@ namespace Xamarin.Forms.Platform.Android
 					});
 				}
 				else
-					_refresh.Refreshing = Element.IsRefreshing;
+					_refresh.Refreshing = isRefreshing;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -141,7 +141,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateHeader();
 				UpdateFooter();
 				UpdateIsSwipeToRefreshEnabled();
-				UpdateIsRefreshing();
+				UpdateIsRefreshing(isInitialValue: true);
 			}
 		}
 
@@ -296,10 +296,21 @@ namespace Xamarin.Forms.Platform.Android
 			Platform.SetRenderer(header, _headerRenderer);
 		}
 
-		void UpdateIsRefreshing()
+		void UpdateIsRefreshing(bool isInitialValue = false)
 		{
 			if (_refresh != null)
-				_refresh.Refreshing = Element.IsRefreshing;
+			{
+				if (Element.IsRefreshing && isInitialValue)
+				{
+					_refresh.Refreshing = false;
+					_refresh.Post(() =>
+					{
+						_refresh.Refreshing = true;
+					});
+				}
+				else
+					_refresh.Refreshing = Element.IsRefreshing;
+			}
 		}
 
 		void UpdateIsSwipeToRefreshEnabled()

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Layout.LayoutChildIntoBoundingRegion(Element, new Rectangle(Element.X, Element.Y, size.Width, size.Height));
 		}
 
-		public UIViewController ViewController
+		public virtual UIViewController ViewController
 		{
 			get { return null; }
 		}


### PR DESCRIPTION
### Description of Change ###

Now restarting the indicator animation when the `ListView` reappears and is still refreshing. A manual test has been provided for review.

### Bugs Fixed ###

- [Bugzilla 33561 - Listview Pull-to-Refresh ActicityIndicator animation stuck when navigating away and then back again] (https://bugzilla.xamarin.com/show_bug.cgi?id=33561)

### API Changes ###

Added:
- `override UIViewController Platform.iOS.ListViewRenderer.ViewController`

Changed:
 - `UIViewController Platform.iOS.VisualElementRenderer.ViewController` is now virtual

### Behavioral Changes ###

- [Android] `Refreshing` event will trigger again when the `ListView` appears again while it is still refreshing.
- [iOS] `ListView` will now received forwarded events from its parent `UIViewController` (e.g., `ViewWillAppear`), even when the parent is a `UINavigationController` or `UITabBarController`. Should not affect any renderers deriving from `ListViewRenderer` but may affect any custom renderers inheriting from `ViewRenderer<ListView, UITableView>`.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
