### PR TITLE
[A] Pre-AppCompat ListView Pull-To-Refresh indicator animates when navigating back to it 

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -84,6 +84,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			_isAttached = true;
 			_adapter.IsAttachedToWindow = _isAttached;
+			UpdateIsRefreshing(isInitialValue: true);
 		}
 
 		protected override void OnDetachedFromWindow()
@@ -141,7 +142,6 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateHeader();
 				UpdateFooter();
 				UpdateIsSwipeToRefreshEnabled();
-				UpdateIsRefreshing(isInitialValue: true);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Builds on #274. This time, we're restarting it `OnAttachedToWindow`. Will use the same test.

### Bugs Fixed ###

- [Bugzilla 33561 - Listview Pull-to-Refresh ActicityIndicator animation stuck when navigating away and then back again] (https://bugzilla.xamarin.com/show_bug.cgi?id=33561)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense