### PR TITLE
Add the key in the message on throwing a KeyNotFoundException

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -252,14 +252,14 @@ namespace Xamarin.Forms.Core.UnitTests
 			elt.Parent = parent;
 			Assert.Fail ();
 		}
-	}
 
-	[Test]
-	public void ShowKeyInExceptionIfNotFound()
-	{
-		var rd = new ResourceDictionary();
-		rd.Add("foo", "bar");
-		var ex = Assert.Throws<KeyNotFoundException>(() => { var foo = rd["test_invalid_key"]; });
-		Assert.That(ex.Message, Is.StringContaining("test_invalid_key"));
-	}
+        [Test]
+        public void ShowKeyInExceptionIfNotFound()
+        {
+            var rd = new ResourceDictionary();
+            rd.Add("foo", "bar");
+            var ex = Assert.Throws<KeyNotFoundException>(() => { var foo = rd["test_invalid_key"]; });
+            Assert.That(ex.Message, Is.StringContaining("test_invalid_key"));
+        }
+    }
 }

--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -253,4 +253,13 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.Fail ();
 		}
 	}
+
+	[Test]
+	public void ShowKeyInExceptionIfNotFound()
+	{
+		var rd = new ResourceDictionary();
+		rd.Add("foo", "bar");
+		var ex = Assert.Throws<KeyNotFoundException>(() => { var foo = rd["test_invalid_key"]; });
+		Assert.That(ex.Message, Is.StringContaining("test_invalid_key"));
+	}
 }

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -98,7 +98,7 @@ namespace Xamarin.Forms
 					return _innerDictionary[index];
 				if (_mergedInstance != null && _mergedInstance.ContainsKey(index))
 					return _mergedInstance[index];
-				throw new KeyNotFoundException();
+				throw new KeyNotFoundException("The resource '" + index + "' is not present in the dictionary.");
 			}
 			set
 			{

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -98,7 +98,7 @@ namespace Xamarin.Forms
 					return _innerDictionary[index];
 				if (_mergedInstance != null && _mergedInstance.ContainsKey(index))
 					return _mergedInstance[index];
-				throw new KeyNotFoundException("The resource '" + index + "' is not present in the dictionary.");
+				throw new KeyNotFoundException($"The resource '{index}' is not present in the dictionary.");
 			}
 			set
 			{


### PR DESCRIPTION
### Description of Change ###
Add the key in the message on throwing a KeyNotFoundException for trying to access an invalid key in the ResourceDictionary. This helps in tracking down what resource is actually missing. 

### Bugs Fixed ###
None

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

…ing to access an invalid key in the ResourceDictionary. This helps a lot in tracking down what resource is actually missing.