### PR TITLE
[Android] Close the correct mode if it wasn't disposed

### DIFF
--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -81,15 +81,15 @@ namespace Xamarin.Forms.Platform.Android
 		public bool OnActionItemClicked(ActionMode mode, IMenuItem item)
 		{
 			OnActionItemClickedImpl(item);
-			if (mode != null && mode.Handle != IntPtr.Zero)
-				mode.Finish();
+			_actionMode?.Finish();
 			return true;
 		}
 
 		bool global::Android.Support.V7.View.ActionMode.ICallback.OnActionItemClicked(global::Android.Support.V7.View.ActionMode mode, IMenuItem item)
 		{
 			OnActionItemClickedImpl(item);
-			mode.Finish();
+
+			_supportActionMode?.Finish();
 			return true;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fixing a issue where destroy is called first on cell adapter, there we dispose the current mode open.
Then on click we weren't trying to finish the already disposed mode, by closing the correct one we don't need to check if the pointer is null. 

### Bugs Fixed ###

- Fixes failing uitest on android on master 32541

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
