### PR TITLE
Fix bugzilla 41559

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzill41559.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzill41559.cs
@@ -6,6 +6,7 @@ using Xamarin.Forms.CustomAttributes;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using System.Linq;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
@@ -31,7 +32,11 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Bugzilla41559Test ()
 		{
 			RunningApp.Tap("NumericEntry");
-			var buttonCount = RunningApp.Query("Done").Count();
+
+			const string DoneButtonText = "Done";
+			RunningApp.WaitForElement(DoneButtonText);
+			var buttonCount = RunningApp.Query(DoneButtonText).Count();
+
 			Assert.GreaterOrEqual(buttonCount, 1, "Done keyboard button is not added");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzill41559.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzill41559.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Bugzilla, 41559, "In iOS Entry.keyboard=Keyboard.Numeric does not have a done button")]
+	public class Bugzill41559 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var numericEntry = new Entry { Keyboard = Keyboard.Numeric, AutomationId = "NumericEntry" };
+			Content = new StackLayout
+			{
+				Children = {
+					numericEntry
+				}
+			};
+
+			numericEntry.Focus();
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla41559Test ()
+		{
+			RunningApp.Tap("NumericEntry");
+			var buttonCount = RunningApp.Query("Done").Count();
+			Assert.GreaterOrEqual(buttonCount, 1, "Done keyboard button is not added");
+		}
+#endif
+	}
+}
+
+

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -427,6 +427,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39486.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue55555.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41029.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzill41559.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -2,11 +2,18 @@ using System;
 using System.Drawing;
 using System.Runtime.Remoting.Channels;
 using System.ComponentModel;
+
 #if __UNIFIED__
 using UIKit;
+using RectangleF = CoreGraphics.CGRect;
+using SizeF = CoreGraphics.CGSize;
+using PointF = CoreGraphics.CGPoint;
 
 #else
 using MonoTouch.UIKit;
+using nfloat=System.Single;
+using nint=System.Int32;
+using nuint=System.UInt32;
 #endif
 
 namespace Xamarin.Forms.Platform.iOS
@@ -14,6 +21,7 @@ namespace Xamarin.Forms.Platform.iOS
 	public class EntryRenderer : ViewRenderer<Entry, UITextField>
 	{
 		UIColor _defaultTextColor;
+		UIToolbar _accessoryView;
 
 		public EntryRenderer()
 		{
@@ -144,6 +152,21 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateKeyboard()
 		{
 			Control.ApplyKeyboard(Element.Keyboard);
+
+			if (Device.Idiom == TargetIdiom.Phone && Element.Keyboard == Keyboard.Numeric)
+			{
+				// iPhone does not have a dismiss keyboard button
+				var keyboardWidth = UIScreen.MainScreen.Bounds.Width;
+				_accessoryView = new UIToolbar(new RectangleF(0, 0, keyboardWidth, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
+
+				var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);
+				var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) =>
+				{
+					Control.ResignFirstResponder();
+				});
+				_accessoryView.SetItems(new[] { spacer, doneButton }, false);
+				Control.InputAccessoryView = _accessoryView;
+			}
 		}
 
 		void UpdatePassword()


### PR DESCRIPTION
### Description of Change

Added a “Done” button to dismiss the Numeric keyboard on iPhone/iPod

### Bugs Fixed
https://bugzilla.xamarin.com/show_bug.cgi?id=41559

### API Changes
None.

### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense