### PR TITLE
[Android] Fix for NullReferenceException when using the wrong activit…

### DIFF
--- a/Xamarin.Forms.Platform.Android/KeyboardManager.cs
+++ b/Xamarin.Forms.Platform.Android/KeyboardManager.cs
@@ -11,6 +11,9 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		internal static void HideKeyboard(this AView inputView, bool overrideValidation = false)
 		{
+            if (Forms.Context == null)
+                throw new InvalidOperationException("Call Forms.Init() before HideKeyboard");
+
 			using (var inputMethodManager = (InputMethodManager)Forms.Context.GetSystemService(Context.InputMethodService))
 			{
 				IBinder windowToken = null;
@@ -26,6 +29,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal static void ShowKeyboard(this AView inputView)
 		{
+            if (Forms.Context == null)
+                throw new InvalidOperationException("Call Forms.Init() before ShowKeyboard");
+            
 			using (var inputMethodManager = (InputMethodManager)Forms.Context.GetSystemService(Context.InputMethodService))
 			{
 				if (inputView is EditText || inputView is TextView || inputView is SearchView)

--- a/Xamarin.Forms.Platform.Android/KeyboardManager.cs
+++ b/Xamarin.Forms.Platform.Android/KeyboardManager.cs
@@ -11,8 +11,8 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		internal static void HideKeyboard(this AView inputView, bool overrideValidation = false)
 		{
-            if (Forms.Context == null)
-                throw new InvalidOperationException("Call Forms.Init() before HideKeyboard");
+			if (Forms.Context == null)
+				throw new InvalidOperationException("Call Forms.Init() before HideKeyboard");
 
 			using (var inputMethodManager = (InputMethodManager)Forms.Context.GetSystemService(Context.InputMethodService))
 			{
@@ -29,9 +29,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal static void ShowKeyboard(this AView inputView)
 		{
-            if (Forms.Context == null)
-                throw new InvalidOperationException("Call Forms.Init() before ShowKeyboard");
-            
+			if (Forms.Context == null)
+				throw new InvalidOperationException("Call Forms.Init() before ShowKeyboard");
+
 			using (var inputMethodManager = (InputMethodManager)Forms.Context.GetSystemService(Context.InputMethodService))
 			{
 				if (inputView is EditText || inputView is TextView || inputView is SearchView)


### PR DESCRIPTION
### Description of Change ###

Better exception message than NullReferenceException in KeyboardManager if using the wrong Activity on a Android SplashScreen.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=32733
According to StackTrace in bugzilla:
"at Xamarin.Forms.Platform.Android.FormsApplicationActivity.OnPause () <IL 0x00007, 0x0004b>"

### API Changes ###

None

### Behavioral Changes ###

Just an extra "if nullcheck" when calling HideKeyboard and ShowKeyboard on KeyboardManager. No other.
