### PR TITLE
Don't render empty TextCells for TableSections without Title (bugs 26104 and 42926)

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
@@ -45,5 +45,13 @@ namespace Xamarin.Forms.Platform.Android
 			TableViewModelRenderer source = GetModelRenderer(listView, view);
 			listView.Adapter = source;
 		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if(disposing)
+				Control?.Adapter?.Dispose();
+
+			base.Dispose(disposing);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

When a TableSection has no header, then iOS doesn't render a header cell. Android rendered an empty TextCell and a separator line in the accent color. This could not be removed by the user.

With this change, the empty TextCell and the separator are not rendered. If you still want them, then you can set the Title to " ".

When I debugged the GetCellForPosition method, I saw that it was called very often. Before a TableView was rendered, the method was called twice for each Cell from GetView and twice for each Cell from IsEnabled. I removed one call from GetView, but IsEnabled is called twice from the adapter. I think the result of GetCellForPosition should be cached in a Cell[] or WeakReference<Cell>[] and two bool[] for isHeader and nextIsHeader. Then it would not have to iterate over all Cells every time the method is called.
But for this PR I only wanted to fix the bugs and didn't want to mix it up with caching.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=26104
- https://bugzilla.xamarin.com/show_bug.cgi?id=42926
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
