### PR TITLE
[Win] Set BindingContext for default cell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41205.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41205.cs
@@ -10,12 +10,21 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Bugzilla, 41205, "UWP CreateDefault passes string instead of object")]
 	public class Bugzilla41205 : ContentPage
 	{
+		public class ViewModel
+		{
+			public string Text { get { return "Pass"; } }
+		}
+
 		public class CustomListView : ListView
 		{
 			protected override Cell CreateDefault(object item)
 			{
 				if (item is ViewModel)
-					return base.CreateDefault("Pass");
+				{
+					var newTextCell = new TextCell();
+					newTextCell.SetBinding(TextCell.TextProperty, nameof(ViewModel.Text));
+					return newTextCell;
+				}
 				return base.CreateDefault("Fail");
 			}
 		}

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -235,6 +235,7 @@ namespace Xamarin.Forms.Platform.WinRT
 						defaultContext = listViewController.GetDisplayTextFromGroup(newContext);
 
 					cell = listViewController.CreateDefaultCell(defaultContext);
+					cell.BindingContext = defaultContext;
 				}
 
 				// A TableView cell should already have its parent,

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -215,32 +215,33 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				bool isGroupHeader = IsGroupHeader;
 				DataTemplate template = isGroupHeader ? lv.GroupHeaderTemplate : lv.ItemTemplate;
+				object bindingContext = newContext;
 
 				if (template is DataTemplateSelector)
 				{
-					template = ((DataTemplateSelector)template).SelectTemplate(newContext, lv);
+					template = ((DataTemplateSelector)template).SelectTemplate(bindingContext, lv);
 				}
 
 				if (template != null)
 				{
 					cell = template.CreateContent() as Cell;
-					cell.BindingContext = newContext;
 				}
 				else
 				{
 					IListViewController listViewController = lv;
-					var defaultContext = newContext;
 
 					if (isGroupHeader)
-						defaultContext = listViewController.GetDisplayTextFromGroup(newContext);
+						bindingContext = listViewController.GetDisplayTextFromGroup(bindingContext);
 
-					cell = listViewController.CreateDefaultCell(defaultContext);
-					cell.BindingContext = defaultContext;
+					cell = listViewController.CreateDefaultCell(bindingContext);
 				}
 
 				// A TableView cell should already have its parent,
 				// but we need to set the parent for a ListView cell.
 				cell.Parent = lv;
+
+				// Set inherited BindingContext after setting the Parent so it won't be wiped out
+				BindableObject.SetInheritedBindingContext(cell, bindingContext);
 
 				// This provides the Group Header styling (e.g., larger font, etc.) when the
 				// template is loaded later.


### PR DESCRIPTION
### Description of Change ###

Win/UWP cells created by `.CreateDefaultCell` will have their `BindingContext` set to the `item`.

### Bugs Fixed ###

- [Bug 41205  - Override ListView.CreateDefault, parameter is always string] (https://bugzilla.xamarin.com/show_bug.cgi?id=41205)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
