### PR TITLE
[Windows] Correct enter/esc keypress behaviors for MessageDialog

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -738,13 +738,13 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (options.Accept != null)
 			{
 				dialog.Commands.Add(new UICommand(options.Accept));
-				dialog.DefaultCommandIndex = (uint)dialog.Commands.Count - 1;
+				dialog.DefaultCommandIndex = 0;
 			}
 
 			if (options.Cancel != null)
 			{
 				dialog.Commands.Add(new UICommand(options.Cancel));
-				dialog.CancelCommandIndex = 0;
+				dialog.CancelCommandIndex = (uint)dialog.Commands.Count - 1;
 			}
 
 			IUICommand command = await dialog.ShowAsync();


### PR DESCRIPTION
### Description of Change ###

`DisplayAlert` was returning a true value when pressing the escape key while it was open on Windows (reported under UWP, but the behavior is a WinRT issue in general). It was also returning true when pressing the enter key. Inside of the `OnPageAlert` method where the `DefaultCommandIndex` value was being signed, that value was being set to zero as only one `UICommand` had been added by that point. Subsequently, the `CancelCommandIndex` was then being set to 0, which in this case would trigger the Accept command when pressing the escape key. Swapping the manner in which the values are set corrects the behavior.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=43230

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

