### PR TITLE
[docs] Fix ambiguous description about Image.IsOpaque

### DIFF
--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Image.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Image.xml
@@ -191,7 +191,7 @@ indicator.BindingContext = image;]]></code>
       <Docs>
         <summary>Gets or sets the opacity flag for the image. This is a bindable property.</summary>
         <value>A <see cref="T:System.Boolean" /> indicating the value for the property. Default is false.</value>
-        <remarks>If true, you'll be able to see through transparent parts of the image.</remarks>
+        <remarks>If true, you'll be able to see transparent parts of the image.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsOpaqueProperty">
@@ -203,7 +203,7 @@ indicator.BindingContext = image;]]></code>
         <AssemblyVersion>1.1.0.0</AssemblyVersion>
         <AssemblyVersion>1.2.0.0</AssemblyVersion>
         <AssemblyVersion>1.3.0.0</AssemblyVersion>
-        <AssemblyVersion>1.4.0.0</AssemblyVersion>
+I        <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Image.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Image.xml
@@ -203,7 +203,7 @@ indicator.BindingContext = image;]]></code>
         <AssemblyVersion>1.1.0.0</AssemblyVersion>
         <AssemblyVersion>1.2.0.0</AssemblyVersion>
         <AssemblyVersion>1.3.0.0</AssemblyVersion>
-I        <AssemblyVersion>1.4.0.0</AssemblyVersion>
+        <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>


### PR DESCRIPTION
### Description of Change ###
I'd like to change ambiguous remarks of Image.IsOpaque.
> If true, you'll be able to see through transparent parts of the image.

If false, I can see the behind object of Image through transparent parts of the image.
It is different with current remarks

> If true, you'll be able to see transparent parts of the image.

I think, it is more clear

### Bugs Fixed ###
N/A

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
