### PR TITLE
[Xaml] Clone node tree on DT

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/MarkupExpressionParserTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MarkupExpressionParserTests.cs
@@ -68,7 +68,13 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				throw new NotImplementedException ();
 			}
 
+
 			public List<string> IgnorablePrefixes { get; set; }
+
+			public INode Clone()
+			{
+				throw new NotImplementedException();
+			}
 		}
 
 		[SetUp]

--- a/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.TypeExtension">
+	<ListView.ItemTemplate>
+		<DataTemplate>
+			<ViewCell>
+				<Button Command="{local:Navigate Operation=Forward, Type={x:Type Grid}}" />
+			</ViewCell>
+		</DataTemplate>
+	</ListView.ItemTemplate>
+</ListView>

--- a/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Input;
+using Xamarin.Forms;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public enum NavigationOperation
+	{
+		Forward,
+		Back,
+		Replace,
+	}
+
+	[ContentProperty(nameof(Operation))]
+	public class NavigateExtension : IMarkupExtension<ICommand>
+	{
+		public NavigationOperation Operation { get; set; }
+
+		public Type Type { get; set; }
+
+		public ICommand ProvideValue(IServiceProvider serviceProvider)
+		{
+			return new Command(() => { });
+		}
+
+		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
+		{
+			return ProvideValue(serviceProvider);
+		}
+	}
+
+	public partial class TypeExtension : ListView
+	{
+		public TypeExtension()
+		{
+			InitializeComponent();
+		}
+
+		public TypeExtension(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[TestCase(false)]
+			[TestCase(true)]
+			public void NestedMarkupExtensionInsideDataTemplate(bool useCompiledXaml)
+			{
+				var listView = new TypeExtension(useCompiledXaml);
+				listView.ItemsSource = new string [2];
+
+				var cell = (ViewCell)listView.TemplatedItems [0];
+				var button = (Button)cell.View;
+				Assert.IsNotNull(button.Command);
+
+				cell = (ViewCell)listView.TemplatedItems [1];
+				button = (Button)cell.View;
+				Assert.IsNotNull(button.Command);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -353,6 +353,9 @@
     <Compile Include="SetValue.xaml.cs">
       <DependentUpon>SetValue.xaml</DependentUpon>
     </Compile>
+    <Compile Include="TypeExtension.xaml.cs">
+      <DependentUpon>TypeExtension.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -627,6 +630,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="SetValue.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TypeExtension.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/XamlLoaderCreateTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlLoaderCreateTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Windows.Input;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -434,14 +434,16 @@ namespace Xamarin.Forms.Xaml
 			((IDataTemplate)dt).LoadTemplate = () =>
 			{
 #pragma warning restore 0612
+				var cnode = node.Clone();
 				var context = new HydratationContext { ParentContext = Context, RootElement = Context.RootElement };
-				node.Accept(new ExpandMarkupsVisitor(context), null);
-				node.Accept(new NamescopingVisitor(context), null);
-				node.Accept(new CreateValuesVisitor(context), null);
-				node.Accept(new RegisterXNamesVisitor(context), null);
-				node.Accept(new FillResourceDictionariesVisitor(context), null);
-				node.Accept(new ApplyPropertiesVisitor(context, true), null);
-				return context.Values[node];
+				cnode.Accept(new XamlNodeVisitor((n, parent) => n.Parent = parent), node.Parent); //set parents for {StaticResource}
+				cnode.Accept(new ExpandMarkupsVisitor(context), null);
+				cnode.Accept(new NamescopingVisitor(context), null);
+				cnode.Accept(new CreateValuesVisitor(context), null);
+				cnode.Accept(new RegisterXNamesVisitor(context), null);
+				cnode.Accept(new FillResourceDictionariesVisitor(context), null);
+				cnode.Accept(new ApplyPropertiesVisitor(context, true), null);
+				return context.Values[cnode];
 			};
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Clone node tree on DataTemplates, allowing markup extensions (like x:Type and x:Static) to be evaluated multiple times.

### Bugs Fixed ###

- @jonathanpeppers: do you have link for this ?

### API Changes ###

None

### Behavioral Changes ###

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense