### PR TITLE
Extend Picker to ease programming MVVM paradigm

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -1,341 +1,336 @@
 using System;
-
 using NUnit.Framework;
 using System.Collections.ObjectModel;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
-    internal class ContextFixture
-    {
-        public string DisplayName { get; set; }
+	internal class ContextFixture
+	{
+		public string DisplayName { get; set; }
 
-        public string ComplexName { get; set; }
+		public string ComplexName { get; set; }
 
-        public ContextFixture(string displayName, string complexName)
-        {
-            DisplayName = displayName;
-            ComplexName = complexName;
-        }
+		public ContextFixture(string displayName, string complexName)
+		{
+			DisplayName = displayName;
+			ComplexName = complexName;
+		}
 
-        public ContextFixture()
-        {
-        }
-    }
+		public ContextFixture()
+		{
+		}
+	}
 
-    internal class BindingContext
-    {
-        public ObservableCollection<object> Items { get; set; }
+	internal class BindingContext
+	{
+		public ObservableCollection<object> Items { get; set; }
 
-        public object SelectedItem { get; set; }
-    }
+		public object SelectedItem { get; set; }
+	}
 
-    [TestFixture]
-    public class PickerTests : BaseTestFixture
-    {
-        [Test]
-        public void TestSetSelectedIndexOnNullRows()
-        {
-            var picker = new Picker();
+	[TestFixture]
+	public class PickerTests : BaseTestFixture
+	{
+		[Test]
+		public void TestSetSelectedIndexOnNullRows()
+		{
+			var picker = new Picker();
 
-            Assert.IsEmpty(picker.Items);
-            Assert.AreEqual(-1, picker.SelectedIndex);
+			Assert.IsEmpty(picker.Items);
+			Assert.AreEqual(-1, picker.SelectedIndex);
 
-            picker.SelectedIndex = 2;
+			picker.SelectedIndex = 2;
 
-            Assert.AreEqual(-1, picker.SelectedIndex);
-        }
+			Assert.AreEqual(-1, picker.SelectedIndex);
+		}
 
-        [Test]
-        public void TestSelectedIndexInRange()
-        {
-            var picker = new Picker
-            {
-                Items = { "John", "Paul", "George", "Ringo" },
-                SelectedIndex = 2
-            };
+		[Test]
+		public void TestSelectedIndexInRange()
+		{
+			var picker = new Picker
+			{
+				Items = { "John", "Paul", "George", "Ringo" },
+				SelectedIndex = 2
+			};
 
-            Assert.AreEqual(2, picker.SelectedIndex);
+			Assert.AreEqual(2, picker.SelectedIndex);
 
-            picker.SelectedIndex = 42;
-            Assert.AreEqual(3, picker.SelectedIndex);
+			picker.SelectedIndex = 42;
+			Assert.AreEqual(3, picker.SelectedIndex);
 
-            picker.SelectedIndex = -1;
-            Assert.AreEqual(-1, picker.SelectedIndex);
+			picker.SelectedIndex = -1;
+			Assert.AreEqual(-1, picker.SelectedIndex);
 
-            picker.SelectedIndex = -42;
-            Assert.AreEqual(-1, picker.SelectedIndex);
-        }
+			picker.SelectedIndex = -42;
+			Assert.AreEqual(-1, picker.SelectedIndex);
+		}
 
-        [Test]
-        public void TestSelectedIndexInRangeDefaultSelectedIndex()
-        {
-            var picker = new Picker
-            {
-                Items = { "John", "Paul", "George", "Ringo" }
-            };
+		[Test]
+		public void TestSelectedIndexInRangeDefaultSelectedIndex()
+		{
+			var picker = new Picker
+			{
+				Items = { "John", "Paul", "George", "Ringo" }
+			};
 
-            Assert.AreEqual(-1, picker.SelectedIndex);
+			Assert.AreEqual(-1, picker.SelectedIndex);
 
-            picker.SelectedIndex = -5;
-            Assert.AreEqual(-1, picker.SelectedIndex);
+			picker.SelectedIndex = -5;
+			Assert.AreEqual(-1, picker.SelectedIndex);
 
-            picker.SelectedIndex = 2;
-            Assert.AreEqual(2, picker.SelectedIndex);
+			picker.SelectedIndex = 2;
+			Assert.AreEqual(2, picker.SelectedIndex);
 
-            picker.SelectedIndex = 42;
-            Assert.AreEqual(3, picker.SelectedIndex);
+			picker.SelectedIndex = 42;
+			Assert.AreEqual(3, picker.SelectedIndex);
 
-            picker.SelectedIndex = -1;
-            Assert.AreEqual(-1, picker.SelectedIndex);
+			picker.SelectedIndex = -1;
+			Assert.AreEqual(-1, picker.SelectedIndex);
 
-            picker.SelectedIndex = -42;
-            Assert.AreEqual(-1, picker.SelectedIndex);
-        }
+			picker.SelectedIndex = -42;
+			Assert.AreEqual(-1, picker.SelectedIndex);
+		}
 
-        [Test]
-        public void TestSelectedIndexChangedOnCollectionShrink()
-        {
-            var picker = new Picker { Items = { "John", "Paul", "George", "Ringo" }, SelectedIndex = 3 };
+		[Test]
+		public void TestSelectedIndexChangedOnCollectionShrink()
+		{
+			var picker = new Picker { Items = { "John", "Paul", "George", "Ringo" }, SelectedIndex = 3 };
 
-            Assert.AreEqual(3, picker.SelectedIndex);
+			Assert.AreEqual(3, picker.SelectedIndex);
 
-            picker.Items.RemoveAt(3);
-            picker.Items.RemoveAt(2);
+			picker.Items.RemoveAt(3);
+			picker.Items.RemoveAt(2);
 
+			Assert.AreEqual(1, picker.SelectedIndex);
 
-            Assert.AreEqual(1, picker.SelectedIndex);
+			picker.Items.Clear();
+			Assert.AreEqual(-1, picker.SelectedIndex);
+		}
 
-            picker.Items.Clear();
-            Assert.AreEqual(-1, picker.SelectedIndex);
-        }
+		[Test]
+		public void TestSetItemsSourceProperty()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo",
+				0,
+				new DateTime(1970, 1, 1),
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items
+			};
+			Assert.AreEqual(5, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+			Assert.AreEqual("0", picker.Items[3]);
+		}
 
-        [Test]
-        public void TestSetItemsSourceProperty()
-        {
-            var items = new ObservableCollection<object>
-            {
-                new {Name = "John"},
-                "Paul",
-                "Ringo",
-                0,
-                new DateTime(1970, 1, 1),
-            };
-            var picker = new Picker
-            {
-                DisplayMemberPath = "Name",
-                ItemsSource = items
-            };
-            Assert.AreEqual(5, picker.Items.Count);
-            Assert.AreEqual("John", picker.Items[0]);
-            Assert.AreEqual("0", picker.Items[3]);
-        }
+		[Test]
+		public void TestItemsSourceCollectionChangedAppend()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+			items.Add(new { Name = "George" });
+			Assert.AreEqual(4, picker.Items.Count);
+			Assert.AreEqual("George", picker.Items[picker.Items.Count - 1]);
+		}
 
-        [Test]
-        public void TestItemsSourceCollectionChangedAppend()
-        {
-            var items = new ObservableCollection<object>
-            {
-                new {Name = "John"},
-                "Paul",
-                "Ringo"
-            };
-            var picker = new Picker
-            {
-                DisplayMemberPath = "Name",
-                ItemsSource = items,
-                SelectedIndex = 0
-            };
-            Assert.AreEqual(3, picker.Items.Count);
-            Assert.AreEqual("John", picker.Items[0]);
-            items.Add(new { Name = "George" });
-            Assert.AreEqual(4, picker.Items.Count);
-            Assert.AreEqual("George", picker.Items[picker.Items.Count - 1]);
-        }
+		[Test]
+		public void TestItemsSourceCollectionChangedClear()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			items.Clear();
+			Assert.AreEqual(0, picker.Items.Count);
+		}
 
-        [Test]
-        public void TestItemsSourceCollectionChangedClear()
-        {
-            var items = new ObservableCollection<object>
-            {
-                new {Name = "John"},
-                "Paul",
-                "Ringo"
-            };
-            var picker = new Picker
-            {
-                DisplayMemberPath = "Name",
-                ItemsSource = items,
-                SelectedIndex = 0
-            };
-            Assert.AreEqual(3, picker.Items.Count);
-            items.Clear();
-            Assert.AreEqual(0, picker.Items.Count);
-        }
+		[Test]
+		public void TestItemsSourceCollectionChangedInsert()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+			items.Insert(1, new { Name = "George" });
+			Assert.AreEqual(4, picker.Items.Count);
+			Assert.AreEqual("George", picker.Items[1]);
+		}
 
-        [Test]
-        public void TestItemsSourceCollectionChangedInsert()
-        {
-            var items = new ObservableCollection<object>
-            {
-                new {Name = "John"},
-                "Paul",
-                "Ringo"
-            };
-            var picker = new Picker
-            {
-                DisplayMemberPath = "Name",
-                ItemsSource = items,
-                SelectedIndex = 0
-            };
-            Assert.AreEqual(3, picker.Items.Count);
-            Assert.AreEqual("John", picker.Items[0]);
-            items.Insert(1, new { Name = "George" });
-            Assert.AreEqual(4, picker.Items.Count);
-            Assert.AreEqual("George", picker.Items[1]);
-        }
+		[Test]
+		public void TestItemsSourceCollectionChangedReAssign()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var bindingContext = new { Items = items };
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				BindingContext = bindingContext
+			};
+			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+			Assert.AreEqual(3, picker.Items.Count);
+			items = new ObservableCollection<object>
+			{
+				"Peach",
+				"Orange"
+			};
+			picker.BindingContext = new { Items = items };
+			Assert.AreEqual(2, picker.Items.Count);
+			Assert.AreEqual("Peach", picker.Items[0]);
+		}
 
-        [Test]
-        public void TestItemsSourceCollectionChangedReAssign()
-        {
-            var items = new ObservableCollection<object>
-            {
-                new {Name = "John"},
-                "Paul",
-                "Ringo"
-            };
-            var bindingContext = new { Items = items };
-            var picker = new Picker
-            {
-                DisplayMemberPath = "Name",
-                BindingContext = bindingContext
-            };
-            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
-            Assert.AreEqual(3, picker.Items.Count);
-            items = new ObservableCollection<object>
-            {
-                "Peach",
-                "Orange"
-            };
-            picker.BindingContext = new { Items = items };
-            Assert.AreEqual(2, picker.Items.Count);
-            Assert.AreEqual("Peach", picker.Items[0]);
-        }
+		[Test]
+		public void TestItemsSourceCollectionChangedRemove()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+			items.RemoveAt(1);
+			Assert.AreEqual(2, picker.Items.Count);
+			Assert.AreEqual("Ringo", picker.Items[1]);
+		}
 
-        [Test]
-        public void TestItemsSourceCollectionChangedRemove()
-        {
-            var items = new ObservableCollection<object>
-            {
-                new {Name = "John"},
-                "Paul",
-                "Ringo"
-            };
-            var picker = new Picker
-            {
-                DisplayMemberPath = "Name",
-                ItemsSource = items,
-                SelectedIndex = 0
-            };
-            Assert.AreEqual(3, picker.Items.Count);
-            Assert.AreEqual("John", picker.Items[0]);
-            items.RemoveAt(1);
-            Assert.AreEqual(2, picker.Items.Count);
-            Assert.AreEqual("Ringo", picker.Items[1]);
-        }
+		[Test]
+		public void TestItemsSourceCollectionOfStrings()
+		{
+			var items = new ObservableCollection<string>
+			{
+				"John",
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+		}
 
-        [Test]
-        public void TestItemsSourceCollectionOfStrings()
-        {
-            var items = new ObservableCollection<string>
-            {
-                "John",
-                "Paul",
-                "Ringo"
-            };
-            var picker = new Picker
-            {
-                ItemsSource = items,
-                SelectedIndex = 0
-            };
-            Assert.AreEqual(3, picker.Items.Count);
-            Assert.AreEqual("John", picker.Items[0]);
-        }
+		[Test]
+		public void TestSelectedItemDefault()
+		{
+			var bindingContext = new BindingContext
+			{
+				Items = new ObservableCollection<object>
+				{
+					new ContextFixture("John", "John")
+				}
+			};
+			var picker = new Picker
+			{
+				BindingContext = bindingContext
+			};
+			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+			picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
+			Assert.AreEqual(1, picker.Items.Count);
+			Assert.AreEqual(-1, picker.SelectedIndex);
+			Assert.AreEqual(bindingContext.SelectedItem, picker.SelectedItem);
+		}
 
-        [Test]
-        public void TestSelectedItemDefault()
-        {
-            var bindingContext = new BindingContext
-            {
-                Items = new ObservableCollection<object>
-                {
-                    new ContextFixture("John", "John")
-                }
-            };
-            var picker = new Picker
-            {
-                BindingContext = bindingContext
-            };
-            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
-            picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
-            Assert.AreEqual(1, picker.Items.Count);
-            Assert.AreEqual(-1, picker.SelectedIndex);
-            Assert.AreEqual(bindingContext.SelectedItem, picker.SelectedItem);
-        }
+		[Test]
+		public void TestSelectedItemSet()
+		{
+			var obj = new ContextFixture("John", "John");
+			var bindingContext = new BindingContext
+			{
+				Items = new ObservableCollection<object>
+				{
+					obj
+				},
+				SelectedItem = obj
+			};
+			var picker = new Picker
+			{
+				BindingContext = bindingContext,
+				DisplayMemberPath = "DisplayName"
+			};
+			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+			picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
+			Assert.AreEqual(1, picker.Items.Count);
+			Assert.AreEqual(0, picker.SelectedIndex);
+			Assert.AreEqual(obj, picker.SelectedItem);
+		}
 
-        [Test]
-        public void TestSelectedItemSet()
-        {
-            var obj = new ContextFixture("John", "John");
-            var bindingContext = new BindingContext
-            {
-                Items = new ObservableCollection<object>
-                {
-                    obj
-                },
-                SelectedItem = obj
-            };
-            var picker = new Picker
-            {
-                BindingContext = bindingContext,
-                DisplayMemberPath = "DisplayName"
-            };
-            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
-            picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
-            Assert.AreEqual(1, picker.Items.Count);
-            Assert.AreEqual(0, picker.SelectedIndex);
-            Assert.AreEqual(obj, picker.SelectedItem);
-        }
-
-        [Test]
-        public void TestSelectedItemChangeSelectedIndex()
-        {
-            var obj = new ContextFixture("John", "John");
-            var bindingContext = new BindingContext
-            {
-                Items = new ObservableCollection<object>
-                {
-                    obj
-                },
-            };
-            var picker = new Picker
-            {
-                BindingContext = bindingContext,
-                DisplayMemberPath = "DisplayName"
-            };
-            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
-            picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
-            Assert.AreEqual(1, picker.Items.Count);
-            Assert.AreEqual(-1, picker.SelectedIndex);
-            Assert.AreEqual(null, picker.SelectedItem);
-            picker.SelectedItem = obj;
-            Assert.AreEqual(0, picker.SelectedIndex);
-            Assert.AreEqual(obj, picker.SelectedItem);
-            picker.SelectedIndex = -1;
-            Assert.AreEqual(-1, picker.SelectedIndex);
-            Assert.AreEqual(null, picker.SelectedItem);
-        }
-
-
-
-    }
+		[Test]
+		public void TestSelectedItemChangeSelectedIndex()
+		{
+			var obj = new ContextFixture("John", "John");
+			var bindingContext = new BindingContext
+			{
+				Items = new ObservableCollection<object>
+				{
+					obj
+				},
+			};
+			var picker = new Picker
+			{
+				BindingContext = bindingContext,
+				DisplayMemberPath = "DisplayName"
+			};
+			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+			picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
+			Assert.AreEqual(1, picker.Items.Count);
+			Assert.AreEqual(-1, picker.SelectedIndex);
+			Assert.AreEqual(null, picker.SelectedItem);
+			picker.SelectedItem = obj;
+			Assert.AreEqual(0, picker.SelectedIndex);
+			Assert.AreEqual(obj, picker.SelectedItem);
+			picker.SelectedIndex = -1;
+			Assert.AreEqual(-1, picker.SelectedIndex);
+			Assert.AreEqual(null, picker.SelectedItem);
+		}
+	}
 }

--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -107,7 +107,49 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(-1, picker.SelectedIndex);
 		}
 
-		[Test]
+        [Test]
+        public void TestSelectedIndexOutOfRangeUpdatesSelectedItem()
+        {
+            var picker = new Picker
+            {
+                ItemsSource = new ObservableCollection<string>
+                {
+                    "Monkey",
+                    "Banana",
+                    "Lemon"
+                },
+                SelectedIndex = 0
+            };
+            Assert.AreEqual("Monkey", picker.SelectedItem);
+            picker.SelectedIndex = 42;
+            Assert.AreEqual("Lemon", picker.SelectedItem);
+            picker.SelectedIndex = -42;
+            Assert.IsNull(picker.SelectedItem);
+        }
+
+        [Test]
+        public void TestDisplayFunc()
+        {
+            Func<object, string> customDisplayFunc = o =>
+            {
+                var f = (ContextFixture)o;
+                return $"{f.DisplayName} ({f.ComplexName})";
+            };
+            var obj = new ContextFixture("Monkey", "Complex Monkey");
+            var picker = new Picker
+            {
+                DisplayMemberPath = "Name",
+                DisplayFunc = customDisplayFunc,
+                ItemsSource = new ObservableCollection<object>
+                {
+                    obj
+                },
+                SelectedIndex = 1
+            };
+            Assert.AreEqual("Monkey (Complex Monkey)", picker.Items[0]);
+        }
+
+        [Test]
 		public void TestSetItemsSourceProperty()
 		{
 			var items = new ObservableCollection<object>
@@ -128,7 +170,23 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("0", picker.Items[3]);
 		}
 
-		[Test]
+        [Test]
+        public void TestDisplayMemberPathShouldThrowArgumentExceptionInvalidPath()
+        {
+            var obj = new ContextFixture("Monkey", "Complex Monkey");
+            Func<Picker> picker = () => new Picker
+            {
+                DisplayMemberPath = "Name",
+                ItemsSource = new ObservableCollection<object>
+                {
+                    obj
+                },
+                SelectedIndex = 1
+            };
+            Assert.Throws<ArgumentException>(() => picker());
+        }
+
+        [Test]
 		public void TestItemsSourceCollectionChangedAppend()
 		{
 			var items = new ObservableCollection<object>

--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using NUnit.Framework;
 using System.Collections.ObjectModel;
-using System.Runtime.InteropServices;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -399,6 +398,22 @@ namespace Xamarin.Forms.Core.UnitTests
 				SelectedIndex = 0
 			};
 			Assert.AreEqual("NestedProperty", picker.Items[0]);
+		}
+
+		[Test]
+		public void TestItemsSourceEnums()
+		{
+			var picker = new Picker
+			{
+				ItemsSource = new ObservableCollection<TextAlignment>
+				{
+					TextAlignment.Start,
+					TextAlignment.Center,
+					TextAlignment.End
+				},
+				SelectedIndex = 0
+			};
+			Assert.AreEqual("Start", picker.Items[0]);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -335,56 +335,7 @@ namespace Xamarin.Forms.Core.UnitTests
             Assert.AreEqual(null, picker.SelectedItem);
         }
 
-        [Test]
-        public void TestSelectedValue()
-        {
-            var bindingContext = new BindingContext
-            {
-                Items = new ObservableCollection<object>
-                {
-                    new Tuple<string,int>("John", 42),
-                    new Tuple<string,int>("Ringo", 13),
-                    new Tuple<string,int>("George", 2)
-                },
-            };
-            var picker = new Picker
-            {
-                ItemsSource = bindingContext.Items,
-                DisplayMemberPath = "Item1",
-                SelectedValueMemberPath = "Item2",
-                SelectedIndex = 0
-            };
-            Assert.AreEqual(0, picker.SelectedIndex);
-            Assert.AreEqual("John", picker.Items[0]);
-            Assert.AreEqual(42, picker.SelectedValue);
-        }
 
-        [Test]
-        public void TestSelectedValueBindingContext()
-        {
-            var bindingContext = new BindingContext
-            {
-                Items = new ObservableCollection<object>
-                {
-                    new Tuple<string,int>("John", 42),
-                    new Tuple<string,int>("Ringo", 13),
-                    new Tuple<string,int>("George", 2)
-                },
-            };
-            // TODO: Setting the SelectedIndex to zero prior to the BindingContext
-            // has evaluated and the ItemsSource property is set is a no-op since Items is empty
-            var picker = new Picker
-            {
-                DisplayMemberPath = "Item1",
-                SelectedValueMemberPath = "Item2",
-                SelectedIndex = 0,
-                BindingContext = bindingContext
-            };
-            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
-            // picker.SelectedIndex = 0; // Uncomment this line and it works
-            Assert.AreEqual(0, picker.SelectedIndex);
-            Assert.AreEqual("John", picker.Items[0]);
-            Assert.AreEqual(42, picker.SelectedValue);
-        }
+
     }
 }

--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using NUnit.Framework;
 using System.Collections.ObjectModel;
+using System.Globalization;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -33,6 +34,23 @@ namespace Xamarin.Forms.Core.UnitTests
 		public ObservableCollection<object> Items { get; set; }
 
 		public object SelectedItem { get; set; }
+	}
+
+	internal class PickerTestValueConverter : IValueConverter
+	{
+		public bool ConvertCalled { get; private set; }
+
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			ConvertCalled = true;
+			var cf = (ContextFixture)value;
+			return cf.DisplayName;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
 	}
 
 	[TestFixture]
@@ -208,6 +226,23 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(5, picker.Items.Count);
 			Assert.AreEqual("John", picker.Items[0]);
 			Assert.AreEqual("0", picker.Items[3]);
+		}
+
+		[Test]
+		public void TestDisplayConverter()
+		{
+			var obj = new ContextFixture("John", "John Doe");
+			var converter = new PickerTestValueConverter();
+			var picker = new Picker
+			{
+				DisplayConverter = converter,
+				ItemsSource = new ObservableCollection<object>
+				{
+					obj
+				}
+			};
+			Assert.IsTrue(converter.ConvertCalled);
+			Assert.AreEqual("John", picker.Items[0]);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -1,59 +1,390 @@
 using System;
 
 using NUnit.Framework;
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
-	[TestFixture]
-	public class PickerTests : BaseTestFixture
-	{
-		[Test]
-		public void TestSetSelectedIndexOnNullRows()
-		{
-			var picker = new Picker ();
+    internal class ContextFixture
+    {
+        public string DisplayName { get; set; }
 
-			Assert.IsEmpty (picker.Items);
-			Assert.AreEqual (-1, picker.SelectedIndex);
+        public string ComplexName { get; set; }
 
-			picker.SelectedIndex = 2;
+        public ContextFixture(string displayName, string complexName)
+        {
+            DisplayName = displayName;
+            ComplexName = complexName;
+        }
 
-			Assert.AreEqual (-1, picker.SelectedIndex);		
-		}
+        public ContextFixture()
+        {
+        }
+    }
 
-		[Test]
-		public void TestSelectedIndexInRange ()
-		{
-			var picker = new Picker { Items =  { "John", "Paul", "George", "Ringo" } };
+    internal class BindingContext
+    {
+        public ObservableCollection<object> Items { get; set; }
 
-			picker.SelectedIndex = 2;
-			Assert.AreEqual (2, picker.SelectedIndex);
+        public object SelectedItem { get; set; }
+    }
 
-			picker.SelectedIndex = 42;
-			Assert.AreEqual (3, picker.SelectedIndex);
+    [TestFixture]
+    public class PickerTests : BaseTestFixture
+    {
+        [Test]
+        public void TestSetSelectedIndexOnNullRows()
+        {
+            var picker = new Picker();
 
-			picker.SelectedIndex = -1;
-			Assert.AreEqual (-1, picker.SelectedIndex);
+            Assert.IsEmpty(picker.Items);
+            Assert.AreEqual(-1, picker.SelectedIndex);
 
-			picker.SelectedIndex = -42;
-			Assert.AreEqual (-1, picker.SelectedIndex);
-		}
+            picker.SelectedIndex = 2;
 
-		[Test]
-		public void TestSelectedIndexChangedOnCollectionShrink()
-		{
-			var picker = new Picker { Items = { "John", "Paul", "George", "Ringo" }, SelectedIndex = 3 };
+            Assert.AreEqual(-1, picker.SelectedIndex);
+        }
 
-			Assert.AreEqual (3, picker.SelectedIndex);
+        [Test]
+        public void TestSelectedIndexInRange()
+        {
+            var picker = new Picker
+            {
+                Items = { "John", "Paul", "George", "Ringo" },
+                SelectedIndex = 2
+            };
 
-			picker.Items.RemoveAt (3);
-			picker.Items.RemoveAt (2);
+            Assert.AreEqual(2, picker.SelectedIndex);
+
+            picker.SelectedIndex = 42;
+            Assert.AreEqual(3, picker.SelectedIndex);
+
+            picker.SelectedIndex = -1;
+            Assert.AreEqual(-1, picker.SelectedIndex);
+
+            picker.SelectedIndex = -42;
+            Assert.AreEqual(-1, picker.SelectedIndex);
+        }
+
+        [Test]
+        public void TestSelectedIndexInRangeDefaultSelectedIndex()
+        {
+            var picker = new Picker
+            {
+                Items = { "John", "Paul", "George", "Ringo" }
+            };
+
+            Assert.AreEqual(-1, picker.SelectedIndex);
+
+            picker.SelectedIndex = -5;
+            Assert.AreEqual(-1, picker.SelectedIndex);
+
+            picker.SelectedIndex = 2;
+            Assert.AreEqual(2, picker.SelectedIndex);
+
+            picker.SelectedIndex = 42;
+            Assert.AreEqual(3, picker.SelectedIndex);
+
+            picker.SelectedIndex = -1;
+            Assert.AreEqual(-1, picker.SelectedIndex);
+
+            picker.SelectedIndex = -42;
+            Assert.AreEqual(-1, picker.SelectedIndex);
+        }
+
+        [Test]
+        public void TestSelectedIndexChangedOnCollectionShrink()
+        {
+            var picker = new Picker { Items = { "John", "Paul", "George", "Ringo" }, SelectedIndex = 3 };
+
+            Assert.AreEqual(3, picker.SelectedIndex);
+
+            picker.Items.RemoveAt(3);
+            picker.Items.RemoveAt(2);
 
 
-			Assert.AreEqual (1, picker.SelectedIndex);
+            Assert.AreEqual(1, picker.SelectedIndex);
 
-			picker.Items.Clear ();
-			Assert.AreEqual (-1, picker.SelectedIndex);
-		}
-	}	
+            picker.Items.Clear();
+            Assert.AreEqual(-1, picker.SelectedIndex);
+        }
+
+        [Test]
+        public void TestSetItemsSourceProperty()
+        {
+            var items = new ObservableCollection<object>
+            {
+                new {Name = "John"},
+                "Paul",
+                "Ringo",
+                0,
+                new DateTime(1970, 1, 1),
+            };
+            var picker = new Picker
+            {
+                DisplayMemberPath = "Name",
+                ItemsSource = items
+            };
+            Assert.AreEqual(5, picker.Items.Count);
+            Assert.AreEqual("John", picker.Items[0]);
+            Assert.AreEqual("0", picker.Items[3]);
+        }
+
+        [Test]
+        public void TestItemsSourceCollectionChangedAppend()
+        {
+            var items = new ObservableCollection<object>
+            {
+                new {Name = "John"},
+                "Paul",
+                "Ringo"
+            };
+            var picker = new Picker
+            {
+                DisplayMemberPath = "Name",
+                ItemsSource = items,
+                SelectedIndex = 0
+            };
+            Assert.AreEqual(3, picker.Items.Count);
+            Assert.AreEqual("John", picker.Items[0]);
+            items.Add(new { Name = "George" });
+            Assert.AreEqual(4, picker.Items.Count);
+            Assert.AreEqual("George", picker.Items[picker.Items.Count - 1]);
+        }
+
+        [Test]
+        public void TestItemsSourceCollectionChangedClear()
+        {
+            var items = new ObservableCollection<object>
+            {
+                new {Name = "John"},
+                "Paul",
+                "Ringo"
+            };
+            var picker = new Picker
+            {
+                DisplayMemberPath = "Name",
+                ItemsSource = items,
+                SelectedIndex = 0
+            };
+            Assert.AreEqual(3, picker.Items.Count);
+            items.Clear();
+            Assert.AreEqual(0, picker.Items.Count);
+        }
+
+        [Test]
+        public void TestItemsSourceCollectionChangedInsert()
+        {
+            var items = new ObservableCollection<object>
+            {
+                new {Name = "John"},
+                "Paul",
+                "Ringo"
+            };
+            var picker = new Picker
+            {
+                DisplayMemberPath = "Name",
+                ItemsSource = items,
+                SelectedIndex = 0
+            };
+            Assert.AreEqual(3, picker.Items.Count);
+            Assert.AreEqual("John", picker.Items[0]);
+            items.Insert(1, new { Name = "George" });
+            Assert.AreEqual(4, picker.Items.Count);
+            Assert.AreEqual("George", picker.Items[1]);
+        }
+
+        [Test]
+        public void TestItemsSourceCollectionChangedReAssign()
+        {
+            var items = new ObservableCollection<object>
+            {
+                new {Name = "John"},
+                "Paul",
+                "Ringo"
+            };
+            var bindingContext = new { Items = items };
+            var picker = new Picker
+            {
+                DisplayMemberPath = "Name",
+                BindingContext = bindingContext
+            };
+            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+            Assert.AreEqual(3, picker.Items.Count);
+            items = new ObservableCollection<object>
+            {
+                "Peach",
+                "Orange"
+            };
+            picker.BindingContext = new { Items = items };
+            Assert.AreEqual(2, picker.Items.Count);
+            Assert.AreEqual("Peach", picker.Items[0]);
+        }
+
+        [Test]
+        public void TestItemsSourceCollectionChangedRemove()
+        {
+            var items = new ObservableCollection<object>
+            {
+                new {Name = "John"},
+                "Paul",
+                "Ringo"
+            };
+            var picker = new Picker
+            {
+                DisplayMemberPath = "Name",
+                ItemsSource = items,
+                SelectedIndex = 0
+            };
+            Assert.AreEqual(3, picker.Items.Count);
+            Assert.AreEqual("John", picker.Items[0]);
+            items.RemoveAt(1);
+            Assert.AreEqual(2, picker.Items.Count);
+            Assert.AreEqual("Ringo", picker.Items[1]);
+        }
+
+        [Test]
+        public void TestItemsSourceCollectionOfStrings()
+        {
+            var items = new ObservableCollection<string>
+            {
+                "John",
+                "Paul",
+                "Ringo"
+            };
+            var picker = new Picker
+            {
+                ItemsSource = items,
+                SelectedIndex = 0
+            };
+            Assert.AreEqual(3, picker.Items.Count);
+            Assert.AreEqual("John", picker.Items[0]);
+        }
+
+        [Test]
+        public void TestSelectedItemDefault()
+        {
+            var bindingContext = new BindingContext
+            {
+                Items = new ObservableCollection<object>
+                {
+                    new ContextFixture("John", "John")
+                }
+            };
+            var picker = new Picker
+            {
+                BindingContext = bindingContext
+            };
+            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+            picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
+            Assert.AreEqual(1, picker.Items.Count);
+            Assert.AreEqual(-1, picker.SelectedIndex);
+            Assert.AreEqual(bindingContext.SelectedItem, picker.SelectedItem);
+        }
+
+        [Test]
+        public void TestSelectedItemSet()
+        {
+            var obj = new ContextFixture("John", "John");
+            var bindingContext = new BindingContext
+            {
+                Items = new ObservableCollection<object>
+                {
+                    obj
+                },
+                SelectedItem = obj
+            };
+            var picker = new Picker
+            {
+                BindingContext = bindingContext,
+                DisplayMemberPath = "DisplayName"
+            };
+            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+            picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
+            Assert.AreEqual(1, picker.Items.Count);
+            Assert.AreEqual(0, picker.SelectedIndex);
+            Assert.AreEqual(obj, picker.SelectedItem);
+        }
+
+        [Test]
+        public void TestSelectedItemChangeSelectedIndex()
+        {
+            var obj = new ContextFixture("John", "John");
+            var bindingContext = new BindingContext
+            {
+                Items = new ObservableCollection<object>
+                {
+                    obj
+                },
+            };
+            var picker = new Picker
+            {
+                BindingContext = bindingContext,
+                DisplayMemberPath = "DisplayName"
+            };
+            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+            picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
+            Assert.AreEqual(1, picker.Items.Count);
+            Assert.AreEqual(-1, picker.SelectedIndex);
+            Assert.AreEqual(null, picker.SelectedItem);
+            picker.SelectedItem = obj;
+            Assert.AreEqual(0, picker.SelectedIndex);
+            Assert.AreEqual(obj, picker.SelectedItem);
+            picker.SelectedIndex = -1;
+            Assert.AreEqual(-1, picker.SelectedIndex);
+            Assert.AreEqual(null, picker.SelectedItem);
+        }
+
+        [Test]
+        public void TestSelectedValue()
+        {
+            var bindingContext = new BindingContext
+            {
+                Items = new ObservableCollection<object>
+                {
+                    new Tuple<string,int>("John", 42),
+                    new Tuple<string,int>("Ringo", 13),
+                    new Tuple<string,int>("George", 2)
+                },
+            };
+            var picker = new Picker
+            {
+                ItemsSource = bindingContext.Items,
+                DisplayMemberPath = "Item1",
+                SelectedValueMemberPath = "Item2",
+                SelectedIndex = 0
+            };
+            Assert.AreEqual(0, picker.SelectedIndex);
+            Assert.AreEqual("John", picker.Items[0]);
+            Assert.AreEqual(42, picker.SelectedValue);
+        }
+
+        [Test]
+        public void TestSelectedValueBindingContext()
+        {
+            var bindingContext = new BindingContext
+            {
+                Items = new ObservableCollection<object>
+                {
+                    new Tuple<string,int>("John", 42),
+                    new Tuple<string,int>("Ringo", 13),
+                    new Tuple<string,int>("George", 2)
+                },
+            };
+            // TODO: Setting the SelectedIndex to zero prior to the BindingContext
+            // has evaluated and the ItemsSource property is set is a no-op since Items is empty
+            var picker = new Picker
+            {
+                DisplayMemberPath = "Item1",
+                SelectedValueMemberPath = "Item2",
+                SelectedIndex = 0,
+                BindingContext = bindingContext
+            };
+            picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+            // picker.SelectedIndex = 0; // Uncomment this line and it works
+            Assert.AreEqual(0, picker.SelectedIndex);
+            Assert.AreEqual("John", picker.Items[0]);
+            Assert.AreEqual(42, picker.SelectedValue);
+        }
+    }
 }

--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -107,49 +107,82 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(-1, picker.SelectedIndex);
 		}
 
-        [Test]
-        public void TestSelectedIndexOutOfRangeUpdatesSelectedItem()
-        {
-            var picker = new Picker
-            {
-                ItemsSource = new ObservableCollection<string>
-                {
-                    "Monkey",
-                    "Banana",
-                    "Lemon"
-                },
-                SelectedIndex = 0
-            };
-            Assert.AreEqual("Monkey", picker.SelectedItem);
-            picker.SelectedIndex = 42;
-            Assert.AreEqual("Lemon", picker.SelectedItem);
-            picker.SelectedIndex = -42;
-            Assert.IsNull(picker.SelectedItem);
-        }
+		[Test]
+		public void TestSelectedIndexOutOfRangeUpdatesSelectedItem()
+		{
+			var picker = new Picker
+			{
+				ItemsSource = new ObservableCollection<string>
+				{
+					"Monkey",
+					"Banana",
+					"Lemon"
+				},
+				SelectedIndex = 0
+			};
+			Assert.AreEqual("Monkey", picker.SelectedItem);
+			picker.SelectedIndex = 42;
+			Assert.AreEqual("Lemon", picker.SelectedItem);
+			picker.SelectedIndex = -42;
+			Assert.IsNull(picker.SelectedItem);
+		}
 
-        [Test]
-        public void TestDisplayFunc()
-        {
-            Func<object, string> customDisplayFunc = o =>
-            {
-                var f = (ContextFixture)o;
-                return $"{f.DisplayName} ({f.ComplexName})";
-            };
-            var obj = new ContextFixture("Monkey", "Complex Monkey");
-            var picker = new Picker
-            {
-                DisplayMemberPath = "Name",
-                DisplayFunc = customDisplayFunc,
-                ItemsSource = new ObservableCollection<object>
-                {
-                    obj
-                },
-                SelectedIndex = 1
-            };
-            Assert.AreEqual("Monkey (Complex Monkey)", picker.Items[0]);
-        }
+		[Test]
+		public void TestUnsubscribeINotifyCollectionChanged()
+		{
+			var list = new ObservableCollection<string>();
+			var picker = new Picker
+			{
+				ItemsSource = list
+			};
+			Assert.AreEqual(0, picker.Items.Count);
+			var newList = new ObservableCollection<string>();
+			picker.ItemsSource = newList;
+			list.Add("item");
+			Assert.AreEqual(0, picker.Items.Count);
+		}
 
-        [Test]
+		[Test]
+		public void TestEmptyCollectionResetItems()
+		{
+			var list = new ObservableCollection<string>
+			{
+				"John",
+				"George",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				ItemsSource = list
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			picker.ItemsSource = new ObservableCollection<string>();
+			Assert.AreEqual(0, picker.Items.Count);
+		}
+
+		[Test]
+		public void TestDisplayFunc()
+		{
+			Func<object, string> customDisplayFunc = o =>
+			{
+				var f = (ContextFixture)o;
+				return $"{f.DisplayName} ({f.ComplexName})";
+			};
+			var obj = new ContextFixture("Monkey", "Complex Monkey");
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				DisplayFunc = customDisplayFunc,
+				ItemsSource = new ObservableCollection<object>
+				{
+					obj
+				},
+				SelectedIndex = 1
+			};
+			Assert.AreEqual("Monkey (Complex Monkey)", picker.Items[0]);
+		}
+
+		[Test]
 		public void TestSetItemsSourceProperty()
 		{
 			var items = new ObservableCollection<object>
@@ -170,23 +203,23 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("0", picker.Items[3]);
 		}
 
-        [Test]
-        public void TestDisplayMemberPathShouldThrowArgumentExceptionInvalidPath()
-        {
-            var obj = new ContextFixture("Monkey", "Complex Monkey");
-            Func<Picker> picker = () => new Picker
-            {
-                DisplayMemberPath = "Name",
-                ItemsSource = new ObservableCollection<object>
-                {
-                    obj
-                },
-                SelectedIndex = 1
-            };
-            Assert.Throws<ArgumentException>(() => picker());
-        }
+		[Test]
+		public void TestDisplayMemberPathShouldThrowArgumentExceptionInvalidPath()
+		{
+			var obj = new ContextFixture("Monkey", "Complex Monkey");
+			Func<Picker> picker = () => new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = new ObservableCollection<object>
+				{
+					obj
+				},
+				SelectedIndex = 1
+			};
+			Assert.Throws<ArgumentException>(() => picker());
+		}
 
-        [Test]
+		[Test]
 		public void TestItemsSourceCollectionChangedAppend()
 		{
 			var items = new ObservableCollection<object>

--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -1,11 +1,19 @@
 using System;
 using NUnit.Framework;
 using System.Collections.ObjectModel;
+using System.Runtime.InteropServices;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
 	internal class ContextFixture
 	{
+		public class NestedClass
+		{
+			public string Nested { get; set; }
+		}
+
+		public NestedClass Nested { get; set; }
+
 		public string DisplayName { get; set; }
 
 		public string ComplexName { get; set; }
@@ -369,6 +377,28 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(1, picker.Items.Count);
 			Assert.AreEqual(-1, picker.SelectedIndex);
 			Assert.AreEqual(bindingContext.SelectedItem, picker.SelectedItem);
+		}
+
+		[Test]
+		public void TestNestedDisplayMemberPathExpression()
+		{
+			var obj = new ContextFixture
+			{
+				Nested = new ContextFixture.NestedClass
+				{
+					Nested = "NestedProperty"
+				}
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Nested.Nested",
+				ItemsSource = new ObservableCollection<object>
+				{
+					obj
+				},
+				SelectedIndex = 0
+			};
+			Assert.AreEqual("NestedProperty", picker.Items[0]);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -7,246 +7,246 @@ using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
 {
-    [RenderWith(typeof(_PickerRenderer))]
-    public class Picker : View
-    {
-        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Picker), Color.Default);
+	[RenderWith(typeof(_PickerRenderer))]
+	public class Picker : View
+	{
+		public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Picker), Color.Default);
 
-        public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
+		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
 
-        public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
-            propertyChanged: OnSelectedIndexChanged,
-            coerceValue: CoerceSelectedIndex);
+		public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
+			propertyChanged: OnSelectedIndexChanged,
+			coerceValue: CoerceSelectedIndex);
 
-        public static readonly BindableProperty SelectedValueMemberPathProperty = BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
+		public static readonly BindableProperty SelectedValueMemberPathProperty = BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
 
-        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IList), typeof(Picker), default(IList), propertyChanged: OnItemsSourceChanged);
+		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IList), typeof(Picker), default(IList), propertyChanged: OnItemsSourceChanged);
 
-        public static readonly BindableProperty DisplayMemberPathProperty = BindableProperty.Create(nameof(DisplayMemberPath), typeof(string), typeof(Picker), propertyChanged: OnDisplayMemberPathChanged);
+		public static readonly BindableProperty DisplayMemberPathProperty = BindableProperty.Create(nameof(DisplayMemberPath), typeof(string), typeof(Picker), propertyChanged: OnDisplayMemberPathChanged);
 
-        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay, propertyChanged: OnSelectedItemChanged);
+		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay, propertyChanged: OnSelectedItemChanged);
 
-        public Picker()
-        {
-            ((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
-        }
+		public Picker()
+		{
+			((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
+		}
 
-        public string DisplayMemberPath
-        {
-            get { return (string)GetValue(DisplayMemberPathProperty); }
-            set { SetValue(DisplayMemberPathProperty, value); }
-        }
+		public string DisplayMemberPath
+		{
+			get { return (string)GetValue(DisplayMemberPathProperty); }
+			set { SetValue(DisplayMemberPathProperty, value); }
+		}
 
-        public IList<string> Items { get; } = new ObservableList<string>();
+		public IList<string> Items { get; } = new ObservableList<string>();
 
-        public IList ItemsSource
-        {
-            get { return (IList)GetValue(ItemsSourceProperty); }
-            set { SetValue(ItemsSourceProperty, value); }
-        }
+		public IList ItemsSource
+		{
+			get { return (IList)GetValue(ItemsSourceProperty); }
+			set { SetValue(ItemsSourceProperty, value); }
+		}
 
-        public int SelectedIndex
-        {
-            get { return (int)GetValue(SelectedIndexProperty); }
-            set { SetValue(SelectedIndexProperty, value); }
-        }
+		public int SelectedIndex
+		{
+			get { return (int)GetValue(SelectedIndexProperty); }
+			set { SetValue(SelectedIndexProperty, value); }
+		}
 
-        public object SelectedItem
-        {
-            get { return GetValue(SelectedItemProperty); }
-            set { SetValue(SelectedItemProperty, value); }
-        }
+		public object SelectedItem
+		{
+			get { return GetValue(SelectedItemProperty); }
+			set { SetValue(SelectedItemProperty, value); }
+		}
 
-        public string SelectedValueMemberPath
-        {
-            get { return (string)GetValue(SelectedValueMemberPathProperty); }
-            set { SetValue(SelectedValueMemberPathProperty, value); }
-        }
+		public string SelectedValueMemberPath
+		{
+			get { return (string)GetValue(SelectedValueMemberPathProperty); }
+			set { SetValue(SelectedValueMemberPathProperty, value); }
+		}
 
-        public Color TextColor
-        {
-            get { return (Color)GetValue(TextColorProperty); }
-            set { SetValue(TextColorProperty, value); }
-        }
+		public Color TextColor
+		{
+			get { return (Color)GetValue(TextColorProperty); }
+			set { SetValue(TextColorProperty, value); }
+		}
 
-        public string Title
-        {
-            get { return (string)GetValue(TitleProperty); }
-            set { SetValue(TitleProperty, value); }
-        }
+		public string Title
+		{
+			get { return (string)GetValue(TitleProperty); }
+			set { SetValue(TitleProperty, value); }
+		}
 
-        public event EventHandler SelectedIndexChanged;
+		public event EventHandler SelectedIndexChanged;
 
-        protected virtual string GetDisplayMember(object item)
-        {
-            return GetPropertyValue(item, DisplayMemberPath) as string;
-        }
+		protected virtual string GetDisplayMember(object item)
+		{
+			return GetPropertyValue(item, DisplayMemberPath) as string;
+		}
 
-        protected virtual object GetSelectedValue(object item)
-        {
-            return GetPropertyValue(item, SelectedValueMemberPath);
-        }
+		protected virtual object GetSelectedValue(object item)
+		{
+			return GetPropertyValue(item, SelectedValueMemberPath);
+		}
 
-        void AddItems(NotifyCollectionChangedEventArgs e)
-        {
-            int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
-            foreach (object newItem in e.NewItems)
-            {
-                Items.Insert(index++, GetDisplayMember(newItem));
-            }
-        }
+		void AddItems(NotifyCollectionChangedEventArgs e)
+		{
+			int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
+			foreach (object newItem in e.NewItems)
+			{
+				Items.Insert(index++, GetDisplayMember(newItem));
+			}
+		}
 
-        void BindItems()
-        {
-            Items.Clear();
-            foreach (object item in ItemsSource)
-            {
-                Items.Add(GetDisplayMember(item));
-            }
-            UpdateSelectedItem();
-        }
+		void BindItems()
+		{
+			Items.Clear();
+			foreach (object item in ItemsSource)
+			{
+				Items.Add(GetDisplayMember(item));
+			}
+			UpdateSelectedItem();
+		}
 
-        static object CoerceSelectedIndex(BindableObject bindable, object value)
-        {
-            var picker = (Picker)bindable;
-            return picker.Items == null ? -1 : ((int)value).Clamp(-1, picker.Items.Count - 1);
-        }
+		static object CoerceSelectedIndex(BindableObject bindable, object value)
+		{
+			var picker = (Picker)bindable;
+			return picker.Items == null ? -1 : ((int)value).Clamp(-1, picker.Items.Count - 1);
+		}
 
-        void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Move:
-                case NotifyCollectionChangedAction.Replace:
-                case NotifyCollectionChangedAction.Reset:
-                    // Clear Items collection and re-populate it with values from ItemsSource
-                    BindItems();
-                    return;
-                case NotifyCollectionChangedAction.Remove:
-                    RemoveItems(e);
-                    break;
-                case NotifyCollectionChangedAction.Add:
-                    AddItems(e);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
+		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			switch (e.Action)
+			{
+				case NotifyCollectionChangedAction.Move:
+				case NotifyCollectionChangedAction.Replace:
+				case NotifyCollectionChangedAction.Reset:
+					// Clear Items collection and re-populate it with values from ItemsSource
+					BindItems();
+					return;
+				case NotifyCollectionChangedAction.Remove:
+					RemoveItems(e);
+					break;
+				case NotifyCollectionChangedAction.Add:
+					AddItems(e);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
 
-        static object GetPropertyValue(object item, string memberPath)
-        {
-            if (item == null)
-            {
-                return null;
-            }
-            // TODO How to handle Nullable types
-            if (IsPrimitive(item) || string.IsNullOrEmpty(memberPath))
-            {
-                return item.ToString();
-            }
-            // Find the property by walking the display member path to find any nested properties
-            string[] propertyPathParts = memberPath.Split('.');
-            object propertyValue = null;
-            foreach (string propertyPathPart in propertyPathParts)
-            {
-                PropertyInfo propInfo = item.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
-                propertyValue = propInfo.GetValue(item);
-            }
+		static object GetPropertyValue(object item, string memberPath)
+		{
+			if (item == null)
+			{
+				return null;
+			}
+			// TODO How to handle Nullable types
+			if (IsPrimitive(item) || string.IsNullOrEmpty(memberPath))
+			{
+				return item.ToString();
+			}
+			// Find the property by walking the display member path to find any nested properties
+			string[] propertyPathParts = memberPath.Split('.');
+			object propertyValue = null;
+			foreach (string propertyPathPart in propertyPathParts)
+			{
+				PropertyInfo propInfo = item.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
+				propertyValue = propInfo.GetValue(item);
+			}
 
-            if (propertyValue == null)
-            {
-                throw new ArgumentException(
-                    $"No property with name '{memberPath}' was found on '{item.GetType().FullName}'");
-            }
-            return propertyValue;
-        }
+			if (propertyValue == null)
+			{
+				throw new ArgumentException(
+					$"No property with name '{memberPath}' was found on '{item.GetType().FullName}'");
+			}
+			return propertyValue;
+		}
 
-        static bool IsPrimitive(object item)
-        {
-            return item is string || item is int || item is double || item is decimal || item is Enum ||
-                   item is DateTime;
-        }
+		static bool IsPrimitive(object item)
+		{
+			return item is string || item is int || item is double || item is decimal || item is Enum ||
+				   item is DateTime;
+		}
 
-        static void OnDisplayMemberPathChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            var picker = (Picker)bindable;
-            if (picker.ItemsSource?.Count > 0)
-            {
-                picker.BindItems();
-            }
-        }
+		static void OnDisplayMemberPathChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			if (picker.ItemsSource?.Count > 0)
+			{
+				picker.BindItems();
+			}
+		}
 
-        void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
-            UpdateSelectedItem();
-        }
+		void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
+			UpdateSelectedItem();
+		}
 
-        static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            var picker = (Picker)bindable;
-            // Check if the ItemsSource value has changed and if so, unsubscribe from collection changed
-            var observable = oldValue as INotifyCollectionChanged;
-            if (observable != null)
-            {
-                observable.CollectionChanged -= picker.CollectionChanged;
-            }
-            observable = newValue as INotifyCollectionChanged;
-            if (observable != null)
-            {
-                observable.CollectionChanged += picker.CollectionChanged;
-                picker.BindItems();
-            }
-            else
-            {
-                // newValue is null so clear the items collection
-                picker.Items.Clear();
-            }
-        }
+		static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			// Check if the ItemsSource value has changed and if so, unsubscribe from collection changed
+			var observable = oldValue as INotifyCollectionChanged;
+			if (observable != null)
+			{
+				observable.CollectionChanged -= picker.CollectionChanged;
+			}
+			observable = newValue as INotifyCollectionChanged;
+			if (observable != null)
+			{
+				observable.CollectionChanged += picker.CollectionChanged;
+				picker.BindItems();
+			}
+			else
+			{
+				// newValue is null so clear the items collection
+				picker.Items.Clear();
+			}
+		}
 
-        static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)
-        {
-            var picker = (Picker)bindable;
-            EventHandler eh = picker.SelectedIndexChanged;
-            eh?.Invoke(bindable, EventArgs.Empty);
-            picker.UpdateSelectedItem();
-        }
+		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			EventHandler eh = picker.SelectedIndexChanged;
+			eh?.Invoke(bindable, EventArgs.Empty);
+			picker.UpdateSelectedItem();
+		}
 
-        static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            var picker = (Picker)bindable;
-            picker.UpdateSelectedIndex(newValue);
-        }
+		static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			picker.UpdateSelectedIndex(newValue);
+		}
 
-        void RemoveItems(NotifyCollectionChangedEventArgs e)
-        {
-            int index = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count;
-            // TODO: How do we determine the order of which the items were removed
-            foreach (object _ in e.OldItems)
-            {
-                Items.RemoveAt(index--);
-            }
-        }
+		void RemoveItems(NotifyCollectionChangedEventArgs e)
+		{
+			int index = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count;
+			// TODO: How do we determine the order of which the items were removed
+			foreach (object _ in e.OldItems)
+			{
+				Items.RemoveAt(index--);
+			}
+		}
 
-        void UpdateSelectedIndex(object selectedItem)
-        {
-            string displayMember = GetDisplayMember(selectedItem);
-            int index = Items.IndexOf(displayMember);
-            // TODO Should we prevent call to FindObject since the object is already known
-            // by setting a flag, or otherwise indicate, that we, internally, forced a SelectedIndex changed
-            SelectedIndex = index;
-        }
+		void UpdateSelectedIndex(object selectedItem)
+		{
+			string displayMember = GetDisplayMember(selectedItem);
+			int index = Items.IndexOf(displayMember);
+			// TODO Should we prevent call to FindObject since the object is already known
+			// by setting a flag, or otherwise indicate, that we, internally, forced a SelectedIndex changed
+			SelectedIndex = index;
+		}
 
-        void UpdateSelectedItem()
-        {
-            if (SelectedIndex < 0 || SelectedIndex > Items.Count - 1)
-            {
-                SelectedItem = null;
-            }
-            else
-            {
-                SelectedItem = ItemsSource?[SelectedIndex];
-            }
-        }
-    }
+		void UpdateSelectedItem()
+		{
+			if (SelectedIndex < 0 || SelectedIndex > Items.Count - 1)
+			{
+				SelectedItem = null;
+			}
+			else
+			{
+				SelectedItem = ItemsSource?[SelectedIndex];
+			}
+		}
+	}
 }

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -10,76 +10,42 @@ namespace Xamarin.Forms
     [RenderWith(typeof(_PickerRenderer))]
     public class Picker : View
     {
-        public static readonly BindableProperty TextColorProperty =
-            BindableProperty.Create(
-                nameof(TextColor),
-                typeof(Color),
-                typeof(Picker),
-                Color.Default);
+        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor),
+            typeof(Color), typeof(Picker), Color.Default);
 
-        public static readonly BindableProperty TitleProperty =
-            BindableProperty.Create(
-                nameof(Title),
-                typeof(string),
-                typeof(Picker),
-                default(string));
+        public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string),
+            typeof(Picker), default(string));
 
-        public static readonly BindableProperty SelectedIndexProperty =
-            BindableProperty.Create(
-                nameof(SelectedIndex),
-                typeof(int),
-                typeof(Picker),
-                -1,
-                BindingMode.TwoWay,
-                propertyChanged: OnSelectedIndexChanged,
-                coerceValue: CoerceSelectedIndex);
+        public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex),
+            typeof(int), typeof(Picker), -1,
+            BindingMode.TwoWay,
+            propertyChanged: OnSelectedIndexChanged,
+            coerceValue: CoerceSelectedIndex);
 
         public static readonly BindableProperty SelectedValueMemberPathProperty =
-            BindableProperty.Create(
-                nameof(SelectedValueMemberPath),
-                typeof(string),
-                typeof(Picker));
+            BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
 
-        public static readonly BindableProperty ItemsSourceProperty =
-            BindableProperty.Create(
-                nameof(ItemsSource),
-                typeof(IList),
-                typeof(Picker),
-                default(IList),
-                propertyChanged: OnItemsSourceChanged);
+        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource),
+            typeof(IList), typeof(Picker),
+            default(IList),
+            propertyChanged: OnItemsSourceChanged);
 
         public static readonly BindableProperty DisplayMemberPathProperty =
-            BindableProperty.Create(
-                nameof(DisplayMemberPath),
-                typeof(string),
+            BindableProperty.Create(nameof(DisplayMemberPath), typeof(string),
                 typeof(Picker),
                 propertyChanged: OnDisplayMemberPathChanged);
 
-        public static readonly BindableProperty SelectedItemProperty =
-            BindableProperty.Create(
-                nameof(SelectedItem),
-                typeof(object),
-                typeof(Picker),
-                null,
-                BindingMode.TwoWay,
-                propertyChanged: OnSelectedItemChanged);
+        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem),
+            typeof(object), typeof(Picker),
+            null,
+            BindingMode.TwoWay,
+            propertyChanged: OnSelectedItemChanged);
 
         public Picker()
         {
             ((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
         }
 
-        /// <summary>
-        /// Set the name of the property that should be used to display the objects in <see cref="ItemsSource" />.
-        /// If left blank the <see cref="object.ToString" /> will be called
-        /// </summary>
-        /// <remarks>
-        /// Setting a value that does not exists on the object cause exception
-        /// </remarks>
-        /// <para>
-        /// Settings this value only affect objects that are not primitive types.
-        /// </para>
-        /// <exception cref="ArgumentException">Setting a value that does not exists on the object cause exception</exception>
         public string DisplayMemberPath
         {
             get { return (string)GetValue(DisplayMemberPathProperty); }
@@ -126,12 +92,6 @@ namespace Xamarin.Forms
 
         public event EventHandler SelectedIndexChanged;
 
-        /// <summary>
-        /// Get the value to display through reflection on <paramref name="item" /> using property <see cref="DisplayMemberPath" />
-        /// </summary>
-        /// <param name="item">Item to get value from.</param>
-        /// <returns>Value of the property <see cref="DisplayMemberPath" /> if not <c>null</c>; otherwise ToString()</returns>
-        /// <exception cref="ArgumentException">If no property with name <see cref="DisplayMemberPath" /> is found</exception>
         protected virtual string GetDisplayMember(object item)
         {
             return GetPropertyValue(item, DisplayMemberPath) as string;

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -95,6 +95,18 @@ namespace Xamarin.Forms
 			{
 				return DisplayFunc(item);
 			}
+			if (item == null)
+			{
+				return null;
+			}
+			bool isValueType = item.GetType().GetTypeInfo().IsValueType;
+			if (isValueType || string.IsNullOrEmpty(DisplayMemberPath) || item is string)
+			{
+				// For a mix of objects in ItemsSourc to be handled correctly in conjunction with DisplayMemberPath
+				// we need to handle value types and string so that GetPropertyValue doesn't throw exception if the property
+				// doesn't exist on the item object
+				return item.ToString();
+			}
 			return GetPropertyValue(item, DisplayMemberPath) as string;
 		}
 
@@ -148,12 +160,11 @@ namespace Xamarin.Forms
 		{
 			if (item == null)
 			{
-				return null;
+				throw new ArgumentNullException(nameof(item));
 			}
-			// TODO How to handle Nullable types
-			if (IsPrimitive(item) || string.IsNullOrEmpty(memberPath))
+			if (string.IsNullOrEmpty(memberPath))
 			{
-				return item.ToString();
+				throw new ArgumentNullException(nameof(memberPath));
 			}
 			// Find the property by walking the display member path to find any nested properties
 			string[] propertyPathParts = memberPath.Split('.');
@@ -169,12 +180,6 @@ namespace Xamarin.Forms
 				propertyValue = propInfo.GetValue(propertyValue);
 			}
 			return propertyValue;
-		}
-
-		static bool IsPrimitive(object item)
-		{
-			return item is string || item is int || item is double || item is decimal || item is Enum ||
-				   item is DateTime;
 		}
 
 		static void OnDisplayMemberPathChanged(BindableObject bindable, object oldValue, object newValue)

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -1,62 +1,333 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Reflection;
 using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
 {
-	[RenderWith(typeof(_PickerRenderer))]
-	public class Picker : View
-	{
-		public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Picker), Color.Default);
+    [RenderWith(typeof(_PickerRenderer))]
+    public class Picker : View
+    {
+        public static readonly BindableProperty TextColorProperty =
+            BindableProperty.Create(
+                nameof(TextColor),
+                typeof(Color),
+                typeof(Picker),
+                Color.Default);
 
-		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
+        public static readonly BindableProperty TitleProperty =
+            BindableProperty.Create(
+                nameof(Title),
+                typeof(string),
+                typeof(Picker),
+                default(string));
 
-		public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
-			propertyChanged: (bindable, oldvalue, newvalue) =>
-			{
-				EventHandler eh = ((Picker)bindable).SelectedIndexChanged;
-				if (eh != null)
-					eh(bindable, EventArgs.Empty);
-			}, coerceValue: CoerceSelectedIndex);
+        public static readonly BindableProperty SelectedIndexProperty =
+            BindableProperty.Create(
+                nameof(SelectedIndex),
+                typeof(int),
+                typeof(Picker),
+                -1,
+                BindingMode.TwoWay,
+                propertyChanged: OnSelectedIndexChanged,
+                coerceValue: CoerceSelectedIndex);
 
-		public Picker()
-		{
-			Items = new ObservableList<string>();
-			((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
-		}
+        public static readonly BindableProperty SelectedValueMemberPathProperty =
+            BindableProperty.Create(
+                nameof(SelectedValueMemberPath),
+                typeof(string),
+                typeof(Picker));
 
-		public IList<string> Items { get; }
+        public static readonly BindableProperty ItemsSourceProperty =
+            BindableProperty.Create(
+                nameof(ItemsSource),
+                typeof(IList),
+                typeof(Picker),
+                default(IList),
+                propertyChanged: OnItemsSourceChanged);
 
-		public int SelectedIndex
-		{
-			get { return (int)GetValue(SelectedIndexProperty); }
-			set { SetValue(SelectedIndexProperty, value); }
-		}
+        public static readonly BindableProperty DisplayMemberPathProperty =
+            BindableProperty.Create(
+                nameof(DisplayMemberPath),
+                typeof(string),
+                typeof(Picker),
+                propertyChanged: OnDisplayMemberPathChanged);
 
-		public Color TextColor
-		{
-			get { return (Color)GetValue(TextColorProperty); }
-			set { SetValue(TextColorProperty, value); }
-		}
+        public static readonly BindableProperty SelectedItemProperty =
+            BindableProperty.Create(
+                nameof(SelectedItem),
+                typeof(object),
+                typeof(Picker),
+                null,
+                BindingMode.TwoWay,
+                propertyChanged: OnSelectedItemChanged);
 
-		public string Title
-		{
-			get { return (string)GetValue(TitleProperty); }
-			set { SetValue(TitleProperty, value); }
-		}
+        static readonly BindablePropertyKey s_selectedValuePropertyKey =
+            BindableProperty.CreateReadOnly(
+                nameof(SelectedValue),
+                typeof(object),
+                typeof(Picker),
+                null);
 
-		public event EventHandler SelectedIndexChanged;
+        public static readonly BindableProperty SelectedValueProperty = s_selectedValuePropertyKey.BindableProperty;
 
-		static object CoerceSelectedIndex(BindableObject bindable, object value)
-		{
-			var picker = (Picker)bindable;
-			return picker.Items == null ? -1 : ((int)value).Clamp(-1, picker.Items.Count - 1);
-		}
+        public Picker()
+        {
+            ((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
+        }
 
-		void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-		{
-			SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
-		}
-	}
+        /// <summary>
+        /// Set the name of the property that should be used to display the objects in <see cref="ItemsSource" />.
+        /// If left blank the <see cref="object.ToString" /> will be called
+        /// </summary>
+        /// <remarks>
+        /// Setting a value that does not exists on the object cause exception
+        /// </remarks>
+        /// <para>
+        /// Settings this value only affect objects that are not primitive types.
+        /// </para>
+        /// <exception cref="ArgumentException">Setting a value that does not exists on the object cause exception</exception>
+        public string DisplayMemberPath
+        {
+            get { return (string)GetValue(DisplayMemberPathProperty); }
+            set { SetValue(DisplayMemberPathProperty, value); }
+        }
+
+        public IList<string> Items { get; } = new ObservableList<string>();
+
+        public IList ItemsSource
+        {
+            get { return (IList)GetValue(ItemsSourceProperty); }
+            set { SetValue(ItemsSourceProperty, value); }
+        }
+
+        public int SelectedIndex
+        {
+            get { return (int)GetValue(SelectedIndexProperty); }
+            set { SetValue(SelectedIndexProperty, value); }
+        }
+
+        public object SelectedItem
+        {
+            get { return GetValue(SelectedItemProperty); }
+            set { SetValue(SelectedItemProperty, value); }
+        }
+
+        public object SelectedValue
+        {
+            get { return GetValue(SelectedValueProperty); }
+            private set { SetValue(s_selectedValuePropertyKey, value); }
+        }
+
+        public string SelectedValueMemberPath
+        {
+            get { return (string)GetValue(SelectedValueMemberPathProperty); }
+            set { SetValue(SelectedValueMemberPathProperty, value); }
+        }
+
+        public Color TextColor
+        {
+            get { return (Color)GetValue(TextColorProperty); }
+            set { SetValue(TextColorProperty, value); }
+        }
+
+        public string Title
+        {
+            get { return (string)GetValue(TitleProperty); }
+            set { SetValue(TitleProperty, value); }
+        }
+
+        public event EventHandler SelectedIndexChanged;
+
+        /// <summary>
+        /// Get the value to display through reflection on <paramref name="item" /> using property <see cref="DisplayMemberPath" />
+        /// </summary>
+        /// <param name="item">Item to get value from.</param>
+        /// <returns>Value of the property <see cref="DisplayMemberPath" /> if not <c>null</c>; otherwise ToString()</returns>
+        /// <exception cref="ArgumentException">If no property with name <see cref="DisplayMemberPath" /> is found</exception>
+        protected virtual string GetDisplayMember(object item)
+        {
+            return GetPropertyValue(item, DisplayMemberPath) as string;
+        }
+
+        protected virtual object GetSelectedValue(object item)
+        {
+            return GetPropertyValue(item, SelectedValueMemberPath);
+        }
+
+        void AddItems(NotifyCollectionChangedEventArgs e)
+        {
+            int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
+            foreach (object newItem in e.NewItems)
+            {
+                Items.Insert(index++, GetDisplayMember(newItem));
+            }
+        }
+
+        void BindItems()
+        {
+            Items.Clear();
+            foreach (object item in ItemsSource)
+            {
+                Items.Add(GetDisplayMember(item));
+            }
+            UpdateSelectedItem();
+        }
+
+        static object CoerceSelectedIndex(BindableObject bindable, object value)
+        {
+            var picker = (Picker)bindable;
+            return picker.Items == null ? -1 : ((int)value).Clamp(-1, picker.Items.Count - 1);
+        }
+
+        void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Reset:
+                    BindItems();
+                    return;
+                case NotifyCollectionChangedAction.Remove:
+                    RemoveItems(e);
+                    break;
+                case NotifyCollectionChangedAction.Add:
+                    AddItems(e);
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    // TODO Make more intelligent decision
+                    BindItems();
+                    break;
+                case NotifyCollectionChangedAction.Replace:
+                    // TODO Make more intelligent decision
+                    BindItems();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        static object GetPropertyValue(object item, string memberPath)
+        {
+            if (item == null)
+            {
+                return null;
+            }
+            // TODO How to handle Nullable types
+            if (IsPrimitive(item) || string.IsNullOrEmpty(memberPath))
+            {
+                return item.ToString();
+            }
+            // Find the property by walking the display member path to find any nested properties
+            string[] propertyPathParts = memberPath.Split('.');
+            object propertyValue = null;
+            foreach (string propertyPathPart in propertyPathParts)
+            {
+                PropertyInfo propInfo = item.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
+                propertyValue = propInfo.GetValue(item);
+            }
+
+            if (propertyValue == null)
+            {
+                throw new ArgumentException(
+                    $"No property with name '{memberPath}' was found on '{item.GetType().FullName}'");
+            }
+            return propertyValue;
+        }
+
+        static bool IsPrimitive(object item)
+        {
+            // TODO What is missing
+            return item is string || item is int || item is double || item is decimal || item is Enum ||
+                   item is DateTime;
+        }
+
+        static void OnDisplayMemberPathChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var picker = (Picker)bindable;
+            if (picker.ItemsSource?.Count > 0)
+            {
+                picker.BindItems();
+            }
+        }
+
+        void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action == NotifyCollectionChangedAction.Remove || e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
+                UpdateSelectedItem();
+            }
+        }
+
+        static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var picker = (Picker)bindable;
+            // Check if the ItemsSource value has changed and if so, unsubscribe from collection changed
+            var observable = oldValue as INotifyCollectionChanged;
+            if (observable != null)
+            {
+                observable.CollectionChanged -= picker.CollectionChanged;
+            }
+            observable = newValue as INotifyCollectionChanged;
+            if (observable != null)
+            {
+                observable.CollectionChanged += picker.CollectionChanged;
+                picker.BindItems();
+            }
+            else
+            {
+                // newValue is null so clear the items collection
+                picker.Items.Clear();
+            }
+        }
+
+        static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)
+        {
+            var picker = (Picker)bindable;
+            EventHandler eh = picker.SelectedIndexChanged;
+            eh?.Invoke(bindable, EventArgs.Empty);
+            picker.UpdateSelectedItem();
+        }
+
+        static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var picker = (Picker)bindable;
+            picker.UpdateSelectedIndex(newValue);
+        }
+
+        void RemoveItems(NotifyCollectionChangedEventArgs e)
+        {
+            int index = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count;
+            // TODO: How do we determine the order of which the items were removed
+            foreach (object _ in e.OldItems)
+            {
+                Items.RemoveAt(index--);
+            }
+        }
+
+        void UpdateSelectedIndex(object selectedItem)
+        {
+            string displayMember = GetDisplayMember(selectedItem);
+            int index = Items.IndexOf(displayMember);
+            // TODO Should we prevent call to FindObject since the object is already known
+            // by setting a flag, or otherwise indicate, that we, internally, forced a SelectedIndex changed
+            SelectedIndex = index;
+            SelectedValue = GetSelectedValue(selectedItem);
+        }
+
+        void UpdateSelectedItem()
+        {
+            if (SelectedIndex < 0 || SelectedIndex > Items.Count - 1)
+            {
+                SelectedItem = null;
+            }
+            else
+            {
+                SelectedItem = ItemsSource?[SelectedIndex];
+                SelectedValue = GetSelectedValue(SelectedItem);
+            }
+        }
+    }
 }

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -157,16 +157,16 @@ namespace Xamarin.Forms
 			}
 			// Find the property by walking the display member path to find any nested properties
 			string[] propertyPathParts = memberPath.Split('.');
-			object propertyValue = null;
+			object propertyValue = item;
 			foreach (string propertyPathPart in propertyPathParts)
 			{
-				PropertyInfo propInfo = item.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
+				PropertyInfo propInfo = propertyValue.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
 				if (propInfo == null)
 				{
 					throw new ArgumentException(
-						$"No property with name '{memberPath}' was found on '{item.GetType().FullName}'");
+						$"No property with name '{propertyPathPart}' was found on '{propertyValue.GetType().FullName}'");
 				}
-				propertyValue = propInfo.GetValue(item);
+				propertyValue = propInfo.GetValue(propertyValue);
 			}
 			return propertyValue;
 		}

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -7,249 +7,250 @@ using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
 {
-    [RenderWith(typeof(_PickerRenderer))]
-    public class Picker : View
-    {
-        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Picker), Color.Default);
+	[RenderWith(typeof(_PickerRenderer))]
+	public class Picker : View
+	{
+		public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Picker), Color.Default);
 
-        public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
+		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
 
-        public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
-            propertyChanged: OnSelectedIndexChanged,
-            coerceValue: CoerceSelectedIndex);
+		public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
+			propertyChanged: OnSelectedIndexChanged,
+			coerceValue: CoerceSelectedIndex);
 
-        public static readonly BindableProperty SelectedValueMemberPathProperty = BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
+		public static readonly BindableProperty SelectedValueMemberPathProperty = BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
 
-        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IList), typeof(Picker), default(IList), propertyChanged: OnItemsSourceChanged);
+		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IList), typeof(Picker), default(IList), propertyChanged: OnItemsSourceChanged);
 
-        public static readonly BindableProperty DisplayMemberPathProperty = BindableProperty.Create(nameof(DisplayMemberPath), typeof(string), typeof(Picker), propertyChanged: OnDisplayMemberPathChanged);
+		public static readonly BindableProperty DisplayMemberPathProperty = BindableProperty.Create(nameof(DisplayMemberPath), typeof(string), typeof(Picker), propertyChanged: OnDisplayMemberPathChanged);
 
-        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay, propertyChanged: OnSelectedItemChanged);
+		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay, propertyChanged: OnSelectedItemChanged);
 
-        public static readonly BindableProperty DisplayFuncProperty =
-            BindableProperty.Create(
-                nameof(DisplayFunc),
-                typeof(Func<object, string>),
-                typeof(Picker));
-        public Picker()
-        {
-            ((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
-        }
+		public static readonly BindableProperty DisplayFuncProperty =
+			BindableProperty.Create(
+				nameof(DisplayFunc),
+				typeof(Func<object, string>),
+				typeof(Picker));
 
-        public string DisplayMemberPath
-        {
-            get { return (string)GetValue(DisplayMemberPathProperty); }
-            set { SetValue(DisplayMemberPathProperty, value); }
-        }
+		public Picker()
+		{
+			((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
+		}
 
-        public Func<object, string> DisplayFunc
-        {
-            get { return (Func<object, string>)GetValue(DisplayFuncProperty); }
-            set { SetValue(DisplayFuncProperty, value); }
-        }
+		public string DisplayMemberPath
+		{
+			get { return (string)GetValue(DisplayMemberPathProperty); }
+			set { SetValue(DisplayMemberPathProperty, value); }
+		}
 
-        public IList<string> Items { get; } = new ObservableList<string>();
+		public Func<object, string> DisplayFunc
+		{
+			get { return (Func<object, string>)GetValue(DisplayFuncProperty); }
+			set { SetValue(DisplayFuncProperty, value); }
+		}
 
-        public IList ItemsSource
-        {
-            get { return (IList)GetValue(ItemsSourceProperty); }
-            set { SetValue(ItemsSourceProperty, value); }
-        }
+		public IList<string> Items { get; } = new ObservableList<string>();
 
-        public int SelectedIndex
-        {
-            get { return (int)GetValue(SelectedIndexProperty); }
-            set { SetValue(SelectedIndexProperty, value); }
-        }
+		public IList ItemsSource
+		{
+			get { return (IList)GetValue(ItemsSourceProperty); }
+			set { SetValue(ItemsSourceProperty, value); }
+		}
 
-        public object SelectedItem
-        {
-            get { return GetValue(SelectedItemProperty); }
-            set { SetValue(SelectedItemProperty, value); }
-        }
+		public int SelectedIndex
+		{
+			get { return (int)GetValue(SelectedIndexProperty); }
+			set { SetValue(SelectedIndexProperty, value); }
+		}
 
-        public string SelectedValueMemberPath
-        {
-            get { return (string)GetValue(SelectedValueMemberPathProperty); }
-            set { SetValue(SelectedValueMemberPathProperty, value); }
-        }
+		public object SelectedItem
+		{
+			get { return GetValue(SelectedItemProperty); }
+			set { SetValue(SelectedItemProperty, value); }
+		}
 
-        public Color TextColor
-        {
-            get { return (Color)GetValue(TextColorProperty); }
-            set { SetValue(TextColorProperty, value); }
-        }
+		public string SelectedValueMemberPath
+		{
+			get { return (string)GetValue(SelectedValueMemberPathProperty); }
+			set { SetValue(SelectedValueMemberPathProperty, value); }
+		}
 
-        public string Title
-        {
-            get { return (string)GetValue(TitleProperty); }
-            set { SetValue(TitleProperty, value); }
-        }
+		public Color TextColor
+		{
+			get { return (Color)GetValue(TextColorProperty); }
+			set { SetValue(TextColorProperty, value); }
+		}
 
-        public event EventHandler SelectedIndexChanged;
+		public string Title
+		{
+			get { return (string)GetValue(TitleProperty); }
+			set { SetValue(TitleProperty, value); }
+		}
 
-        protected virtual string GetDisplayMember(object item)
-        {
-            if (DisplayFunc != null)
-            {
-                return DisplayFunc(item);
-            }
-            return GetPropertyValue(item, DisplayMemberPath) as string;
-        }
+		public event EventHandler SelectedIndexChanged;
 
-        void AddItems(NotifyCollectionChangedEventArgs e)
-        {
-            int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
-            foreach (object newItem in e.NewItems)
-            {
-                Items.Insert(index++, GetDisplayMember(newItem));
-            }
-        }
+		protected virtual string GetDisplayMember(object item)
+		{
+			if (DisplayFunc != null)
+			{
+				return DisplayFunc(item);
+			}
+			return GetPropertyValue(item, DisplayMemberPath) as string;
+		}
 
-        void BindItems()
-        {
-            Items.Clear();
-            foreach (object item in ItemsSource)
-            {
-                Items.Add(GetDisplayMember(item));
-            }
-            UpdateSelectedItem();
-        }
+		void AddItems(NotifyCollectionChangedEventArgs e)
+		{
+			int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
+			foreach (object newItem in e.NewItems)
+			{
+				Items.Insert(index++, GetDisplayMember(newItem));
+			}
+		}
 
-        static object CoerceSelectedIndex(BindableObject bindable, object value)
-        {
-            var picker = (Picker)bindable;
-            return picker.Items == null ? -1 : ((int)value).Clamp(-1, picker.Items.Count - 1);
-        }
+		void BindItems()
+		{
+			Items.Clear();
+			foreach (object item in ItemsSource)
+			{
+				Items.Add(GetDisplayMember(item));
+			}
+			UpdateSelectedItem();
+		}
 
-        void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Move:
-                case NotifyCollectionChangedAction.Replace:
-                case NotifyCollectionChangedAction.Reset:
-                    // Clear Items collection and re-populate it with values from ItemsSource
-                    BindItems();
-                    return;
-                case NotifyCollectionChangedAction.Remove:
-                    RemoveItems(e);
-                    break;
-                case NotifyCollectionChangedAction.Add:
-                    AddItems(e);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
+		static object CoerceSelectedIndex(BindableObject bindable, object value)
+		{
+			var picker = (Picker)bindable;
+			return picker.Items == null ? -1 : ((int)value).Clamp(-1, picker.Items.Count - 1);
+		}
 
-        static object GetPropertyValue(object item, string memberPath)
-        {
-            if (item == null)
-            {
-                return null;
-            }
-            // TODO How to handle Nullable types
-            if (IsPrimitive(item) || string.IsNullOrEmpty(memberPath))
-            {
-                return item.ToString();
-            }
-            // Find the property by walking the display member path to find any nested properties
-            string[] propertyPathParts = memberPath.Split('.');
-            object propertyValue = null;
-            foreach (string propertyPathPart in propertyPathParts)
-            {
-                PropertyInfo propInfo = item.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
-                if (propInfo == null)
-                {
-                    throw new ArgumentException(
-                        $"No property with name '{memberPath}' was found on '{item.GetType().FullName}'");
-                }
-                propertyValue = propInfo.GetValue(item);
-            }
-            return propertyValue;
-        }
+		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			switch (e.Action)
+			{
+				case NotifyCollectionChangedAction.Move:
+				case NotifyCollectionChangedAction.Replace:
+				case NotifyCollectionChangedAction.Reset:
+					// Clear Items collection and re-populate it with values from ItemsSource
+					BindItems();
+					return;
+				case NotifyCollectionChangedAction.Remove:
+					RemoveItems(e);
+					break;
+				case NotifyCollectionChangedAction.Add:
+					AddItems(e);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
 
-        static bool IsPrimitive(object item)
-        {
-            return item is string || item is int || item is double || item is decimal || item is Enum ||
-                   item is DateTime;
-        }
+		static object GetPropertyValue(object item, string memberPath)
+		{
+			if (item == null)
+			{
+				return null;
+			}
+			// TODO How to handle Nullable types
+			if (IsPrimitive(item) || string.IsNullOrEmpty(memberPath))
+			{
+				return item.ToString();
+			}
+			// Find the property by walking the display member path to find any nested properties
+			string[] propertyPathParts = memberPath.Split('.');
+			object propertyValue = null;
+			foreach (string propertyPathPart in propertyPathParts)
+			{
+				PropertyInfo propInfo = item.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
+				if (propInfo == null)
+				{
+					throw new ArgumentException(
+						$"No property with name '{memberPath}' was found on '{item.GetType().FullName}'");
+				}
+				propertyValue = propInfo.GetValue(item);
+			}
+			return propertyValue;
+		}
 
-        static void OnDisplayMemberPathChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            var picker = (Picker)bindable;
-            if (picker.ItemsSource?.Count > 0)
-            {
-                picker.BindItems();
-            }
-        }
+		static bool IsPrimitive(object item)
+		{
+			return item is string || item is int || item is double || item is decimal || item is Enum ||
+				   item is DateTime;
+		}
 
-        void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
-            UpdateSelectedItem();
-        }
+		static void OnDisplayMemberPathChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			if (picker.ItemsSource?.Count > 0)
+			{
+				picker.BindItems();
+			}
+		}
 
-        static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            var picker = (Picker)bindable;
-            // Check if the ItemsSource value has changed and if so, unsubscribe from collection changed
-            var observable = oldValue as INotifyCollectionChanged;
-            if (observable != null)
-            {
-                observable.CollectionChanged -= picker.CollectionChanged;
-            }
-            observable = newValue as INotifyCollectionChanged;
-            if (observable != null)
-            {
-                observable.CollectionChanged += picker.CollectionChanged;
-                picker.BindItems();
-            }
-            else
-            {
-                // newValue is null so clear the items collection
-                picker.Items.Clear();
-            }
-        }
+		void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
+			UpdateSelectedItem();
+		}
 
-        static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)
-        {
-            var picker = (Picker)bindable;
-            EventHandler eh = picker.SelectedIndexChanged;
-            eh?.Invoke(bindable, EventArgs.Empty);
-            picker.UpdateSelectedItem();
-        }
+		static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			// Check if the ItemsSource value has changed and if so, unsubscribe from collection changed
+			var observable = oldValue as INotifyCollectionChanged;
+			if (observable != null)
+			{
+				observable.CollectionChanged -= picker.CollectionChanged;
+			}
+			observable = newValue as INotifyCollectionChanged;
+			if (observable != null)
+			{
+				observable.CollectionChanged += picker.CollectionChanged;
+				picker.BindItems();
+			}
+			else
+			{
+				// newValue is null so clear the items collection
+				picker.Items.Clear();
+			}
+		}
 
-        static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            var picker = (Picker)bindable;
-            picker.UpdateSelectedIndex(newValue);
-        }
+		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			EventHandler eh = picker.SelectedIndexChanged;
+			eh?.Invoke(bindable, EventArgs.Empty);
+			picker.UpdateSelectedItem();
+		}
 
-        void RemoveItems(NotifyCollectionChangedEventArgs e)
-        {
-            int index = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count;
-            // TODO: How do we determine the order of which the items were removed
-            foreach (object _ in e.OldItems)
-            {
-                Items.RemoveAt(index--);
-            }
-        }
+		static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			picker.UpdateSelectedIndex(newValue);
+		}
 
-        void UpdateSelectedIndex(object selectedItem)
-        {
-            string displayMember = GetDisplayMember(selectedItem);
-            int index = Items.IndexOf(displayMember);
-            // TODO Should we prevent call to FindObject since the object is already known
-            // by setting a flag, or otherwise indicate, that we, internally, forced a SelectedIndex changed
-            SelectedIndex = index;
-        }
+		void RemoveItems(NotifyCollectionChangedEventArgs e)
+		{
+			int index = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count;
+			// TODO: How do we determine the order of which the items were removed
+			foreach (object _ in e.OldItems)
+			{
+				Items.RemoveAt(index--);
+			}
+		}
 
-        void UpdateSelectedItem()
-        {
-            // coerceSelectedIndex ensures that SelectedIndex is in range [-1,ItemsSource.Count)
-            SelectedItem = SelectedIndex == -1 ? null : ItemsSource?[SelectedIndex];
-        }
-    }
+		void UpdateSelectedIndex(object selectedItem)
+		{
+			string displayMember = GetDisplayMember(selectedItem);
+			int index = Items.IndexOf(displayMember);
+			// TODO Should we prevent call to FindObject since the object is already known
+			// by setting a flag, or otherwise indicate, that we, internally, forced a SelectedIndex changed
+			SelectedIndex = index;
+		}
+
+		void UpdateSelectedItem()
+		{
+			// coerceSelectedIndex ensures that SelectedIndex is in range [-1,ItemsSource.Count)
+			SelectedItem = SelectedIndex == -1 ? null : ItemsSource?[SelectedIndex];
+		}
+	}
 }

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -7,246 +7,249 @@ using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
 {
-	[RenderWith(typeof(_PickerRenderer))]
-	public class Picker : View
-	{
-		public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Picker), Color.Default);
+    [RenderWith(typeof(_PickerRenderer))]
+    public class Picker : View
+    {
+        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Picker), Color.Default);
 
-		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
+        public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
 
-		public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
-			propertyChanged: OnSelectedIndexChanged,
-			coerceValue: CoerceSelectedIndex);
+        public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
+            propertyChanged: OnSelectedIndexChanged,
+            coerceValue: CoerceSelectedIndex);
 
-		public static readonly BindableProperty SelectedValueMemberPathProperty = BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
+        public static readonly BindableProperty SelectedValueMemberPathProperty = BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
 
-		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IList), typeof(Picker), default(IList), propertyChanged: OnItemsSourceChanged);
+        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IList), typeof(Picker), default(IList), propertyChanged: OnItemsSourceChanged);
 
-		public static readonly BindableProperty DisplayMemberPathProperty = BindableProperty.Create(nameof(DisplayMemberPath), typeof(string), typeof(Picker), propertyChanged: OnDisplayMemberPathChanged);
+        public static readonly BindableProperty DisplayMemberPathProperty = BindableProperty.Create(nameof(DisplayMemberPath), typeof(string), typeof(Picker), propertyChanged: OnDisplayMemberPathChanged);
 
-		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay, propertyChanged: OnSelectedItemChanged);
+        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay, propertyChanged: OnSelectedItemChanged);
 
-		public Picker()
-		{
-			((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
-		}
+        public static readonly BindableProperty DisplayFuncProperty =
+            BindableProperty.Create(
+                nameof(DisplayFunc),
+                typeof(Func<object, string>),
+                typeof(Picker));
+        public Picker()
+        {
+            ((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
+        }
 
-		public string DisplayMemberPath
-		{
-			get { return (string)GetValue(DisplayMemberPathProperty); }
-			set { SetValue(DisplayMemberPathProperty, value); }
-		}
+        public string DisplayMemberPath
+        {
+            get { return (string)GetValue(DisplayMemberPathProperty); }
+            set { SetValue(DisplayMemberPathProperty, value); }
+        }
 
-		public IList<string> Items { get; } = new ObservableList<string>();
+        public Func<object, string> DisplayFunc
+        {
+            get { return (Func<object, string>)GetValue(DisplayFuncProperty); }
+            set { SetValue(DisplayFuncProperty, value); }
+        }
 
-		public IList ItemsSource
-		{
-			get { return (IList)GetValue(ItemsSourceProperty); }
-			set { SetValue(ItemsSourceProperty, value); }
-		}
+        public IList<string> Items { get; } = new ObservableList<string>();
 
-		public int SelectedIndex
-		{
-			get { return (int)GetValue(SelectedIndexProperty); }
-			set { SetValue(SelectedIndexProperty, value); }
-		}
+        public IList ItemsSource
+        {
+            get { return (IList)GetValue(ItemsSourceProperty); }
+            set { SetValue(ItemsSourceProperty, value); }
+        }
 
-		public object SelectedItem
-		{
-			get { return GetValue(SelectedItemProperty); }
-			set { SetValue(SelectedItemProperty, value); }
-		}
+        public int SelectedIndex
+        {
+            get { return (int)GetValue(SelectedIndexProperty); }
+            set { SetValue(SelectedIndexProperty, value); }
+        }
 
-		public string SelectedValueMemberPath
-		{
-			get { return (string)GetValue(SelectedValueMemberPathProperty); }
-			set { SetValue(SelectedValueMemberPathProperty, value); }
-		}
+        public object SelectedItem
+        {
+            get { return GetValue(SelectedItemProperty); }
+            set { SetValue(SelectedItemProperty, value); }
+        }
 
-		public Color TextColor
-		{
-			get { return (Color)GetValue(TextColorProperty); }
-			set { SetValue(TextColorProperty, value); }
-		}
+        public string SelectedValueMemberPath
+        {
+            get { return (string)GetValue(SelectedValueMemberPathProperty); }
+            set { SetValue(SelectedValueMemberPathProperty, value); }
+        }
 
-		public string Title
-		{
-			get { return (string)GetValue(TitleProperty); }
-			set { SetValue(TitleProperty, value); }
-		}
+        public Color TextColor
+        {
+            get { return (Color)GetValue(TextColorProperty); }
+            set { SetValue(TextColorProperty, value); }
+        }
 
-		public event EventHandler SelectedIndexChanged;
+        public string Title
+        {
+            get { return (string)GetValue(TitleProperty); }
+            set { SetValue(TitleProperty, value); }
+        }
 
-		protected virtual string GetDisplayMember(object item)
-		{
-			return GetPropertyValue(item, DisplayMemberPath) as string;
-		}
+        public event EventHandler SelectedIndexChanged;
 
-		protected virtual object GetSelectedValue(object item)
-		{
-			return GetPropertyValue(item, SelectedValueMemberPath);
-		}
+        protected virtual string GetDisplayMember(object item)
+        {
+            if (DisplayFunc != null)
+            {
+                return DisplayFunc(item);
+            }
+            return GetPropertyValue(item, DisplayMemberPath) as string;
+        }
 
-		void AddItems(NotifyCollectionChangedEventArgs e)
-		{
-			int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
-			foreach (object newItem in e.NewItems)
-			{
-				Items.Insert(index++, GetDisplayMember(newItem));
-			}
-		}
+        void AddItems(NotifyCollectionChangedEventArgs e)
+        {
+            int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
+            foreach (object newItem in e.NewItems)
+            {
+                Items.Insert(index++, GetDisplayMember(newItem));
+            }
+        }
 
-		void BindItems()
-		{
-			Items.Clear();
-			foreach (object item in ItemsSource)
-			{
-				Items.Add(GetDisplayMember(item));
-			}
-			UpdateSelectedItem();
-		}
+        void BindItems()
+        {
+            Items.Clear();
+            foreach (object item in ItemsSource)
+            {
+                Items.Add(GetDisplayMember(item));
+            }
+            UpdateSelectedItem();
+        }
 
-		static object CoerceSelectedIndex(BindableObject bindable, object value)
-		{
-			var picker = (Picker)bindable;
-			return picker.Items == null ? -1 : ((int)value).Clamp(-1, picker.Items.Count - 1);
-		}
+        static object CoerceSelectedIndex(BindableObject bindable, object value)
+        {
+            var picker = (Picker)bindable;
+            return picker.Items == null ? -1 : ((int)value).Clamp(-1, picker.Items.Count - 1);
+        }
 
-		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-		{
-			switch (e.Action)
-			{
-				case NotifyCollectionChangedAction.Move:
-				case NotifyCollectionChangedAction.Replace:
-				case NotifyCollectionChangedAction.Reset:
-					// Clear Items collection and re-populate it with values from ItemsSource
-					BindItems();
-					return;
-				case NotifyCollectionChangedAction.Remove:
-					RemoveItems(e);
-					break;
-				case NotifyCollectionChangedAction.Add:
-					AddItems(e);
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
-			}
-		}
+        void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Move:
+                case NotifyCollectionChangedAction.Replace:
+                case NotifyCollectionChangedAction.Reset:
+                    // Clear Items collection and re-populate it with values from ItemsSource
+                    BindItems();
+                    return;
+                case NotifyCollectionChangedAction.Remove:
+                    RemoveItems(e);
+                    break;
+                case NotifyCollectionChangedAction.Add:
+                    AddItems(e);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
 
-		static object GetPropertyValue(object item, string memberPath)
-		{
-			if (item == null)
-			{
-				return null;
-			}
-			// TODO How to handle Nullable types
-			if (IsPrimitive(item) || string.IsNullOrEmpty(memberPath))
-			{
-				return item.ToString();
-			}
-			// Find the property by walking the display member path to find any nested properties
-			string[] propertyPathParts = memberPath.Split('.');
-			object propertyValue = null;
-			foreach (string propertyPathPart in propertyPathParts)
-			{
-				PropertyInfo propInfo = item.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
-				propertyValue = propInfo.GetValue(item);
-			}
+        static object GetPropertyValue(object item, string memberPath)
+        {
+            if (item == null)
+            {
+                return null;
+            }
+            // TODO How to handle Nullable types
+            if (IsPrimitive(item) || string.IsNullOrEmpty(memberPath))
+            {
+                return item.ToString();
+            }
+            // Find the property by walking the display member path to find any nested properties
+            string[] propertyPathParts = memberPath.Split('.');
+            object propertyValue = null;
+            foreach (string propertyPathPart in propertyPathParts)
+            {
+                PropertyInfo propInfo = item.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
+                if (propInfo == null)
+                {
+                    throw new ArgumentException(
+                        $"No property with name '{memberPath}' was found on '{item.GetType().FullName}'");
+                }
+                propertyValue = propInfo.GetValue(item);
+            }
+            return propertyValue;
+        }
 
-			if (propertyValue == null)
-			{
-				throw new ArgumentException(
-					$"No property with name '{memberPath}' was found on '{item.GetType().FullName}'");
-			}
-			return propertyValue;
-		}
+        static bool IsPrimitive(object item)
+        {
+            return item is string || item is int || item is double || item is decimal || item is Enum ||
+                   item is DateTime;
+        }
 
-		static bool IsPrimitive(object item)
-		{
-			return item is string || item is int || item is double || item is decimal || item is Enum ||
-				   item is DateTime;
-		}
+        static void OnDisplayMemberPathChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var picker = (Picker)bindable;
+            if (picker.ItemsSource?.Count > 0)
+            {
+                picker.BindItems();
+            }
+        }
 
-		static void OnDisplayMemberPathChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			var picker = (Picker)bindable;
-			if (picker.ItemsSource?.Count > 0)
-			{
-				picker.BindItems();
-			}
-		}
+        void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
+            UpdateSelectedItem();
+        }
 
-		void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-		{
-			SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
-			UpdateSelectedItem();
-		}
+        static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var picker = (Picker)bindable;
+            // Check if the ItemsSource value has changed and if so, unsubscribe from collection changed
+            var observable = oldValue as INotifyCollectionChanged;
+            if (observable != null)
+            {
+                observable.CollectionChanged -= picker.CollectionChanged;
+            }
+            observable = newValue as INotifyCollectionChanged;
+            if (observable != null)
+            {
+                observable.CollectionChanged += picker.CollectionChanged;
+                picker.BindItems();
+            }
+            else
+            {
+                // newValue is null so clear the items collection
+                picker.Items.Clear();
+            }
+        }
 
-		static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			var picker = (Picker)bindable;
-			// Check if the ItemsSource value has changed and if so, unsubscribe from collection changed
-			var observable = oldValue as INotifyCollectionChanged;
-			if (observable != null)
-			{
-				observable.CollectionChanged -= picker.CollectionChanged;
-			}
-			observable = newValue as INotifyCollectionChanged;
-			if (observable != null)
-			{
-				observable.CollectionChanged += picker.CollectionChanged;
-				picker.BindItems();
-			}
-			else
-			{
-				// newValue is null so clear the items collection
-				picker.Items.Clear();
-			}
-		}
+        static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)
+        {
+            var picker = (Picker)bindable;
+            EventHandler eh = picker.SelectedIndexChanged;
+            eh?.Invoke(bindable, EventArgs.Empty);
+            picker.UpdateSelectedItem();
+        }
 
-		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)
-		{
-			var picker = (Picker)bindable;
-			EventHandler eh = picker.SelectedIndexChanged;
-			eh?.Invoke(bindable, EventArgs.Empty);
-			picker.UpdateSelectedItem();
-		}
+        static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var picker = (Picker)bindable;
+            picker.UpdateSelectedIndex(newValue);
+        }
 
-		static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			var picker = (Picker)bindable;
-			picker.UpdateSelectedIndex(newValue);
-		}
+        void RemoveItems(NotifyCollectionChangedEventArgs e)
+        {
+            int index = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count;
+            // TODO: How do we determine the order of which the items were removed
+            foreach (object _ in e.OldItems)
+            {
+                Items.RemoveAt(index--);
+            }
+        }
 
-		void RemoveItems(NotifyCollectionChangedEventArgs e)
-		{
-			int index = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count;
-			// TODO: How do we determine the order of which the items were removed
-			foreach (object _ in e.OldItems)
-			{
-				Items.RemoveAt(index--);
-			}
-		}
+        void UpdateSelectedIndex(object selectedItem)
+        {
+            string displayMember = GetDisplayMember(selectedItem);
+            int index = Items.IndexOf(displayMember);
+            // TODO Should we prevent call to FindObject since the object is already known
+            // by setting a flag, or otherwise indicate, that we, internally, forced a SelectedIndex changed
+            SelectedIndex = index;
+        }
 
-		void UpdateSelectedIndex(object selectedItem)
-		{
-			string displayMember = GetDisplayMember(selectedItem);
-			int index = Items.IndexOf(displayMember);
-			// TODO Should we prevent call to FindObject since the object is already known
-			// by setting a flag, or otherwise indicate, that we, internally, forced a SelectedIndex changed
-			SelectedIndex = index;
-		}
-
-		void UpdateSelectedItem()
-		{
-			if (SelectedIndex < 0 || SelectedIndex > Items.Count - 1)
-			{
-				SelectedItem = null;
-			}
-			else
-			{
-				SelectedItem = ItemsSource?[SelectedIndex];
-			}
-		}
-	}
+        void UpdateSelectedItem()
+        {
+            // coerceSelectedIndex ensures that SelectedIndex is in range [-1,ItemsSource.Count)
+            SelectedItem = SelectedIndex == -1 ? null : ItemsSource?[SelectedIndex];
+        }
+    }
 }

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -10,36 +10,21 @@ namespace Xamarin.Forms
     [RenderWith(typeof(_PickerRenderer))]
     public class Picker : View
     {
-        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor),
-            typeof(Color), typeof(Picker), Color.Default);
+        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Picker), Color.Default);
 
-        public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string),
-            typeof(Picker), default(string));
+        public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
 
-        public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex),
-            typeof(int), typeof(Picker), -1,
-            BindingMode.TwoWay,
+        public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
             propertyChanged: OnSelectedIndexChanged,
             coerceValue: CoerceSelectedIndex);
 
-        public static readonly BindableProperty SelectedValueMemberPathProperty =
-            BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
+        public static readonly BindableProperty SelectedValueMemberPathProperty = BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
 
-        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource),
-            typeof(IList), typeof(Picker),
-            default(IList),
-            propertyChanged: OnItemsSourceChanged);
+        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IList), typeof(Picker), default(IList), propertyChanged: OnItemsSourceChanged);
 
-        public static readonly BindableProperty DisplayMemberPathProperty =
-            BindableProperty.Create(nameof(DisplayMemberPath), typeof(string),
-                typeof(Picker),
-                propertyChanged: OnDisplayMemberPathChanged);
+        public static readonly BindableProperty DisplayMemberPathProperty = BindableProperty.Create(nameof(DisplayMemberPath), typeof(string), typeof(Picker), propertyChanged: OnDisplayMemberPathChanged);
 
-        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem),
-            typeof(object), typeof(Picker),
-            null,
-            BindingMode.TwoWay,
-            propertyChanged: OnSelectedItemChanged);
+        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay, propertyChanged: OnSelectedItemChanged);
 
         public Picker()
         {
@@ -131,7 +116,10 @@ namespace Xamarin.Forms
         {
             switch (e.Action)
             {
+                case NotifyCollectionChangedAction.Move:
+                case NotifyCollectionChangedAction.Replace:
                 case NotifyCollectionChangedAction.Reset:
+                    // Clear Items collection and re-populate it with values from ItemsSource
                     BindItems();
                     return;
                 case NotifyCollectionChangedAction.Remove:
@@ -139,14 +127,6 @@ namespace Xamarin.Forms
                     break;
                 case NotifyCollectionChangedAction.Add:
                     AddItems(e);
-                    break;
-                case NotifyCollectionChangedAction.Move:
-                    // TODO Make more intelligent decision
-                    BindItems();
-                    break;
-                case NotifyCollectionChangedAction.Replace:
-                    // TODO Make more intelligent decision
-                    BindItems();
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -183,7 +163,6 @@ namespace Xamarin.Forms
 
         static bool IsPrimitive(object item)
         {
-            // TODO What is missing
             return item is string || item is int || item is double || item is decimal || item is Enum ||
                    item is DateTime;
         }
@@ -199,11 +178,8 @@ namespace Xamarin.Forms
 
         void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            if (e.Action == NotifyCollectionChangedAction.Remove || e.Action == NotifyCollectionChangedAction.Reset)
-            {
-                SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
-                UpdateSelectedItem();
-            }
+            SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
+            UpdateSelectedItem();
         }
 
         static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Globalization;
 using System.Reflection;
 using Xamarin.Forms.Platform;
 
@@ -32,6 +33,14 @@ namespace Xamarin.Forms
 				typeof(Func<object, string>),
 				typeof(Picker));
 
+		public static readonly BindableProperty DisplayConverterProperty =
+			BindableProperty.Create(
+				nameof(DisplayConverter),
+				typeof(IValueConverter),
+				typeof(Picker),
+				default(IValueConverter));
+
+		
 		public Picker()
 		{
 			((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
@@ -47,6 +56,12 @@ namespace Xamarin.Forms
 		{
 			get { return (Func<object, string>)GetValue(DisplayFuncProperty); }
 			set { SetValue(DisplayFuncProperty, value); }
+		}
+
+		public IValueConverter DisplayConverter
+		{
+			get { return (IValueConverter)GetValue(DisplayConverterProperty); }
+			set { SetValue(DisplayConverterProperty, value); }
 		}
 
 		public IList<string> Items { get; } = new ObservableList<string>();
@@ -91,6 +106,15 @@ namespace Xamarin.Forms
 
 		protected virtual string GetDisplayMember(object item)
 		{
+			if (DisplayConverter != null)
+			{
+				var display = DisplayConverter.Convert(item, typeof(string), null, CultureInfo.CurrentUICulture) as string;
+				if (display == null)
+				{
+					throw new ArgumentException("value must be converted to string");
+				}
+				return display;
+			}
 			if (DisplayFunc != null)
 			{
 				return DisplayFunc(item);

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -64,15 +64,6 @@ namespace Xamarin.Forms
                 BindingMode.TwoWay,
                 propertyChanged: OnSelectedItemChanged);
 
-        static readonly BindablePropertyKey s_selectedValuePropertyKey =
-            BindableProperty.CreateReadOnly(
-                nameof(SelectedValue),
-                typeof(object),
-                typeof(Picker),
-                null);
-
-        public static readonly BindableProperty SelectedValueProperty = s_selectedValuePropertyKey.BindableProperty;
-
         public Picker()
         {
             ((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
@@ -113,12 +104,6 @@ namespace Xamarin.Forms
         {
             get { return GetValue(SelectedItemProperty); }
             set { SetValue(SelectedItemProperty, value); }
-        }
-
-        public object SelectedValue
-        {
-            get { return GetValue(SelectedValueProperty); }
-            private set { SetValue(s_selectedValuePropertyKey, value); }
         }
 
         public string SelectedValueMemberPath
@@ -314,7 +299,6 @@ namespace Xamarin.Forms
             // TODO Should we prevent call to FindObject since the object is already known
             // by setting a flag, or otherwise indicate, that we, internally, forced a SelectedIndex changed
             SelectedIndex = index;
-            SelectedValue = GetSelectedValue(selectedItem);
         }
 
         void UpdateSelectedItem()
@@ -326,7 +310,6 @@ namespace Xamarin.Forms
             else
             {
                 SelectedItem = ItemsSource?[SelectedIndex];
-                SelectedValue = GetSelectedValue(SelectedItem);
             }
         }
     }


### PR DESCRIPTION
### Description of Change

Extended functionality of `Picker` to be more MVVM friendly with bindable properties
### Bugs Fixed

None
### API Changes

Added:
- **ItemsSourceProperty** _(IList)_ Bind a list of objects that synchronize with the visual presentation
- **DisplayMemberPath** _(string)_ The member of the object to display. Can be nested property exprerssion
- ~~**SelectedValueMemberPath** _(string)_ The member of the object that will be available in the **SelectedValueProperty**. Can be nested property expression~~
- ~~**SelectedValueProperty** _(object)_ The selected value for the object~~
- **SelectedItemProperty** _(object)_ The selected object (TwoWay-binding)
- **DisplayFunc** _(Func&lt;object, string&gt;)_ Func for creating custom string representation. Input is object's bound to **ItemsSource**
- **DisplayConverter** _(IValueConverter)_ Converter for creating custom string representation. _value_ is the object in **ItemsSource**. _targetType_ is **string**. _parameter_ is **null**. _culture_ is **CurrentCulture.CurrentUICulture**
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
### Issues
- There is one think (at least that I'm aware of) that might break backwards compatability. If the `BindingContext` is set the the `Picker` and the  `SelectedIndex` property is set to something else than `-1` it will be a no-op since the `Items` property is empty because it hasn't been populated with data from `ItemsSource` at the time `CoerceSelectedIndex` executes and it will return `-1` (hence `OnSelectedIndexChanged` is never called)
