### PR TITLE
Update OnPlatform to return Windows

### DIFF
--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -58,7 +58,8 @@ namespace Xamarin.Forms
 			return GetNamedSize(size, targetElementType, false);
 		}
 
-		public static void OnPlatform(Action iOS = null, Action Android = null, Action WinPhone = null, Action Default = null)
+#warning Windows 8.1 or UWP applications no longer use the WinPhone action parameter. Please use the Windows parameter to run Action on a Windows 8.1 or UWP application.
+		public static void OnPlatform(Action iOS = null, Action Android = null, Action WinPhone = null, Action Windows, Action Default = null)
 		{
 			switch (OS)
 			{
@@ -75,6 +76,11 @@ namespace Xamarin.Forms
 						Default();
 					break;
 				case TargetPlatform.Windows:
+					if (Windows != null)
+						Windows();
+					else if (Default != null)
+						Default();
+					break;
 				case TargetPlatform.WinPhone:
 					if (WinPhone != null)
 						WinPhone();
@@ -88,7 +94,8 @@ namespace Xamarin.Forms
 			}
 		}
 
-		public static T OnPlatform<T>(T iOS, T Android, T WinPhone)
+#warning Windows 8.1 or UWP applications no longer retun the WinPhone type, please update your application to reflect this change.
+		public static T OnPlatform<T>(T iOS, T Android, T WinPhone, T Windows)
 		{
 			switch (OS)
 			{
@@ -96,9 +103,10 @@ namespace Xamarin.Forms
 					return iOS;
 				case TargetPlatform.Android:
 					return Android;
-				case TargetPlatform.Windows:
 				case TargetPlatform.WinPhone:
 					return WinPhone;
+				case TargetPlatform.Windows:
+					return Windows;
 			}
 
 			return iOS;

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Forms
 		}
 
 #warning Windows 8.1 or UWP applications no longer use the WinPhone action parameter. Please use the Windows parameter to run Action on a Windows 8.1 or UWP application.
-		public static void OnPlatform(Action iOS = null, Action Android = null, Action WinPhone = null, Action Windows, Action Default = null)
+		public static void OnPlatform(Action iOS = null, Action Android = null, Action WinPhone = null, Action Windows = null, Action Default = null)
 		{
 			switch (OS)
 			{

--- a/Xamarin.Forms.Core/OnPlatform.cs
+++ b/Xamarin.Forms.Core/OnPlatform.cs
@@ -27,9 +27,6 @@ namespace Xamarin.Forms
 				case TargetPlatform.Windows:
 					return ( onPlatform.Windows ?? onPlatform.Default ) ?? onPlatform.WinPhone;
 					break;
-				default:
-					onPlatform.Default;
-					break;
 			}
 
 			return onPlatform.iOS;

--- a/Xamarin.Forms.Core/OnPlatform.cs
+++ b/Xamarin.Forms.Core/OnPlatform.cs
@@ -10,18 +10,26 @@ namespace Xamarin.Forms
 		
 		public T Windows { get; set; }
 
+#warning This method no longer returns TargetPlatform.WinPhone for Windows 8.1 or UWP applications. Please use Windows type for Windows 8.1 and UWP applications.
 		public static implicit operator T(OnPlatform<T> onPlatform)
 		{
 			switch (Device.OS)
 			{
 				case TargetPlatform.iOS:
-					return onPlatform.iOS;
+					return onPlatform.iOS ?? onPlatform.Default;
+					break;
 				case TargetPlatform.Android:
-					return onPlatform.Android;
+					return onPlatform.Android ?? onPlatform.Default;
+					break;
 				case TargetPlatform.WinPhone:
-					return onPlatform.WinPhone;
+					return onPlatform.WinPhone ?? onPlatform.Default;
+					break;
 				case TargetPlatform.Windows:
-					return onPlatform.Windows;
+					return ( onPlatform.Windows ?? onPlatform.Default ) ?? onPlatform.WinPhone;
+					break;
+				default:
+					onPlatform.Default;
+					break;
 			}
 
 			return onPlatform.iOS;


### PR DESCRIPTION
With the introduction of UWP, we need the ability to use the TargetPlatform.**Windows** enum value of Device.OS in the OnPlatform XAMLExtension. 

As an example, this update allows the following use case:

```
<core:OnPlatform x:TypeArguments="GridLength"
                              Android="50"
                              WinPhone="50"
                              Windows="40"
                              iOS="70" />

```
