### PR TITLE
[iOS] Throw InvalidOperationException if AppLinkEntry.Thumbnail source is not valid

### DIFF
--- a/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
+++ b/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
@@ -126,13 +126,17 @@ namespace Xamarin.Forms.Platform.iOS
 				try
 				{
 					uiimage = await handler.LoadImageAsync(source);
+
+					if (uiimage == null)
+						throw new InvalidOperationException("AppLinkEntry Thumbnail must be set to a valid source");
+
+					searchableAttributeSet.ThumbnailData = uiimage.AsPNG();
+					uiimage.Dispose();
 				}
 				catch (OperationCanceledException)
 				{
 					uiimage = null;
 				}
-				searchableAttributeSet.ThumbnailData = uiimage.AsPNG();
-				uiimage.Dispose();
 			}
 
 			return searchableAttributeSet;


### PR DESCRIPTION
### Description of Change ###

Currently if the thumbnail source for an AppLinkEntry is not valid on iOS, a generic NRE is thrown when calling `uiimage.AsPNG()`. This fix checks if `uiimage` is null after trying to load the image and if so throws an InvalidOperationException to inform the user why. It also moves other code into the try block in order to avoid another NRE if an OperationCanceledException is caught.

This all assumes that the thumbnail is always required for an AppLinkEntry. If it's not, the null check should be used to just avoid calling `uiimage.AsPNG()` then instead of throwing an exception.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=42061

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
