### PR TITLE
Invalidate measure of Label when FormattedText changes

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/LabelTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/LabelTests.cs
@@ -46,6 +46,32 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void InvalidateMeasureWhenTextChanges ()
+		{
+			var label = new Label();
+
+			bool fired;
+			label.MeasureInvalidated += (sender, args) =>
+			{
+				fired = true;
+			};
+
+			fired = false;
+			label.Text = "Foo";
+			Assert.IsTrue (fired);
+
+			var fs = new FormattedString ();
+
+			fired = false;
+			label.FormattedText = fs;
+			Assert.IsTrue (fired);
+
+			fired = false;
+			fs.Spans.Add (new Span {Text = "bar"});
+			Assert.IsTrue (fired);
+		}
+
+		[Test]
 		public void AssignToFontStructUpdatesFontFamily (
 			[Values (NamedSize.Default, NamedSize.Large, NamedSize.Medium, NamedSize.Small, NamedSize.Micro)] NamedSize size,
 			[Values (FontAttributes.None, FontAttributes.Bold, FontAttributes.Italic, FontAttributes.Bold | FontAttributes.Italic)] FontAttributes attributes)

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -253,6 +253,7 @@ namespace Xamarin.Forms
 
 		void OnFormattedTextChanged(object sender, PropertyChangedEventArgs e)
 		{
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 			OnPropertyChanged("FormattedText");
 		}
 


### PR DESCRIPTION
### Description of Change ###

Changes in `FormattedText` such as `FormattedText.Spans.Add` can change the length of text and the measure of `Label`. This commit assures that `Label` properly apply the change.

### Bugs Fixed ###

- Sorry but I have not opened an issue.

### API Changes ###

Nothing.

### Behavioral Changes ###

Nothing.

### PR Checklist ###

- [*] Has tests (if omitted, state reason in description)
- [*] Rebased on top of master at time of PR
- [*] Changes adhere to coding standard
- [*] Consolidate commits as makes sense

