### PR TITLE
[WinRT] Remove preemptive setting of null upon action sheet closure

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -643,7 +643,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			list.ItemClick += (s, e) =>
 			{
 				_currentActionSheet.IsOpen = false;
-				_currentActionSheet = null;
 				options.SetResult((string)e.ClickedItem);
 			};
 


### PR DESCRIPTION
### Description of Change ###

Rapidly double-clicking an item in an action sheet twice under WinRT could cause an NRE due to the `_currentActionSheet` value being set to null right away within the `ItemClick` event handler. The value is set to null in the `CancelActionSheet` method which ultimately gets called via the `Closed` event, so it should be safe to remove the earlier null to prevent this potential crash.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=43328

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

