### PR TITLE
[iOS] Fixed bug that made pull-to-refresh indicator always visible after 2+ pulls

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43214.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43214.cs
@@ -1,0 +1,52 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43214, "Setting Listview.IsRefreshing to false does not work on second \"pull\"")]
+	public class Bugzilla43214 : TestContentPage
+	{
+		public class MyViewModel : ViewModel
+		{
+			bool _isBusy;
+
+			public bool IsBusy
+			{
+				get { return _isBusy; }
+				set
+				{
+					_isBusy = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		protected override void Init()
+		{
+			var vm = new MyViewModel();
+
+			var label = new Label { Text = "Pull list to refresh once, then pull to refresh again. If the indicator does not disappear, this test has failed." };
+			var listview = new ListView
+			{
+				ItemsSource = Enumerable.Range(0, 20),
+				IsPullToRefreshEnabled = true,
+				RefreshCommand = new Command(async () =>
+				{
+					vm.IsBusy = true;
+					await Task.Delay(1000);
+					vm.IsBusy = false;
+				})
+			};
+
+			listview.SetBinding(ListView.IsRefreshingProperty, nameof(MyViewModel.IsBusy));
+
+			var stacklayout = new StackLayout { Children = { label, listview }, BindingContext = vm };
+
+			Content = stacklayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -173,6 +173,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42277.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ImageLoadingErrorHandling.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33561.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1016,7 +1016,6 @@ namespace Xamarin.Forms.Platform.iOS
 		readonly ListView _list;
 		IListViewController Controller => _list;
 		UIRefreshControl _refresh;
-		bool _refreshingEventSent;
 
 		bool _refreshAdded;
 
@@ -1124,13 +1123,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnRefreshingChanged(object sender, EventArgs eventArgs)
 		{
-			if (_refresh.Refreshing && !_refreshingEventSent)
-			{
+			if (_refresh.Refreshing)
 				Controller.SendRefreshing();
-				_refreshingEventSent = true;
-			}
-			else if (!_refresh.Refreshing)
-				_refreshingEventSent = false;
 		}
 
 		void RemoveRefresh()


### PR DESCRIPTION
### Description of Change ###

No longer trying to prevent unnecessary calling of `SendRefreshing()`.

### Bugs Fixed ###

- [Bug 43214 - Setting Listview.IsRefreshing to false does not work on second "pull"] (https://bugzilla.xamarin.com/show_bug.cgi?id=43214)

### API Changes ###

None

### Behavioral Changes ###

iOS ListView may fire SendRefreshing more than once when navigating between tabs or pages.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
