### PR TITLE
[C] Prevent enabling a Button via setting a Command

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43354.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43354.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43354, "Button command being set after IsEnabled enables the button", PlatformAffected.All)]
+	public class Bugzilla43354 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var buttonIsEnabledSetFirst = new Button
+			{
+				Text = "Click to display an alert",
+				IsEnabled = false,
+				Command = new Command(() => DisplayAlert("Test", "Message", "Cancel")),
+			};
+
+			var buttonIsEnabledSetSecond = new Button
+			{
+				Text = "Click to enable/disable button",
+				Command = new Command(() =>
+				{
+					if (buttonIsEnabledSetFirst.IsEnabled)
+						buttonIsEnabledSetFirst.IsEnabled = false;
+					else
+						buttonIsEnabledSetFirst.IsEnabled = true;
+				})
+			};
+
+			var buttonSetCommandToNull = new Button
+			{
+				Text = "Click to set first button's command to null",
+				Command = new Command(() => buttonIsEnabledSetFirst.Command = null)
+			};
+
+			Content = Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+						buttonIsEnabledSetFirst,
+						buttonIsEnabledSetSecond,
+						buttonSetCommandToNull
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -124,6 +124,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42364.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43354.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -180,7 +180,7 @@ namespace Xamarin.Forms
 		void CommandCanExecuteChanged(object sender, EventArgs eventArgs)
 		{
 			ICommand cmd = Command;
-			if (cmd != null)
+			if (cmd != null && IsEnabled)
 				IsEnabledCore = cmd.CanExecute(CommandParameter);
 		}
 
@@ -225,8 +225,6 @@ namespace Xamarin.Forms
 				Command.CanExecuteChanged += CommandCanExecuteChanged;
 				CommandCanExecuteChanged(this, EventArgs.Empty);
 			}
-			else
-				IsEnabledCore = true;
 		}
 
 		void OnSourceChanged(object sender, EventArgs eventArgs)


### PR DESCRIPTION
### Description of Change ###

When creating a `Button` it was possible to unintentionally re-enable it by either:

* Setting `IsEnabled` before `Command` in the constructor/assignment sequence
* Setting the `Command` value to null at another point in time (assuming the above did not occur) 

A visual reproduction has been added to the issues.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=43354

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

