### PR TITLE
[Android] Fix NRE When Scrolling ListView and Item With Context Actions Is Selected

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42832.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42832.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 42832, "Scrolling a ListView with active ContextAction Items causes NRE", PlatformAffected.Android)]
+    public class Bugzilla42832 : TestContentPage
+	{
+        ListView listview;
+
+        protected override void Init()
+        {
+            var items = new List<string>();
+            for(int i=0; i<20; i++)
+                items.Add($"Item #{i}");
+
+            var template = new DataTemplate(typeof(TestCell));
+            template.SetBinding(TextCell.TextProperty, ".");
+
+            listview = new ListView(ListViewCachingStrategy.RetainElement)
+            {
+                AutomationId = "mainList",
+                ItemsSource = items,
+                ItemTemplate = template
+            };
+
+            Content = listview;
+        }
+
+        [Preserve(AllMembers = true)]
+        public class TestCell : TextCell
+        {
+            public TestCell()
+            {
+                var menuItem = new MenuItem { Text = "Test Item" };
+                ContextActions.Add(menuItem);
+            }
+        }
+
+#if UITEST
+        [Test]
+        public void ContextActionsScrollNRE()
+        {
+            // mark is an icon on android
+            RunningApp.TouchAndHold(q => q.Marked("Item #0"));
+            RunningApp.WaitForElement(q => q.Marked("Test Item"));
+
+            int counter = 0;
+            while(counter < 5)
+            {
+                RunningApp.ScrollDownTo("Item #15", "mainList", ScrollStrategy.Gesture, timeout:TimeSpan.FromMinutes(1));
+                RunningApp.ScrollUpTo("Item #0", "mainList", ScrollStrategy.Gesture, timeout: TimeSpan.FromMinutes(1));
+                counter++;
+            }
+
+            RunningApp.Screenshot("If the app did not crash, then the test has passed.");
+        }
+#endif
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -128,6 +128,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -210,13 +210,6 @@ namespace Xamarin.Forms.Platform.Android
 				}
 				cell = (Cell)boxedCell.Element;
 
-				if (ActionModeContext == cell)
-				{
-					// This appears to never happen, the theory is android keeps all views alive that are currently selected for long-press (preventing them from being recycled).
-					// This is convenient since we wont have to worry about the user scrolling the cell offscreen and us losing our context actions.
-					ActionModeContext = null;
-					ContextView = null;
-				}
 				// We are going to re-set the Platform here because in some cases (headers mostly) its possible this is unset and
 				// when the binding context gets updated the measure passes will all fail. By applying this here the Update call
 				// further down will result in correct layouts.


### PR DESCRIPTION
### Description of Change ###

This fixes an NRE that was being thrown when scrolling the ListView when an item with context actions was selected. It turns out this bit of code was being called after all contrary to the original comment.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=42832

### API Changes ###

None

### Behavioral Changes ###

Doesn't appear to be any. Removing the code doesn't seem to affect the cell rendering.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

