### PR TITLE
Fix memory leaks caused by BaseCellView and RendererHolder

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35132.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35132.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 35132, "Pages are not collected when using a Navigationpage (FormsApplicationActivity)")]
+	public class Bugzilla35132 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new RootPage());
+		}
+
+		[Preserve(AllMembers = true)]
+		public class BugPage : ContentPage
+		{
+			public static int Livecount;
+
+			public BugPage(IEnumerable<string> items)
+			{
+				Interlocked.Increment(ref Livecount);
+
+				Content = new StackLayout
+				{
+					Children =
+					{
+						new Label { Text = items.Count() < 3 ? "Running" : Livecount < 3 ? "Success" : "Failure" },
+						new ListView { ItemsSource = items }
+					}
+				};
+			}
+
+			~BugPage()
+			{
+				Debug.WriteLine(">>>>>>>> BugPage Finalized");
+				Interlocked.Decrement(ref Livecount);
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class RootPage : ContentPage
+		{
+			readonly List<string> _items = new List<string>();
+
+			public RootPage()
+			{
+				var button = new Button { Text = "Open" };
+				button.Clicked += Button_Clicked;
+				Content = button;
+			}
+
+			async void Button_Clicked(object sender, EventArgs e)
+			{
+				Debug.WriteLine(">>>>>>>> Invoking Garbage Collector");
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+
+				_items.Add((BugPage.Livecount).ToString());
+				await Navigation.PushAsync(new BugPage(_items));
+			}
+		}
+
+#if UITEST 
+		[Test]
+		public void Issue1Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked ("Open"));
+			RunningApp.Tap(q => q.Marked ("Open"));
+			RunningApp.Back();
+			RunningApp.WaitForElement (q => q.Marked ("Open"));
+			RunningApp.Tap(q => q.Marked ("Open"));
+			RunningApp.Back();
+			RunningApp.WaitForElement (q => q.Marked ("Open"));
+			RunningApp.Tap(q => q.Marked ("Open"));
+			RunningApp.WaitForElement (q => q.Marked ("Success"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34007.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35127.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35132.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35157.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35294.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35472.cs" />

--- a/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.Android
 		public const double DefaultMinHeight = 44;
 
 		readonly Color _androidDefaultTextColor;
-		readonly Cell _cell;
+		Cell _cell;
 		readonly TextView _detailText;
 		readonly ImageView _imageView;
 		readonly TextView _mainText;
@@ -177,6 +177,12 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			height = Context.ToPixels(height);
 			LayoutParameters = new LayoutParams(ViewGroup.LayoutParams.MatchParent, (int)(height == -1 ? ViewGroup.LayoutParams.WrapContent : height));
+		}
+
+		protected override void OnDetachedFromWindow()
+		{
+			base.OnDetachedFromWindow();
+			_cell = null;
 		}
 
 		async void UpdateBitmap(ImageSource source, ImageSource previousSource = null)


### PR DESCRIPTION
### Description of Change ###

Fixes an Android memory leak caused by BaseCellView holding a reference to a Xamarin.Forms.Cell and another caused by a strong reference (via RendererHolder) between native views and CellRenderers.

### Bugs Fixed ###

- [35132 – Pages are not collected when using a Navigationpage](https://bugzilla.xamarin.com/show_bug.cgi?id=35132)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

