### PR TITLE
Fix for ListView BindingContext for Header/Footer

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ListViewTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ListViewTests.cs
@@ -87,6 +87,24 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		[Description("Setting BindingContext should trickle down to Header and Footer.")]
+		public void SettingBindingContextPassesToHeaderAndFooter()
+		{
+			var bc = new object();
+			var header = new BoxView();
+			var footer = new BoxView();
+			var listView = new ListView
+			{
+				Header = header,
+				Footer = footer,
+				BindingContext = bc,
+			};
+
+			Assert.That(header.BindingContext, Is.SameAs(bc));
+			Assert.That(footer.BindingContext, Is.SameAs(bc));
+		}
+
+		[Test]
 		[Description ("Setting GroupDisplayBinding or GroupHeaderTemplate when the other is set should set the other one to null.")]
 		public void SettingGroupHeaderTemplateSetsDisplayBindingToNull()
 		{

--- a/Xamarin.Forms.Core.UnitTests/ListViewTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ListViewTests.cs
@@ -105,6 +105,25 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		[Description("Setting Header and Footer should pass BindingContext.")]
+		public void SettingHeaderFooterPassesBindingContext()
+		{
+			var bc = new object();
+			var listView = new ListView
+			{
+				BindingContext = bc,
+			};
+
+			var header = new BoxView();
+			var footer = new BoxView();
+			listView.Footer = footer;
+			listView.Header = header;
+
+			Assert.That(header.BindingContext, Is.SameAs(bc));
+			Assert.That(footer.BindingContext, Is.SameAs(bc));
+		}
+
+		[Test]
 		[Description ("Setting GroupDisplayBinding or GroupHeaderTemplate when the other is set should set the other one to null.")]
 		public void SettingGroupHeaderTemplateSetsDisplayBindingToNull()
 		{

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -84,6 +84,25 @@ namespace Xamarin.Forms
 			set { SetValue(FooterTemplateProperty, value); }
 		}
 
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+
+			object bc = BindingContext;
+
+			var header = Header as Element;
+			if (header != null)
+			{
+				SetChildInheritedBindingContext(header, bc);
+			}
+
+			var footer = Footer as Element;
+			if (footer != null)
+			{
+				SetChildInheritedBindingContext(footer, bc);
+			}
+		}
+
 		public BindingBase GroupDisplayBinding
 		{
 			get { return _groupDisplayBinding; }


### PR DESCRIPTION
### Description of Change ###

In many places we use the same `BindingContext` for an entire page/view. One pain point, was that the `Header` and `Footer` of a `ListView` didn't get it's `BindingContext` passed down like the rest of the views on a page. 

Hopefully, this is not a design decision for `ListView` as it was an easy fix. It does not look like the change will cause much of a performance impact. There may be other views like `ListView` missing this same functionality, but I haven't ran into them yet.

### Bugs Fixed ###

- See unit test reproducing the issue.

### API Changes ###

None

### Behavioral Changes ###

When setting the `BindingContext` of a `ListView` the `Header` and `Footer` will also receive the same `BindingContext`.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
