### PR TITLE
[A] PanGestureRecognizer will consistently send Completed event

### DIFF
--- a/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
+++ b/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
@@ -38,10 +38,16 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		// This is needed because GestureRecognizer callbacks can be delayed several hundred milliseconds
-		// which can result in the need to resurect this object if it has already been disposed. We dispose
+		// which can result in the need to resurrect this object if it has already been disposed. We dispose
 		// eagerly to allow easier garbage collection of the renderer
 		internal InnerGestureListener(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
 		{
+		}
+
+		internal void OnTouchEvent(MotionEvent e)
+		{
+			if (e.Action == MotionEventActions.Up)
+				EndScrolling();
 		}
 
 		bool GestureDetector.IOnDoubleTapListener.OnDoubleTap(MotionEvent e)

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -98,6 +98,9 @@ namespace Xamarin.Forms.Platform.Android
 					ScaleGestureDetectorCompat.SetQuickScaleEnabled(_scaleDetector.Value, true);
 				handled = _scaleDetector.Value.OnTouchEvent(e);
 			}
+
+			_gestureListener?.OnTouchEvent(e);
+
 			return _gestureDetector.Value.OnTouchEvent(e) || handled;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Now sending the Completed event for Pan on Up event.

### Bugs Fixed ###

- [Bug 39768  - PanGestureRecognizer sometimes won't fire completed event when dragging very slowly] (https://bugzilla.xamarin.com/show_bug.cgi?id=39768)

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - Android: `internal void InnerGestureListener.OnTouchEvent(MotionEvent e)`

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
