### PR TITLE
Fix regression by adding null check in Windows ListView selection

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -538,7 +538,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			// This is used for respecting ListView selection changes via keyboard, as the SelectedItem
 			// value is otherwise not set.
-			if (Element.SelectedItem != List.SelectedItem)
+			if (Element.SelectedItem != null && Element.SelectedItem != List.SelectedItem)
 			{
 				((IElementController)Element).SetValueFromRenderer(ListView.SelectedItemProperty, List.SelectedItem);
 			}


### PR DESCRIPTION
### Description of Change ###

Fix a regression due to a prior change (#182) which could cause a crash due to `Element.SelectedItem` being null prior to actually selecting an item in a ListView (and then using the keyboard to select items). Adding a null check prevents this from occurring until the ListView has actually had something initially selected.

### Bugs Fixed ###

N/A

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

