### PR TITLE
Keys/ContainsKey/Values implementation with MergedDictionary

### DIFF
--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms
 
 		public bool ContainsKey(string key)
 		{
-			return _innerDictionary.ContainsKey(key);
+			return _innerDictionary.ContainsKey(key) || (_mergedInstance != null && _mergedInstance.ContainsKey(key));
 		}
 
 		[IndexerName("Item")]
@@ -109,7 +109,20 @@ namespace Xamarin.Forms
 
 		public ICollection<string> Keys
 		{
-			get { return _innerDictionary.Keys; }
+			get
+            {
+                ICollection<string> result = new List<string>(_innerDictionary.Keys);
+
+                if (_mergedInstance != null)
+                {
+                    foreach (string keysNot in _mergedInstance.Keys.Where((key) => !_innerDictionary.ContainsKey(key)))
+                    {
+                        result.Add(keysNot);
+                    } 
+                }
+
+                return result;
+            }
 		}
 
 		public bool Remove(string key)
@@ -119,7 +132,20 @@ namespace Xamarin.Forms
 
 		public ICollection<object> Values
 		{
-			get { return _innerDictionary.Values; }
+			get
+            {
+                ICollection<object> result = new List<object>(_innerDictionary.Values);
+
+                if (_mergedInstance != null)
+                {
+                    foreach (string keysNot in _mergedInstance.Keys.Where((key) => !_innerDictionary.ContainsKey(key)))
+                    {
+                        result.Add(_mergedInstance[keysNot]);
+                    }
+                }
+
+                return result;
+            }
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
older implementation of these methods did not take into account the
_mergedInstance attribute, so the values returned did not reflect the
real dictionaries within.
