### PR TITLE
Added support for all languages that have a registered CodeDomProvider

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -14,8 +14,6 @@ namespace Xamarin.Forms.Build.Tasks
 {
 	public class XamlGTask : Task
 	{
-		internal static CodeDomProvider Provider = new CSharpCodeProvider();
-
 		[Required]
 		public string Source { get; set; }
 
@@ -41,7 +39,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 			try
 			{
-				GenerateFile(Source, OutputFile);
+				GenerateFile(Source, OutputFile, Language);
 				return true;
 			}
 			catch (XmlException xe)
@@ -101,7 +99,7 @@ namespace Xamarin.Forms.Build.Tasks
 		}
 
 		internal static void GenerateCode(string rootType, string rootNs, CodeTypeReference baseType,
-			IDictionary<string, CodeTypeReference> namesAndTypes, string outFile)
+			IDictionary<string, CodeTypeReference> namesAndTypes, string outFile, string language)
 		{
 			if (rootType == null)
 			{
@@ -172,17 +170,20 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 
 			using (var writer = new StreamWriter(outFile))
-				Provider.GenerateCodeFromCompileUnit(ccu, writer, new CodeGeneratorOptions());
+			{
+				using (var provider = CodeDomProvider.CreateProvider(language ?? "C#"))
+					provider.GenerateCodeFromCompileUnit(ccu, writer, new CodeGeneratorOptions());
+			}
 		}
 
-		internal static void GenerateFile(string xamlFile, string outFile)
+		internal static void GenerateFile(string xamlFile, string outFile, string language)
 		{
 			string rootType, rootNs;
 			CodeTypeReference baseType;
 			IDictionary<string, CodeTypeReference> namesAndTypes;
 			using (StreamReader reader = File.OpenText(xamlFile))
 				ParseXaml(reader, out rootType, out rootNs, out baseType, out namesAndTypes);
-			GenerateCode(rootType, rootNs, baseType, namesAndTypes, outFile);
+			GenerateCode(rootType, rootNs, baseType, namesAndTypes, outFile, language);
 		}
 
 		static Dictionary<string, CodeTypeReference> GetNamesAndTypes(XmlNode root, XmlNamespaceManager nsmgr)

--- a/Xamarin.Forms.Xaml.Xamlg/Xamlg.cs
+++ b/Xamarin.Forms.Xaml.Xamlg/Xamlg.cs
@@ -39,8 +39,9 @@ namespace Xamarin.Forms.Xaml
 	public class Xamlg
 	{
 		static readonly string HelpString = "xamlg.exe - a utility for generating partial classes from XAML.\n" +
-		                                    "xamlg.exe xamlfile[,outputfile]...\n\n" +
-		                                    "If an outputfile is not specified one will be created using the format <xamlfile>.g.cs\n\n";
+											"xamlg.exe xamlfile[,outputfile][,language]...\n\n" +
+											"If an outputfile is not specified one will be created using the format <xamlfile>.g.cs\n\n" +
+											"If a language is specified the output file will be generated with that CodeDomProvider\n\n";
 
 		public static void Main(string[] args)
 		{
@@ -70,17 +71,25 @@ namespace Xamarin.Forms.Xaml
 			{
 				var f = file;
 				var n = "";
-
+				var language = "C#";
 				var sub = file.IndexOf(",", StringComparison.InvariantCulture);
 				if (sub > 0)
 				{
-					n = f.Substring(sub + 1);
+					var subLang = file.IndexOf(',', sub + 1);
+					if (subLang > 0)
+					{
+						n = f.Substring(sub + 1, subLang - sub - 1);
+						language = f.Substring(subLang + 1);
+					}
+					else
+						n = f.Substring(sub + 1);
+
 					f = f.Substring(0, sub);
 				}
 				else
-					n = string.Concat(Path.GetFileName(f), ".g.", XamlGTask.Provider.FileExtension);
+					n = string.Concat(Path.GetFileName(f), ".g.cs");
 
-				XamlGTask.GenerateFile(f, n);
+				XamlGTask.GenerateFile(f, n, language);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

I've based the created codedomprovider on the language property of the build task instead of hard coding it to only work for C#.

### API Changes ###

one more optional parameter for xamlg.exe to take the requested language.

