### PR TITLE
[Android] Fix TabbedPage crash when ItemsSource is set to null

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -190,7 +190,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			base.OnElementPropertyChanged(sender, e);
 
 			if (e.PropertyName == nameof(TabbedPage.CurrentPage))
-				ScrollToCurrentPage();
+				if(Element.CurrentPage != null)
+					ScrollToCurrentPage();
 			else if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor();
 			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName)


### PR DESCRIPTION
### Description of Change ###

When ItemsSource is set to null, CurrentPage also becomes null. This fix adds a check in TabbedPageRenderer on Android to prevent trying to scroll to a null CurrentPage and crashing.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=43726

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

