### PR TITLE
Add a CheckBox.

### DIFF
--- a/Stubs/Xamarin.Forms.Platform.cs
+++ b/Stubs/Xamarin.Forms.Platform.cs
@@ -44,7 +44,10 @@ namespace Xamarin.Forms.Platform
 	[RenderWith (typeof (ButtonRenderer))]
 	internal class _ButtonRenderer { }
 
-	[RenderWith (typeof (TableViewRenderer))]
+    [RenderWith(typeof(CheckBoxRenderer))]
+    internal class _CheckBoxRenderer { }
+
+    [RenderWith (typeof (TableViewRenderer))]
 	internal class _TableViewRenderer { }
 
 	[RenderWith (typeof (ListViewRenderer))]

--- a/Xamarin.Forms.Core/CheckBox.cs
+++ b/Xamarin.Forms.Core/CheckBox.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Windows.Input;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Platform;
+
+namespace Xamarin.Forms
+{
+    [RenderWith(typeof(_CheckBoxRenderer))]
+    public class CheckBox : View, IFontElement
+    {
+        public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(CheckBox), null,
+            propertyChanged: (bindable, oldVal, newVal) => ((CheckBox)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
+
+        public static readonly BindableProperty TextColorProperty = BindableProperty.Create("TextColor", typeof(Color), typeof(CheckBox), Color.Default);
+
+        public static readonly BindableProperty FontProperty = BindableProperty.Create("Font", typeof(Font), typeof(CheckBox), default(Font), propertyChanged: FontStructPropertyChanged);
+
+        public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create("FontFamily", typeof(string), typeof(CheckBox), default(string), propertyChanged: SpecificFontPropertyChanged);
+
+        public static readonly BindableProperty FontSizeProperty = BindableProperty.Create("FontSize", typeof(double), typeof(CheckBox), -1.0, propertyChanged: SpecificFontPropertyChanged,
+            defaultValueCreator: bindable => Device.GetNamedSize(NamedSize.Default, (CheckBox)bindable));
+
+        public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(CheckBox), FontAttributes.None,
+            propertyChanged: SpecificFontPropertyChanged);
+
+        public static readonly BindableProperty IsCheckedProperty = BindableProperty.Create("IsChecked", typeof(bool), typeof(CheckBox), default(bool), propertyChanged: OnCheckedChanged, defaultBindingMode: BindingMode.TwoWay);
+
+        bool _cancelEvents;
+
+        public Font Font
+        {
+            get { return (Font)GetValue(FontProperty); }
+            set { SetValue(FontProperty, value); }
+        }
+
+        public string Text
+        {
+            get { return (string)GetValue(TextProperty); }
+            set { SetValue(TextProperty, value); }
+        }
+
+        public Color TextColor
+        {
+            get { return (Color)GetValue(TextColorProperty); }
+            set { SetValue(TextColorProperty, value); }
+        }
+
+        bool IsEnabledCore
+        {
+            set { SetValueCore(IsEnabledProperty, value); }
+        }
+
+        public FontAttributes FontAttributes
+        {
+            get { return (FontAttributes)GetValue(FontAttributesProperty); }
+            set { SetValue(FontAttributesProperty, value); }
+        }
+
+        public string FontFamily
+        {
+            get { return (string)GetValue(FontFamilyProperty); }
+            set { SetValue(FontFamilyProperty, value); }
+        }
+
+        public bool IsChecked
+        {
+            get { return (bool)GetValue(IsCheckedProperty); }
+            set { SetValue(IsCheckedProperty, value); }
+        }
+
+        [TypeConverter(typeof(FontSizeConverter))]
+        public double FontSize
+        {
+            get { return (double)GetValue(FontSizeProperty); }
+            set { SetValue(FontSizeProperty, value); }
+        }
+
+        public event EventHandler<CheckedEventArgs> Checked;
+
+        static void OnCheckedChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            ((CheckBox)bindable).Checked?.Invoke(bindable, new CheckedEventArgs((bool)newValue));
+        }
+
+        static void FontStructPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var checkBox = (CheckBox)bindable;
+
+            if (checkBox._cancelEvents)
+                return;
+
+            checkBox.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+
+            checkBox._cancelEvents = true;
+
+            if (checkBox.Font == Font.Default)
+            {
+                checkBox.FontFamily = null;
+                checkBox.FontSize = Device.GetNamedSize(NamedSize.Default, checkBox);
+                checkBox.FontAttributes = FontAttributes.None;
+            }
+            else
+            {
+                checkBox.FontFamily = checkBox.Font.FontFamily;
+                if (checkBox.Font.UseNamedSize)
+                {
+                    checkBox.FontSize = Device.GetNamedSize(checkBox.Font.NamedSize, checkBox.GetType(), true);
+                }
+                else
+                {
+                    checkBox.FontSize = checkBox.Font.FontSize;
+                }
+                checkBox.FontAttributes = checkBox.Font.FontAttributes;
+            }
+
+            checkBox._cancelEvents = false;
+        }
+
+        static void SpecificFontPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var checkBox = (CheckBox)bindable;
+
+            if (checkBox._cancelEvents)
+                return;
+
+            checkBox.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+
+            checkBox._cancelEvents = true;
+
+            if (checkBox.FontFamily != null)
+            {
+                checkBox.Font = Font.OfSize(checkBox.FontFamily, checkBox.FontSize).WithAttributes(checkBox.FontAttributes);
+            }
+            else
+            {
+                checkBox.Font = Font.SystemFontOfSize(checkBox.FontSize, checkBox.FontAttributes);
+            }
+
+            checkBox._cancelEvents = false;
+        }
+    }
+}

--- a/Xamarin.Forms.Core/CheckedEventArgs.cs
+++ b/Xamarin.Forms.Core/CheckedEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+    public class CheckedEventArgs : EventArgs
+    {
+        public CheckedEventArgs(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Value { get; private set; }
+    }
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -69,6 +69,8 @@
     <Compile Include="Cells\ImageCell.cs" />
     <Compile Include="Cells\INativeElementView.cs" />
     <Compile Include="ChatKeyboard.cs" />
+    <Compile Include="CheckBox.cs" />
+    <Compile Include="CheckedEventArgs.cs" />
     <Compile Include="ChildCollectionChangedEventArgs.cs" />
     <Compile Include="CollectionSynchronizationCallback.cs" />
     <Compile Include="CollectionSynchronizationContext.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/CheckBoxDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CheckBoxDrawable.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using Android.Graphics;
+using Android.Graphics.Drawables;
+
+namespace Xamarin.Forms.Platform.Android
+{
+    internal class CheckBoxDrawable : Drawable
+    {
+        bool _isDisposed;
+        Bitmap _normalBitmap;
+        bool _pressed;
+        Bitmap _pressedBitmap;
+        double defaultBorderWidth = 0d;
+        int defaultBorderRadius = 5;
+
+        public CheckBoxDrawable()
+        {
+            _pressed = false;
+        }
+
+        public CheckBox CheckBox { get; set; }
+
+        public override bool IsStateful
+        {
+            get { return true; }
+        }
+
+        public override int Opacity
+        {
+            get { return 0; }
+        }
+
+        public override void Draw(Canvas canvas)
+        {
+            int width = Bounds.Width();
+            int height = Bounds.Height();
+
+            if (width <= 0 || height <= 0)
+                return;
+
+            if (_normalBitmap == null || _normalBitmap.Height != height || _normalBitmap.Width != width)
+            {
+                Reset();
+
+                _normalBitmap = CreateBitmap(false, width, height);
+                _pressedBitmap = CreateBitmap(true, width, height);
+            }
+
+            Bitmap bitmap = GetState().Contains(global::Android.Resource.Attribute.StatePressed) ? _pressedBitmap : _normalBitmap;
+            canvas.DrawBitmap(bitmap, 0, 0, new Paint());
+        }
+
+        public void Reset()
+        {
+            if (_normalBitmap != null)
+            {
+                _normalBitmap.Recycle();
+                _normalBitmap.Dispose();
+                _normalBitmap = null;
+            }
+
+            if (_pressedBitmap != null)
+            {
+                _pressedBitmap.Recycle();
+                _pressedBitmap.Dispose();
+                _pressedBitmap = null;
+            }
+        }
+
+        public override void SetAlpha(int alpha)
+        {
+        }
+
+        public override void SetColorFilter(ColorFilter cf)
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
+
+            if (disposing)
+                Reset();
+
+            base.Dispose(disposing);
+        }
+
+        protected override bool OnStateChange(int[] state)
+        {
+            bool old = _pressed;
+            _pressed = state.Contains(global::Android.Resource.Attribute.StatePressed);
+            if (_pressed != old)
+            {
+                InvalidateSelf();
+                return true;
+            }
+            return false;
+        }
+
+        Bitmap CreateBitmap(bool pressed, int width, int height)
+        {
+            Bitmap bitmap = Bitmap.CreateBitmap(width, height, Bitmap.Config.Argb8888);
+            using (var canvas = new Canvas(bitmap))
+            {
+                DrawBackground(canvas, width, height, pressed);
+                DrawOutline(canvas, width, height);
+            }
+
+            return bitmap;
+        }
+
+        void DrawBackground(Canvas canvas, int width, int height, bool pressed)
+        {
+            var paint = new Paint { AntiAlias = true };
+            var path = new Path();
+
+            float borderRadius = Forms.Context.ToPixels(defaultBorderRadius);
+
+            path.AddRoundRect(new RectF(0, 0, width, height), borderRadius, borderRadius, Path.Direction.Cw);
+
+            paint.Color = pressed ? CheckBox.BackgroundColor.AddLuminosity(-0.1).ToAndroid() : CheckBox.BackgroundColor.ToAndroid();
+            paint.SetStyle(Paint.Style.Fill);
+            canvas.DrawPath(path, paint);
+        }
+
+        void DrawOutline(Canvas canvas, int width, int height)
+        {
+            if (defaultBorderWidth <= 0)
+                return;
+
+            using (var paint = new Paint { AntiAlias = true })
+            using (var path = new Path())
+            {
+                float borderWidth = Forms.Context.ToPixels(defaultBorderWidth);
+                float inset = borderWidth / 2;
+
+                // adjust border radius so outer edge of stroke is same radius as border radius of background
+                float borderRadius = Forms.Context.ToPixels(defaultBorderRadius) - inset;
+
+                path.AddRoundRect(new RectF(inset, inset, width - inset, height - inset), borderRadius, borderRadius, Path.Direction.Cw);
+                paint.StrokeWidth = borderWidth;
+                paint.SetStyle(Paint.Style.Stroke);
+                paint.Color = Color.Default.ToAndroid();
+
+                canvas.DrawPath(path, paint);
+            }
+        }
+    }
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/CheckBoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CheckBoxRenderer.cs
@@ -1,0 +1,206 @@
+using System;
+using System.ComponentModel;
+using Android.Content.Res;
+using Android.Graphics;
+using Android.Graphics.Drawables;
+using Android.Util;
+using Android.Widget;
+using static System.String;
+using ACheckBox = Android.Widget.CheckBox;
+using Object = Java.Lang.Object;
+
+namespace Xamarin.Forms.Platform.Android
+{
+    public class CheckBoxRenderer : ViewRenderer<CheckBox, ACheckBox>, CompoundButton.IOnCheckedChangeListener
+    {
+        CheckBoxDrawable _backgroundDrawable;
+        TextColorSwitcher _textColorSwitcher;
+        Drawable _defaultDrawable;
+        float _defaultFontSize;
+        Typeface _defaultTypeface;
+        bool _drawableEnabled;
+        bool _isDisposed;
+
+        public CheckBoxRenderer()
+        {
+            AutoPackage = false;
+        }
+
+        ACheckBox NativeCheckBox
+        {
+            get { return Control; }
+        }
+
+        public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
+        {
+            UpdateText();
+            return base.GetDesiredSize(widthConstraint, heightConstraint);
+        }
+
+        protected override void OnLayout(bool changed, int l, int t, int r, int b)
+        {
+            base.OnLayout(changed, l, t, r, b);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
+
+            if (disposing)
+            {
+                if (_backgroundDrawable != null)
+                {
+                    _backgroundDrawable.Dispose();
+                    _backgroundDrawable = null;
+                }
+                
+            }
+            base.Dispose(disposing);
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<CheckBox> e)
+        {
+            base.OnElementChanged(e);
+
+            if (e.OldElement == null)
+            {
+                ACheckBox checkBox = Control;
+                if (checkBox == null)
+                {
+                    checkBox = new ACheckBox(Context);
+                    checkBox.Tag = this;
+                    SetNativeControl(checkBox);
+                    _textColorSwitcher = new TextColorSwitcher(checkBox.TextColors);
+                    checkBox.SetOnCheckedChangeListener(this);
+                }
+            }
+            else
+            {
+                if (_drawableEnabled)
+                {
+                    _drawableEnabled = false;
+                    _backgroundDrawable.Reset();
+                    _backgroundDrawable = null;
+                }
+            }
+            UpdateAll();
+        }
+
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == CheckBox.TextProperty.PropertyName)
+                UpdateText();
+            else if (e.PropertyName == CheckBox.TextColorProperty.PropertyName)
+                UpdateTextColor();
+            else if (e.PropertyName == CheckBox.FontProperty.PropertyName)
+                UpdateFont();
+            else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+                UpdateEnabled();
+            else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
+                UpdateDrawable();
+            else if (e.PropertyName == VisualElement.IsVisibleProperty.PropertyName)
+                UpdateText();
+
+            if (_drawableEnabled && (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName))
+            {
+               _backgroundDrawable.Reset();
+                Control.Invalidate();
+            }
+
+            base.OnElementPropertyChanged(sender, e);
+        }
+
+        protected override void UpdateBackgroundColor()
+        {
+            // Do nothing, the drawable handles this now
+        }
+
+        void UpdateAll()
+        {
+            UpdateFont();
+            UpdateText();
+            UpdateTextColor();
+            UpdateEnabled();
+            UpdateDrawable();
+        }
+
+        void UpdateDrawable()
+        {
+            if (Element.BackgroundColor == Color.Default)
+            {
+                if (!_drawableEnabled)
+                    return;
+
+                if (_defaultDrawable != null)
+                    Control.SetBackground(_defaultDrawable);
+
+                _drawableEnabled = false;
+            }
+            else
+            {
+                if (_backgroundDrawable == null)
+                    _backgroundDrawable = new CheckBoxDrawable();
+
+                _backgroundDrawable.CheckBox = Element;
+
+                if (_drawableEnabled)
+                    return;
+
+                if (_defaultDrawable == null)
+                    _defaultDrawable = Control.Background;
+
+                Control.SetBackground(_backgroundDrawable);
+                _drawableEnabled = true;
+            }
+            Control.Invalidate();
+        }
+
+        void UpdateEnabled()
+        {
+            Control.Enabled = Element.IsEnabled;
+        }
+
+        void UpdateFont()
+        {
+            CheckBox checkbox = Element;
+            if (checkbox.Font == Font.Default && _defaultFontSize == 0f)
+                return;
+
+            if (_defaultFontSize == 0f)
+            {
+                _defaultTypeface = NativeCheckBox.Typeface;
+                _defaultFontSize = NativeCheckBox.TextSize;
+            }
+
+            if (checkbox.Font == Font.Default)
+            {
+                NativeCheckBox.Typeface = _defaultTypeface;
+                NativeCheckBox.SetTextSize(ComplexUnitType.Px, _defaultFontSize);
+            }
+            else
+            {
+                NativeCheckBox.Typeface = checkbox.Font.ToTypeface();
+                NativeCheckBox.SetTextSize(ComplexUnitType.Sp, checkbox.Font.ToScaledPixel());
+            }
+        }
+
+        void UpdateText()
+        {
+            var oldText = NativeCheckBox.Text;
+            NativeCheckBox.Text = Element.Text;
+        }
+
+        void UpdateTextColor()
+        {
+            _textColorSwitcher?.UpdateTextColor(Control, Element.TextColor);
+        }
+
+        void CompoundButton.IOnCheckedChangeListener.OnCheckedChanged(CompoundButton buttonView, bool isChecked)
+        {
+            ((IViewController)Element).SetValueFromRenderer(CheckBox.IsCheckedProperty, isChecked);
+        }
+    }
+}

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -154,6 +154,8 @@
     <Compile Include="Renderers\ButtonDrawable.cs" />
     <Compile Include="Renderers\AlignmentExtensions.cs" />
     <Compile Include="IStartActivityForResult.cs" />
+    <Compile Include="Renderers\CheckBoxDrawable.cs" />
+    <Compile Include="Renderers\CheckBoxRenderer.cs" />
     <Compile Include="Renderers\ConditionalFocusLayout.cs" />
     <Compile Include="Renderers\DescendantFocusToggler.cs" />
     <Compile Include="Renderers\EditorEditText.cs" />

--- a/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
@@ -17,6 +17,7 @@ using Xamarin.Forms.Platform.UWP;
 [assembly: ExportRenderer(typeof(Image), typeof(ImageRenderer))]
 [assembly: ExportRenderer(typeof(Label), typeof(LabelRenderer))]
 [assembly: ExportRenderer(typeof(Button), typeof(ButtonRenderer))]
+[assembly: ExportRenderer(typeof(CheckBox), typeof(CheckBoxRenderer))]
 [assembly: ExportRenderer(typeof(ListView), typeof(ListViewRenderer))]
 [assembly: ExportRenderer(typeof(ScrollView), typeof(ScrollViewRenderer))]
 [assembly: ExportRenderer(typeof(ProgressBar), typeof(ProgressBarRenderer))]

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -134,6 +134,9 @@
     <Compile Include="..\Xamarin.Forms.Platform.WinRT\BrushHelpers.cs">
       <Link>BrushHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\Xamarin.Forms.Platform.WinRT\CheckBoxRenderer.cs">
+      <Link>CheckBoxRenderer.cs</Link>
+    </Compile>
     <Compile Include="..\Xamarin.Forms.Platform.WinRT\FormsTextBox.cs">
       <Link>FormsTextBox.cs</Link>
     </Compile>

--- a/Xamarin.Forms.Platform.WP8/CheckBoxRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/CheckBoxRenderer.cs
@@ -1,0 +1,82 @@
+﻿using System.ComponentModel;
+using System.Windows;
+using WCheckBox = System.Windows.Controls.CheckBox;
+using System.Windows.Media;
+
+namespace Xamarin.Forms.Platform.WinPhone
+{
+    public class CheckBoxRenderer : ViewRenderer<CheckBox, WCheckBox>
+	{
+        private bool _fontApplied;
+
+		protected override void OnElementChanged(ElementChangedEventArgs<CheckBox> e)
+		{
+			base.OnElementChanged(e);
+            if (e.NewElement != null)
+            {
+                if (Control == null)
+                {
+                    var check = new WCheckBox();
+                    check.Checked += OnCheckedChanged;
+                    check.Unchecked += OnCheckedChanged;
+                    SetNativeControl(check);
+                }
+            }
+		}
+
+        private void OnCheckedChanged(object sender, RoutedEventArgs e)
+        {
+            ((IElementController)Element).SetValueFromRenderer(CheckBox.IsCheckedProperty, Control.IsChecked);
+        }
+
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+            if (e.PropertyName == CheckBox.TextProperty.PropertyName)
+                UpdateContent();
+            else if (e.PropertyName == CheckBox.TextColorProperty.PropertyName)
+                UpdateTextColor();
+            else if (e.PropertyName == CheckBox.FontProperty.PropertyName)
+                UpdateFont();
+            else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
+                UpdateBackground();
+            else if (e.PropertyName == CheckBox.IsCheckedProperty.PropertyName)
+                UpdateIsChecked();
+        }
+
+        void UpdateIsChecked()
+        {
+            if (Control.IsChecked != Element.IsChecked)
+                Control.IsChecked = Element.IsChecked;
+        }
+
+        void UpdateContent()
+        {
+            Control.Content = Element.Text;
+        }
+
+        void UpdateFont()
+        {
+            if (Control == null || Element == null)
+                return;
+
+            if (Element.Font == Font.Default && !_fontApplied)
+                return;
+
+            Font fontToApply = Element.Font == Font.Default ? Font.SystemFontOfSize(NamedSize.Medium) : Element.Font;
+
+            Control.ApplyFont(fontToApply);
+            _fontApplied = true;
+        }
+        void UpdateBackground()
+        {
+            Control.Background = Element.BackgroundColor != Color.Default ? Element.BackgroundColor.ToBrush() : (Brush)System.Windows.Application.Current.Resources["PhoneForegroundBrush"];
+        }
+
+        void UpdateTextColor()
+        {
+            Control.Foreground = Element.TextColor != Color.Default ? Element.TextColor.ToBrush() : (Brush)System.Windows.Application.Current.Resources["PhoneForegroundBrush"];
+        }
+    }
+}

--- a/Xamarin.Forms.Platform.WP8/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.WP8/Properties/AssemblyInfo.cs
@@ -34,6 +34,7 @@ using TableView = Xamarin.Forms.TableView;
 [assembly: ExportRenderer(typeof(Label), typeof(LabelRenderer))]
 [assembly: ExportRenderer(typeof(Image), typeof(ImageRenderer))]
 [assembly: ExportRenderer(typeof(Button), typeof(ButtonRenderer))]
+[assembly: ExportRenderer(typeof(CheckBox), typeof(CheckBoxRenderer))]
 [assembly: ExportRenderer(typeof(Slider), typeof(SliderRenderer))]
 [assembly: ExportRenderer(typeof(WebView), typeof(WebViewRenderer))]
 [assembly: ExportRenderer(typeof(SearchBar), typeof(SearchBarRenderer))]

--- a/Xamarin.Forms.Platform.WP8/Xamarin.Forms.Platform.WP8.csproj
+++ b/Xamarin.Forms.Platform.WP8/Xamarin.Forms.Platform.WP8.csproj
@@ -144,6 +144,7 @@
     <Compile Include="AsyncValue.cs" />
     <Compile Include="BrushHelpers.cs" />
     <Compile Include="CellControl.cs" />
+    <Compile Include="CheckBoxRenderer.cs" />
     <Compile Include="CollapseWhenEmptyConverter.cs" />
     <Compile Include="Deserializer.cs" />
     <Compile Include="CustomContextMenu.cs" />

--- a/Xamarin.Forms.Platform.WinRT/CheckBoxRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/CheckBoxRenderer.cs
@@ -1,0 +1,101 @@
+﻿using System.ComponentModel;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+using WCheckBox = Windows.UI.Xaml.Controls.CheckBox;
+
+#if WINDOWS_UWP
+
+namespace Xamarin.Forms.Platform.UWP
+#else
+
+namespace Xamarin.Forms.Platform.WinRT
+#endif
+{
+    public class CheckBoxRenderer : ViewRenderer<CheckBox, WCheckBox>
+	{
+		bool _fontApplied;
+
+		protected override void OnElementChanged(ElementChangedEventArgs<CheckBox> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+			{
+				if (Control == null)
+				{
+					var check = new WCheckBox();
+                    check.Checked += OnCheckedChanged;
+                    check.Unchecked += OnCheckedChanged;
+                    SetNativeControl(check);
+				}
+
+				UpdateContent();
+
+				if (Element.BackgroundColor != Color.Default)
+					UpdateBackground();
+
+				if (Element.TextColor != Color.Default)
+					UpdateTextColor();
+
+				UpdateFont();
+                UpdateIsChecked();
+            }
+		}
+
+        private void OnCheckedChanged(object sender, RoutedEventArgs e)
+        {
+            ((IElementController)Element).SetValueFromRenderer(CheckBox.IsCheckedProperty, Control.IsChecked);
+        }
+
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == CheckBox.TextProperty.PropertyName)
+				UpdateContent();
+			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
+				UpdateBackground();
+			else if (e.PropertyName == CheckBox.TextColorProperty.PropertyName)
+				UpdateTextColor();
+			else if (e.PropertyName == CheckBox.FontProperty.PropertyName)
+				UpdateFont();
+            else if (e.PropertyName == CheckBox.IsCheckedProperty.PropertyName)
+                UpdateIsChecked();
+        }
+
+        void UpdateIsChecked()
+        {
+            if (Control.IsChecked != Element.IsChecked)
+                Control.IsChecked = Element.IsChecked;
+        }
+
+        void UpdateBackground()
+		{
+			Control.Background = Element.BackgroundColor != Color.Default ? Element.BackgroundColor.ToBrush() : (Brush)Windows.UI.Xaml.Application.Current.Resources["CheckBoxBackgroundThemeBrush"];
+		}
+
+		void UpdateContent()
+		{
+            Control.Content = Element.Text;
+		}
+
+		void UpdateFont()
+		{
+			if (Control == null || Element == null)
+				return;
+
+			if (Element.Font == Font.Default && !_fontApplied)
+				return;
+
+			Font fontToApply = Element.Font == Font.Default ? Font.SystemFontOfSize(NamedSize.Medium) : Element.Font;
+
+			Control.ApplyFont(fontToApply);
+			_fontApplied = true;
+		}
+
+		void UpdateTextColor()
+		{
+			Control.Foreground = Element.TextColor != Color.Default ? Element.TextColor.ToBrush() : (Brush)Windows.UI.Xaml.Application.Current.Resources["CheckBoxContentForegroundThemeBrush"];
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.WinRT/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.WinRT/Properties/AssemblyInfo.cs
@@ -17,6 +17,7 @@ using Xamarin.Forms.Platform.WinRT;
 [assembly: ExportRenderer(typeof(Image), typeof(ImageRenderer))]
 [assembly: ExportRenderer(typeof(Label), typeof(LabelRenderer))]
 [assembly: ExportRenderer(typeof(Button), typeof(ButtonRenderer))]
+[assembly: ExportRenderer(typeof(CheckBox), typeof(CheckBoxRenderer))]
 [assembly: ExportRenderer(typeof(ListView), typeof(ListViewRenderer))]
 [assembly: ExportRenderer(typeof(ScrollView), typeof(ScrollViewRenderer))]
 [assembly: ExportRenderer(typeof(ProgressBar), typeof(ProgressBarRenderer))]

--- a/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.csproj
+++ b/Xamarin.Forms.Platform.WinRT/Xamarin.Forms.Platform.WinRT.csproj
@@ -66,10 +66,11 @@
     <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="CheckBoxRenderer.cs" />
     <Compile Include="PlatformConfigurationExtensions.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(OS)' != 'Unix' ">
-	<Compile Include="BrushHelpers.cs" />
+    <Compile Include="BrushHelpers.cs" />
     <Compile Include="NativeViewWrapper.cs" />
     <Compile Include="NativeViewWrapperRenderer.cs" />
     <Compile Include="ViewExtensions.cs" />

--- a/Xamarin.Forms.Platform/Xamarin.Forms.Platform.cs
+++ b/Xamarin.Forms.Platform/Xamarin.Forms.Platform.cs
@@ -27,7 +27,11 @@
 	{
 	}
 
-	internal class _ButtonRenderer
+    internal class _CheckBoxRenderer
+    {
+    }
+
+    internal class _ButtonRenderer
 	{
 	}
 


### PR DESCRIPTION
### Description of Change ###
Add a CheckBox Control to Xamarin.Forms. 
A CheckBox is a specific control that has two states which are 'checked' and 'unchecked'.
A CheckBox allows the user to select multiple options among several items in a list. 

### Bugs Fixed ###
N/A

### API Changes ###

A CheckBox Control has the following properties and event.:

Added:
- String Text { get; set; } A value for the text that is displayed as the content of the CheckBox. This is a bindable property.
- Color  TextColor { get; set; } A value that indicates the color for the text of CheckBox. This is a bindable property.
- Font Font { get; set; } A value that indicates the font of the CheckBox. This is a bindable property.
- FontAttributes FontAttributes { get; set; } A value that indicates whether the font of the CheckBox is bold, italic or neither. This is a bindable property.
- String FontFamily { get; set; } A value that indicates the font family which the CheckBox font belongs to. This is a bindable property.
- Double FontSize { get; set; } A value that indicates the font size of the CheckBox. This is a bindable property.
- bool   IsChecked { get; set; } A value that indicates whether the CheckBox is checked or not. This is a bindable property.

- event EventHandler Checked This event occurs when the CheckBox is checked or unchecked.  

### Behavioral Changes ###
N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
