### PR TITLE
[Windows] Fix Device Style inheritance

### DIFF
--- a/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -25,6 +27,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		Style GetStyle (object nativeKey)
 		{
 			var style = (Windows.UI.Xaml.Style) Windows.UI.Xaml.Application.Current.Resources[nativeKey];
+			style = GetAncestorSetters(style);
 
 			var formsStyle = new Style (typeof (Label));
 			foreach (var b in style.Setters) {
@@ -45,6 +48,48 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 
 			return formsStyle;
+		}
+
+		static Windows.UI.Xaml.Style GetAncestorSetters(Windows.UI.Xaml.Style value)
+		{
+			var style = new Windows.UI.Xaml.Style(value.TargetType)
+			{
+				BasedOn = value.BasedOn
+			};
+			foreach (var valSetter in value.Setters)
+			{
+				style.Setters.Add(valSetter);
+			}
+
+			var ancestorStyles = new List<Windows.UI.Xaml.Style>();
+
+			Windows.UI.Xaml.Style currStyle = style;
+			while (currStyle.BasedOn != null)
+			{
+				ancestorStyles.Add(currStyle.BasedOn);
+				currStyle = currStyle.BasedOn;
+			}
+
+			foreach (var styleParent in ancestorStyles)
+			{
+				foreach (var b in styleParent.Setters)
+				{
+					var parentSetter = b as Windows.UI.Xaml.Setter;
+					if (parentSetter == null)
+						continue;
+
+					var derviedSetter = style.Setters
+						.OfType<Windows.UI.Xaml.Setter>()
+						.FirstOrDefault(x => x.Property == parentSetter.Property);
+
+					//Ignore any ancestor setters which a child setter has already overridden
+					if (derviedSetter != null)
+						continue;
+					else
+						style.Setters.Add(parentSetter);
+				}
+			}
+			return style;
 		}
 
 		static LineBreakMode ToLineBreakMode (TextWrapping value)

--- a/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
@@ -50,9 +50,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			return formsStyle;
 		}
 
-		static Windows.UI.Xaml.Style GetAncestorSetters(Windows.UI.Xaml.Style value)
+		static Windows.UI.Xaml.Style GetAncestorSetters (Windows.UI.Xaml.Style value)
 		{
-			var style = new Windows.UI.Xaml.Style(value.TargetType)
+			var style = new Windows.UI.Xaml.Style (value.TargetType)
 			{
 				BasedOn = value.BasedOn
 			};
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				style.Setters.Add(valSetter);
 			}
 
-			var ancestorStyles = new List<Windows.UI.Xaml.Style>();
+			var ancestorStyles = new List<Windows.UI.Xaml.Style> ();
 
 			Windows.UI.Xaml.Style currStyle = style;
 			while (currStyle.BasedOn != null)
@@ -79,14 +79,14 @@ namespace Xamarin.Forms.Platform.WinRT
 						continue;
 
 					var derviedSetter = style.Setters
-						.OfType<Windows.UI.Xaml.Setter>()
-						.FirstOrDefault(x => x.Property == parentSetter.Property);
+						.OfType<Windows.UI.Xaml.Setter> ()
+						.FirstOrDefault (x => x.Property == parentSetter.Property);
 
 					//Ignore any ancestor setters which a child setter has already overridden
 					if (derviedSetter != null)
 						continue;
 					else
-						style.Setters.Add(parentSetter);
+						style.Setters.Add (parentSetter);
 				}
 			}
 			return style;


### PR DESCRIPTION
### Description of Change ###

Changes the Windows Phone RT platform resource lookup to get Setters from ancestor Styles in addition to the defined style.

Tests omitted because, as far as I can tell, testing the PlatformResourceProviders isn't possible.

### Bugs Fixed ###

- Part 1 of fixing [47873 - Most Device Styles do not render correctly in Windows Phone 8.1 (RT) applications](https://bugzilla.xamarin.com/show_bug.cgi?id=43783). Doesn't address the failure to lookup ThemeResources, however. Once that's addressed, will fix certain styles, such as the `BodyStyle`, which maps to the native `BodyTextBlockStyle`, which only directly defines a new `TextBlock.LineHeight` value. As Xamarin's style translation ignores that particular property, any Label using the Xamarin `BodyStyle` would get an unstyled Label, when they should, at the very least, receive the styling from the native `BaseTextBlockStyle`.

### API Changes ###

None.

### Behavioral Changes ###

There should be no visible changes _yet_. The only two Device Styles that render correctly on Windows Phone 8.1 RT, TitleStyle and SubtitleStyle do not have any elements inherited from their BasedOn Styles that a Xamarin Style uses. However, if [43783](https://bugzilla.xamarin.com/show_bug.cgi?id=43783) were to be fixed without also fixing this, the styles would be incomplete.

Recommend do **not** merge until [43783](https://bugzilla.xamarin.com/show_bug.cgi?id=43783) is fixed.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
