### PR TITLE
[Win] Fix FontAttributes unexpectedly changing a label's size

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43516.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43516.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43516, "Changing FontAttributes on a label to None changes its font size")]
+	public class Bugzill43516 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var label = new Label
+			{
+				FontAttributes = FontAttributes.Bold
+			};
+			label.BindingContext = label;
+			label.SetBinding(Label.TextProperty, "FontAttributes");
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					label,
+					new Button
+					{
+						Text = "Click to set FontAttributes.None",
+						Command = new Command(() =>
+						{
+							label.FontAttributes = FontAttributes.None;
+						})
+					},
+					new Button
+					{
+						Text = "Click to set FontAttributes.Bold",
+						Command = new Command(() =>
+						{
+							label.FontAttributes = FontAttributes.Bold;
+						})
+					},
+					new Button
+					{
+						Text = "Click to set Font.SystemFontOfSize to NamedSize.Medium",
+						Command = new Command(() => label.FontSize = Device.GetNamedSize(NamedSize.Medium, typeof(Label)))
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -123,6 +123,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42329.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42364.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Forms.Platform.WinRT
 	public class LabelRenderer : ViewRenderer<Label, TextBlock>
 	{
 		bool _fontApplied;
+		bool _isInitiallyDefault;
 
 		protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)
 		{
@@ -70,6 +71,8 @@ namespace Xamarin.Forms.Platform.WinRT
 				{
 					SetNativeControl(new TextBlock());
 				}
+
+				_isInitiallyDefault = Element.IsDefault();
 
 				UpdateText(Control);
 				UpdateColor(Control);
@@ -134,7 +137,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				return;
 
 #pragma warning disable 618
-			Font fontToApply = label.IsDefault() ? Font.SystemFontOfSize(NamedSize.Medium) : label.Font;
+			Font fontToApply = label.IsDefault() && _isInitiallyDefault ? Font.SystemFontOfSize(NamedSize.Medium) : label.Font;
 #pragma warning restore 618
 
 			textBlock.ApplyFont(fontToApply);


### PR DESCRIPTION
### Description of Change ###

Changing a label's `FontAttributes` to `None` in Windows after having it initially set to `Bold` or `Italic` would cause the size of the label to change. This stems from the `IsDefault` method which would subsequently apply the `NamedSize.Medium` value on it. Adding a simple bool value to flag whether it was initially default or not based on the `IsDefault` is true when the control is being created.

For reference, on standard 8.1/UWP apps, the `TextBlock` size stays the same when its `FontWeight` value is changed. A visual reproduction has been added to the gallery.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=43516

### API Changes ###

None

### Behavioral Changes ###

While it is technically possible that some apps might expect this odd functionality, it doesn't make much sense from a logical standpoint and presumably one could be correcting the font's size when this presently occurs.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

