### PR TITLE
KeyboardExtensions is now public

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/KeyboardExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/KeyboardExtensions.cs
@@ -2,7 +2,7 @@ using Android.Text;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal static class KeyboardExtensions
+	public static class KeyboardExtensions
 	{
 		public static InputTypes ToInputType(this Keyboard self)
 		{

--- a/Xamarin.Forms.Platform.WP8/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/EntryRenderer.cs
@@ -9,7 +9,7 @@ using WControl = System.Windows.Controls.Control;
 
 namespace Xamarin.Forms.Platform.WinPhone
 {
-	internal static class KeyboardExtensions
+	public static class KeyboardExtensions
 	{
 		public static InputScope ToInputScope(this Keyboard self)
 		{


### PR DESCRIPTION
### Description of Change ###

KeyboardExtensions (Extensions for iOS) was already public in all projects except for Android and WP8. This gets rid of internal modifier so that we can use ToInputType() and ToInputScope() methods in custom renderers to create custom keyboards.

Here's a basic example:

 ```
 // Making sure Android numeric keyboard is the same as iOS
 if (Element.Keyboard == Keyboard.Numeric)
 {
     Control.InputType = InputTypes.ClassNumber | InputTypes.NumberFlagDecimal;
  }
  else
  {
      Control.InputType = Element.Keyboard.ToInputType();
  }
```

### Bugs Fixed ###

N/A

### API Changes ###

Changed:
- internal static class KeyboardExtensions => public static class KeyboardExtensions
- internal static InputTypes ToInputType(this Keyboard self) => public static InputTypes ToInputType(this Keyboard self)

### Behavioral Changes ###

N/A