### PR TITLE
Fixed tab not updating when page title is changed

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -100,6 +100,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 						pageRenderer.ViewGroup.RemoveFromParent();
 						pageRenderer.Dispose();
 					}
+					pageToRemove.PropertyChanged -= OnPagePropertyChanged;
 					pageToRemove.ClearValue(Android.Platform.RendererProperty);
 				}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -254,7 +254,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			e.Apply((o, i, c) => SetupPage((Page)o, i), (o, i) => TeardownPage((Page)o, i), Reset);
+			e.Apply((o, i, c) => SetupPage((Page)o), (o, i) => TeardownPage((Page)o), Reset);
 
 			FormsViewPager pager = _viewPager;
 			TabLayout tabs = _tabLayout;
@@ -278,24 +278,23 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			UpdateIgnoreContainerAreas();
 		}
 
-		void TeardownPage(Page page, int i)
+		void TeardownPage(Page page)
 		{
 			page.PropertyChanged -= OnPagePropertyChanged;
 		}
 
-		void SetupPage(Page page, int i)
+		void SetupPage(Page page)
 		{
 			page.PropertyChanged += OnPagePropertyChanged;
 		}
 
 		void Reset()
 		{
-			var i = 0;
 			foreach (var page in Element.Children)
-				SetupPage(page, i++);
+				SetupPage(page);
 		}
 
-		private void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)
+		void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Page.TitleProperty.PropertyName)
 			{


### PR DESCRIPTION
### Description of Change

With AppCompat, changing the Title of a TabbedPage child Page would no longer update its tab text. This fixes that by wiring up to each child page's PropertyChanged event using the same mechanism as in the iOS TabbedRenderer in order to respond to the change. This also sets up the ability to respond to other child page property changes later if needed.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=43734
### API Changes

None
### Behavioral Changes
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
