### PR TITLE
[A] Check UserVisibleHint to prevent non-active tabs from firing SendAppearing in OnResume

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
@@ -127,7 +127,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		
 		public override void OnResume()
 		{
-			PageController?.SendAppearing();
+			if (UserVisibleHint)
+				PageController?.SendAppearing();
 			base.OnResume();
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

The `OnResume` method in the `FragmentContainer` would falsely fire off `SendAppearing` for the non-visible tabs on a `TabbedPage`, causing the first switch to a tab to not fire the `Appearing` event as otherwise expected. Checking the UserVisibleHint value prevents this from occurring.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=43774

### API Changes ###

None

### Behavioral Changes ###

None involving this, specifically. Note that there is a separate issue, however; when using a test reproduction in the gallery project, the `Appearing` event is still firing twice when first opening the page (Appearing -> Disappearing -> Appearing, after the correction), with the first occurrence coming via [Page.cs#L311](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Core/Page.cs#L311). That issue would likely need to be revisited further, but this particular check should presumably help for this particular case with `Appearing` not activating on another tab the first time around.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense