### PR TITLE
Fix incorrect background property name on Win 8.1 phone and tablet styles

### DIFF
--- a/Xamarin.Forms.Platform.WinRT.Phone/PhoneResources.xaml
+++ b/Xamarin.Forms.Platform.WinRT.Phone/PhoneResources.xaml
@@ -435,9 +435,8 @@
 							<RowDefinition Height="Auto" />
 							<RowDefinition Height="*" />
 						</Grid.RowDefinitions>
-
-                        <Grid Height="79" Background="{TemplateBinding NavigationBarBackground}" 
-							  Visibility="{TemplateBinding TitleVisibility}">
+						
+						<Grid Height="79" Background="{TemplateBinding ToolbarBackground}"  Visibility="{TemplateBinding TitleVisibility}">
                             <TextBlock Margin="10,0,0,0" Name="title" Foreground="{TemplateBinding TitleBrush}" VerticalAlignment="Center" Style="{ThemeResource HeaderTextBlockStyle}" Text="{Binding Title}" />
                         </Grid>
                    		<ContentPresenter x:Name="presenter" Grid.Row="1" ContentTransitions="{TemplateBinding ContentTransitions}" />

--- a/Xamarin.Forms.Platform.WinRT.Tablet/TabletResources.xaml
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/TabletResources.xaml
@@ -327,8 +327,7 @@
 							<RowDefinition Height="*" />
 						</Grid.RowDefinitions>
 
-						<Grid Grid.Row="0" Grid.Column="0" Height="79" VerticalAlignment="Center" Background="{TemplateBinding NavigationBarBackground}" 
-							  Visibility="{TemplateBinding TitleVisibility}">
+						<Grid Grid.Row="0" Grid.Column="0" Height="79" VerticalAlignment="Center" Background="{TemplateBinding ToolbarBackground}" Visibility="{TemplateBinding TitleVisibility}">
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="Auto" MinWidth="{Binding TitleInset,RelativeSource={RelativeSource TemplatedParent}}" />
 								<ColumnDefinition Width="*" />


### PR DESCRIPTION
### Description of Change ###

Fixes incorrect property name in XAML resources

