### PR TITLE
Fix potential NRE accessing current application via Page.RealParent

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -318,20 +318,15 @@ namespace Xamarin.Forms.ControlGallery.Android
 			// uncomment to verify turning off title bar works. This is not intended to be dynamic really.
 			//Forms.SetTitleBarVisibility (AndroidTitleBarVisibility.Never);
 
-			var app = new App ();
+			var app = new App();
 
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 
-					var nncgPage1 = args.Page as NativeBindingGalleryPage;
+			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
+			MessagingCenter.Subscribe<NativeBindingGalleryPage >(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
 
-					if (nncgPage1 != null)
-					{
-						AddNativeBindings(nncgPage1);
-					}
-
-
-			LoadApplication (app);
+			LoadApplication(app);
 		}
 
 		public override void OnConfigurationChanged (global::Android.Content.Res.Configuration newConfig)

--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -205,17 +205,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			var app = new App ();
 
-			var mdp = app.MainPage as MasterDetailPage;
-			var detail = mdp?.Detail as NavigationPage;
-			if (detail != null) {
-				detail.Pushed += (sender, args) => {
-					var nncgPage = args.Page as NestedNativeControlGalleryPage;
-
-					if (nncgPage != null) {
-						AddNativeControls (nncgPage);
-					}
-				};
-			} 
+			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
+			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 
 			LoadApplication (app);
 		}
@@ -329,15 +320,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			var app = new App ();
 
-			var mdp = app.MainPage as MasterDetailPage;
-			var detail = mdp?.Detail as NavigationPage;
-			if (detail != null) {
-				detail.Pushed += (sender, args) => {
-					var nncgPage = args.Page as NestedNativeControlGalleryPage;
-
-					if (nncgPage != null) {
-						AddNativeControls (nncgPage);
-					}
+			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
+			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 
 					var nncgPage1 = args.Page as NativeBindingGalleryPage;
 
@@ -346,8 +330,6 @@ namespace Xamarin.Forms.ControlGallery.Android
 						AddNativeBindings(nncgPage1);
 					}
 
-				};
-			}
 
 			LoadApplication (app);
 		}

--- a/Xamarin.Forms.ControlGallery.WP8/MainPage.xaml.cs
+++ b/Xamarin.Forms.ControlGallery.WP8/MainPage.xaml.cs
@@ -61,18 +61,8 @@ namespace Xamarin.Forms.ControlGallery.WP8
 
 			var app = new Controls.App ();
 
-			var mdp = app.MainPage as MasterDetailPage;
-
-			var detail = mdp?.Detail as NavigationPage;
-			if (detail != null) {
-				detail.Pushed += (sender, args) => {
-					var nncgPage = args.Page as NestedNativeControlGalleryPage;
-
-					if (nncgPage != null) {
-						AddNativeControls (nncgPage);
-					}
-				};
-			}
+			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
+			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 
 			LoadApplication (app);
 		}

--- a/Xamarin.Forms.ControlGallery.Windows/MainPage.xaml.cs
+++ b/Xamarin.Forms.ControlGallery.Windows/MainPage.xaml.cs
@@ -17,18 +17,8 @@ namespace Xamarin.Forms.ControlGallery.Windows
 
 			var app = new Controls.App ();
 
-			var mdp = app.MainPage as MasterDetailPage;
-
-			var detail = mdp?.Detail as NavigationPage;
-			if (detail != null) {
-				detail.Pushed += (sender, args) => {
-					var nncgPage = args.Page as NestedNativeControlGalleryPage;
-
-					if (nncgPage != null) {
-						AddNativeControls (nncgPage);
-					}
-				};
-			}
+			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
+			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 
 			LoadApplication (app);
 		}

--- a/Xamarin.Forms.ControlGallery.WindowsPhone/MainPage.xaml.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsPhone/MainPage.xaml.cs
@@ -23,18 +23,8 @@ namespace Xamarin.Forms.ControlGallery.WindowsPhone
 
 			var app = new Controls.App ();
 
-			var mdp = app.MainPage as MasterDetailPage;
-
-			var detail = mdp?.Detail as NavigationPage;
-			if (detail != null) {
-				detail.Pushed += (sender, args) => {
-					var nncgPage = args.Page as NestedNativeControlGalleryPage;
-
-					if (nncgPage != null) {
-						AddNativeControls (nncgPage);
-					}
-				};
-			}
+			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
+			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 
 			LoadApplication (app);
 		}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/MainPage.xaml.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/MainPage.xaml.cs
@@ -24,24 +24,14 @@ namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 
 			var app = new Controls.App ();
 
-			var mdp = app.MainPage as MasterDetailPage;
-
-			var detail = mdp?.Detail as NavigationPage;
-			if (detail != null) {
-				detail.Pushed += (sender, args) => {
-					var nncgPage = args.Page as NestedNativeControlGalleryPage;
-
-					if (nncgPage != null) {
-						AddNativeControls (nncgPage);
+			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
+			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 					}
 
 					var nncgPage1 = args.Page as NativeBindingGalleryPage;
 
 					if (nncgPage1 != null) {
 						AddNativeBindings(nncgPage1);
-					}
-				};
-			} 
 
 			LoadApplication (app);
         }

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/MainPage.xaml.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/MainPage.xaml.cs
@@ -26,12 +26,9 @@ namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
-					}
-
-					var nncgPage1 = args.Page as NativeBindingGalleryPage;
-
-					if (nncgPage1 != null) {
-						AddNativeBindings(nncgPage1);
+					
+			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
+			MessagingCenter.Subscribe<NativeBindingGalleryPage >(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
 
 			LoadApplication (app);
         }

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -151,27 +151,16 @@ namespace Xamarin.Forms.ControlGallery.iOS
 
 			var app = new App();
 
-			var mdp = app.MainPage as MasterDetailPage;
-			var detail = mdp?.Detail as NavigationPage;
-			if (detail != null)
-			{
-				detail.Pushed += (sender, args) =>
-				{
-					var nncgPage = args.Page as NestedNativeControlGalleryPage;
-
-					if (nncgPage != null)
-					{
-						AddNativeControls(nncgPage);
-					}
+			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
+			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
+			MessagingCenter.Subscribe<Bugzilla40911>(this, Bugzilla40911.ReadyToSetUp40911Test, SetUp40911Test);
+		
 
 					var nncgPage1 = args.Page as NativeBindingGalleryPage;
 
 					if (nncgPage1 != null)
 					{
 						AddNativeBindings(nncgPage1);
-					}
-				};
-			}
 
 			LoadApplication(app);
 			return base.FinishedLaunching(uiApplication, launchOptions);
@@ -321,6 +310,48 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			sl?.Children.Add(colorPicker);
 			page.NativeControlsAdded = true;
 		}
+#region Stuff for repro of Bugzilla case 40911
+
+		void SetUp40911Test(Bugzilla40911 page)
+		{
+			var button = new Button { Text = "Start" };
+
+			button.Clicked += (s, e) =>
+			{
+				StartPressed40911();
+			};
+
+			page.Layout.Children.Add(button);
+		}
+
+		public void StartPressed40911 ()
+        {
+			var loginViewController = new UIViewController { View = { BackgroundColor = UIColor.White } };
+			var button = UIButton.FromType (UIButtonType.RoundedRect);
+            button.SetTitle ("Login", UIControlState.Normal);
+#if __UNIFIED__
+            button.Frame = new CoreGraphics.CGRect (20, 100, 200, 44);
+#else
+			button.Frame = new RectangleF (20, 100, 200, 44);
+#endif
+            loginViewController.View.AddSubview (button);
+
+            button.TouchUpInside += (sender, e) => {
+                Xamarin.Forms.Application.Current.MainPage = new ContentPage {Content = new Label {Text = "40911 Success"} };
+                loginViewController.DismissViewController (true, null);
+			};
+
+			var window= UIApplication.SharedApplication.KeyWindow;
+			var vc = window.RootViewController;
+			while (vc.PresentedViewController != null)
+			{
+				vc = vc.PresentedViewController;
+			}
+
+            vc.PresentViewController (loginViewController, true, null);
+		}
+
+#endregion
 	}
 
 	public class ColorConverter : IValueConverter

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -154,13 +154,9 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 			MessagingCenter.Subscribe<Bugzilla40911>(this, Bugzilla40911.ReadyToSetUp40911Test, SetUp40911Test);
-		
 
-					var nncgPage1 = args.Page as NativeBindingGalleryPage;
-
-					if (nncgPage1 != null)
-					{
-						AddNativeBindings(nncgPage1);
+			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
+			MessagingCenter.Subscribe<NativeBindingGalleryPage >(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
 
 			LoadApplication(app);
 			return base.FinishedLaunching(uiApplication, launchOptions);
@@ -310,7 +306,8 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			sl?.Children.Add(colorPicker);
 			page.NativeControlsAdded = true;
 		}
-#region Stuff for repro of Bugzilla case 40911
+
+		#region Stuff for repro of Bugzilla case 40911
 
 		void SetUp40911Test(Bugzilla40911 page)
 		{
@@ -329,11 +326,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			var loginViewController = new UIViewController { View = { BackgroundColor = UIColor.White } };
 			var button = UIButton.FromType (UIButtonType.RoundedRect);
             button.SetTitle ("Login", UIControlState.Normal);
-#if __UNIFIED__
-            button.Frame = new CoreGraphics.CGRect (20, 100, 200, 44);
-#else
-			button.Frame = new RectangleF (20, 100, 200, 44);
-#endif
+            button.Frame = new CGRect (20, 100, 200, 44);
             loginViewController.View.AddSubview (button);
 
             button.TouchUpInside += (sender, e) => {
@@ -351,7 +344,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
             vc.PresentViewController (loginViewController, true, null);
 		}
 
-#endregion
+		#endregion
 	}
 
 	public class ColorConverter : IValueConverter

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40911.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40911.cs
@@ -1,0 +1,41 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+namespace Xamarin.Forms.Controls
+{
+	[Preserve (AllMembers = true)]
+	[Issue (IssueTracker.Bugzilla, 40911, "NRE with Facebook Login", PlatformAffected.iOS)]
+	public class Bugzilla40911 : TestContentPage 
+	{
+		public StackLayout Layout { get; private set; }
+
+		public const string ReadyToSetUp40911Test = "ReadyToSetUp40911Test";
+
+		protected override void Init ()
+		{
+			Layout = new StackLayout();
+
+			Layout.Children.Add(new Label{Text = "This is an iOS-specific issue. If you're on another platform, you can ignore this." });
+
+			Content = Layout;
+
+			MessagingCenter.Send(this, ReadyToSetUp40911Test);
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void CanFinishLoginWithoutNRE ()
+		{
+			RunningApp.WaitForElement("Start");
+			RunningApp.Tap("Start");
+			RunningApp.WaitForElement("Login");
+			RunningApp.Tap("Login");
+			RunningApp.WaitForElement("40911 Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -108,6 +108,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31806.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40858.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40824.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40911.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />

--- a/Xamarin.Forms.Controls/ControlGalleryPages/NativeBindingGalleryPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/NativeBindingGalleryPage.cs
@@ -10,6 +10,14 @@ namespace Xamarin.Forms.Controls
 
 		NestedNativeViewModel ViewModel { get; set; }
 
+		public const string ReadyForNativeBindingsMessage = "ReadyForNativeBindings";
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			MessagingCenter.Send(this, ReadyForNativeBindingsMessage);
+		}
+
 		public NativeBindingGalleryPage()
 		{
 

--- a/Xamarin.Forms.Controls/ControlGalleryPages/NestedNativeControlGalleryPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/NestedNativeControlGalleryPage.cs
@@ -6,6 +6,14 @@ namespace Xamarin.Forms.Controls
 
 		public bool NativeControlsAdded { get; set; }
 
+		public const string ReadyForNativeControlsMessage = "ReadyForNativeControls";
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			MessagingCenter.Send(this, ReadyForNativeControlsMessage);
+		}
+
 		public NestedNativeControlGalleryPage ()
 		{
 			Layout = new StackLayout { Padding = 20, VerticalOptions = LayoutOptions.FillAndExpand };

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -238,7 +238,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Page.Platform = this;
 			AddChild(Page, layout);
 
-			((Application)Page.RealParent).NavigationProxy.Inner = this;
+			Application.Current.NavigationProxy.Inner = this;
 		}
 
 		void AddChild(Page page, bool layout = false)

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -413,7 +413,7 @@ namespace Xamarin.Forms.Platform.Android
 			Page.Platform = this;
 			AddChild(Page, layout);
 
-			((Application)Page.RealParent).NavigationProxy.Inner = this;
+			Application.Current.NavigationProxy.Inner = this;
 
 			_toolbarTracker.Target = newRoot;
 

--- a/Xamarin.Forms.Platform.WP8/Platform.cs
+++ b/Xamarin.Forms.Platform.WP8/Platform.cs
@@ -437,7 +437,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			_navModel.PushModal(newRoot);
 			SetCurrent(newRoot, false, true);
 
-			((Application)newRoot.RealParent).NavigationProxy.Inner = this;
+			Application.Current.NavigationProxy.Inner = this;
 		}
 
 		internal event EventHandler SizeChanged;

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			_navModel.Push(newRoot, null);
 			newRoot.NavigationProxy.Inner = this;
 			SetCurrent(newRoot, false, true);
-			((Application)newRoot.RealParent).NavigationProxy.Inner = this;
+			Application.Current.NavigationProxy.Inner = this;
 		}
 
 		public IReadOnlyList<Page> NavigationStack

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -149,16 +149,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		Page Page { get; set; }
 
-		Application TargetApplication
-		{
-			get
-			{
-				if (Page == null)
-					return null;
-				return Page.RealParent as Application;
-			}
-		}
-
 		void IDisposable.Dispose()
 		{
 			if (_disposed)
@@ -304,7 +294,7 @@ namespace Xamarin.Forms.Platform.iOS
 		internal void DidAppear()
 		{
 			_animateModals = false;
-			TargetApplication.NavigationProxy.Inner = this;
+			Application.Current.NavigationProxy.Inner = this;
 			_animateModals = true;
 		}
 
@@ -388,7 +378,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			Page.DescendantRemoved += HandleChildRemoved;
 
-			TargetApplication.NavigationProxy.Inner = this;
+			Application.Current.NavigationProxy.Inner = this;
 		}
 
 		internal void WillAppear()


### PR DESCRIPTION
### Description of Change ###

iOS Platform was using the current `Page`'s `RealParent` property to reach the current `Application` instance so it could set the `NavigationProxy.Inner` property during `ViewDidAppear`. But it's possible to have a situation where `ViewDidAppear` occurs while the current `Page` property is null (when setting the `MainPage` property from the native iOS app), which results in a NullReferenceException. Replaced the cast of `RealParent` with `Application.Current` to avoid the NRE.

Also updates the integration between the XF and native parts of Control Gallery to use MessagingCenter (and be less fragile).

### Bugs Fixed ###

- [40911 – NRE with Facebook Login](https://bugzilla.xamarin.com/show_bug.cgi?id=40911)
- [42214 – Project crashes with NRE in Main.cs - Xamarin Studio](https://bugzilla.xamarin.com/show_bug.cgi?id=42214)

### API Changes ###

None

### Behavioral Changes ###

None 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

