### PR TITLE
Android AppCompat: Don't do NavigationPage menu updates for disposed page

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -670,6 +670,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void UpdateMenu()
 		{
+			if (_disposed)
+				return;
+
 			AToolbar bar = _toolbar;
 			Context context = Context;
 			IMenu menu = bar.Menu;


### PR DESCRIPTION
### Description of Change ###

Added a similar check for disposed object in UpdateMenu() as there is in UpdateToolbar().

### Bugs Fixed ###

- Fixed a random crash in my work area. No bug report created and no sample app available now.

### API Changes ###

None

### Behavioral Changes ###

App may stop crashing.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
