### PR TITLE
Fixed bug 43993 by removing call to base ViewWillAppear

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1090,7 +1090,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewWillAppear(bool animated)
 		{
-			base.ViewWillAppear(animated);
+            // TODO: Uncommenting this line results in Bug 43993.
+			//base.ViewWillAppear(animated);
 
 			if (_list.IsRefreshing && _refresh.Refreshing)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1090,15 +1090,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewWillAppear(bool animated)
 		{
-            // TODO: Uncommenting this line results in Bug 43993.
-			//base.ViewWillAppear(animated);
+		    if (!_list.IsRefreshing || !_refresh.Refreshing) return;
 
-			if (_list.IsRefreshing && _refresh.Refreshing)
-			{
-				// Restart the refreshing to get the animation to trigger
-				UpdateIsRefreshing(false);
-				UpdateIsRefreshing(true);
-			}
+		    // Restart the refreshing to get the animation to trigger
+		    UpdateIsRefreshing(false);
+		    UpdateIsRefreshing(true);
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change ###

#274 added call to ViewWillAppear of UITableViewController, but this seems to have broken iOS ListView scrollbar size when the soft keyboard disappears. I removed the base call though I'm not sure why this was necessary. We should either understand the root cause of the problem and invoke base ViewWillAppear or bypass this call as before.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=43993