### PR TITLE
[XamlC] replace the runtime type check by compiletime

### DIFF
--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -396,7 +396,7 @@ namespace Xamarin.Forms.Build.Tasks
 #if NOSERVICEPROVIDER
 			yield return Instruction.Create (OpCodes.Ldnull);
 			yield break;
-			#endif
+#endif
 
 			var ctorinfo = typeof (XamlServiceProvider).GetConstructor(new Type[] { });
 			var ctor = module.Import(ctorinfo);

--- a/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Forms.Build.Tasks
 				return;
 			if (propertyName.LocalName != "MergedWith")
 				return;
-			SetPropertiesVisitor.SetPropertyValue(Context.Variables[(IElementNode)parentNode], propertyName, node, Context, node);
+			Context.IL.Append(SetPropertiesVisitor.SetPropertyValue(Context.Variables[(IElementNode)parentNode], propertyName, node, Context, node));
 		}
 
 		public void Visit(MarkupNode node, INode parentNode)
@@ -118,10 +118,10 @@ namespace Xamarin.Forms.Build.Tasks
 							Context.Variables[node] = vardef;
 						}
 
-						//						IL_0013:  ldloc.0 
-						//						IL_0014:  ldstr "key"
-						//						IL_0019:  ldstr "foo"
-						//						IL_001e:  callvirt instance void class [Xamarin.Forms.Core]Xamarin.Forms.ResourceDictionary::Add(string, object)
+//						IL_0013:  ldloc.0 
+//						IL_0014:  ldstr "key"
+//						IL_0019:  ldstr "foo"
+//						IL_001e:  callvirt instance void class [Xamarin.Forms.Core]Xamarin.Forms.ResourceDictionary::Add(string, object)
 						Context.IL.Emit(OpCodes.Ldloc, parentVar);
 						Context.IL.Emit(OpCodes.Ldstr, (node.Properties[XmlName.xKey] as ValueNode).Value as string);
 						var varDef = Context.Variables[node];
@@ -143,7 +143,7 @@ namespace Xamarin.Forms.Build.Tasks
 			    (propertyName.LocalName == "Resources" || propertyName.LocalName.EndsWith(".Resources", StringComparison.Ordinal)) &&
 				(Context.Variables[node].VariableType.FullName == "Xamarin.Forms.ResourceDictionary" ||
 					Context.Variables[node].VariableType.Resolve().BaseType.FullName == "Xamarin.Forms.ResourceDictionary"))
-				SetPropertiesVisitor.SetPropertyValue(Context.Variables[(IElementNode)parentNode], propertyName, node, Context, node);
+				Context.IL.Append(SetPropertiesVisitor.SetPropertyValue(Context.Variables[(IElementNode)parentNode], propertyName, node, Context, node));
 		}
 
 		public void Visit(RootNode node, INode parentNode)

--- a/Xamarin.Forms.Core/ConstraintExpression.cs
+++ b/Xamarin.Forms.Core/ConstraintExpression.cs
@@ -6,7 +6,7 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms
 {
-	public class ConstraintExpression : IMarkupExtension
+	public class ConstraintExpression : IMarkupExtension<Constraint>
 	{
 		public ConstraintExpression()
 		{
@@ -23,7 +23,12 @@ namespace Xamarin.Forms
 
 		public ConstraintType Type { get; set; }
 
-		public object ProvideValue(IServiceProvider serviceProvider)
+		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
+		{
+			return (this as IMarkupExtension<Constraint>).ProvideValue(serviceProvider);
+		}
+
+		public Constraint ProvideValue(IServiceProvider serviceProvider)
 		{
 			MethodInfo minfo;
 			switch (Type)

--- a/Xamarin.Forms.Xaml.UnitTests/GenericCollections.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/GenericCollections.xaml.cs
@@ -14,6 +14,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			typeof(GenericCollection),
 			typeof(AttachedBP),
 			null);
+
+		public static GenericCollection GetAttachedBP(BindableObject bindable)
+		{
+			throw new NotImplementedException();
+		}
 	}
 
 	public class GenericCollection : ObservableCollection<object>

--- a/Xamarin.Forms.Xaml.UnitTests/Validation/SetterOnNonBP.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Validation/SetterOnNonBP.xaml
@@ -1,14 +1,14 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage 
 	xmlns="http://xamarin.com/schemas/2014/forms" 
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
 	x:Class="Xamarin.Forms.Xaml.UnitTests.SetterOnNonBP"
 	xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests">
-	<local:FakeVisualElement>
-		<local:FakeVisualElement.Style>
-			<Style TargetType="local:FakeVisualElement">
+	<local:FakeView>
+		<local:FakeView.Style>
+			<Style TargetType="local:FakeView">
 				<Setter Property="NonBindable" Value="Should Fail"/>
 			</Style>
-		</local:FakeVisualElement.Style>
-	</local:FakeVisualElement>
+		</local:FakeView.Style>
+	</local:FakeView>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Validation/SetterOnNonBP.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Validation/SetterOnNonBP.xaml.cs
@@ -3,7 +3,7 @@
 using Xamarin.Forms;
 namespace Xamarin.Forms.Xaml.UnitTests
 {	
-	public class FakeVisualElement : VisualElement
+	public class FakeView : View
 	{
 		public string NonBindable { get; set; }
 	}


### PR DESCRIPTION
### Description of Change ###

Replace runtime type check for SetValue by a compiletime one. It assumes our users are not morons and respect the naming conventions for bindable properties fields and accessors.
This also splits the most monstrous method in the Xamlc into manageable chunks.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
