### PR TITLE
Fix updating Label.FormattedText property in WinRT/LabelRenderer

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == Label.TextProperty.PropertyName)
+			if (e.PropertyName == Label.TextProperty.PropertyName || e.PropertyName == Label.FormattedTextProperty.PropertyName)
 				UpdateText(Control);
 			else if (e.PropertyName == Label.TextColorProperty.PropertyName)
 				UpdateColor(Control);


### PR DESCRIPTION
After Label.FormattedText property changed  need invoke UpdateText method.