### PR TITLE
[iOS] ViewCells with Accessories will be properly laid out again

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -29,6 +29,7 @@ using MonoTouch.CoreLocation;
 [assembly: ExportRenderer(typeof(NativeListView), typeof(NativeListViewRenderer))]
 [assembly: ExportRenderer(typeof(CustomMapView), typeof(CustomIOSMapRenderer))]
 [assembly: ExportRenderer(typeof(TabbedPage), typeof(TabbedPageWithCustomBarColorRenderer))]
+[assembly: ExportRenderer(typeof(Bugzilla43161.AccessoryViewCell), typeof(AccessoryViewCellRenderer))]
 namespace Xamarin.Forms.ControlGallery.iOS
 {
 	public class CustomIOSMapRenderer : ViewRenderer<CustomMapView, MKMapView>
@@ -602,6 +603,22 @@ namespace Xamarin.Forms.ControlGallery.iOS
 
 			//UITabBar.Appearance.TintColor = UIColor.White;
 			//UITabBar.Appearance.BarTintColor = UIColor.Purple;
+		}
+	}
+
+	public class AccessoryViewCellRenderer : ViewCellRenderer
+	{
+		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+		{
+			var cell = base.GetCell(item, reusableCell, tv);
+
+			// remove highlight on selected cell
+			cell.SelectionStyle = UITableViewCellSelectionStyle.None;
+
+			// iOS right arrow
+			cell.Accessory = UITableViewCellAccessory.DisclosureIndicator;
+
+			return cell;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43161.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43161.cs
@@ -1,0 +1,64 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43161, "[iOS] Setting Accessory in ViewCellRenderer breaks layout", PlatformAffected.iOS)]
+	public class Bugzilla43161 : TestContentPage
+	{
+		const string Instructions = "On iOS, all three of the following ListViews should have ListItems labeled with numbers and a right arrow. If any of the ListViews does not contain numbers, this test has failed.";
+		const string ListView1 = "Accessory with Context Actions";
+		const string ListView2 = "Accessory with RecycleElement";
+		const string ListView3 = "Accessory with RetainElement";
+
+		public class AccessoryViewCell : ViewCell
+		{
+			public AccessoryViewCell()
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				View = label;
+			}
+		}
+
+		public class AccessoryViewCellWithContextActions : AccessoryViewCell
+		{
+			public AccessoryViewCellWithContextActions()
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				View = label; 
+				
+				var delete = new MenuItem { Text = "Delete" };
+				ContextActions.Add(delete);
+			}
+		}
+
+		protected override void Init()
+		{
+			var label = new Label { Text = Instructions };
+			var listView = new ListView { ItemTemplate = new DataTemplate(typeof(AccessoryViewCellWithContextActions)), ItemsSource = Enumerable.Range(0, 9), Header = ListView1 };
+			var listView2 = new ListView(ListViewCachingStrategy.RecycleElement) { ItemTemplate = new DataTemplate(typeof(AccessoryViewCell)), ItemsSource = Enumerable.Range(10, 19), Header = ListView2 };
+			var listView3 = new ListView { ItemTemplate = new DataTemplate(typeof(AccessoryViewCell)), ItemsSource = Enumerable.Range(20, 29), Header = ListView3 };
+
+			Content = new StackLayout { Children = { label, listView, listView2, listView3 } };
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla43161Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("0"));
+			RunningApp.WaitForElement(q => q.Marked("10"));
+			RunningApp.WaitForElement(q => q.Marked("20"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -181,6 +181,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ImageLoadingErrorHandling.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43214.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43161.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -119,10 +119,10 @@ namespace Xamarin.Forms.Platform.iOS
 				if (!_rendererRef.TryGetTarget(out renderer))
 					return base.SizeThatFits(size);
 
-                		if (renderer.Element == null)
-                			return SizeF.Empty;
-                			
-                		double width = size.Width;
+				if (renderer.Element == null)
+					return SizeF.Empty;
+
+				double width = size.Width;
 				var height = size.Height > 0 ? size.Height : double.PositiveInfinity;
 				var result = renderer.Element.Measure(width, height);
 

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -93,7 +93,8 @@ namespace Xamarin.Forms.Platform.iOS
 				//This sets the content views frame.
 				base.LayoutSubviews();
 
-				if (SupressSeparator)
+				//TODO: Determine how best to hide the separator line when there is an accessory on the cell
+				if (SupressSeparator && Accessory == UITableViewCellAccessory.None)
 				{
 					var oldFrame = Frame;
 					ContentView.Bounds = Frame = new RectangleF(oldFrame.Location, new SizeF(oldFrame.Width, oldFrame.Height + 0.5f));


### PR DESCRIPTION
### Description of Change ###

Will no longer adjust the Bounds of a ViewCell to hide the separator gap if there is an Accessory on the Cell.

### Bugs Fixed ###

- [Bug 43161  - Setting Accessory in ViewCellRenderer breakes layout] (https://bugzilla.xamarin.com/show_bug.cgi?id=43161)

### API Changes ###

None

### Behavioral Changes ###

[iOS] Custom ViewCells with Accessories may still have a gap between ListView cells even if SeparatorVisibility is set to none. See #217.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
