### PR TITLE
[iOS] Adjust Started/Ended hooks in pickers for iOS 10

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -48,8 +48,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var entry = new NoCaretField { BorderStyle = UITextBorderStyle.RoundedRect };
 
-				entry.Started += OnStarted;
-				entry.Ended += OnEnded;
+				entry.EditingDidBegin += OnStarted;
+				entry.EditingDidEnd += OnEnded;
 
 				_picker = new UIDatePicker { Mode = UIDatePickerMode.Date, TimeZone = new NSTimeZone("UTC") };
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -37,8 +37,8 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					var entry = new NoCaretField { BorderStyle = UITextBorderStyle.RoundedRect };
 
-					entry.Started += OnStarted;
-					entry.Ended += OnEnded;
+					entry.EditingDidBegin += OnStarted;
+					entry.EditingDidEnd += OnEnded;
 
 					_picker = new UIPickerView();
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -32,8 +32,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (disposing)
 			{
-				Control.Started -= OnStarted;
-				Control.Ended -= OnEnded;
+				Control.EditingDidBegin -= OnStarted;
+				Control.EditingDidEnd -= OnEnded;
 
 				_picker.ValueChanged -= OnValueChanged;
 			}
@@ -49,8 +49,8 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					var entry = new NoCaretField { BorderStyle = UITextBorderStyle.RoundedRect };
 
-					entry.Started += OnStarted;
-					entry.Ended += OnEnded;
+					entry.EditingDidBegin += OnStarted;
+					entry.EditingDidEnd += OnEnded;
 
 					_picker = new UIDatePicker { Mode = UIDatePickerMode.Time, TimeZone = new NSTimeZone("UTC") };
 


### PR DESCRIPTION
### Description of Change ###

There's presently an issue where the `Ended` event on a `UITextView` doesn't appear to be firing off in iOS 10, but the `EditingDidEnd` hook is fine. This is just switching out those hooks as well as the ones for `Started` to keep them in line.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=44056

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x]  Changes adhere to coding standard
- [x] Consolidate commits as makes sense

