### PR TITLE
[A] Fix regression on NavAnimationInProgress

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -607,8 +607,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 						transaction.Show(toShow);
 					else
 						transaction.Add(Id, toShow);
-
-					((Platform)Element.Platform).NavAnimationInProgress = false;
 				}
 				else
 				{
@@ -617,7 +615,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					transaction.Hide(currentToHide);
 					transaction.Add(Id, fragment);
 					fragments.Add(fragment);
-					((Platform)Element.Platform).NavAnimationInProgress = false;
 				}
 			}
 			transaction.Commit();
@@ -657,6 +654,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 
 			Context.HideKeyboard(this);
+			((Platform)Element.Platform).NavAnimationInProgress = false;
 
 			// 200ms is how long the animations are, and they are "reversible" in the sense that starting another one slightly before it's done is fine
 


### PR DESCRIPTION
### Description of Change ###

Android running in AppCompat wouldn't go back to the home screen using the back button until a navigation was made; this was due to the fix in #272 not setting the `NavAnimationInProgress` value to false when the app first opened. Just moving it to the end and setting it once should fix this issue while leaving the old fix intact.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=44018

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

