### PR TITLE
[Android] Forward appearing / disappearing methods only for the last item on the stack

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		public override void OnPause()
 		{
-		    Page currentPage = (Application.Current.MainPage as IPageContainer<Page>)?.CurrentPage;
+            Page currentPage = (Application.Current.MainPage as IPageContainer<Page>)?.CurrentPage;
             if (currentPage == null || currentPage == PageController)
                 PageController?.SendDisappearing();
 
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
             Page currentPage = (Application.Current.MainPage as IPageContainer<Page>)?.CurrentPage;
             if (UserVisibleHint && (currentPage == null || currentPage == PageController))
-				PageController?.SendAppearing();
+                PageController?.SendAppearing();
 
 			base.OnResume();
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
@@ -121,14 +121,19 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		public override void OnPause()
 		{
-			PageController?.SendDisappearing();
+		    Page currentPage = (Application.Current.MainPage as IPageContainer<Page>)?.CurrentPage;
+            if (currentPage == null || currentPage == PageController)
+                PageController?.SendDisappearing();
+
 			base.OnPause();
 		}
 		
 		public override void OnResume()
 		{
-			if (UserVisibleHint)
+            Page currentPage = (Application.Current.MainPage as IPageContainer<Page>)?.CurrentPage;
+            if (UserVisibleHint && (currentPage == null || currentPage == PageController))
 				PageController?.SendAppearing();
+
 			base.OnResume();
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

When Android app was backgrounded or foregrounded, any page that implements `IPageContainer` was invoking appearing / disappearing methods for all pages on the stack. This change ensures that only the current page triggers its life cycle events. I'm not sure how `MasterDetailPage` behaves as I don't use it in my app, but this change should not break existing functionality.

In addition to this, I realized that if `MainPage` is set to a `ContentPage`, backgrounding / foregrounding the app does **NOT** raise appearing / disappearing events on the page. I will submit a bug in case this is a bug (not intended behavior) and needs to be fixed.

### Bugs Fixed ###

Possibly fixes:

- https://bugzilla.xamarin.com/show_bug.cgi?id=41322
- https://bugzilla.xamarin.com/show_bug.cgi?id=43815

I did not read the bug descriptions in detail or run the repros, but fixing my own use case might fix those as well.

### Comments ###

iOS seems to never raise page life cycle events when the app is put to sleep or resumed. Instead, developers should use `OnSleep` and `OnResume` events in the Application class and use simple pub/sub messages to deal with individual pages.  Android is different as each (or the topmost) fragment needs to sync up with the activity life cycle events. **Can you please confirm?**

UPDATE:

Please see [Coordinating with the activity lifecycle](https://developer.android.com/guide/components/fragments.html#Lifecycle)

> The lifecycle of the activity in which the fragment lives directly affects the lifecycle of the fragment, such that each lifecycle callback for the activity results in a similar callback for each fragment. For example, when the activity receives onPause(), each fragment in the activity receives onPause().

While this mentions how Fragments should behave, it says nothing about Pages. If XF implements each Page as a Fragment, then there should be a design decision as to whether `OnPause` and `OnResume` should translate to `OnDisappearing` and `OnAppearing` with **each page on the stack** (which is the case with the latest version of XF). However, [bug 41322](https://bugzilla.xamarin.com/show_bug.cgi?id=41322) was CONFIRMED.