### PR TITLE
[Android] InputTransparent and IsEnabled fixes on visual elements

### DIFF
--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -16,7 +16,6 @@ namespace Xamarin.Forms.Platform.Android
 		readonly Lazy<GestureDetector> _gestureDetector;
 		readonly PanGestureHandler _panGestureHandler;
 		readonly PinchGestureHandler _pinchGestureHandler;
-
 		readonly TapGestureHandler _tapGestureHandler;
 
 		NotifyCollectionChangedEventHandler _collectionChangeHandler;
@@ -72,12 +71,9 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		View View
-		{
-			get { return Element as View; }
-		}
+		View View => Element as View;
 
-		void IEffectControlProvider.RegisterEffect(Effect effect)
+	    void IEffectControlProvider.RegisterEffect(Effect effect)
 		{
 			var platformEffect = effect as PlatformEffect;
 			if (platformEffect != null)
@@ -89,7 +85,15 @@ namespace Xamarin.Forms.Platform.Android
 			_tapGestureHandler.OnSingleClick();
 		}
 
-		bool IOnTouchListener.OnTouch(AView v, MotionEvent e)
+        public override bool OnInterceptTouchEvent(MotionEvent ev)
+        {
+            if (Element.InputTransparent && Element.IsEnabled)
+                return false;
+
+            return base.OnInterceptTouchEvent(ev);
+        }
+
+        bool IOnTouchListener.OnTouch(AView v, MotionEvent e)
 		{
 			var handled = false;
 			if (_pinchGestureHandler.IsPinchSupported)
@@ -101,15 +105,12 @@ namespace Xamarin.Forms.Platform.Android
 
 			_gestureListener?.OnTouchEvent(e);
 
-			return _gestureDetector.Value.OnTouchEvent(e) || handled;
+		    return _gestureDetector.Value.OnTouchEvent(e) || handled;
 		}
 
-		VisualElement IVisualElementRenderer.Element
-		{
-			get { return Element; }
-		}
+		VisualElement IVisualElementRenderer.Element => Element;
 
-		event EventHandler<VisualElementChangedEventArgs> IVisualElementRenderer.ElementChanged
+	    event EventHandler<VisualElementChangedEventArgs> IVisualElementRenderer.ElementChanged
 		{
 			add { _elementChangedHandlers.Add(value); }
 			remove { _elementChangedHandlers.Remove(value); }
@@ -124,7 +125,7 @@ namespace Xamarin.Forms.Platform.Android
 		void IVisualElementRenderer.SetElement(VisualElement element)
 		{
 			if (!(element is TElement))
-				throw new ArgumentException("element is not of type " + typeof(TElement), "element");
+				throw new ArgumentException("element is not of type " + typeof(TElement), nameof(element));
 
 			SetElement((TElement)element);
 		}
@@ -134,23 +135,18 @@ namespace Xamarin.Forms.Platform.Android
 		public void UpdateLayout()
 		{
 			Performance.Start();
-			if (Tracker != null)
-				Tracker.UpdateLayout();
-
-			Performance.Stop();
+		    Tracker?.UpdateLayout();
+		    Performance.Stop();
 		}
 
-		public ViewGroup ViewGroup
-		{
-			get { return this; }
-		}
+		public ViewGroup ViewGroup => this;
 
-		public event EventHandler<ElementChangedEventArgs<TElement>> ElementChanged;
+	    public event EventHandler<ElementChangedEventArgs<TElement>> ElementChanged;
 
 		public void SetElement(TElement element)
 		{
 			if (element == null)
-				throw new ArgumentNullException("element");
+				throw new ArgumentNullException(nameof(element));
 
 			TElement oldElement = Element;
 			Element = element;
@@ -288,13 +284,11 @@ namespace Xamarin.Forms.Platform.Android
 		protected virtual void OnElementChanged(ElementChangedEventArgs<TElement> e)
 		{
 			var args = new VisualElementChangedEventArgs(e.OldElement, e.NewElement);
-			for (var i = 0; i < _elementChangedHandlers.Count; i++)
-				_elementChangedHandlers[i](this, args);
+			foreach (EventHandler<VisualElementChangedEventArgs> handler in _elementChangedHandlers)
+			    handler(this, args);
 
-			EventHandler<ElementChangedEventArgs<TElement>> changed = ElementChanged;
-			if (changed != null)
-				changed(this, e);
-		}
+		    ElementChanged?.Invoke(this, e);
+        }
 
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
@@ -310,14 +304,14 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			ReadOnlyCollection<Element> children = ((IElementController)Element).LogicalChildren;
-			for (var i = 0; i < children.Count; i++)
+			foreach (Element element in children)
 			{
-				var visualElement = children[i] as VisualElement;
-				if (visualElement == null)
-					continue;
+			    var visualElement = element as VisualElement;
+			    if (visualElement == null)
+			        continue;
 
-				IVisualElementRenderer renderer = Platform.GetRenderer(visualElement);
-				renderer?.UpdateLayout();
+			    IVisualElementRenderer renderer = Platform.GetRenderer(visualElement);
+			    renderer?.UpdateLayout();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		View View => Element as View;
 
-	    void IEffectControlProvider.RegisterEffect(Effect effect)
+		void IEffectControlProvider.RegisterEffect(Effect effect)
 		{
 			var platformEffect = effect as PlatformEffect;
 			if (platformEffect != null)
@@ -85,15 +85,15 @@ namespace Xamarin.Forms.Platform.Android
 			_tapGestureHandler.OnSingleClick();
 		}
 
-        public override bool OnInterceptTouchEvent(MotionEvent ev)
-        {
-            if (Element.InputTransparent && Element.IsEnabled)
-                return false;
+		public override bool OnInterceptTouchEvent(MotionEvent ev)
+		{
+			if (Element.InputTransparent && Element.IsEnabled)
+				return false;
 
-            return base.OnInterceptTouchEvent(ev);
-        }
+			return base.OnInterceptTouchEvent(ev);
+		}
 
-        bool IOnTouchListener.OnTouch(AView v, MotionEvent e)
+		bool IOnTouchListener.OnTouch(AView v, MotionEvent e)
 		{
 			var handled = false;
 			if (_pinchGestureHandler.IsPinchSupported)
@@ -105,12 +105,12 @@ namespace Xamarin.Forms.Platform.Android
 
 			_gestureListener?.OnTouchEvent(e);
 
-		    return _gestureDetector.Value.OnTouchEvent(e) || handled;
+			return _gestureDetector.Value.OnTouchEvent(e) || handled;
 		}
 
 		VisualElement IVisualElementRenderer.Element => Element;
 
-	    event EventHandler<VisualElementChangedEventArgs> IVisualElementRenderer.ElementChanged
+		event EventHandler<VisualElementChangedEventArgs> IVisualElementRenderer.ElementChanged
 		{
 			add { _elementChangedHandlers.Add(value); }
 			remove { _elementChangedHandlers.Remove(value); }
@@ -135,13 +135,13 @@ namespace Xamarin.Forms.Platform.Android
 		public void UpdateLayout()
 		{
 			Performance.Start();
-		    Tracker?.UpdateLayout();
-		    Performance.Stop();
+			Tracker?.UpdateLayout();
+			Performance.Stop();
 		}
 
 		public ViewGroup ViewGroup => this;
 
-	    public event EventHandler<ElementChangedEventArgs<TElement>> ElementChanged;
+		public event EventHandler<ElementChangedEventArgs<TElement>> ElementChanged;
 
 		public void SetElement(TElement element)
 		{
@@ -285,10 +285,10 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var args = new VisualElementChangedEventArgs(e.OldElement, e.NewElement);
 			foreach (EventHandler<VisualElementChangedEventArgs> handler in _elementChangedHandlers)
-			    handler(this, args);
+				handler(this, args);
 
-		    ElementChanged?.Invoke(this, e);
-        }
+			ElementChanged?.Invoke(this, e);
+		}
 
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
@@ -306,12 +306,12 @@ namespace Xamarin.Forms.Platform.Android
 			ReadOnlyCollection<Element> children = ((IElementController)Element).LogicalChildren;
 			foreach (Element element in children)
 			{
-			    var visualElement = element as VisualElement;
-			    if (visualElement == null)
-			        continue;
+				var visualElement = element as VisualElement;
+				if (visualElement == null)
+					continue;
 
-			    IVisualElementRenderer renderer = Platform.GetRenderer(visualElement);
-			    renderer?.UpdateLayout();
+				IVisualElementRenderer renderer = Platform.GetRenderer(visualElement);
+				renderer?.UpdateLayout();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Setting `InputTransparent="False"` does not work on Android if the background color is not set or if it is set to Transparent. The color must be set to a **non-transparent** color in order for taps not to propagate down. This change ensures for at least elements that use `VisualElementRenderer` that touch events are intercepted accordingly. Other renderers might have to do the same.

Another issue was `Grid`, `StackLayout`, and `ContentView` still participated in hit testing after `IsEnabled` is set to false.

This code takes care of both cases:

```
public override bool OnInterceptTouchEvent(MotionEvent ev)
{
     if (Element.InputTransparent && Element.IsEnabled)
          return false;

     return base.OnInterceptTouchEvent(ev);
}
```

Note that parent elements do not push `IsEnabled` changes to their children. This will require another fix in the future if it's not intended behavior.

Also made some refactoring.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44176
- https://bugzilla.xamarin.com/show_bug.cgi?id=44096

### API Changes ###

Added:
 - bool OnInterceptTouchEvent(MotionEvent ev)