### PR TITLE
[WinRT] Use a queue to prevent multiple MessageDialogs from causing a crash

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43469.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43469.cs
@@ -1,0 +1,37 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43469, "Calling DisplayAlert twice in WinRT causes a crash", PlatformAffected.WinRT)]
+	public class Bugzilla43469 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var button = new Button { Text = "Click to call DisplayAlert twice" };
+
+			button.Clicked += (sender, args) =>
+			{
+				Device.BeginInvokeOnMainThread(new Action(async () =>
+				{
+					await DisplayAlert("First", "Text", "Cancel");
+				}));
+
+				Device.BeginInvokeOnMainThread(new Action(async () =>
+				{
+					await DisplayAlert("Second", "Text", "Cancel");
+				}));
+			};
+
+			Content = button;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -130,6 +130,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42364.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43313.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43469.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43663.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44944.cs" />

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -761,8 +761,35 @@ namespace Xamarin.Forms.Platform.WinRT
 				dialog.CancelCommandIndex = (uint)dialog.Commands.Count - 1;
 			}
 
-			IUICommand command = await dialog.ShowAsync();
+			IUICommand command = await dialog.ShowAsyncQueue();
 			options.SetResult(command.Label == options.Accept);
+		}
+	}
+	
+	// refer to http://stackoverflow.com/questions/29209954/multiple-messagedialog-app-crash for why this is used
+	// in order to allow for multiple MessageDialogs, or a crash occurs otherwise
+	public static class MessageDialogExtensions
+	{
+		static TaskCompletionSource<MessageDialog> _currentDialogShowRequest;
+
+		public static async Task<IUICommand> ShowAsyncQueue(this MessageDialog dialog)
+		{
+			if (!Window.Current.Dispatcher.HasThreadAccess)
+			{
+				throw new InvalidOperationException("This method can only be invoked from UI thread.");
+			}
+
+			while (_currentDialogShowRequest != null)
+			{
+				await _currentDialogShowRequest.Task;
+			}
+
+			var request = _currentDialogShowRequest = new TaskCompletionSource<MessageDialog>();
+			var result = await dialog.ShowAsync();
+			_currentDialogShowRequest = null;
+			request.SetResult(dialog);
+
+			return result;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -761,8 +761,19 @@ namespace Xamarin.Forms.Platform.WinRT
 				dialog.CancelCommandIndex = (uint)dialog.Commands.Count - 1;
 			}
 
-			IUICommand command = await dialog.ShowAsyncQueue();
-			options.SetResult(command.Label == options.Accept);
+			if (Device.IsInvokeRequired)
+			{
+				Device.BeginInvokeOnMainThread(async () =>
+				{
+					IUICommand command = await dialog.ShowAsyncQueue();
+					options.SetResult(command.Label == options.Accept);
+				});
+			}
+			else
+			{
+				IUICommand command = await dialog.ShowAsyncQueue();
+				options.SetResult(command.Label == options.Accept);
+			}
 		}
 	}
 	
@@ -774,11 +785,6 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		public static async Task<IUICommand> ShowAsyncQueue(this MessageDialog dialog)
 		{
-			if (!Window.Current.Dispatcher.HasThreadAccess)
-			{
-				throw new InvalidOperationException("This method can only be invoked from UI thread.");
-			}
-
 			while (_currentDialogShowRequest != null)
 			{
 				await _currentDialogShowRequest.Task;


### PR DESCRIPTION
### Description of Change

Calling `DisplayAlert` to show multiple dialogs would cause a crash. According to [this StackOverflow question](http://stackoverflow.com/questions/29209954/multiple-messagedialog-app-crash) it appears that there cannot be multiple MessageDialogs. Per the answer there, the dialogs can instead be queued. This functionality could perhaps be discussed further, but it brings the behavior in line with Android and iOS and prevents this crash from occurring.
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=43469
### API Changes

Added:
`public static class MessageDialogExtensions` 
- contains `public static async Task<IUICommand> ShowAsyncQueue(this MessageDialog dialog)`
### Behavioral Changes

The SO post does mention a reason or two that having multiple dialogs might not be desirable, but again, this behavior can be discussed further if need be.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
