### PR TITLE
[Android, Help Needed, Do Not Merge] TabbedPage child should not call disappearing on initial run

### DIFF
--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -311,7 +311,17 @@ namespace Xamarin.Forms
 				handler(this, EventArgs.Empty);
 
 			var pageContainer = this as IPageContainer<Page>;
-			((IPageController)pageContainer?.CurrentPage)?.SendAppearing();
+            if (Device.OS == TargetPlatform.Android)
+            {
+                if (pageContainer != null && pageContainer.GetType() != typeof(TabbedPage))
+                {
+                    ((IPageController)pageContainer.CurrentPage)?.SendAppearing();
+                }
+            }
+            else
+            {
+                ((IPageController)pageContainer?.CurrentPage)?.SendAppearing();
+            }
 		}
 
 		void IPageController.SendDisappearing()

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -314,14 +314,10 @@ namespace Xamarin.Forms
             if (Device.OS == TargetPlatform.Android)
             {
                 if (pageContainer != null && pageContainer.GetType() != typeof(TabbedPage))
-                {
                     ((IPageController)pageContainer.CurrentPage)?.SendAppearing();
-                }
             }
             else
-            {
                 ((IPageController)pageContainer?.CurrentPage)?.SendAppearing();
-            }
 		}
 
 		void IPageController.SendDisappearing()

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -311,12 +311,15 @@ namespace Xamarin.Forms
 				handler(this, EventArgs.Empty);
 
 			var pageContainer = this as IPageContainer<Page>;
+
+			// hack for Android
 			if (Device.OS == TargetPlatform.Android)
 			{
 				if (pageContainer != null && pageContainer.GetType() != typeof(TabbedPage))
 					((IPageController)pageContainer.CurrentPage)?.SendAppearing();
 			}
 			else
+				// original calls
 				((IPageController)pageContainer?.CurrentPage)?.SendAppearing();
 		}
 

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -310,7 +310,7 @@ namespace Xamarin.Forms
 			if (handler != null)
 				handler(this, EventArgs.Empty);
 
-            var pageContainer = this as IPageContainer<Page>;
+			var pageContainer = this as IPageContainer<Page>;
 			if (Device.OS == TargetPlatform.Android)
 			{
 				if (pageContainer != null && pageContainer.GetType() != typeof(TabbedPage))

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -310,14 +310,14 @@ namespace Xamarin.Forms
 			if (handler != null)
 				handler(this, EventArgs.Empty);
 
-			var pageContainer = this as IPageContainer<Page>;
-            if (Device.OS == TargetPlatform.Android)
-            {
-                if (pageContainer != null && pageContainer.GetType() != typeof(TabbedPage))
-                    ((IPageController)pageContainer.CurrentPage)?.SendAppearing();
-            }
-            else
-                ((IPageController)pageContainer?.CurrentPage)?.SendAppearing();
+            var pageContainer = this as IPageContainer<Page>;
+			if (Device.OS == TargetPlatform.Android)
+			{
+				if (pageContainer != null && pageContainer.GetType() != typeof(TabbedPage))
+					((IPageController)pageContainer.CurrentPage)?.SendAppearing();
+			}
+			else
+				((IPageController)pageContainer?.CurrentPage)?.SendAppearing();
 		}
 
 		void IPageController.SendDisappearing()

--- a/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		IPageController PageController => Page as IPageController;
 
-		// pager measure sets this to false
+		// set by pager measure, calls SendDisappearing of Page
 		public override bool UserVisibleHint
 		{
 			get { return base.UserVisibleHint; }

--- a/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
@@ -33,6 +33,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		IPageController PageController => Page as IPageController;
 
+		// pager measure sets this to false
 		public override bool UserVisibleHint
 		{
 			get { return base.UserVisibleHint; }

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -215,7 +215,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			else
 				tabsHeight = Math.Min(height, tabs.MeasuredHeight);
 
-			// Calls SendDisappearing of Page
+			// Sets UserVisibleHint to false
 			pager.Measure(MeasureSpecFactory.MakeMeasureSpec(width, MeasureSpecMode.AtMost), MeasureSpecFactory.MakeMeasureSpec(height, MeasureSpecMode.AtMost));
 
 			if (width > 0 && height > 0)

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -215,6 +215,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			else
 				tabsHeight = Math.Min(height, tabs.MeasuredHeight);
 
+			// Calls SendDisappearing of Page
 			pager.Measure(MeasureSpecFactory.MakeMeasureSpec(width, MeasureSpecMode.AtMost), MeasureSpecFactory.MakeMeasureSpec(height, MeasureSpecMode.AtMost));
 
 			if (width > 0 && height > 0)


### PR DESCRIPTION
### Description of Change ###

Currently, there is a bug with Android TabbedPage that triggers appearing / disappearing events the wrong way. When you load a TabbedPage, the following happens:

- TabbedPage Appearing
- Page1 Appearing
- Page1 Disappearing
- Page1 Appearing

Page1 should **NOT** call its `Disappearing` event. I was able to identify how this bug happens but not why. 

In `Page.cs`, after TabbedPage invokes its `Appearing` event inside `IPageController.SendAppearing()`, it also invokes its current page's `Appearing` event like so:

`((IPageController)pageContainer?.CurrentPage)?.SendAppearing();`

Then, `TabbedPageRenderer` invokes `pager.Measure(...)` inside `OnLayout(...)` which in turn triggers `IPageController.SendDisappearing()` in `Page.cs`. I'm not sure why this is the case. This will fire `Disappearing` event for the current page.

The hack is to skip calling current page's appearing event as seen in the commit. This way, `IPageController.SendDisappearing()` will be called but not processed since `_hasAppeared` is false.

Can anyone comment why `pager.Measure(...)` sets `UserVisibleHint` of `FragmentContainer` to false?

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44211