### PR TITLE
AppCompat should now be able to set title bar visibility programmatic…

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -478,7 +478,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (@params.Flags.HasFlag(WindowManagerFlags.Fullscreen))
 			{
-				if(Forms.TitleBarVisibility != AndroidTitleBarVisibility.Never)
+				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Never)
 					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Never;
 			}
 			else
@@ -487,7 +487,8 @@ namespace Xamarin.Forms.Platform.Android
 					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Default;
 			}
 
-			if (Xamarin.Forms.Application.Current == null || Xamarin.Forms.Application.Current.MainPage == null) return;
+			if (Xamarin.Forms.Application.Current == null || Xamarin.Forms.Application.Current.MainPage == null)
+				return;
 
 			var displayMetrics = Resources.DisplayMetrics;
 			var width = displayMetrics.WidthPixels;

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -472,6 +472,29 @@ namespace Xamarin.Forms.Platform.Android
 			SetStatusBarVisibility(adjust);
 		}
 
+		public override void OnWindowAttributesChanged(WindowManagerLayoutParams @params)
+		{
+			base.OnWindowAttributesChanged(@params);
+
+			if (@params.Flags.HasFlag(WindowManagerFlags.Fullscreen))
+			{
+				if(Forms.TitleBarVisibility != AndroidTitleBarVisibility.Never)
+					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Never;
+			}
+			else
+			{
+				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Default)
+					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Default;
+			}
+
+			if (Xamarin.Forms.Application.Current == null || Xamarin.Forms.Application.Current.MainPage == null) return;
+
+			var displayMetrics = Resources.DisplayMetrics;
+			var width = displayMetrics.WidthPixels;
+			var height = displayMetrics.HeightPixels;
+			AppCompat.Platform.LayoutRootPage(this, Xamarin.Forms.Application.Current.MainPage, width, height);
+		}
+
 		void SetStatusBarVisibility(SoftInput mode)
 		{
 			if (!Forms.IsLollipopOrNewer)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		AndroidApplicationLifecycleState _previousState;
 
-		bool _renderersAdded;
+		bool _renderersAdded, _isFullScreen;
 		int _statusBarHeight = -1;
 		global::Android.Views.View _statusBarUnderlay;
 
@@ -476,19 +476,27 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnWindowAttributesChanged(@params);
 
+			if (Xamarin.Forms.Application.Current == null || Xamarin.Forms.Application.Current.MainPage == null)
+				return;
+
 			if (@params.Flags.HasFlag(WindowManagerFlags.Fullscreen))
 			{
 				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Never)
 					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Never;
+
+				if (_isFullScreen)
+					return;
 			}
 			else
 			{
 				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Default)
 					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Default;
+
+				if (!_isFullScreen)
+					return;
 			}
 
-			if (Xamarin.Forms.Application.Current == null || Xamarin.Forms.Application.Current.MainPage == null)
-				return;
+			_isFullScreen = !_isFullScreen;
 
 			var displayMetrics = Resources.DisplayMetrics;
 			var width = displayMetrics.WidthPixels;

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -193,7 +193,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void IPlatformLayout.OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			if (changed)
-				LayoutRootPage(Page, r - l, b - t);
+				LayoutRootPage((FormsAppCompatActivity)_context, Page, r - l, b - t);
 
 			Android.Platform.GetRenderer(Page).UpdateLayout();
 
@@ -251,7 +251,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Android.Platform.SetRenderer(page, renderView);
 
 			if (layout)
-				LayoutRootPage(page, _renderer.Width, _renderer.Height);
+				LayoutRootPage((FormsAppCompatActivity)_context, page, _renderer.Width, _renderer.Height);
 
 			_renderer.AddView(renderView.ViewGroup);
 		}
@@ -267,16 +267,17 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			return handled;
 		}
 
-		void LayoutRootPage(Page page, int width, int height)
+		internal static void LayoutRootPage(FormsAppCompatActivity activity, Page page, int width, int height)
 		{
-			var activity = (FormsAppCompatActivity)_context;
 			int statusBarHeight = Forms.IsLollipopOrNewer ? activity.GetStatusBarHeight() : 0;
+			statusBarHeight = activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen) ? 0 : statusBarHeight;
+			statusBarHeight = Forms.TitleBarVisibility == AndroidTitleBarVisibility.Never ? 0 : statusBarHeight; // just to be sure
 
 			if (page is MasterDetailPage)
-				page.Layout(new Rectangle(0, 0, _context.FromPixels(width), _context.FromPixels(height)));
+				page.Layout(new Rectangle(0, 0, activity.FromPixels(width), activity.FromPixels(height)));
 			else
 			{
-				page.Layout(new Rectangle(0, _context.FromPixels(statusBarHeight), _context.FromPixels(width), _context.FromPixels(height - statusBarHeight)));
+				page.Layout(new Rectangle(0, activity.FromPixels(statusBarHeight), activity.FromPixels(width), activity.FromPixels(height - statusBarHeight)));
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -270,8 +270,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		internal static void LayoutRootPage(FormsAppCompatActivity activity, Page page, int width, int height)
 		{
 			int statusBarHeight = Forms.IsLollipopOrNewer ? activity.GetStatusBarHeight() : 0;
-			statusBarHeight = activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen) ? 0 : statusBarHeight;
-			statusBarHeight = Forms.TitleBarVisibility == AndroidTitleBarVisibility.Never ? 0 : statusBarHeight; // just to be sure
+			statusBarHeight = activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen) || Forms.TitleBarVisibility == AndroidTitleBarVisibility.Never ? 0 : statusBarHeight;
 
 			if (page is MasterDetailPage)
 				page.Layout(new Rectangle(0, 0, activity.FromPixels(width), activity.FromPixels(height)));

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -15,6 +15,7 @@ using Android.Content;
 using Android.Content.Res;
 using Android.OS;
 using Android.Util;
+using Android.Views;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.Android;
 using Resource = Android.Resource;
@@ -61,7 +62,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		internal static AndroidTitleBarVisibility TitleBarVisibility { get; private set; }
+		internal static AndroidTitleBarVisibility TitleBarVisibility { get; set; }
 
 		// Provide backwards compat for Forms.Init and AndroidActivity
 		// Why is bundle a param if never used?
@@ -76,9 +77,26 @@ namespace Xamarin.Forms
 			SetupInit(activity, resourceAssembly);
 		}
 
+		/// <summary>
+		/// Sets title bar visibility programmatically. Must be called after Xamarin.Forms.Forms.Init() method
+		/// </summary>
+		/// <param name="visibility">Title bar visibility enum</param>
 		public static void SetTitleBarVisibility(AndroidTitleBarVisibility visibility)
 		{
+			if((Activity)Context == null) throw new NullReferenceException("Must be called after Xamarin.Forms.Forms.Init() method");
+
 			TitleBarVisibility = visibility;
+
+			if (TitleBarVisibility == AndroidTitleBarVisibility.Never)
+			{
+				if(!((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen))
+					((Activity)Context).Window.AddFlags(WindowManagerFlags.Fullscreen);
+			}
+			else
+			{
+				if (((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen))
+					((Activity)Context).Window.ClearFlags(WindowManagerFlags.Fullscreen);
+			}
 		}
 
 		public static event EventHandler<ViewInitializedEventArgs> ViewInitialized;

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -83,13 +83,14 @@ namespace Xamarin.Forms
 		/// <param name="visibility">Title bar visibility enum</param>
 		public static void SetTitleBarVisibility(AndroidTitleBarVisibility visibility)
 		{
-			if((Activity)Context == null) throw new NullReferenceException("Must be called after Xamarin.Forms.Forms.Init() method");
+			if((Activity)Context == null)
+				throw new NullReferenceException("Must be called after Xamarin.Forms.Forms.Init() method");
 
 			TitleBarVisibility = visibility;
 
 			if (TitleBarVisibility == AndroidTitleBarVisibility.Never)
 			{
-				if(!((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen))
+				if (!((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen))
 					((Activity)Context).Window.AddFlags(WindowManagerFlags.Fullscreen);
 			}
 			else


### PR DESCRIPTION
### Description of Change ###

Created a bug 8 months ago that got no love. Decided to fix it myself. If you use AppCompat, you can't hide title bar (title bar controls are hidden but the background is still visible.) This change ensures that developers can toggle status bar visibility programmatically. Right now, there are two ways to achieve this:

- Call `Xamarin.Forms.Forms.SetTitleBarVisibility(param)`
- Add / clear fullscreen window flag

Updating title bar visibility should set the equivalent window flag or vice versa.

There is still more work to be done. For example, ~~there is no way at the moment to hide status bar on splash screen~~. Also not sure if `SystemUiFlags` works (haven't tested immersive stuff). I will either add to this PR to fix those or submit another in the future.

EDIT: 

Setting `<item name="android:windowFullscreen">true</item>` should work because this actually raises `OnWindowAttributesChanged()` with the fullscreen flag added.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=38019

### API Changes ###

Changed:
 - void LayoutRootPage(Page page, int width, int height) => internal static void LayoutRootPage(FormsAppCompatActivity activity, Page page, int width, int height)

- internal static AndroidTitleBarVisibility TitleBarVisibility { get; private set; } => internal static AndroidTitleBarVisibility TitleBarVisibility { get; set; }