### PR TITLE
[iOS] - Revert setting the frame for ViewCell to try to hide the gap …

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Forms.Platform.iOS
 				contextCell.Update(tableView, cell, nativeCell);
 				var viewTableCell = contextCell.ContentCell as ViewCellRenderer.ViewTableCell;
 				if (viewTableCell != null)
-					viewTableCell.SupressSeparator = true;
+					viewTableCell.SupressSeparator = tableView.SeparatorStyle == UITableViewCellSeparatorStyle.None;
 				nativeCell = contextCell;
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -81,10 +81,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			}
 
-			Element INativeElementView.Element
-			{
-				get { return ViewCell; }
-			}
+			Element INativeElementView.Element => ViewCell;
 
 			internal bool SupressSeparator { get; set; }
 
@@ -96,7 +93,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (SupressSeparator)
 				{
 					var oldFrame = Frame;
-					ContentView.Bounds = Frame = new RectangleF(oldFrame.Location, new SizeF(oldFrame.Width, oldFrame.Height + 0.5f));
+					ContentView.Bounds = new RectangleF(oldFrame.Location, new SizeF(oldFrame.Width, oldFrame.Height + 0.5f));
 				}
 
 				var contentFrame = ContentView.Frame;


### PR DESCRIPTION
### Description of Change ###

Revert setting the frame, setting the bounds on the ContentView works, doesn't bring a problem. Setting the Frame of the ViewCell was the issue.

Also we just need to try to hide it if the user set the separator to be hidden.

### Bugs Fixed ###

- Actualy i reopen 39802, since now we see a gap between view cells when using no separator. 


### Behavioral Changes ###

Doesn't crash the app

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense