### PR TITLE
[C] Check for TabbedPage in Page's SendAppearing

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44211.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44211.cs
@@ -1,0 +1,65 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.ComponentModel;
+
+#if UITEST
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44211, "SelectedPage's Appearing called twice upon opening a TabbedPage in AppCompat")]
+	public class Bugzilla44211 : TestTabbedPage
+	{
+		class CountPage : ContentPage, INotifyPropertyChanged
+		{
+			public int AppearingCount { get; set; } = 0;
+			public CountPage()
+			{
+				var countLabel = new Label
+				{
+					AutomationId = "AppearingCountLabel"
+				};
+				countLabel.BindingContext = this;
+				countLabel.SetBinding(Label.TextProperty, "AppearingCount");
+
+				Appearing += (s, e) =>
+				{
+					AppearingCount += 1;
+					OnPropertyChanged("AppearingCount");
+				};
+				Content = new StackLayout
+				{
+					Children =
+					{
+						new Label { Text = "Times Appeared called (should only say 1 to start):" },
+						countLabel
+					}
+				};
+			}
+		}
+
+		protected override void Init()
+		{
+			var page1 = new CountPage { Title = "Page1" };
+			var page2 = new CountPage { Title = "Page2" };
+			var page3 = new CountPage { Title = "Page3" };
+
+			Children.Add(page1);
+			Children.Add(page2);
+			Children.Add(page3);
+			SelectedItem = page2;
+		}
+
+#if UITEST
+		[Test]
+		public void TabbedPageShouldOnlyFireAppearingOnce()
+		{
+			RunningApp.Screenshot("I am at the TabbedPage");
+			var label = RunningApp.WaitForElement(q => q.Marked("AppearingCountLabel"));
+			Assert.AreEqual("1", label[0].Text);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -187,6 +187,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52266.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44211.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -308,7 +308,8 @@ namespace Xamarin.Forms
 				handler(this, EventArgs.Empty);
 
 			var pageContainer = this as IPageContainer<Page>;
-			((IPageController)pageContainer?.CurrentPage)?.SendAppearing();
+			if (!(this is TabbedPage))
+				((IPageController)pageContainer?.CurrentPage)?.SendAppearing();
 		}
 
 		void IPageController.SendDisappearing()


### PR DESCRIPTION
### Description of Change

There was an issue where the initially selected page in a `TabbedPage` on AppCompat was sending its `Appearing` event twice (Appearing -> Disappearing -> Appearing again). This appears to be because the `Page`'s `SendAppearing` is letting its current page call `SendAppearing`. This wasn't posing any trouble in the other platforms, but `FragmentContainer`' in the AppCompat implementation has `UserVisibleHint`  overridden to call `SendAppearing` itself which is causing some sort of clash as the page initially loads. The simplest fix I could personally find here is merely checking to see if the `Page` isn't a `TabbedPage` that prevents that clash from happening.
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=44211
### API Changes

None
### Behavioral Changes

I'm having some issues checking this against WP for some reason, but pre-Lollipop Android, iOS, and UWP seemed the same in checking things out in terms of behavior.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
