### PR TITLE
Fix various Android memory leaks

### DIFF
--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -17,7 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -18,7 +18,7 @@
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.ControlGallery.Android/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Properties/AssemblyInfo.cs
@@ -33,5 +33,4 @@ using Android.App;
 [assembly: UsesPermission (Android.Manifest.Permission.Internet)]
 [assembly: UsesPermission (Android.Manifest.Permission.WriteExternalStorage)]
 
-[assembly: Android.App.MetaData("com.google.android.maps.v2.API_KEY", Value = "AIzaSyAdstcJQswxEjzX5YjLaMcu2aRVEBJw39Y")]
 [assembly: Xamarin.Forms.ResolutionGroupName ("XamControl")]

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
@@ -1,0 +1,95 @@
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading;
+using System;
+using System.Threading.Tasks;
+using Xamarin.Forms.Maps;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39489, "Memory leak when using NavigationPage with Maps")]
+	public class Bugzilla39489 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new Bz39489Content());
+		}
+
+		#if UITEST
+		[Test]
+		public async void Bugzilla39458Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("New Page"));
+			RunningApp.Tap(q => q.Marked("New Page"));
+			RunningApp.WaitForElement(q => q.Marked("New Page"));
+			await Task.Delay(3000);
+			RunningApp.Back();
+		}
+		#endif
+	}
+
+	public class MyXFMap : Map
+	{
+		static int s_count;
+
+		public MyXFMap()
+		{
+			Interlocked.Increment(ref s_count);
+			System.Diagnostics.Debug.WriteLine($"++++++++ {nameof(MyXFMap)} : {s_count}");
+		}
+
+		~MyXFMap()
+		{
+			Interlocked.Decrement(ref s_count);
+			System.Diagnostics.Debug.WriteLine($"-------- {nameof(MyXFMap)} : {s_count}");
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Bz39489Content : ContentPage
+	{
+		static int s_count;
+
+		public Bz39489Content()
+		{
+			Interlocked.Increment(ref s_count);
+			System.Diagnostics.Debug.WriteLine($"++++++++ {nameof(Bz39489Content)} : {s_count}");
+
+			var button = new Button { Text = "New Page" };
+
+			var gcbutton = new Button { Text = "GC" };
+
+			var map = new Map();
+
+			button.Clicked += Button_Clicked;
+			gcbutton.Clicked += GCbutton_Clicked;
+
+			Content = new StackLayout { Children = { button, gcbutton, map } };
+		}
+
+		void GCbutton_Clicked(object sender, EventArgs e)
+		{
+			System.Diagnostics.Debug.WriteLine(">>>>>>>> Running Garbage Collection");
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			System.Diagnostics.Debug.WriteLine($">>>>>>>> GC.GetTotalMemory = {GC.GetTotalMemory(true):n0}");
+		}
+
+		void Button_Clicked(object sender, EventArgs e)
+		{
+			Navigation.PushAsync(new Bz39489Content());
+		}
+
+		~Bz39489Content()
+		{
+			Interlocked.Decrement(ref s_count);
+			System.Diagnostics.Debug.WriteLine($"-------- {nameof(Bz39489Content)} : {s_count}");
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -437,6 +437,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue55555.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41029.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39908.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39489.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -15,10 +15,10 @@ using System.Collections;
 
 namespace Xamarin.Forms.Maps.Android
 {
-	public class MapRenderer : ViewRenderer<Map,MapView>, 
-		GoogleMap.IOnCameraChangeListener 
+	public class MapRenderer : ViewRenderer<Map, MapView>,
+		GoogleMap.IOnCameraChangeListener
 	{
-		public MapRenderer ()
+		public MapRenderer()
 		{
 			AutoPackage = false;
 		}
@@ -31,14 +31,14 @@ namespace Xamarin.Forms.Maps.Android
 		const string MoveMessageName = "MapMoveToRegion";
 
 #pragma warning disable 618
-		protected GoogleMap NativeMap => ((MapView) Control).Map;
+		protected GoogleMap NativeMap => Control.Map;
 #pragma warning restore 618
 
-		protected Map Map => (Map) Element;
+		protected Map Map => (Map)Element;
 
-		public override SizeRequest GetDesiredSize (int widthConstraint, int heightConstraint)
+		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
-			return new SizeRequest (new Size (Context.ToPixels (40), Context.ToPixels (40)));
+			return new SizeRequest(new Size(Context.ToPixels(40), Context.ToPixels(40)));
 		}
 
 		protected override MapView CreateNativeControl()
@@ -46,29 +46,32 @@ namespace Xamarin.Forms.Maps.Android
 			return new MapView(Context);
 		}
 
-		protected override void OnElementChanged (ElementChangedEventArgs<Map> e)
+		protected override void OnElementChanged(ElementChangedEventArgs<Map> e)
 		{
-			base.OnElementChanged (e);
+			base.OnElementChanged(e);
 
 			var oldMapView = (MapView)Control;
 
 			var mapView = CreateNativeControl();
-			mapView.OnCreate (s_bundle);
-			mapView.OnResume ();
-			SetNativeControl (mapView);
 
-			if (e.OldElement != null) {
+			mapView.OnCreate(s_bundle);
+			mapView.OnResume();
+			SetNativeControl(mapView);
+
+			if (e.OldElement != null)
+			{
 				var oldMapModel = e.OldElement;
 				((ObservableCollection<Pin>)oldMapModel.Pins).CollectionChanged -= OnCollectionChanged;
 
-				MessagingCenter.Unsubscribe<Map, MapSpan> (this, MoveMessageName);
+				MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
 
 #pragma warning disable 618
-				if (oldMapView.Map != null) {
+				if (oldMapView.Map != null)
+				{
 #pragma warning restore 618
 
 #pragma warning disable 618
-					oldMapView.Map.SetOnCameraChangeListener (null);
+					oldMapView.Map.SetOnCameraChangeListener(null);
 #pragma warning restore 618
 					NativeMap.InfoWindowClick -= MapOnMarkerClick;
 				}
@@ -77,98 +80,109 @@ namespace Xamarin.Forms.Maps.Android
 			}
 
 			var map = NativeMap;
-			if (map != null) {
-				map.SetOnCameraChangeListener (this);
+			if (map != null)
+			{
+				map.SetOnCameraChangeListener(this);
 				NativeMap.InfoWindowClick += MapOnMarkerClick;
 
 				map.UiSettings.ZoomControlsEnabled = Map.HasZoomEnabled;
 				map.UiSettings.ZoomGesturesEnabled = Map.HasZoomEnabled;
 				map.UiSettings.ScrollGesturesEnabled = Map.HasScrollEnabled;
 				map.MyLocationEnabled = map.UiSettings.MyLocationButtonEnabled = Map.IsShowingUser;
-				SetMapType ();
+				SetMapType();
 			}
-			
-			MessagingCenter.Subscribe<Map, MapSpan> (this, MoveMessageName, OnMoveToRegionMessage, Map);
+
+			MessagingCenter.Subscribe<Map, MapSpan>(this, MoveMessageName, OnMoveToRegionMessage, Map);
 
 			var incc = Map.Pins as INotifyCollectionChanged;
 			if (incc != null)
 				incc.CollectionChanged += OnCollectionChanged;
 		}
 
-		void OnCollectionChanged (object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
+		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 		{
-			switch (notifyCollectionChangedEventArgs.Action) {
-			case NotifyCollectionChangedAction.Add:
-				AddPins (notifyCollectionChangedEventArgs.NewItems);
-				break;
-			case NotifyCollectionChangedAction.Remove:
-				RemovePins (notifyCollectionChangedEventArgs.OldItems);
-				break;
-			case NotifyCollectionChangedAction.Replace:
-				RemovePins (notifyCollectionChangedEventArgs.OldItems);
-				AddPins (notifyCollectionChangedEventArgs.NewItems);
-				break;
-			case NotifyCollectionChangedAction.Reset:
-					_markers?.ForEach (m => m.Remove ());
+			switch (notifyCollectionChangedEventArgs.Action)
+			{
+				case NotifyCollectionChangedAction.Add:
+					AddPins(notifyCollectionChangedEventArgs.NewItems);
+					break;
+				case NotifyCollectionChangedAction.Remove:
+					RemovePins(notifyCollectionChangedEventArgs.OldItems);
+					break;
+				case NotifyCollectionChangedAction.Replace:
+					RemovePins(notifyCollectionChangedEventArgs.OldItems);
+					AddPins(notifyCollectionChangedEventArgs.NewItems);
+					break;
+				case NotifyCollectionChangedAction.Reset:
+					_markers?.ForEach(m => m.Remove());
 					_markers = null;
-				AddPins ((IList)(Element as Map).Pins);
-				break;
-			case NotifyCollectionChangedAction.Move:
-				//do nothing
-				break;
+					AddPins((IList)(Element as Map).Pins);
+					break;
+				case NotifyCollectionChangedAction.Move:
+					//do nothing
+					break;
 			}
 		}
 
-		void OnMoveToRegionMessage (Map s, MapSpan a)
+		void OnMoveToRegionMessage(Map s, MapSpan a)
 		{
-			MoveToRegion (a, true);
+			MoveToRegion(a, true);
 		}
 
-		void MoveToRegion (MapSpan span, bool animate)
+		void MoveToRegion(MapSpan span, bool animate)
 		{
 			var map = NativeMap;
 			if (map == null)
 				return;
 
-			span = span.ClampLatitude (85, -85);
-			var ne = new LatLng (span.Center.Latitude + span.LatitudeDegrees / 2, span.Center.Longitude + span.LongitudeDegrees / 2);
-			var sw = new LatLng (span.Center.Latitude - span.LatitudeDegrees / 2, span.Center.Longitude - span.LongitudeDegrees / 2);
-			var update = CameraUpdateFactory.NewLatLngBounds (new LatLngBounds (sw, ne), 0);
-	
-			try {
+			span = span.ClampLatitude(85, -85);
+			var ne = new LatLng(span.Center.Latitude + span.LatitudeDegrees / 2, span.Center.Longitude + span.LongitudeDegrees / 2);
+			var sw = new LatLng(span.Center.Latitude - span.LatitudeDegrees / 2, span.Center.Longitude - span.LongitudeDegrees / 2);
+			var update = CameraUpdateFactory.NewLatLngBounds(new LatLngBounds(sw, ne), 0);
+
+			try
+			{
 				if (animate)
-					map.AnimateCamera (update);
+					map.AnimateCamera(update);
 				else
-					map.MoveCamera (update);
-			} catch (IllegalStateException exc) {
-				System.Diagnostics.Debug.WriteLine ("MoveToRegion exception: " + exc);
+					map.MoveCamera(update);
+			}
+			catch (IllegalStateException exc)
+			{
+				System.Diagnostics.Debug.WriteLine("MoveToRegion exception: " + exc);
+				Log.Warning("Xamarin.Forms MapRenderer", $"MoveToRegion exception: {exc}");
 			}
 		}
 
 		bool _init = true;
+		bool _disposed;
 
-		protected override void OnLayout (bool changed, int l, int t, int r, int b)
+		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
-			base.OnLayout (changed, l, t, r, b);
+			base.OnLayout(changed, l, t, r, b);
 
-			if (_init) {
-				MoveToRegion (((Map)Element).LastMoveToRegion, false);
-				OnCollectionChanged (((Map)Element).Pins, new NotifyCollectionChangedEventArgs( NotifyCollectionChangedAction.Reset));
+			if (_init)
+			{
+				MoveToRegion(((Map)Element).LastMoveToRegion, false);
+				OnCollectionChanged(((Map)Element).Pins, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 				_init = false;
-			} else if (changed) {
-				UpdateVisibleRegion (NativeMap.CameraPosition.Target);
+			}
+			else if (changed)
+			{
+				UpdateVisibleRegion(NativeMap.CameraPosition.Target);
 			}
 		}
 
-		protected override void OnElementPropertyChanged (object sender, PropertyChangedEventArgs e)
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			base.OnElementPropertyChanged (sender, e);
+			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == Map.MapTypeProperty.PropertyName) {
+			if (e.PropertyName == Map.MapTypeProperty.PropertyName)
+			{
 				SetMapType();
 				return;
 			}
-			
+
 			var gmap = NativeMap;
 			if (gmap == null)
 				return;
@@ -177,19 +191,21 @@ namespace Xamarin.Forms.Maps.Android
 				gmap.MyLocationEnabled = gmap.UiSettings.MyLocationButtonEnabled = Map.IsShowingUser;
 			else if (e.PropertyName == Map.HasScrollEnabledProperty.PropertyName)
 				gmap.UiSettings.ScrollGesturesEnabled = Map.HasScrollEnabled;
-			else if (e.PropertyName == Map.HasZoomEnabledProperty.PropertyName) {
+			else if (e.PropertyName == Map.HasZoomEnabledProperty.PropertyName)
+			{
 				gmap.UiSettings.ZoomControlsEnabled = Map.HasZoomEnabled;
 				gmap.UiSettings.ZoomGesturesEnabled = Map.HasZoomEnabled;
 			}
 		}
 
-		void SetMapType ()
+		void SetMapType()
 		{
 			var map = NativeMap;
 			if (map == null)
 				return;
 
-			switch (Map.MapType) {
+			switch (Map.MapType)
+			{
 				case MapType.Street:
 					map.MapType = GoogleMap.MapTypeNormal;
 					break;
@@ -200,16 +216,16 @@ namespace Xamarin.Forms.Maps.Android
 					map.MapType = GoogleMap.MapTypeHybrid;
 					break;
 				default:
-					throw new ArgumentOutOfRangeException ();
+					throw new ArgumentOutOfRangeException();
 			}
 		}
 
-		public void OnCameraChange (CameraPosition pos)
+		public void OnCameraChange(CameraPosition pos)
 		{
-			UpdateVisibleRegion (pos.Target);
+			UpdateVisibleRegion(pos.Target);
 		}
 
-		void UpdateVisibleRegion (LatLng pos)
+		void UpdateVisibleRegion(LatLng pos)
 		{
 			var map = NativeMap;
 			if (map == null)
@@ -217,14 +233,14 @@ namespace Xamarin.Forms.Maps.Android
 			var projection = map.Projection;
 			var width = Control.Width;
 			var height = Control.Height;
-			var ul = projection.FromScreenLocation (new global::Android.Graphics.Point (0, 0));
-			var ur = projection.FromScreenLocation (new global::Android.Graphics.Point (width, 0));
-			var ll = projection.FromScreenLocation (new global::Android.Graphics.Point (0, height));
-			var lr = projection.FromScreenLocation (new global::Android.Graphics.Point (width, height));
-			var dlat = Math.Max (Math.Abs (ul.Latitude - lr.Latitude), Math.Abs (ur.Latitude - ll.Latitude));
-			var dlong = Math.Max (Math.Abs (ul.Longitude - lr.Longitude), Math.Abs (ur.Longitude - ll.Longitude));
-			((Map)Element).VisibleRegion = new MapSpan (
-					new Position (
+			var ul = projection.FromScreenLocation(new global::Android.Graphics.Point(0, 0));
+			var ur = projection.FromScreenLocation(new global::Android.Graphics.Point(width, 0));
+			var ll = projection.FromScreenLocation(new global::Android.Graphics.Point(0, height));
+			var lr = projection.FromScreenLocation(new global::Android.Graphics.Point(width, height));
+			var dlat = Math.Max(Math.Abs(ul.Latitude - lr.Latitude), Math.Abs(ur.Latitude - ll.Latitude));
+			var dlong = Math.Max(Math.Abs(ul.Longitude - lr.Longitude), Math.Abs(ur.Longitude - ll.Longitude));
+			((Map)Element).VisibleRegion = new MapSpan(
+					new Position(
 						pos.Latitude,
 						pos.Longitude
 					),
@@ -233,22 +249,23 @@ namespace Xamarin.Forms.Maps.Android
 			);
 		}
 
-		void AddPins (IList pins)
+		void AddPins(IList pins)
 		{
 			var map = NativeMap;
 			if (map == null)
 				return;
 
 			if (_markers == null)
-				_markers = new List<Marker> ();
+				_markers = new List<Marker>();
 
-			_markers.AddRange( pins.Cast<Pin>().Select (p => {
+			_markers.AddRange(pins.Cast<Pin>().Select(p =>
+			{
 				var pin = (Pin)p;
-				var opts = new MarkerOptions ();
-				opts.SetPosition (new LatLng (pin.Position.Latitude, pin.Position.Longitude));
-				opts.SetTitle (pin.Label);
-				opts.SetSnippet (pin.Address);
-				var marker = map.AddMarker (opts);
+				var opts = new MarkerOptions();
+				opts.SetPosition(new LatLng(pin.Position.Latitude, pin.Position.Longitude));
+				opts.SetTitle(pin.Label);
+				opts.SetSnippet(pin.Address);
+				var marker = map.AddMarker(opts);
 
 				// associate pin with marker for later lookup in event handlers
 				pin.Id = marker.Id;
@@ -256,31 +273,33 @@ namespace Xamarin.Forms.Maps.Android
 			}));
 		}
 
-		void RemovePins (IList pins)
+		void RemovePins(IList pins)
 		{
 			var map = NativeMap;
 			if (map == null)
 				return;
 			if (_markers == null)
 				return;
-			
-			foreach (Pin p in pins) {
-				var marker = _markers.FirstOrDefault (m => (object)m.Id == p.Id);
+
+			foreach (Pin p in pins)
+			{
+				var marker = _markers.FirstOrDefault(m => (object)m.Id == p.Id);
 				if (marker == null)
 					continue;
-				marker.Remove ();
-				_markers.Remove (marker);
+				marker.Remove();
+				_markers.Remove(marker);
 			}
 		}
 
-		void MapOnMarkerClick (object sender, GoogleMap.InfoWindowClickEventArgs eventArgs)
+		void MapOnMarkerClick(object sender, GoogleMap.InfoWindowClickEventArgs eventArgs)
 		{
 			// clicked marker
 			var marker = eventArgs.Marker;
 
 			// lookup pin
 			Pin targetPin = null;
-			for (var i = 0; i < Map.Pins.Count; i++) {
+			for (var i = 0; i < Map.Pins.Count; i++)
+			{
 				var pin = Map.Pins[i];
 				if ((string)pin.Id != marker.Id)
 					continue;
@@ -291,30 +310,40 @@ namespace Xamarin.Forms.Maps.Android
 
 			// only consider event handled if a handler is present. 
 			// Else allow default behavior of displaying an info window.
-			targetPin?.SendTap ();
+			targetPin?.SendTap();
 		}
 
-		bool _disposed;
-		protected override void Dispose (bool disposing)
+		protected override void Dispose(bool disposing)
 		{
-			if (disposing && !_disposed) {
-				_disposed = true;
-			
-				var mapModel = Element as Map;
-				if (mapModel != null) {
-					MessagingCenter.Unsubscribe<Map, MapSpan> (this, MoveMessageName);
-					((ObservableCollection<Pin>)mapModel.Pins).CollectionChanged -= OnCollectionChanged;
-				}
-
-				var gmap = NativeMap;
-				if (gmap == null)
-					return;
-				gmap.MyLocationEnabled = false;
-				gmap.InfoWindowClick -= MapOnMarkerClick;
-				gmap.Dispose ();
+			if (_disposed)
+			{
+				return;
 			}
 
-			base.Dispose (disposing);
+			if (disposing)
+			{
+				_disposed = true;
+
+				if (Element != null)
+				{
+					MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+					((ObservableCollection<Pin>)Element.Pins).CollectionChanged -= OnCollectionChanged;
+				}
+
+				if (NativeMap != null)
+				{
+					NativeMap.MyLocationEnabled = false;
+					NativeMap.SetOnCameraChangeListener(null);
+					NativeMap.InfoWindowClick -= MapOnMarkerClick;
+					NativeMap.Dispose();
+				}
+
+				Control?.OnDestroy();
+			}
+
+			_disposed = true;
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -13,7 +13,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>Xamarin.Forms.Platform.Android.AppLinks</AssemblyName>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -71,6 +71,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (disposing)
 			{
+				if (Control != null)
+				{
+					Control.SetOnClickListener(null);
+					Control.RemoveOnAttachStateChangeListener(this);
+					Control.Tag = null;
+					_textColorSwitcher = null;
+				}
 			}
 
 			base.Dispose(disposing);

--- a/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FragmentContainer.cs
@@ -1,9 +1,9 @@
 using System;
 using Android.OS;
 using Android.Runtime;
-using Android.Support.V4.App;
 using Android.Views;
 using AView = Android.Views.View;
+using Fragment = Android.Support.V4.App.Fragment;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -75,7 +75,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			return null;
 		}
-		
+
 		public override void OnDestroyView()
 		{
 			if (Page != null)
@@ -90,18 +90,16 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					_visualElementRenderer.Dispose();
 				}
 
-				if (_pageContainer != null && _pageContainer.Handle != IntPtr.Zero)
-				{
-					_pageContainer.RemoveFromParent();
-					_pageContainer.Dispose();
-				}
+				// We do *not* eagerly dispose of the _pageContainer here; doing so  causes a memory leak 
+				// if animated fragment transitions are enabled (it removes some info that the animation's 
+				// onAnimationEnd handler requires to properly clean things up)
+				// Instead, we let the garbage collector pick it up later, when we can be sure it's safe
 
 				Page?.ClearValue(Android.Platform.RendererProperty);
 			}
 
 			_onCreateCallback = null;
 			_visualElementRenderer = null;
-			_pageContainer = null;
 
 			base.OnDestroyView();
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -41,6 +41,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		ToolbarTracker _toolbarTracker;
 		bool _toolbarVisible;
 
+		// The following is based on https://android.googlesource.com/platform/frameworks/support/+/refs/heads/master/v4/java/android/support/v4/app/FragmentManager.java#849
+		const int TransitionDuration = 220;
+
 		public NavigationPageRenderer()
 		{
 			AutoPackage = false;
@@ -71,7 +74,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 
-		FragmentManager FragmentManager => _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
+		FragmentManager FragmentManager
+			=> _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
 
 		IPageController PageController => Element as IPageController;
 
@@ -132,14 +136,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				if (Element != null)
 				{
-					foreach(Element element in PageController.InternalChildren)
+					foreach (Element element in PageController.InternalChildren)
 					{
 						var child = element as VisualElement;
 						if (child == null)
 						{
 							continue;
 						}
-							
+
 						IVisualElementRenderer renderer = Android.Platform.GetRenderer(child);
 						renderer?.Dispose();
 					}
@@ -280,7 +284,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 			_lastActionBarHeight = barHeight;
 
-			bar.Measure(MeasureSpecFactory.MakeMeasureSpec(r - l, MeasureSpecMode.Exactly), MeasureSpecFactory.MakeMeasureSpec(barHeight, MeasureSpecMode.Exactly));
+			bar.Measure(MeasureSpecFactory.MakeMeasureSpec(r - l, MeasureSpecMode.Exactly),
+				MeasureSpecFactory.MakeMeasureSpec(barHeight, MeasureSpecMode.Exactly));
 
 			int internalHeight = b - t - barHeight;
 			int containerHeight = ToolbarVisible ? internalHeight : b - t;
@@ -320,7 +325,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			else
 				transaction.SetTransition((int)FragmentTransit.FragmentClose);
 		}
-
+		
 		internal int GetNavBarHeight()
 		{
 			if (!ToolbarVisible)
@@ -401,7 +406,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void HandleToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == MenuItem.IsEnabledProperty.PropertyName || e.PropertyName == MenuItem.TextProperty.PropertyName || e.PropertyName == MenuItem.IconProperty.PropertyName)
+			if (e.PropertyName == MenuItem.IsEnabledProperty.PropertyName || e.PropertyName == MenuItem.TextProperty.PropertyName ||
+			    e.PropertyName == MenuItem.IconProperty.PropertyName)
 				UpdateMenu();
 		}
 
@@ -496,12 +502,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				return;
 
 			_drawerLayout = (DrawerLayout)renderer;
-			_drawerToggle = new ActionBarDrawerToggle((Activity)context, _drawerLayout, bar, global::Android.Resource.String.Ok, global::Android.Resource.String.Ok)
+			_drawerToggle = new ActionBarDrawerToggle((Activity)context, _drawerLayout, bar, global::Android.Resource.String.Ok,
+				global::Android.Resource.String.Ok)
 			{
 				ToolbarNavigationClickListener = new ClickListener(Element)
 			};
 
-			if (_drawerListener != null) 
+			if (_drawerListener != null)
 			{
 				_drawerLayout.RemoveDrawerListener(_drawerListener);
 			}
@@ -569,6 +576,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			var tcs = new TaskCompletionSource<bool>();
 			Fragment fragment = FragmentContainer.CreateInstance(view);
 			FragmentManager fm = FragmentManager;
+
+#if DEBUG
+			// Enables logging of moveToState operations to logcat
+			FragmentManager.EnableDebugLogging(true);
+#endif
+
 			List<Fragment> fragments = _fragmentStack;
 
 			Current = view;
@@ -599,7 +612,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 						transaction.Remove(currentToRemove);
 						popPage = popToRoot;
 					}
-
+					
 					Fragment toShow = fragments.Last();
 					// Execute pending transactions so that we can be sure the fragment list is accurate.
 					fm.ExecutePendingTransactions();
@@ -621,7 +634,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			// The fragment transitions don't really SUPPORT telling you when they end
 			// There are some hacks you can do, but they actually are worse than just doing this:
-			
+
 			if (animated)
 			{
 				if (!removed)
@@ -633,12 +646,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else if (_drawerToggle != null && ((INavigationPageController)Element).StackDepth == 2)
 					AnimateArrowOut();
 
-				Device.StartTimer(TimeSpan.FromMilliseconds(200), () =>
+				Device.StartTimer(TimeSpan.FromMilliseconds(TransitionDuration), () =>
 				{
 					tcs.TrySetResult(true);
-					fragment.UserVisibleHint = true;
+					fragment.UserVisibleHint = !removed;
 					if (removed)
+					{
 						UpdateToolbar();
+					}
+
 					return false;
 				});
 			}
@@ -647,8 +663,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				Device.StartTimer(TimeSpan.FromMilliseconds(1), () =>
 				{
 					tcs.TrySetResult(true);
-					fragment.UserVisibleHint = true;
+					fragment.UserVisibleHint = !removed;
 					UpdateToolbar();
+
 					return false;
 				});
 			}
@@ -656,7 +673,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Context.HideKeyboard(this);
 			((Platform)Element.Platform).NavAnimationInProgress = false;
 
-			// 200ms is how long the animations are, and they are "reversible" in the sense that starting another one slightly before it's done is fine
+			// TransitionDuration is how long the built-in animations are, and they are "reversible" in the sense that starting another one slightly before it's done is fine
 
 			return tcs.Task;
 		}

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -76,7 +76,8 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (Control != null && ManageNativeControlLifetime)
 				{
-					Control.RemoveFromParent();
+					Control.OnFocusChangeListener = null;
+					RemoveView(Control);
 					Control.Dispose();
 					Control = null;
 				}

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -5,7 +5,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class VisualElementPackager : IDisposable
+	public sealed class VisualElementPackager : IDisposable
 	{
 		readonly EventHandler<ElementEventArgs> _childAddedHandler;
 		readonly EventHandler<ElementEventArgs> _childRemovedHandler;
@@ -26,7 +26,12 @@ namespace Xamarin.Forms.Platform.Android
 			_childReorderedHandler = OnChildrenReordered;
 
 			_renderer = renderer;
-			_renderer.ElementChanged += (sender, args) => SetElement(args.OldElement, args.NewElement);
+			_renderer.ElementChanged += RendererOnElementChanged;
+		}
+
+		void RendererOnElementChanged(object sender, VisualElementChangedEventArgs args)
+		{
+			SetElement(args.OldElement, args.NewElement);
 		}
 
 		IElementController ElementController => _renderer.Element as IElementController;
@@ -47,8 +52,10 @@ namespace Xamarin.Forms.Platform.Android
 
 				_renderer.Element.ChildAdded -= _childAddedHandler;
 				_renderer.Element.ChildRemoved -= _childRemovedHandler;
-
 				_renderer.Element.ChildrenReordered -= _childReorderedHandler;
+
+				_renderer.ElementChanged -= RendererOnElementChanged;
+
 				_renderer = null;
 			}
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -229,6 +229,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (disposing)
 			{
+				SetOnClickListener(null);
+				SetOnTouchListener(null);
+
 				if (Tracker != null)
 				{
 					Tracker.Dispose();
@@ -272,6 +275,8 @@ namespace Xamarin.Forms.Platform.Android
 
 					if (Platform.GetRenderer(Element) == this)
 						Platform.SetRenderer(Element, null);
+
+					(Element as IElementController).EffectControlProvider = null;
 
 					Element = null;
 				}

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -9,7 +9,7 @@ using Object = Java.Lang.Object;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class VisualElementTracker : IDisposable
+	public sealed class VisualElementTracker : IDisposable
 	{
 		readonly EventHandler<EventArg<VisualElement>> _batchCommittedHandler;
 		readonly IList<string> _batchedProperties = new List<string>();

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Xamarin.Forms", "Xamarin.Forms", "{9AD757F5-E57A-459D-A0A7-E0675E045B84}"
 EndProject
@@ -143,15 +143,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Platform.Andr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Pages.Azure", "Xamarin.Forms.Pages.Azure\Xamarin.Forms.Pages.Azure.csproj", "{C9696465-7657-4843-872E-3C01891C4A9B}"
 EndProject
-Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "PagesGallery.iOS", "PagesGallery\PagesGallery.iOS\PagesGallery.iOS.csproj", "{62DE9FC4-F77B-400C-A47C-F1559741C44B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PagesGallery.iOS", "PagesGallery\PagesGallery.iOS\PagesGallery.iOS.csproj", "{392156B2-760A-4EE3-A822-CABD3238A21D}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		docs\APIDocs.projitems*{dc1f3933-ac99-4887-8b09-e13c2b346d4f}*SharedItemsImports = 13
-		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{a34ebe01-25bf-4e69-a2dc-2288dc625541}*SharedItemsImports = 4
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{0a39a74b-6f7a-4d41-84f2-b0ccdce899df}*SharedItemsImports = 4
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{0f0db9cc-ea65-429c-9363-38624bf8f49c}*SharedItemsImports = 13
+		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{a34ebe01-25bf-4e69-a2dc-2288dc625541}*SharedItemsImports = 4
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{cb9c96ce-125c-4a68-b6a1-c3ff1fbf93e1}*SharedItemsImports = 4
+		docs\APIDocs.projitems*{dc1f3933-ac99-4887-8b09-e13c2b346d4f}*SharedItemsImports = 13
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{eadd8100-b3ae-4a31-92c4-267a64a1c6eb}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1505,25 +1505,25 @@ Global
 		{C9696465-7657-4843-872E-3C01891C4A9B}.Release|x64.Build.0 = Release|Any CPU
 		{C9696465-7657-4843-872E-3C01891C4A9B}.Release|x86.ActiveCfg = Release|Any CPU
 		{C9696465-7657-4843-872E-3C01891C4A9B}.Release|x86.Build.0 = Release|Any CPU
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|ARM.ActiveCfg = Debug|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|iPhone.ActiveCfg = Debug|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|iPhone.Build.0 = Debug|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|Templates.ActiveCfg = Debug|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|x64.ActiveCfg = Debug|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Debug|x86.ActiveCfg = Debug|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Release|Any CPU.ActiveCfg = Release|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Release|ARM.ActiveCfg = Release|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Release|iPhone.ActiveCfg = Release|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Release|iPhone.Build.0 = Release|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Release|Templates.ActiveCfg = Release|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Release|x64.ActiveCfg = Release|iPhone
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B}.Release|x86.ActiveCfg = Release|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|ARM.ActiveCfg = Debug|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|iPhone.Build.0 = Debug|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|Templates.ActiveCfg = Debug|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|x64.ActiveCfg = Debug|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Debug|x86.ActiveCfg = Debug|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Release|Any CPU.ActiveCfg = Release|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Release|ARM.ActiveCfg = Release|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Release|iPhone.ActiveCfg = Release|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Release|iPhone.Build.0 = Release|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Release|Templates.ActiveCfg = Release|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Release|x64.ActiveCfg = Release|iPhone
+		{392156B2-760A-4EE3-A822-CABD3238A21D}.Release|x86.ActiveCfg = Release|iPhone
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1581,6 +1581,6 @@ Global
 		{95FEB8D4-D57E-4B96-A8D8-59D241C0501B} = {80BAC3FB-357A-4D05-A050-9F234DF49C97}
 		{42DB052E-0909-45D2-8240-187F99F393FB} = {29AC50BF-B4FB-450B-9386-0C5AD4B84226}
 		{C9696465-7657-4843-872E-3C01891C4A9B} = {9AD757F5-E57A-459D-A0A7-E0675E045B84}
-		{62DE9FC4-F77B-400C-A47C-F1559741C44B} = {80BAC3FB-357A-4D05-A050-9F234DF49C97}
+		{392156B2-760A-4EE3-A822-CABD3238A21D} = {80BAC3FB-357A-4D05-A050-9F234DF49C97}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
### Description of Change ###

Fixes for several memory leaks on Android. Changes include:

- Calling Destroy() on Map during disposal (leaking the Map object)
- Cleaning up OnFocusChangeListener on ViewRenderer during disposal (leaking various renderers)
- Cleaning up listeners and tag on ButtonRenderer during disposal (leaking ButtonRenderer)
- Fixing bug where animated fragment transactions leaked FragmentContainer and PageContainer

Also marks VisualElementTracker and VisualElementPackager as sealed so their disposal implementations are now correct

### Bugs Fixed ###

- [39489 – [Android] Memory leak when using NavigationPage with Maps](https://bugzilla.xamarin.com/show_bug.cgi?id=39489)
- [40970 – Memory Leak in the Xamarin Forms Maps component on iOS](https://bugzilla.xamarin.com/show_bug.cgi?id=40970) (the Android parts)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
