### PR TITLE
Seal VisualElementPackager and VisualElementTracker

### DIFF
--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -5,7 +5,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class VisualElementPackager : IDisposable
+	public sealed class VisualElementPackager : IDisposable
 	{
 		readonly EventHandler<ElementEventArgs> _childAddedHandler;
 		readonly EventHandler<ElementEventArgs> _childRemovedHandler;
@@ -47,7 +47,6 @@ namespace Xamarin.Forms.Platform.Android
 
 				_renderer.Element.ChildAdded -= _childAddedHandler;
 				_renderer.Element.ChildRemoved -= _childRemovedHandler;
-
 				_renderer.Element.ChildrenReordered -= _childReorderedHandler;
 				_renderer = null;
 			}

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -9,7 +9,7 @@ using Object = Java.Lang.Object;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class VisualElementTracker : IDisposable
+	public sealed class VisualElementTracker : IDisposable
 	{
 		readonly EventHandler<EventArg<VisualElement>> _batchCommittedHandler;
 		readonly IList<string> _batchedProperties = new List<string>();


### PR DESCRIPTION
### Description of Change ###

The current Dispose implementations for VisualElementPackager and VisualElementTracker are incorrect if they're meant to handle derived classes. So they either need to have their Dispose implementations updated or be marked as `sealed`. The latter option is safer and requires less maintenance. 

If it turns out that someone is depending on inheriting from one of these classes, we'll have to revert this and implement Dispose for inheritance.

No tests, this isn't a runtime behavior change.

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense