### PR TITLE
Implement dispose pattern correctly to support derived classes

### DIFF
--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -33,8 +33,15 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void Dispose()
 		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
 			if (_disposed)
 				return;
+
 			_disposed = true;
 
 			if (_renderer != null)

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -45,18 +45,28 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void Dispose()
 		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
 			if (_disposed)
 				return;
+
 			_disposed = true;
 
-			SetElement(_element, null);
-
-			if (_renderer != null)
+			if (disposing)
 			{
-				_renderer.ElementChanged -= RendererOnElementChanged;
-				_renderer.ViewGroup.RemoveOnAttachStateChangeListener(AttachTracker.Instance);
-				_renderer = null;
-				_context = null;
+				SetElement(_element, null);
+
+				if (_renderer != null)
+				{
+					_renderer.ElementChanged -= RendererOnElementChanged;
+					_renderer.ViewGroup.RemoveOnAttachStateChangeListener(AttachTracker.Instance);
+					_renderer = null;
+					_context = null;
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.WP8/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WP8/VisualElementTracker.cs
@@ -13,7 +13,15 @@ namespace Xamarin.Forms.Platform.WinPhone
 	{
 		public abstract FrameworkElement Child { get; set; }
 
-		public abstract void Dispose();
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+		}
 
 		public event EventHandler Updated;
 
@@ -106,29 +114,35 @@ namespace Xamarin.Forms.Platform.WinPhone
 			}
 		}
 
-		public override void Dispose()
+		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)
 				return;
+
 			_disposed = true;
 
-			if (_element != null)
+			if (disposing)
 			{
-				_element.Tap -= ElementOnTap;
-				_element.DoubleTap -= ElementOnDoubleTap;
-				_element.ManipulationDelta -= OnManipulationDelta;
-				_element.ManipulationCompleted -= OnManipulationCompleted;
+				if (_element != null)
+				{
+					_element.Tap -= ElementOnTap;
+					_element.DoubleTap -= ElementOnDoubleTap;
+					_element.ManipulationDelta -= OnManipulationDelta;
+					_element.ManipulationCompleted -= OnManipulationCompleted;
+				}
+
+				if (_model != null)
+				{
+					_model.BatchCommitted -= HandleRedrawNeeded;
+					_model.PropertyChanged -= HandlePropertyChanged;
+				}
+
+				Child = null;
+				Model = null;
+				Element = null;
 			}
 
-			if (_model != null)
-			{
-				_model.BatchCommitted -= HandleRedrawNeeded;
-				_model.PropertyChanged -= HandlePropertyChanged;
-			}
-
-			Child = null;
-			Model = null;
-			Element = null;
+			base.Dispose(disposing);
 		}
 
 		protected virtual void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.WinRT/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementPackager.cs
@@ -46,6 +46,12 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		public void Dispose()
 		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
 			if (_disposed)
 				return;
 


### PR DESCRIPTION
### Description of Change ###

Some implementations of `VisualElementPackager` and `VisualElementTracker` are marked public and aren't sealed, but don't implement the [Dispose pattern](https://msdn.microsoft.com/en-us/library/b1yfkh5e(v=vs.110).aspx) in a way which supports derived classes. This change updates those implementations to support derived classes. 