### PR TITLE
[A] Check for ViewStates.Gone in AppCompat TabbedPageRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -209,11 +209,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			tabs.Measure(MeasureSpecFactory.MakeMeasureSpec(width, MeasureSpecMode.Exactly), MeasureSpecFactory.MakeMeasureSpec(height, MeasureSpecMode.AtMost));
 			var tabsHeight = 0;
 
-			//MinimumHeight is only available on API 16+
-			if ((int)Build.VERSION.SdkInt >= 16)
-				tabsHeight = Math.Min(height, Math.Max(tabs.MeasuredHeight, tabs.MinimumHeight));
-			else
-				tabsHeight = Math.Min(height, tabs.MeasuredHeight);
+			if (tabs.Visibility != ViewStates.Gone)
+			{
+				//MinimumHeight is only available on API 16+
+				if ((int)Build.VERSION.SdkInt >= 16)
+					tabsHeight = Math.Min(height, Math.Max(tabs.MeasuredHeight, tabs.MinimumHeight));
+				else
+					tabsHeight = Math.Min(height, tabs.MeasuredHeight);
+			}
 
 			pager.Measure(MeasureSpecFactory.MakeMeasureSpec(width, MeasureSpecMode.AtMost), MeasureSpecFactory.MakeMeasureSpec(height, MeasureSpecMode.AtMost));
 


### PR DESCRIPTION
### Description of Change ###

The use of `ViewStates.Gone` was not being taken into account when calculating the tab height in `OnLayout` in the AppCompat `TabbedPageRenderer` and as a result was always taking up space in the layout when it shouldn't be.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=43108

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

