### PR TITLE
[UWP/WinRT] ListView UI virtualization works without explicit height on Cell/Row

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41271.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41271.cs
@@ -1,0 +1,91 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41271, "[UWP] Memory Leak from ListView in TabbedPage")]
+	public class Bugzilla41271 : TestTabbedPage
+	{
+		[Preserve(AllMembers = true)]
+		class Person
+		{
+			public Person(string firstName, string lastName, string city, string state)
+			{
+				FirstName = firstName;
+				LastName = lastName;
+				City = city;
+				State = state;
+			}
+			public string FirstName { get; set; }
+			public string LastName { get; set; }
+			public string City { get; set; }
+			public string State { get; set; }
+		}
+		[Preserve(AllMembers = true)]
+		class ListViewCell : ViewCell
+		{
+			Label firstNameLabel = new Label();
+			Label lastNameLabel = new Label();
+			Label cityLabel = new Label();
+			Label stateLabel = new Label();
+
+			public ListViewCell()
+			{
+				View = new StackLayout
+				{
+					Orientation = StackOrientation.Horizontal,
+					Children =
+					{
+						firstNameLabel,
+						lastNameLabel,
+						cityLabel,
+						stateLabel
+					}
+				};
+			}
+
+			protected override void OnBindingContextChanged()
+			{
+				base.OnBindingContextChanged();
+				var item = BindingContext as Person;
+				if (item != null)
+				{
+					firstNameLabel.Text = item.FirstName;
+					lastNameLabel.Text = item.LastName;
+					cityLabel.Text = item.City;
+					stateLabel.Text = item.State;
+				}
+			}
+		}
+		[Preserve(AllMembers = true)]
+		class ListViewPage : ContentPage
+		{
+			public ListViewPage(string id)
+			{
+				Title = $"List {id}";
+
+				var people = new List<Person>();
+
+				for (var x = 0; x < 1000; x++)
+				{
+					people.Add(new Person("Bob", "Bobson", "San Francisco", "California"));
+				}
+
+				Content = new ListView(ListViewCachingStrategy.RecycleElement) { ItemsSource = people, ItemTemplate = new DataTemplate(typeof(ListViewCell)) };
+			}
+		}
+
+		protected override void Init()
+		{
+			var counter = 1;
+
+			for (var x = 0; x < 10; x++)
+			{
+				Children.Add(new ListViewPage(counter.ToString()));
+				counter++;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41271.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41271.cs
@@ -62,18 +62,34 @@ namespace Xamarin.Forms.Controls
 		[Preserve(AllMembers = true)]
 		class ListViewPage : ContentPage
 		{
+			ListView _ListView;
+			List<Person> _People = new List<Person>();
+
 			public ListViewPage(string id)
 			{
 				Title = $"List {id}";
 
-				var people = new List<Person>();
-
 				for (var x = 0; x < 1000; x++)
 				{
-					people.Add(new Person("Bob", "Bobson", "San Francisco", "California"));
+					_People.Add(new Person("Bob", "Bobson", "San Francisco", "California"));
 				}
 
-				Content = new ListView(ListViewCachingStrategy.RecycleElement) { ItemsSource = people, ItemTemplate = new DataTemplate(typeof(ListViewCell)) };
+				_ListView = new ListView(ListViewCachingStrategy.RecycleElement) { ItemTemplate = new DataTemplate(typeof(ListViewCell)) };
+				Content = _ListView;
+			}
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+
+				_ListView.ItemsSource = _People;
+			}
+
+			protected override void OnDisappearing()
+			{
+				base.OnDisappearing();
+
+				_ListView.ItemsSource = null;
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -182,6 +182,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43161.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41271.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Core/Cells/Cell.cs
+++ b/Xamarin.Forms.Core/Cells/Cell.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms
 {
 	public abstract class Cell : Element, ICellController
 	{
+		public const int DefaultCellHeight = 40;
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool), typeof(Cell), true, propertyChanged: OnIsEnabledPropertyChanged);
 
 		ObservableCollection<MenuItem> _contextActions;
@@ -70,7 +71,7 @@ namespace Xamarin.Forms
 				if (list != null)
 					return list.HasUnevenRows && Height > 0 ? Height : list.RowHeight;
 
-				return 40;
+				return DefaultCellHeight;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -97,7 +97,9 @@ namespace Xamarin.Forms.Platform.WinRT
 					}
 				}
 
-				return new Windows.Foundation.Size(0, 0);
+				// This needs to return a size with a non-zero height; 
+				// otherwise, it kills virtualization.
+				return new Windows.Foundation.Size(0, Cell.DefaultCellHeight);
 			}
 
 			// Children still need measure called on them

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Cell.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Cell.xml
@@ -195,6 +195,22 @@ Content = new TableView
         <remarks>The context gesture on the iOS platform is a left swipe. For Android and Windows Phone operating systems, the context gesture is a press and hold.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="DefaultCellHeight">
+      <MemberSignature Language="C#" Value="public const int DefaultCellHeight = 40;" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal int32 DefaultCellHeight = (40)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <MemberValue>40</MemberValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Disappearing">
       <MemberSignature Language="C#" Value="public event EventHandler Disappearing;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler Disappearing" />


### PR DESCRIPTION
### Description of Change ###

The `CellControl`'s `MeasureOverride` method will now return a non-zero height on the first pass so the `ListView` can estimate properly for UI virtualization. This will allow users to create `ListView`s without explicit heights set on the `Cell`s and without an explicit `RowHeight` and still take advantage of UI virtualization on Windows platforms.

There is also a sample reproduction for 41271 that demonstrates a workaround for the apparent memory leak that is caused by UWP's default behavior, which is to cache all pages loaded into a tabbed layout. This sample also serves as a manual test case for the UI virtualization, as each tab contains a `ListView` with 1000 items, yet a fraction of that are loaded into the visual tree.

### Bugs Fixed ###

- [Bug 38777  - Inserting 10000 items into ListView causes UWP app to exit] (https://bugzilla.xamarin.com/show_bug.cgi?id=38777)
- [Bug 38948  - [UWP] ListViewCachingStrategy.RecycleElement Not Working] (https://bugzilla.xamarin.com/show_bug.cgi?id=38948)
- [Bug 41271  - [UWP] Memory Leak from ListView in TabbedPage] (https://bugzilla.xamarin.com/show_bug.cgi?id=41271)

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - `const int Cell.DefaultCellHeight = 40;`

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
