### PR TITLE
[iOS] Handle transition of a page not showing the NavBar to one showing it

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43955.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43955.cs
@@ -1,0 +1,146 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43955, "White space created during navigation from page without the NavigationBar to one with it", PlatformAffected.iOS)]
+	public class Bugzilla43995 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+
+			Title = "ToolbarItem Page";
+			var toolbarItemPage = new ContentPage
+			{
+				Title = "ToolbarItem Page",
+				Content = new StackLayout
+				{
+					VerticalOptions = LayoutOptions.End,
+					Children =
+					{
+						new Label
+						{
+							Text = "This should also be visible"
+						}
+					}
+				}
+			};
+			toolbarItemPage.ToolbarItems.Add(new ToolbarItem("Action 1", null, () => { }, ToolbarItemOrder.Primary, 1));
+			toolbarItemPage.ToolbarItems.Add(new ToolbarItem("Action 2", null, () => { }, ToolbarItemOrder.Primary, 2));
+
+			toolbarItemPage.ToolbarItems.Add(new ToolbarItem("Action 3", null, () => { }, ToolbarItemOrder.Secondary, 3));
+			toolbarItemPage.ToolbarItems.Add(new ToolbarItem("Action 4", null, () => { }, ToolbarItemOrder.Secondary, 4));
+			toolbarItemPage.ToolbarItems.Add(new ToolbarItem("Action 5", null, () => { }, ToolbarItemOrder.Secondary, 5));
+
+			var page4 = new ContentPage
+			{
+				BackgroundColor = Color.Yellow,
+				Title = "Page 4"
+			};
+			page4.Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.End,
+				Padding = new Thickness(0, 15, 0, 0),
+				Children =
+					{
+						new Button
+						{
+							Text = "Click to toggle SetHasNavigationBar",
+							Command = new Command(() => SetHasNavigationBar(page4, !GetHasNavigationBar(page4)))
+						},
+						new Button
+						{
+							Text = "Click for ToolbarItem Page",
+							Command = new Command(async () =>
+							{
+								await PushAsync(toolbarItemPage);
+							})
+						}
+					}
+			};
+			SetHasNavigationBar(page4, false);
+
+			var page3 = new ContentPage
+			{
+				BackgroundColor = Color.Silver,
+				Title = "Page 3",
+			};
+			page3.Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.End,
+				Children =
+				{
+					new Button
+					{
+						Text = "Go back",
+						Command = new Command(async () =>
+						{
+							await Navigation.PopAsync();
+						})
+					},
+					new Button
+					{
+						Text = "Click to Navigate",
+						Command = new Command(async () =>
+						{
+							await PushAsync(page4);
+						})
+					}
+				}
+			};
+
+			var page2 = new ContentPage
+			{
+				BackgroundColor = Color.Red,
+				Title = "Page 2",
+				Content = new StackLayout
+				{
+					VerticalOptions = LayoutOptions.End,
+					Children =
+					{
+						new Label
+						{
+							Text = "This should be visible"
+						}
+					}
+				}
+			};
+			SetHasNavigationBar(page2, false);
+
+			var page1 = new ContentPage
+			{
+				Title = "Page 1",
+				BackgroundColor = Color.Green,
+				Content = new StackLayout
+				{
+					Children =
+					{
+						new Button
+						{
+							Text = "Click to Navigate",
+							Command = new Command(() =>
+							{
+								SetHasNavigationBar(page3, false);
+								PushAsync(page3);
+							})
+						}
+					}
+				}
+			};
+
+			var tabbedPage = new TabbedPage();
+			tabbedPage.Children.Add(page1);
+			tabbedPage.Children.Add(page2);
+
+			SetHasNavigationBar(tabbedPage, false);
+
+			PushAsync(tabbedPage);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -128,6 +128,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _appeared;
 		bool _ignorePopCall;
 		bool _loaded;
+		bool _isNavigating;
 		MasterDetailPage _parentMasterDetailPage;
 		Size _queuedSize;
 		UIViewController[] _removeControllers;
@@ -135,7 +136,6 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateToolBarVisible();
 
 			var navBarFrame = NavigationBar.Frame;
-
 			var toolbar = _secondaryToolbar;
 			// Use 0 if the NavBar is hidden or will be hidden
 			var toolbarY = NavigationBarHidden || !NavigationPage.GetHasNavigationBar(Current) ? 0 : navBarFrame.Bottom;
@@ -143,8 +143,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			double trueBottom = toolbar.Hidden ? toolbarY : toolbar.Frame.Bottom;
 			var modelSize = _queuedSize.IsZero ? Element.Bounds.Size : _queuedSize;
-			PageController.ContainerArea = 
-				new Rectangle(0, toolbar.Hidden ? 0 : toolbar.Frame.Height, modelSize.Width, modelSize.Height - trueBottom);
+			if (!_isNavigating)
+				PageController.ContainerArea = new Rectangle(0, toolbar.Hidden ? 0 : toolbar.Frame.Height, modelSize.Width, modelSize.Height - trueBottom);
 
 			if (!_queuedSize.IsZero)
 			{
@@ -317,9 +317,12 @@ namespace Xamarin.Forms.Platform.iOS
 			var pack = CreateViewControllerForPage(page);
 			var task = GetAppearedOrDisappearedTask(page);
 
+			_isNavigating = true;
 			PushViewController(pack, animated);
 
 			var shown = await task;
+			_isNavigating = false;
+			View.SetNeedsLayout();
 			UpdateToolBarVisible();
 			return shown;
 		}


### PR DESCRIPTION
### Description of Change ###

There is presently an issue with the way in which the `NavigationRenderer` behaves where, if navigating from a page which is not having the NavBar shown to one which is, there will be a white box at the bottom of the page being transitioned from as it's animating. 

Edit: Simpler "fix" here by setting an `_isNavigating` statue and only set `ContainerArea` if it's false (although we might want a more elegant solution).

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=43955

### API Changes ###

None

### Behavioral Changes ###

I attempted to add some variation into a gallery reproduction to make sure that nothing was being affected other than the behavior in question being resolved, so nothing to my knowledge.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense