### PR TITLE
iOS ScrollView should not scroll out of place on scrolling to element

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44461.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44461.cs
@@ -1,0 +1,49 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44461, "ScrollToPosition.Center works differently on Android and iOS", PlatformAffected.iOS)]
+	public class Bugzilla44461 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var grid = new Grid
+			{
+				RowSpacing = 0,
+			};
+
+			var scrollView = new ScrollView
+			{
+				Orientation = ScrollOrientation.Horizontal,
+				VerticalOptions = LayoutOptions.Center,
+				BackgroundColor = Color.Yellow,
+				HeightRequest = 50
+			};
+			grid.Children.Add(scrollView);
+
+			var stackLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal,
+				Spacing = 20
+			};
+
+			for (var i = 0; i < 10; i++)
+			{
+				var button = new Button
+				{
+					Text = "Button" + i
+				};
+				button.Clicked += (sender, args) =>
+				{
+					scrollView.ScrollToAsync(sender as Button, ScrollToPosition.Center, true);
+				};
+
+				stackLayout.Children.Add(button);
+			}
+			scrollView.Content = stackLayout;
+			Content = grid;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -124,6 +124,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42364.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -209,23 +209,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var positionOnScroll = Controller.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
 
-				if (positionOnScroll.X < 0)
-				{
-					positionOnScroll.X = 0;
-				}
-				else if (positionOnScroll.X > ContentSize.Width - Bounds.Size.Width)
-				{
-					positionOnScroll.X = ContentSize.Width - Bounds.Size.Width;
-				}
-
-				if (positionOnScroll.Y < 0)
-				{
-					positionOnScroll.Y = 0;
-				}
-				else if (positionOnScroll.Y > ContentSize.Height - Bounds.Size.Height)
-				{
-					positionOnScroll.Y = ContentSize.Height - Bounds.Size.Height;
-				}
+				positionOnScroll.X = positionOnScroll.X.Clamp(0, ContentSize.Width - Bounds.Size.Width);
+				positionOnScroll.Y = positionOnScroll.Y.Clamp(0, ContentSize.Height - Bounds.Size.Height);
 
 				switch (ScrollView.Orientation)
 				{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -208,6 +208,25 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				var positionOnScroll = Controller.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
+
+				if (positionOnScroll.X < 0)
+				{
+					positionOnScroll.X = 0;
+				}
+				else if (positionOnScroll.X > ContentSize.Width - Bounds.Size.Width)
+				{
+					positionOnScroll.X = ContentSize.Width - Bounds.Size.Width;
+				}
+
+				if (positionOnScroll.Y < 0)
+				{
+					positionOnScroll.Y = 0;
+				}
+				else if (positionOnScroll.Y > ContentSize.Height - Bounds.Size.Height)
+				{
+					positionOnScroll.Y = ContentSize.Height - Bounds.Size.Height;
+				}
+
 				switch (ScrollView.Orientation)
 				{
 					case ScrollOrientation.Horizontal:


### PR DESCRIPTION
### Description of Change ###

iOS `ScrollView` was behaving differently than Android when using `ScrollToPosition` enums. If you center or end scroll the first element, iOS moves the scrollview out of place by setting the x position to a negative value. Similarly, if you start or center scroll the last element, the x position is set to a value greater than what should be allowed. This change ensures iOS and Android behave the same.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44461

### Behavioral Changes ###

iOS is now more intelligent such that `ScrollView` elements are positioned without going out of bounds. Developers can still set to any position they want by using `ScrollToAsync(double x, double y, bool animated)`.