### PR TITLE
[C] specify type and default value for native bindings

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/XamlNativeViews.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/XamlNativeViews.xaml
@@ -9,6 +9,6 @@
 	<ContentPage.Content>
 		<ios:UILabel Text="{Binding NativeText}" View.HorizontalOptions="Start"/>
 		<androidWidget:TextView Text="{Binding NativeText}" x:Arguments="{x:Static formsandroid:Forms.Context}" />
-    <win:TextBlock Text="Foo"/>
+    <win:TextBlock Text="{Binding NativeText}"/>
 	</ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Core.UnitTests/NativeBindingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/NativeBindingTests.cs
@@ -13,6 +13,16 @@ namespace Xamarin.Forms.Core.UnitTests
 		public int Bar { get; set; }
 		public string Baz { get; set; }
 
+		string cantBeNull = "";
+		public string CantBeNull {
+			get { return cantBeNull; }
+			set {
+				if (value == null)
+					throw new NullReferenceException();
+				cantBeNull = value;
+			}
+		}
+
 		public void FireBazChanged()
 		{
 			BazChanged?.Invoke(this, new TappedEventArgs(null));
@@ -380,17 +390,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void ThrowsNeedsConverter()
-		{
-			var nativeView = new MockNativeView();
-			Assert.AreEqual(null, nativeView.Foo);
-			Assert.AreEqual(0, nativeView.Bar);
-			var vm = new MockVMForNativeBinding();
-			nativeView.SetBinding("SelectedColor", new Binding("CColor"));
-			Assert.Throws<ArgumentException>(() => nativeView.SetBindingContext(vm));
-		}
-
-		[Test]
 		public void TestConverterDoesNotThrow()
 		{
 			var nativeView = new MockNativeView();
@@ -481,6 +480,17 @@ namespace Xamarin.Forms.Core.UnitTests
 			var vm = new MockVMForNativeBinding { FFoo = "qux" };
 			nativeView.SetBindingContext(vm);
 			Assert.AreEqual("foobar", vm.FFoo);
+		}
+
+		[Test]
+		public void DoNotApplyNull()
+		{
+			var native = new MockNativeView();
+			Assert.NotNull(native.CantBeNull);
+			native.SetBinding("CantBeNull", new Binding("FFoo", BindingMode.TwoWay));
+			Assert.NotNull(native.CantBeNull);
+			native.SetBindingContext(new { FFoo = "foo" });
+			Assert.AreEqual("foo", native.CantBeNull);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/NativeBindingHelpers.cs
+++ b/Xamarin.Forms.Core/NativeBindingHelpers.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms
 {
 	static class NativeBindingHelpers
 	{
-		public static void SetBinding<TNativeView>(TNativeView target, string targetProperty, BindingBase bindingBase, string updateSourceEventName=null) where TNativeView : class
+		public static void SetBinding<TNativeView>(TNativeView target, string targetProperty, BindingBase bindingBase, string updateSourceEventName = null) where TNativeView : class
 		{
 			var binding = bindingBase as Binding;
 			//This will allow setting bindings from Xaml by reusing the MarkupExtension
@@ -36,7 +36,9 @@ namespace Xamarin.Forms
 			var proxy = BindableObjectProxy<TNativeView>.BindableObjectProxies.GetValue(target, (TNativeView key) => new BindableObjectProxy<TNativeView>(key));
 			BindableProperty bindableProperty = null;
 			propertyChanged = propertyChanged ?? target as INotifyPropertyChanged;
-			bindableProperty = CreateBindableProperty<TNativeView>(targetProperty);
+			var propertyType = target.GetType().GetProperty(targetProperty)?.PropertyType;
+			var defaultValue = target.GetType().GetProperty(targetProperty)?.GetMethod.Invoke(target, new object [] { });
+			bindableProperty = CreateBindableProperty<TNativeView>(targetProperty, propertyType, defaultValue);
 			if (binding != null && binding.Mode != BindingMode.OneWay && propertyChanged != null)
 				propertyChanged.PropertyChanged += (sender, e) => {
 					if (e.PropertyName != targetProperty)
@@ -50,17 +52,20 @@ namespace Xamarin.Forms
 			proxy.SetBinding(bindableProperty, bindingBase);
 		}
 
-		static BindableProperty CreateBindableProperty<TNativeView>(string targetProperty) where TNativeView : class
+		static BindableProperty CreateBindableProperty<TNativeView>(string targetProperty, Type propertyType = null, object defaultValue = null) where TNativeView : class
 		{
+			propertyType = propertyType ?? typeof(object);
+			defaultValue = defaultValue ?? (propertyType.GetTypeInfo().IsValueType ? Activator.CreateInstance(propertyType) : null);
 			return BindableProperty.Create(
-					targetProperty,
-					typeof(object),
-					typeof(BindableObjectProxy<TNativeView>),
-					defaultBindingMode: BindingMode.Default,
-					propertyChanged: (bindable, oldValue, newValue) => {
-						TNativeView nativeView;
-						if ((bindable as BindableObjectProxy<TNativeView>).TargetReference.TryGetTarget(out nativeView))
-							SetNativeValue(nativeView, targetProperty, newValue);
+				targetProperty,
+				propertyType,
+				typeof(BindableObjectProxy<TNativeView>),
+				defaultValue: defaultValue,
+				defaultBindingMode: BindingMode.Default,
+				propertyChanged: (bindable, oldValue, newValue) => {
+					TNativeView nativeView;
+					if ((bindable as BindableObjectProxy<TNativeView>).TargetReference.TryGetTarget(out nativeView))
+						SetNativeValue(nativeView, targetProperty, newValue);
 				}
 			);
 		}


### PR DESCRIPTION
### Description of Change ###

When creating the BP proxy, create it with the right type, and use the default value of the target property as default value for the BP

### Bugs Fixed ###

- fix binding to TextBlock.Text on UWP (you can't set Text to null)

### Behavioral Changes ###

It's been a long time since I've sent any PR during weekend. I think it classifies as a behavioral change. I'm quite interested about the final results of that transformation. It'll probably end up with the kids getting 2 xmas gifts.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
