### PR TITLE
[Android] Slider should show user-set value on initial load

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -7,8 +7,8 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public class SliderRenderer : ViewRenderer<Slider, SeekBar>, SeekBar.IOnSeekBarChangeListener
 	{
-		double _max;
-		double _min;
+		double _max, _min;
+		bool _progressChangedOnce;
 
 		public SliderRenderer()
 		{
@@ -23,6 +23,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		void SeekBar.IOnSeekBarChangeListener.OnProgressChanged(SeekBar seekBar, int progress, bool fromUser)
 		{
+			if (!_progressChangedOnce)
+			{
+				_progressChangedOnce = true;
+				return;
+			}
+
 			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, Value);
 		}
 
@@ -84,20 +90,20 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnLayout(changed, l, t, r, b);
 
 			BuildVersionCodes androidVersion = Build.VERSION.SdkInt;
-			if (androidVersion >= BuildVersionCodes.JellyBean)
-			{
-				// Thumb only supported JellyBean and higher
+			if (androidVersion < BuildVersionCodes.JellyBean)
+				return;
 
-				if (Control == null)
-					return;
+			// Thumb only supported JellyBean and higher
 
-				SeekBar seekbar = Control;
+			if (Control == null)
+				return;
 
-				Drawable thumb = seekbar.Thumb;
-				int thumbTop = seekbar.Height / 2 - thumb.IntrinsicHeight / 2;
+			SeekBar seekbar = Control;
 
-				thumb.SetBounds(thumb.Bounds.Left, thumbTop, thumb.Bounds.Left + thumb.IntrinsicWidth, thumbTop + thumb.IntrinsicHeight);
-			}
+			Drawable thumb = seekbar.Thumb;
+			int thumbTop = seekbar.Height / 2 - thumb.IntrinsicHeight / 2;
+
+			thumb.SetBounds(thumb.Bounds.Left, thumbTop, thumb.Bounds.Left + thumb.IntrinsicWidth, thumbTop + thumb.IntrinsicHeight);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Android `SeekBar` does not allow Min to be set and `Progress` is an int. This creates a problem when `Slider`'s Min and Max values can be double. For example, when Min is 1 and Max is 10, SeekBar's 1000 ticks need to be distributed over this range. When `Slider` loads initially with a value of 5, Progress will be calculated as an int which results in precision loss. When we read this int back and try to convert it to a double, then the user sees 4.996. To me, it looked like there is no way to fix this problem.

What I did was letting the user see whatever value they set in XF even if this value is slightly off (4.996 is the correct value whereas 5 would be incorrect). However, once they move the slider, then they should begin seeing floating point numbers.

Perhaps, the truly correct thing to do is to use something like a `ValueRequest` property and let the user know their requested value might not always come back the same on initial load.

Also made minor refactoring.

@hartez 
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=43429
