### PR TITLE
Fix NullReferenceException in BindableObject.GetContext

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -486,7 +486,7 @@ namespace Xamarin.Forms
 			for (var i = 0; i < properties.Count; i++)
 			{
 				BindablePropertyContext context = properties[i];
-				if (context != null || ReferenceEquals(context.Property, property))
+				if (context != null && ReferenceEquals(context.Property, property))
 					return context;
 			}
 

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -486,7 +486,7 @@ namespace Xamarin.Forms
 			for (var i = 0; i < properties.Count; i++)
 			{
 				BindablePropertyContext context = properties[i];
-				if (ReferenceEquals(context.Property, property))
+				if (context != null || ReferenceEquals(context.Property, property))
 					return context;
 			}
 


### PR DESCRIPTION
### Description of Change

I often get `NullReferenceException` if `OnLayout` is invoked or `BindableProperty' is changed in other code (not my) when page is in disappear process.

I have this problem when I change `MainPage` or I change `Detail` in `MasterDetailPage`.

This problem often be in Android.

Maybe this problem is thrown because code is invoked in second thread.

Stack trace:

```
Xamarin caused by: android.runtime.JavaProxyThrowable: System.NullReferenceException: Object reference not set to an instance of an object.
  at Xamarin.Forms.BindableObject.GetContext (Xamarin.Forms.BindableProperty property) [0x00013] in C:\BuildAgent2\work\aad494dc9bc9783\Xamarin.Forms.Core\BindableObject.cs:489 
  at Xamarin.Forms.BindableObject.GetValue (Xamarin.Forms.BindableProperty property) [0x0000e] in C:\BuildAgent2\work\aad494dc9bc9783\Xamarin.Forms.Core\BindableObject.cs:54 
  at Xamarin.Forms.ListView.get_IsGroupingEnabled () [0x00000] in C:\BuildAgent2\work\aad494dc9bc9783\Xamarin.Forms.Core\ListView.cs:145 
  at Xamarin.Forms.Platform.Android.ListViewAdapter.get_Count () [0x00013] in C:\BuildAgent2\work\aad494dc9bc9783\Xamarin.Forms.Platform.Android\Renderers\ListViewAdapter.cs:69 
  at Android.Widget.BaseAdapter.n_GetCount (System.IntPtr jnienv, System.IntPtr native__this) [0x00009] in /Users/builder/data/lanes/3511/0e59c362/source/monodroid/src/Mono.Android/platforms/android-24/src/generated/Android.Widget.BaseAdapter.cs:464 
  at (wrapper dynamic-method) System.Object:68991893-2d17-4499-a819-dba110a71d9d (intptr,intptr)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.ListViewAdapter.n_getCount(Native Method)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.ListViewAdapter.getCount(ListViewAdapter.java:44)
    at android.widget.HeaderViewListAdapter.getCount(HeaderViewListAdapter.java:132)
    at android.widget.ListView.onMeasure(ListView.java:1171)
    at android.view.View.measure(View.java:18580)
    at android.support.v4.widget.SwipeRefreshLayout.onMeasure(SwipeRefreshLayout.java:612)
    at android.view.View.measure(View.java:18580)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.ListViewRenderer.n_onLayout(Native Method)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.ListViewRenderer.onLayout(ListViewRenderer.java:65)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at com.xamarin.forms.platform.android.FormsViewGroup.measureAndLayout(FormsViewGroup.java:29)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.ViewRenderer_2.n_onLayout(Native Method)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.ViewRenderer_2.onLayout(ViewRenderer_2.java:47)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at com.xamarin.forms.platform.android.FormsViewGroup.measureAndLayout(FormsViewGroup.java:29)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.VisualElementRenderer_1.n_onLayout(Native Method)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.VisualElementRenderer_1.onLayout(VisualElementRenderer_1.java:49)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at com.xamarin.forms.platform.android.FormsViewGroup.measureAndLayout(FormsViewGroup.java:29)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.PageContainer.n_onLayout(Native Method)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.PageContainer.onLayout(PageContainer.java:54)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at md5270abb39e60627f0f200893b490a1ade.NavigationPageRenderer.n_onLayout(Native Method)
    at md5270abb39e60627f0f200893b490a1ade.NavigationPageRenderer.onLayout(NavigationPageRenderer.java:63)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at com.xamarin.forms.platform.android.FormsViewGroup.measureAndLayout(FormsViewGroup.java:29)
    at md5270abb39e60627f0f200893b490a1ade.MasterDetailContainer.n_onLayout(Native Method)
    at md5270abb39e60627f0f200893b490a1ade.MasterDetailContainer.onLayout(MasterDetailContainer.java:53)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at android.support.v4.widget.DrawerLayout.onLayout(DrawerLayout.java:1187)
    at md5270abb39e60627f0f200893b490a1ade.MasterDetailPageRenderer.n_onLayout(Native Method)
    at md5270abb39e60627f0f200893b490a1ade.MasterDetailPageRenderer.onLayout(MasterDetailPageRenderer.java:68)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.PlatformRenderer.n_onLayout(Native Method)
    at md5b60ffeb829f638581ab2bb9b1a7f4f3f.PlatformRenderer.onLayout(PlatformRenderer.java:63)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at android.widget.RelativeLayout.onLayout(RelativeLayout.java:1077)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:573)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:508)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:573)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:508)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:573)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:508)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1702)
    at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1556)
    at android.widget.LinearLayout.onLayout(LinearLayout.java:1465)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:573)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:508)
    at android.view.View.layout(View.java:16695)
    at android.view.ViewGroup.layout(ViewGroup.java:5328)
    at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:2319)
    at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2032)
    at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1191)
    at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:6642)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:777)
    at android.view.Choreographer.doCallbacks(Choreographer.java:590)
    at android.view.Choreographer.doFrame(Choreographer.java:560)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:763)
    at android.os.Handler.handleCallback(Handler.java:739)
    at android.os.Handler.dispatchMessage(Handler.java:95)
    at android.os.Looper.loop(Looper.java:145)
    at android.app.ActivityThread.main(ActivityThread.java:5951)
    at java.lang.reflect.Method.invoke(Native Method)
    at java.lang.reflect.Method.invoke(Method.java:372)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1400)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1195)
```

```
Xamarin caused by: android.runtime.JavaProxyThrowable: System.NullReferenceException: Object reference not set to an instance of an object
Xamarin.Forms.BindableObject.GetContext(BindableProperty property)<b0fc14d4e5b04749b7241d1235a68329>:0
Xamarin.Forms.BindableObject.GetValue(BindableProperty property)<b0fc14d4e5b04749b7241d1235a68329>:0
Xamarin.Forms.VisualElement.get_Width()<b0fc14d4e5b04749b7241d1235a68329>:0
Xamarin.Forms.Platform.Android.VisualElementTracker.UpdateAnchorX()<95895bcb439e42ebb8e7134a545f1acc>:0
Xamarin.Forms.Platform.Android.VisualElementTracker.UpdateLayout()<95895bcb439e42ebb8e7134a545f1acc>:0
Xamarin.Forms.Platform.Android.VisualElementRenderer<TElement>.UpdateLayout()<95895bcb439e42ebb8e7134a545f1acc>:0
Xamarin.Forms.Platform.Android.VisualElementRenderer<TElement>.OnLayout(bool changed, int l, int t, int r, int b)<95895bcb439e42ebb8e7134a545f1acc>:0
Xamarin.Forms.Platform.Android.ViewRenderer<TView, TNativeView>.OnLayout(bool changed, int l, int t, int r, int b)<95895bcb439e42ebb8e7134a545f1acc>:0
Xamarin.Forms.Platform.Android.FormsViewGroup.n_OnLayout_ZIIII(IntPtr jnienv, IntPtr native__this, bool p0, int p1, int p2, int p3, int p4)<2727d869763141fbae32189add254e74>:0
at (wrapper dynamic-method) System.Object:6d762c2f-39e9-4d3d-a4ef-f546fa735398 (intptr,intptr,bool,int,int,int,int)
md5b60ffeb829f638581ab2bb9b1a7f4f3f.ViewRenderer_2.n_onLayout(Native Method)
md5b60ffeb829f638581ab2bb9b1a7f4f3f.ViewRenderer_2.onLayout()ViewRenderer_2.java:47
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
com.xamarin.forms.platform.android.FormsViewGroup.measureAndLayout()FormsViewGroup.java:29
md5b60ffeb829f638581ab2bb9b1a7f4f3f.VisualElementRenderer_1.n_onLayout(Native Method)
md5b60ffeb829f638581ab2bb9b1a7f4f3f.VisualElementRenderer_1.onLayout()VisualElementRenderer_1.java:49
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
com.xamarin.forms.platform.android.FormsViewGroup.measureAndLayout()FormsViewGroup.java:29
md5b60ffeb829f638581ab2bb9b1a7f4f3f.PageContainer.n_onLayout(Native Method)
md5b60ffeb829f638581ab2bb9b1a7f4f3f.PageContainer.onLayout()PageContainer.java:46
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
md5270abb39e60627f0f200893b490a1ade.NavigationPageRenderer.n_onLayout(Native Method)
md5270abb39e60627f0f200893b490a1ade.NavigationPageRenderer.onLayout()NavigationPageRenderer.java:63
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
com.xamarin.forms.platform.android.FormsViewGroup.measureAndLayout()FormsViewGroup.java:29
md5270abb39e60627f0f200893b490a1ade.MasterDetailContainer.n_onLayout(Native Method)
md5270abb39e60627f0f200893b490a1ade.MasterDetailContainer.onLayout()MasterDetailContainer.java:45
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
android.support.v4.widget.DrawerLayout.onLayout()DrawerLayout.java:1187
md5270abb39e60627f0f200893b490a1ade.MasterDetailPageRenderer.n_onLayout(Native Method)
md5270abb39e60627f0f200893b490a1ade.MasterDetailPageRenderer.onLayout()MasterDetailPageRenderer.java:68
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
md5b60ffeb829f638581ab2bb9b1a7f4f3f.PlatformRenderer.n_onLayout(Native Method)
md5b60ffeb829f638581ab2bb9b1a7f4f3f.PlatformRenderer.onLayout()PlatformRenderer.java:55
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
android.widget.RelativeLayout.onLayout()RelativeLayout.java:1077
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
android.widget.FrameLayout.layoutChildren()FrameLayout.java:573
android.widget.FrameLayout.onLayout()FrameLayout.java:508
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
android.widget.LinearLayout.setChildFrame()LinearLayout.java:1702
android.widget.LinearLayout.layoutVertical()LinearLayout.java:1556
android.widget.LinearLayout.onLayout()LinearLayout.java:1465
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
android.widget.FrameLayout.layoutChildren()FrameLayout.java:573
android.widget.FrameLayout.onLayout()FrameLayout.java:508
android.view.View.layout()View.java:16695
android.view.ViewGroup.layout()ViewGroup.java:5328
android.view.ViewRootImpl.performLayout()ViewRootImpl.java:2319
android.view.ViewRootImpl.performTraversals()ViewRootImpl.java:2032
android.view.ViewRootImpl.doTraversal()ViewRootImpl.java:1191
android.view.ViewRootImpl$TraversalRunnable.run()ViewRootImpl.java:6642
android.view.Choreographer$CallbackRecord.run()Choreographer.java:777
android.view.Choreographer.doCallbacks()Choreographer.java:590
android.view.Choreographer.doFrame()Choreographer.java:560
android.view.Choreographer$FrameDisplayEventReceiver.run()Choreographer.java:763
android.os.Handler.handleCallback()Handler.java:739
android.os.Handler.dispatchMessage()Handler.java:95
android.os.Looper.loop()Looper.java:145
android.app.ActivityThread.main()ActivityThread.java:5951
java.lang.reflect.Method.invoke(Native Method)
java.lang.reflect.Method.invoke()Method.java:372
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run()ZygoteInit.java:1400
com.android.internal.os.ZygoteInit.main()ZygoteInit.java:1195
```
### Bugs Fixed
- [BindableObject.GetContext(BindableProperty property) NullReferenceException](https://bugzilla.xamarin.com/show_bug.cgi?id=44721)
- [CADisplayLinkTicker with ActivityIndicator accesses UI off main thread and crashes](https://bugzilla.xamarin.com/show_bug.cgi?id=23940)
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
