### PR TITLE
Use Null-conditaional operator

### DIFF
--- a/Xamarin.Forms.Core/Animation.cs
+++ b/Xamarin.Forms.Core/Animation.cs
@@ -104,8 +104,7 @@ namespace Xamarin.Forms
 					if (val >= 1.0f)
 					{
 						animation._finishedTriggered = true;
-						if (animation._finished != null)
-							animation._finished();
+						animation._finished?.Invoke();
 					}
 				}
 			};

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -246,39 +246,30 @@ namespace Xamarin.Forms
 
 		void OnModalPopped(Page modalPage)
 		{
-			EventHandler<ModalPoppedEventArgs> handler = ModalPopped;
-			if (handler != null)
-				handler(this, new ModalPoppedEventArgs(modalPage));
+			ModalPopped?.Invoke(this, new ModalPoppedEventArgs(modalPage));
 		}
 
 		bool OnModalPopping(Page modalPage)
 		{
 			EventHandler<ModalPoppingEventArgs> handler = ModalPopping;
 			var args = new ModalPoppingEventArgs(modalPage);
-			if (handler != null)
-				handler(this, args);
+			handler?.Invoke(this, args);
 			return args.Cancel;
 		}
 
 		void OnModalPushed(Page modalPage)
 		{
-			EventHandler<ModalPushedEventArgs> handler = ModalPushed;
-			if (handler != null)
-				handler(this, new ModalPushedEventArgs(modalPage));
+			ModalPushed?.Invoke(this, new ModalPushedEventArgs(modalPage));
 		}
 
 		void OnModalPushing(Page modalPage)
 		{
-			EventHandler<ModalPushingEventArgs> handler = ModalPushing;
-			if (handler != null)
-				handler(this, new ModalPushingEventArgs(modalPage));
+			ModalPushing?.Invoke(this, new ModalPushingEventArgs(modalPage));
 		}
 
 		void OnPopCanceled()
 		{
-			EventHandler handler = PopCanceled;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			PopCanceled?.Invoke(this, EventArgs.Empty);
 		}
 
 		async Task SetPropertiesAsync()

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -125,23 +125,17 @@ namespace Xamarin.Forms
 
 		protected virtual void OnBindingContextChanged()
 		{
-			EventHandler change = BindingContextChanged;
-			if (change != null)
-				change(this, EventArgs.Empty);
+			BindingContextChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null)
-				handler(this, new PropertyChangedEventArgs(propertyName));
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 
 		protected virtual void OnPropertyChanging([CallerMemberName] string propertyName = null)
 		{
-			PropertyChangingEventHandler changing = PropertyChanging;
-			if (changing != null)
-				changing(this, new PropertyChangingEventArgs(propertyName));
+			PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
 		}
 
 		protected void UnapplyBindings()
@@ -275,8 +269,7 @@ namespace Xamarin.Forms
 			BindingBase oldBinding = context.Binding;
 			context.Binding = binding;
 
-			if (targetProperty.BindingChanging != null)
-				targetProperty.BindingChanging(this, oldBinding, binding);
+			targetProperty.BindingChanging?.Invoke(this, oldBinding, binding);
 
 			binding.Apply(BindingContext, this, targetProperty);
 		}
@@ -448,8 +441,7 @@ namespace Xamarin.Forms
 			bool same = Equals(original, newValue);
 			if (!same)
 			{
-				if (property.PropertyChanging != null)
-					property.PropertyChanging(this, original, newValue);
+				property.PropertyChanging?.Invoke(this, original, newValue);
 
 				OnPropertyChanging(property.PropertyName);
 			}
@@ -461,8 +453,7 @@ namespace Xamarin.Forms
 			if (!same)
 			{
 				OnPropertyChanged(property.PropertyName);
-				if (property.PropertyChanged != null)
-					property.PropertyChanged(this, original, newValue);
+				property.PropertyChanged?.Invoke(this, original, newValue);
 			}
 		}
 
@@ -509,8 +500,7 @@ namespace Xamarin.Forms
 		{
 			context.Binding.Unapply();
 
-			if (property.BindingChanging != null)
-				property.BindingChanging(this, context.Binding, null);
+			property.BindingChanging?.Invoke(this, context.Binding, null);
 
 			context.Binding = null;
 		}
@@ -543,8 +533,7 @@ namespace Xamarin.Forms
 			bool same = Equals(value, original);
 			if (!silent && (!same || raiseOnEqual))
 			{
-				if (property.PropertyChanging != null)
-					property.PropertyChanging(this, original, value);
+				property.PropertyChanging?.Invoke(this, original, value);
 
 				OnPropertyChanging(property.PropertyName);
 			}
@@ -580,8 +569,7 @@ namespace Xamarin.Forms
 
 				OnPropertyChanged(property.PropertyName);
 
-				if (property.PropertyChanged != null)
-					property.PropertyChanged(this, original, value);
+				property.PropertyChanged?.Invoke(this, original, value);
 			}
 		}
 

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -120,9 +120,7 @@ namespace Xamarin.Forms
 			if (cmd != null)
 				cmd.Execute(CommandParameter);
 
-			EventHandler handler = Clicked;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Clicked?.Invoke(this, EventArgs.Empty);
 		}
 
 		public FontAttributes FontAttributes

--- a/Xamarin.Forms.Core/Cells/Cell.cs
+++ b/Xamarin.Forms.Core/Cells/Cell.cs
@@ -101,15 +101,12 @@ namespace Xamarin.Forms
 
 		protected internal virtual void OnTapped()
 		{
-			if (Tapped != null)
-				Tapped(this, EventArgs.Empty);
+			Tapped?.Invoke(this, EventArgs.Empty);
 		}
 
 		protected virtual void OnAppearing()
 		{
-			EventHandler handler = Appearing;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Appearing?.Invoke(this, EventArgs.Empty);
 		}
 
 		protected override void OnBindingContextChanged()
@@ -125,9 +122,7 @@ namespace Xamarin.Forms
 
 		protected virtual void OnDisappearing()
 		{
-			EventHandler handler = Disappearing;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Disappearing?.Invoke(this, EventArgs.Empty);
 		}
 
 		protected override void OnParentSet()
@@ -185,9 +180,7 @@ namespace Xamarin.Forms
 		{
 			// don't run more than once per 16 milliseconds
 			await Task.Delay(TimeSpan.FromMilliseconds(16));
-			EventHandler handler = ForceUpdateSizeRequested;
-			if (handler != null)
-				handler(this, null);
+			ForceUpdateSizeRequested?.Invoke(this, null);
 
 			_nextCallToForceUpdateSizeQueued = false;
 		}

--- a/Xamarin.Forms.Core/Cells/EntryCell.cs
+++ b/Xamarin.Forms.Core/Cells/EntryCell.cs
@@ -66,9 +66,7 @@ namespace Xamarin.Forms
 
 		void IEntryCellController.SendCompleted()
 		{
-			EventHandler handler = Completed;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Completed?.Invoke(this, EventArgs.Empty);
 		}
 
 		static void OnHorizontalTextAlignmentPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/Xamarin.Forms.Core/Cells/SwitchCell.cs
+++ b/Xamarin.Forms.Core/Cells/SwitchCell.cs
@@ -7,9 +7,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty OnProperty = BindableProperty.Create("On", typeof(bool), typeof(SwitchCell), false, propertyChanged: (obj, oldValue, newValue) =>
 		{
 			var switchCell = (SwitchCell)obj;
-			EventHandler<ToggledEventArgs> handler = switchCell.OnChanged;
-			if (handler != null)
-				handler(obj, new ToggledEventArgs((bool)newValue));
+			switchCell.OnChanged?.Invoke(obj, new ToggledEventArgs((bool)newValue));
 		}, defaultBindingMode: BindingMode.TwoWay);
 
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(SwitchCell), default(string));

--- a/Xamarin.Forms.Core/ColumnDefinition.cs
+++ b/Xamarin.Forms.Core/ColumnDefinition.cs
@@ -26,9 +26,7 @@ namespace Xamarin.Forms
 
 		void OnSizeChanged()
 		{
-			EventHandler eh = SizeChanged;
-			if (eh != null)
-				eh(this, EventArgs.Empty);
+			SizeChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 
 namespace Xamarin.Forms
@@ -72,9 +72,7 @@ namespace Xamarin.Forms
 
 		public void ChangeCanExecute()
 		{
-			EventHandler changed = CanExecuteChanged;
-			if (changed != null)
-				changed(this, EventArgs.Empty);
+			CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -95,10 +95,7 @@ namespace Xamarin.Forms
 		static void DatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var datePicker = (DatePicker)bindable;
-			EventHandler<DateChangedEventArgs> selected = datePicker.DateSelected;
-
-			if (selected != null)
-				selected(datePicker, new DateChangedEventArgs((DateTime)oldValue, (DateTime)newValue));
+			datePicker.DateSelected?.Invoke(datePicker, new DateChangedEventArgs((DateTime)oldValue, (DateTime)newValue));
 		}
 
 		static bool ValidateMaximumDate(BindableObject bindable, object value)

--- a/Xamarin.Forms.Core/DefinitionCollection.cs
+++ b/Xamarin.Forms.Core/DefinitionCollection.cs
@@ -101,9 +101,7 @@ namespace Xamarin.Forms
 
 		void OnItemSizeChanged(object sender, EventArgs e)
 		{
-			EventHandler eh = ItemSizeChanged;
-			if (eh != null)
-				eh(this, EventArgs.Empty);
+			ItemSizeChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -65,26 +65,22 @@ namespace Xamarin.Forms
 				case TargetPlatform.iOS:
 					if (iOS != null)
 						iOS();
-					else if (Default != null)
-						Default();
-					break;
+					else Default?.Invoke();
+				break;
 				case TargetPlatform.Android:
 					if (Android != null)
 						Android();
-					else if (Default != null)
-						Default();
-					break;
+					else Default?.Invoke();
+				break;
 				case TargetPlatform.Windows:
 				case TargetPlatform.WinPhone:
 					if (WinPhone != null)
 						WinPhone();
-					else if (Default != null)
-						Default();
-					break;
+					else Default?.Invoke();
+				break;
 				case TargetPlatform.Other:
-					if (Default != null)
-						Default();
-					break;
+				Default?.Invoke();
+				break;
 			}
 		}
 

--- a/Xamarin.Forms.Core/DeviceInfo.cs
+++ b/Xamarin.Forms.Core/DeviceInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -43,9 +43,7 @@ namespace Xamarin.Forms
 
 		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null)
-				handler(this, new PropertyChangedEventArgs(propertyName));
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -9,8 +9,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(Editor), null, BindingMode.TwoWay, propertyChanged: (bindable, oldValue, newValue) =>
 		{
 			var editor = (Editor)bindable;
-			if (editor.TextChanged != null)
-				editor.TextChanged(editor, new TextChangedEventArgs((string)oldValue, (string)newValue));
+			editor.TextChanged?.Invoke(editor, new TextChangedEventArgs((string)oldValue, (string)newValue));
 		});
 
 		public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create("FontFamily", typeof(string), typeof(Editor), default(string));
@@ -70,9 +69,7 @@ namespace Xamarin.Forms
 
 		internal void SendCompleted()
 		{
-			EventHandler handler = Completed;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Completed?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -146,13 +146,11 @@ namespace Xamarin.Forms
 				if (_platform == value)
 					return;
 				_platform = value;
-				if (PlatformSet != null)
-					PlatformSet(this, EventArgs.Empty);
+				PlatformSet?.Invoke(this, EventArgs.Empty);
 				foreach (Element descendant in Descendants())
 				{
 					descendant._platform = _platform;
-					if (descendant.PlatformSet != null)
-						descendant.PlatformSet(this, EventArgs.Empty);
+					descendant.PlatformSet?.Invoke(this, EventArgs.Empty);
 				}
 			}
 		}
@@ -349,8 +347,7 @@ namespace Xamarin.Forms
 
 			child.ApplyBindings();
 
-			if (ChildAdded != null)
-				ChildAdded(this, new ElementEventArgs(child));
+			ChildAdded?.Invoke(this, new ElementEventArgs(child));
 
 			OnDescendantAdded(child);
 			foreach (Element element in child.Descendants())
@@ -361,8 +358,7 @@ namespace Xamarin.Forms
 		{
 			child.Parent = null;
 
-			if (ChildRemoved != null)
-				ChildRemoved(child, new ElementEventArgs(child));
+			ChildRemoved?.Invoke(child, new ElementEventArgs(child));
 
 			OnDescendantRemoved(child);
 			foreach (Element element in child.Descendants())
@@ -587,8 +583,7 @@ namespace Xamarin.Forms
 
 		void OnDescendantAdded(Element child)
 		{
-			if (DescendantAdded != null)
-				DescendantAdded(this, new ElementEventArgs(child));
+			DescendantAdded?.Invoke(this, new ElementEventArgs(child));
 
 			if (RealParent != null)
 				RealParent.OnDescendantAdded(child);
@@ -596,8 +591,7 @@ namespace Xamarin.Forms
 
 		void OnDescendantRemoved(Element child)
 		{
-			if (DescendantRemoved != null)
-				DescendantRemoved(this, new ElementEventArgs(child));
+			DescendantRemoved?.Invoke(this, new ElementEventArgs(child));
 
 			if (RealParent != null)
 				RealParent.OnDescendantRemoved(child);

--- a/Xamarin.Forms.Core/FormattedString.cs
+++ b/Xamarin.Forms.Core/FormattedString.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -72,9 +72,7 @@ namespace Xamarin.Forms
 
 		void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null)
-				handler(this, new PropertyChangedEventArgs(propertyName));
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 
 		class SpanCollection : ObservableCollection<Span>

--- a/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
@@ -93,8 +93,7 @@ namespace Xamarin.Forms
 			if (newState == oldState)
 				return;
 
-			if (ConditionChanged != null)
-				ConditionChanged(bindable, oldState, newState);
+			ConditionChanged?.Invoke(bindable, oldState, newState);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Interactivity/MultiCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/MultiCondition.cs
@@ -43,8 +43,7 @@ namespace Xamarin.Forms
 			if ((bool)oldValue == (bool)newValue)
 				return;
 
-			if (ConditionChanged != null)
-				ConditionChanged(bindable, (bool)oldValue, (bool)newValue);
+			ConditionChanged?.Invoke(bindable, (bool)oldValue, (bool)newValue);
 		}
 
 		void OnConditionChanged(BindableObject bindable, bool oldValue, bool newValue)

--- a/Xamarin.Forms.Core/Interactivity/PropertyCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/PropertyCondition.cs
@@ -93,8 +93,7 @@ namespace Xamarin.Forms
 			if ((bool)oldValue == (bool)newValue)
 				return;
 
-			if (ConditionChanged != null)
-				ConditionChanged(bindable, (bool)oldValue, (bool)newValue);
+			ConditionChanged?.Invoke(bindable, (bool)oldValue, (bool)newValue);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
+++ b/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -56,8 +56,7 @@ namespace Xamarin.Forms.Internals
 
 		void EmitCollectionChanged()
 		{
-			if (CollectionChanged != null)
-				CollectionChanged(this, EventArgs.Empty);
+			CollectionChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		IEnumerable<ToolbarItem> GetCurrentToolbarItems(Page page)

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -234,9 +234,7 @@ namespace Xamarin.Forms
 				Rectangle newBound = ((VisualElement)LogicalChildrenInternal[i]).Bounds;
 				if (oldBound != newBound)
 				{
-					EventHandler handler = LayoutChanged;
-					if (handler != null)
-						handler(this, EventArgs.Empty);
+					LayoutChanged?.Invoke(this, EventArgs.Empty);
 					return;
 				}
 			}

--- a/Xamarin.Forms.Core/ListProxy.cs
+++ b/Xamarin.Forms.Core/ListProxy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -225,16 +225,12 @@ namespace Xamarin.Forms
 
 		void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
 		{
-			NotifyCollectionChangedEventHandler changed = CollectionChanged;
-			if (changed != null)
-				changed(this, e);
+			CollectionChanged?.Invoke(this, e);
 		}
 
 		void OnCountChanged()
 		{
-			EventHandler changed = CountChanged;
-			if (changed != null)
-				changed(this, EventArgs.Empty);
+			CountChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		bool TryGetValue(int index, out object value)

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -249,16 +249,12 @@ namespace Xamarin.Forms
 
 		void IListViewController.SendCellAppearing(Cell cell)
 		{
-			EventHandler<ItemVisibilityEventArgs> handler = ItemAppearing;
-			if (handler != null)
-				handler(this, new ItemVisibilityEventArgs(cell.BindingContext));
+			ItemAppearing?.Invoke(this, new ItemVisibilityEventArgs(cell.BindingContext));
 		}
 
 		void IListViewController.SendCellDisappearing(Cell cell)
 		{
-			EventHandler<ItemVisibilityEventArgs> handler = ItemDisappearing;
-			if (handler != null)
-				handler(this, new ItemVisibilityEventArgs(cell.BindingContext));
+			ItemDisappearing?.Invoke(this, new ItemVisibilityEventArgs(cell.BindingContext));
 		}
 
 		void IListViewController.SendRefreshing()
@@ -569,23 +565,18 @@ namespace Xamarin.Forms
 
 		void OnRefreshing(EventArgs e)
 		{
-			EventHandler handler = Refreshing;
-			if (handler != null)
-				handler(this, e);
+			Refreshing?.Invoke(this, e);
 		}
 
 		void OnScrollToRequested(ScrollToRequestedEventArgs e)
 		{
-			EventHandler<ScrollToRequestedEventArgs> handler = ScrollToRequested;
-			if (handler != null)
-				handler(this, e);
+			ScrollToRequested?.Invoke(this, e);
 		}
 
 		static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var list = (ListView)bindable;
-			if (list.ItemSelected != null)
-				list.ItemSelected(list, new SelectedItemChangedEventArgs(newValue));
+			list.ItemSelected?.Invoke(list, new SelectedItemChangedEventArgs(newValue));
 		}
 
 		static bool ValidateHeaderFooterTemplate(BindableObject bindable, object value)

--- a/Xamarin.Forms.Core/MasterDetailPage.cs
+++ b/Xamarin.Forms.Core/MasterDetailPage.cs
@@ -221,9 +221,7 @@ namespace Xamarin.Forms
 		static void OnIsPresentedPropertyChanged(BindableObject sender, object oldValue, object newValue)
 		{
 			var page = (MasterDetailPage)sender;
-			EventHandler handler = page.IsPresentedChanged;
-			if (handler != null)
-				handler(page, EventArgs.Empty);
+			page.IsPresentedChanged?.Invoke(page, EventArgs.Empty);
 		}
 
 		static void OnIsPresentedPropertyChanging(BindableObject sender, object oldValue, object newValue)

--- a/Xamarin.Forms.Core/MenuItem.cs
+++ b/Xamarin.Forms.Core/MenuItem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 
 namespace Xamarin.Forms
@@ -80,9 +80,7 @@ namespace Xamarin.Forms
 
 		protected virtual void OnClicked()
 		{
-			EventHandler handler = Clicked;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Clicked?.Invoke(this, EventArgs.Empty);
 		}
 
 		void IMenuItemController.Activate()

--- a/Xamarin.Forms.Core/MultiPage.cs
+++ b/Xamarin.Forms.Core/MultiPage.cs
@@ -115,16 +115,12 @@ namespace Xamarin.Forms
 
 		protected virtual void OnCurrentPageChanged()
 		{
-			EventHandler changed = CurrentPageChanged;
-			if (changed != null)
-				changed(this, EventArgs.Empty);
+			CurrentPageChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		protected virtual void OnPagesChanged(NotifyCollectionChangedEventArgs e)
 		{
-			NotifyCollectionChangedEventHandler handler = PagesChanged;
-			if (handler != null)
-				handler(this, e);
+			PagesChanged?.Invoke(this, e);
 		}
 
 		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -257,8 +257,7 @@ namespace Xamarin.Forms
 
 			CurrentPage = (Page)PageController.InternalChildren.Last();
 
-			if (Popped != null)
-				Popped(this, args);
+			Popped?.Invoke(this, args);
 
 			return page;
 		}
@@ -338,8 +337,7 @@ namespace Xamarin.Forms
 					await args.Task;
 			}
 
-			if (PoppedToRoot != null)
-				PoppedToRoot(this, new PoppedToRootEventArgs(root, childrenToRemove.OfType<Page>().ToList()));
+			PoppedToRoot?.Invoke(this, new PoppedToRootEventArgs(root, childrenToRemove.OfType<Page>().ToList()));
 		}
 
 		async Task PushAsyncInner(Page page, bool animated)
@@ -360,8 +358,7 @@ namespace Xamarin.Forms
 					await args.Task;
 			}
 
-			if (Pushed != null)
-				Pushed(this, args);
+			Pushed?.Invoke(this, args);
 		}
 
 		void PushPage(Page page)
@@ -385,9 +382,7 @@ namespace Xamarin.Forms
 			if (!PageController.InternalChildren.Contains(page))
 				throw new ArgumentException("Page to remove must be contained on this Navigation Page");
 
-			EventHandler<NavigationRequestedEventArgs> handler = RemovePageRequestedInternal;
-			if (handler != null)
-				handler(this, new NavigationRequestedEventArgs(page, true));
+			RemovePageRequestedInternal?.Invoke(this, new NavigationRequestedEventArgs(page, true));
 
 			PageController.InternalChildren.Remove(page);
 		}

--- a/Xamarin.Forms.Core/OpenGLView.cs
+++ b/Xamarin.Forms.Core/OpenGLView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
@@ -30,9 +30,7 @@ namespace Xamarin.Forms
 
 		public void Display()
 		{
-			EventHandler handler = DisplayRequested;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			DisplayRequested?.Invoke(this, EventArgs.Empty);
 		}
 
 		event EventHandler DisplayRequested;

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -260,9 +260,7 @@ namespace Xamarin.Forms
 
 				if (c.Bounds != startingLayout[i])
 				{
-					EventHandler handler = LayoutChanged;
-					if (handler != null)
-						handler(this, EventArgs.Empty);
+					LayoutChanged?.Invoke(this, EventArgs.Empty);
 					return;
 				}
 			}
@@ -306,9 +304,7 @@ namespace Xamarin.Forms
 				MessagingCenter.Send(this, BusySetSignalName, true);
 
 			OnAppearing();
-			EventHandler handler = Appearing;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Appearing?.Invoke(this, EventArgs.Empty);
 
 			var pageContainer = this as IPageContainer<Page>;
 			((IPageController)pageContainer?.CurrentPage)?.SendAppearing();
@@ -328,9 +324,7 @@ namespace Xamarin.Forms
 			((IPageController)pageContainer?.CurrentPage)?.SendDisappearing();
 
 			OnDisappearing();
-			EventHandler handler = Disappearing;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Disappearing?.Invoke(this, EventArgs.Empty);
 		}
 
 		void InternalChildrenOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -15,9 +15,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
 			propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
-				EventHandler eh = ((Picker)bindable).SelectedIndexChanged;
-				if (eh != null)
-					eh(bindable, EventArgs.Empty);
+				((Picker)bindable).SelectedIndexChanged?.Invoke(bindable, EventArgs.Empty);
 			}, coerceValue: CoerceSelectedIndex);
 
 		readonly Lazy<PlatformConfigurationRegistry<Picker>> _platformConfigurationRegistry;

--- a/Xamarin.Forms.Core/PinchGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/PinchGestureRecognizer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Xamarin.Forms
 {
@@ -8,41 +8,25 @@ namespace Xamarin.Forms
 
 		void IPinchGestureController.SendPinch(Element sender, double delta, Point currentScalePoint)
 		{
-			EventHandler<PinchGestureUpdatedEventArgs> handler = PinchUpdated;
-			if (handler != null)
-			{
-				handler(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Running, delta, currentScalePoint));
-			}
+			PinchUpdated?.Invoke(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Running, delta, currentScalePoint));
 			((IPinchGestureController)this).IsPinching = true;
 		}
 
 		void IPinchGestureController.SendPinchCanceled(Element sender)
 		{
-			EventHandler<PinchGestureUpdatedEventArgs> handler = PinchUpdated;
-			if (handler != null)
-			{
-				handler(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Canceled));
-			}
+			PinchUpdated?.Invoke(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Canceled));
 			((IPinchGestureController)this).IsPinching = false;
 		}
 
 		void IPinchGestureController.SendPinchEnded(Element sender)
 		{
-			EventHandler<PinchGestureUpdatedEventArgs> handler = PinchUpdated;
-			if (handler != null)
-			{
-				handler(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Completed));
-			}
+			PinchUpdated?.Invoke(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Completed));
 			((IPinchGestureController)this).IsPinching = false;
 		}
 
 		void IPinchGestureController.SendPinchStarted(Element sender, Point initialScalePoint)
 		{
-			EventHandler<PinchGestureUpdatedEventArgs> handler = PinchUpdated;
-			if (handler != null)
-			{
-				handler(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Started, 1, initialScalePoint));
-			}
+			PinchUpdated?.Invoke(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Started, 1, initialScalePoint));
 			((IPinchGestureController)this).IsPinching = true;
 		}
 

--- a/Xamarin.Forms.Core/RowDefinition.cs
+++ b/Xamarin.Forms.Core/RowDefinition.cs
@@ -26,9 +26,7 @@ namespace Xamarin.Forms
 
 		void OnSizeChanged()
 		{
-			EventHandler eh = SizeChanged;
-			if (eh != null)
-				eh(this, EventArgs.Empty);
+			SizeChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/ScrollView.cs
+++ b/Xamarin.Forms.Core/ScrollView.cs
@@ -133,9 +133,7 @@ namespace Xamarin.Forms
 			ScrollX = x;
 			ScrollY = y;
 
-			EventHandler<ScrolledEventArgs> handler = Scrolled;
-			if (handler != null)
-				handler(this, new ScrolledEventArgs(x, y));
+			Scrolled?.Invoke(this, new ScrolledEventArgs(x, y));
 		}
 
 		public event EventHandler<ScrolledEventArgs> Scrolled;
@@ -289,9 +287,7 @@ namespace Xamarin.Forms
 		void OnScrollToRequested(ScrollToRequestedEventArgs e)
 		{
 			CheckTaskCompletionSource();
-			EventHandler<ScrollToRequestedEventArgs> handler = ScrollToRequested;
-			if (handler != null)
-				handler(this, e);
+			ScrollToRequested?.Invoke(this, e);
 		}
 
 		event EventHandler<ScrollToRequestedEventArgs> ScrollToRequested;

--- a/Xamarin.Forms.Core/SearchBar.cs
+++ b/Xamarin.Forms.Core/SearchBar.cs
@@ -15,9 +15,7 @@ namespace Xamarin.Forms
 			propertyChanged: (bindable, oldValue, newValue) =>
 			{
 				var searchBar = (SearchBar)bindable;
-				EventHandler<TextChangedEventArgs> eh = searchBar.TextChanged;
-				if (eh != null)
-					eh(searchBar, new TextChangedEventArgs((string)oldValue, (string)newValue));
+				searchBar.TextChanged?.Invoke(searchBar, new TextChangedEventArgs((string)oldValue, (string)newValue));
 			});
 
 		public static readonly BindableProperty CancelButtonColorProperty = BindableProperty.Create("CancelButtonColor", typeof(Color), typeof(SearchBar), default(Color));

--- a/Xamarin.Forms.Core/Slider.cs
+++ b/Xamarin.Forms.Core/Slider.cs
@@ -35,9 +35,7 @@ namespace Xamarin.Forms
 		}, propertyChanged: (bindable, oldValue, newValue) =>
 		{
 			var slider = (Slider)bindable;
-			EventHandler<ValueChangedEventArgs> eh = slider.ValueChanged;
-			if (eh != null)
-				eh(slider, new ValueChangedEventArgs((double)oldValue, (double)newValue));
+			slider.ValueChanged?.Invoke(slider, new ValueChangedEventArgs((double)oldValue, (double)newValue));
 		});
 
 		readonly Lazy<PlatformConfigurationRegistry<Slider>> _platformConfigurationRegistry;

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -121,9 +121,7 @@ namespace Xamarin.Forms
 
 		void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null)
-				handler(this, new PropertyChangedEventArgs(propertyName));
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 
 #pragma warning disable 0618 // retain until Span.Font removed

--- a/Xamarin.Forms.Core/Stepper.cs
+++ b/Xamarin.Forms.Core/Stepper.cs
@@ -35,9 +35,7 @@ namespace Xamarin.Forms
 		}, propertyChanged: (bindable, oldValue, newValue) =>
 		{
 			var stepper = (Stepper)bindable;
-			EventHandler<ValueChangedEventArgs> eh = stepper.ValueChanged;
-			if (eh != null)
-				eh(stepper, new ValueChangedEventArgs((double)oldValue, (double)newValue));
+			stepper.ValueChanged?.Invoke(stepper, new ValueChangedEventArgs((double)oldValue, (double)newValue));
 		});
 
 		public static readonly BindableProperty IncrementProperty = BindableProperty.Create("Increment", typeof(double), typeof(Stepper), 1.0);

--- a/Xamarin.Forms.Core/StreamWrapper.cs
+++ b/Xamarin.Forms.Core/StreamWrapper.cs
@@ -71,9 +71,7 @@ namespace Xamarin.Forms
 		protected override void Dispose(bool disposing)
 		{
 			_wrapped.Dispose();
-			EventHandler eh = Disposed;
-			if (eh != null)
-				eh(this, EventArgs.Empty);
+			Disposed?.Invoke(this, EventArgs.Empty);
 
 			base.Dispose(disposing);
 		}

--- a/Xamarin.Forms.Core/Switch.cs
+++ b/Xamarin.Forms.Core/Switch.cs
@@ -8,9 +8,7 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty IsToggledProperty = BindableProperty.Create("IsToggled", typeof(bool), typeof(Switch), false, propertyChanged: (bindable, oldValue, newValue) =>
 		{
-			EventHandler<ToggledEventArgs> eh = ((Switch)bindable).Toggled;
-			if (eh != null)
-				eh(bindable, new ToggledEventArgs((bool)newValue));
+			((Switch)bindable).Toggled?.Invoke(bindable, new ToggledEventArgs((bool)newValue));
 		}, defaultBindingMode: BindingMode.TwoWay);
 
 		readonly Lazy<PlatformConfigurationRegistry<Switch>> _platformConfigurationRegistry;

--- a/Xamarin.Forms.Core/TableModel.cs
+++ b/Xamarin.Forms.Core/TableModel.cs
@@ -46,8 +46,7 @@ namespace Xamarin.Forms
 
 		public void RowLongPressed(object item)
 		{
-			if (ItemLongPressed != null)
-				ItemLongPressed(this, new EventArg<object>(item));
+			ItemLongPressed?.Invoke(this, new EventArg<object>(item));
 
 			OnRowLongPressed(item);
 		}
@@ -59,8 +58,7 @@ namespace Xamarin.Forms
 
 		public void RowSelected(object item)
 		{
-			if (ItemSelected != null)
-				ItemSelected(this, new EventArg<object>(item));
+			ItemSelected?.Invoke(this, new EventArg<object>(item));
 
 			OnRowSelected(item);
 		}

--- a/Xamarin.Forms.Core/TableRoot.cs
+++ b/Xamarin.Forms.Core/TableRoot.cs
@@ -20,9 +20,7 @@ namespace Xamarin.Forms
 
 		void ChildCollectionChanged(object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 		{
-			EventHandler<ChildCollectionChangedEventArgs> handler = SectionCollectionChanged;
-			if (handler != null)
-				handler(this, new ChildCollectionChangedEventArgs(notifyCollectionChangedEventArgs));
+			SectionCollectionChanged?.Invoke(this, new ChildCollectionChangedEventArgs(notifyCollectionChangedEventArgs));
 		}
 
 		void ChildPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)

--- a/Xamarin.Forms.Core/TableView.cs
+++ b/Xamarin.Forms.Core/TableView.cs
@@ -109,8 +109,7 @@ namespace Xamarin.Forms
 			foreach (Cell cell in Root.SelectMany(r => r))
 				cell.Parent = this;
 
-			if (ModelChanged != null)
-				ModelChanged(this, EventArgs.Empty);
+			ModelChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		[Obsolete("Use OnMeasure")]

--- a/Xamarin.Forms.Core/TapGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/TapGestureRecognizer.cs
@@ -46,9 +46,7 @@ namespace Xamarin.Forms
 				handler(sender, new TappedEventArgs(CommandParameter));
 
 #pragma warning disable 0618 // retain until TappedCallback removed
-			Action<View, object> callback = TappedCallback;
-			if (callback != null)
-				callback(sender, TappedCallbackParameter);
+			TappedCallback?.Invoke(sender, TappedCallbackParameter);
 #pragma warning restore
 		}
 

--- a/Xamarin.Forms.Core/TemplatedItemsList.cs
+++ b/Xamarin.Forms.Core/TemplatedItemsList.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -752,9 +752,7 @@ namespace Xamarin.Forms
 
 		void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
 		{
-			NotifyCollectionChangedEventHandler changed = CollectionChanged;
-			if (changed != null)
-				changed(this, e);
+			CollectionChanged?.Invoke(this, e);
 		}
 
 		void OnCollectionChangedGrouped(NotifyCollectionChangedEventArgs e)
@@ -916,9 +914,7 @@ namespace Xamarin.Forms
 
 		void OnInnerCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			NotifyCollectionChangedEventHandler handler = GroupedCollectionChanged;
-			if (handler != null)
-				handler(sender, e);
+			GroupedCollectionChanged?.Invoke(sender, e);
 		}
 
 		void OnItemsSourceChanged(bool fromGrouping = false)
@@ -1318,9 +1314,7 @@ namespace Xamarin.Forms
 
 			void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
 			{
-				NotifyCollectionChangedEventHandler changed = CollectionChanged;
-				if (changed != null)
-					changed(this, e);
+				CollectionChanged?.Invoke(this, e);
 			}
 
 			void OnItemsListCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Xamarin.Forms.Core/Tweener.cs
+++ b/Xamarin.Forms.Core/Tweener.cs
@@ -74,8 +74,7 @@ namespace Xamarin.Forms
 
 				_lastMilliseconds = ms;
 
-				if (ValueUpdated != null)
-					ValueUpdated(this, EventArgs.Empty);
+				ValueUpdated?.Invoke(this, EventArgs.Empty);
 
 				if (Value >= 1.0f)
 				{
@@ -86,8 +85,7 @@ namespace Xamarin.Forms
 						return true;
 					}
 
-					if (Finished != null)
-						Finished(this, EventArgs.Empty);
+					Finished?.Invoke(this, EventArgs.Empty);
 					Value = 0.0f;
 					_timer = 0;
 					return false;
@@ -100,8 +98,7 @@ namespace Xamarin.Forms
 		{
 			Pause();
 			Value = 1.0f;
-			if (Finished != null)
-				Finished(this, EventArgs.Empty);
+			Finished?.Invoke(this, EventArgs.Empty);
 			Value = 0.0f;
 		}
 

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -551,11 +551,7 @@ namespace Xamarin.Forms
 			if (!IsFocused)
 				return;
 
-			EventHandler<FocusRequestArgs> unfocus = FocusChangeRequested;
-			if (unfocus != null)
-			{
-				unfocus(this, new FocusRequestArgs());
-			}
+			FocusChangeRequested?.Invoke(this, new FocusRequestArgs());
 		}
 
 		public event EventHandler<FocusEventArgs> Unfocused;
@@ -583,8 +579,7 @@ namespace Xamarin.Forms
 
 		protected void OnChildrenReordered()
 		{
-			if (ChildrenReordered != null)
-				ChildrenReordered(this, EventArgs.Empty);
+			ChildrenReordered?.Invoke(this, EventArgs.Empty);
 		}
 
 		protected virtual SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
@@ -718,9 +713,7 @@ namespace Xamarin.Forms
 
 		void OnFocused()
 		{
-			EventHandler<FocusEventArgs> focus = Focused;
-			if (focus != null)
-				focus(this, new FocusEventArgs(this, true));
+			Focused?.Invoke(this, new FocusEventArgs(this, true));
 		}
 
 		static void OnIsFocusedPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
@@ -757,9 +750,7 @@ namespace Xamarin.Forms
 
 		void OnUnfocus()
 		{
-			EventHandler<FocusEventArgs> unFocus = Unfocused;
-			if (unFocus != null)
-				unFocus(this, new FocusEventArgs(this, false));
+			Unfocused?.Invoke(this, new FocusEventArgs(this, false));
 		}
 
 		void SetSize(double width, double height)
@@ -771,8 +762,7 @@ namespace Xamarin.Forms
 			Height = height;
 
 			SizeAllocated(width, height);
-			if (SizeChanged != null)
-				SizeChanged(this, EventArgs.Empty);
+			SizeChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		internal class FocusRequestArgs : EventArgs

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -66,16 +66,12 @@ namespace Xamarin.Forms
 
 		public void GoBack()
 		{
-			EventHandler handler = GoBackRequested;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			GoBackRequested?.Invoke(this, EventArgs.Empty);
 		}
 
 		public void GoForward()
 		{
-			EventHandler handler = GoForwardRequested;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			GoForwardRequested?.Invoke(this, EventArgs.Empty);
 		}
 
 		public event EventHandler<WebNavigatedEventArgs> Navigated;
@@ -118,16 +114,12 @@ namespace Xamarin.Forms
 
 		internal void SendNavigated(WebNavigatedEventArgs args)
 		{
-			EventHandler<WebNavigatedEventArgs> handler = Navigated;
-			if (handler != null)
-				handler(this, args);
+			Navigated?.Invoke(this, args);
 		}
 
 		internal void SendNavigating(WebNavigatingEventArgs args)
 		{
-			EventHandler<WebNavigatingEventArgs> handler = Navigating;
-			if (handler != null)
-				handler(this, args);
+			Navigating?.Invoke(this, args);
 		}
 
 		public IPlatformElementConfiguration<T, WebView> On<T>() where T : IConfigPlatform

--- a/Xamarin.Forms.Core/WebViewSource.cs
+++ b/Xamarin.Forms.Core/WebViewSource.cs
@@ -16,9 +16,7 @@ namespace Xamarin.Forms
 
 		protected void OnSourceChanged()
 		{
-			EventHandler eh = SourceChanged;
-			if (eh != null)
-				eh(this, EventArgs.Empty);
+			SourceChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		internal abstract void Load(IWebViewDelegate renderer);


### PR DESCRIPTION
### Description of Change ###

Using Null-conditional operator for invoking delegates in a thread-safe way with much less code.
(https://msdn.microsoft.com/en-us/library/dn986595.aspx)

This is recommended by Visual Studio IDE (quick actions and refactoring) - IDE1005 (delegate invocation can be simplified).

### Bugs Fixed ###

N/A

### API Changes ###

N/A

### Behavioral Changes ###

N/A

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
