### PR TITLE
Reuse Handler when invoking on main thread

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -262,9 +262,16 @@ namespace Xamarin.Forms
 			double _microSize;
 			double _smallSize;
 
+			static Handler s_handler;
+
 			public void BeginInvokeOnMainThread(Action action)
 			{
-				new Handler(Looper.MainLooper).Post(action);
+				if (s_handler == null || s_handler.Looper != Looper.MainLooper)
+				{
+					s_handler = new Handler(Looper.MainLooper);
+				}
+
+				s_handler.Post(action);
 			}
 
 			public Ticker CreateTicker()


### PR DESCRIPTION
### Description of Change ###

Currently, every time `Device.BeginInvokeOnMainThread()` is called on a Android device, a new instance of `Handler` is created to post the action to the main thread. This means that every time a bound property is changed, a new instance of `Handler` is created; this creates additional GC pressure, especially during floods of property changes. 

This change reuses the `Handler` each time rather than creating a new one, significantly reducing the number of objects allocated as a result of property changes.



