### PR TITLE
[A] PanGestureRecognizer will consistently send Started/Move event

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39768.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39768.cs
@@ -1,0 +1,87 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39768, "PanGestureRecognizer sometimes won't fire completed event when dragging very slowly")]
+	public class Bugzilla39768 : TestContentPage
+	{
+		Image _Image;
+		Label _Label;
+		const string ImageName = "image";
+
+		[Preserve(AllMembers = true)]
+		public class PanContainer : ContentView
+		{
+			double x, y;
+
+			public EventHandler<PanUpdatedEventArgs> Panning;
+			public EventHandler<PanUpdatedEventArgs> PanningCompleted;
+
+			public PanContainer()
+			{
+				var panGesture = new PanGestureRecognizer();
+				panGesture.PanUpdated += OnPanUpdated;
+				GestureRecognizers.Add(panGesture);
+			}
+
+			void OnPanUpdated(object sender, PanUpdatedEventArgs e)
+			{
+				switch (e.StatusType)
+				{
+					case GestureStatus.Started:
+						break;
+
+					case GestureStatus.Running:
+						Content.TranslationX = x + e.TotalX;
+						Content.TranslationY = y + e.TotalY;
+
+						Panning?.Invoke(sender, e);
+						break;
+
+					case GestureStatus.Completed:
+						x = Content.TranslationX;
+						y = Content.TranslationY;
+
+						PanningCompleted?.Invoke(sender, e);
+						break;
+				}
+			}
+		}
+
+		protected override void Init()
+		{
+			_Image = new Image { Source = ImageSource.FromFile("crimson.jpg"), WidthRequest = 350, HeightRequest = 350, AutomationId = ImageName };
+			_Label = new Label { Text = "Press and hold the image for 1 second without moving it, then attempt to drag the image. If the image does not move, this test has failed. If this label does not display 'Success' when you have finished the pan, this test has failed." };
+
+			var panView = new PanContainer()
+			{
+				Content = _Image,
+				Panning = (s, e) =>
+				{
+					_Label.Text = $"TotalX: {e.TotalX}, TotalY: {e.TotalY}";
+				},
+				PanningCompleted = (s, e) =>
+				{
+					_Label.Text = "Success";
+				}
+			};
+
+			Content = new StackLayout
+			{
+				Children = {
+
+					panView,
+					_Label
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -184,6 +184,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42602.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43161.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39768.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41271.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />


### PR DESCRIPTION
### Description of Change ###

Continuation of #313. Now sending the Started/Running events for Pan on Move event, which will allow Pan to function after a long press is detected without having to lift your finger. Previously, a long press would swallow the Scroll event, which gave the appearance that the Pan did not work when dragging very slowly.

### Bugs Fixed ###

- [Bug 39768  - PanGestureRecognizer sometimes won't fire completed event when dragging very slowly] (https://bugzilla.xamarin.com/show_bug.cgi?id=39768)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
