### PR TITLE
Fix for Xamarin.Forms Xaml code behind generator with .Xamarin namespace

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -109,6 +109,18 @@ namespace Xamarin.Forms.Build.Tasks
 				return;
 			}
 
+			CodeCompileUnit compileUnit = GenerateCode(rootType, rootNs, baseType, namesAndTypes);
+
+			using (var writer = new StreamWriter(outFile))
+				Provider.GenerateCodeFromCompileUnit(compileUnit, writer, new CodeGeneratorOptions());
+		}
+
+		internal static CodeCompileUnit GenerateCode(string rootType, string rootNs, CodeTypeReference baseType,
+			IDictionary<string, CodeTypeReference> namesAndTypes)
+		{
+			if (rootType == null)
+				throw new ArgumentNullException(nameof(rootType));
+
 			var ccu = new CodeCompileUnit();
 			var declNs = new CodeNamespace(rootNs);
 			ccu.Namespaces.Add(declNs);
@@ -171,8 +183,7 @@ namespace Xamarin.Forms.Build.Tasks
 				initcomp.Statements.Add(assign);
 			}
 
-			using (var writer = new StreamWriter(outFile))
-				Provider.GenerateCodeFromCompileUnit(ccu, writer, new CodeGeneratorOptions());
+			return ccu;
 		}
 
 		internal static void GenerateFile(string xamlFile, string outFile)

--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -113,9 +113,9 @@ namespace Xamarin.Forms.Build.Tasks
 			var declNs = new CodeNamespace(rootNs);
 			ccu.Namespaces.Add(declNs);
 
-			declNs.Imports.Add(new CodeNamespaceImport("System"));
-			declNs.Imports.Add(new CodeNamespaceImport("Xamarin.Forms"));
-			declNs.Imports.Add(new CodeNamespaceImport("Xamarin.Forms.Xaml"));
+			declNs.Imports.Add(new CodeNamespaceImport("global::System"));
+			declNs.Imports.Add(new CodeNamespaceImport("global::Xamarin.Forms"));
+			declNs.Imports.Add(new CodeNamespaceImport("global::Xamarin.Forms.Xaml"));
 
 			var declType = new CodeTypeDeclaration(rootType);
 			declType.IsPartial = true;

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Validation\SetterOnNonBP.xaml.cs">
       <DependentUpon>SetterOnNonBP.xaml</DependentUpon>
     </Compile>
+    <Compile Include="XamlG\XamlGTaskTests.cs" />
     <Compile Include="XamlParseExceptionConstraint.cs" />
     <Compile Include="Issues\Issue2062.xaml.cs">
       <DependentUpon>Issue2062.xaml</DependentUpon>
@@ -368,8 +369,8 @@
     <Compile Include="XStaticException.xaml.cs">
       <DependentUpon>XStaticException.xaml</DependentUpon>
     </Compile>
-     <Compile Include="CompiledTypeConverter.xaml.cs" >
-       <DependentUpon>CompiledTypeConverter.xaml</DependentUpon>
+    <Compile Include="CompiledTypeConverter.xaml.cs">
+      <DependentUpon>CompiledTypeConverter.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -656,7 +657,7 @@
     <EmbeddedResource Include="XStaticException.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-    <EmbeddedResource Include="CompiledTypeConverter.xaml" >
+    <EmbeddedResource Include="CompiledTypeConverter.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/XamlG/XamlGTaskTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlG/XamlGTaskTests.cs
@@ -1,0 +1,27 @@
+﻿namespace Xamarin.Forms.Xaml.UnitTests.XamlG
+{
+	using System.CodeDom;
+	using System.Collections.Generic;
+	using System.Linq;
+	using NUnit.Framework;
+	using Xamarin.Forms.Build.Tasks;
+	using Xamarin.Forms.Core.UnitTests;
+
+	public class XamlGTaskTests : BaseTestFixture
+	{
+		[Test]
+		public void NamespaceUsingsAreGlobal()
+		{
+			var namesAndTypes = new Dictionary<string, CodeTypeReference>();
+			var baseType = new CodeTypeReference(typeof(object));
+
+			CodeCompileUnit code = XamlGTask.GenerateCode("TestType", "MyProject.Xamarin", baseType, namesAndTypes);
+
+			var codeNamespace = code.Namespaces.Cast<CodeNamespace>().First();
+			var imports = codeNamespace.Imports.Cast<CodeNamespaceImport>().Select(ns => ns.Namespace).ToArray();
+			Assert.Contains("global::System", imports);
+			Assert.Contains("global::Xamarin.Forms", imports);
+			Assert.Contains("global::Xamarin.Forms.Xaml", imports);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Using global::* for imports (usings) in generated Xaml code behind to avoid namespace conflict

### Bugs Fixed ###

~~https://bugzilla.xamarin.com/show_bug.cgi?id=44807~~
https://bugzilla.xamarin.com/show_bug.cgi?id=43301
### API Changes ###

None

### Behavioral Changes ###

See Description

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense