### PR TITLE
Fixed Bug 43285, added default width to ActivityIndicator on WinRT.

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ActivityIndicatorRenderer.cs
@@ -43,6 +43,8 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnControlLoaded(object sender, RoutedEventArgs routedEventArgs)
 		{
+			Width = 200;
+
 			_foregroundDefault = Control.GetForegroundCache();
 			UpdateColor();
 		}


### PR DESCRIPTION
### Description of Change ###

None

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=43285

### API Changes ###

None

### Behavioral Changes ###

Activity indicator will have a default with on 200 when running on WinRT.

### PR Checklist ###


- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
