### PR TITLE
ScrollView should account for Content margin

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41418.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41418.cs
@@ -1,0 +1,30 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41418, "Margin inside ScrollView not working properly", PlatformAffected.All)]
+	public class Bugzilla41418 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new ScrollView()
+			{
+				BackgroundColor = Color.Yellow,
+				Content = new BoxView
+				{
+					Margin = 100,
+					WidthRequest = 500,
+					HeightRequest = 800,
+					BackgroundColor = Color.Red
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -114,6 +114,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41205.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41418.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42069.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42069_Page.xaml.cs">

--- a/Xamarin.Forms.Core.UnitTests/ScrollViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ScrollViewUnitTests.cs
@@ -399,5 +399,59 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (scroll.ScrollX, Is.EqualTo (100));
 			Assert.That (scroll.ScrollY, Is.EqualTo (100));
 		}
+
+		[Test]
+		public void TestScrollContentMarginHorizontal()
+		{
+			View view = new View { IsPlatformEnabled = true, Margin = 100, WidthRequest = 100, HeightRequest = 100 };
+
+			var scroll = new ScrollView
+			{
+				Content = view,
+				Orientation = ScrollOrientation.Horizontal,
+				Platform = new UnitPlatform()
+			};
+			scroll.Layout(new Rectangle(0, 0, 100, 100));
+
+			Assert.AreEqual(new Size(300, 100), scroll.ContentSize);
+			Assert.AreEqual(100, scroll.Height);
+			Assert.AreEqual(100, scroll.Width);
+		}
+
+		[Test]
+		public void TestScrollContentMarginVertical()
+		{
+			View view = new View { IsPlatformEnabled = true, Margin = 100, WidthRequest = 100, HeightRequest = 100 };
+
+			var scroll = new ScrollView
+			{
+				Content = view,
+				Orientation = ScrollOrientation.Vertical,
+				Platform = new UnitPlatform()
+			};
+			scroll.Layout(new Rectangle(0, 0, 100, 100));
+
+			Assert.AreEqual(new Size(100, 300), scroll.ContentSize);
+			Assert.AreEqual(100, scroll.Height);
+			Assert.AreEqual(100, scroll.Width);
+		}
+
+		[Test]
+		public void TestScrollContentMarginBiDirectional()
+		{
+			View view = new View { IsPlatformEnabled = true, Margin = 100, WidthRequest = 100, HeightRequest = 100 };
+
+			var scroll = new ScrollView
+			{
+				Content = view,
+				Orientation = ScrollOrientation.Both,
+				Platform = new UnitPlatform()
+			};
+			scroll.Layout(new Rectangle(0, 0, 100, 100));
+
+			Assert.AreEqual(new Size(300, 300), scroll.ContentSize);
+			Assert.AreEqual(100, scroll.Height);
+			Assert.AreEqual(100, scroll.Width);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/ScrollView.cs
+++ b/Xamarin.Forms.Core/ScrollView.cs
@@ -268,7 +268,7 @@ namespace Xamarin.Forms
 
 		double GetMaxHeight(double height)
 		{
-			return Math.Max(height, _content.Bounds.Bottom + Padding.Bottom);
+			return Math.Max(height, _content.Bounds.Top + Padding.Top + _content.Bounds.Bottom + Padding.Bottom);
 		}
 
 		static double GetMaxHeight(double height, SizeRequest size)
@@ -278,7 +278,7 @@ namespace Xamarin.Forms
 
 		double GetMaxWidth(double width)
 		{
-			return Math.Max(width, _content.Bounds.Right + Padding.Right);
+			return Math.Max(width, _content.Bounds.Left + Padding.Left + _content.Bounds.Right + Padding.Right);
 		}
 
 		static double GetMaxWidth(double width, SizeRequest size)


### PR DESCRIPTION
### Description of Change ###

`ScrollView` did not get the correct maximum height and width of its content and failed to show the correct content margin. If the content is 800 units tall with 200 units of vertical thickness, then `_content.Bounds.Bottom` returns 900 and `Top` is 100. 

We shouldn't ignore top and left positions as well as top and left paddings.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=41418