### PR TITLE
[Android] ScrollView should send correct ScrollX and ScrollY

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
@@ -101,13 +101,13 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Tap(q => q.Marked(ButtonText));
 			RunningApp.WaitForElement(q => q.Marked("x: 100"));
 			RunningApp.WaitForElement(q => q.Marked("y: 100"));
-			RunningApp.WaitForElement(q => q.Marked("z: true"));
-			RunningApp.WaitForElement(q => q.Marked("a: true"));
+			RunningApp.WaitForElement(q => q.Marked("z: True"));
+			RunningApp.WaitForElement(q => q.Marked("a: True"));
 			RunningApp.Tap(q => q.Marked(ButtonText));
 			RunningApp.WaitForElement(q => q.Marked("x: 200"));
 			RunningApp.WaitForElement(q => q.Marked("y: 100"));
-			RunningApp.WaitForElement(q => q.Marked("z: true"));
-			RunningApp.WaitForElement(q => q.Marked("a: false"));
+			RunningApp.WaitForElement(q => q.Marked("z: True"));
+			RunningApp.WaitForElement(q => q.Marked("a: False"));
 		}
 
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
@@ -1,0 +1,49 @@
+﻿using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41415, "ScrollX and ScrollY values are not consistent with iOS", PlatformAffected.Android)]
+	public class Bugzilla41415 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var scrollView = new ScrollView
+			{
+				Orientation = ScrollOrientation.Both,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var grid = new Grid
+			{
+				BackgroundColor = Color.Yellow,
+				WidthRequest = 1000,
+				HeightRequest = 1000,
+				Children =
+				{
+					new BoxView
+					{
+						WidthRequest =  200,
+						HeightRequest = 200,
+						BackgroundColor = Color.Red,
+						HorizontalOptions = LayoutOptions.Center,
+						VerticalOptions = LayoutOptions.Center
+					}
+				}
+			};
+
+			scrollView.Content = grid;
+			scrollView.Scrolled += (sender, args) => { Debug.WriteLine("{0:0.0} {1:0.0}", args.ScrollX, args.ScrollY); };
+
+			Content = scrollView;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
@@ -13,8 +13,8 @@ namespace Xamarin.Forms.Controls
 	public class Bugzilla41415 : TestContentPage
 	{
 		const string ButtonText = "Click Me";
-		float _x = 0;
-		float _y = 0;
+		float _x, _y;
+		bool _didXChange, _didYChange;
 
 		protected override void Init()
 		{
@@ -38,6 +38,8 @@ namespace Xamarin.Forms.Controls
 
 			var labelx = new Label();
 			var labely = new Label();
+			var labelz = new Label();
+			var labela = new Label();
 
 			var scrollView = new ScrollView
 			{
@@ -51,16 +53,43 @@ namespace Xamarin.Forms.Controls
 			{
 				labelx.Text = $"x: {args.ScrollX}";
 				labely.Text = $"y: {args.ScrollY}";
+
+				// first and second taps
+				if (_x == 0)
+				{
+					if (args.ScrollX != 0 && args.ScrollX != 100)
+						_didXChange = true;
+					if (args.ScrollY != 0 && args.ScrollY != 100)
+						_didYChange = true;
+				}
+				else if (_x == 100)
+				{
+					if (args.ScrollX != _x && args.ScrollX != _x + 100)
+						_didXChange = true;
+					if (args.ScrollY != 100)
+						_didYChange = true;
+				}
+
+				labelz.Text = "z: " + _didXChange.ToString();
+				labela.Text = "a: " + _didYChange.ToString();
 			};
 
 			var button = new Button { Text = ButtonText };
 			button.Clicked += async (sender, e) =>
 			{
+				// reset
+				labelx.Text = null;
+				labely.Text = null;
+				labelz.Text = null;
+				labela.Text = null;
+				_didXChange = false;
+				_didYChange = false;
+
 				await scrollView.ScrollToAsync(_x + 100, _y + 100, true);
 				_x = 100;
 			};
 
-			Content = new StackLayout { Children = { button, labelx, labely, scrollView } };
+			Content = new StackLayout { Children = { button, labelx, labely, labelz, labela, scrollView } };
 		}
 
 #if UITEST
@@ -72,9 +101,13 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Tap(q => q.Marked(ButtonText));
 			RunningApp.WaitForElement(q => q.Marked("x: 100"));
 			RunningApp.WaitForElement(q => q.Marked("y: 100"));
+			RunningApp.WaitForElement(q => q.Marked("z: true"));
+			RunningApp.WaitForElement(q => q.Marked("a: true"));
 			RunningApp.Tap(q => q.Marked(ButtonText));
 			RunningApp.WaitForElement(q => q.Marked("x: 200"));
 			RunningApp.WaitForElement(q => q.Marked("y: 100"));
+			RunningApp.WaitForElement(q => q.Marked("z: true"));
+			RunningApp.WaitForElement(q => q.Marked("a: false"));
 		}
 
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Xamarin.Forms.CustomAttributes;
+﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
 #if UITEST
@@ -13,15 +12,12 @@ namespace Xamarin.Forms.Controls
 	[Issue(IssueTracker.Bugzilla, 41415, "ScrollX and ScrollY values are not consistent with iOS", PlatformAffected.Android)]
 	public class Bugzilla41415 : TestContentPage
 	{
+		const string ButtonText = "Click Me";
+		float _x = 0;
+		float _y = 0;
+
 		protected override void Init()
 		{
-			var scrollView = new ScrollView
-			{
-				Orientation = ScrollOrientation.Both,
-				HorizontalOptions = LayoutOptions.FillAndExpand,
-				VerticalOptions = LayoutOptions.FillAndExpand
-			};
-
 			var grid = new Grid
 			{
 				BackgroundColor = Color.Yellow,
@@ -40,10 +36,47 @@ namespace Xamarin.Forms.Controls
 				}
 			};
 
-			scrollView.Content = grid;
-			scrollView.Scrolled += (sender, args) => { Debug.WriteLine("{0:0.0} {1:0.0}", args.ScrollX, args.ScrollY); };
+			var labelx = new Label();
+			var labely = new Label();
 
-			Content = scrollView;
+			var scrollView = new ScrollView
+			{
+				Orientation = ScrollOrientation.Both,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			scrollView.Content = grid;
+			scrollView.Scrolled += (sender, args) =>
+			{
+				labelx.Text = $"x: {args.ScrollX}";
+				labely.Text = $"y: {args.ScrollY}";
+			};
+
+			var button = new Button { Text = ButtonText };
+			button.Clicked += async (sender, e) =>
+			{
+				await scrollView.ScrollToAsync(_x + 100, _y + 100, true);
+				_x = 100;
+			};
+
+			Content = new StackLayout { Children = { button, labelx, labely, scrollView } };
 		}
+
+#if UITEST
+
+		[Test]
+		public void Bugzilla41415Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(ButtonText));
+			RunningApp.Tap(q => q.Marked(ButtonText));
+			RunningApp.WaitForElement(q => q.Marked("x: 100"));
+			RunningApp.WaitForElement(q => q.Marked("y: 100"));
+			RunningApp.Tap(q => q.Marked(ButtonText));
+			RunningApp.WaitForElement(q => q.Marked("x: 200"));
+			RunningApp.WaitForElement(q => q.Marked("y: 100"));
+		}
+
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -115,6 +115,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41078.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40998.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41205.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41415.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41418.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42069.cs" />

--- a/Xamarin.Forms.Core.UnitTests/ScrollViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ScrollViewUnitTests.cs
@@ -453,5 +453,36 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(100, scroll.Height);
 			Assert.AreEqual(100, scroll.Width);
 		}
+
+		[Test]
+		public void TestBackToBackBiDirectionalScroll()
+		{
+			var scrollView = new ScrollView
+			{
+				Orientation = ScrollOrientation.Both,
+				Platform = new UnitPlatform(),
+				Content = new Grid
+				{
+					WidthRequest = 1000,
+					HeightRequest = 1000
+				}
+			};
+
+			var y100Count = 0;
+
+			((IScrollViewController)scrollView).ScrollToRequested += (sender, args) =>
+			{
+				if (args.ScrollY == 100)
+				{
+					++y100Count;
+				}
+			};
+
+			scrollView.ScrollToAsync(100, 100, true);
+			Assert.AreEqual(y100Count, 1);
+
+			scrollView.ScrollToAsync(0, 100, true);
+			Assert.AreEqual(y100Count, 2);
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -203,7 +203,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (_view != null)
 			{
-				if (_view.Orientation == ScrollOrientation.Horizontal || _view.Orientation == ScrollOrientation.Both)
+				if (_view.Orientation == ScrollOrientation.Both)
 				{
 					if (x == 0)
 						x = _hScrollView.ScrollX;

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -206,10 +206,10 @@ namespace Xamarin.Forms.Platform.Android
 				if (_view.Orientation == ScrollOrientation.Both)
 				{
 					if (x == 0)
-						x = _hScrollView.ScrollX;
+						x = Forms.Context.FromPixels(_hScrollView.ScrollX);
 
 					if (y == 0)
-						y = ScrollY;
+						y = Forms.Context.FromPixels(ScrollY);
 				}
 
 				Controller.SetScrolledPosition(x, y);

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -202,7 +202,18 @@ namespace Xamarin.Forms.Platform.Android
 		internal void UpdateScrollPosition(double x, double y)
 		{
 			if (_view != null)
+			{
+				if (_view.Orientation == ScrollOrientation.Horizontal || _view.Orientation == ScrollOrientation.Both)
+				{
+					if (x == 0)
+						x = _hScrollView.ScrollX;
+
+					if (y == 0)
+						y = ScrollY;
+				}
+
 				Controller.SetScrolledPosition(x, y);
+			}
 		}
 
 		static int GetDistance(double start, double position, double v)

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -286,10 +286,19 @@ namespace Xamarin.Forms.Platform.Android
 						return;
 					}
 
-					if (_view.Orientation == ScrollOrientation.Horizontal)
-						_hScrollView.ScrollTo(distX, distY);
-					else
-						ScrollTo(distX, distY);
+					switch (_view.Orientation)
+					{
+						case ScrollOrientation.Horizontal:
+							_hScrollView.ScrollTo(distX, distY);
+							break;
+						case ScrollOrientation.Vertical:
+							ScrollTo(distX, distY);
+							break;
+						default:
+							_hScrollView.ScrollTo(distX, distY);
+							ScrollTo(distX, distY);
+							break;
+					}
 				};
 				animator.AnimationEnd += delegate
 				{
@@ -302,10 +311,19 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else
 			{
-				if (_view.Orientation == ScrollOrientation.Horizontal)
-					_hScrollView.ScrollTo(x, y);
-				else
-					ScrollTo(x, y);
+				switch (_view.Orientation)
+				{
+					case ScrollOrientation.Horizontal:
+						_hScrollView.ScrollTo(x, y);
+						break;
+					case ScrollOrientation.Vertical:
+						ScrollTo(x, y);
+						break;
+					default:
+						_hScrollView.ScrollTo(x, y);
+						ScrollTo(x, y);
+						break;
+				}
 				Controller.SendScrollFinished();
 			}
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -259,8 +259,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			var x = (int)Forms.Context.ToPixels(e.ScrollX);
 			var y = (int)Forms.Context.ToPixels(e.ScrollY);
-			int currentX = _view.Orientation == ScrollOrientation.Horizontal ? _hScrollView.ScrollX : ScrollX;
-			int currentY = _view.Orientation == ScrollOrientation.Horizontal ? _hScrollView.ScrollY : ScrollY;
+			int currentX = _view.Orientation == ScrollOrientation.Horizontal || _view.Orientation == ScrollOrientation.Both ? _hScrollView.ScrollX : ScrollX;
+			int currentY = _view.Orientation == ScrollOrientation.Vertical || _view.Orientation == ScrollOrientation.Both ? ScrollY : _hScrollView.ScrollY;
 			if (e.Mode == ScrollToMode.Element)
 			{
 				Point itemPosition = Controller.GetScrollPositionForElement(e.Element as VisualElement, e.Position);


### PR DESCRIPTION
### Description of Change

Android `ScrollView` was incorrectly sending `ScrollX` and `ScrollY` values when scroll orientation was `Both`. This is because a horizontal scrollview is a child of a vertical scrollview and they are raising scroll events independently of each other. The user saw alternating 0 values for both positions.

This should send the final `ScrollX` and `ScrollY` to Core with every position update.

**EDIT:**

While testing horizontal + vertical scrolling, I discovered a bug. `ScrollToAsync()` method did not work when orientation was set to `Both`. Maybe I should have created a bug report for this and submitted it in a new PR. However, the fix works nicely with the fix for this bug. See the switch blocks for proper scroll calls. I also added a unit test to watch out for possible incorrect animation positioning. When you do back to back scroll animations, there shouldn't be an intermediate position. The second animation should begin where the first left off. 
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=41415
