### PR TITLE
[Windows] Fix modal pages being laid out below soft buttons

### DIFF
--- a/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhonePlatform.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhonePlatform.cs
@@ -14,18 +14,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			_status.Hiding += OnStatusBarHiding;
 		}
 
-		internal override Rectangle WindowBounds
-		{
-			get
-			{
-				bool landscape = Device.Info.CurrentOrientation.IsLandscape ();
-				double offset = (landscape) ? _status.OccludedRect.Width : _status.OccludedRect.Height;
-
-				Rectangle original = base.WindowBounds;
-				return new Rectangle (original.X, original.Y, original.Width - ((landscape) ? offset : 0), original.Height - ((landscape) ? 0 : offset));
-			}
-		}
-
 		readonly StatusBar _status;
 
 		void OnStatusBarHiding (StatusBar sender, object args)

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -213,14 +213,14 @@ namespace Xamarin.Forms.Platform.WinRT
 			return new SizeRequest();
 		}
 
-		internal virtual Rectangle WindowBounds
+		internal virtual Rectangle ContainerBounds
 		{
 			get { return _bounds; }
 		}
 
 		internal void UpdatePageSizes()
 		{
-			Rectangle bounds = WindowBounds;
+			Rectangle bounds = ContainerBounds;
 			if (bounds.IsEmpty)
 				return;
 			foreach (Page root in _navModel.Roots)
@@ -435,27 +435,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void UpdateBounds()
 		{
-			_bounds = new Rectangle(0, 0, _page.ActualWidth, _page.ActualHeight);
-#if WINDOWS_UWP
-			StatusBar statusBar = MobileStatusBar;
-			if (statusBar != null)
-			{
-				bool landscape = Device.Info.CurrentOrientation.IsLandscape();
-				bool titleBar = CoreApplication.GetCurrentView().TitleBar.IsVisible;
-				double offset = landscape ? statusBar.OccludedRect.Width : statusBar.OccludedRect.Height;
-
-				_bounds = new Rectangle(0, 0, _page.ActualWidth - (landscape ? offset : 0), _page.ActualHeight - (landscape ? 0 : offset));
-
-				// Even if the MainPage is a ContentPage not inside of a NavigationPage, the calculated bounds
-				// assume the TitleBar is there even if it isn't visible. When UpdatePageSizes is called,
-				// _container.ActualWidth is correct because it's aware that the TitleBar isn't there, but the
-				// bounds aren't, and things can subsequently run under the StatusBar.
-				if (!titleBar)
-				{
-					_bounds.Width -= (_bounds.Width - _container.ActualWidth);
-				}
-			}
-#endif
+			_bounds = new Rectangle(0, 0, _container.ActualWidth, _container.ActualHeight);
 		}
 
 		void OnRendererSizeChanged(object sender, SizeChangedEventArgs sizeChangedEventArgs)
@@ -481,7 +461,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					previousPage.Cleanup();
 			}
 
-			newPage.Layout(new Rectangle(0, 0, _page.ActualWidth, _page.ActualHeight));
+			newPage.Layout(ContainerBounds);
 
 			IVisualElementRenderer pageRenderer = newPage.GetOrCreateRenderer();
 			_container.Children.Add(pageRenderer.ContainerElement);
@@ -726,7 +706,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			if (Device.Idiom == TargetIdiom.Phone)
 			{
-				double height = WindowBounds.Height;
+				double height = _page.ActualHeight;
 				stack.Height = height;
 				stack.Width = size.Width;
 				border.BorderThickness = new Windows.UI.Xaml.Thickness(0);


### PR DESCRIPTION
### Description of Change

This fix makes use of the Page.Content bounds to lay out elements as opposed to the Page bounds. Page.Content already compensates for the status bar and on screen buttons if present so it prevents elements from being laid out below them.

This issue mostly affected stand alone ContentPages and pages pushed modally since they would be laid out based on the Page's bounds.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=42055
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
