### PR TITLE
[iOS] Entry should not pass a newline to the next responder

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33248.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33248.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest;
+
+#endif
+
+namespace Xamarin.Forms.Controls.TestCasesPages
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 33248, "Entry.Completed calling Editor.Focus() inserts new line to the focused Editor in iOS", PlatformAffected.iOS)]
+	public class Bugzilla33248 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var editor = new Editor
+			{
+				BackgroundColor = Color.Yellow,
+				HeightRequest = 300
+			};
+			var entry = new Entry
+			{
+				BackgroundColor = Color.Red,
+				HeightRequest = 100
+			};
+
+			entry.Completed += (sender, e) => editor.Focus();
+
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Start,
+				Children =
+				{
+					new Label
+					{
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "Entry:"
+					},
+					entry,
+					new Label
+					{
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "Editor:"
+					},
+					editor
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -55,6 +55,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32847.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33248.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33268.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33612.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33714.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			Control.ResignFirstResponder();
 			((IEntryController)Element).SendCompleted();
-			return true;
+			return false;
 		}
 
 		void UpdateAlignment()


### PR DESCRIPTION
### Description of Change

When the `Completed` event of an `Entry` fires after keyboard return button is hit, the entry should not pass a newline to the next responder. Circumventing this iOS issue by returning false from the respective method.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=33248
