### PR TITLE
Add extensibility point to load tab icons from another source

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -331,11 +331,16 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					continue;
 
 				TabLayout.Tab tab = tabs.GetTabAt(i);
-				tab.SetIcon(ResourceManager.IdFromTitle(icon, ResourceManager.DrawableClass));
+			    SetTabIcon(tab, icon);
 			}
 		}
 
-		void UpdateBarBackgroundColor()
+	    protected virtual void SetTabIcon(TabLayout.Tab tab, FileImageSource icon)
+	    {
+            tab.SetIcon(ResourceManager.IdFromTitle(icon, ResourceManager.DrawableClass));
+        }
+
+        void UpdateBarBackgroundColor()
 		{
 			if (_disposed || _tabLayout == null)
 				return;


### PR DESCRIPTION
### Description of Change

Added an extensibily point to be able to load tab icons directly from a custom Drawable. 
This is the only way to get them to load from embedded svg files.
### API Changes

Added a protected method to TabbedPageRenderer :
- SetTabIcon(TabLayout.Tab tab, FileImageSource icon)
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

There is no test project for the Android platform project.
The change is extremely simple, but powerful.
