### PR TITLE
[WinRT] Fix regression on ListView selection with enter key

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -511,7 +511,12 @@ namespace Xamarin.Forms.Platform.WinRT
 		void OnKeyPressed(object sender, KeyRoutedEventArgs e)
 		{
 			if (e.Key == VirtualKey.Enter)
-				OnListItemClicked(List.SelectedIndex);
+			{
+				if (Element.SelectedItem != null && Element.SelectedItem != List.SelectedItem)
+				{
+					((IElementController)Element).SetValueFromRenderer(ListView.SelectedItemProperty, List.SelectedItem);
+				}
+			}
 		}
 
 		void OnControlSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -535,13 +540,6 @@ namespace Xamarin.Forms.Platform.WinRT
 				}
 			}
 #endif
-
-			// This is used for respecting ListView selection changes via keyboard, as the SelectedItem
-			// value is otherwise not set.
-			if (Element.SelectedItem != null && Element.SelectedItem != List.SelectedItem)
-			{
-				((IElementController)Element).SetValueFromRenderer(ListView.SelectedItemProperty, List.SelectedItem);
-			}
 		}
 
 		FrameworkElement FindElement(object cell)


### PR DESCRIPTION
### Description of Change ###

In PR #241 some code was added for allowing ListView selection via the enter key. After the first selection was made with the key, it appeared that subsequent selections via mouse would cause a double firing of `ItemSelected`. This code can just be handled inside the `OnKeyPressed` method instead to prevent this.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=44886

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

