### PR TITLE
[iOS] Fixes KVO native binding

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -156,7 +156,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			MessagingCenter.Subscribe<Bugzilla40911>(this, Bugzilla40911.ReadyToSetUp40911Test, SetUp40911Test);
 
 			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
-			MessagingCenter.Subscribe<NativeBindingGalleryPage >(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
+			MessagingCenter.Subscribe<NativeBindingGalleryPage>(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
 
 			LoadApplication(app);
 			return base.FinishedLaunching(uiApplication, launchOptions);
@@ -297,6 +297,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			uilabel.SetBinding("Text", new Binding("NativeLabel"));
 			uilabel.SetBinding(nameof(uilabel.TextColor), new Binding("NativeLabelColor", converter: nativeColorConverter));
 
+			var kvoSlider = new KVOUISlider();
+			kvoSlider.MaxValue = 100;
+			kvoSlider.MinValue = 0;
+			kvoSlider.SetBinding(nameof(kvoSlider.KVOValue), new Binding("Age", BindingMode.TwoWay));
+			sl?.Children.Add(kvoSlider);
+
 			var uiView = new UIView(new RectangleF(0, 0, width, heightCustomLabelView));
 			uiView.Add(uilabel);
 			sl?.Children.Add(uiView);
@@ -321,30 +327,59 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			page.Layout.Children.Add(button);
 		}
 
-		public void StartPressed40911 ()
-        {
+		public void StartPressed40911()
+		{
 			var loginViewController = new UIViewController { View = { BackgroundColor = UIColor.White } };
-			var button = UIButton.FromType (UIButtonType.RoundedRect);
-            button.SetTitle ("Login", UIControlState.Normal);
-            button.Frame = new CGRect (20, 100, 200, 44);
-            loginViewController.View.AddSubview (button);
+			var button = UIButton.FromType(UIButtonType.RoundedRect);
+			button.SetTitle("Login", UIControlState.Normal);
+			button.Frame = new CGRect(20, 100, 200, 44);
+			loginViewController.View.AddSubview(button);
 
-            button.TouchUpInside += (sender, e) => {
-                Xamarin.Forms.Application.Current.MainPage = new ContentPage {Content = new Label {Text = "40911 Success"} };
-                loginViewController.DismissViewController (true, null);
+			button.TouchUpInside += (sender, e) =>
+			{
+				Xamarin.Forms.Application.Current.MainPage = new ContentPage { Content = new Label { Text = "40911 Success" } };
+				loginViewController.DismissViewController(true, null);
 			};
 
-			var window= UIApplication.SharedApplication.KeyWindow;
+			var window = UIApplication.SharedApplication.KeyWindow;
 			var vc = window.RootViewController;
 			while (vc.PresentedViewController != null)
 			{
 				vc = vc.PresentedViewController;
 			}
 
-            vc.PresentViewController (loginViewController, true, null);
+			vc.PresentViewController(loginViewController, true, null);
 		}
 
 		#endregion
+	}
+
+	[Register("KVOUISlider")]
+	public class KVOUISlider : UISlider
+	{
+
+		public KVOUISlider()
+		{
+			ValueChanged += (s, e) => KVOValue = Value;
+		}
+
+		float _kVOValue;
+		[Export("kvovalue")]
+		public float KVOValue
+		{
+			get
+			{
+
+				return _kVOValue;
+			}
+			set
+			{
+
+				WillChangeValue(nameof(KVOValue).ToLower());
+				_kVOValue = Value = value;
+				DidChangeValue(nameof(KVOValue).ToLower());
+			}
+		}
 	}
 
 	public class ColorConverter : IValueConverter

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -24,7 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <MtouchArch>i386, x86_64</MtouchArch>
-    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchLink>None</MtouchLink>
     <MtouchDebug>True</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchSdkVersion></MtouchSdkVersion>

--- a/Xamarin.Forms.Controls/ControlGalleryPages/NativeBindingGalleryPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/NativeBindingGalleryPage.cs
@@ -52,13 +52,14 @@ namespace Xamarin.Forms.Controls
 
 			var label = new Label();
 			label.SetBinding(Label.TextProperty, "FormsLabel");
+			var labelAge = new Label();
+			labelAge.SetBinding(Label.TextProperty, nameof(vm.Age));
 
 			Layout.Children.Add(buttonNav);
-
 			Layout.Children.Add(label);
-
 			Layout.Children.Add(boxView);
 			Layout.Children.Add(button);
+			Layout.Children.Add(labelAge);
 
 			BindingContext = ViewModel = vm; ;
 
@@ -74,35 +75,35 @@ namespace Xamarin.Forms.Controls
 		public string FormsLabel
 		{
 			get { return _formsLabel; }
-			set { _formsLabel = value; OnPropertyChanged(); }
+			set { if (_formsLabel == value) return; _formsLabel = value; OnPropertyChanged(); }
 		}
 
 		string _nativeLabel;
 		public string NativeLabel
 		{
 			get { return _nativeLabel; }
-			set { _nativeLabel = value; OnPropertyChanged(); }
+			set { if (_nativeLabel == value) return; _nativeLabel = value; OnPropertyChanged(); }
 		}
 
 		Color _nativeLabelColor;
 		public Color NativeLabelColor
 		{
 			get { return _nativeLabelColor; }
-			set { _nativeLabelColor = value; OnPropertyChanged(); }
+			set { if (_nativeLabelColor == value) return; _nativeLabelColor = value; OnPropertyChanged(); }
 		}
 
 		int _age;
 		public int Age
 		{
 			get { return _age; }
-			set { _age = value; OnPropertyChanged(); }
+			set { if (_age == value) return; _age = value; OnPropertyChanged(); }
 		}
 
 		bool _selected;
 		public bool Selected
 		{
 			get { return _selected; }
-			set { _selected = value; OnPropertyChanged(); }
+			set { if (_selected == value) return; _selected = value; OnPropertyChanged(); }
 		}
 	}
 

--- a/Xamarin.Forms.Core/NativeBindingHelpers.cs
+++ b/Xamarin.Forms.Core/NativeBindingHelpers.cs
@@ -43,8 +43,10 @@ namespace Xamarin.Forms
 				propertyChanged.PropertyChanged += (sender, e) => {
 					if (e.PropertyName != targetProperty)
 						return;
-				SetValueFromNative<TNativeView>(sender as TNativeView, targetProperty, bindableProperty);
-			};
+					SetValueFromNative<TNativeView>(sender as TNativeView, targetProperty, bindableProperty);
+					//we need to keep the listener around he same time we have the proxy
+					proxy.NativeINPCListener = propertyChanged;
+				};
 
 			if (binding != null && binding.Mode != BindingMode.OneWay)
 				SetValueFromNative(target, targetProperty, bindableProperty);
@@ -178,6 +180,7 @@ namespace Xamarin.Forms
 			public WeakReference<TNativeView> TargetReference { get; set; }
 			public IList<KeyValuePair<BindableProperty, BindingBase>> BindingsBackpack { get; } = new List<KeyValuePair<BindableProperty, BindingBase>>();
 			public IList<KeyValuePair<BindableProperty, object>> ValuesBackpack { get; } = new List<KeyValuePair<BindableProperty, object>>();
+			public INotifyPropertyChanged NativeINPCListener;
 
 			public BindableObjectProxy(TNativeView target)
 			{

--- a/Xamarin.Forms.Platform.iOS/NativeViewPropertyListener.cs
+++ b/Xamarin.Forms.Platform.iOS/NativeViewPropertyListener.cs
@@ -17,8 +17,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ObserveValue(NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
 		{
-			if (keyPath == TargetProperty)
+			if (keyPath.ToString().Equals(TargetProperty, StringComparison.InvariantCultureIgnoreCase))
 				PropertyChanged?.Invoke(ofObject, new PropertyChangedEventArgs(TargetProperty));
+			else
+				base.ObserveValue(keyPath, ofObject, change, context);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
Keep our native property listener around the same time we keep our proxy, check if we are KVO compliant before adding observer

This fixes a crash when using NativeBinding 2-way without using a event. The KVO implementation wasn't ok, first we need to keep the observer around, nativePropertyListener, and we also need to make sure the a key for our property exists, normally it's a lowercase of XIOS public property. The only way was to catch the exception that the key wasn't found. 

Also added a example of how one can make a KVO compliant control to use 2 way binding in iOS without specifying the event. 


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
