### PR TITLE
[Windows] Fix crash when toggling IsPassword on multiple Entry controls

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		public new static readonly DependencyProperty TextProperty = DependencyProperty.Register(nameof(Text), typeof(string), typeof(FormsTextBox), new PropertyMetadata("", TextPropertyChanged));
 
-		InputScope s_passwordInputScope;
+		InputScope passwordInputScope;
 		Border _borderElement;
 		InputScope _cachedInputScope;
 		bool _cachedPredictionsSetting;
@@ -91,16 +91,16 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			get
 			{
-				if (s_passwordInputScope != null)
+				if (passwordInputScope != null)
 				{
-					return s_passwordInputScope;
+					return passwordInputScope;
 				}
 
-				s_passwordInputScope = new InputScope();
+				passwordInputScope = new InputScope();
 				var name = new InputScopeName { NameValue = InputScopeNameValue.Default };
-				s_passwordInputScope.Names.Add(name);
+				passwordInputScope.Names.Add(name);
 
-				return s_passwordInputScope;
+				return passwordInputScope;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		public new static readonly DependencyProperty TextProperty = DependencyProperty.Register(nameof(Text), typeof(string), typeof(FormsTextBox), new PropertyMetadata("", TextPropertyChanged));
 
-		static InputScope s_passwordInputScope;
+		InputScope s_passwordInputScope;
 		Border _borderElement;
 		InputScope _cachedInputScope;
 		bool _cachedPredictionsSetting;
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			set { SetValue(TextProperty, value); }
 		}
 
-		static InputScope PasswordInputScope
+		InputScope PasswordInputScope
 		{
 			get
 			{


### PR DESCRIPTION
### Description of Change ###

A System.ArgumentException was being thrown when trying to set the `InputScope` on a subsequent Entry control to `PasswordInputScope`. 

It looks like the same` InputScope` cannot be applied to multiple elements so this fix makes `PasswordInputScope` not static, which allows each Entry control to initialize its own if needed.

A similar report about this issue can be seen in the last few replies in [this thread](https://social.msdn.microsoft.com/Forums/en-US/24bec920-425b-4a9e-8a3e-be4417a2c5f4/ageruntimesetvalue-line-0-position-0?forum=wpdevelop).

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44679
- https://bugzilla.xamarin.com/show_bug.cgi?id=44954

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

