### PR TITLE
Make CreateNativeControl virtual instead of abstract

### DIFF
--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -13,7 +13,10 @@ namespace Xamarin.Forms.Platform.Android
 
 	public abstract class ViewRenderer<TView, TNativeView> : VisualElementRenderer<TView>, AView.IOnFocusChangeListener where TView : View where TNativeView : AView
 	{
-		protected abstract TNativeView CreateNativeControl();
+		protected virtual TNativeView CreateNativeControl()
+		{
+			return default(TNativeView);
+		}
 
 		ViewGroup _container;
 


### PR DESCRIPTION
### Description of Change ###

Make CreateNativeControl virtual instead of abstract

### Bugs Fixed ###

None

### API Changes ###

Nothing in core. Android ViewRenderer now has default impl of CreateNativeControl

### Behavioral Changes ###

Old renderers which dont use this method no longer crash.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

Fixes backwards compatibility issue.