### PR TITLE
Set UserVisibleHint for new fragment to true

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -645,7 +645,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				Device.StartTimer(TimeSpan.FromMilliseconds(TransitionDuration), () =>
 				{
 					tcs.TrySetResult(true);
-					fragment.UserVisibleHint = !removed;
+					fragment.UserVisibleHint = true;
 					if (removed)
 					{
 						UpdateToolbar();
@@ -659,7 +659,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				Device.StartTimer(TimeSpan.FromMilliseconds(1), () =>
 				{
 					tcs.TrySetResult(true);
-					fragment.UserVisibleHint = !removed;
+					fragment.UserVisibleHint = true;
 					UpdateToolbar();
 
 					return false;


### PR DESCRIPTION
### Description of Change ###

Fixes a regression introduced by [PR 360](https://github.com/xamarin/Xamarin.Forms/pull/360) where UserVisibleHint was set to false when a fragment was removed

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None (restores the original, correct behavior)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

