### PR TITLE
[C] fix TranslateTo for easing going outside of (0,1)

### DIFF
--- a/Xamarin.Forms.Core/ViewExtensions.cs
+++ b/Xamarin.Forms.Core/ViewExtensions.cs
@@ -188,7 +188,7 @@ namespace Xamarin.Forms
 				if (weakView.TryGetTarget(out v))
 					v.TranslationY = f;
 			};
-			new Animation { { 0, 1, new Animation(translateX, view.TranslationX, x) }, { 0, 1, new Animation(translateY, view.TranslationY, y) } }.Commit(view, "TranslateTo", 16, length, easing,
+			new Animation { { 0, 1, new Animation(translateX, view.TranslationX, x, easing: easing) }, { 0, 1, new Animation(translateY, view.TranslationY, y, easing:easing) } }.Commit(view, "TranslateTo", 16, length, null,
 				(f, a) => tcs.SetResult(a));
 
 			return tcs.Task;


### PR DESCRIPTION
### Description of Change ###

When using Animation with Children animation, and doing easing at the top level, the Children are only animated from 0 to 1, so for Spring animation (going 0, -0.2, 1), the spring part of the animation is lost.

No test provided. that's Math, I can compute it all in my head up to the 5th decimal.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44609

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
