### PR TITLE
[Android] Fix possible NRE when detaching NavigationPageRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
@@ -74,13 +74,13 @@ namespace Xamarin.Forms.Platform.Android
 		protected override void OnAttachedToWindow()
 		{
 			base.OnAttachedToWindow();
-			PageController.SendAppearing();
+			PageController?.SendAppearing();
 		}
 
 		protected override void OnDetachedFromWindow()
 		{
 			base.OnDetachedFromWindow();
-			PageController.SendDisappearing();
+			PageController?.SendDisappearing();
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<NavigationPage> e)
@@ -145,7 +145,7 @@ namespace Xamarin.Forms.Platform.Android
 		void InsertPageBefore(Page page, Page before)
 		{
 
-			int index = ((IPageController)Element).InternalChildren.IndexOf(before);
+			int index = PageController.InternalChildren.IndexOf(before);
 			if (index == -1)
 				throw new InvalidOperationException("This should never happen, please file a bug");
 


### PR DESCRIPTION
### Description of Change ###

Check if PageController is null before calling it

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=44175

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
