### PR TITLE
Update ToolbarVisibility to TitleVisibility in PhoneResources

### DIFF
--- a/Xamarin.Forms.Platform.WinRT.Phone/PhoneResources.xaml
+++ b/Xamarin.Forms.Platform.WinRT.Phone/PhoneResources.xaml
@@ -277,7 +277,7 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <Grid x:Name="grdToolbar" Background="{TemplateBinding ToolbarBackground}" >
-                            <TextBlock Padding="10,0,0,0" Text="{TemplateBinding Title}" VerticalAlignment="Center" Style="{ThemeResource HeaderTextBlockStyle}" Foreground="{TemplateBinding ToolbarForeground}" Visibility="{TemplateBinding ToolbarVisibility}"  Height="79"/>
+							<TextBlock Padding="10,0,0,0" Text="{TemplateBinding Title}" VerticalAlignment="Center" Style="{ThemeResource HeaderTextBlockStyle}" Foreground="{TemplateBinding ToolbarForeground}" Visibility="{TemplateBinding TitleVisibility}"  Height="79"/>
                         </Grid>
                         <ScrollViewer x:Name="ScrollViewer" HorizontalSnapPointsAlignment="Center" HorizontalSnapPointsType="MandatorySingle" HorizontalScrollBarVisibility="Hidden" Margin="{TemplateBinding Padding}" Grid.Row="1" Template="{StaticResource ScrollViewerScrollBarlessTemplate}" VerticalSnapPointsType="None" VerticalScrollBarVisibility="Disabled" VerticalScrollMode="Disabled" VerticalContentAlignment="Stretch" ZoomMode="Disabled">
                             <PivotPanel x:Name="Panel" VerticalAlignment="Stretch">


### PR DESCRIPTION
### Description of Change ###

Change incorrect property name `ToolbarVisibility` to `TitleVisibility`. 

### Bugs Fixed ###

- [45010 – Forms Sample "WorkingWithListview" throw exception with WinPhone8.1](https://bugzilla.xamarin.com/show_bug.cgi?id=45010)

