### PR TITLE
[XamlG] Fully qualify method names

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -113,10 +113,6 @@ namespace Xamarin.Forms.Build.Tasks
 			var declNs = new CodeNamespace(rootNs);
 			ccu.Namespaces.Add(declNs);
 
-			declNs.Imports.Add(new CodeNamespaceImport("System"));
-			declNs.Imports.Add(new CodeNamespaceImport("Xamarin.Forms"));
-			declNs.Imports.Add(new CodeNamespaceImport("Xamarin.Forms.Xaml"));
-
 			var declType = new CodeTypeDeclaration(rootType);
 			declType.IsPartial = true;
 			declType.BaseTypes.Add(baseType);
@@ -136,8 +132,8 @@ namespace Xamarin.Forms.Build.Tasks
 			declType.Members.Add(initcomp);
 
 			initcomp.Statements.Add(new CodeMethodInvokeExpression(
-				new CodeThisReferenceExpression(),
-				"LoadFromXaml", new CodeTypeOfExpression(declType.Name)));
+				new CodeTypeReferenceExpression(new CodeTypeReference("global::Xamarin.Forms.Xaml.Extensions")),
+				"LoadFromXaml", new CodeThisReferenceExpression(), new CodeTypeOfExpression(declType.Name)));
 
 			foreach (var entry in namesAndTypes)
 			{
@@ -160,8 +156,9 @@ namespace Xamarin.Forms.Build.Tasks
 
 				var find_invoke = new CodeMethodInvokeExpression(
 					new CodeMethodReferenceExpression(
-						new CodeThisReferenceExpression(),
-						"FindByName", type), new CodePrimitiveExpression(name));
+						new CodeTypeReferenceExpression(new CodeTypeReference("global::Xamarin.Forms.NameScopeExtensions")),
+						"FindByName", type),
+					new CodeThisReferenceExpression(), new CodePrimitiveExpression(name));
 
 				//CodeCastExpression cast = new CodeCastExpression (type, find_invoke);
 

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz43301.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz43301.xaml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Foo.Xamarin.Bar.Bz43301">
+	<ContentPage.Content>
+	</ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz43301.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz43301.xaml.cs
@@ -1,0 +1,31 @@
+﻿using Xamarin.Forms;
+using NUnit.Framework;
+
+namespace Foo.Xamarin.Bar
+{
+	public partial class Bz43301 : ContentPage
+	{
+		public Bz43301()
+		{
+			InitializeComponent();
+		}
+
+		public Bz43301(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true)]
+			[TestCase(false)]
+			//No need for any actual [Test]. If this compiles, the bug is fixed.
+			public void DoesCompile(bool useCompiledXaml)
+			{
+				var layout = new Bz43301(useCompiledXaml);
+				Assert.Pass();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -368,9 +368,12 @@
     <Compile Include="XStaticException.xaml.cs">
       <DependentUpon>XStaticException.xaml</DependentUpon>
     </Compile>
-     <Compile Include="CompiledTypeConverter.xaml.cs" >
+     <Compile Include="CompiledTypeConverter.xaml.cs">
        <DependentUpon>CompiledTypeConverter.xaml</DependentUpon>
     </Compile>
+     <Compile Include="Issues\Bz43301.xaml.cs">
+       <DependentUpon>Bz43301.xaml</DependentUpon>
+     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -656,7 +659,10 @@
     <EmbeddedResource Include="XStaticException.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-    <EmbeddedResource Include="CompiledTypeConverter.xaml" >
+    <EmbeddedResource Include="CompiledTypeConverter.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz43301.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Prevent namespace collisions in XamlG, and prevent providing own extensions methods for LoadFromXaml and FindByName.

This PR replaces #390

### Bugs Fixed ###

~~https://bugzilla.xamarin.com/show_bug.cgi?id=44807~~
https://bugzilla.xamarin.com/show_bug.cgi?id=43301

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
