### PR TITLE
[WinRT] Conform page size to container in Platform.SetCurrent

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42301.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42301.cs
@@ -1,0 +1,86 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 42301, "Grid or ContentPage extends beyond screen bounds after certain navigation types.", PlatformAffected.WinRT)]
+	public class Bugzilla42301 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new TestPage42301());
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class TestPage42301 : ContentPage
+	{
+		public TestPage42301()
+		{
+			var button = new Button
+			{
+				Text = "Click Me"
+			};
+
+			button.Clicked += (sender, e) =>
+			{
+				Navigation.PushModalAsync(new TestPage42301());
+			};
+
+			var grid = new Grid
+			{
+				AutomationId = "Grid",
+				BackgroundColor = Color.Fuchsia,
+				Padding = 0,
+				RowSpacing = 0,
+				ColumnSpacing = 0,
+				RowDefinitions =
+					{
+						new RowDefinition {Height = new GridLength(1, GridUnitType.Auto)},
+						new RowDefinition {Height = new GridLength(1, GridUnitType.Star)}
+					}
+			};
+
+			grid.Children.Add(
+				new ContentView
+				{
+					BackgroundColor = Color.Red,
+					HeightRequest = 50
+				},
+				0, 0);
+
+			grid.Children.Add(
+				new ContentView
+				{
+					BackgroundColor = Color.Green,
+					Content = button
+				},
+				0, 1);
+
+			grid.Children.Add(
+				new ContentView
+				{
+					BackgroundColor = Color.Blue,
+					HeightRequest = 50,
+					VerticalOptions = LayoutOptions.End,
+					Content = new StackLayout
+					{
+						VerticalOptions = LayoutOptions.End,
+						Children =
+						{
+							new Label { Text = "This should remain visible" }
+						}
+					}
+				},
+				0, 1);
+
+			Content = grid;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -123,6 +123,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42074.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42075.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42301.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42329.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42364.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -467,7 +467,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					previousPage.Cleanup();
 			}
 
-			newPage.Layout(new Rectangle(0, 0, _page.ActualWidth, _page.ActualHeight));
+			newPage.Layout(new Rectangle(0, 0, _container.ActualWidth, _container.ActualHeight));
 
 			IVisualElementRenderer pageRenderer = newPage.GetOrCreateRenderer();
 			_container.Children.Add(pageRenderer.ContainerElement);


### PR DESCRIPTION
### Description of Change

Certain navigation types involving `SetCurrent` were causing the page's height to be the full size of the window, ignoring the status bar if it exists. It appears that setting the height instead to that of the container on layout prevents this from being ignored and allows it to correctly fit.
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=42301
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
