### PR TITLE
OnIdiom support for Desktop (UWP)

### DIFF
--- a/Xamarin.Forms.Core/OnIdiom.cs
+++ b/Xamarin.Forms.Core/OnIdiom.cs
@@ -5,6 +5,8 @@
 		public T Phone { get; set; }
 
 		public T Tablet { get; set; }
+		
+		public T Desktop { get; set; }
 
 		public static implicit operator T(OnIdiom<T> onIdiom)
 		{
@@ -15,6 +17,8 @@
 					return onIdiom.Phone;
 				case TargetIdiom.Tablet:
 					return onIdiom.Tablet;
+				case TargetIdiom.Desktop:
+					return onIdiom.Desktop;
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

The current implementation for OnIdiom<T> is missing the Desktop property. When running in a Windows UWP "desktop" app, it always returns the Phone property.

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - Desktop property to OnIdiom

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
