### PR TITLE
[A] Prevent blank page from appearing when MainPage is switched

### DIFF
--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -8,6 +8,25 @@ using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
 namespace Xamarin.Forms.Controls
 {
+	public class Bugzilla44596SplashPage : ContentPage
+	{
+		Action FinishedLoading { get; set; }
+
+
+		public Bugzilla44596SplashPage(Action finishedLoading)
+		{
+			BackgroundColor = Color.Blue;
+			FinishedLoading = finishedLoading;
+		}
+
+
+		protected async override void OnAppearing()
+		{
+			base.OnAppearing();
+			await Task.Delay(2000);
+			FinishedLoading?.Invoke();
+		}
+	}
 	public class App : Application
 	{
 		public const string AppName = "XamarinFormsControls";
@@ -26,11 +45,17 @@ namespace Xamarin.Forms.Controls
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 			InitInsights();
 
-			MainPage = new MasterDetailPage
-			{
-				Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
-				Detail = CoreGallery.GetMainPage()
-			};
+			//IF I AM STILL HERE IN THE PR NOT COMMENTED OUT THEN SOMETHING HAS GONE TERRIBLY WRONG
+			MainPage = new Bugzilla44596SplashPage(() =>
+						{
+							var newTabbedPage = new TabbedPage();
+							newTabbedPage.Children.Add(new ContentPage { BackgroundColor = Color.Red, Content = new Label { Text = "yay" } });
+							MainPage = new MasterDetailPage
+							{
+								Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
+								Detail = newTabbedPage
+							};
+						});
 		}
 
 		protected override void OnAppLinkRequestReceived(Uri uri)

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -8,25 +8,7 @@ using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
 namespace Xamarin.Forms.Controls
 {
-	public class Bugzilla44596SplashPage : ContentPage
-	{
-		Action FinishedLoading { get; set; }
 
-
-		public Bugzilla44596SplashPage(Action finishedLoading)
-		{
-			BackgroundColor = Color.Blue;
-			FinishedLoading = finishedLoading;
-		}
-
-
-		protected async override void OnAppearing()
-		{
-			base.OnAppearing();
-			await Task.Delay(2000);
-			FinishedLoading?.Invoke();
-		}
-	}
 	public class App : Application
 	{
 		public const string AppName = "XamarinFormsControls";
@@ -45,17 +27,23 @@ namespace Xamarin.Forms.Controls
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 			InitInsights();
 
-			//IF I AM STILL HERE IN THE PR NOT COMMENTED OUT THEN SOMETHING HAS GONE TERRIBLY WRONG
-			MainPage = new Bugzilla44596SplashPage(() =>
-						{
-							var newTabbedPage = new TabbedPage();
-							newTabbedPage.Children.Add(new ContentPage { BackgroundColor = Color.Red, Content = new Label { Text = "yay" } });
-							MainPage = new MasterDetailPage
-							{
-								Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
-								Detail = newTabbedPage
-							};
-						});
+			MainPage = new MasterDetailPage
+			{
+				Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
+				Detail = CoreGallery.GetMainPage()
+			};
+
+			//// Uncomment to verify that there is no gray screen displayed between the blue splash and red MasterDetailPage.
+			//MainPage = new Bugzilla44596SplashPage(() =>
+			//{
+			//	var newTabbedPage = new TabbedPage();
+			//	newTabbedPage.Children.Add(new ContentPage { BackgroundColor = Color.Red, Content = new Label { Text = "yay" } });
+			//	MainPage = new MasterDetailPage
+			//	{
+			//		Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
+			//		Detail = newTabbedPage
+			//	};
+			//});
 		}
 
 		protected override void OnAppLinkRequestReceived(Uri uri)

--- a/Xamarin.Forms.Controls/Bugzilla44596SplashPage.cs
+++ b/Xamarin.Forms.Controls/Bugzilla44596SplashPage.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Controls
+{
+	public class Bugzilla44596SplashPage : ContentPage
+	{
+		Action FinishedLoading { get; set; }
+
+
+		public Bugzilla44596SplashPage(Action finishedLoading)
+		{
+			BackgroundColor = Color.Blue;
+			FinishedLoading = finishedLoading;
+		}
+
+
+		protected async override void OnAppearing()
+		{
+			base.OnAppearing();
+			await Task.Delay(2000);
+			FinishedLoading?.Invoke();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -84,6 +84,7 @@
   <ItemGroup>
     <Compile Include="App.cs" />
     <Compile Include="AppLifeCycle.cs" />
+    <Compile Include="Bugzilla44596SplashPage.cs" />
     <Compile Include="ControlGalleryPages\CellForceUpdateSizeGalleryPage.cs" />
     <Compile Include="ControlGalleryPages\LayoutAddPerformance.xaml.cs">
       <DependentUpon>LayoutAddPerformance.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 
 				transaction.Add(Id, fragment);
-				transaction.SetTransition((int)FragmentTransit.None);
+				transaction.SetTransition((int)FragmentTransit.FragmentOpen);
 				transaction.Commit();
 
 				_currentFragment = fragment;

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 
 				transaction.Add(Id, fragment);
-				transaction.SetTransition((int)FragmentTransit.FragmentOpen);
+				transaction.SetTransition((int)FragmentTransit.None);
 				transaction.Commit();
 
 				_currentFragment = fragment;

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -1,5 +1,6 @@
 using Android.App;
 using Android.Content;
+using Android.OS;
 using Fragment = Android.Support.V4.App.Fragment;
 using FragmentManager = Android.Support.V4.App.FragmentManager;
 using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
@@ -82,7 +83,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				// The renderers for NavigationPage and TabbedPage both host fragments, so they need to be wrapped in a 
 				// FragmentContainer in order to get isolated fragment management
 				Fragment fragment = FragmentContainer.CreateInstance(page);
-				
+
 				var fc = fragment as FragmentContainer;
 
 				fc?.SetOnCreateCallback(pc =>
@@ -100,10 +101,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 
 				transaction.Add(Id, fragment);
-				transaction.SetTransition((int)FragmentTransit.FragmentOpen);
+				transaction.SetTransition((int)FragmentTransit.None);
 				transaction.Commit();
 
 				_currentFragment = fragment;
+
+				new Handler(Looper.MainLooper).PostAtFrontOfQueue(() => FragmentManager.ExecutePendingTransactions());
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -220,25 +220,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			var layout = false;
 			if (Page != null)
 			{
-				var removeList = new List<global::Android.Views.View>();
-				for (int i = 0; i < _renderer.ChildCount; i++)
-				{
-					removeList.Add(_renderer.GetChildAt(i));
-				}
+				_renderer.RemoveAllViews();
 
-				var renderersToDispose = _navModel.Roots.Select(Android.Platform.GetRenderer).ToList();
-
-				Device.StartTimer(TimeSpan.FromSeconds(1), () =>
-				{
-					foreach (var view in removeList)
-					{
-						_renderer.RemoveView(view);
-						foreach (IVisualElementRenderer rootRenderer in renderersToDispose)
-							rootRenderer.Dispose();
-					}
-					return false;
-				});
-
+				foreach (IVisualElementRenderer rootRenderer in _navModel.Roots.Select(Android.Platform.GetRenderer))
+					rootRenderer.Dispose();
 				_navModel = new NavigationModel();
 
 				layout = true;

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -220,10 +220,25 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			var layout = false;
 			if (Page != null)
 			{
-				_renderer.RemoveAllViews();
+				var removeList = new List<global::Android.Views.View>();
+				for (int i = 0; i < _renderer.ChildCount; i++)
+				{
+					removeList.Add(_renderer.GetChildAt(i));
+				}
 
-				foreach (IVisualElementRenderer rootRenderer in _navModel.Roots.Select(Android.Platform.GetRenderer))
-					rootRenderer.Dispose();
+				var renderersToDispose = _navModel.Roots.Select(Android.Platform.GetRenderer).ToList();
+
+				Device.StartTimer(TimeSpan.FromSeconds(1), () =>
+				{
+					foreach (var view in removeList)
+					{
+						_renderer.RemoveView(view);
+						foreach (IVisualElementRenderer rootRenderer in renderersToDispose)
+							rootRenderer.Dispose();
+					}
+					return false;
+				});
+
 				_navModel = new NavigationModel();
 
 				layout = true;


### PR DESCRIPTION
### Description of Change ###

On Android, delay disposal of `PageRenderer`s to prevent a blank screen from appearing when the `MainPage` is switched to a `MasterDetailPage` containing a `TabbedPage` or `NavigationPage`. Also removing animation from above scenario.

Test is included, but must be uncommented in the App.cs.

### Bugs Fixed ###

- [Bug 44596 - Grey/Blank Screen when switching MainPage to MasterDetail with TabbedPage](https://bugzilla.xamarin.com/show_bug.cgi?id=44596)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
