### PR TITLE
[Android] MasterDetailPage & AdjustResize should handle fullscreen changes

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -210,8 +210,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (diff != 0)
 			{
-				// clear status bar color so master page can take whole screen height
-				if(Forms.IsLollipopOrNewer)
+				// set status bar color so status controls have a background
+				if (Forms.IsLollipopOrNewer)
 					Window.SetStatusBarColor(((ColorDrawable)_statusBarUnderlay.Background).Color);
 
 				if (Window.Attributes.SoftInputMode != SoftInput.AdjustResize)
@@ -225,7 +225,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else
 			{
-				// set status bar color so status controls have a background
+				// clear status bar color so master page can take whole screen height
 				if (Forms.IsLollipopOrNewer)
 					Window.SetStatusBarColor(AColor.Transparent);
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 {
 	internal class MasterDetailContainer : Xamarin.Forms.Platform.Android.MasterDetailContainer, IManageFragments
 	{
-		PageContainer _pageContainer;
+		internal PageContainer PageContainer;
 		FragmentManager _fragmentManager;
 		readonly bool _isMaster;
 		MasterDetailPage _parent;
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			// If we're using a PageContainer (i.e., we've wrapped our contents in a Fragment),
 			// Make sure that it gets laid out
-			if (_pageContainer != null)
+			if (PageContainer != null)
 			{
 				if (_isMaster)
 				{
@@ -43,20 +43,20 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					// so we subtract _parent.MasterBounds.Top from our starting point (to get 0) and add it to the 
 					// bottom (so the master page stretches to the bottom of the screen)
 					var height = (int)Context.ToPixels(controller.MasterBounds.Height + controller.MasterBounds.Top);
-					_pageContainer.Layout(0, 0, width, height);
+					PageContainer.Layout(0, 0, width, height);
 				}
 				else
 				{
-					_pageContainer.Layout(l, t, r, b);
+					PageContainer.Layout(l, t, r, b);
 				}
 
-				_pageContainer.Child.UpdateLayout();
+				PageContainer.Child.UpdateLayout();
 			}
 		}
 
 		protected override void AddChildView(VisualElement childView)
 		{
-			_pageContainer = null;
+			PageContainer = null;
 
 			Page page = childView as NavigationPage ?? (Page)(childView as TabbedPage);
 
@@ -91,7 +91,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				fc?.SetOnCreateCallback(pc =>
 				{
-					_pageContainer = pc;
+					PageContainer = pc;
 					SetDefaultBackgroundColor(pc.Child);
 				});
 
@@ -140,7 +140,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 
 				_parent = null;
-				_pageContainer = null;
+				PageContainer = null;
 				_fragmentManager = null;
 			}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -263,14 +263,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
-		bool HasAncestorNavigationPage(Element element)
+		internal bool HasAncestorNavigationPage(IElement element)
 		{
 			if (element.Parent == null)
 				return false;
-			else if (element.Parent is NavigationPage)
+			if (element.Parent is NavigationPage)
 				return true;
-			else
-				return HasAncestorNavigationPage(element.Parent);
+			return HasAncestorNavigationPage(element.Parent);
 		}
 
 		void HandleMasterPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -270,30 +270,31 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		internal static void LayoutRootPage(FormsAppCompatActivity activity, Page page, int width, int height)
 		{
 			int statusBarHeight = !Forms.IsLollipopOrNewer || activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen) || Forms.TitleBarVisibility == AndroidTitleBarVisibility.Never ? 0 : activity.GetStatusBarHeight();
-			IVisualElementRenderer renderer = Android.Platform.GetRenderer(page);
 
-			if (page is MasterDetailPage)
+			var masterDetailPage = page as MasterDetailPage;
+			if (masterDetailPage != null)
 			{
-				var detailContainer = (renderer as MasterDetailPageRenderer).GetChildAt(0) as MasterDetailContainer;
-				var detail = ((MasterDetailPage)page).Detail;
+				var renderer = (MasterDetailPageRenderer)Android.Platform.GetRenderer(page);
+				var detailContainer = renderer.GetChildAt(0) as MasterDetailContainer;
+				Page detail = masterDetailPage.Detail;
 
-				detailContainer.TopPadding = page.Parent is NavigationPage ? 0 : statusBarHeight;
+				detailContainer.TopPadding = renderer.HasAncestorNavigationPage(masterDetailPage) ? 0 : statusBarHeight;
 				((IMasterDetailPageController)page).DetailBounds = detailContainer.GetBounds(false, 0, 0, width, height);
 				detailContainer.PageContainer?.Child.UpdateLayout();
 				detail.Layout(new Rectangle(0, 0, width, height));
 
 				if (((IMasterDetailPageController)page).ShouldShowSplitMode)
 				{
-					var masterContainer = (renderer as MasterDetailPageRenderer).GetChildAt(1) as MasterDetailContainer;
-					var master = ((MasterDetailPage)page).Master;
+					var masterContainer = renderer.GetChildAt(1) as MasterDetailContainer;
+					Page master = masterDetailPage.Master;
 
-					masterContainer.TopPadding = page.Parent is NavigationPage ? 0 : statusBarHeight;
+					masterContainer.TopPadding = statusBarHeight;
 					((IMasterDetailPageController)page).MasterBounds = masterContainer.GetBounds(true, 0, 0, width, height);
 					masterContainer.PageContainer?.Child.UpdateLayout();
 					master.Layout(new Rectangle(0, 0, width, height));
 				}
 
-				page.Layout(new Rectangle(0, 0, activity.FromPixels(width), activity.FromPixels(height)));
+				masterDetailPage.Layout(new Rectangle(0, 0, activity.FromPixels(width), activity.FromPixels(height)));
 			}
 			else
 			{

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -277,7 +277,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				var detailContainer = (renderer as MasterDetailPageRenderer).GetChildAt(0) as MasterDetailContainer;
 				var detail = ((MasterDetailPage)page).Detail;
 
-				detailContainer.TopPadding = statusBarHeight;
+				detailContainer.TopPadding = page.Parent is NavigationPage ? 0 : statusBarHeight;
 				((IMasterDetailPageController)page).DetailBounds = detailContainer.GetBounds(false, 0, 0, width, height);
 				detailContainer.PageContainer?.Child.UpdateLayout();
 				detail.Layout(new Rectangle(0, 0, width, height));
@@ -287,7 +287,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					var masterContainer = (renderer as MasterDetailPageRenderer).GetChildAt(1) as MasterDetailContainer;
 					var master = ((MasterDetailPage)page).Master;
 
-					masterContainer.TopPadding = statusBarHeight;
+					masterContainer.TopPadding = page.Parent is NavigationPage ? 0 : statusBarHeight;
 					((IMasterDetailPageController)page).MasterBounds = masterContainer.GetBounds(true, 0, 0, width, height);
 					masterContainer.PageContainer?.Child.UpdateLayout();
 					master.Layout(new Rectangle(0, 0, width, height));

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailContainer.cs
@@ -115,7 +115,7 @@ namespace Xamarin.Forms.Platform.Android
 			_childView.ClearValue(Platform.RendererProperty);
 		}
 
-		Rectangle GetBounds(bool isMasterPage, int left, int top, int right, int bottom)
+		internal Rectangle GetBounds(bool isMasterPage, int left, int top, int right, int bottom)
 		{
 			double width = Context.FromPixels(right - left);
 			double height = Context.FromPixels(bottom - top);


### PR DESCRIPTION
### Description of Change

I worked on #350 to allow AppCompat to toggle fullscreen flag. I hadn't tested `MasterDetailPage` well at the time, and I didn't address the issue of `AdjustResize` not handling fullscreen mode. This work builds upon the former to set a more robust status bar and scroll experience. I'll leave comments in the code to further explain things.

Here's a test run: https://1drv.ms/v/s!AjlbPgOcTyP2a0N_689eCImyou4
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=44368
- https://bugzilla.xamarin.com/show_bug.cgi?id=37205

This doesn't really fix the issue. `AdjustPan` is not supposed to resize; hence, the entire `ScrollView` content isn't available when the soft keyboard shows. I suggested switching to `AdjustResize`. Strangely, XF defaults to pan while I think it should have been resize. In most cases, resize is more preferable.
### API Changes

Added:
- void ViewTreeObserverOnGlobalLayout(object sender, EventArgs eventArgs)

Changed:
- void SetStatusBarVisibility(SoftInput mode) => void SetSystemUiVisibility(SoftInput mode)
- PageContainer _pageContainer; => internal PageContainer PageContainer;
- Rectangle GetBounds(bool isMasterPage, int left, int top, int right, int bottom) => internal Rectangle GetBounds(bool isMasterPage, int left, int top, int right, int bottom)
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
