### PR TITLE
Fix MasterDetailPage/NavigationPage leaks on iPad

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44166.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44166.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Controls
 			};
 		}
 
-		#if UITEST
+#if UITEST
 		[Test]
 		public void Bugzilla44166Test()
 		{
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Controls
 			RunningApp.WaitForElement(q => q.Marked("Back"));
 			RunningApp.Tap(q => q.Marked("Back"));
 
-			for(int n = 0; n < 10; n++)
+			for (var n = 0; n < 10; n++)
 			{
 				RunningApp.WaitForElement(q => q.Marked("GC"));
 				RunningApp.Tap(q => q.Marked("GC"));
@@ -82,7 +82,7 @@ namespace Xamarin.Forms.Controls
 				}
 			}
 
-			var pageStats = string.Empty;
+			string pageStats = string.Empty;
 
 			if (_44166MDP.Counter > 0)
 			{
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Controls
 
 			Assert.Fail($"At least one of the pages was not collected: {pageStats}");
 		}
-		#endif
+#endif
 	}
 
 	[Preserve(AllMembers = true)]
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Controls
 
 			Master = new _44166Master();
 			Detail = new _44166Detail();
-		}
+        }
 
 		~_44166MDP()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -831,7 +831,13 @@ namespace Xamarin.Forms.Platform.iOS
 				if (disposing)
 				{
 					((IPageController)Child).SendDisappearing();
-					Child = null;
+
+					if (Child != null)
+					{
+						Child.PropertyChanged -= HandleChildPropertyChanged;
+						Child = null;
+					}
+
 					_tracker.Target = null;
 					_tracker.CollectionChanged -= TrackerOnCollectionChanged;
 					_tracker = null;

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected MasterDetailPage MasterDetailPage => _masterDetailPage ?? (_masterDetailPage = (MasterDetailPage)Element);
 
-	    IMasterDetailPageController MasterDetailPageController => MasterDetailPage as IMasterDetailPageController;
+		IMasterDetailPageController MasterDetailPageController => MasterDetailPage as IMasterDetailPageController;
 
 		UIBarButtonItem PresentButton
 		{
@@ -68,48 +68,50 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
-		    if (_disposed)
-		    {
-                return;
-		    }
+			if (_disposed)
+			{
+				return;
+			}
 
-		    _disposed = true;
+			_disposed = true;
 
-		    if (disposing)
-		    {
-		        if (Element != null)
-		        {
-		            PageController.SendDisappearing();
-		            Element.PropertyChanged -= HandlePropertyChanged;
+			if (disposing)
+			{
+				if (Element != null)
+				{
+					PageController.SendDisappearing();
+					Element.PropertyChanged -= HandlePropertyChanged;
 
-		            if (MasterDetailPage?.Master != null)
-		            {
-                        MasterDetailPage.Master.PropertyChanged -= HandleMasterPropertyChanged;
-                    }
+					if (MasterDetailPage?.Master != null)
+					{
+						MasterDetailPage.Master.PropertyChanged -= HandleMasterPropertyChanged;
+					}
 
-		            Element = null;
-		        }
+					Element = null;
+				}
 
-		        if (_tracker != null)
-		        {
-		            _tracker.Dispose();
-		            _tracker = null;
-		        }
+				if (_tracker != null)
+				{
+					_tracker.Dispose();
+					_tracker = null;
+				}
 
-		        if (_events != null)
-		        {
-		            _events.Dispose();
-		            _events = null;
-		        }
+				if (_events != null)
+				{
+					_events.Dispose();
+					_events = null;
+				}
 
-		        if (_masterController != null)
-		        {
-		            _masterController.WillAppear -= MasterControllerWillAppear;
-		            _masterController.WillDisappear -= MasterControllerWillDisappear;
-		        }
-		    }
+				if (_masterController != null)
+				{
+					_masterController.WillAppear -= MasterControllerWillAppear;
+					_masterController.WillDisappear -= MasterControllerWillDisappear;
+				}
 
-		    base.Dispose(disposing);
+				ClearControllers();
+			}
+
+			base.Dispose(disposing);
 		}
 
 		public VisualElement Element { get; private set; }

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -57,12 +57,9 @@ namespace Xamarin.Forms.Platform.iOS
 		IPageController PageController => Element as IPageController;
 		IElementController ElementController => Element as IElementController;
 
-		protected MasterDetailPage MasterDetailPage
-		{
-			get { return _masterDetailPage ?? (_masterDetailPage = (MasterDetailPage)Element); }
-		}
+		protected MasterDetailPage MasterDetailPage => _masterDetailPage ?? (_masterDetailPage = (MasterDetailPage)Element);
 
-		IMasterDetailPageController MasterDetailPageController => MasterDetailPage as IMasterDetailPageController;
+	    IMasterDetailPageController MasterDetailPageController => MasterDetailPage as IMasterDetailPageController;
 
 		UIBarButtonItem PresentButton
 		{
@@ -71,12 +68,25 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
-		    if (!_disposed && disposing)
+		    if (_disposed)
+		    {
+                return;
+		    }
+
+		    _disposed = true;
+
+		    if (disposing)
 		    {
 		        if (Element != null)
 		        {
 		            PageController.SendDisappearing();
 		            Element.PropertyChanged -= HandlePropertyChanged;
+
+		            if (MasterDetailPage?.Master != null)
+		            {
+                        MasterDetailPage.Master.PropertyChanged -= HandleMasterPropertyChanged;
+                    }
+
 		            Element = null;
 		        }
 
@@ -97,9 +107,8 @@ namespace Xamarin.Forms.Platform.iOS
 		            _masterController.WillAppear -= MasterControllerWillAppear;
 		            _masterController.WillDisappear -= MasterControllerWillDisappear;
 		        }
-
-		        _disposed = true;
 		    }
+
 		    base.Dispose(disposing);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fixes leaks preventing MasterDetailPage and its child pages from being garbage collected on iPad.

### Bugs Fixed ###

- [44166 – but on the iPad](https://bugzilla.xamarin.com/show_bug.cgi?id=44166)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
