### PR TITLE
[A]Don't crash when emptying/populating TabbedPage.ItemsSource

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44129.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44129.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44129, "Crash when adding tabbed page after removing all pages using DataTemplates")]
+	public class Bugzilla44129 : TestTabbedPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			// Initialize ui here instead of ctor
+			var viewModels = new ObservableCollection<string>();
+			viewModels.Add("First");
+			viewModels.Add("Second");
+			var template = new DataTemplate(() =>
+			{
+				ContentPage page = new ContentPage();
+				var crashMe = new Button { Text = "Crash Me" };
+				crashMe.Clicked += (sender, args) =>
+				{
+					viewModels.Clear();
+					viewModels.Add("Third");
+				};
+
+				page.Content = crashMe;
+				page.SetBinding(ContentPage.TitleProperty, ".");
+
+				return page;
+			});
+
+			ItemTemplate = template;
+			ItemsSource = viewModels;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue44129Test ()
+		{
+			RunningApp.Screenshot ("I am at Issue 1");
+			RunningApp.WaitForElement (q => q.Marked ("First"));
+			RunningApp.Screenshot ("I see the Label");
+			RunningApp.Tap(q => q.Marked("Second"));
+			RunningApp.Tap(q => q.Marked("Crash Me"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -190,6 +190,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39768.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41271.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41153.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44129.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -252,7 +252,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			TabLayout tabs = _tabLayout;
 
 			((FormsFragmentPagerAdapter<Page>)pager.Adapter).CountOverride = Element.Children.Count;
-			pager.Adapter.NotifyDataSetChanged();
+			
 
 			if (Element.Children.Count == 0)
 				tabs.RemoveAllTabs();
@@ -262,6 +262,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateTabIcons();
 				tabs.SetOnTabSelectedListener(this);
 			}
+
+			pager.Adapter.NotifyDataSetChanged();
 
 			UpdateIgnoreContainerAreas();
 		}


### PR DESCRIPTION
### Description of Change ###

Ensure that the tab bar is updated before updating the pager which will attempt to then switch those tabs. If pager is empty it will attempt to switch to tab 0 when you add the first item to the view. This will result in a crash.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44129

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

