### PR TITLE
[WinRT] Fix back button not showing if current page has no title

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -495,7 +495,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			UpdateTitleOnParents();
 
 			bool showing = _container.TitleVisibility == Visibility.Visible;
-			bool newValue = GetIsNavBarPossible() && NavigationPage.GetHasNavigationBar(_currentPage) && !string.IsNullOrEmpty(_currentPage.Title);
+			bool newValue = GetIsNavBarPossible() && NavigationPage.GetHasNavigationBar(_currentPage);
 			if (showing == newValue)
 				return;
 


### PR DESCRIPTION
### Description of Change ###

Fixes the back button and navigation bar not being visible if the current page does not have title on Windows 8.1 projects.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=45255

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

