### PR TITLE
[iOS] Add check for UIGestureRecognizerState.Cancelled when closing a context action

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44338.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44338.cs
@@ -1,0 +1,45 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44338, "Tapping off of a cell with an open context action causes a crash in iOS 10", PlatformAffected.iOS)]
+	public class Bugzilla44338 : TestContentPage
+	{
+		protected override void Init()
+		{
+			string[] items = new string[] { "A", "B", "C" };
+			Content = new ListView
+			{
+				ItemsSource = items,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, ".");
+					var view = new ViewCell
+					{
+						View = new StackLayout
+						{
+							Children =
+							{
+								label
+							}
+						}
+					};
+					view.ContextActions.Add(new MenuItem
+					{
+						Text = "Action",
+						Command = new Command(() => DisplayAlert("Alert", "Context Action Pressed", "Close"))
+					});
+					return view;
+				})	
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -129,9 +129,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
+
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44584.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
@@ -210,7 +210,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void ClearCloserRecognizer(UIScrollView scrollView)
 		{
-			if (_globalCloser == null)
+			if (_globalCloser == null || _globalCloser.State == UIGestureRecognizerState.Cancelled)
 				return;
 
 			var cell = GetContextCell(scrollView);


### PR DESCRIPTION
### Description of Change ###

An issue in iOS 10 exists where if a context action is open, tapping off of it will cause a crash. In the [iOS 10 Release Notes](https://developer.apple.com/library/content/releasenotes/General/RN-iOSSDK-10.0/) it mentions the following:

> In iOS 10, there is a slight `UIGestureRecognizer` behavior change when removing a currently recognizing (that is, midflight) gesture recognizer from its view. Previously, removing the gesture recognizer midflight would not explicitly cancel the gesture recognizer, allowing you to re-add the gesture recognizer back to the same view or to a different view. In iOS 10, calling `removeGestureRecognizer:` on the view of a midflight gesture recognizer explicitly cancels the gesture recognizer. If a user desires to change the view of a midflight gesture recognizer, you can simply call `addGestureRecognizer:` on the view you wish to move the gesture recognizer to.

This now-forced `Cancelled` state is never accounted for inside of the delegate assigned for closing the action (pre-iOS 10 it seems like the `_globalCloser` would be in the `Began` state as this was closing), and as such it would end up calling the `ClearCloserRecognizer` method a second time, subsequently leading to a null error. By checking for `Cancelled` it should only be called once.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=44338

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense