### PR TITLE
[iOS] Change keyboard type while keyboard is visible

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31141.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31141.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 31141, "Change Entry keyboard type while typing", PlatformAffected.iOS)]
+	public class Bugzilla31141 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var stackLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				Spacing = 10,
+				VerticalOptions = LayoutOptions.Start,
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			var label = new Label
+			{
+				Text = "Focus Entry or Editor and type characters. For every 3 characters, the keyboard type will change while keyboard is focused up to 12 characters."
+			};
+			stackLayout.Children.Add(label);
+
+			var entry = new Entry
+			{
+				WidthRequest = 250,
+				HeightRequest = 50,
+				BackgroundColor = Color.DarkGoldenrod
+			};
+			entry.TextChanged += InputViewOnTextChanged;
+			stackLayout.Children.Add(entry);
+
+			var editor = new Editor
+			{
+				WidthRequest = 250,
+				HeightRequest = 50,
+				BackgroundColor = Color.AntiqueWhite
+			};
+			editor.TextChanged += InputViewOnTextChanged;
+			stackLayout.Children.Add(editor);
+
+			Content = stackLayout;
+		}
+
+		void InputViewOnTextChanged(object sender, TextChangedEventArgs textChangedEventArgs)
+		{
+			if (textChangedEventArgs.NewTextValue.Length >= 15)
+				return;
+
+			switch (textChangedEventArgs.NewTextValue.Length % 15)
+			{
+				case 0:
+					(sender as InputView).Keyboard = Keyboard.Default;
+					break;
+				case 3:
+					(sender as InputView).Keyboard = Keyboard.Numeric;
+					break;
+				case 6:
+					(sender as InputView).Keyboard = Keyboard.Email;
+					break;
+				case 9:
+					(sender as InputView).Keyboard = Keyboard.Telephone;
+					break;
+				case 12:
+					(sender as InputView).Keyboard = Keyboard.Url;
+					break;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -43,6 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla29158.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla29363.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla29229.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31141.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31145.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31333.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31366.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -118,6 +118,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateKeyboard()
 		{
 			Control.ApplyKeyboard(Element.Keyboard);
+			Control.ReloadInputViews();
 		}
 
 		void UpdateText()

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -155,6 +155,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateKeyboard()
 		{
 			Control.ApplyKeyboard(Element.Keyboard);
+			Control.ReloadInputViews();
 		}
 
 		void UpdatePassword()


### PR DESCRIPTION
### Description of Change

iOS does not reload new keyboard type while keyboard is visible and the user makes changes to the `Keyboard` property. This PR ensures the behavior will be similar to Android.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=31141
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
