### PR TITLE
[Android][AppCompat] Add flag to support async navigation in NavigationPage

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/NavigationPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/NavigationPage.cs
@@ -1,0 +1,44 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using FormsElement = Forms.NavigationPage;
+
+	public static class NavigationPage
+	{
+		public static readonly BindableProperty IsAllowingStateLossProperty =
+			BindableProperty.Create(nameof(IsAllowingStateLoss), typeof(bool),
+			typeof(NavigationPage), false);
+
+		public static bool GetIsAllowingStateLoss(BindableObject element)
+		{
+			return (bool)element.GetValue(IsAllowingStateLossProperty);
+		}
+
+		public static void SetIsAllowingStateLoss(BindableObject element, bool value)
+		{
+			element.SetValue(IsAllowingStateLossProperty, value);
+		}
+
+		public static bool IsAllowingStateLoss(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetIsAllowingStateLoss(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetIsAllowingStateLoss(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
+		{
+			SetIsAllowingStateLoss(config.Element, value);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> EnableIsAllowingStateLoss(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			SetIsAllowingStateLoss(config.Element, true);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> DisableIsAllowingStateLoss(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			SetIsAllowingStateLoss(config.Element, false);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -88,6 +88,7 @@
     <Compile Include="DelegateLogListener.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\Application.cs" />
+    <Compile Include="PlatformConfiguration\AndroidSpecific\NavigationPage.cs" />
     <Compile Include="PlatformConfiguration\ExtensionPoints.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\NavigationPage.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -23,6 +23,7 @@ using Fragment = Android.Support.V4.App.Fragment;
 using FragmentManager = Android.Support.V4.App.FragmentManager;
 using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
 using Object = Java.Lang.Object;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -627,7 +628,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					fragments.Add(fragment);
 				}
 			}
-			transaction.Commit();
+
+			if (Element.On<PlatformConfiguration.Android>().IsAllowingStateLoss())
+			{
+				transaction.CommitAllowingStateLoss();
+			}
+			else
+			{
+				transaction.Commit();
+			}
 
 			// The fragment transitions don't really SUPPORT telling you when they end
 			// There are some hacks you can do, but they actually are worse than just doing this:


### PR DESCRIPTION
### Description of Change

While trying to migrate our [App](http://welcome.mycloud.ch/) to the AppCompat backend of Xamarin.Forms we noted a difference in the behaviour of `NavigationPage`. When using `FormsApplicationActivity` everything worked fine, but switching to `FormsAppCompatActivity` lead to the following exception in some cases:

```
[MonoDroid] UNHANDLED EXCEPTION:
[MonoDroid] Java.Lang.IllegalStateException: Can not perform this action after onSaveInstanceState
...
```

The reason for this is obviously that Android does not support changing the active Fragment when the current Activity has been stopped. [Here](http://www.androiddesignpatterns.com/2013/08/fragment-transaction-commit-state-loss.html) is a good read about this.

However, the last resort solution for cases like this is unfortunately not possible with Xamarin.Forms because there's no way to switch from `transaction.Commit()` to `transaction.CommitAllowingStateLoss()`. The idea of this pull request is to add the possibility to enable this behaviour on `NavigationPage`.

Here's a scenario where this would be really helpful: Consider an app that allows the user to upload files to a backend and tracks the progress on a new page. As soon as the file is uploaded the app should pop the current page and go back to where the user was before. If the user would switch to another app before the upload is finished the app would always crash.

Since `CommitAllowingStateLoss()` should still be considered as a last resort, it wouldn't be the default behaviour. However, for people who know what they are doing it would be cool to have this as an option. Most Xamarin.Forms apps don't use the Fragment SaveInstanceState() machinery anyway.

Here's a repo project that shows the suggested behaviour:

https://github.com/monostefan/Xamarin.Forms.NavFix_Demo
### Bugs Fixed
- No bug created yet, cause it's a new feature, but can do so of course anytime if it make life easier for aynbody :)
### API Changes

Added:
- `bool NavigationPage.On<Android>().IsAllowingStateLoss()`
- `void NavigationPage.On<Android>().EnableIsAllowingStateLoss()`
- `void NavigationPage.On<Android>().DisableIsAllowingStateLoss()`

The name of the flag is suboptimal to be honest. I'm open for better suggestions.
### Behavioral Changes

None, if the `IsAllowingStateLoss` flag is not set.
### PR Checklist
- [ ] Has tests (Unfortunately I really don't know how a test for this could be written. Can UI Tests pause an app and return to it?)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
