### PR TITLE
Temporarily disabling 39489 UITest on iOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Controls
 		}
 
 #if UITEST
+#if !__IOS__ // Temporarily disabling this test on iOS
 		[Test]
 		public async Task Bugzilla39489Test()
 		{
@@ -39,6 +40,7 @@ namespace Xamarin.Forms.Controls
 				RunningApp.Back();
 			}
 		}
+#endif
 #endif
 	}
 


### PR DESCRIPTION
### Description of Change ###

UI Test for 39489 (originally an Android bug) doesn't run to completion on iOS devices; disabling the test for iOS temporarily while we work out what's going on with that platform.

