### PR TITLE
Modified type cast to appropriate type

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			_measured = true;
 
-			var result = new Size { Width = ((BitmapImage)Control.Source).PixelWidth, Height = ((BitmapImage)Control.Source).PixelHeight };
+			var result = new Size { Width = ((BitmapSource)Control.Source).PixelWidth, Height = ((BitmapSource)Control.Source).PixelHeight };
 
 			return new SizeRequest(result);
 		}


### PR DESCRIPTION
### Description of Change ###

I changed the type cast from BitmapImage to BitmapSource because if you want to do image manipulation, in UWP, you use the WriteableBitmap class.

### Bugs Fixed ###

This fixes the InvalidCastException which can result in the app crashing

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense