### PR TITLE
[iOS] Fix extra tab icon appearing in iOS for TabbedPage

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -30,6 +30,8 @@ namespace Xamarin.Forms
 
 		static bool? s_isiOS9OrNewer;
 
+		static bool? s_isiOS10OrNewer;
+
 		static Forms()
 		{
 			if (nevertrue)
@@ -65,6 +67,16 @@ namespace Xamarin.Forms
 				if (!s_isiOS9OrNewer.HasValue)
 					s_isiOS9OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(9, 0);
 				return s_isiOS9OrNewer.Value;
+			}
+		}
+
+		internal static bool IsiOS10OrNewer
+		{
+			get
+			{
+				if (!s_isiOS10OrNewer.HasValue)
+					s_isiOS10OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(10, 0);
+				return s_isiOS10OrNewer.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -177,7 +177,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == Page.TitleProperty.PropertyName)
+			// Setting TabBarItem.Title in iOS 10 causes rendering bugs
+			// Work around this by creating a new UITabBarItem on each change
+			if (e.PropertyName == Page.TitleProperty.PropertyName && !Forms.IsiOS10OrNewer)
 			{
 				var page = (Page)sender;
 				var renderer = Platform.GetRenderer(page);
@@ -187,7 +189,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (renderer.ViewController.TabBarItem != null)
 					renderer.ViewController.TabBarItem.Title = page.Title;
 			}
-			else if (e.PropertyName == Page.IconProperty.PropertyName)
+			else if (e.PropertyName == Page.IconProperty.PropertyName || e.PropertyName == Page.TitleProperty.PropertyName && Forms.IsiOS10OrNewer)
 			{
 				var page = (Page)sender;
 


### PR DESCRIPTION
### Description of Change

This adds a workaround for an iOS 10 bug that displays extra icons in a `UITabBarController` when the `UITabBarItem.Title` property is changed. More info here: http://stackoverflow.com/questions/38776978/ios-10-uitabbar-more-items-visible-after-setting-title
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=45284
### API Changes

Added:
- Forms.IsiOS10OrNewer { get; } // internal
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
