### PR TITLE
Add null check to prevent crashes if Deserializer is not registered

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -233,7 +233,7 @@ namespace Xamarin.Forms
 			var deserializer = DependencyService.Get<IDeserializer>();
 			if (deserializer == null)
 			{
-				Log.Warning("Startup", "No IDeserialzier was found registered");
+				Log.Warning("Startup", "No IDeserializer was found registered");
 				return new Dictionary<string, object>(4);
 			}
 
@@ -283,15 +283,21 @@ namespace Xamarin.Forms
 
 		async Task SetPropertiesAsync()
 		{
+			var deserializer = DependencyService.Get<IDeserializer>();
+			if (deserializer == null)
+			{
+				Log.Warning("SetProperties", "No IDeserializer was found registered");
+				return;
+			}
 			if (_isSaving)
 			{
 				_saveAgain = true;
 				return;
 			}
 			_isSaving = true;
-			await DependencyService.Get<IDeserializer>().SerializePropertiesAsync(Properties);
+			await deserializer.SerializePropertiesAsync(Properties);
 			if (_saveAgain)
-				await DependencyService.Get<IDeserializer>().SerializePropertiesAsync(Properties);
+				await deserializer.SerializePropertiesAsync(Properties);
 			_isSaving = _saveAgain = false;
 		}
 


### PR DESCRIPTION
### Description of Change ###

If a derived class of IDeserializer is not registered in DependencyService,
crashes will be occurred in Application.SetPropertiesAsync().

Tests of this change is omitted because it is difficult to make cases calling Application.SendSleepAsync() without Deserializer in UnitTests.

### Bugs Fixed ###

- None

### API Changes ###

- None

### Behavioral Changes ###

- None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
