### PR TITLE
[A] Better fix for BZ44129

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -253,17 +253,19 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			((FormsFragmentPagerAdapter<Page>)pager.Adapter).CountOverride = Element.Children.Count;
 			
+			pager.Adapter.NotifyDataSetChanged();
 
 			if (Element.Children.Count == 0)
+			{
 				tabs.RemoveAllTabs();
+				tabs.SetupWithViewPager(null);
+			}
 			else
 			{
 				tabs.SetupWithViewPager(pager);
 				UpdateTabIcons();
 				tabs.SetOnTabSelectedListener(this);
 			}
-
-			pager.Adapter.NotifyDataSetChanged();
 
 			UpdateIgnoreContainerAreas();
 		}


### PR DESCRIPTION
### Description of Change ###

Instead of moving where we do the update and thus potentially side effect, just unhook from empty pagers to prevent confusing the tab layout when we blow away its tabs.

### Bugs Fixed ###

bugzilla.xamarin.com/show_bug.cgi?id=44129

### API Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

