### PR TITLE
Fix Text value on Entry after autocorrect

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -106,6 +106,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnEditingEnded(object sender, EventArgs e)
 		{
+			ElementController.SetValueFromRenderer(Entry.TextProperty, Control.Text);
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 		}
 


### PR DESCRIPTION
### Description of Change ###

After the automatic correction of the text in UITextField does not work EditingChanged and Entry not saved the new value.
Added Text setting when editing is complete so that has always been correct and relevant.


### Bugs Fixed ###

- Provide links to bugs here

### API Changes ###

None

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

