### PR TITLE
[Windows] Make Editor focused background color behavior consistent with Entry

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44584.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44584.cs
@@ -1,0 +1,44 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44584,
+		"UWP - Editor: changing the background color will only take effect after the entry gained focus")]
+	public class Bugzilla44584 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var instructions = new Label
+			{
+				Text = @"
+Tap the first button once to turn the Entry background color to Green. Tap the Entry to focus it; the background should remain green; if it does not, the test has failed. 
+Tap the second button once to turn the Editor background color to Green. Tap the Editor to focus it; the background should remain green; if it does not, the test has failed." 
+			};
+
+			var entryButton = new Button { Text = "Toggle Entry Background (Green/Default)" };
+			var entry = new Entry();
+
+			entryButton.Clicked +=
+				(sender, args) => { entry.BackgroundColor = entry.BackgroundColor != Color.Green ? Color.Green : Color.Default; };
+
+			var editorButton = new Button { Text = "Toggle Editor Background (Green/Default)" };
+			var editor = new Editor()
+			{
+				HeightRequest = 80
+			};
+
+			editorButton.Clicked +=
+				(sender, args) => { editor.BackgroundColor = editor.BackgroundColor != Color.Green ? Color.Green : Color.Default; };
+
+			var layout = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children = { instructions, entryButton, entry, editorButton, editor }
+			};
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -128,6 +128,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44584.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />

--- a/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (Device.Idiom == TargetIdiom.Phone)
 			{
 				// If we're on the phone, we need to grab this from the template
-				// so we can manually handle it's background when focused
+				// so we can manually handle its background when focused
 				_borderElement = (Border)GetTemplateChild("BorderElement");
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Fixes disparity between the Editor and Entry controls on Windows with regard to background color when focused. The Entry preserves the background color set by the developer when it is focused; the Editor does not. This change makes the Editor behave like the Entry.

### Bugs Fixed ###

- [44584 – UWP - Editor: changing the background color will only take effect after the entry gained focus](https://bugzilla.xamarin.com/show_bug.cgi?id=44584)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

…n Windows