### PR TITLE
Return group instead of internal class on ItemTapped of grouped ListView

### DIFF
--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows.Input;
 using Xamarin.Forms.Platform;
-using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
@@ -409,7 +409,7 @@ namespace Xamarin.Forms
 
 			cell.OnTapped();
 
-			ItemTapped?.Invoke(this, new ItemTappedEventArgs(group, cell.BindingContext));
+			ItemTapped?.Invoke(this, new ItemTappedEventArgs(ItemsSource.Cast<object>().ElementAt(groupIndex), cell.BindingContext));
 		}
 
 		internal void NotifyRowTapped(int index, Cell cell = null)


### PR DESCRIPTION
### Description of Change

`ItemTapped` of `ListView` returns `ItemTappedEventArgs` that is supposed to be showing item tapped as well as the group it lives in. As of now, XF is returning an internal object `TemplatedItemsList`. This PR will ensure that parameters are directly convertible to user-defined models.

```
void OnItemTapped(Object sender, ItemTappedEventArgs e)
{
    var item = (MyItem)(e.Item);
    var group = (MyGroup)(e.Group);
}
```

There is no point in returning an internal member. Similarly, users should not be using reflection. This will be a breaking change for those who were using reflection. So, please make sure to communicate the change.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=45092
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
