### PR TITLE
[iOS] Add Platform Specific features for PrefersStatusBarHidden/UIStatusBarAnimation

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Info.plist
+++ b/Xamarin.Forms.ControlGallery.iOS/Info.plist
@@ -35,7 +35,7 @@
 		<string>Default-568h@2x.png</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>We are using your location</string>
 	<key>NSLocationAlwaysUsageDescription</key>

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/MasterDetailPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/MasterDetailPageiOS.cs
@@ -1,0 +1,178 @@
+﻿using System.Collections.Generic;
+using System.Windows.Input;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
+{
+	public class MasterDetailPageiOS : MasterDetailPage
+	{
+		public MasterDetailPageiOS(ICommand restore)
+		{
+			MasterBehavior = MasterBehavior.Popover;
+
+			var master = new ContentPage { Title = "Master Detail Page" };
+			var masterContent = new StackLayout { Spacing = 10, Margin = new Thickness(0, 10, 5, 0) };
+			var detail = new ContentPage
+			{
+				Title = "This is the detail page's Title",
+				Padding = new Thickness(0,20,0,0)
+			};
+			
+			var navItems = new List<NavItem>
+			{
+				new NavItem("Display Alert", "\uE171", new Command(() => DisplayAlert("Alert", "This is an alert", "OK"))),
+				new NavItem("Return To Gallery", "\uE106", restore),
+				new NavItem("Save", "\uE105", new Command(() => DisplayAlert("Save", "Fake save dialog", "OK"))),
+				new NavItem("Audio", "\uE189", new Command(() => DisplayAlert("Audio", "Never gonna give you up...", "OK"))),
+				new NavItem("Set Detail to Navigation Page", "\uE16F", new Command(() => Detail = CreateNavigationPage())),
+				new NavItem("Set Detail to Content Page", "\uE160", new Command(() => Detail = detail)),
+			};
+
+			var navList = new NavList(navItems);
+			
+			masterContent.Children.Add(navList);
+			master.Content = masterContent;
+
+			var detailContent = new StackLayout {
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Label
+					{
+						Text = "This is a ContentPage with StatusBarHiddenMode.True"
+					}
+				}
+			};
+
+			detail.Content = detailContent;
+
+			Master = master;
+
+			detail.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.True);
+
+			Detail = detail;
+		}
+
+		public class NavItem
+		{
+			public NavItem(string text, string icon, ICommand command)
+			{
+				Text = text;
+				Icon = icon;
+				Command = command;
+			}
+
+			public ICommand Command { get; set; }
+
+			public string Icon { get; set; }
+
+			public string Text { get; set; }
+		}
+
+		public class NavList : ListView
+		{
+			public NavList(IEnumerable<NavItem> items)
+			{
+				ItemsSource = items;
+				ItemTapped += (sender, args) => (args.Item as NavItem)?.Command.Execute(null);
+
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var grid = new Grid();
+					grid.ColumnDefinitions.Add(new ColumnDefinition { Width = 48 });
+					grid.ColumnDefinitions.Add(new ColumnDefinition { Width = 200 });
+
+					grid.Margin = new Thickness(0, 10, 0, 10);
+
+					var text = new Label
+					{
+						VerticalOptions = LayoutOptions.Fill
+					};
+					text.SetBinding(Label.TextProperty, "Text");
+
+					var glyph = new Label
+					{
+						FontSize = 24,
+						HorizontalTextAlignment = TextAlignment.Center
+					};
+
+					glyph.SetBinding(Label.TextProperty, "Icon");
+
+					grid.Children.Add(glyph);
+					grid.Children.Add(text);
+
+					Grid.SetColumn(glyph, 0);
+					Grid.SetColumn(text, 1);
+
+					grid.WidthRequest = 48;
+
+					var cell = new ViewCell
+					{
+						View = grid
+					};
+
+					return cell;
+				});
+			}
+		}
+
+		static NavigationPage CreateNavigationPage()
+		{
+			var page = new NavigationPage { Title = "This is the Navigation Page Title" };
+
+			page.PushAsync(CreateNavSubPage());
+
+			return page;
+		}
+
+		static ContentPage CreateNavSubPage()
+		{
+			var page = new ContentPage();
+			var content = new StackLayout();
+			var navigateButton = new Button() { Text = "Push Another Page" };
+
+			navigateButton.Clicked += (sender, args) => page.Navigation.PushAsync(CreateNavSubPage());
+
+			var togglePrefersStatusBarHiddenButtonForPageButton = new Button
+			{
+				Text = "Toggle PrefersStatusBarHidden for Page"
+			};
+			var togglePreferredStatusBarUpdateAnimationButton = new Button
+			{
+				Text = "Toggle PreferredStatusBarUpdateAnimation"
+			};
+
+			togglePrefersStatusBarHiddenButtonForPageButton.Command = new Command(() =>
+			{
+				var mode = page.On<iOS>().PrefersStatusBarHidden();
+				if (mode == StatusBarHiddenMode.Default)
+					page.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.True);
+				else if (mode == StatusBarHiddenMode.True)
+					page.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.False);
+				else
+					page.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.Default);
+			});
+
+			togglePreferredStatusBarUpdateAnimationButton.Command = new Command(() =>
+			{
+				var animation = page.On<iOS>().PreferredStatusBarUpdateAnimation();
+				if (animation == UIStatusBarAnimation.Fade)
+					page.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Slide);
+				else if (animation == UIStatusBarAnimation.Slide)
+					page.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.None);
+				else
+					page.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Fade);
+			});
+			
+			content.Children.Add(navigateButton);
+			content.Children.Add(togglePrefersStatusBarHiddenButtonForPageButton);
+			content.Children.Add(togglePreferredStatusBarUpdateAnimationButton);
+
+			page.Content = content;
+
+			return page;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/NavigationPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/NavigationPageiOS.cs
@@ -6,13 +6,27 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 {
 	public class NavigationPageiOS : NavigationPage
 	{
+		public NavigationPageiOS(Page root, ICommand restore) : base(root)
+		{
+			BackgroundColor = Color.Pink;
+			On<iOS>().EnableTranslucentNavigationBar();
+			CurrentPage.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Fade);
+		}
+
 		public static NavigationPageiOS Create(ICommand restore)
 		{
 			var restoreButton = new Button { Text = "Back To Gallery" };
 			restoreButton.Clicked += (sender, args) => restore.Execute(null);
 
 			var translucentToggleButton = new Button { Text = "Toggle Translucent NavBar" };
-
+			var togglePrefersStatusBarHiddenButton = new Button
+			{
+				Text = "Toggle PrefersStatusBarHidden"
+			};
+			var togglePreferredStatusBarUpdateAnimationButton = new Button
+			{
+				Text = "Toggle PreferredStatusBarUpdateAnimation"
+			};
 			var content = new ContentPage
 			{
 				Title = "Navigation Page Features",
@@ -20,7 +34,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 				{
 					VerticalOptions = LayoutOptions.Center,
 					HorizontalOptions = LayoutOptions.Center,
-					Children = { translucentToggleButton, restoreButton }
+					Children = { translucentToggleButton, restoreButton, togglePrefersStatusBarHiddenButton, togglePreferredStatusBarUpdateAnimationButton}
 				}
 			};
 
@@ -28,13 +42,29 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 
 			translucentToggleButton.Clicked += (sender, args) => navPage.On<iOS>().SetIsNavigationBarTranslucent(!navPage.On<iOS>().IsNavigationBarTranslucent());
 
-			return navPage;
-		}
+			togglePrefersStatusBarHiddenButton.Command = new Command(() =>
+			{
+				var mode = navPage.CurrentPage.On<iOS>().PrefersStatusBarHidden();
+				if (mode == StatusBarHiddenMode.Default)
+					navPage.CurrentPage.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.True);
+				else if (mode == StatusBarHiddenMode.True)
+					navPage.CurrentPage.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.False);
+				else
+					navPage.CurrentPage.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.Default);
+			});
 
-		public NavigationPageiOS(Page root, ICommand restore) : base(root)
-		{
-			BackgroundColor = Color.Pink;
-			On<iOS>().EnableTranslucentNavigationBar();
+			togglePreferredStatusBarUpdateAnimationButton.Command = new Command(() =>
+			{
+				var animation = navPage.On<iOS>().PreferredStatusBarUpdateAnimation();
+				if (animation == UIStatusBarAnimation.Fade)
+					navPage.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Slide);
+				else if (animation == UIStatusBarAnimation.Slide)
+					navPage.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.None);
+				else
+					navPage.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Fade);
+			});
+
+			return navPage;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/TabbedPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/TabbedPageiOS.cs
@@ -1,0 +1,97 @@
+﻿using System.Windows.Input;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
+{
+	public class TabbedPageiOS : TabbedPage
+	{
+		public TabbedPageiOS(ICommand restore)
+		{
+			Children.Add(CreatePage(restore, "Page One"));
+			Children.Add(CreatePage(restore, "Page Two"));
+		}
+
+		ContentPage CreatePage(ICommand restore, string title)
+		{
+			var page = new ContentPage {
+				Title = title
+			};
+			var content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Fill,
+				HorizontalOptions = LayoutOptions.Fill,
+				Padding = new Thickness(0, 20, 0, 0)
+			};
+			content.Children.Add(new Label
+			{
+				Text = "TabbedPage iOS Features",
+				FontAttributes = FontAttributes.Bold,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center
+			});
+
+			var togglePrefersStatusBarHiddenButton = new Button
+			{
+				Text = "Toggle PrefersStatusBarHidden for TabbedPage"
+			};
+			var togglePrefersStatusBarHiddenForPageButton = new Button
+			{
+				Text = "Toggle PrefersStatusBarHidden for Page"
+			};
+			var togglePreferredStatusBarUpdateAnimationButton = new Button
+			{
+				Text = "Toggle PreferredStatusBarUpdateAnimation"
+			};
+
+			togglePrefersStatusBarHiddenButton.Command = new Command(() =>
+			{
+				var mode = On<iOS>().PrefersStatusBarHidden();
+				if (mode == StatusBarHiddenMode.Default)
+					On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.True);
+				else if (mode == StatusBarHiddenMode.True)
+					On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.False);
+				else
+					On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.Default);
+			});
+
+			togglePrefersStatusBarHiddenForPageButton.Command = new Command(() =>
+			{
+				var mode = page.On<iOS>().PrefersStatusBarHidden();
+				if (mode == StatusBarHiddenMode.Default)
+					page.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.True);
+				else if (mode == StatusBarHiddenMode.True)
+					page.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.False);
+				else
+					page.On<iOS>().SetPrefersStatusBarHidden(StatusBarHiddenMode.Default);
+			});
+
+			togglePreferredStatusBarUpdateAnimationButton.Command = new Command(() =>
+			{
+				var animation = page.On<iOS>().PreferredStatusBarUpdateAnimation();
+				if (animation == UIStatusBarAnimation.Fade)
+					page.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Slide);
+				else if (animation == UIStatusBarAnimation.Slide)
+					page.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.None);
+				else
+					page.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Fade);
+			});
+
+			var restoreButton = new Button { Text = "Back To Gallery" };
+			restoreButton.Clicked += (sender, args) => restore.Execute(null);
+			content.Children.Add(restoreButton);
+			content.Children.Add(togglePrefersStatusBarHiddenButton);
+			content.Children.Add(togglePrefersStatusBarHiddenForPageButton);
+			content.Children.Add(togglePreferredStatusBarUpdateAnimationButton);
+			content.Children.Add(new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				Text = "Note: Setting the PrefersStatusBarHidden value on a TabbedPage applies that value to all its subpages."
+			});
+
+			page.Content = content;
+
+			return page;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
@@ -8,19 +8,23 @@ namespace Xamarin.Forms.Controls
 
 		public PlatformSpecificsGallery()
 		{
-			var mdpWindowsButton = new Button { Text = "Master Detail Page (Windows)" };
-			var npWindowsButton = new Button { Text = "Navigation Page (Windows)" };
-			var tbWindowsButton = new Button { Text = "Tabbed Page (Windows)" };
-			var navpageiOSButton = new Button() { Text = "Navigation Page (iOS)" };
+			var mdpiOSButton = new Button { Text = "MasterDetailPage (iOS)" };
+			var mdpWindowsButton = new Button { Text = "MasterDetailPage (Windows)" };
+			var npiOSButton = new Button() { Text = "NavigationPage (iOS)" };
+			var npWindowsButton = new Button { Text = "NavigationPage (Windows)" };
+			var tbiOSButton = new Button { Text = "TabbedPage (iOS)" };
+			var tbWindowsButton = new Button { Text = "TabbedPage (Windows)" };
 			var viselemiOSButton = new Button() { Text = "Visual Element (iOS)" };
 			var appAndroidButton = new Button() { Text = "Application (Android)" };
 			var tbAndroidButton = new Button { Text = "TabbedPage (Android)" };
 			var entryiOSButton = new Button() { Text = "Entry (iOS)" };
 
+			mdpiOSButton.Clicked += (sender, args) => { SetRoot(new MasterDetailPageiOS(new Command(RestoreOriginal))); };
 			mdpWindowsButton.Clicked += (sender, args) => { SetRoot(new MasterDetailPageWindows(new Command(RestoreOriginal))); };
+			npiOSButton.Clicked += (sender, args) => { SetRoot(NavigationPageiOS.Create(new Command(RestoreOriginal))); };
 			npWindowsButton.Clicked += (sender, args) => { SetRoot(new NavigationPageWindows(new Command(RestoreOriginal))); };
+			tbiOSButton.Clicked += (sender, args) => { SetRoot(new TabbedPageiOS(new Command(RestoreOriginal))); };
 			tbWindowsButton.Clicked += (sender, args) => { SetRoot(new TabbedPageWindows(new Command(RestoreOriginal))); };
-			navpageiOSButton.Clicked += (sender, args) => { SetRoot(NavigationPageiOS.Create(new Command(RestoreOriginal))); };
 			viselemiOSButton.Clicked += (sender, args) => { SetRoot(new VisualElementiOS(new Command(RestoreOriginal))); };
 			appAndroidButton.Clicked += (sender, args) => { SetRoot(new ApplicationAndroid(new Command(RestoreOriginal))); };
 			tbAndroidButton.Clicked += (sender, args) => { SetRoot(new TabbedPageAndroid(new Command(RestoreOriginal))); };
@@ -29,7 +33,7 @@ namespace Xamarin.Forms.Controls
 
 			Content = new StackLayout
 			{
-				Children = { mdpWindowsButton, npWindowsButton, tbWindowsButton, navpageiOSButton, viselemiOSButton, appAndroidButton, entryiOSButton }
+				Children = { mdpiOSButton, mdpWindowsButton, npWindowsButton, tbiOSButton, tbWindowsButton, viselemiOSButton, appAndroidButton, tbAndroidButton, entryiOSButton }
 			};
 		}
 

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -104,10 +104,14 @@
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\MasterDetailPageWindows.cs" />
     <Compile Include="GalleryPages\NavigationPropertiesGallery.cs" />
     <Compile Include="ControlGalleryPages\ListViewSelectionColor.cs" />
+    <Compile Include="GalleryPages\PlatformSpecificsGalleries\ApplicationAndroid.cs" />
+    <Compile Include="GalleryPages\PlatformSpecificsGalleries\MasterDetailPageiOS.cs" />
+    <Compile Include="GalleryPages\PlatformSpecificsGalleries\MasterDetailPageWindows.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\NavigationPageiOS.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\NavigationPageWindows.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\ApplicationAndroid.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\TabbedPageAndroid.cs" />
+    <Compile Include="GalleryPages\PlatformSpecificsGalleries\TabbedPageiOS.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\TabbedPageWindows.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\VisualElementiOS.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\WindowsPlatformSpecificsGalleryHelpers.cs" />

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -100,16 +100,14 @@
       <DependentUpon>ControlTemplateXamlPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="GalleryPages\LayoutPerformanceGallery.cs" />
-    <Compile Include="GalleryPages\PlatformSpecificsGalleries\EntryPageiOS.cs" />
-    <Compile Include="GalleryPages\PlatformSpecificsGalleries\MasterDetailPageWindows.cs" />
     <Compile Include="GalleryPages\NavigationPropertiesGallery.cs" />
     <Compile Include="ControlGalleryPages\ListViewSelectionColor.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\ApplicationAndroid.cs" />
+    <Compile Include="GalleryPages\PlatformSpecificsGalleries\EntryPageiOS.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\MasterDetailPageiOS.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\MasterDetailPageWindows.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\NavigationPageiOS.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\NavigationPageWindows.cs" />
-    <Compile Include="GalleryPages\PlatformSpecificsGalleries\ApplicationAndroid.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\TabbedPageAndroid.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\TabbedPageiOS.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\TabbedPageWindows.cs" />

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -1,0 +1,60 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.Page;
+
+	public static class Page
+	{
+		public static readonly BindableProperty PrefersStatusBarHiddenProperty =
+			BindableProperty.Create("PrefersStatusBarHidden", typeof(StatusBarHiddenMode), typeof(Page), StatusBarHiddenMode.Default);
+
+		public static StatusBarHiddenMode GetPrefersStatusBarHidden(BindableObject element)
+		{
+			return (StatusBarHiddenMode)element.GetValue(PrefersStatusBarHiddenProperty);
+		}
+
+		public static void SetPrefersStatusBarHidden(BindableObject element, StatusBarHiddenMode value)
+		{
+			element.SetValue(PrefersStatusBarHiddenProperty, value);
+		}
+
+		public static StatusBarHiddenMode PrefersStatusBarHidden(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetPrefersStatusBarHidden(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersStatusBarHidden(this IPlatformElementConfiguration<iOS, FormsElement> config, StatusBarHiddenMode value)
+		{
+			SetPrefersStatusBarHidden(config.Element, value);
+			return config;
+		}
+
+		public static readonly BindableProperty PreferredStatusBarUpdateAnimationProperty =
+			BindableProperty.Create("PreferredStatusBarUpdateAnimation", typeof(UIStatusBarAnimation), typeof(Page), UIStatusBarAnimation.None);
+
+		public static UIStatusBarAnimation GetPreferredStatusBarUpdateAnimation(BindableObject element)
+		{
+			return (UIStatusBarAnimation)element.GetValue(PreferredStatusBarUpdateAnimationProperty);
+		}
+
+		public static void SetPreferredStatusBarUpdateAnimation(BindableObject element, UIStatusBarAnimation value)
+		{
+			if (value == UIStatusBarAnimation.Fade)
+				element.SetValue(PreferredStatusBarUpdateAnimationProperty, value);
+			else if (value == UIStatusBarAnimation.Slide)
+				element.SetValue(PreferredStatusBarUpdateAnimationProperty, value);
+			else 
+				element.SetValue(PreferredStatusBarUpdateAnimationProperty, value);
+		}
+
+		public static UIStatusBarAnimation PreferredStatusBarUpdateAnimation(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetPreferredStatusBarUpdateAnimation(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetPreferredStatusBarUpdateAnimation(this IPlatformElementConfiguration<iOS, FormsElement> config, UIStatusBarAnimation value)
+		{
+			SetPreferredStatusBarUpdateAnimation(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/StatusBarHiddenMode.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/StatusBarHiddenMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	public enum StatusBarHiddenMode
+	{
+		Default,
+		True,
+		False
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/UIStatusBarAnimation.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/UIStatusBarAnimation.cs
@@ -1,0 +1,9 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	public enum UIStatusBarAnimation
+	{
+		None,
+		Slide,
+		Fade
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -94,6 +94,9 @@
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\Entry.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\NavigationPage.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\Page.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\StatusBarHiddenMode.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\UIStatusBarAnimation.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\VisualElement.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\MasterDetailPage.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\CollapseStyle.cs" />

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -147,7 +147,7 @@ namespace Xamarin.Forms.Platform.iOS
 			get { return _renderer; }
 		}
 
-		Page Page { get; set; }
+		internal Page Page { get; set; }
 
 		void IDisposable.Dispose()
 		{

--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -1,4 +1,5 @@
 using UIKit;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -102,6 +103,11 @@ namespace Xamarin.Forms.Platform.iOS
 				return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
 			}
 			return base.PreferredInterfaceOrientationForPresentation();
+		}
+		
+		public override UIViewController ChildViewControllerForStatusBarHidden()
+		{
+			return (UIViewController)Platform.GetRenderer(this.Platform.Page);
 		}
 
 		public override bool ShouldAutorotate()

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1,12 +1,14 @@
+using CoreGraphics;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
-using CoreGraphics;
 using UIKit;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using static Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page;
+using PageUIStatusBarAnimation = Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation;
 using PointF = CoreGraphics.CGPoint;
 using RectangleF = CoreGraphics.CGRect;
 
@@ -424,6 +426,29 @@ namespace Xamarin.Forms.Platform.iOS
 				Current = ((NavigationPage)Element).CurrentPage;
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.NavigationPage.IsNavigationBarTranslucentProperty.PropertyName)
 				UpdateTranslucent();
+			else if (e.PropertyName == PreferredStatusBarUpdateAnimationProperty.PropertyName)
+				UpdateCurrentPagePreferredStatusBarUpdateAnimation();
+		}
+
+		void UpdateCurrentPagePreferredStatusBarUpdateAnimation()
+		{
+			PageUIStatusBarAnimation animation = ((Page)Element).OnThisPlatform().PreferredStatusBarUpdateAnimation();
+			Current.OnThisPlatform().SetPreferredStatusBarUpdateAnimation(animation);
+		}
+
+		UIKit.UIStatusBarAnimation GetPreferredStatusBarUpdateAnimation()
+		{
+			var animation = Current.OnThisPlatform().PreferredStatusBarUpdateAnimation();
+			switch (animation)
+			{
+				case (PageUIStatusBarAnimation.Fade):
+					return UIKit.UIStatusBarAnimation.Fade;
+				case (PageUIStatusBarAnimation.Slide):
+					return UIKit.UIStatusBarAnimation.Slide;
+				case (PageUIStatusBarAnimation.None):
+				default:
+					return UIKit.UIStatusBarAnimation.None;
+			}
 		}
 
 		void UpdateTranslucent()
@@ -865,6 +890,14 @@ namespace Xamarin.Forms.Platform.iOS
 					NavigationItem.Title = Child.Title;
 				else if (e.PropertyName == NavigationPage.HasBackButtonProperty.PropertyName)
 					UpdateHasBackButton();
+				else if (e.PropertyName == PrefersStatusBarHiddenProperty.PropertyName)
+					UpdatePrefersStatusBarHidden();
+			}
+
+			void UpdatePrefersStatusBarHidden()
+			{
+				View.SetNeedsLayout();
+				ParentViewController?.View.SetNeedsLayout();
 			}
 
 			void TrackerOnCollectionChanged(object sender, EventArgs eventArgs)
@@ -961,6 +994,11 @@ namespace Xamarin.Forms.Platform.iOS
 			public override bool ShouldAutomaticallyForwardRotationMethods => true;
 		}
 
+		public override UIViewController ChildViewControllerForStatusBarHidden()
+		{
+			return (UIViewController)Platform.GetRenderer(Current);
+		}
+		
 		void IEffectControlProvider.RegisterEffect(Effect effect)
 		{
 			var platformEffect = effect as PlatformEffect;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using UIKit;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using PointF = CoreGraphics.CGPoint;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -318,8 +319,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_detailController.View.AddSubview(detailRenderer.NativeView);
 			_detailController.AddChildViewController(detailRenderer.ViewController);
+
+			SetNeedsStatusBarAppearanceUpdate();
 		}
 
+		public override UIViewController ChildViewControllerForStatusBarHidden()
+		{
+			return (UIViewController)Platform.GetRenderer(((MasterDetailPage)Element).Detail);
+		}
+		
 		void UpdatePanGesture()
 		{
 			var model = (MasterDetailPage)Element;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -325,7 +325,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override UIViewController ChildViewControllerForStatusBarHidden()
 		{
-			return (UIViewController)Platform.GetRenderer(((MasterDetailPage)Element).Detail);
+			if (((MasterDetailPage)Element).Detail != null)
+				return (UIViewController)Platform.GetRenderer(((MasterDetailPage)Element).Detail);
+			else
+				return base.ChildViewControllerForStatusBarHidden();
 		}
 		
 		void UpdatePanGesture()

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -4,6 +4,8 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using UIKit;
 using Xamarin.Forms.Internals;
+using static Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page;
+using PageUIStatusBarAnimation = Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -241,6 +243,29 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateBarBackgroundColor();
 			else if (e.PropertyName == TabbedPage.BarTextColorProperty.PropertyName)
 				UpdateBarTextColor();
+			else if (e.PropertyName == PrefersStatusBarHiddenProperty.PropertyName)
+				UpdatePrefersStatusBarHiddenOnPages();
+			else if (e.PropertyName == PreferredStatusBarUpdateAnimationProperty.PropertyName)
+				UpdateCurrentPagePreferredStatusBarUpdateAnimation();
+		}
+
+		public override UIViewController ChildViewControllerForStatusBarHidden()
+		{
+			return GetViewController(Tabbed.CurrentPage);
+		}
+
+		void UpdateCurrentPagePreferredStatusBarUpdateAnimation()
+		{
+			PageUIStatusBarAnimation animation = ((Page)Element).OnThisPlatform().PreferredStatusBarUpdateAnimation();
+			Tabbed.CurrentPage.OnThisPlatform().SetPreferredStatusBarUpdateAnimation(animation);
+		}
+
+		void UpdatePrefersStatusBarHiddenOnPages()
+		{
+			for (var i = 0; i < ViewControllers.Length; i++)
+			{
+				Tabbed.GetPageByIndex(i).OnThisPlatform().SetPrefersStatusBarHidden(Tabbed.OnThisPlatform().PrefersStatusBarHidden());
+			}
 		}
 
 		void Reset()

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using UIKit;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -232,6 +233,11 @@ namespace Xamarin.Forms.Platform.iOS
 			MasterDetailPageController.UpdateMasterBehavior();
 			MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
 			base.WillRotate(toInterfaceOrientation, duration);
+		}
+
+		public override UIViewController ChildViewControllerForStatusBarHidden()
+		{
+			return (UIViewController)Platform.GetRenderer(((MasterDetailPage)Element).Detail);
 		}
 
 		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -237,7 +237,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override UIViewController ChildViewControllerForStatusBarHidden()
 		{
-			return (UIViewController)Platform.GetRenderer(((MasterDetailPage)Element).Detail);
+			if (((MasterDetailPage)Element).Detail != null)
+				return (UIViewController)Platform.GetRenderer(((MasterDetailPage)Element).Detail);
+			else
+				return base.ChildViewControllerForStatusBarHidden();
 		}
 
 		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Page.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Page.xml
@@ -1,0 +1,214 @@
+<Type Name="Page" FullName="Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page">
+  <TypeSignature Language="C#" Value="public static class Page" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Page extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetPreferredStatusBarUpdateAnimation">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation GetPreferredStatusBarUpdateAnimation (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation GetPreferredStatusBarUpdateAnimation(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetPrefersStatusBarHidden">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode GetPrefersStatusBarHidden (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode GetPrefersStatusBarHidden(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PreferredStatusBarUpdateAnimation">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation PreferredStatusBarUpdateAnimation (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation PreferredStatusBarUpdateAnimation(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Page&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PreferredStatusBarUpdateAnimationProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty PreferredStatusBarUpdateAnimationProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty PreferredStatusBarUpdateAnimationProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PrefersStatusBarHidden">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode PrefersStatusBarHidden (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode PrefersStatusBarHidden(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Page&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PrefersStatusBarHiddenProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty PrefersStatusBarHiddenProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty PrefersStatusBarHiddenProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetPreferredStatusBarUpdateAnimation">
+      <MemberSignature Language="C#" Value="public static void SetPreferredStatusBarUpdateAnimation (Xamarin.Forms.BindableObject element, Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetPreferredStatusBarUpdateAnimation(class Xamarin.Forms.BindableObject element, valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetPreferredStatusBarUpdateAnimation">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt; SetPreferredStatusBarUpdateAnimation (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt; config, Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Page&gt; SetPreferredStatusBarUpdateAnimation(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Page&gt; config, valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt;" RefType="this" />
+        <Parameter Name="value" Type="Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetPrefersStatusBarHidden">
+      <MemberSignature Language="C#" Value="public static void SetPrefersStatusBarHidden (Xamarin.Forms.BindableObject element, Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetPrefersStatusBarHidden(class Xamarin.Forms.BindableObject element, valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetPrefersStatusBarHidden">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt; SetPrefersStatusBarHidden (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt; config, Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Page&gt; SetPrefersStatusBarHidden(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Page&gt; config, valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Page&gt;" RefType="this" />
+        <Parameter Name="value" Type="Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/StatusBarHiddenMode.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/StatusBarHiddenMode.xml
@@ -1,0 +1,59 @@
+<Type Name="StatusBarHiddenMode" FullName="Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode">
+  <TypeSignature Language="C#" Value="public enum StatusBarHiddenMode" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed StatusBarHiddenMode extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Default">
+      <MemberSignature Language="C#" Value="Default" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode Default = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="False">
+      <MemberSignature Language="C#" Value="False" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode False = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="True">
+      <MemberSignature Language="C#" Value="True" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode True = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.StatusBarHiddenMode</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/UIStatusBarAnimation.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/UIStatusBarAnimation.xml
@@ -1,0 +1,59 @@
+<Type Name="UIStatusBarAnimation" FullName="Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation">
+  <TypeSignature Language="C#" Value="public enum UIStatusBarAnimation" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed UIStatusBarAnimation extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Fade">
+      <MemberSignature Language="C#" Value="Fade" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation Fade = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="None">
+      <MemberSignature Language="C#" Value="None" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation None = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Slide">
+      <MemberSignature Language="C#" Value="Slide" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation Slide = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>


### PR DESCRIPTION
### Description of Change

This is a Platform Specific feature which enables setting the visibility of the iOS status bar on a per-view basis. See some examples below:

![output_1iqobs](https://cloud.githubusercontent.com/assets/1251024/19415577/e2ffd8e4-9339-11e6-8361-94686d45edfa.gif)
![output_qnofag](https://cloud.githubusercontent.com/assets/1251024/19415584/024332b4-933a-11e6-9b33-482ccdd87a12.gif)
![output_yi11ig](https://cloud.githubusercontent.com/assets/1251024/19415588/1a03c86e-933a-11e6-8b8d-51663f291dd2.gif)

This is accomplished through the `StatusBarHiddenMode` and `UIStatusBarAnimation` enumerators, which contain the following values:

`StatusBarHiddenMode.Default`
`StatusBarHiddenMode.True`
`StatusBarHiddenMode.False`

`UIStatusBarAnimation.None`
`UIStatusBarAnimation.Fade`
`UIStatusBarAnimation.Slide`

Per [Apple's documentation](https://developer.apple.com/reference/uikit/uiviewcontroller/1621440-prefersstatusbarhidden), since iOS 8 the `prefersStatusBarHidden` method returns true on vertically compact environments. This represents the `StatusBarHiddenMode.Default` value, while the latter two apply the respective values to both the vertical and landscape orientations. This can be set as follows, for example:

`page.On<iOS>().PrefersStatusBarHidden(StatusBarHiddenMode.True)`

As one might guess, the `UIStatusBarAnimation` values represent the three possible manners by which the status bar can enter or leave the view. If a `Fade` or `Slide` value is set, a 0.25 second animation of [setNeedsStatusBarAppearanceUpdate](https://developer.apple.com/reference/uikit/uiviewcontroller/1621354-setneedsstatusbarappearanceupdat) will execute. That can be used like so:

`page.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Fade)`

Starting with the `Page` value on the `Platform` (which has been subsequently marked as internal in order for the `PlatformRenderer` to get at it), [childViewControllerForStatusBarHidden](https://developer.apple.com/reference/uikit/uiviewcontroller/1621451-childviewcontrollerforstatusbarh) is utilized to redirect the views down to `PageRenderer` as a baseline for setting the values on a per-view basis. An exception is that in a `TabbedPage`, setting the `PrefersStatusBarHidden` value directly on that page will update all of its contained pages.

As of this submission, tests can still be added, though they may be somewhat complex due to the need to check the status bar -- screenshots might be preferable.
### Bugs Fixed

This was technically not a bug, per se, but was reported under https://bugzilla.xamarin.com/show_bug.cgi?id=44803.
### API Changes

Added:
- public static readonly BindableProperty PrefersStatusBarHiddenProperty
- public static StatusBarHiddenMode GetPrefersStatusBarHidden(BindableObject element)
- public static void SetPrefersStatusBarHidden(BindableObject element, StatusBarHiddenMode value)
- public static StatusBarHiddenMode PrefersStatusBarHidden(this IPlatformElementConfiguration<iOS, FormsElement> config)
- public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersStatusBarHidden(this IPlatformElementConfiguration<iOS, FormsElement> config, StatusBarHiddenMode value)
- public static readonly BindableProperty PreferredStatusBarUpdateAnimationProperty
- public static UIStatusBarAnimation GetPreferredStatusBarUpdateAnimation(BindableObject element)
- public static void SetPreferredStatusBarUpdateAnimation(BindableObject element, UIStatusBarAnimation value)
- public static UIStatusBarAnimation PreferredStatusBarUpdateAnimation(this IPlatformElementConfiguration<iOS, FormsElement> config)
- public static IPlatformElementConfiguration<iOS, FormsElement> SetPreferredStatusBarUpdateAnimation(this IPlatformElementConfiguration<iOS, FormsElement> config, UIStatusBarAnimation value)

Changed:
- Page page => internal Page Page { get; set; }
### Behavioral Changes

N/A
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
