### PR TITLE
[Core] Added RootPage to NavigationPage

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
@@ -112,15 +112,15 @@ namespace Xamarin.Forms.Core.UnitTests
 			bool fired = false;
 			nav.Pushed += (sender, e) => fired = true;
 
-			Assert.AreEqual(childRoot, nav.RootPage);
-			Assert.AreEqual(childRoot, nav.CurrentPage);
+			Assert.AreSame(childRoot, nav.RootPage);
+			Assert.AreSame(childRoot, nav.CurrentPage);
 
 			await nav.PushAsync (childRoot);
 			
 			Assert.False (fired);
-			Assert.AreEqual(childRoot, nav.RootPage);
-			Assert.AreEqual(childRoot, nav.CurrentPage);
-			Assert.AreEqual(nav.RootPage, nav.CurrentPage);
+			Assert.AreSame(childRoot, nav.RootPage);
+			Assert.AreSame(childRoot, nav.CurrentPage);
+			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
 		[Test]
@@ -205,9 +205,9 @@ namespace Xamarin.Forms.Core.UnitTests
 			nav.PopToRootAsync ();
 
 			Assert.True (signaled);
-			Assert.AreEqual (root, nav.RootPage);
-			Assert.AreEqual(root, nav.CurrentPage);
-			Assert.AreEqual(nav.RootPage, nav.CurrentPage);
+			Assert.AreSame (root, nav.RootPage);
+			Assert.AreSame(root, nav.CurrentPage);
+			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
 		[Test]
@@ -232,9 +232,9 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (2, poppedChildren.Count);
 			Assert.Contains (child1, poppedChildren);
 			Assert.Contains (child2, poppedChildren);
-			Assert.AreEqual(root, nav.RootPage);
-			Assert.AreEqual(root, nav.CurrentPage);
-			Assert.AreEqual(nav.RootPage, nav.CurrentPage);
+			Assert.AreSame(root, nav.RootPage);
+			Assert.AreSame(root, nav.CurrentPage);
+			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			NavigationPage nav = new NavigationPage ();
 
+			Assert.IsNull(nav.RootPage);
 			Assert.IsNull (nav.CurrentPage);
 
 			Label child = new Label {Text = "Label"};
@@ -21,7 +22,9 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			await nav.Navigation.PushAsync (childRoot);
 
-			Assert.AreSame (childRoot, nav.CurrentPage);
+			Assert.AreSame(childRoot, nav.RootPage);
+			Assert.AreSame(childRoot, nav.CurrentPage);
+			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
 		[Test]
@@ -40,16 +43,26 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			bool fired = false;
 			nav.Popped += (sender, e) => fired = true;
+
+			Assert.AreSame(childRoot, nav.RootPage);
+			Assert.AreNotSame(childRoot2, nav.RootPage);
+			Assert.AreNotSame(nav.RootPage, nav.CurrentPage);
+
 			var popped = await nav.Navigation.PopAsync ();
 
 			Assert.True (fired);
-			Assert.AreSame (childRoot, nav.CurrentPage);
+			Assert.AreSame(childRoot, nav.RootPage);
+			Assert.AreSame(childRoot, nav.CurrentPage);
+			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 			Assert.AreEqual (childRoot2, popped);
 
 			await nav.PopAsync ();
 			var last = await nav.Navigation.PopAsync ();
 
 			Assert.IsNull (last);
+			Assert.IsNotNull(nav.RootPage);
+			Assert.IsNotNull(nav.CurrentPage);
+			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
 		[Test]
@@ -57,6 +70,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			NavigationPage nav = new NavigationPage ();
 
+			Assert.IsNull(nav.RootPage);
 			Assert.IsNull (nav.CurrentPage);
 
 			Label child = new Label {Text = "Label"};
@@ -64,7 +78,9 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			await nav.PushAsync (childRoot);
 
-			Assert.AreSame (childRoot, nav.CurrentPage);
+			Assert.AreSame (childRoot, nav.RootPage);
+			Assert.AreSame(childRoot, nav.CurrentPage);
+			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
 		[Test]
@@ -96,10 +112,15 @@ namespace Xamarin.Forms.Core.UnitTests
 			bool fired = false;
 			nav.Pushed += (sender, e) => fired = true;
 
+			Assert.AreEqual(childRoot, nav.RootPage);
+			Assert.AreEqual(childRoot, nav.CurrentPage);
+
 			await nav.PushAsync (childRoot);
 			
 			Assert.False (fired);
-			Assert.AreEqual (childRoot, nav.CurrentPage);
+			Assert.AreEqual(childRoot, nav.RootPage);
+			Assert.AreEqual(childRoot, nav.CurrentPage);
+			Assert.AreEqual(nav.RootPage, nav.CurrentPage);
 		}
 
 		[Test]
@@ -184,7 +205,9 @@ namespace Xamarin.Forms.Core.UnitTests
 			nav.PopToRootAsync ();
 
 			Assert.True (signaled);
-			Assert.AreEqual (root, nav.CurrentPage);
+			Assert.AreEqual (root, nav.RootPage);
+			Assert.AreEqual(root, nav.CurrentPage);
+			Assert.AreEqual(nav.RootPage, nav.CurrentPage);
 		}
 
 		[Test]
@@ -209,7 +232,9 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (2, poppedChildren.Count);
 			Assert.Contains (child1, poppedChildren);
 			Assert.Contains (child2, poppedChildren);
-			Assert.AreEqual (root, nav.CurrentPage);
+			Assert.AreEqual(root, nav.RootPage);
+			Assert.AreEqual(root, nav.CurrentPage);
+			Assert.AreEqual(nav.RootPage, nav.CurrentPage);
 		}
 
 		[Test]
@@ -456,6 +481,72 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var result = navPage.SendBackButtonPressed ();
 			Assert.False (result);
+		}
+
+		[Test]
+		public void TestInsertPage()
+		{
+			var root = new ContentPage { Title = "Root" };
+			var newPage = new ContentPage();
+			var navPage = new NavigationPage(root);
+
+			navPage.Navigation.InsertPageBefore(newPage, navPage.RootPage);
+
+			Assert.AreSame(newPage, navPage.RootPage);
+			Assert.AreNotSame(newPage, navPage.CurrentPage);
+			Assert.AreNotSame(navPage.RootPage, navPage.CurrentPage);
+			Assert.AreSame(root, navPage.CurrentPage);
+
+			Assert.Throws<ArgumentException>(() =>
+			{
+				navPage.Navigation.InsertPageBefore(new ContentPage(), new ContentPage());
+			});
+
+			Assert.Throws<ArgumentException>(() =>
+			{
+				navPage.Navigation.InsertPageBefore(navPage.RootPage, navPage.CurrentPage);
+			});
+
+			Assert.Throws<ArgumentException>(() =>
+			{
+				navPage.Navigation.InsertPageBefore(null, navPage.CurrentPage);
+			});
+
+			Assert.Throws<ArgumentException>(() =>
+			{
+				navPage.Navigation.InsertPageBefore(new ContentPage(), null);
+			});
+		}
+
+		[Test]
+		public async void TestRemovePage()
+		{
+			var root = new ContentPage { Title = "Root" };
+			var newPage = new ContentPage();
+			var navPage = new NavigationPage(root);
+			await navPage.PushAsync(newPage);
+
+			navPage.Navigation.RemovePage(root);
+
+			Assert.AreSame(newPage, navPage.RootPage);
+			Assert.AreSame(newPage, navPage.CurrentPage);
+			Assert.AreSame(navPage.RootPage, navPage.CurrentPage);
+			Assert.AreNotSame(root, navPage.CurrentPage);
+
+			Assert.Throws<ArgumentException>(() =>
+			{
+				navPage.Navigation.RemovePage(root);
+			});
+
+			Assert.Throws<InvalidOperationException>(() =>
+			{
+				navPage.Navigation.RemovePage(newPage);
+			});
+
+			Assert.Throws<ArgumentException>(() =>
+			{
+				navPage.Navigation.RemovePage(null);
+			});
 		}
 
 		[Test (Description = "CurrentPage should not be set to null when you attempt to pop the last page")]

--- a/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
@@ -507,12 +507,12 @@ namespace Xamarin.Forms.Core.UnitTests
 				navPage.Navigation.InsertPageBefore(navPage.RootPage, navPage.CurrentPage);
 			});
 
-			Assert.Throws<ArgumentException>(() =>
+			Assert.Throws<ArgumentNullException>(() =>
 			{
 				navPage.Navigation.InsertPageBefore(null, navPage.CurrentPage);
 			});
 
-			Assert.Throws<ArgumentException>(() =>
+			Assert.Throws<ArgumentNullException>(() =>
 			{
 				navPage.Navigation.InsertPageBefore(new ContentPage(), null);
 			});
@@ -543,7 +543,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				navPage.Navigation.RemovePage(newPage);
 			});
 
-			Assert.Throws<ArgumentException>(() =>
+			Assert.Throws<ArgumentNullException>(() =>
 			{
 				navPage.Navigation.RemovePage(null);
 			});

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -314,10 +314,10 @@ namespace Xamarin.Forms
 		void InsertPageBefore(Page page, Page before)
 		{
 			if (page == null || before == null)
-				throw new ArgumentException($"Both {nameof(page)} and {nameof(before)} must be initialized.");
+				throw new ArgumentNullException($"Neither {nameof(page)} nor {nameof(before)} can be null.");
 
 			if (!PageController.InternalChildren.Contains(before))
-				throw new ArgumentException("before must be a child of the NavigationPage", "before");
+				throw new ArgumentException($"{nameof(before)} must be a child of the NavigationPage", nameof(before));
 
 			if (PageController.InternalChildren.Contains(page))
 				throw new ArgumentException("Cannot insert page which is already in the navigation stack");
@@ -396,7 +396,7 @@ namespace Xamarin.Forms
 		void RemovePage(Page page)
 		{
 			if (page == null)
-				throw new ArgumentException($"{nameof(page)} must be initialized.");
+				throw new ArgumentNullException($"{nameof(page)} cannot be null.");
 
 			if (page == CurrentPage && CurrentPage == RootPage)
 				throw new InvalidOperationException("Cannot remove root page when it is also the currently displayed page.");

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -313,8 +313,11 @@ namespace Xamarin.Forms
 
 		void InsertPageBefore(Page page, Page before)
 		{
-			if (page == null || before == null)
-				throw new ArgumentNullException($"Neither {nameof(page)} nor {nameof(before)} can be null.");
+			if (page == null)
+				throw new ArgumentNullException($"{nameof(page)} cannot be null.");
+
+			if (before == null)
+				throw new ArgumentNullException($"{nameof(before)} cannot be null.");
 
 			if (!PageController.InternalChildren.Contains(before))
 				throw new ArgumentException($"{nameof(before)} must be a child of the NavigationPage", nameof(before));
@@ -341,8 +344,8 @@ namespace Xamarin.Forms
 			if (((INavigationPageController)this).StackDepth == 1)
 				return;
 
-			var childrenToRemove = PageController.InternalChildren.ToArray().Where(c => c != RootPage);
-			foreach (var child in childrenToRemove)
+			Element[] childrenToRemove = PageController.InternalChildren.Skip(1).ToArray();
+			foreach (Element child in childrenToRemove)
 				PageController.InternalChildren.Remove(child);
 
 			CurrentPage = RootPage;
@@ -379,8 +382,7 @@ namespace Xamarin.Forms
 					await args.Task;
 			}
 
-			if (Pushed != null)
-				Pushed(this, args);
+			Pushed?.Invoke(this, args);
 		}
 
 		void PushPage(Page page)
@@ -411,8 +413,7 @@ namespace Xamarin.Forms
 				throw new ArgumentException("Page to remove must be contained on this Navigation Page");
 
 			EventHandler<NavigationRequestedEventArgs> handler = RemovePageRequestedInternal;
-			if (handler != null)
-				handler(this, new NavigationRequestedEventArgs(page, true));
+			handler?.Invoke(this, new NavigationRequestedEventArgs(page, true));
 
 			PageController.InternalChildren.Remove(page);
 			if (RootPage == page)

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -92,10 +92,7 @@ namespace Xamarin.Forms
 		public Page CurrentPage
 		{
 			get { return (Page)GetValue(CurrentPageProperty); }
-			private set
-			{
-				SetValue(CurrentPagePropertyKey, value);
-			}
+			private set { SetValue(CurrentPagePropertyKey, value); }
 		}
 
 		public Page RootPage

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/NavigationPage.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/NavigationPage.xml
@@ -226,6 +226,42 @@
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="RootPage">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Page RootPage { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.Page RootPage" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Page</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>
+          The <see cref="T:Xamarin.Forms.Page" /> that is the root of the navigation stack.
+        </summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RootPageProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty RootPageProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty RootPageProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>
+          Identifies the <see cref="P:Xamarin.Forms.NavigationPage.RootPage" /> property.
+        </summary>
+        <remarks>
+        </remarks>
+      </Docs>
+    </Member>
     <Member MemberName="GetBackButtonTitle">
       <MemberSignature Language="C#" Value="public static string GetBackButtonTitle (Xamarin.Forms.BindableObject page);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig string GetBackButtonTitle(class Xamarin.Forms.BindableObject page) cil managed" />


### PR DESCRIPTION
### Description of Change

`NavigationPage` has `CurrentPage` which points to the tail of the stack, but it lacks a pointer to the head. `RootPage` (a read-only property) should be used to get access to the first element of the stack. This makes it easier to look up the root and change it if needed via `InsertPageBefore()`

When changing root, I should be able to do something like:

```
np.InsertPageBefore(newPage, np.RootPage);
await np.PopToRootAsync();
```

Removing root should be even easier:

`np.RemovePage(np.RootPage);`

Also edited & added unit tests.
### API Changes

Added:
- static readonly BindablePropertyKey RootPagePropertyKey
- public static readonly BindableProperty RootPageProperty
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
