### PR TITLE
[Android] SoftInputMode works with initial value

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -126,6 +126,8 @@ namespace Xamarin.Forms.Platform.Android
 			(application as IApplicationController)?.SetAppIndexingProvider(new AndroidAppIndexProvider(this));
 			Xamarin.Forms.Application.Current = application;
 
+			SetSoftInputMode();
+
 			CheckForAppLink(Intent);
 
 			application.PropertyChanged += AppOnPropertyChanged;
@@ -166,8 +168,6 @@ namespace Xamarin.Forms.Platform.Android
 				bar = new AToolbar(this);
 
 			SetSupportActionBar(bar);
-
-			SetSoftInputMode();
 
 			_layout = new ARelativeLayout(BaseContext);
 			SetContentView(_layout);

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -106,6 +106,8 @@ namespace Xamarin.Forms.Platform.Android
 			_application = application;
 			Xamarin.Forms.Application.Current = application;
 
+			SetSoftInputMode();
+
 			application.PropertyChanged += AppOnPropertyChanged;
 
 			SetMainPage();
@@ -126,8 +128,6 @@ namespace Xamarin.Forms.Platform.Android
 			Window.RequestFeature(WindowFeatures.IndeterminateProgress);
 
 			base.OnCreate(savedInstanceState);
-
-			SetSoftInputMode();
 
 			_layout = new LinearLayout(BaseContext);
 			SetContentView(_layout);


### PR DESCRIPTION
### Description of Change ###

Can now use the Android Platform Specific `WindowSoftInputModeAdjust` in XAML and in constructor.

### Bugs Fixed ###

- n/a, reported internally

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

