### PR TITLE
[Windows] Fix Transparent Default Button

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/FormsButton.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsButton.cs
@@ -74,7 +74,9 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void UpdateBackgroundColor()
 		{
-			Background = Color.Transparent.ToBrush();
+			if (BackgroundColor == null)
+				BackgroundColor = Background;
+
 #if WINDOWS_UWP
 			if (_contentPresenter != null)
 				_contentPresenter.Background = BackgroundColor;
@@ -82,6 +84,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (_border != null)
 				_border.Background = BackgroundColor;
 #endif
+			Background = Color.Transparent.ToBrush();
 		}
 
 		void UpdateBorderRadius()


### PR DESCRIPTION
### Description of Change

This fixes two issues introduced in #31:
1. The default background for a button is transparent
2. Background color set in a static resource style is ignored

When a FormsButton is first loaded, `BackgroundColor` will be null if the user did not set a color. In this case we will use the native control's `Background` instead as it will either be the default theme color or one from a style.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=42100
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
