### PR TITLE
[iOS] Add platform-specific methods to customize tab bar

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabBarItem.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabBarItem.cs
@@ -1,0 +1,19 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	public class TabBarItem
+	{
+		public FileImageSource SelectedImage { get; set; }
+
+		public bool ShouldRemoveImageTint { get; set; }
+		public bool ShouldRemoveSelectedImageTint { get; set; }
+
+		public Color TitleTextColor { get; set; }
+		public Color SelectedTitleTextColor { get; set; }
+
+		public string BadgeValue { get; set; }
+		public Color BadgeColor { get; set; } = Color.Red;
+
+		public Color BadgeTextColor { get; set; } = Color.White;
+		public Color SelectedBadgeTextColor { get; set; } = Color.White;
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.TabbedPage;
+
+	public static class TabbedPage
+	{
+		public static readonly BindableProperty TabBarItemsProperty = BindableProperty.Create(nameof(TabBarItems), typeof(Dictionary<int, TabBarItem>), typeof(TabbedPage));
+
+		public static Dictionary<int, TabBarItem> GetTabBarItems(BindableObject element)
+		{
+			return (Dictionary<int, TabBarItem>)element.GetValue(TabBarItemsProperty);
+		}
+
+		public static void SetTabBarItems(BindableObject element, Dictionary<int, TabBarItem> value)
+		{
+			element.SetValue(TabBarItemsProperty, value);
+		}
+
+		public static Dictionary<int, TabBarItem> TabBarItems(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetTabBarItems(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetTabBarItems(this IPlatformElementConfiguration<iOS, FormsElement> config, Dictionary<int, TabBarItem> value)
+		{
+			SetTabBarItems(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -92,6 +92,8 @@
     <Compile Include="PlatformConfiguration\ExtensionPoints.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\NavigationPage.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\TabBarItem.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\TabbedPage.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\VisualElement.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\MasterDetailPage.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\CollapseStyle.cs" />

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -30,6 +30,8 @@ namespace Xamarin.Forms
 
 		static bool? s_isiOS9OrNewer;
 
+		static bool? s_isiOs10OrNewer;
+
 		static Forms()
 		{
 			if (nevertrue)
@@ -65,6 +67,16 @@ namespace Xamarin.Forms
 				if (!s_isiOS9OrNewer.HasValue)
 					s_isiOS9OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(9, 0);
 				return s_isiOS9OrNewer.Value;
+			}
+		}
+
+		internal static bool IsiOS10OrNewer
+		{
+			get
+			{
+				if (!s_isiOs10OrNewer.HasValue)
+					s_isiOs10OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(10, 0);
+				return s_isiOs10OrNewer.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -400,20 +400,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 			foreach (KeyValuePair<int, TabBarItem> keyValuePair in tabBarItems)
 			{
-				if(Forms.IsiOS10OrNewer)
-					TabBar.Items[keyValuePair.Key].BadgeColor = keyValuePair.Value.BadgeColor.ToUIColor();
-
-				TabBar.Items[keyValuePair.Key].BadgeValue = keyValuePair.Value.BadgeValue;
-
-				if (keyValuePair.Value.ShouldRemoveImageTint)
+				if (Forms.IsiOS8OrNewer)
 				{
-					if (TabBar.Items[keyValuePair.Key].Image != null)
-						TabBar.Items[keyValuePair.Key].Image = TabBar.Items[keyValuePair.Key].Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
-				}
-				else
-				{
-					if (TabBar.Items[keyValuePair.Key].Image != null)
-						TabBar.Items[keyValuePair.Key].Image = TabBar.Items[keyValuePair.Key].Image.ImageWithRenderingMode(UIImageRenderingMode.Automatic);
+					TabBar.Items[keyValuePair.Key].BadgeValue = keyValuePair.Value.BadgeValue;
+
+					if (keyValuePair.Value.ShouldRemoveImageTint)
+					{
+						if (TabBar.Items[keyValuePair.Key].Image != null)
+							TabBar.Items[keyValuePair.Key].Image = TabBar.Items[keyValuePair.Key].Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+					}
+					else
+					{
+						if (TabBar.Items[keyValuePair.Key].Image != null)
+							TabBar.Items[keyValuePair.Key].Image = TabBar.Items[keyValuePair.Key].Image.ImageWithRenderingMode(UIImageRenderingMode.Automatic);
+					}
 				}
 
 				TabBar.Items[keyValuePair.Key].SelectedImage = keyValuePair.Value.SelectedImage != null ? new UIImage(keyValuePair.Value.SelectedImage) : null;
@@ -430,15 +430,20 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 
 				UIColor titleTextColor = keyValuePair.Value.TitleTextColor == Color.Default ? null : keyValuePair.Value.TitleTextColor.ToUIColor();
-				UIColor selectedTitleTextColor = keyValuePair.Value.SelectedTitleTextColor == Color.Default ? null : keyValuePair.Value.SelectedTitleTextColor.ToUIColor();
+				UIColor selectedTitleTextColor = keyValuePair.Value.SelectedTitleTextColor == Color.Default ? TabBar.TintColor : keyValuePair.Value.SelectedTitleTextColor.ToUIColor();
 				UIColor badgeTextColor = keyValuePair.Value.BadgeTextColor == Color.Default ? null : keyValuePair.Value.BadgeTextColor.ToUIColor();
 				UIColor selectedBadgeTextColor = keyValuePair.Value.SelectedBadgeTextColor == Color.Default ? null : keyValuePair.Value.SelectedBadgeTextColor.ToUIColor();
 
 				TabBar.Items[keyValuePair.Key].SetTitleTextAttributes(new UITextAttributes {TextColor = titleTextColor }, UIControlState.Normal);
 				TabBar.Items[keyValuePair.Key].SetTitleTextAttributes(new UITextAttributes { TextColor = selectedTitleTextColor }, UIControlState.Selected);
 
-				TabBar.Items[keyValuePair.Key].SetBadgeTextAttributes(new UIStringAttributes { ForegroundColor = badgeTextColor }, UIControlState.Normal);
-				TabBar.Items[keyValuePair.Key].SetBadgeTextAttributes(new UIStringAttributes { ForegroundColor = selectedBadgeTextColor }, UIControlState.Selected);
+				if (Forms.IsiOS10OrNewer)
+				{
+					TabBar.Items[keyValuePair.Key].BadgeColor = keyValuePair.Value.BadgeColor.ToUIColor();
+
+					TabBar.Items[keyValuePair.Key].SetBadgeTextAttributes(new UIStringAttributes { ForegroundColor = badgeTextColor }, UIControlState.Normal);
+					TabBar.Items[keyValuePair.Key].SetBadgeTextAttributes(new UIStringAttributes { ForegroundColor = selectedBadgeTextColor }, UIControlState.Selected);
+				}
 			}
 		}
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/TabbedPage.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/TabbedPage.xml
@@ -1,0 +1,116 @@
+﻿<Type Name="TabbedPage" FullName="Xamarin.Forms.PlatformConfiguration.iOSSpecific.TabbedPage">
+  <TypeSignature Language="C#" Value="public static class TabbedPage" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit TabbedPage extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetTabBarItems">
+      <MemberSignature Language="C#" Value="public static Dictionary&#60;int, TabBarItem&#62; GetTabBarItems (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig Dictionary&#60;int, TabBarItem&#62; GetTabBarItems(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.Dictionary</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TabBarItems">
+      <MemberSignature Language="C#" Value="public static Dictionary&#60;int, TabBarItem&#62; TabBarItems (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TabbedPage&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig Dictionary&#60;int, TabBarItem&#62; TabBarItems(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.Dictionary</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TabBarItemsProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty TabBarItemsProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty TabBarItemsProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetTabBarItems">
+      <MemberSignature Language="C#" Value="public static void SetTabBarItems (Xamarin.Forms.BindableObject element, Dictionary&#60;int, TabBarItem&#62; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetTabBarItems(class Xamarin.Forms.BindableObject element, Dictionary&#60;int, TabBarItem&#62; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Collections.Generic.Dictionary" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetTabBarItems">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TabbedPage&gt; SetTabBarItems (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TabbedPage&gt; config, Dictionary&#60;int, TabBarItem&#62; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TabbedPage&gt; SetTabBarItems(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TabbedPage&gt; config, Dictionary&#60;int, TabBarItem&#62; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TabbedPage&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Collections.Generic.Dictionary" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>


### PR DESCRIPTION
### Description of Change

This PR creates a platform-specific option to customize many things in the tab bar such as creating badges and selected image icons. More specifically, it lets you use a `TabBarItem` to do the following:

~~`Image`: Did not want to add this one since page icon controls this.~~
`ShouldRemoveImageTint`: remove tinting applied by iOS to each tab

`SelectedImage`: icon to show when a tab is selected
`ShouldRemoveSelectedImageTint`: remove tinting applied by iOS when a tab is selected

`TitleTextColor`: text color when a tab is NOT selected.
`SelectedTitleTextColor`: text color when a tab is selected. This is similar to `TabbedPage.BarTextColor`. The latter sets selected title text color for all items. When this is null, selected text color will default to bar text color.

`BadgeValue`: string to set the number of notification-like items.
`BadgeColor`: background color of each badge

`BadgeTextColor`: Foreground color of each badge text
`SelectedBadgeTextColor`: selected foreground color of each badge text

Here's a demo: https://1drv.ms/v/s!AjlbPgOcTyP2bfs-sK3RHy2ISsY
### API Changes

Added:
- public static readonly BindableProperty TabBarItemsProperty
- public static Dictionary<int, TabBarItem> GetTabBarItems(BindableObject element)
- public static void SetTabBarItems(BindableObject element, Dictionary<int, TabBarItem> value)
- public static Dictionary<int, TabBarItem> TabBarItems(this IPlatformElementConfiguration<iOS, FormsElement> config)
- public static IPlatformElementConfiguration<iOS, FormsElement> SetTabBarItems(this IPlatformElementConfiguration<iOS, FormsElement> config, Dictionary<int, TabBarItem> value)
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
