### PR TITLE
BindingContext changes are called multiple times on app start

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -98,6 +98,10 @@ namespace Xamarin.Forms
 				return;
 
 			object oldContext = bindable._inheritedContext;
+
+			if (ReferenceEquals(oldContext, value))
+				return;
+
 			if (bpContext != null && oldContext == null)
 				oldContext = bpContext.Value;
 
@@ -108,9 +112,6 @@ namespace Xamarin.Forms
 			}
 			else
 			{
-				if (ReferenceEquals(oldContext, value))
-					return;
-
 				bindable._inheritedContext = value;
 			}
 

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -343,11 +343,14 @@ namespace Xamarin.Forms
 
 		protected virtual void OnChildAdded(Element child)
 		{
+			var bindingContext = child.BindingContext;
+
 			child.Parent = this;
 			if (Platform != null)
 				child.Platform = Platform;
 
-			child.ApplyBindings();
+			if(bindingContext == child.BindingContext)
+				child.ApplyBindings();
 
 			if (ChildAdded != null)
 				ChildAdded(this, new ElementEventArgs(child));

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -343,14 +343,11 @@ namespace Xamarin.Forms
 
 		protected virtual void OnChildAdded(Element child)
 		{
-			var bindingContext = child.BindingContext;
-
 			child.Parent = this;
 			if (Platform != null)
 				child.Platform = Platform;
 
-			if(bindingContext == child.BindingContext)
-				child.ApplyBindings();
+			child.ApplyBindings();
 
 			if (ChildAdded != null)
 				ChildAdded(this, new ElementEventArgs(child));


### PR DESCRIPTION
### Description of Change

If you put a view model locator as an App resource and set your binding context in MainPage, the locator gets called multiple times. This happens first when XAML for the main page is being loaded and then when the page is being parented by App.

This PR ensures that binding context changes are not made if the inherited context is the same as the value passed to `SetInheritedBindingContext()`
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=45557
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
