### PR TITLE
[Android] Forward ScrollView touch events to custom renderers

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Platform.Android
 		public override bool OnTouchEvent(MotionEvent ev)
 		{
 			// If the touch is caught by the horizontal scrollview, forward it to the parent so custom renderers can be notified of the touch.
-			var verticalScrollViewerRenderer = (global::Android.Widget.ScrollView)Parent as ScrollViewRenderer;
+			var verticalScrollViewerRenderer = Parent as ScrollViewRenderer;
 			if (verticalScrollViewerRenderer != null)
 			{
 				verticalScrollViewerRenderer.ShouldSkipOnTouch = true;

--- a/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
@@ -31,6 +31,14 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override bool OnTouchEvent(MotionEvent ev)
 		{
+			// If the touch is caught by the horizontal scrollview, forward it to the parent so custom renderers can be notified of the touch.
+			var verticalScrollViewerRenderer = (global::Android.Widget.ScrollView)Parent as ScrollViewRenderer;
+			if (verticalScrollViewerRenderer != null)
+			{
+				verticalScrollViewerRenderer.ShouldSkipOnTouch = true;
+				verticalScrollViewerRenderer.OnTouchEvent(ev);
+			}
+
 			// The nested ScrollViews will allow us to scroll EITHER vertically OR horizontally in a single gesture.
 			// This will allow us to also scroll diagonally.
 			// We'll fall through to the base event so we still get the fling from the ScrollViews.
@@ -49,6 +57,7 @@ namespace Xamarin.Forms.Platform.Android
 					ScrollBy((int)dX, 0);
 				}
 			}
+
 			return base.OnTouchEvent(ev);
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.Android
 		ScrollViewContainer _container;
 		HorizontalScrollView _hScrollView;
 		bool _isAttached;
-
+		internal bool ShouldSkipOnTouch;
 		bool _isBidirectional;
 		ScrollView _view;
 
@@ -118,6 +118,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override bool OnTouchEvent(MotionEvent ev)
 		{
+			if (ShouldSkipOnTouch)
+			{
+				ShouldSkipOnTouch = false;
+				return false;
+			}
+
 			// The nested ScrollViews will allow us to scroll EITHER vertically OR horizontally in a single gesture.
 			// This will allow us to also scroll diagonally.
 			// We'll fall through to the base event so we still get the fling from the ScrollViews.


### PR DESCRIPTION
### Description of Change

Android `ScrollViewer` is not forwarding touch events when they are caught by the nested horizontal scroll viewer. This PR will ask the nested item to forward its touch capture to the parent and ask it not to process the touch again. So, the touch bubbles up to the custom renderer and when it's back in the vertical scroll viewer, it won't go any further.

Just to add more, if scroll view orientation is vertical, touch events will be caught by the vertical (parent) scroll view. If horizontal, they will be forwarded. If bidirectional, depending on who captures the event, it will either be processed by the parent or forwarded to the parent.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=42883
### API Changes

Added:
- internal bool ShouldSkipOnTouch;
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
