### PR TITLE
[A] Check for parent NavigationPage when setting MDP detail's TopPadding

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44476.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44476.cs
@@ -1,0 +1,56 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44476, "[Android] Unwanted margin at top of details page when nested in a NavigationPage")]
+	public class Bugzilla44476 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			BackgroundColor = Color.Maroon;
+			
+			PushAsync(new MasterDetailPage
+			{
+				Title = "Bugzilla Issue 44476",
+				Master = new ContentPage
+				{
+					Title = "Master",
+					Content = new StackLayout
+					{
+						Children =
+						{
+							new Label { Text = "Master" }
+						}
+					}
+				},
+				Detail = new ContentPage
+				{
+					Title = "Detail",
+					Content = new StackLayout
+					{
+						VerticalOptions = LayoutOptions.FillAndExpand,
+						Children =
+						{
+							new Label { Text = "Detail Page" },
+							new StackLayout
+							{
+								VerticalOptions = LayoutOptions.EndAndExpand,
+								Children =
+								{
+									new Label { Text = "This should be visible." }
+								}
+							}
+						}
+					}
+				},
+			});
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -137,6 +137,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					_detailLayout = new MasterDetailContainer(newElement, false, Context)
 					{
-						TopPadding = statusBarHeight,
+						TopPadding = HasAncestorNavigationPage(Element) ? 0 : statusBarHeight,
 						LayoutParameters = new LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent)
 					};
 
@@ -262,6 +262,16 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		}
 
 		event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+
+		bool HasAncestorNavigationPage(Element element)
+		{
+			if (element.Parent == null)
+				return false;
+			else if (element.Parent is NavigationPage)
+				return true;
+			else
+				return HasAncestorNavigationPage(element.Parent);
+		}
 
 		void HandleMasterPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{


### PR DESCRIPTION
### Description of Change

Additional top padding was being added onto a MasterDetailPage's detail when inside of a NavigationPage in AppCompat, presumably from the calculations that the NavigationPage itself was already doing. This additional status bar height being set as padding can be avoided by checking to see if the parent is a NavigationPage or not.

Gallery reproduction added, although it's a visual issue.
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=44476
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
