### PR TITLE
[iOS] Use ViewWillAppear for Page.Appearing.

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -66,9 +66,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public UIViewController ViewController => _disposed ? null : this;
 
-		public override void ViewDidAppear(bool animated)
+		public override void ViewWillAppear(bool animated)
 		{
-			base.ViewDidAppear(animated);
+			base.ViewWillAppear(animated);
 
 			if (_appeared || _disposed)
 				return;


### PR DESCRIPTION
### Description of Change

Instead of using `ViewDidAppear` to trigger the `Page.Appearing` event, use `ViewWillAppear`.

**I am opening this early for discussion. The implementation is the simplest thing that worked for me and that gets the point across. I'm aware there may be a need to improve things, adjust tests, and use the same technique elsewhere (not just for pages).**
### Bugs Fixed

I do not know of any official bug reports. However, for me this fixes the problem of getting a `Page` set up _before_ it appears on the screen rather than after.
### API Changes

None
### Behavioral Changes

Hooking into `Page.Appearing` on iOS will now result in the event being raised just _before_ the page becomes visible rather than just after. This is intuitively what one would expect given the name of the event.
### PR Checklist
- [ ] Come to an agreement on the proposed behavioral change
- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
