### PR TITLE
[iOS] Allow deselection of rows in multi selection mode with editing turned on

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Platform.iOS.Resources;
@@ -656,9 +657,20 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 
 				var table = (UITableView)recognizer.View;
-				if (!selector._lastPath.Equals(table.IndexPathForSelectedRow))
+
+				if (table.IndexPathsForSelectedRows != null && table.IndexPathsForSelectedRows.Contains(selector._lastPath))
+				{
+					if (!table.AllowsMultipleSelectionDuringEditing || !table.Editing)
+						return;
+
+					table.DeselectRow(selector._lastPath, false);
+					table.Source.RowDeselected(table, selector._lastPath);
+				}
+				else
+				{
 					table.SelectRow(selector._lastPath, false, UITableViewScrollPosition.None);
-				table.Source.RowSelected(table, selector._lastPath);
+					table.Source.RowSelected(table, selector._lastPath);
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -658,16 +658,19 @@ namespace Xamarin.Forms.Platform.iOS
 				var table = (UITableView)recognizer.View;
 				var isRowSelected = false;
 
-				foreach(var indexPath in table.IndexPathsForSelectedRows)
+				if (table.IndexPathsForSelectedRows != null)
 				{
-					if(indexPath == selector._lastPath)
+					foreach (NSIndexPath indexPath in table.IndexPathsForSelectedRows)
 					{
+						if (indexPath != selector._lastPath)
+							continue;
+
 						isRowSelected = true;
 						break;
 					}
 				}
 
-				if (table.IndexPathsForSelectedRows != null && isRowSelected)
+				if (isRowSelected)
 				{
 					if (!table.AllowsMultipleSelectionDuringEditing || !table.Editing)
 						return;

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Linq;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Platform.iOS.Resources;
@@ -657,8 +656,18 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 
 				var table = (UITableView)recognizer.View;
+				var isRowSelected = false;
 
-				if (table.IndexPathsForSelectedRows != null && table.IndexPathsForSelectedRows.Contains(selector._lastPath))
+				foreach(var indexPath in table.IndexPathsForSelectedRows)
+				{
+					if(indexPath == selector._lastPath)
+					{
+						isRowSelected = true;
+						break;
+					}
+				}
+
+				if (table.IndexPathsForSelectedRows != null && isRowSelected)
 				{
 					if (!table.AllowsMultipleSelectionDuringEditing || !table.Editing)
 						return;


### PR DESCRIPTION
### Description of Change

iOS `ListView` does not let you deselect rows in `RecycleElement` mode when multi selection is enabled with editing turned on. This PR will let you select/deselect any row.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=41069
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
