### PR TITLE
Remove unnecessary string replace in Color.FromHex

### DIFF
--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -311,7 +311,7 @@ namespace Xamarin.Forms
 					hex = string.Format("ff{0}", hex);
 					break;
 			}
-			return FromUint(Convert.ToUInt32(hex.Replace("#", ""), 16));
+			return FromUint(Convert.ToUInt32(hex, 16));
 		}
 
 		public static Color FromUint(uint argb)


### PR DESCRIPTION
### Description of Change ###

Remove duplicate string replace call to replace the '#' a second time in Color.FromHex(). 

### Bugs Fixed ###

none

### API Changes ###

none

### Behavioral Changes ###

none

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
