### PR TITLE
[iOS] Do not update Picker SelectedIndex as picker view is scrolling

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -177,7 +177,6 @@ namespace Xamarin.Forms.Platform.iOS
 					SelectedItem = _renderer.Element.Items[(int)row];
 					SelectedIndex = (int)row;
 				}
-				_renderer.UpdatePickerFromModel(this);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change

iOS `Picker` is updating selected index while picker view is scrolling instead of updating it once when the `Done` button is hit. This is how Android is working right now with the OK/Cancel buttons. In the bug description, it's mentioned that this is regression.

Of course, it could also be converted to a platform-specific option, but I wanted to get your opinion before going that route. For consistency reasons and if this is indeed a regression, I prefer Android's approach.

To expand further, I don't think it makes sense to keep firing an event while scrolling. This is potentially heavy on the UI thread. In many cases, I don't think people would be interested in keeping tally of the changes. If this kind of behavior is needed, we could add a platform-specific property, but the default behavior should match Android.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=38204
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
