### PR TITLE
[Windows] Setting ActivityIndicator.Color works now on W8.1

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ActivityIndicatorRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Windows.UI.Xaml;
 
 #if WINDOWS_UWP
@@ -11,6 +12,9 @@ namespace Xamarin.Forms.Platform.WinRT
 {
 	public class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, Windows.UI.Xaml.Controls.ProgressBar>
 	{
+#if !WINDOWS_UWP
+		Windows.UI.Xaml.Media.SolidColorBrush _resourceBrush;
+#endif
 		object _foregroundDefault;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<ActivityIndicator> e)
@@ -43,20 +47,34 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnControlLoaded(object sender, RoutedEventArgs routedEventArgs)
 		{
+#if !WINDOWS_UWP
+			_resourceBrush = (Control.Resources["ProgressBarIndeterminateForegroundThemeBrush"] as Windows.UI.Xaml.Media.SolidColorBrush);
+			_foregroundDefault = _resourceBrush.Color;
+#else
 			_foregroundDefault = Control.GetForegroundCache();
+#endif
 			UpdateColor();
 		}
 
 		void UpdateColor()
 		{
 			Color color = Element.Color;
+
 			if (color.IsDefault)
 			{
+#if !WINDOWS_UWP
+				_resourceBrush.Color = (Windows.UI.Color) _foregroundDefault;
+#else
 				Control.RestoreForegroundCache(_foregroundDefault);
+#endif
 			}
 			else
 			{
+#if !WINDOWS_UWP
+				_resourceBrush.Color = color.ToWindowsColor();
+#else
 				Control.Foreground = color.ToBrush();
+#endif
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

It turns out that setting the `Foreground` of an indeterminate ProgressBar on Windows 8.1 simply does not work: https://social.msdn.microsoft.com/Forums/windowsapps/en-US/957b333f-035f-448e-9f4a-213d1290ee51/indeterminate-progressbar-foreground-dosent-work?forum=winappswithcsharp

You have to override the control's ProgressBarIndeterminateForegroundThemeBrush brush resource instead. Fortunately this can be done programmatically so users can dynamically change the color.
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=45725
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
