### PR TITLE
[Android] Show keyboard on app resume if control has focus

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
@@ -50,26 +50,26 @@
 			return config;
 		}
 
-		public static readonly BindableProperty CanShowKeyboardOnResumeProperty = BindableProperty.Create(nameof(CanShowKeyboardOnResume), typeof(bool), typeof(Application), false);
+		public static readonly BindableProperty ShouldPreserveKeyboardOnResumeProperty = BindableProperty.Create(nameof(ShouldPreserveKeyboardOnResume), typeof(bool), typeof(Application), false);
 
-		public static bool GetCanShowKeyboardOnResume(BindableObject element)
+		public static bool GetShouldPreserveKeyboardOnResume(BindableObject element)
 		{
-			return (bool)element.GetValue(CanShowKeyboardOnResumeProperty);
+			return (bool)element.GetValue(ShouldPreserveKeyboardOnResumeProperty);
 		}
 
-		public static void SetCanShowKeyboardOnResume(BindableObject element, bool value)
+		public static void SetShouldPreserveKeyboardOnResume(BindableObject element, bool value)
 		{
-			element.SetValue(CanShowKeyboardOnResumeProperty, value);
+			element.SetValue(ShouldPreserveKeyboardOnResumeProperty, value);
 		}
 
-		public static bool GetCanShowKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config)
+		public static bool GetShouldPreserveKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
-			return GetCanShowKeyboardOnResume(config.Element);
+			return GetShouldPreserveKeyboardOnResume(config.Element);
 		}
 
-		public static IPlatformElementConfiguration<Android, FormsElement> CanShowKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
+		public static IPlatformElementConfiguration<Android, FormsElement> ShouldPreserveKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
-			SetCanShowKeyboardOnResume(config.Element, value);
+			SetShouldPreserveKeyboardOnResume(config.Element, value);
 			return config;
 		}
 	}

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
@@ -4,9 +4,7 @@
 
 	public static class Application
 	{
-		public static readonly BindableProperty SendDisappearingEventOnPauseProperty =
-			BindableProperty.Create("SendDisappearingEventOnPause", typeof(bool),
-			typeof(Application), true);
+		public static readonly BindableProperty SendDisappearingEventOnPauseProperty = BindableProperty.Create(nameof(SendDisappearingEventOnPause), typeof(bool), typeof(Application), true);
 
 		public static bool GetSendDisappearingEventOnPause(BindableObject element)
 		{
@@ -29,9 +27,7 @@
 			return config;
 		}
 
-		public static readonly BindableProperty SendAppearingEventOnResumeProperty =
-			BindableProperty.Create("SendAppearingEventOnResume", typeof(bool),
-			typeof(Application), true);
+		public static readonly BindableProperty SendAppearingEventOnResumeProperty = BindableProperty.Create(nameof(SendAppearingEventOnResume), typeof(bool), typeof(Application), true);
 
 		public static bool GetSendAppearingEventOnResume(BindableObject element)
 		{
@@ -54,9 +50,7 @@
 			return config;
 		}
 
-		public static readonly BindableProperty CanShowKeyboardOnResumeProperty =
-			BindableProperty.Create(nameof(CanShowKeyboardOnResume), typeof(bool),
-			typeof(Application), false);
+		public static readonly BindableProperty CanShowKeyboardOnResumeProperty = BindableProperty.Create(nameof(CanShowKeyboardOnResume), typeof(bool), typeof(Application), false);
 
 		public static bool GetCanShowKeyboardOnResume(BindableObject element)
 		{

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
@@ -53,5 +53,30 @@
 			SetSendAppearingEventOnResume(config.Element, value);
 			return config;
 		}
+
+		public static readonly BindableProperty CanShowKeyboardOnResumeProperty =
+			BindableProperty.Create(nameof(CanShowKeyboardOnResume), typeof(bool),
+			typeof(Application), false);
+
+		public static bool GetCanShowKeyboardOnResume(BindableObject element)
+		{
+			return (bool)element.GetValue(CanShowKeyboardOnResumeProperty);
+		}
+
+		public static void SetCanShowKeyboardOnResume(BindableObject element, bool value)
+		{
+			element.SetValue(CanShowKeyboardOnResumeProperty, value);
+		}
+
+		public static bool GetCanShowKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetCanShowKeyboardOnResume(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> CanShowKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
+		{
+			SetCanShowKeyboardOnResume(config.Element, value);
+			return config;
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -233,7 +233,7 @@ namespace Xamarin.Forms.Platform.Android
 			// counterpart to OnPause
 			base.OnResume();
 
-			if (_application.OnThisPlatform().GetCanShowKeyboardOnResume())
+			if (_application.OnThisPlatform().GetShouldPreserveKeyboardOnResume())
 			{
 				if (CurrentFocus != null && (CurrentFocus is EditText || CurrentFocus is TextView || CurrentFocus is SearchView))
 				{

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -15,6 +15,7 @@ using Android.Views;
 using Android.Widget;
 using Xamarin.Forms.Platform.Android.AppCompat;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat;
 using AToolbar = Android.Support.V7.Widget.Toolbar;
 using AColor = Android.Graphics.Color;
 using AlertDialog = Android.Support.V7.App.AlertDialog;
@@ -231,6 +232,14 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			// counterpart to OnPause
 			base.OnResume();
+
+			if (_application.OnThisPlatform().GetCanShowKeyboardOnResume())
+			{
+				if (CurrentFocus != null && (CurrentFocus is EditText || CurrentFocus is TextView || CurrentFocus is SearchView))
+				{
+					CurrentFocus.ShowKeyboard();
+				}
+			}
 
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnResume;

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml
@@ -210,9 +210,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="GetCanShowKeyboardOnResume">
-      <MemberSignature Language="C#" Value="public static bool GetCanShowKeyboardOnResume (Xamarin.Forms.BindableObject element);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetCanShowKeyboardOnResume(class Xamarin.Forms.BindableObject element) cil managed" />
+    <Member MemberName="GetShouldPreserveKeyboardOnResume">
+      <MemberSignature Language="C#" Value="public static bool GetShouldPreserveKeyboardOnResume (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetShouldPreserveKeyboardOnResume(class Xamarin.Forms.BindableObject element) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -230,9 +230,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="GetCanShowKeyboardOnResume">
-      <MemberSignature Language="C#" Value="public static bool GetCanShowKeyboardOnResume (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt; config);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetCanShowKeyboardOnResume(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Application&gt; config) cil managed" />
+    <Member MemberName="GetShouldPreserveKeyboardOnResume">
+      <MemberSignature Language="C#" Value="public static bool GetShouldPreserveKeyboardOnResume (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetShouldPreserveKeyboardOnResume(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Application&gt; config) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -250,9 +250,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="CanShowKeyboardOnResume">
-      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt; CanShowKeyboardOnResume (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt; config, bool value);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Application&gt; CanShowKeyboardOnResume(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Application&gt; config, bool value) cil managed" />
+    <Member MemberName="ShouldPreserveKeyboardOnResume">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt; ShouldPreserveKeyboardOnResume (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Application&gt; ShouldPreserveKeyboardOnResume(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Application&gt; config, bool value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -272,9 +272,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="CanShowKeyboardOnResumeProperty">
-      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty CanShowKeyboardOnResumeProperty;" />
-      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty CanShowKeyboardOnResumeProperty" />
+    <Member MemberName="ShouldPreserveKeyboardOnResumeProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ShouldPreserveKeyboardOnResumeProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ShouldPreserveKeyboardOnResumeProperty" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -287,9 +287,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="SetCanShowKeyboardOnResume">
-      <MemberSignature Language="C#" Value="public static void SetCanShowKeyboardOnResume (Xamarin.Forms.BindableObject element, bool value);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetCanShowKeyboardOnResume(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
+    <Member MemberName="SetShouldPreserveKeyboardOnResume">
+      <MemberSignature Language="C#" Value="public static void SetShouldPreserveKeyboardOnResume (Xamarin.Forms.BindableObject element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetShouldPreserveKeyboardOnResume(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml
@@ -210,5 +210,103 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="GetCanShowKeyboardOnResume">
+      <MemberSignature Language="C#" Value="public static bool GetCanShowKeyboardOnResume (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetCanShowKeyboardOnResume(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetCanShowKeyboardOnResume">
+      <MemberSignature Language="C#" Value="public static bool GetCanShowKeyboardOnResume (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetCanShowKeyboardOnResume(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Application&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CanShowKeyboardOnResume">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt; CanShowKeyboardOnResume (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Application&gt; CanShowKeyboardOnResume(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Application&gt; config, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CanShowKeyboardOnResumeProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty CanShowKeyboardOnResumeProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty CanShowKeyboardOnResumeProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetCanShowKeyboardOnResume">
+      <MemberSignature Language="C#" Value="public static void SetCanShowKeyboardOnResume (Xamarin.Forms.BindableObject element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetCanShowKeyboardOnResume(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>


### PR DESCRIPTION
### Description of Change

Converting the work done in #441 to platform-specific functionality.
### API Changes

Added:
- public static readonly BindableProperty CanShowKeyboardOnResumeProperty
- public static bool GetCanShowKeyboardOnResume(BindableObject element)
- public static void SetCanShowKeyboardOnResume(BindableObject element, bool value)
- public static bool GetCanShowKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config)
- public static IPlatformElementConfiguration<Android, FormsElement> CanShowKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)

EDIT: APIs were renamed to reflect `PreserveKeyboardOnResume`.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
