### PR TITLE
[iOS] Use separate UIWindow for UIAlertController

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45743.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45743.cs
@@ -1,0 +1,71 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 45743, "[iOS] Calling DisplayAlert via BeginInvokeOnMainThread blocking other calls on iOS", PlatformAffected.iOS)]
+	public class Bugzilla45743 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new ContentPage
+			{
+				Content = new StackLayout
+				{
+					AutomationId = "Page1",
+					Children =
+					{
+						new Label { Text = "Page 1" }
+					}
+				}
+			});
+
+			Device.BeginInvokeOnMainThread(async () =>
+			{
+				await DisplayAlert("Title", "Message", "Accept", "Cancel");
+			});
+
+			Device.BeginInvokeOnMainThread(async () =>
+			{
+				await PushAsync(new ContentPage
+				{
+					AutomationId = "Page2",
+					Content = new StackLayout
+					{
+						Children =
+						{
+							new Label { Text = "Page 2" }
+						}
+					}
+				});
+			});
+
+			Device.BeginInvokeOnMainThread(async () =>
+			{
+				await DisplayAlert("Title 2", "Message", "Accept", "Cancel");
+			});
+		}
+
+#if UITEST
+
+#if __IOS__
+		[Test]
+		public void Bugzilla45743Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Title 2"));
+			RunningApp.Tap("Accept");
+			RunningApp.WaitForElement(q => q.Marked("Title"));
+			RunningApp.Tap("Accept");
+			Assert.True(RunningApp.Query(q => q.Text("Page 2")).Length > 0);
+		}
+#endif
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45743.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45743.cs
@@ -50,6 +50,11 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				await DisplayAlert("Title 2", "Message", "Accept", "Cancel");
 			});
+
+			Device.BeginInvokeOnMainThread(async () =>
+			{
+				await DisplayActionSheet("ActionSheet Title", "Cancel", "Close", new string[] { "Test", "Test 2" });
+			});
 		}
 
 #if UITEST
@@ -58,6 +63,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla45743Test()
 		{
+			RunningApp.WaitForElement(q => q.Marked("ActionSheet Title"));
+			RunningApp.Tap("Close");
 			RunningApp.WaitForElement(q => q.Marked("Title 2"));
 			RunningApp.Tap("Accept");
 			RunningApp.WaitForElement(q => q.Marked("Title"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -133,6 +133,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44338.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -55,8 +55,12 @@ namespace Xamarin.Forms.Platform.iOS
 					if (arguments.Accept != null)
 						alert.AddAction(UIAlertAction.Create(arguments.Accept, UIAlertActionStyle.Default, a => arguments.SetResult(true)));
 					var page = _modals.Any() ? _modals.Last() : Page;
-					var vc = GetRenderer(page).ViewController;
-					vc.PresentViewController(alert, true, null);
+
+					var window = new UIWindow { BackgroundColor = Color.Transparent.ToUIColor() };
+					window.RootViewController = new UIViewController();
+					window.RootViewController.View.BackgroundColor = Color.Transparent.ToUIColor();
+					window.MakeKeyAndVisible();
+					window.RootViewController.PresentViewController(alert, true, null);
 				}
 				else
 				{

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -54,13 +54,8 @@ namespace Xamarin.Forms.Platform.iOS
 					alert.AddAction(UIAlertAction.Create(arguments.Cancel, UIAlertActionStyle.Cancel, a => arguments.SetResult(false)));
 					if (arguments.Accept != null)
 						alert.AddAction(UIAlertAction.Create(arguments.Accept, UIAlertActionStyle.Default, a => arguments.SetResult(true)));
-					var page = _modals.Any() ? _modals.Last() : Page;
 
-					var window = new UIWindow { BackgroundColor = Color.Transparent.ToUIColor() };
-					window.RootViewController = new UIViewController();
-					window.RootViewController.View.BackgroundColor = Color.Transparent.ToUIColor();
-					window.MakeKeyAndVisible();
-					window.RootViewController.PresentViewController(alert, true, null);
+					PresentAlert(alert);
 				}
 				else
 				{
@@ -125,7 +120,7 @@ namespace Xamarin.Forms.Platform.iOS
 						alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
 					}
 
-					pageRenderer.ViewController.PresentViewController(alert, true, null);
+					PresentAlert(alert);
 				}
 				else
 				{
@@ -433,6 +428,15 @@ namespace Xamarin.Forms.Platform.iOS
 				page = (Page)page.RealParent;
 
 			return Page == page || _modals.Contains(page);
+		}
+
+		void PresentAlert(UIAlertController alert)
+		{
+			var window = new UIWindow { BackgroundColor = Color.Transparent.ToUIColor() };
+			window.RootViewController = new UIViewController();
+			window.RootViewController.View.BackgroundColor = Color.Transparent.ToUIColor();
+			window.MakeKeyAndVisible();
+			window.RootViewController.PresentViewController(alert, true, null);
 		}
 
 		async Task PresentModal(Page modal, bool animated)


### PR DESCRIPTION
### Description of Change

Presently, calling `DisplayAlert` via `Device.BeginInvokeOnMainThread` prevents a subsequent use of `BeginInvokeOnMainThread` to do something such as push a new page prevents it from working. After doing some digging around, some [best practices](http://stackoverflow.com/questions/26554894/how-to-present-uialertcontroller-when-not-in-a-view-controller) Apple uses according to a reputable SO user suggests that they present a `UIAlertController` on a new `UIWindow`. Doing this appears to allow for such behavior to work as expected. DisplayActionSheet's behavior has been tweaked as well and to avoid repetition of code a `void PresentAlert(UIAlertController alert)` method was added.

![bugzilla45743](https://cloud.githubusercontent.com/assets/1251024/19612804/4e06a9b0-97ae-11e6-89f4-c7b1480e5d70.gif)
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=45743
### API Changes

None
### Behavioral Changes

The DisplayAlert gallery appears to work as usual and a test was added in the case that a second alert is pushed, so presumably there are no odd effects here.
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
