### PR TITLE
[iOS] ListView on steroids Platform Specific IsUsingAutoSizedViewCell

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -4,26 +4,26 @@
 
 	public static class ListView
 	{
-		public static readonly BindableProperty IsUsingDynamicViewCellsOnlyProperty = BindableProperty.Create(nameof(IsUsingDynamicViewCellsOnly), typeof(bool), typeof(ListView), false);
+		public static readonly BindableProperty IsUsingAutoSizedViewCellsOnlyProperty = BindableProperty.Create(nameof(IsUsingAutoSizedViewCellsOnly), typeof(bool), typeof(ListView), false);
 
-		public static bool GetIsUsingDynamicViewCellsOnly(BindableObject element)
+		public static bool GetIsUsingAutoSizedViewCellsOnly(BindableObject element)
 		{
-			return (bool)element.GetValue(IsUsingDynamicViewCellsOnlyProperty);
+			return (bool)element.GetValue(IsUsingAutoSizedViewCellsOnlyProperty);
 		}
 
-		public static void SetIsUsingDynamicViewCellsOnly(BindableObject element, bool value)
+		public static void SetIsUsingAutoSizedViewCellsOnly(BindableObject element, bool value)
 		{
-			element.SetValue(IsUsingDynamicViewCellsOnlyProperty, value);
+			element.SetValue(IsUsingAutoSizedViewCellsOnlyProperty, value);
 		}
 
-		public static bool IsUsingDynamicViewCellsOnly(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		public static bool IsUsingAutoSizedViewCellsOnly(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
-			return GetIsUsingDynamicViewCellsOnly(config.Element);
+			return GetIsUsingAutoSizedViewCellsOnly(config.Element);
 		}
 
-		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsUsingDynamicViewCellsOnly(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsUsingAutoSizedViewCellsOnly(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
-			SetIsUsingDynamicViewCellsOnly(config.Element, value);
+			SetIsUsingAutoSizedViewCellsOnly(config.Element, value);
 			return config;
 		}
 	}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -1,0 +1,30 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.ListView;
+
+	public static class ListView
+	{
+		public static readonly BindableProperty IsUsingDynamicViewCellsOnlyProperty = BindableProperty.Create(nameof(IsUsingDynamicViewCellsOnly), typeof(bool), typeof(ListView), false);
+
+		public static bool GetIsUsingDynamicViewCellsOnly(BindableObject element)
+		{
+			return (bool)element.GetValue(IsUsingDynamicViewCellsOnlyProperty);
+		}
+
+		public static void SetIsUsingDynamicViewCellsOnly(BindableObject element, bool value)
+		{
+			element.SetValue(IsUsingDynamicViewCellsOnlyProperty, value);
+		}
+
+		public static bool IsUsingDynamicViewCellsOnly(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetIsUsingDynamicViewCellsOnly(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsUsingDynamicViewCellsOnly(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		{
+			SetIsUsingDynamicViewCellsOnly(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -93,6 +93,7 @@
     <Compile Include="PlatformConfiguration\ExtensionPoints.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\Entry.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\ListView.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\NavigationPage.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\VisualElement.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\MasterDetailPage.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
 
@@ -608,6 +609,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
 			{
+				if (List.OnThisPlatform().IsUsingDynamicViewCellsOnly())
+				{
+					if(Forms.IsiOS8OrNewer && List.HasUnevenRows && List.RowHeight == -1 && List.TemplatedItems.AsQueryable().ElementType == typeof(ViewCell))
+						return UITableView.AutomaticDimension;
+
+					throw new InvalidOperationException("IsUsingDynamicViewCellsOnly works on iOS 8+ with uneven rows, row height of -1, and ViewCell items.");
+				}
+
 				var cell = GetCellForPath(indexPath);
 
 				if (List.RowHeight == -1 && cell.Height == -1 && cell is ViewCell)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -609,12 +609,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
 			{
-				if (List.OnThisPlatform().IsUsingDynamicViewCellsOnly())
+				if (List.OnThisPlatform().IsUsingAutoSizedViewCellsOnly())
 				{
-					if(Forms.IsiOS8OrNewer && List.HasUnevenRows && List.RowHeight == -1 && List.TemplatedItems.AsQueryable().ElementType == typeof(ViewCell))
+					if (Forms.IsiOS8OrNewer && List.HasUnevenRows && List.RowHeight == -1)
 						return UITableView.AutomaticDimension;
 
-					throw new InvalidOperationException("IsUsingDynamicViewCellsOnly works on iOS 8+ with uneven rows, row height of -1, and ViewCell items.");
+					throw new InvalidOperationException("IsUsingAutoSizedViewCellsOnly works on iOS 8+ with uneven rows, a row height of -1, and ViewCell items only.");
 				}
 
 				var cell = GetCellForPath(indexPath);


### PR DESCRIPTION
### Description of Change

`ListView` scrolling on iOS is not good at all. It seems this behavior was carried over since March (That's as far back as I could see history.) The problem is when uneven rows are used, we're trying to determine if row heights should be calculated by us or iOS. The logic for doing that isn't very efficient.

`GetHeightForRow` (through `GetCellForPath`) is getting the current cell at `indexPath` every time it's called. Unfortunately, this could be quite time-consuming. I have a **simple** setup where looking up cells takes anywhere between 25 and 85 ms. The end result is the listview creates a jarring scroll animation as if it's struggling to scroll.

The solution is to return `AutomaticDimension` as fast as possible if we need it. I created a platform specific option to tell the renderer we're only using view cells (that's because the original code is checking for that and I'm not sure if it's necessary.) Other checks are also in place.

Perhaps, the platform specific is unnecessary. It was mentioned in the code that only `ViewCell` resizes - not other cells. Maybe we can create an internal flag to monitor `TemplatedItemsView` to see if it contains only `ViewCell` instances.

That said, I'd assume most people use `ViewCell` in templates instead of a mix of cells. If this is not the case, `IsUsingAutoSizedViewCellsOnly` can be set to false, which of course would default to the existing behavior.

Finally, I'm not sure what the significance of `cell.Height == -1` is. 

This could wait until #454 is merged.

Before: https://1drv.ms/v/s!AjlbPgOcTyP2bt9knobeoD4YcBQ
After: https://1drv.ms/v/s!AjlbPgOcTyP2b7u8gU4p-6y43cQ

I think it's easier to see the difference if you put the videos side by side. It's even more apparent on the phone.
### Bugs Fixed
- N/A
- **Update:** https://bugzilla.xamarin.com/show_bug.cgi?id=52487
### API Changes

Added:
- public static readonly BindableProperty IsUsingAutoSizedViewCellsOnlyProperty
- public static bool GetIsUsingAutoSizedViewCellsOnly(BindableObject element)
- public static void SetIsUsingAutoSizedViewCellsOnly(BindableObject element, bool value)
- public static bool IsUsingAutoSizedViewCellsOnly(this IPlatformElementConfiguration<iOS, FormsElement> config)
- public static IPlatformElementConfiguration<iOS, FormsElement> SetIsUsingAutoSizedViewCellsOnly(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
