### PR TITLE
Disable ShouldResetPerFixture to see if that will fix the sequential UITests

### DIFF
--- a/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		protected BaseTestFixture()
 		{
-			ShouldResetPerFixture = true;
+			ShouldResetPerFixture = false;
 		}
 
 		protected abstract void NavigateToGallery();


### PR DESCRIPTION
### Description of Change

Testing to see if we can run our tests sequentially by disabling the `ShouldResetPerFixture` property.
### Bugs Fixed
