### PR TITLE
[Win] Toolbar placement works with initial value

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/Page.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/Page.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.PlatformConfiguration.WindowsSpecific
 
 		public static readonly BindableProperty ToolbarPlacementProperty =
 			BindableProperty.CreateAttached("ToolbarPlacement", typeof(ToolbarPlacement),
-				typeof(Page), ToolbarPlacement.Default);
+				typeof(FormsElement), ToolbarPlacement.Default);
 
 		public static ToolbarPlacement GetToolbarPlacement(BindableObject element)
 		{

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -239,6 +239,13 @@ namespace Xamarin.Forms.Platform.UWP
 			_bottomCommandBarArea = GetTemplateChild("BottomCommandBarArea") as Border;
 			_topCommandBarArea = GetTemplateChild("TopCommandBarArea") as Border;
 
+			if (_commandBar != null && _bottomCommandBarArea != null && _topCommandBarArea != null)
+			{
+				// We have to wait for the command bar to load so that it'll be in the control hierarchy
+				// otherwise we can't properly move it to wherever the toolbar is supposed to be
+				_commandBar.Loaded += (sender, args) => UpdateToolbarPlacement();
+			} 
+
 			UpdateToolbarPlacement();
 			UpdateMode(); 
 

--- a/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
@@ -44,7 +46,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			get { return (Visibility)GetValue(TitleVisibilityProperty); }
 			set { SetValue(TitleVisibilityProperty, value); }
-		}
+		} 
 
         public ToolbarPlacement ToolbarPlacement
 	    {
@@ -77,7 +79,13 @@ namespace Xamarin.Forms.Platform.WinRT
 #if WINDOWS_UWP
 			_bottomCommandBarArea = GetTemplateChild("BottomCommandBarArea") as Border;
 			_topCommandBarArea = GetTemplateChild("TopCommandBarArea") as Border;
-			UpdateToolbarPlacement();
+
+			if (_commandBar != null && _bottomCommandBarArea != null && _topCommandBarArea != null)
+			{
+				// We have to wait for the command bar to load so that it'll be in the control hierarchy
+				// otherwise we can't properly move it to wherever the toolbar is supposed to be
+				_commandBar.Loaded += (sender, args) => UpdateToolbarPlacement();
+			}
 #endif
 
 			TaskCompletionSource<CommandBar> tcs = _commandBarTcs;

--- a/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
@@ -46,7 +44,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			get { return (Visibility)GetValue(TitleVisibilityProperty); }
 			set { SetValue(TitleVisibilityProperty, value); }
-		} 
+		}
 
         public ToolbarPlacement ToolbarPlacement
 	    {

--- a/Xamarin.Forms.Platform.WinRT/PageControl.xaml.cs
+++ b/Xamarin.Forms.Platform.WinRT/PageControl.xaml.cs
@@ -150,7 +150,13 @@ namespace Xamarin.Forms.Platform.WinRT
 #if WINDOWS_UWP
 			_bottomCommandBarArea = GetTemplateChild("BottomCommandBarArea") as Border;
 			_topCommandBarArea = GetTemplateChild("TopCommandBarArea") as Border;
-			UpdateToolbarPlacement();
+
+			if (_commandBar != null && _bottomCommandBarArea != null && _topCommandBarArea != null)
+			{
+				// We have to wait for the command bar to load so that it'll be in the control hierarchy
+				// otherwise we can't properly move it to wherever the toolbar is supposed to be
+				_commandBar.Loaded += (sender, args) => UpdateToolbarPlacement();
+			} 
 #endif
 
 			TaskCompletionSource<CommandBar> tcs = _commandBarTcs;


### PR DESCRIPTION
### Description of Change ###

Can now use the Windows Platform Specific ToolbarPlacement in XAML and in constructor.

### Bugs Fixed ###

- n/a, reported internally

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
