### PR TITLE
[WinRT] Fix ModalPushed/ModalPopped not firing

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43663.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43663.cs
@@ -1,0 +1,93 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Runtime.CompilerServices;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43663, "ModalPushed and ModalPopped not working on WinRT", PlatformAffected.WinRT)]
+	public class Bugzilla43663 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			Application.Current.ModalPushed += ModalPushed;
+			Application.Current.ModalPopped += ModalPopped;
+
+			var initialPage = new ContentPage();
+			var insertedPage = new ContentPage
+			{
+				Content = new StackLayout
+				{
+					Children =
+					{
+						new Label { Text = "This page's appearing unsubscribes from the ModalPushed/ModalPopped events" },
+						new Button
+						{
+							Text = "Go back",
+							Command = new Command(async () => await Navigation.PopModalAsync())
+						}
+					}
+				}
+			};
+			insertedPage.Appearing += (s, e) =>
+			{
+				Application.Current.ModalPushed -= ModalPushed;
+				Application.Current.ModalPopped -= ModalPopped;
+			};
+
+			var modalPage = new ContentPage();
+			modalPage.Content = new StackLayout
+			{
+				Children =
+				{
+					new Label { Text = "Modal" },
+					new Button
+					{
+						Text = "Click to dismiss modal",
+						Command = new Command(async() =>
+						{
+							await Navigation.PopModalAsync();
+						})
+					}
+				},
+			};
+
+			initialPage.Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Button
+					{
+						Text = "Click to push Modal",
+						Command = new Command(async () => await Navigation.PushModalAsync(modalPage))
+					},
+					new Button
+					{
+						Text = "Go back",
+						Command = new Command(async () => await Navigation.PopAsync())
+					}
+				}
+			};
+
+			PushAsync(initialPage);
+			Navigation.InsertPageBefore(insertedPage, initialPage);
+		}
+
+		void ModalPushed(object sender, ModalPushedEventArgs e)
+		{
+			DisplayAlert("Pushed", "Message", "Cancel");
+		}
+
+		void ModalPopped(object sender, ModalPoppedEventArgs e)
+		{
+			DisplayAlert("Popped", "Message", "Cancel");
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -127,6 +127,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42364.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43663.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44584.cs" />

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -98,7 +98,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			_navModel.Clear();
 
 			_navModel.Push(newRoot, null);
-			newRoot.NavigationProxy.Inner = this;
 			SetCurrent(newRoot, false, true);
 			Application.Current.NavigationProxy.Inner = this;
 		}
@@ -171,7 +170,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			var tcs = new TaskCompletionSource<bool>();
 			_navModel.PushModal(page);
 			SetCurrent(page, animated, completedCallback: () => tcs.SetResult(true));
-			page.NavigationProxy.Inner = this;
 			return tcs.Task;
 		}
 


### PR DESCRIPTION
### Description of Change

The `ModalPushed` and `ModalPopped` events were not firing on WinRT, which appears due to the `NavigationProxy.Inner` being assigned to `newRoot` and `page` values -- it appears that strictly leaving the value being assigned to `Application.Current` corrects this behavior (and Android/iOS both appear to set it similarly). The reproduction in the gallery checks the functionality while using other `NavigationProxy` functionality via `InsertPageBefore` to make certain it's still working after the changes, as well as inserting another page which unsubscribes from the added push/pop events when it appears.
### Bugs Fixed

https://bugzilla.xamarin.com/show_bug.cgi?id=43663
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
