### PR TITLE
[UWP] Explicitly set mobile StatusBar colors to white Background/black Foreground on Light theme

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/App.xaml
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/App.xaml
@@ -2,7 +2,8 @@
     x:Class="Xamarin.Forms.ControlGallery.WindowsUniversal.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Xamarin.Forms.ControlGallery.WindowsUniversal">
+    xmlns:local="using:Xamarin.Forms.ControlGallery.WindowsUniversal"
+	RequestedTheme="Light">
 
 
 </Application>

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/App.xaml.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/App.xaml.cs
@@ -7,6 +7,9 @@ using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.Foundation.Metadata;
+using Windows.UI;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -76,8 +79,21 @@ namespace Xamarin.Forms.ControlGallery.WindowsUniversal
                 // parameter
                 rootFrame.Navigate(typeof(MainPage), e.Arguments);
             }
-            // Ensure the current window is active
-            Window.Current.Activate();
+
+			//// Uncomment to test overriding the status bar color
+			//if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
+			//{
+			//	var statusBar = StatusBar.GetForCurrentView();
+			//	if (statusBar != null)
+			//	{
+			//		statusBar.BackgroundOpacity = 1;
+			//		statusBar.BackgroundColor = Colors.Black;
+			//		statusBar.ForegroundColor = Colors.White;
+			//	}
+			//}
+
+			// Ensure the current window is active
+			Window.Current.Activate();
         }
 
         /// <summary>

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -193,6 +193,11 @@
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
+  <ItemGroup>
+    <SDKReference Include="WindowsMobile, Version=10.0.10586.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -89,6 +89,20 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				statusBar.Showing += (sender, args) => UpdateBounds();
 				statusBar.Hiding += (sender, args) => UpdateBounds();
+
+				// UWP 14393 Bug: If RequestedTheme is Light (which it is by default), then the 
+				// status bar uses White Foreground with White Background. 
+				// UWP 10586 Bug: If RequestedTheme is Light (which it is by default), then the 
+				// status bar uses Black Foreground with Black Background. 
+				// Since the Light theme should have a Black on White status bar, we will set it explicitly. 
+				// This can be overriden by setting the status bar colors in App.xaml.cs OnLaunched.
+
+				if (statusBar.BackgroundColor == null && statusBar.ForegroundColor == null && Windows.UI.Xaml.Application.Current.RequestedTheme == ApplicationTheme.Light)
+				{
+					statusBar.BackgroundColor = Colors.White;
+					statusBar.ForegroundColor = Colors.Black;
+					statusBar.BackgroundOpacity = 1;
+				}
 			}
 #endif
 		}

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -32,6 +32,10 @@ namespace Xamarin.Forms.Platform.WinRT
 	{
 		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer", typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer));
 
+#if WINDOWS_UWP
+		internal static StatusBar MobileStatusBar => ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar") ? StatusBar.GetForCurrentView() : null;
+#endif
+
 		public static IVisualElementRenderer GetRenderer(VisualElement element)
 		{
 			return (IVisualElementRenderer)element.GetValue(RendererProperty);
@@ -79,11 +83,10 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			UpdateBounds();
 
-
 #if WINDOWS_UWP
-			if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
+			StatusBar statusBar = MobileStatusBar;
+			if (statusBar != null)
 			{
-				StatusBar statusBar = StatusBar.GetForCurrentView();
 				statusBar.Showing += (sender, args) => UpdateBounds();
 				statusBar.Hiding += (sender, args) => UpdateBounds();
 			}
@@ -422,10 +425,9 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			_bounds = new Rectangle(0, 0, _page.ActualWidth, _page.ActualHeight);
 #if WINDOWS_UWP
-			if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
+			StatusBar statusBar = MobileStatusBar;
+			if (statusBar != null)
 			{
-				StatusBar statusBar = StatusBar.GetForCurrentView();
-
 				bool landscape = Device.Info.CurrentOrientation.IsLandscape();
 				bool titleBar = CoreApplication.GetCurrentView().TitleBar.IsVisible;
 				double offset = landscape ? statusBar.OccludedRect.Width : statusBar.OccludedRect.Height;


### PR DESCRIPTION
### Description of Change

The mobile status bar appears as a blank white bar on version 14393 and a blank black bar on 10586 when the `RequestedTheme` is `Light`. This can be reproduced with a new UWP application independent of Xamarin.Forms. 

Since the `Light` theme should have a white bar with black text, we are now explicitly setting the status bar to be those colors. 

This is a VISUAL CHANGE on mobile devices targeting 10586, which would have a black status bar (with black text) in the Light theme. 

Users preferring the black status bar can explicitly change the status bar colors in `App.xaml.cs` `OnLaunched` in the UWP project. See a1e802e for a complete example.
### Bugs Fixed
- [Bug 45835 - There is a blank space on the screen top on UWP 14393(Windows 10 1607 Mobile)](https://bugzilla.xamarin.com/show_bug.cgi?id=45835)
### API Changes

None
### Behavioral Changes

This is a VISUAL CHANGE on mobile devices targeting 10586, which would have a black status bar (with black text) in the Light theme. See a1e802e for an example of reverting to the black status bar if desired.
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
