### PR TITLE
[iOS] Fix AccessoryView covered by section index list

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -18,6 +18,7 @@ using RectangleF = CoreGraphics.CGRect;
 [assembly: ExportRenderer(typeof(CustomMapView), typeof(CustomIOSMapRenderer))]
 [assembly: ExportRenderer(typeof(TabbedPage), typeof(TabbedPageWithCustomBarColorRenderer))]
 [assembly: ExportRenderer(typeof(Bugzilla43161.AccessoryViewCell), typeof(AccessoryViewCellRenderer))]
+[assembly: ExportRenderer(typeof(Bugzilla36802.AccessoryViewCell), typeof(AccessoryViewCellRenderer))]
 namespace Xamarin.Forms.ControlGallery.iOS
 {
 	public class CustomIOSMapRenderer : ViewRenderer<CustomMapView, MKMapView>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36802.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36802.cs
@@ -1,0 +1,79 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Collections.ObjectModel;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 36802, "[iOS] AccessoryView Partially Hidden When Using RecycleElement and GroupShortName", PlatformAffected.iOS)]
+    public class Bugzilla36802 : TestContentPage
+    {
+        const string Instructions = "On iOS, all the list items below should have an AccessoryView visible. If any are not visible or are covered by the section index list then this test has failed.";
+        ObservableCollection<GroupedItem> grouped { get; set; }
+        ListView lstView;
+
+        public class AccessoryViewCell : ViewCell
+        {
+            public AccessoryViewCell()
+            {
+                var label = new Label();
+                label.SetBinding(Label.TextProperty, ".");
+                View = label;
+            }
+        }
+
+        public class GroupedItem : ObservableCollection<string>
+        {
+            public string LongName { get; set; }
+            public string ShortName { get; set; }
+        }
+
+        protected override void Init()
+        {
+            var label = new Label { Text = Instructions };
+            grouped = new ObservableCollection<GroupedItem>();
+            lstView = new ListView(ListViewCachingStrategy.RecycleElement) {
+                IsGroupingEnabled = true,
+                ItemTemplate = new DataTemplate(typeof(AccessoryViewCell)),
+                ItemsSource = grouped,
+                GroupDisplayBinding = new Binding("LongName"),
+                GroupShortNameBinding = new Binding("ShortName")
+            };
+
+            var grp1 = new GroupedItem() { LongName = "Group 1", ShortName = "1" };
+            var grp2 = new GroupedItem() { LongName = "Group 2", ShortName = "2" };
+
+            for (int i = 1; i < 4; i++)
+            {
+                grp1.Add($"Item #{i}");
+                grp2.Add($"Item #{i}");
+            }
+
+            grouped.Add(grp1); 
+            grouped.Add(grp2);
+
+            Content = new StackLayout
+            {
+                Children = {
+                    label,
+                    lstView
+                }
+            };
+        }
+
+#if (UITEST && __IOS__)
+        [Test]
+        public void Bugzilla36802Test()
+        {
+            RunningApp.Screenshot("AccessoryView partially hidden test");
+        }
+#endif
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -454,6 +454,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41029.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39908.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39489.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36802.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -87,13 +87,13 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.LayoutSubviews();
 
-			if (_scroller == null || (_scroller != null && _scroller.Frame == Bounds))
+			if (_scroller == null || (_scroller != null && _scroller.Frame.Width == ContentView.Bounds.Width))
 				return;
 
 			Update(_tableView, _cell, ContentCell);
 
-			_scroller.Frame = Bounds;
-			ContentCell.Frame = Bounds;
+			//_scroller.Frame = Bounds;
+			//ContentCell.Frame = Bounds;
 
 			if (ContentCell is ViewCellRenderer.ViewTableCell && ContentCell.Subviews.Length > 0 && Math.Abs(ContentCell.Subviews[0].Frame.Height - Bounds.Height) > 1)
 			{
@@ -130,7 +130,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			var height = Frame.Height;
-			var width = tableView.Frame.Width;
+			var width = ContentView.Frame.Width;
 
 			nativeCell.Frame = new RectangleF(0, 0, width, height);
 			nativeCell.SetNeedsLayout();

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -92,9 +92,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			Update(_tableView, _cell, ContentCell);
 
-			//_scroller.Frame = Bounds;
-			//ContentCell.Frame = Bounds;
-
 			if (ContentCell is ViewCellRenderer.ViewTableCell && ContentCell.Subviews.Length > 0 && Math.Abs(ContentCell.Subviews[0].Frame.Height - Bounds.Height) > 1)
 			{
 				// Something goes weird inside iOS where LayoutSubviews wont get called when updating the bounds if the user


### PR DESCRIPTION
### Description of Change

On iOS, when a ListView is using RecycleElement along with GroupShortNameBinding, the UITableViewCellAccessory of a cell is partially hidden underneath the section index list.

Since `ContextActionCell.ContentView.Bounds` factors in the index list, this fix adjusts the width of the cell's contents to match the ContentView width so the AccessoryView is completely visible
### Bugs Fixed
- https://bugzilla.xamarin.com/show_bug.cgi?id=36802
### API Changes

None
### Behavioral Changes

None
### PR Checklist
- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
