### PR TITLE
[iOS] Fix NRE when updating page Content in Picker SelectedIndexChanged

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38723.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38723.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 38723, "Update Content in Picker's SelectedIndexChanged event causes NullReferenceException", PlatformAffected.iOS)]
+	public class Bugzilla38723 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		Picker _datePicker;
+		Label _dateLabel;
+
+		protected override void Init()
+		{
+			_datePicker = new Picker
+			{
+				//HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.Center,
+				Title = "Pick a Date",
+			};
+			_datePicker.SelectedIndexChanged += DatePickerSelected;
+
+			for (var i = 0; i < 7; i++)
+			{
+				_datePicker.Items.Add(DateTime.Now.AddDays(i).ToString("dd, MMM, yyyy(dddd)"));
+			}
+
+			var stackLayout = new StackLayout
+			{
+				Padding = new Thickness(10, 10)
+			};
+
+			_dateLabel = new Label
+			{
+				HorizontalOptions = LayoutOptions.StartAndExpand,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Placeholder"
+			};
+
+			stackLayout.Children.Add(_datePicker);
+			stackLayout.Children.Add(_dateLabel);
+			// Update current page's UI would cause NullReferenceException
+			Content = stackLayout;
+		}
+
+		void DatePickerSelected(object sender, EventArgs args)
+		{
+			_dateLabel.Text = args.ToString();
+			Content = _dateLabel;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -82,6 +82,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37863.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37601.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38105.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38723.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38827.xaml.cs">
       <DependentUpon>Bugzilla38827.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -108,9 +108,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element != null)
 			{
 				var oldText = Control.Text;
-				ElementController.SetValueFromRenderer(Picker.SelectedIndexProperty, s.SelectedIndex);
 				Control.Text = s.SelectedItem;
 				UpdatePickerNativeSize(oldText);
+				ElementController.SetValueFromRenderer(Picker.SelectedIndexProperty, s.SelectedIndex);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

If you change page content in Picker's `SelectedIndexChanged` so that the picker is no longer attached to the page, this throws an NRE. This should be tested on top of #478 or you can hit the `Done` button without scrolling.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=38723

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

