### PR TITLE
[iOS] ActivityIndicator should not disappear when used in a ViewCell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44980.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44980.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44980, "ActivityIndicator disappears when scrolling", PlatformAffected.iOS)]
+	public class Bugzilla44980 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var list = new List<string>();
+			for (var i = 0; i < 100; i++)
+				list.Add(i.ToString());
+
+			Content = new CListView
+			{
+				ItemsSource = list,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var activityIndicator = new ActivityIndicator
+					{
+						IsRunning = true,
+						IsVisible = true
+					};
+					return new ViewCell { View = activityIndicator };
+				})
+			};
+		}
+	}
+
+	public class CListView : ListView
+	{
+		public CListView() : base(ListViewCachingStrategy.RecycleElement)
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -164,6 +164,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44338.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44980.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45027.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45330.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44955.cs" />

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -43,6 +43,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (e.PropertyName == Cell.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled(realCell, viewCell);
+			else if (e.PropertyName == "Index")
+				MessagingCenter.Send(this, "PreserveActivityIndicatorState");
 		}
 
 		internal class ViewTableCell : UITableViewCell, INativeElementView

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -27,7 +27,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UpdateBackground(cell, item);
 			UpdateIsEnabled(cell, viewCell);
-
 			return cell;
 		}
 
@@ -43,7 +42,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var realCell = (ViewTableCell)GetRealCell(viewCell);
 
 			if (e.PropertyName == Cell.IsEnabledProperty.PropertyName)
-				UpdateIsEnabled(realCell, viewCell);	
+				UpdateIsEnabled(realCell, viewCell);
 		}
 
 		internal class ViewTableCell : UITableViewCell, INativeElementView

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -27,6 +27,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UpdateBackground(cell, item);
 			UpdateIsEnabled(cell, viewCell);
+
 			return cell;
 		}
 
@@ -42,9 +43,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var realCell = (ViewTableCell)GetRealCell(viewCell);
 
 			if (e.PropertyName == Cell.IsEnabledProperty.PropertyName)
-				UpdateIsEnabled(realCell, viewCell);
-			else if (e.PropertyName == "Index")
-				MessagingCenter.Send(this, "PreserveActivityIndicatorState");
+				UpdateIsEnabled(realCell, viewCell);	
 		}
 
 		internal class ViewTableCell : UITableViewCell, INativeElementView

--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -8,6 +8,17 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		bool _disposed;
 
+		public ActivityIndicatorRenderer()
+		{
+			MessagingCenter.Subscribe<ListViewRenderer.ListViewDataSource>(this, "PreserveActivityIndicatorState", sender =>
+			{
+				if (Control != null && !Control.IsAnimating && Element != null && Element.IsRunning)
+				{
+					Control.StartAnimating();
+				}
+			});
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<ActivityIndicator> e)
 		{
 			if (e.NewElement != null)
@@ -15,13 +26,6 @@ namespace Xamarin.Forms.Platform.iOS
 				if (Control == null)
 				{
 					SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
-					MessagingCenter.Subscribe<ListViewRenderer.ListViewDataSource>(this, "PreserveActivityIndicatorState", sender =>
-					{
-						if (Control != null && !Control.IsAnimating && Element.IsRunning)
-						{
-							Control.StartAnimating();
-						}
-					});
 				}
 
 				UpdateColor();

--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -48,9 +48,7 @@ namespace Xamarin.Forms.Platform.iOS
 		internal void PreserveState()
 		{
 			if (Control != null && !Control.IsAnimating && Element != null && Element.IsRunning)
-			{
 				Control.StartAnimating();
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -6,19 +6,6 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, UIActivityIndicatorView>
 	{
-		bool _disposed;
-
-		public ActivityIndicatorRenderer()
-		{
-			MessagingCenter.Subscribe<ListViewRenderer.ListViewDataSource>(this, "PreserveActivityIndicatorState", sender =>
-			{
-				if (Control != null && !Control.IsAnimating && Element != null && Element.IsRunning)
-				{
-					Control.StartAnimating();
-				}
-			});
-		}
-
 		protected override void OnElementChanged(ElementChangedEventArgs<ActivityIndicator> e)
 		{
 			if (e.NewElement != null)
@@ -58,17 +45,12 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.StopAnimating();
 		}
 
-		protected override void Dispose(bool disposing)
+		internal void PreserveState()
 		{
-			if (_disposed)
-				return;
-
-			if(disposing)
-				MessagingCenter.Unsubscribe<ListViewRenderer.ListViewDataSource>(this, "PreserveActivityIndicatorState");
-
-			_disposed = true;
-
-			base.Dispose(disposing);
+			if (Control != null && !Control.IsAnimating && Element != null && Element.IsRunning)
+			{
+				Control.StartAnimating();
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (Control == null)
 				{
 					SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
-					MessagingCenter.Subscribe<ViewCellRenderer>(this, "PreserveActivityIndicatorState", sender =>
+					MessagingCenter.Subscribe<ListViewRenderer.ListViewDataSource>(this, "PreserveActivityIndicatorState", sender =>
 					{
 						if (Control != null && !Control.IsAnimating && Element.IsRunning)
 						{
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			if(disposing)
-				MessagingCenter.Unsubscribe<ViewCellRenderer>(this, "PreserveActivityIndicatorState");
+				MessagingCenter.Unsubscribe<ListViewRenderer.ListViewDataSource>(this, "PreserveActivityIndicatorState");
 
 			_disposed = true;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -6,6 +6,8 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, UIActivityIndicatorView>
 	{
+		bool _disposed;
+
 		protected override void OnElementChanged(ElementChangedEventArgs<ActivityIndicator> e)
 		{
 			if (e.NewElement != null)
@@ -13,6 +15,13 @@ namespace Xamarin.Forms.Platform.iOS
 				if (Control == null)
 				{
 					SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
+					MessagingCenter.Subscribe<ViewCellRenderer>(this, "PreserveActivityIndicatorState", sender =>
+					{
+						if (Control != null && !Control.IsAnimating && Element.IsRunning)
+						{
+							Control.StartAnimating();
+						}
+					});
 				}
 
 				UpdateColor();
@@ -43,6 +52,19 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.StartAnimating();
 			else
 				Control.StopAnimating();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			if(disposing)
+				MessagingCenter.Unsubscribe<ViewCellRenderer>(this, "PreserveActivityIndicatorState");
+
+			_disposed = true;
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -812,7 +812,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var bgColor = tableView.IndexPathForSelectedRow != null && tableView.IndexPathForSelectedRow.Equals(indexPath) ? UIColor.Clear : DefaultBackgroundColor;
 
 				SetCellBackgroundColor(nativeCell, bgColor);
-
+				MessagingCenter.Send(this, "PreserveActivityIndicatorState");
 				return nativeCell;
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1093,10 +1093,8 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 				else
 				{
-					foreach (Element childElement in element.LogicalChildrenInternal)
-					{
+					foreach (Element childElement in (element as IElementController).LogicalChildren)
 						PreserveActivityIndicatorState(childElement);
-					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

`ActivityIndicator` on iOS disappears when used in a list view cell and it's scrolled off. In `RetainElement` mode, this happens randomly whereas `RecycleElement` has this problem for every reused cell. Native view seems to have its `IsAnimating` property set to false possibly when iOS is preparing cells for reuse, but Element's `IsRunning` stays true. This PR will sync the two so the indicator can be seen.

Instead of using `MessagingCenter`, I wanted to observe changes in `IsAnimating` but could not get the observer to work despite all efforts.

Referencing https://jira.appcelerator.org/browse/TIMOB-15293
and https://github.com/appcelerator/titanium_mobile/pull/4852

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44980

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
