### PR TITLE
Frame CornerRadius

### DIFF
--- a/Xamarin.Forms.Core/Frame.cs
+++ b/Xamarin.Forms.Core/Frame.cs
@@ -11,6 +11,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty HasShadowProperty = BindableProperty.Create("HasShadow", typeof(bool), typeof(Frame), true);
 
+		public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(float), typeof(Frame), -1.0f);
+
 		readonly Lazy<PlatformConfigurationRegistry<Frame>> _platformConfigurationRegistry;
 
 		public Frame()
@@ -29,6 +31,12 @@ namespace Xamarin.Forms
 		{
 			get { return (Color)GetValue(OutlineColorProperty); }
 			set { SetValue(OutlineColorProperty, value); }
+		}
+
+		public float CornerRadius
+		{
+			get { return (float)GetValue(CornerRadiusProperty); }
+			set { SetValue(CornerRadiusProperty, value); }
 		}
 
 		public IPlatformElementConfiguration<T, Frame> On<T>() where T : IConfigPlatform

--- a/Xamarin.Forms.Core/Frame.cs
+++ b/Xamarin.Forms.Core/Frame.cs
@@ -11,7 +11,9 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty HasShadowProperty = BindableProperty.Create("HasShadow", typeof(bool), typeof(Frame), true);
 
-		public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(float), typeof(Frame), -1.0f);
+		public static readonly BindableProperty CornerRadiusProperty =
+			BindableProperty.Create(nameof(CornerRadius), typeof(float), typeof(Frame), -1.0f,
+									validateValue: (bindable, value) => ((float)value) == -1.0f || ((float)value) >= 0f);
 
 		readonly Lazy<PlatformConfigurationRegistry<Frame>> _platformConfigurationRegistry;
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		readonly TapGestureHandler _tapGestureHandler;
 
 		float _defaultElevation = -1f;
+		float _defaultCornerRadius = -1f;
 
 		bool _clickable;
 		bool _disposed;
@@ -184,6 +185,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				e.NewElement.PropertyChanged += OnElementPropertyChanged;
 				UpdateShadow();
 				UpdateBackgroundColor();
+				UpdateCornerRadius();
 				SubscribeGestureRecognizers(e.NewElement);
 			}
 		}
@@ -215,6 +217,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateShadow();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
+			else if (e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
+				UpdateCornerRadius();
 		}
 
 		void SubscribeGestureRecognizers(VisualElement element)
@@ -285,6 +289,23 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				CardElevation = elevation;
 			else
 				CardElevation = 0f;
+		}
+
+		void UpdateCornerRadius()
+		{
+			if (_defaultCornerRadius == -1f)
+			{
+				_defaultCornerRadius = Radius;
+			}
+
+			float cornerRadius = Element.CornerRadius;
+
+			if (cornerRadius == -1f)
+				cornerRadius = _defaultCornerRadius;
+			else
+				cornerRadius = Context.ToPixels(cornerRadius);
+
+			Radius = cornerRadius;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -27,10 +27,18 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnElementChanged(e);
 
 			if (e.NewElement != null && e.OldElement == null)
+			{
 				UpdateBackground();
+				UpdateCornerRadius();
+			}
 		}
 
 		void UpdateBackground()
+		{
+			this.SetBackground(new FrameDrawable(Element));
+		}
+
+		void UpdateCornerRadius()
 		{
 			this.SetBackground(new FrameDrawable(Element));
 		}
@@ -127,14 +135,13 @@ namespace Xamarin.Forms.Platform.Android
 
 				using (var canvas = new ACanvas(bitmap))
 				{
-					DrawBackground(canvas, width, height, pressed);
-					DrawOutline(canvas, width, height);
+					DrawCanvas(canvas, width, height, pressed);
 				}
 
 				return bitmap;
 			}
 
-			void DrawBackground(ACanvas canvas, int width, int height, bool pressed)
+			void DrawBackground(ACanvas canvas, int width, int height, float cornerRadius, bool pressed)
 			{
 				using (var paint = new Paint { AntiAlias = true })
 				using (var path = new Path())
@@ -142,8 +149,8 @@ namespace Xamarin.Forms.Platform.Android
 				using (Paint.Style style = Paint.Style.Fill)
 				using (var rect = new RectF(0, 0, width, height))
 				{
-					float rx = Forms.Context.ToPixels(5);
-					float ry = Forms.Context.ToPixels(5);
+					float rx = Forms.Context.ToPixels(cornerRadius);
+					float ry = Forms.Context.ToPixels(cornerRadius);
 					path.AddRoundRect(rect, rx, ry, direction);
 
 					global::Android.Graphics.Color color = _frame.BackgroundColor.ToAndroid();
@@ -155,7 +162,7 @@ namespace Xamarin.Forms.Platform.Android
 				}
 			}
 
-			void DrawOutline(ACanvas canvas, int width, int height)
+			void DrawOutline(ACanvas canvas, int width, int height, float cornerRadius)
 			{
 				using (var paint = new Paint { AntiAlias = true })
 				using (var path = new Path())
@@ -163,8 +170,8 @@ namespace Xamarin.Forms.Platform.Android
 				using (Paint.Style style = Paint.Style.Stroke)
 				using (var rect = new RectF(0, 0, width, height))
 				{
-					float rx = Forms.Context.ToPixels(5);
-					float ry = Forms.Context.ToPixels(5);
+					float rx = Forms.Context.ToPixels(cornerRadius);
+					float ry = Forms.Context.ToPixels(cornerRadius);
 					path.AddRoundRect(rect, rx, ry, direction);
 
 					paint.StrokeWidth = 1;
@@ -177,18 +184,32 @@ namespace Xamarin.Forms.Platform.Android
 
 			void FrameOnPropertyChanged(object sender, PropertyChangedEventArgs e)
 			{
-				if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == Frame.OutlineColorProperty.PropertyName)
+				if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName ||
+					e.PropertyName == Frame.OutlineColorProperty.PropertyName ||
+					e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
 				{
 					using (var canvas = new ACanvas(_normalBitmap))
 					{
 						int width = Bounds.Width();
 						int height = Bounds.Height();
 						canvas.DrawColor(global::Android.Graphics.Color.Black, PorterDuff.Mode.Clear);
-						DrawBackground(canvas, width, height, false);
-						DrawOutline(canvas, width, height);
+						DrawCanvas(canvas, width, height, false);
 					}
 					InvalidateSelf();
 				}
+			}
+
+			void DrawCanvas(ACanvas canvas, int width, int height, bool pressed)
+			{
+				float cornerRadius = _frame.CornerRadius;
+
+				if (cornerRadius == -1f)
+					cornerRadius = 5f; // default corner radius
+				else
+					cornerRadius = Forms.Context.ToPixels(cornerRadius);
+
+				DrawBackground(canvas, width, height, cornerRadius, pressed);
+				DrawOutline(canvas, width, height, cornerRadius);
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.WP8/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/FrameRenderer.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 			PackChild();
 			UpdateBorder();
+			UpdateCornerRadius();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -29,6 +30,8 @@ namespace Xamarin.Forms.Platform.WinPhone
 				PackChild();
 			else if (e.PropertyName == Frame.OutlineColorProperty.PropertyName || e.PropertyName == Frame.HasShadowProperty.PropertyName)
 				UpdateBorder();
+			else if (e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
+				UpdateCornerRadius();
 		}
 
 		void PackChild()
@@ -44,7 +47,6 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		void UpdateBorder()
 		{
-			Control.CornerRadius = new CornerRadius(5);
 			if (Element.OutlineColor != Color.Default)
 			{
 				Control.BorderBrush = Element.OutlineColor.ToBrush();
@@ -52,6 +54,16 @@ namespace Xamarin.Forms.Platform.WinPhone
 			}
 			else
 				Control.BorderBrush = new Color(0, 0, 0, 0).ToBrush();
+		}
+
+		void UpdateCornerRadius()
+		{
+			float cornerRadius = Element.CornerRadius;
+
+			if (cornerRadius == -1f)
+				cornerRadius = 5f; // default corner radius
+
+			Control.CornerRadius = new CornerRadius(cornerRadius);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WinRT/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/FrameRenderer.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 				PackChild();
 				UpdateBorder();
+				UpdateCornerRadius();
 			}
 		}
 
@@ -43,6 +44,10 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				UpdateBorder();
 			}
+			else if (e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
+			{
+				UpdateCornerRadius();
+			}
 		}
 
 		void PackChild()
@@ -56,7 +61,6 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void UpdateBorder()
 		{
-			Control.CornerRadius = new CornerRadius(5);
 			if (Element.OutlineColor != Color.Default)
 			{
 				Control.BorderBrush = Element.OutlineColor.ToBrush();
@@ -66,6 +70,16 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				Control.BorderBrush = new Color(0, 0, 0, 0).ToBrush();
 			}
+		}
+
+		void UpdateCornerRadius()
+		{
+			float cornerRadius = Element.CornerRadius;
+
+			if (cornerRadius == -1f)
+				cornerRadius = 5f; // default corner radius
+
+			Control.CornerRadius = new CornerRadius(cornerRadius);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -25,7 +25,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void SetupLayer()
 		{
-			Layer.CornerRadius = 5;
+			float cornerRadius = Element.CornerRadius;
+
+			if (cornerRadius == -1f)
+				cornerRadius = 5f; // default corner radius
+
+			Layer.CornerRadius = cornerRadius;
+
 			if (Element.BackgroundColor == Color.Default)
 				Layer.BackgroundColor = UIColor.White.CGColor;
 			else

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Frame.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Frame.xml
@@ -91,6 +91,37 @@ MainPage = new ContentPage () {
         <remarks>A Frame has a default <see cref="P:Xamarin.Forms.Layout.Padding" /> of 20.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="CornerRadius">
+      <MemberSignature Language="C#" Value="public float CornerRadius { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float32 CornerRadius" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CornerRadiusProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty CornerRadiusProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty CornerRadiusProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="HasShadow">
       <MemberSignature Language="C#" Value="public bool HasShadow { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance bool HasShadow" />


### PR DESCRIPTION
this replace #433 from @andreinitescu 

## Please do not squash merge to preserve original author attribution ##

### Description of Change

Added CornerRadius property to the Frame control to customize Frame's corner radius value.

### Bugs Fixed

N/A

### API Changes

Added:
- public float Frame.CornerRadius { get; set; } //Bindable Property
- public static readonly BindableProperty Frame.CornerRadiusProperty;

### Behavioral Changes

The property default value ensures the appearance of the Frame control in current apps remains unchanged.
### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
