### PR TITLE
[iOS] Add ability to toggle selector actions on and off when an input field is long clicked

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38480.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38480.cs
@@ -1,5 +1,8 @@
-﻿using Xamarin.Forms.CustomAttributes;
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 #if UITEST
 using Xamarin.UITest;
@@ -14,12 +17,162 @@ namespace Xamarin.Forms.Controls
 	{
 		protected override void Init()
 		{
-			// Initialize ui here instead of ctor
-			Content = new Label
+			var scrollView = new ScrollView();
+			var stackLayout = new StackLayout
 			{
-				AutomationId = "IssuePageLabel",
-				Text = "See if I'm here"
+				Orientation = StackOrientation.Vertical,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Spacing = 15
 			};
+
+			var datePicker = new Xamarin.Forms.DatePicker
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var picker = new Xamarin.Forms.Picker
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+			picker.Items.Add("item1");
+			picker.Items.Add("item2");
+			picker.Items.Add("item3");
+			picker.Items.Add("item4");
+			picker.Items.Add("item5");
+
+			var timePicker = new Xamarin.Forms.TimePicker
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+
+			var entry = new Xamarin.Forms.Entry
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var button = new Button
+			{
+				Text = "Change",
+				Command = new Command(() => { Change(datePicker, picker, timePicker, entry); })
+			};
+
+			stackLayout.Children.Add(button);
+			stackLayout.Children.Add(datePicker);
+			stackLayout.Children.Add(picker);
+			stackLayout.Children.Add(timePicker);
+			stackLayout.Children.Add(entry);
+
+			SetInitialValues(datePicker, picker, timePicker, entry);
+			scrollView.Content = stackLayout;
+
+			Content = scrollView;
+		}
+
+		void SetInitialValues(Xamarin.Forms.DatePicker datePicker, Xamarin.Forms.Picker picker, Xamarin.Forms.TimePicker timePicker, Xamarin.Forms.Entry entry)
+		{
+			datePicker.On<iOS>().SetDisabledSelectorActions(new List<SelectorAction>
+			{
+				SelectorAction.AddShortcut,
+				SelectorAction.Cut,
+				SelectorAction.Copy,
+				SelectorAction.Define,
+				SelectorAction.Delete,
+				SelectorAction.Lookup,
+				SelectorAction.Select,
+				SelectorAction.SelectAll,
+				SelectorAction.Replace,
+				SelectorAction.Share,
+				SelectorAction.Paste
+			});
+
+			picker.On<iOS>().SetDisabledSelectorActions(new List<SelectorAction>
+			{
+				SelectorAction.AddShortcut,
+				SelectorAction.Cut,
+				SelectorAction.Copy,
+				SelectorAction.Define,
+				SelectorAction.Delete,
+				SelectorAction.Lookup,
+				SelectorAction.Select,
+				SelectorAction.SelectAll,
+				SelectorAction.Replace,
+				SelectorAction.Share,
+				SelectorAction.Paste
+			});
+
+			timePicker.On<iOS>().SetDisabledSelectorActions(new List<SelectorAction>
+			{
+				SelectorAction.AddShortcut,
+				SelectorAction.Cut,
+				SelectorAction.Copy,
+				SelectorAction.Define,
+				SelectorAction.Delete,
+				SelectorAction.Lookup,
+				SelectorAction.Select,
+				SelectorAction.SelectAll,
+				SelectorAction.Replace,
+				SelectorAction.Share,
+				SelectorAction.Paste
+			});
+
+			entry.On<iOS>().SetDisabledSelectorActions(new List<SelectorAction>
+			{
+				SelectorAction.AddShortcut,
+				SelectorAction.Cut,
+				SelectorAction.Copy,
+				SelectorAction.Define,
+				SelectorAction.Delete,
+				SelectorAction.Lookup,
+				SelectorAction.Select,
+				SelectorAction.SelectAll,
+				SelectorAction.Replace,
+				SelectorAction.Share,
+				SelectorAction.Paste
+			});
+		}
+
+		void Change(Xamarin.Forms.DatePicker datePicker, Xamarin.Forms.Picker picker, Xamarin.Forms.TimePicker timePicker, Xamarin.Forms.Entry entry)
+		{
+			datePicker.On<iOS>().SetDisabledSelectorActions(new List<SelectorAction>
+			{
+				SelectorAction.AddShortcut,
+				SelectorAction.Cut,
+				SelectorAction.Copy
+			});
+
+			picker.On<iOS>().SetDisabledSelectorActions(new List<SelectorAction>
+			{
+				SelectorAction.Cut,
+				SelectorAction.Replace,
+				SelectorAction.Share,
+				SelectorAction.Paste
+			});
+
+			timePicker.On<iOS>().SetDisabledSelectorActions(new List<SelectorAction>
+			{
+				SelectorAction.Copy,
+				SelectorAction.Define,
+				SelectorAction.Delete,
+				SelectorAction.Replace,
+				SelectorAction.Share,
+				SelectorAction.Paste
+			});
+
+			entry.On<iOS>().SetDisabledSelectorActions(new List<SelectorAction>
+			{
+				SelectorAction.AddShortcut,
+				SelectorAction.Cut,
+				SelectorAction.Lookup, // not the same as "Look Up" which happens to be Define on iOS 10.
+				SelectorAction.Select,
+				SelectorAction.SelectAll,
+				SelectorAction.Share
+			});
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38480.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38480.cs
@@ -1,0 +1,25 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 38480, "How to disable cut,copy, paste options for textFields in Xamarin.forms", PlatformAffected.iOS)]
+	public class Bugzilla38480 : TestContentPage
+	{
+		protected override void Init()
+		{
+			// Initialize ui here instead of ctor
+			Content = new Label
+			{
+				AutomationId = "IssuePageLabel",
+				Text = "See if I'm here"
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -79,6 +79,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37863.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37601.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38105.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38480.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38827.xaml.cs">
       <DependentUpon>Bugzilla38827.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -129,7 +130,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
-
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44584.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.DatePicker;
+
+	public static class DatePicker
+	{
+		public static readonly BindableProperty DisabledSelectorActionsProperty = BindableProperty.Create(nameof(DisabledSelectorActions), typeof(List<SelectorAction>), typeof(DatePicker));
+
+		public static List<SelectorAction> GetDisabledSelectorActions(BindableObject element)
+		{
+			return (List<SelectorAction>)element.GetValue(DisabledSelectorActionsProperty);
+		}
+
+		public static void SetDisabledSelectorActions(BindableObject element, List<SelectorAction> value)
+		{
+			element.SetValue(DisabledSelectorActionsProperty, value);
+		}
+
+		public static List<SelectorAction> DisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetDisabledSelectorActions(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config, List<SelectorAction> value)
+		{
+			SetDisabledSelectorActions(config.Element, value);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> EnableDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			var disabledSelectorActions = GetDisabledSelectorActions(config.Element);
+
+			if (disabledSelectorActions == null || disabledSelectorActions.Count == 0)
+				disabledSelectorActions = new List<SelectorAction> { SelectorAction.All };
+
+			SetDisabledSelectorActions(config.Element, disabledSelectorActions);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> DisableDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			SetDisabledSelectorActions(config.Element, null);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Entry.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Entry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 {
@@ -40,6 +41,46 @@ namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 		public static IPlatformElementConfiguration<iOS, FormsElement> DisableAdjustsFontSizeToFitWidth(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			SetAdjustsFontSizeToFitWidth(config.Element, false);
+			return config;
+		}
+
+		public static readonly BindableProperty DisabledSelectorActionsProperty = BindableProperty.Create(nameof(DisabledSelectorActions), typeof(List<SelectorAction>), typeof(Entry));
+
+		public static List<SelectorAction> GetDisabledSelectorActions(BindableObject element)
+		{
+			return (List<SelectorAction>)element.GetValue(DisabledSelectorActionsProperty);
+		}
+
+		public static void SetDisabledSelectorActions(BindableObject element, List<SelectorAction> value)
+		{
+			element.SetValue(DisabledSelectorActionsProperty, value);
+		}
+
+		public static List<SelectorAction> DisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetDisabledSelectorActions(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config, List<SelectorAction> value)
+		{
+			SetDisabledSelectorActions(config.Element, value);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> EnableDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			var disabledSelectorActions = GetDisabledSelectorActions(config.Element);
+
+			if(disabledSelectorActions == null || disabledSelectorActions.Count == 0)
+				disabledSelectorActions = new List<SelectorAction> { SelectorAction.All };
+
+			SetDisabledSelectorActions(config.Element, disabledSelectorActions);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> DisableDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			SetDisabledSelectorActions(config.Element, null);
 			return config;
 		}
 	}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Picker.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Picker.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.Picker;
+
+	public static class Picker
+	{
+		public static readonly BindableProperty DisabledSelectorActionsProperty = BindableProperty.Create(nameof(DisabledSelectorActions), typeof(List<SelectorAction>), typeof(Picker));
+
+		public static List<SelectorAction> GetDisabledSelectorActions(BindableObject element)
+		{
+			return (List<SelectorAction>)element.GetValue(DisabledSelectorActionsProperty);
+		}
+
+		public static void SetDisabledSelectorActions(BindableObject element, List<SelectorAction> value)
+		{
+			element.SetValue(DisabledSelectorActionsProperty, value);
+		}
+
+		public static List<SelectorAction> DisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetDisabledSelectorActions(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config, List<SelectorAction> value)
+		{
+			SetDisabledSelectorActions(config.Element, value);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> EnableDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			var disabledSelectorActions = GetDisabledSelectorActions(config.Element);
+
+			if (disabledSelectorActions == null || disabledSelectorActions.Count == 0)
+				disabledSelectorActions = new List<SelectorAction> { SelectorAction.All };
+
+			SetDisabledSelectorActions(config.Element, disabledSelectorActions);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> DisableDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			SetDisabledSelectorActions(config.Element, null);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/SelectorAction.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/SelectorAction.cs
@@ -1,0 +1,12 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	public enum SelectorAction
+	{
+		Copy,
+		Cut,
+		Paste,
+		Select,
+		SelectAll,
+		All
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/SelectorAction.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/SelectorAction.cs
@@ -3,9 +3,11 @@
 	public enum SelectorAction
 	{
 		All,
+		AddShortcut,
 		Copy,
 		Cut,
 		Delete,
+		Define,
 		Lookup,
 		Paste,
 		Replace,

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/SelectorAction.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/SelectorAction.cs
@@ -2,11 +2,15 @@
 {
 	public enum SelectorAction
 	{
+		All,
 		Copy,
 		Cut,
+		Delete,
+		Lookup,
 		Paste,
+		Replace,
 		Select,
 		SelectAll,
-		All
+		Share
 	}
 }

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.TimePicker;
+
+	public static class TimePicker
+	{
+		public static readonly BindableProperty DisabledSelectorActionsProperty = BindableProperty.Create(nameof(DisabledSelectorActions), typeof(List<SelectorAction>), typeof(TimePicker));
+
+		public static List<SelectorAction> GetDisabledSelectorActions(BindableObject element)
+		{
+			return (List<SelectorAction>)element.GetValue(DisabledSelectorActionsProperty);
+		}
+
+		public static void SetDisabledSelectorActions(BindableObject element, List<SelectorAction> value)
+		{
+			element.SetValue(DisabledSelectorActionsProperty, value);
+		}
+
+		public static List<SelectorAction> DisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetDisabledSelectorActions(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config, List<SelectorAction> value)
+		{
+			SetDisabledSelectorActions(config.Element, value);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> EnableDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			var disabledSelectorActions = GetDisabledSelectorActions(config.Element);
+
+			if (disabledSelectorActions == null || disabledSelectorActions.Count == 0)
+				disabledSelectorActions = new List<SelectorAction> { SelectorAction.All };
+
+			SetDisabledSelectorActions(config.Element, disabledSelectorActions);
+			return config;
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> DisableDisabledSelectorActions(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			SetDisabledSelectorActions(config.Element, null);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -94,6 +94,7 @@
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\Entry.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\NavigationPage.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\SelectorAction.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\VisualElement.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\MasterDetailPage.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\CollapseStyle.cs" />

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -95,7 +95,9 @@
     <Compile Include="PlatformConfiguration\iOSSpecific\DatePicker.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\Entry.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\NavigationPage.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\Picker.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\SelectorAction.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\TimePicker.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\VisualElement.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\MasterDetailPage.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\CollapseStyle.cs" />

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -92,6 +92,7 @@
     <Compile Include="PlatformConfiguration\AndroidSpecific\TabbedPage.cs" />
     <Compile Include="PlatformConfiguration\ExtensionPoints.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />
+    <Compile Include="PlatformConfiguration\iOSSpecific\DatePicker.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\Entry.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\NavigationPage.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\SelectorAction.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -160,6 +160,12 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				UnregisterEvents();
 
+				if (_defaultTextColor != null)
+				{
+					_defaultTextColor.Dispose();
+					_defaultTextColor = null;
+				}
+
 				if (_noCaretField != null)
 				{
 					_noCaretField.Dispose();
@@ -170,12 +176,6 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					_picker.Dispose();
 					_picker = null;
-				}
-
-				if (_defaultTextColor != null)
-				{
-					_defaultTextColor.Dispose();
-					_defaultTextColor = null;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -166,16 +166,16 @@ namespace Xamarin.Forms.Platform.iOS
 					_defaultTextColor = null;
 				}
 
-				if (_noCaretField != null)
-				{
-					_noCaretField.Dispose();
-					_noCaretField = null;
-				}
-
 				if (_picker != null)
 				{
 					_picker.Dispose();
 					_picker = null;
+				}
+
+				if (_noCaretField != null)
+				{
+					_noCaretField.Dispose();
+					_noCaretField = null;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateMaximumDate();
 			else if (e.PropertyName == DatePicker.TextColorProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateTextColor();
-			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Entry.DisabledSelectorActionsProperty.PropertyName)
+			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.DatePicker.DisabledSelectorActionsProperty.PropertyName)
 				UpdateDisabledSelectorActions();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -1,14 +1,16 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Foundation;
 using UIKit;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	internal class NoCaretField : UITextField
+	internal class NoCaretField : UITextFieldWrapper
 	{
-		public NoCaretField() : base(new RectangleF())
+		public NoCaretField(List<SelectorAction> disabledSelectorActions) : base(disabledSelectorActions, new RectangleF())
 		{
 		}
 
@@ -22,6 +24,9 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		UIDatePicker _picker;
 		UIColor _defaultTextColor;
+		NoCaretField _noCaretField;
+
+		bool _disposed;
 
 		IElementController ElementController => Element as IElementController;
 
@@ -29,34 +34,39 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementChanged(e);
 
-			if (e.OldElement == null)
+			if (e.OldElement != null)
 			{
-				var entry = new NoCaretField { BorderStyle = UITextBorderStyle.RoundedRect };
-
-				entry.EditingDidBegin += OnStarted;
-				entry.EditingDidEnd += OnEnded;
-
-				_picker = new UIDatePicker { Mode = UIDatePickerMode.Date, TimeZone = new NSTimeZone("UTC") };
-
-				_picker.ValueChanged += HandleValueChanged;
-
-				var width = UIScreen.MainScreen.Bounds.Width;
-				var toolbar = new UIToolbar(new RectangleF(0, 0, width, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
-				var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);
-				var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) => entry.ResignFirstResponder());
-
-				toolbar.SetItems(new[] { spacer, doneButton }, false);
-
-				entry.InputView = _picker;
-				entry.InputAccessoryView = toolbar;
-
-				_defaultTextColor = entry.TextColor;
-
-				SetNativeControl(entry);
+				UnregisterEvents();
 			}
 
 			if (e.NewElement != null)
 			{
+				if (Control == null)
+				{
+					_noCaretField = new NoCaretField(Element.On<PlatformConfiguration.iOS>().DisabledSelectorActions()) { BorderStyle = UITextBorderStyle.RoundedRect };
+
+					_noCaretField.EditingDidBegin += OnStarted;
+					_noCaretField.EditingDidEnd += OnEnded;
+
+					_picker = new UIDatePicker { Mode = UIDatePickerMode.Date, TimeZone = new NSTimeZone("UTC") };
+
+					_picker.ValueChanged += HandleValueChanged;
+
+					var width = UIScreen.MainScreen.Bounds.Width;
+					var toolbar = new UIToolbar(new RectangleF(0, 0, width, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
+					var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);
+					var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) => _noCaretField.ResignFirstResponder());
+
+					toolbar.SetItems(new[] { spacer, doneButton }, false);
+
+					_noCaretField.InputView = _picker;
+					_noCaretField.InputAccessoryView = toolbar;
+
+					_defaultTextColor = _noCaretField.TextColor;
+
+					SetNativeControl(_noCaretField);
+				}
+
 				UpdateDateFromModel(false);
 				UpdateMaximumDate();
 				UpdateMinimumDate();
@@ -76,6 +86,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateMaximumDate();
 			else if (e.PropertyName == DatePicker.TextColorProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Entry.DisabledSelectorActionsProperty.PropertyName)
+				UpdateDisabledSelectorActions();
 		}
 
 		void HandleValueChanged(object sender, EventArgs e)
@@ -119,6 +131,56 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.TextColor = _defaultTextColor;
 			else
 				Control.TextColor = textColor.ToUIColor();
+		}
+
+		void UpdateDisabledSelectorActions()
+		{
+			_noCaretField.DisabledSelectorActions = Element.On<PlatformConfiguration.iOS>().DisabledSelectorActions();
+		}
+
+		void UnregisterEvents()
+		{
+			if (_noCaretField != null)
+			{
+				_noCaretField.EditingDidBegin -= OnStarted;
+				_noCaretField.EditingDidEnd -= OnEnded;
+			}
+
+			if (_picker != null)
+				_picker.ValueChanged -= HandleValueChanged;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			if (disposing)
+			{
+				UnregisterEvents();
+
+				if (_noCaretField != null)
+				{
+					_noCaretField.Dispose();
+					_noCaretField = null;
+				}
+
+				if (_picker != null)
+				{
+					_picker.Dispose();
+					_picker = null;
+				}
+
+				if (_defaultTextColor != null)
+				{
+					_defaultTextColor.Dispose();
+					_defaultTextColor = null;
+				}
+			}
+
+			_disposed = true;
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	internal class NoCaretField : UITextFieldWrapper
 	{
-		public NoCaretField(List<SelectorAction> disabledSelectorActions) : base(disabledSelectorActions, new RectangleF())
+		public NoCaretField() : base(new RectangleF())
 		{
 		}
 
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (Control == null)
 				{
-					_noCaretField = new NoCaretField(Element.On<PlatformConfiguration.iOS>().DisabledSelectorActions()) { BorderStyle = UITextBorderStyle.RoundedRect };
+					_noCaretField = new NoCaretField { BorderStyle = UITextBorderStyle.RoundedRect };
 
 					_noCaretField.EditingDidBegin += OnStarted;
 					_noCaretField.EditingDidEnd += OnEnded;

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -71,6 +71,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateMaximumDate();
 				UpdateMinimumDate();
 				UpdateTextColor();
+				UpdateDisabledSelectorActions();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -2,6 +2,9 @@ using System;
 using System.ComponentModel;
 
 using System.Drawing;
+using CoreGraphics;
+using Foundation;
+using ObjCRuntime;
 using UIKit;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
@@ -37,25 +40,23 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementChanged(e);
 
-			var textField = Control;
-
-			if (Control == null)
-			{
-				SetNativeControl(textField = new UITextField(RectangleF.Empty));
-
-				_defaultTextColor = textField.TextColor;
-				textField.BorderStyle = UITextBorderStyle.RoundedRect;
-
-				textField.EditingChanged += OnEditingChanged;
-
-				textField.ShouldReturn = OnShouldReturn;
-
-				textField.EditingDidBegin += OnEditingBegan;
-				textField.EditingDidEnd += OnEditingEnded;
-			}
-
 			if (e.NewElement != null)
 			{
+				if (Control == null)
+				{
+					SetNativeControl(new UITextFieldWrapper(RectangleF.Empty));
+
+					_defaultTextColor = Control.TextColor;
+					Control.BorderStyle = UITextBorderStyle.RoundedRect;
+
+					Control.EditingChanged += OnEditingChanged;
+
+					Control.ShouldReturn = OnShouldReturn;
+
+					Control.EditingDidBegin += OnEditingBegan;
+					Control.EditingDidEnd += OnEditingEnded;
+				}
+
 				UpdatePlaceholder();
 				UpdatePassword();
 				UpdateText();
@@ -191,6 +192,33 @@ namespace Xamarin.Forms.Platform.iOS
 			// ReSharper disable once RedundantCheckBeforeAssignment
 			if (Control.Text != Element.Text)
 				Control.Text = Element.Text;
+		}
+	}
+
+	public class UITextFieldWrapper : UITextField
+	{
+		public UITextFieldWrapper(CGRect frame) : base(frame)
+		{
+		}
+
+		public override bool CanPerform(Selector action, NSObject withSender)
+		{
+			if (action == new Selector("copy:"))
+				return false;
+
+			if (action == new Selector("cut:"))
+				return false;
+
+			if (action == new Selector("paste:"))
+				return false;
+
+			if (action == new Selector("select:"))
+				return false;
+
+			if (action == new Selector("selectAll:"))
+				return false;
+
+			return base.CanPerform(action, withSender);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -244,13 +244,25 @@ namespace Xamarin.Forms.Platform.iOS
 			if (disabledSelectorActions.Contains(SelectorAction.Cut) && action == new Selector("cut:"))
 				return false;
 
+			if (disabledSelectorActions.Contains(SelectorAction.Delete) && action == new Selector("delete:"))
+				return false;
+
+			if (disabledSelectorActions.Contains(SelectorAction.Lookup) && action == new Selector("_lookup:"))
+				return false;
+
 			if (disabledSelectorActions.Contains(SelectorAction.Paste) && action == new Selector("paste:"))
+				return false;
+
+			if (disabledSelectorActions.Contains(SelectorAction.Replace) && action == new Selector("_promptForReplace:"))
 				return false;
 
 			if (disabledSelectorActions.Contains(SelectorAction.Select) && action == new Selector("select:"))
 				return false;
 
 			if (disabledSelectorActions.Contains(SelectorAction.SelectAll) && action == new Selector("selectAll:"))
+				return false;
+
+			if (disabledSelectorActions.Contains(SelectorAction.Share) && action == new Selector("_share:"))
 				return false;
 
 			return base.CanPerform(action, withSender);

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -119,6 +119,8 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Entry.AdjustsFontSizeToFitWidthProperty.PropertyName)
 				UpdateAdjustsFontSizeToFitWidth();
+			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Entry.DisabledSelectorActionsProperty.PropertyName)
+				UpdateDisabledSelectorActions();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -217,58 +219,61 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Control.Text != Element.Text)
 				Control.Text = Element.Text;
 		}
+
+		void UpdateDisabledSelectorActions()
+		{
+			(_uiTextField as UITextFieldWrapper).DisabledSelectorActions = Element.On<PlatformConfiguration.iOS>().DisabledSelectorActions();
+		}
 	}
 
 	class UITextFieldWrapper : UITextField
 	{
-		readonly Entry _element;
+		internal List<SelectorAction> DisabledSelectorActions { get; set; }
 
-		internal UITextFieldWrapper(Entry element, CGRect frame) : base(frame)
+		internal UITextFieldWrapper(List<SelectorAction> disabledSelectorActions, CGRect frame) : base(frame)
 		{
-			_element = element;
+			DisabledSelectorActions = disabledSelectorActions;
 		}
 
 		public override bool CanPerform(Selector action, NSObject withSender)
 		{
-			List<SelectorAction> disabledSelectorActions = _element.On<PlatformConfiguration.iOS>().DisabledSelectorActions();
-
-			if(disabledSelectorActions == null || disabledSelectorActions.Count == 0)
+			if(DisabledSelectorActions == null || DisabledSelectorActions.Count == 0)
 				return base.CanPerform(action, withSender);
 
-			if (disabledSelectorActions.Contains(SelectorAction.All))
+			if (DisabledSelectorActions.Contains(SelectorAction.All))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.AddShortcut) && action == new Selector("_addShortcut:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.AddShortcut) && action == new Selector("_addShortcut:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Copy) && action == new Selector("copy:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.Copy) && action == new Selector("copy:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Cut) && action == new Selector("cut:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.Cut) && action == new Selector("cut:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Define) && action == new Selector("_define:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.Define) && action == new Selector("_define:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Delete) && action == new Selector("delete:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.Delete) && action == new Selector("delete:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Lookup) && action == new Selector("_lookup:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.Lookup) && action == new Selector("_lookup:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Paste) && action == new Selector("paste:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.Paste) && action == new Selector("paste:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Replace) && action == new Selector("_promptForReplace:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.Replace) && action == new Selector("_promptForReplace:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Select) && action == new Selector("select:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.Select) && action == new Selector("select:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.SelectAll) && action == new Selector("selectAll:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.SelectAll) && action == new Selector("selectAll:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Share) && action == new Selector("_share:"))
+			if (DisabledSelectorActions.Contains(SelectorAction.Share) && action == new Selector("_share:"))
 				return false;
 
 			return base.CanPerform(action, withSender);

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -89,6 +89,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateKeyboard();
 				UpdateAlignment();
 				UpdateAdjustsFontSizeToFitWidth();
+				UpdateDisabledSelectorActions();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -32,6 +32,13 @@ namespace Xamarin.Forms.Platform.iOS
 			if (disposing)
 			{
 				UnregisterEvents();
+
+				if (_defaultTextColor != null)
+				{
+					_defaultTextColor.Dispose();
+					_defaultTextColor = null;
+				}
+
 				if (_uiTextField != null)
 				{
 					_uiTextField.Dispose();

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (Control == null)
 				{
-					_uiTextField = new UITextFieldWrapper(Element, RectangleF.Empty)
+					_uiTextField = new UITextFieldWrapper(RectangleF.Empty)
 					{
 						BorderStyle = UITextBorderStyle.RoundedRect,
 						ShouldReturn = OnShouldReturn
@@ -230,9 +230,8 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		internal List<SelectorAction> DisabledSelectorActions { get; set; }
 
-		internal UITextFieldWrapper(List<SelectorAction> disabledSelectorActions, CGRect frame) : base(frame)
+		internal UITextFieldWrapper(CGRect frame) : base(frame)
 		{
-			DisabledSelectorActions = disabledSelectorActions;
 		}
 
 		public override bool CanPerform(Selector action, NSObject withSender)

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -247,7 +247,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (disabledSelectorActions.Contains(SelectorAction.Cut) && action == new Selector("cut:"))
 				return false;
 
-			if (disabledSelectorActions.Contains(SelectorAction.Define) && action == new Selector("define:"))
+			if (disabledSelectorActions.Contains(SelectorAction.Define) && action == new Selector("_define:"))
 				return false;
 
 			if (disabledSelectorActions.Contains(SelectorAction.Delete) && action == new Selector("delete:"))

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -238,10 +238,16 @@ namespace Xamarin.Forms.Platform.iOS
 			if (disabledSelectorActions.Contains(SelectorAction.All))
 				return false;
 
+			if (disabledSelectorActions.Contains(SelectorAction.AddShortcut) && action == new Selector("_addShortcut:"))
+				return false;
+
 			if (disabledSelectorActions.Contains(SelectorAction.Copy) && action == new Selector("copy:"))
 				return false;
 
 			if (disabledSelectorActions.Contains(SelectorAction.Cut) && action == new Selector("cut:"))
+				return false;
+
+			if (disabledSelectorActions.Contains(SelectorAction.Define) && action == new Selector("define:"))
 				return false;
 
 			if (disabledSelectorActions.Contains(SelectorAction.Delete) && action == new Selector("delete:"))

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -170,6 +170,12 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				UnregisterEvents();
 
+				if (_defaultTextColor != null)
+				{
+					_defaultTextColor.Dispose();
+					_defaultTextColor = null;
+				}
+
 				if (_noCaretField != null)
 				{
 					_noCaretField.Dispose();
@@ -180,12 +186,6 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					_picker.Dispose();
 					_picker = null;
-				}
-
-				if (_defaultTextColor != null)
-				{
-					_defaultTextColor.Dispose();
-					_defaultTextColor = null;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using UIKit;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -9,22 +10,28 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		UIPickerView _picker;
 		UIColor _defaultTextColor;
+		NoCaretField _noCaretField;
+
+		bool _disposed;
 
 		IElementController ElementController => Element as IElementController;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
 		{
 			if (e.OldElement != null)
+			{
 				((ObservableList<string>)e.OldElement.Items).CollectionChanged -= RowsCollectionChanged;
+				UnregisterEvents();
+			}
 
 			if (e.NewElement != null)
 			{
 				if (Control == null)
 				{
-					var entry = new NoCaretField { BorderStyle = UITextBorderStyle.RoundedRect };
+					_noCaretField = new NoCaretField { BorderStyle = UITextBorderStyle.RoundedRect };
 
-					entry.EditingDidBegin += OnStarted;
-					entry.EditingDidEnd += OnEnded;
+					_noCaretField.EditingDidBegin += OnStarted;
+					_noCaretField.EditingDidEnd += OnEnded;
 
 					_picker = new UIPickerView();
 
@@ -37,23 +44,24 @@ namespace Xamarin.Forms.Platform.iOS
 						if (s.SelectedIndex == -1 && Element.Items != null && Element.Items.Count > 0)
 							UpdatePickerSelectedIndex(0);
 						UpdatePickerFromModel(s);
-						entry.ResignFirstResponder();
+						_noCaretField.ResignFirstResponder();
 					});
 
 					toolbar.SetItems(new[] { spacer, doneButton }, false);
 
-					entry.InputView = _picker;
-					entry.InputAccessoryView = toolbar;
+					_noCaretField.InputView = _picker;
+					_noCaretField.InputAccessoryView = toolbar;
 
-					_defaultTextColor = entry.TextColor;
+					_defaultTextColor = _noCaretField.TextColor;
 
-					SetNativeControl(entry);
+					SetNativeControl(_noCaretField);
 				}
 
 				_picker.Model = new PickerSource(this);
 
 				UpdatePicker();
 				UpdateTextColor();
+				UpdateDisabledSelectorActions();
 
 				((ObservableList<string>)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
 			}
@@ -70,6 +78,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdatePicker();
 			if (e.PropertyName == Picker.TextColorProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Picker.DisabledSelectorActionsProperty.PropertyName)
+				UpdateDisabledSelectorActions();
 		}
 
 		void OnEnded(object sender, EventArgs eventArgs)
@@ -135,6 +145,53 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.TextColor = _defaultTextColor;
 			else
 				Control.TextColor = textColor.ToUIColor();
+		}
+
+		void UpdateDisabledSelectorActions()
+		{
+			_noCaretField.DisabledSelectorActions = Element.On<PlatformConfiguration.iOS>().DisabledSelectorActions();
+		}
+
+		void UnregisterEvents()
+		{
+			if (_noCaretField != null)
+			{
+				_noCaretField.EditingDidBegin -= OnStarted;
+				_noCaretField.EditingDidEnd -= OnEnded;
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			if (disposing)
+			{
+				UnregisterEvents();
+
+				if (_noCaretField != null)
+				{
+					_noCaretField.Dispose();
+					_noCaretField = null;
+				}
+
+				if (_picker != null)
+				{
+					_picker.Dispose();
+					_picker = null;
+				}
+
+				if (_defaultTextColor != null)
+				{
+					_defaultTextColor.Dispose();
+					_defaultTextColor = null;
+				}
+			}
+
+			_disposed = true;
+
+			base.Dispose(disposing);
 		}
 
 		class PickerSource : UIPickerViewModel

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -176,16 +176,16 @@ namespace Xamarin.Forms.Platform.iOS
 					_defaultTextColor = null;
 				}
 
-				if (_noCaretField != null)
-				{
-					_noCaretField.Dispose();
-					_noCaretField = null;
-				}
-
 				if (_picker != null)
 				{
 					_picker.Dispose();
 					_picker = null;
+				}
+
+				if (_noCaretField != null)
+				{
+					_noCaretField.Dispose();
+					_noCaretField = null;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -26,6 +26,12 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				UnregisterEvents();
 
+				if (_defaultTextColor != null)
+				{
+					_defaultTextColor.Dispose();
+					_defaultTextColor = null;
+				}
+
 				if (_noCaretField != null)
 				{
 					_noCaretField.Dispose();
@@ -36,13 +42,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					_picker.Dispose();
 					_picker = null;
-				}
-
-				if (_defaultTextColor != null)
-				{
-					_defaultTextColor.Dispose();
-					_defaultTextColor = null;
-				}
+				}		
 			}
 
 			_disposed = true;

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -32,17 +32,17 @@ namespace Xamarin.Forms.Platform.iOS
 					_defaultTextColor = null;
 				}
 
+				if (_picker != null)
+				{
+					_picker.Dispose();
+					_picker = null;
+				}
+
 				if (_noCaretField != null)
 				{
 					_noCaretField.Dispose();
 					_noCaretField = null;
 				}
-
-				if (_picker != null)
-				{
-					_picker.Dispose();
-					_picker = null;
-				}		
 			}
 
 			_disposed = true;

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/DatePicker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/DatePicker.xml
@@ -1,0 +1,156 @@
+﻿<Type Name="DatePicker" FullName="Xamarin.Forms.PlatformConfiguration.iOSSpecific.DatePicker">
+  <TypeSignature Language="C#" Value="public static class DatePicker" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit DatePicker extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="DisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static List&lt;SelectorAction&gt; DisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig List&lt;SelectorAction&gt; DisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.DatePicker&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;SelectorAction&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DisabledSelectorActionsProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty DisabledSelectorActionsProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty DisabledSelectorActionsProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DisableDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt; DisableDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.DatePicker&gt; DisableDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.DatePicker&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="EnableDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt; EnableDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.DatePicker&gt; EnableDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.DatePicker&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static List&lt;SelectorAction&gt; GetDisabledSelectorActions (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig List&lt;SelectorAction&gt; GetDisabledSelectorActions(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;SelectorAction&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static void SetDisabledSelectorActions (Xamarin.Forms.BindableObject element, List&lt;SelectorAction&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetDisabledSelectorActions(class Xamarin.Forms.BindableObject element, List&lt;SelectorAction&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Collections.Generic.List&lt;SelectorAction&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt; SetDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt; config, List&lt;SelectorAction&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.DatePicker&gt; SetDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.DatePicker&gt; config, List&lt;SelectorAction&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.DatePicker&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Collections.Generic.List&lt;SelectorAction&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Entry.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Entry.xml
@@ -152,5 +152,144 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+
+    <Member MemberName="DisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static List&lt;SelectorAction&gt; DisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig List&lt;SelectorAction&gt; DisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;SelectorAction&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DisabledSelectorActionsProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty DisabledSelectorActionsProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty DisabledSelectorActionsProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DisableDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; DisableDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; DisableDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="EnableDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; EnableDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; EnableDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static List&lt;SelectorAction&gt; GetDisabledSelectorActions (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig List&lt;SelectorAction&gt; GetDisabledSelectorActions(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;SelectorAction&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static void SetDisabledSelectorActions (Xamarin.Forms.BindableObject element, List&lt;SelectorAction&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetDisabledSelectorActions(class Xamarin.Forms.BindableObject element, List&lt;SelectorAction&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Collections.Generic.List&lt;SelectorAction&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; SetDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config, List&lt;SelectorAction&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; SetDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config, List&lt;SelectorAction&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Collections.Generic.List&lt;SelectorAction&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Picker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Picker.xml
@@ -1,0 +1,156 @@
+﻿<Type Name="Picker" FullName="Xamarin.Forms.PlatformConfiguration.iOSSpecific.Picker">
+  <TypeSignature Language="C#" Value="public static class Picker" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Picker extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="DisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static List&lt;SelectorAction&gt; DisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig List&lt;SelectorAction&gt; DisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Picker&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;SelectorAction&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DisabledSelectorActionsProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty DisabledSelectorActionsProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty DisabledSelectorActionsProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DisableDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt; DisableDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Picker&gt; DisableDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Picker&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="EnableDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt; EnableDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Picker&gt; EnableDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Picker&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static List&lt;SelectorAction&gt; GetDisabledSelectorActions (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig List&lt;SelectorAction&gt; GetDisabledSelectorActions(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;SelectorAction&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static void SetDisabledSelectorActions (Xamarin.Forms.BindableObject element, List&lt;SelectorAction&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetDisabledSelectorActions(class Xamarin.Forms.BindableObject element, List&lt;SelectorAction&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Collections.Generic.List&lt;SelectorAction&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt; SetDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt; config, List&lt;SelectorAction&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Picker&gt; SetDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Picker&gt; config, List&lt;SelectorAction&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Picker&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Collections.Generic.List&lt;SelectorAction&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/TimePicker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/TimePicker.xml
@@ -1,0 +1,156 @@
+﻿<Type Name="TimePicker" FullName="Xamarin.Forms.PlatformConfiguration.iOSSpecific.TimePicker">
+  <TypeSignature Language="C#" Value="public static class TimePicker" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit TimePicker extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="DisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static List&lt;SelectorAction&gt; DisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig List&lt;SelectorAction&gt; DisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TimePicker&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;SelectorAction&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DisabledSelectorActionsProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty DisabledSelectorActionsProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty DisabledSelectorActionsProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DisableDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt; DisableDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TimePicker&gt; DisableDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TimePicker&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="EnableDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt; EnableDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TimePicker&gt; EnableDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TimePicker&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static List&lt;SelectorAction&gt; GetDisabledSelectorActions (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig List&lt;SelectorAction&gt; GetDisabledSelectorActions(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;SelectorAction&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static void SetDisabledSelectorActions (Xamarin.Forms.BindableObject element, List&lt;SelectorAction&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetDisabledSelectorActions(class Xamarin.Forms.BindableObject element, List&lt;SelectorAction&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Collections.Generic.List&lt;SelectorAction&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetDisabledSelectorActions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt; SetDisabledSelectorActions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt; config, List&lt;SelectorAction&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TimePicker&gt; SetDisabledSelectorActions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.TimePicker&gt; config, List&lt;SelectorAction&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.TimePicker&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Collections.Generic.List&lt;SelectorAction&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>


### PR DESCRIPTION
### Description of Change ###

There is no way on iOS to disable selector actions when an input field is long clicked. This functionality may be needed in cases such as when preventing users from editing a password entry via the clipboard. I wanted to implement the same behavior on Android, but AppCompat seems to be ignoring all efforts. For now, it's left for another time.

This feature is currently implemented for `Entry`, `Picker`, `TimePicker`, and `DatePicker`.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=37311
- https://bugzilla.xamarin.com/show_bug.cgi?id=38480

### API Changes ###

Added:
 - 6 methods and 1 property for each class
 - `SelectorAction` enum

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
