### PR TITLE
[UWP] Add platform specifics for SearchBar's suggestion area

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/SearchBarPageWindows.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/SearchBarPageWindows.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
+
+namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
+{
+	public class SearchBarPageWindows : ContentPage
+	{
+		public SearchBarPageWindows()
+		{
+			SearchBar searchBar = new SearchBar
+			{
+				Placeholder = "Placeholder for SearchBar"
+			};
+
+			var toggleAutoMaximizeButton = new Button
+			{
+				Text = "Toggle AutoMaximizeSuggestionArea",
+				Command = new Command(() => searchBar.On<Windows>().SetAutoMaximizeSuggestionArea(!searchBar.On<Windows>().AutoMaximizeSuggestionArea()))
+			};
+
+			StackLayout content = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Children =
+				{
+					new Label { Text = "Enter the word 'Item' to see various autocompletes below. If needed, the SearchBar will shift upwards if AutoMaximizeSuggestionArea is true; by default, it is false." },
+					searchBar,
+					toggleAutoMaximizeButton
+				}
+			};
+
+			var searchableValues = new ObservableCollection<string>();
+			for (int i = 0; i <= 50; i++)
+				searchableValues.Add("item " + i);
+
+			searchBar.On<Windows>().SetTextChangedAction(() =>
+			{
+				if (searchBar.Text.Length == 0)
+					searchBar.On<Windows>().Suggestions().Clear();
+				else
+				{
+					var filtered = searchableValues.Where(i => i.Contains(searchBar.Text.ToLower()));
+					searchBar.On<Windows>().Suggestions().Clear();
+					foreach (string i in filtered)
+						searchBar.On<Windows>().Suggestions().Add(i);
+				}
+			});
+
+			Content = content;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Controls
 			var appAndroidButton = new Button() { Text = "Application (Android)" };
 			var tbAndroidButton = new Button { Text = "TabbedPage (Android)" };
 			var entryiOSButton = new Button() { Text = "Entry (iOS)" };
+			var sbWindowsButton = new Button() { Text = "SearchBar (Windows)" };
 
 			mdpWindowsButton.Clicked += (sender, args) => { SetRoot(new MasterDetailPageWindows(new Command(RestoreOriginal))); };
 			npWindowsButton.Clicked += (sender, args) => { SetRoot(new NavigationPageWindows(new Command(RestoreOriginal))); };
@@ -25,11 +26,11 @@ namespace Xamarin.Forms.Controls
 			appAndroidButton.Clicked += (sender, args) => { SetRoot(new ApplicationAndroid(new Command(RestoreOriginal))); };
 			tbAndroidButton.Clicked += (sender, args) => { SetRoot(new TabbedPageAndroid(new Command(RestoreOriginal))); };
 			entryiOSButton.Clicked += (sender, args) => { Navigation.PushAsync(new EntryPageiOS()); };
-			
+			sbWindowsButton.Clicked += (sender, args) => { Navigation.PushAsync(new SearchBarPageWindows()); };
 
 			Content = new StackLayout
 			{
-				Children = { mdpWindowsButton, npWindowsButton, tbWindowsButton, navpageiOSButton, viselemiOSButton, appAndroidButton, entryiOSButton }
+				Children = { mdpWindowsButton, npWindowsButton, tbWindowsButton, navpageiOSButton, viselemiOSButton, appAndroidButton, entryiOSButton, sbWindowsButton }
 			};
 		}
 

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -107,6 +107,7 @@
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\NavigationPageiOS.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\NavigationPageWindows.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\ApplicationAndroid.cs" />
+    <Compile Include="GalleryPages\PlatformSpecificsGalleries\SearchBarPageWindows.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\TabbedPageAndroid.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\TabbedPageWindows.cs" />
     <Compile Include="GalleryPages\PlatformSpecificsGalleries\VisualElementiOS.cs" />

--- a/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.ObjectModel;
+
+namespace Xamarin.Forms.PlatformConfiguration.WindowsSpecific
+{
+	using FormsElement = Forms.SearchBar;
+
+	public static class SearchBar
+	{
+		public static readonly BindableProperty SuggestionsProperty =
+			BindableProperty.CreateAttached("Suggestions", typeof(ObservableCollection<string>),
+				typeof(FormsElement), new ObservableCollection<string>());
+
+		public static ObservableCollection<string> GetSuggestions(BindableObject element)
+		{
+			return (ObservableCollection<string>)element.GetValue(SuggestionsProperty);
+		}
+
+		public static void SetSuggestions(BindableObject element, ObservableCollection<string> collection)
+		{
+			element.SetValue(SuggestionsProperty, collection);
+		}
+
+		public static ObservableCollection<string> Suggestions(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			return (ObservableCollection<string>)config.Element.GetValue(SuggestionsProperty);
+		}
+
+		public static readonly BindableProperty TextChangedActionProperty =
+			BindableProperty.CreateAttached("TextChangedAction", typeof(Action),
+				typeof(FormsElement), null);
+
+		public static Action GetTextChangedAction(BindableObject element)
+		{
+			return (Action)element.GetValue(TextChangedActionProperty);
+		}
+
+		public static void SetTextChangedAction(BindableObject element, Action value)
+		{
+			element.SetValue(TextChangedActionProperty, value);
+		}
+
+		public static Action GetTextChangedAction(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			return (Action)config.Element.GetValue(TextChangedActionProperty);
+		}
+
+		public static IPlatformElementConfiguration<Windows, FormsElement> SetTextChangedAction(
+			this IPlatformElementConfiguration<Windows, FormsElement> config, Action value)
+		{
+			config.Element.SetValue(TextChangedActionProperty, value);
+			return config;
+		}
+
+		public static readonly BindableProperty AutoMaximizeSuggestionAreaProperty =
+			BindableProperty.CreateAttached("AutoMaximizeSuggestionArea", typeof(bool),
+				typeof(FormsElement), false);
+
+		public static bool GetAutoMaximizeSuggestionArea(BindableObject element)
+		{
+			return (bool)element.GetValue(AutoMaximizeSuggestionAreaProperty);
+		}
+
+		public static void SetAutoMaximizeSuggestionArea(BindableObject element, bool value)
+		{
+			element.SetValue(AutoMaximizeSuggestionAreaProperty, value);
+		}
+
+		public static bool AutoMaximizeSuggestionArea(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			return (bool)config.Element.GetValue(AutoMaximizeSuggestionAreaProperty);
+		}
+
+		public static IPlatformElementConfiguration<Windows, FormsElement> SetAutoMaximizeSuggestionArea(
+			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
+		{
+			config.Element.SetValue(AutoMaximizeSuggestionAreaProperty, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -212,6 +212,7 @@
     <Compile Include="Performance.cs" />
     <Compile Include="PinchGestureUpdatedEventArgs.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\Page.cs" />
+    <Compile Include="PlatformConfiguration\WindowsSpecific\SearchBar.cs" />
     <Compile Include="PlatformConfiguration\WindowsSpecific\ToolbarPlacement.cs" />
     <Compile Include="PlatformEffect.cs" />
     <Compile Include="PointTypeConverter.cs" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.WindowsSpecific/SearchBar.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.WindowsSpecific/SearchBar.xml
@@ -1,0 +1,290 @@
+<Type Name="SearchBar" FullName="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar">
+  <TypeSignature Language="C#" Value="public static class SearchBar" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit SearchBar extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AutoMaximizeSuggestionArea">
+      <MemberSignature Language="C#" Value="public static bool AutoMaximizeSuggestionArea (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AutoMaximizeSuggestionArea(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AutoMaximizeSuggestionAreaProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty AutoMaximizeSuggestionAreaProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty AutoMaximizeSuggestionAreaProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetAutoMaximizeSuggestionArea">
+      <MemberSignature Language="C#" Value="public static bool GetAutoMaximizeSuggestionArea (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetAutoMaximizeSuggestionArea(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetSuggestions">
+      <MemberSignature Language="C#" Value="public static System.Collections.ObjectModel.ObservableCollection&lt;string&gt; GetSuggestions (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.ObjectModel.ObservableCollection`1&lt;string&gt; GetSuggestions(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.ObjectModel.ObservableCollection&lt;System.String&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetTextChangedAction">
+      <MemberSignature Language="C#" Value="public static Action GetTextChangedAction (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Action GetTextChangedAction(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Action</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetTextChangedAction">
+      <MemberSignature Language="C#" Value="public static Action GetTextChangedAction (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Action GetTextChangedAction(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Action</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetAutoMaximizeSuggestionArea">
+      <MemberSignature Language="C#" Value="public static void SetAutoMaximizeSuggestionArea (Xamarin.Forms.BindableObject element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetAutoMaximizeSuggestionArea(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetAutoMaximizeSuggestionArea">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; SetAutoMaximizeSuggestionArea (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; SetAutoMaximizeSuggestionArea(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetSuggestions">
+      <MemberSignature Language="C#" Value="public static void SetSuggestions (Xamarin.Forms.BindableObject element, System.Collections.ObjectModel.ObservableCollection&lt;string&gt; collection);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetSuggestions(class Xamarin.Forms.BindableObject element, class System.Collections.ObjectModel.ObservableCollection`1&lt;string&gt; collection) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="collection" Type="System.Collections.ObjectModel.ObservableCollection&lt;System.String&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="collection">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetTextChangedAction">
+      <MemberSignature Language="C#" Value="public static void SetTextChangedAction (Xamarin.Forms.BindableObject element, Action value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetTextChangedAction(class Xamarin.Forms.BindableObject element, class System.Action value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Action" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetTextChangedAction">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; SetTextChangedAction (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config, Action value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; SetTextChangedAction(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config, class System.Action value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Action" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Suggestions">
+      <MemberSignature Language="C#" Value="public static System.Collections.ObjectModel.ObservableCollection&lt;string&gt; Suggestions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.ObjectModel.ObservableCollection`1&lt;string&gt; Suggestions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.ObjectModel.ObservableCollection&lt;System.String&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SuggestionsProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty SuggestionsProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty SuggestionsProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TextChangedActionProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty TextChangedActionProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty TextChangedActionProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -478,6 +478,7 @@
       <Type Name="CollapseStyle" Kind="Enumeration" />
       <Type Name="MasterDetailPage" Kind="Class" />
       <Type Name="Page" Kind="Class" />
+      <Type Name="SearchBar" Kind="Class" />
       <Type Name="ToolbarPlacement" Kind="Enumeration" />
     </Namespace>
     <Namespace Name="Xamarin.Forms.Xaml">
@@ -1725,6 +1726,115 @@
           <summary>To be added.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.Page" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.Page.SetToolbarPlacement(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.Page},Xamarin.Forms.PlatformConfiguration.WindowsSpecific.ToolbarPlacement)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="AutoMaximizeSuggestionArea">
+        <MemberSignature Language="C#" Value="public static bool AutoMaximizeSuggestionArea (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AutoMaximizeSuggestionArea(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar.AutoMaximizeSuggestionArea(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="GetTextChangedAction">
+        <MemberSignature Language="C#" Value="public static Action GetTextChangedAction (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Action GetTextChangedAction(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Action</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar.GetTextChangedAction(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetAutoMaximizeSuggestionArea">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; SetAutoMaximizeSuggestionArea (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config, bool value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; SetAutoMaximizeSuggestionArea(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config, bool value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+          <Parameter Name="value" Type="System.Boolean" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar.SetAutoMaximizeSuggestionArea(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar},System.Boolean)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetTextChangedAction">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; SetTextChangedAction (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config, Action value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; SetTextChangedAction(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config, class System.Action value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+          <Parameter Name="value" Type="System.Action" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar.SetTextChangedAction(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar},System.Action)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="Suggestions">
+        <MemberSignature Language="C#" Value="public static System.Collections.ObjectModel.ObservableCollection&lt;string&gt; Suggestions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.ObjectModel.ObservableCollection`1&lt;string&gt; Suggestions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.SearchBar&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Collections.ObjectModel.ObservableCollection&lt;System.String&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar.Suggestions(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar})" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>


### PR DESCRIPTION
### Description of Change ###

Our current implementation of the `SearchBar` on UWP uses the [AutoSuggestBox](https://msdn.microsoft.com/library/windows/apps/Windows.UI.Xaml.Controls.AutoSuggestBox), which is the current standard. However, it does not take advantage of the dropdown that is available, effectively treating it as an empty search entry. This has a side effect of causing the bar to scroll up to the top of the screen if the suggestion area would not fit. The reason it always shows as empty is due to a lack of suggestions being set as the `ItemsSource`.

To rectify this potentially awkward behavior, a platform specific feature can be added which defaults the `AutoSuggestBox` control's `AutoMaximizeSuggestionArea` to false, so that it simply does not scroll on the screen when it would otherwise occur. We can also extend upon the behavior and allow for developers to take advantage of this suggestion area functionality if desired by providing a `BindableProperty` (appropriately) called `SuggestionsProperty`, which is of the type `ObservableCollection<string>`. Users can use `On<Windows>.Suggestions()` to operate on this collection and modify it directly, as needed.

In order to do this, we have a `TextChangedAction` of type `Action` that allows the user to handle this to their liking, which gets used in the `OnTextChanged` method in the `SearchBarRenderer` if the action has been explicitly set by the user (it is otherwise null). The `SuggestionChosen` event is handled inside the renderer and set the text is set to whatever has been chosen by the user.

![searchbar](https://cloud.githubusercontent.com/assets/1251024/19939508/5779bd64-a0f7-11e6-89aa-3ff676a5c2fe.gif)

![searchbar2](https://cloud.githubusercontent.com/assets/1251024/19939509/595780b2-a0f7-11e6-9d1e-46340ac6e3c3.gif)

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=45924

### API Changes ###

Added:
- public static readonly BindableProperty SuggestionsProperty
- public static ObservableCollection<string> GetSuggestions(BindableObject element)
- public static void SetSuggestions(BindableObject element, ObservableCollection<string> collection)
- public static ObservableCollection<string> Suggestions(this IPlatformElementConfiguration<Windows, FormsElement> config)


- public static readonly BindableProperty TextChangedActionProperty
- public static Action GetTextChangedAction(BindableObject element)
- public static Action GetTextChangedAction(this IPlatformElementConfiguration<Windows, FormsElement> config)
- public static IPlatformElementConfiguration<Windows, FormsElement> SetTextChangedAction(this IPlatformElementConfiguration<Windows, FormsElement> config, Action value)

### Behavioral Changes ###

None presumed, as by default the behavior is brought more in line with the other platforms.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
