### PR TITLE
[Android] Add ability to configure TableView dividers

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36911.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36911.cs
@@ -1,0 +1,61 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 36911, "[Android] Cannot Remove Separator Line From A TableView", PlatformAffected.Android)]
+	public class Bugzilla36911 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var tableView = new TableView
+			{
+				Intent = TableIntent.Form,
+				Root = new TableRoot("Table Title")
+				{
+					new TableSection("Section 1 Title")
+					{
+						new TextCell
+						{
+							Text = "TextCell Text",
+							Detail = "TextCell Detail"
+						},
+						new EntryCell
+						{
+							Label = "EntryCell:",
+							Placeholder = "default keyboard",
+							Keyboard = Keyboard.Default
+						}
+					},
+					new TableSection("Section 2 Title")
+					{
+						new EntryCell
+						{
+							Label = "Another EntryCell:",
+							Placeholder = "phone keyboard",
+							Keyboard = Keyboard.Telephone
+						},
+						new SwitchCell
+						{
+							Text = "SwitchCell:"
+						}
+					}
+				}
+			};
+
+			PlatformConfiguration.AndroidSpecific.TableView.SetSectionHeaderDividerBackgroundColor(tableView.On<Android>(), Color.Red);
+			PlatformConfiguration.AndroidSpecific.TableView.SetSectionDividerBackgroundColor(tableView.On<Android>(), Color.Blue);
+			PlatformConfiguration.AndroidSpecific.TableView.SetDividerBackgroundColor(tableView.On<Android>(), Color.Green);
+			PlatformConfiguration.AndroidSpecific.TableView.SetDividerHeight(tableView.On<Android>(), 10);
+
+			Content = tableView;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -73,6 +73,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36559.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36171.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36911.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37462.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37841.cs" />
@@ -129,7 +130,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
-
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44584.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/TableView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/TableView.cs
@@ -1,0 +1,99 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using FormsElement = Forms.TableView;
+
+	public static class TableView
+	{
+		public static readonly BindableProperty SectionHeaderDividerBackgroundColorProperty = BindableProperty.Create(nameof(SectionHeaderDividerBackgroundColor), typeof(Color?), typeof(TableView));
+
+		public static Color? GetSectionHeaderDividerBackgroundColor(BindableObject element)
+		{
+			return (Color?)element.GetValue(SectionHeaderDividerBackgroundColorProperty);
+		}
+
+		public static void SetSectionHeaderDividerBackgroundColor(BindableObject element, Color? value)
+		{
+			element.SetValue(SectionHeaderDividerBackgroundColorProperty, value);
+		}
+
+		public static Color? SectionHeaderDividerBackgroundColor(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetSectionHeaderDividerBackgroundColor(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetSectionHeaderDividerBackgroundColor(this IPlatformElementConfiguration<Android, FormsElement> config, Color? value)
+		{
+			SetSectionHeaderDividerBackgroundColor(config.Element, value);
+			return config;
+		}
+
+		public static readonly BindableProperty SectionDividerBackgroundColorProperty = BindableProperty.Create(nameof(SectionDividerBackgroundColor), typeof(Color?), typeof(TableView));
+
+		public static Color? GetSectionDividerBackgroundColor(BindableObject element)
+		{
+			return (Color?)element.GetValue(SectionDividerBackgroundColorProperty);
+		}
+
+		public static void SetSectionDividerBackgroundColor(BindableObject element, Color? value)
+		{
+			element.SetValue(SectionDividerBackgroundColorProperty, value);
+		}
+
+		public static Color? SectionDividerBackgroundColor(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetSectionDividerBackgroundColor(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetSectionDividerBackgroundColor(this IPlatformElementConfiguration<Android, FormsElement> config, Color? value)
+		{
+			SetSectionDividerBackgroundColor(config.Element, value);
+			return config;
+		}
+
+		public static readonly BindableProperty DividerBackgroundColorProperty = BindableProperty.Create(nameof(DividerBackgroundColor), typeof(Color?), typeof(TableView));
+
+		public static Color? GetDividerBackgroundColor(BindableObject element)
+		{
+			return (Color?)element.GetValue(DividerBackgroundColorProperty);
+		}
+
+		public static void SetDividerBackgroundColor(BindableObject element, Color? value)
+		{
+			element.SetValue(DividerBackgroundColorProperty, value);
+		}
+
+		public static Color? DividerBackgroundColor(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetDividerBackgroundColor(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetDividerBackgroundColor(this IPlatformElementConfiguration<Android, FormsElement> config, Color? value)
+		{
+			SetDividerBackgroundColor(config.Element, value);
+			return config;
+		}
+
+		public static readonly BindableProperty DividerHeightProperty = BindableProperty.Create(nameof(DividerHeight), typeof(int?), typeof(TableView));
+
+		public static int? GetDividerHeight(BindableObject element)
+		{
+			return (int?)element.GetValue(DividerHeightProperty);
+		}
+
+		public static void SetDividerHeight(BindableObject element, int? value)
+		{
+			element.SetValue(DividerHeightProperty, value);
+		}
+
+		public static int? DividerHeight(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetDividerHeight(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetDividerHeight(this IPlatformElementConfiguration<Android, FormsElement> config, int? value)
+		{
+			SetDividerHeight(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/TableView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/TableView.cs
@@ -73,24 +73,24 @@
 			return config;
 		}
 
-		public static readonly BindableProperty DividerHeightProperty = BindableProperty.Create(nameof(DividerHeight), typeof(int?), typeof(TableView));
+		public static readonly BindableProperty DividerHeightProperty = BindableProperty.Create(nameof(DividerHeight), typeof(int), typeof(TableView), 1);
 
-		public static int? GetDividerHeight(BindableObject element)
+		public static int GetDividerHeight(BindableObject element)
 		{
-			return (int?)element.GetValue(DividerHeightProperty);
+			return (int)element.GetValue(DividerHeightProperty);
 		}
 
-		public static void SetDividerHeight(BindableObject element, int? value)
+		public static void SetDividerHeight(BindableObject element, int value)
 		{
 			element.SetValue(DividerHeightProperty, value);
 		}
 
-		public static int? DividerHeight(this IPlatformElementConfiguration<Android, FormsElement> config)
+		public static int DividerHeight(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetDividerHeight(config.Element);
 		}
 
-		public static IPlatformElementConfiguration<Android, FormsElement> SetDividerHeight(this IPlatformElementConfiguration<Android, FormsElement> config, int? value)
+		public static IPlatformElementConfiguration<Android, FormsElement> SetDividerHeight(this IPlatformElementConfiguration<Android, FormsElement> config, int value)
 		{
 			SetDividerHeight(config.Element, value);
 			return config;

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -90,6 +90,7 @@
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\TabbedPage.cs" />
+    <Compile Include="PlatformConfiguration\AndroidSpecific\TableView.cs" />
     <Compile Include="PlatformConfiguration\ExtensionPoints.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\Entry.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
@@ -17,8 +17,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		public Color? SectionHeaderDividerBackgroundColor { get; set; }
 		public Color? SectionDividerBackgroundColor { get; set; }
-		public Drawable Divider { get; set; }
-		public int DividerHeight { get; set; } = 1;
+		public Color? DividerBackgroundColor { get; set; }
+		public int? DividerHeight { get; set; }
 
 		public TableViewModelRenderer(Context context, AListView listView, TableView view) : base(context)
 		{
@@ -119,7 +119,7 @@ namespace Xamarin.Forms.Platform.Android
 			AView bline;
 			if (makeBline)
 			{
-				bline = new AView(Context) { LayoutParameters = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, DividerHeight) };
+				bline = new AView(Context) { LayoutParameters = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, DividerHeight ?? 1) };
 
 				layout.AddView(bline);
 			}
@@ -132,8 +132,8 @@ namespace Xamarin.Forms.Platform.Android
 				bline.SetBackgroundColor(SectionDividerBackgroundColor?.ToAndroid() ?? Color.Transparent.ToAndroid());
 			else
 			{
-				if (Divider != null)
-					bline.SetBackground(Divider);
+				if (DividerBackgroundColor != null)
+					bline.SetBackgroundColor(DividerBackgroundColor.Value.ToAndroid());
 				else
 				{
 					using (var value = new TypedValue())

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.Android
 		public Color? SectionHeaderDividerBackgroundColor { get; set; }
 		public Color? SectionDividerBackgroundColor { get; set; }
 		public Color? DividerBackgroundColor { get; set; }
-		public int? DividerHeight { get; set; }
+		public int DividerHeight { get; set; } = 1;
 
 		public TableViewModelRenderer(Context context, AListView listView, TableView view) : base(context)
 		{
@@ -119,7 +119,7 @@ namespace Xamarin.Forms.Platform.Android
 			AView bline;
 			if (makeBline)
 			{
-				bline = new AView(Context) { LayoutParameters = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, DividerHeight ?? 1) };
+				bline = new AView(Context) { LayoutParameters = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, DividerHeight) };
 
 				layout.AddView(bline);
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
@@ -1,4 +1,5 @@
 using Android.Content;
+using Android.Graphics.Drawables;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
@@ -13,6 +14,11 @@ namespace Xamarin.Forms.Platform.Android
 		protected readonly Context Context;
 		ITableViewController Controller => _view;
 		Cell _restoreFocus;
+
+		public Color? SectionHeaderDividerBackgroundColor { get; set; }
+		public Color? SectionDividerBackgroundColor { get; set; }
+		public Drawable Divider { get; set; }
+		public int DividerHeight { get; set; } = 1;
 
 		public TableViewModelRenderer(Context context, AListView listView, TableView view) : base(context)
 		{
@@ -113,7 +119,7 @@ namespace Xamarin.Forms.Platform.Android
 			AView bline;
 			if (makeBline)
 			{
-				bline = new AView(Context) { LayoutParameters = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, 1) };
+				bline = new AView(Context) { LayoutParameters = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, DividerHeight) };
 
 				layout.AddView(bline);
 			}
@@ -121,20 +127,25 @@ namespace Xamarin.Forms.Platform.Android
 				bline = layout.GetChildAt(1);
 
 			if (isHeader)
-				bline.SetBackgroundColor(Color.Accent.ToAndroid());
+				bline.SetBackgroundColor(SectionHeaderDividerBackgroundColor?.ToAndroid() ?? Color.Accent.ToAndroid());
 			else if (nextIsHeader)
-				bline.SetBackgroundColor(global::Android.Graphics.Color.Transparent);
+				bline.SetBackgroundColor(SectionDividerBackgroundColor?.ToAndroid() ?? Color.Transparent.ToAndroid());
 			else
 			{
-				using (var value = new TypedValue())
+				if (Divider != null)
+					bline.SetBackground(Divider);
+				else
 				{
-					int id = global::Android.Resource.Drawable.DividerHorizontalDark;
-					if (Context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ListDivider, value, true))
-						id = value.ResourceId;
-					else if (Context.Theme.ResolveAttribute(global::Android.Resource.Attribute.Divider, value, true))
-						id = value.ResourceId;
+					using (var value = new TypedValue())
+					{
+						int id = global::Android.Resource.Drawable.DividerHorizontalDark;
+						if (Context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ListDivider, value, true))
+							id = value.ResourceId;
+						else if (Context.Theme.ResolveAttribute(global::Android.Resource.Attribute.Divider, value, true))
+							id = value.ResourceId;
 
-					bline.SetBackgroundResource(id);
+						bline.SetBackgroundResource(id);
+					}
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Android.Views;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AListView = Android.Widget.ListView;
@@ -18,7 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 				SectionHeaderDividerBackgroundColor = Element.On<PlatformConfiguration.Android>().SectionHeaderDividerBackgroundColor(),
 				SectionDividerBackgroundColor = Element.On<PlatformConfiguration.Android>().SectionDividerBackgroundColor(),
 				DividerBackgroundColor = Element.On<PlatformConfiguration.Android>().DividerBackgroundColor(),
-				DividerHeight = Element.On<PlatformConfiguration.Android>().DividerHeight()
+				DividerHeight = Control.DividerHeight
 			};
 		}
 
@@ -50,6 +51,19 @@ namespace Xamarin.Forms.Platform.Android
 
 			TableViewModelRenderer source = GetModelRenderer(listView, view);
 			listView.Adapter = source;
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == PlatformConfiguration.AndroidSpecific.TableView.DividerHeightProperty.PropertyName)
+				UpdateDividerHeight();
+		}
+
+		void UpdateDividerHeight()
+		{
+			Control.DividerHeight = Element.On<PlatformConfiguration.Android>().DividerHeight();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
@@ -1,13 +1,11 @@
 using Android.Views;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AListView = Android.Widget.ListView;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	public class TableViewRenderer : ViewRenderer<TableView, AListView>
 	{
-		public Color? SectionHeaderDividerBackgroundColor { get; set; }
-		public Color? SectionDividerBackgroundColor { get; set; }
-
 		public TableViewRenderer()
 		{
 			AutoPackage = false;
@@ -17,10 +15,10 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			return new TableViewModelRenderer(Context, listView, view)
 			{
-				SectionHeaderDividerBackgroundColor = SectionHeaderDividerBackgroundColor,
-				SectionDividerBackgroundColor = SectionDividerBackgroundColor,
-				Divider = Control.Divider,
-				DividerHeight = Control.DividerHeight
+				SectionHeaderDividerBackgroundColor = Element.On<PlatformConfiguration.Android>().SectionHeaderDividerBackgroundColor(),
+				SectionDividerBackgroundColor = Element.On<PlatformConfiguration.Android>().SectionDividerBackgroundColor(),
+				DividerBackgroundColor = Element.On<PlatformConfiguration.Android>().DividerBackgroundColor(),
+				DividerHeight = Element.On<PlatformConfiguration.Android>().DividerHeight()
 			};
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
@@ -1,11 +1,13 @@
 using Android.Views;
-using AView = Android.Views.View;
 using AListView = Android.Widget.ListView;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	public class TableViewRenderer : ViewRenderer<TableView, AListView>
 	{
+		public Color? SectionHeaderDividerBackgroundColor { get; set; }
+		public Color? SectionDividerBackgroundColor { get; set; }
+
 		public TableViewRenderer()
 		{
 			AutoPackage = false;
@@ -13,7 +15,13 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual TableViewModelRenderer GetModelRenderer(AListView listView, TableView view)
 		{
-			return new TableViewModelRenderer(Context, listView, view);
+			return new TableViewModelRenderer(Context, listView, view)
+			{
+				SectionHeaderDividerBackgroundColor = SectionHeaderDividerBackgroundColor,
+				SectionDividerBackgroundColor = SectionDividerBackgroundColor,
+				Divider = Control.Divider,
+				DividerHeight = Control.DividerHeight
+			};
 		}
 
 		protected override Size MinimumSize()

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
@@ -14,6 +14,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual TableViewModelRenderer GetModelRenderer(AListView listView, TableView view)
 		{
+			// make sure these are in sync or else dividers can't be hidden
+			Control.DividerHeight = Element.On<PlatformConfiguration.Android>().DividerHeight();
+
 			return new TableViewModelRenderer(Context, listView, view)
 			{
 				SectionHeaderDividerBackgroundColor = Element.On<PlatformConfiguration.Android>().SectionHeaderDividerBackgroundColor(),


### PR DESCRIPTION
### Description of Change ###

There seems to be no way on Android to style `TableView` dividers. This PR adds properties to configure dividers for section headers, sections, and list items as well as divider height.

Also referencing #287.

![screenshot_20161113-090220](https://cloud.githubusercontent.com/assets/16855542/19949413/772fe4d0-a11f-11e6-8ec5-b1d6ff22d620.png)

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=36911

### API Changes ###

Added:
 - Added 4 platform specific properties and getters/setters for each

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
