### PR TITLE
[Android] Do not crash when Device.Info is null

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -17,7 +17,8 @@ namespace Xamarin.Forms.Platform.Android
 		public DatePickerRenderer()
 		{
 			AutoPackage = false;
-			if (Forms.IsLollipopOrNewer)
+			// Device.Info will be null in the context of the Android Designer
+			if (Forms.IsLollipopOrNewer && Device.Info != null)
 				Device.Info.PropertyChanged += DeviceInfoPropertyChanged;
 		}
 
@@ -25,7 +26,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (disposing && !_disposed)
 			{
-				if (Forms.IsLollipopOrNewer)
+				// Device.Info will be null in the context of the Android Designer
+				if (Forms.IsLollipopOrNewer && Device.Info)
 					Device.Info.PropertyChanged -= DeviceInfoPropertyChanged;
 
 				_disposed = true;


### PR DESCRIPTION
### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44893

### Behavioral Changes ###

Properly handle the case where Device.Info is null, which will only happen in context of the designer.