### PR TITLE
[Android] Disposing MasterDetailPage when Detail has a FragmentContainer should not crash

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46494.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46494.cs
@@ -1,0 +1,36 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 46494, "Hardware/Software back button from MainPage of type MasterDetail causes crash 'java.lang.IllegalStateException: Activity has been destroyed'", PlatformAffected.Android)]
+	public class Bugzilla46494 : TestMasterDetailPage
+	{
+		protected override void Init()
+		{
+			Master = new ContentPage { Title = "Master", BackgroundColor = Color.Blue };
+			Detail = new NavigationPage(
+				new ContentPage
+				{
+					Title = "Detail",
+					BackgroundColor = Color.Red,
+					Content = new ContentView
+					{
+						Content = new Label
+						{
+							Text = "Hit Back button to destroy Activity. Disposing Fragment should not run into a race condition with Activity destroy.",
+							HorizontalTextAlignment = TextAlignment.Center,
+							VerticalTextAlignment = TextAlignment.Center
+						}
+					}
+				}
+			);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -135,6 +135,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45743.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -185,15 +185,14 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnDestroy()
 		{
-			// may never be called
-			base.OnDestroy();
-
 			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
 			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
 			MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
 
-			if (_platform != null)
-				_platform.Dispose();
+			_platform?.Dispose();
+
+			// call at the end to avoid race conditions with Platform dispose
+			base.OnDestroy();
 		}
 
 		protected override void OnNewIntent(Intent intent)


### PR DESCRIPTION
### Description of Change ###

If you create a `MasterDetailPage` where its detail is set to a `NavigationPage` or any other page wrapped in a fragment container and when you hit the back button to go to home screen, destroying current activity can run into a race condition such that the fragment is attempted to be destroyed after the activity is gone.

We should invoke base activity destroy only after our resources are destroyed.

Note that the test case does not work with the gallery app since the back button dismisses the MDP UI instead of sending you home. 

Ref #444

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=46494

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

