### PR TITLE
[iOS] Fix Entry text and placeholder colors when disabled

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -135,10 +135,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var textColor = Element.TextColor;
 
-			if (textColor.IsDefault || !Element.IsEnabled)
-				Control.TextColor = _defaultTextColor;
-			else
-				Control.TextColor = textColor.ToUIColor();
+			Control.TextColor = textColor.IsDefault ? _defaultTextColor : textColor.ToUIColor();
 		}
 
 		void UpdateAdjustsFontSizeToFitWidth()
@@ -179,9 +176,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var targetColor = Element.PlaceholderColor;
 
 			// Placeholder default color is 70% gray
-			// https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UITextField_Class/index.html#//apple_ref/occ/instp/UITextField/placeholder
+			// https://developer.apple.com/reference/uikit/uitextfield/1619621-placeholder
 
-			var color = Element.IsEnabled && !targetColor.IsDefault ? targetColor : ColorExtensions.SeventyPercentGrey.ToColor();
+			var color = !targetColor.IsDefault ? targetColor : ColorExtensions.SeventyPercentGrey.ToColor();
 
 			Control.AttributedPlaceholder = formatted.ToAttributed(Element, color);
 		}


### PR DESCRIPTION
### Description of Change ###

In the bug description, it's mentioned that Xamarin.iOS `UITextField` does not override user-specific text color when the control is disabled. I made the same adjustment to placeholder color. As a developer, I'd expect to be able to have full control over the styling even when the entry is disabled. Also updated the URL for the default placeholder color since the old one was dead.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=40485

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

