### PR TITLE
[Android] Fix IsClippedToBounds on Layout

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33559.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33559.cs
@@ -1,0 +1,62 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 33559, "Scaled image escapes the bounds of its container", PlatformAffected.Android)]
+	public class Bugzilla33559 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		public Image Image = new Image { HorizontalOptions = LayoutOptions.CenterAndExpand, VerticalOptions = LayoutOptions.CenterAndExpand, Source = "icon.png", Opacity = .85 };
+
+		protected override void Init()
+		{
+			var top = new StackLayout
+			{
+				BackgroundColor = Color.Green,
+				Opacity = .85,
+				Children = {
+					new Label { Text = "Test\nLabel", HorizontalTextAlignment = TextAlignment.Center }
+				}
+			};
+
+			var middle = new StackLayout
+			{
+				BackgroundColor = Color.Teal,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				IsClippedToBounds = true
+			};
+			middle.Children.Add(Image);
+
+			var bottom = new StackLayout
+			{
+				BackgroundColor = Color.Blue,
+				VerticalOptions = LayoutOptions.End,
+				Opacity = .85,
+				Children = {
+					new Button { Text = "Scale", Command = new Command(() => { Image.ScaleTo(Image.Scale == 1 ? 20 : 1, 750); }) }
+				}
+			};
+
+			Content = new StackLayout
+			{
+				IsClippedToBounds = true,
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				Padding = 20,
+				Spacing = 20,
+				Children =
+				{
+					top,
+					middle,
+					bottom
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33559.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33559.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Controls
 	[Issue(IssueTracker.Bugzilla, 33559, "Scaled image escapes the bounds of its container", PlatformAffected.Android)]
 	public class Bugzilla33559 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
-		public Image Image = new Image { HorizontalOptions = LayoutOptions.CenterAndExpand, VerticalOptions = LayoutOptions.CenterAndExpand, Source = "icon.png", Opacity = .85 };
+		public Image Image = new Image { HorizontalOptions = LayoutOptions.CenterAndExpand, VerticalOptions = LayoutOptions.CenterAndExpand, Source = "Icon.png", Opacity = .85 };
 
 		protected override void Init()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -55,6 +55,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32847.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33268.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33559.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33612.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33714.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33890.cs" />
@@ -130,7 +131,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43569.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
-
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44584.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -264,13 +264,13 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateClipToBounds()
 		{
 			var layout = _renderer.Element as Layout;
-			var parent = _renderer.ViewGroup;
+			var viewGroup = _renderer.ViewGroup;
 
-			if (parent == null || layout == null)
+			if (viewGroup == null || layout == null)
 				return;
 
-			parent.SetClipChildren(layout.IsClippedToBounds);
-			parent.Invalidate();
+			viewGroup.SetClipChildren(layout.IsClippedToBounds);
+			viewGroup.Invalidate();
 		}
 
 		void UpdateIsVisible()

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -264,17 +264,12 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateClipToBounds()
 		{
 			var layout = _renderer.Element as Layout;
-			var parent = _renderer.ViewGroup.Parent as ViewGroup;
+			var parent = _renderer.ViewGroup;
 
 			if (parent == null || layout == null)
 				return;
 
-			bool shouldClip = layout.IsClippedToBounds;
-
-			if ((int)Build.VERSION.SdkInt >= 18 && parent.ClipChildren == shouldClip)
-				return;
-
-			parent.SetClipChildren(shouldClip);
+			parent.SetClipChildren(layout.IsClippedToBounds);
 			parent.Invalidate();
 		}
 


### PR DESCRIPTION
### Description of Change ###

I'm having difficulty understanding what `UpdateClipToBounds()` of `VisualElementTracker` is doing. It seems to be setting the property on the parent of the view group instead of the view group itself. Consequently, clipping does not work.

https://developer.android.com/reference/android/view/ViewGroup.html#attr_android:clipChildren
https://developer.xamarin.com/api/property/Xamarin.Forms.Layout.IsClippedToBounds/

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=33559

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
