### PR TITLE
[Core] Mark Page IsBusy Obsolete

### DIFF
--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_PageRenderer))]
 	public class Page : VisualElement, ILayout, IPageController, IElementConfiguration<Page>
 	{
+		[Obsolete]
 		public const string BusySetSignalName = "Xamarin.BusySet";
 
 		public const string AlertSignalName = "Xamarin.SendAlert";
@@ -23,6 +24,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty BackgroundImageProperty = BindableProperty.Create("BackgroundImage", typeof(string), typeof(Page), default(string));
 
+		[Obsolete]
 		public static readonly BindableProperty IsBusyProperty = BindableProperty.Create("IsBusy", typeof(bool), typeof(Page), false, propertyChanged: (bo, o, n) => ((Page)bo).OnPageBusyChanged());
 
 		public static readonly BindableProperty PaddingProperty = BindableProperty.Create("Padding", typeof(Thickness), typeof(Page), default(Thickness), propertyChanged: (bindable, old, newValue) =>
@@ -70,6 +72,7 @@ namespace Xamarin.Forms
 			set { SetValue(IconProperty, value); }
 		}
 
+		[Obsolete]
 		public bool IsBusy
 		{
 			get { return (bool)GetValue(IsBusyProperty); }
@@ -302,8 +305,10 @@ namespace Xamarin.Forms
 
 			_hasAppeared = true;
 
+#pragma warning disable 612
 			if (IsBusy)
 				MessagingCenter.Send(this, BusySetSignalName, true);
+#pragma warning restore 612
 
 			OnAppearing();
 			EventHandler handler = Appearing;
@@ -321,8 +326,10 @@ namespace Xamarin.Forms
 
 			_hasAppeared = false;
 
+#pragma warning disable 612
 			if (IsBusy)
 				MessagingCenter.Send(this, BusySetSignalName, false);
+#pragma warning restore 612
 
 			var pageContainer = this as IPageContainer<Page>;
 			((IPageController)pageContainer?.CurrentPage)?.SendDisappearing();
@@ -368,7 +375,9 @@ namespace Xamarin.Forms
 			if (!_hasAppeared)
 				return;
 
+#pragma warning disable 612
 			MessagingCenter.Send(this, BusySetSignalName, IsBusy);
+#pragma warning restore 612
 		}
 
 		void OnToolbarItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -188,7 +188,9 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnDestroy();
 
 			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
+#pragma warning disable 612
 			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
+#pragma warning restore 612
 			MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
 
 			if (_platform != null)
@@ -363,8 +365,10 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
+#pragma warning disable 612
 			_busyCount = 0;
 			MessagingCenter.Subscribe<Page, bool>(this, Page.BusySetSignalName, OnPageBusy);
+#pragma warning restore 612
 			MessagingCenter.Subscribe<Page, AlertArguments>(this, Page.AlertSignalName, OnAlertRequested);
 			MessagingCenter.Subscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName, OnActionSheetRequested);
 

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -146,7 +146,9 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnDestroy();
 
 			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
+#pragma warning disable 612
 			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
+#pragma warning restore 612
 			MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
 
 			if (_canvas != null)
@@ -239,12 +241,14 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
+#pragma warning disable 612
 			var busyCount = 0;
 			MessagingCenter.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
 			{
 				busyCount = Math.Max(0, enabled ? busyCount + 1 : busyCount - 1);
 				UpdateProgressBarVisibility(busyCount > 0);
 			});
+#pragma warning restore 612
 
 			UpdateProgressBarVisibility(busyCount > 0);
 

--- a/Xamarin.Forms.Platform.WP8/Platform.cs
+++ b/Xamarin.Forms.Platform.WP8/Platform.cs
@@ -50,12 +50,14 @@ namespace Xamarin.Forms.Platform.WinPhone
 			ProgressIndicator indicator;
 			SystemTray.SetProgressIndicator(page, indicator = new ProgressIndicator { IsVisible = false, IsIndeterminate = true });
 
+#pragma warning disable 612
 			var busyCount = 0;
 			MessagingCenter.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
 			{
 				busyCount = Math.Max(0, enabled ? busyCount + 1 : busyCount - 1);
 				indicator.IsVisible = busyCount > 0;
 			});
+#pragma warning restore 612
 
 			MessagingCenter.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
 			{

--- a/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
@@ -40,7 +40,9 @@ namespace Xamarin.Forms
 				typeof (ExportImageSourceHandlerAttribute)
 			});
 
+#pragma warning disable 612
 			MessagingCenter.Subscribe<Page, bool> (Device.PlatformServices, Page.BusySetSignalName, OnPageBusy);
+#pragma warning restore 612
 
 			HardwareButtons.BackPressed += OnBackPressed;
 

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -66,11 +66,13 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			_container.SizeChanged += OnRendererSizeChanged;
 
+#pragma warning disable 612
 			MessagingCenter.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
 			{
 				Windows.UI.Xaml.Controls.ProgressBar indicator = GetBusyIndicator();
 				indicator.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
 			});
+#pragma warning restore 612
 
 			_toolbarTracker.CollectionChanged += OnToolbarItemsChanged;
 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_renderer = new PlatformRenderer(this);
 			_modals = new List<Page>();
 
+#pragma warning disable 612
 			var busyCount = 0;
 			MessagingCenter.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
 			{
@@ -40,6 +41,7 @@ namespace Xamarin.Forms.Platform.iOS
 				busyCount = Math.Max(0, enabled ? busyCount + 1 : busyCount - 1);
 				UIApplication.SharedApplication.NetworkActivityIndicatorVisible = busyCount > 0;
 			});
+#pragma warning restore 612
 
 			MessagingCenter.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
 			{
@@ -158,7 +160,9 @@ namespace Xamarin.Forms.Platform.iOS
 			Page.DescendantRemoved -= HandleChildRemoved;
 			MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
 			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
+#pragma warning disable 612
 			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
+#pragma warning restore 612
 
 			DisposeModelAndChildrenRenderers(Page);
 			foreach (var modal in _modals)


### PR DESCRIPTION
### Description of Change ###

The busy indicator on Forms doesn't seem to be working. On iOS, it's actually the [network indicator](https://developer.apple.com/reference/uikit/uiapplication/1623102-networkactivityindicatorvisible) which is misleading because a page can be busy for many reasons. On AppCompat, this doesn't seem to be working whatsoever. I tried drilling down till the Activity level and adding an indicator to the toolbar, but it does not work. On Windows, there seem to be visibility issues.

Instead of providing a stock busy indicator, perhaps it makes sense to let developers create their own `ActivityIndicator` and place it wherever they want and style it however they want. The current indicators, if they at all work, are not styleable (colors, dimensions, positions, etc.). Also, I'm not sure if these indicators have the ability to block input. There might be cases where touch gestures should be blocked when an activity indicator is busy.

If this property does not work, I'd rather encourage people to roll out their own implementation, which should be simple.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=43589

### API Changes ###

Changed:
 - `IsBusyProperty` and `IsBusy` are marked `Obsolete`.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

