### PR TITLE
[Proposal] Change the way platform specifics work

### DIFF
--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -27,7 +27,21 @@ namespace Xamarin.Forms
 
 		static readonly BindablePropertyKey CurrentPagePropertyKey = BindableProperty.CreateReadOnly("CurrentPage", typeof(Page), typeof(NavigationPage), null);
 		public static readonly BindableProperty CurrentPageProperty = CurrentPagePropertyKey.BindableProperty;
-		
+
+		public static readonly BindableProperty IsNavigationBarTranslucentProperty = BindableProperty.Create("IsNavigationBarTranslucent", typeof(bool), typeof(NavigationPage), false);
+
+		public bool IsNavigationBarTranslucent
+		{
+			get { return (bool)GetValue(IsNavigationBarTranslucentProperty); }
+			set
+			{
+				if (Device.OS != TargetPlatform.iOS)
+					return;
+
+				SetValue(IsNavigationBarTranslucentProperty, value);
+			}
+		}
+
 		public NavigationPage()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<NavigationPage>>(() => new PlatformConfigurationRegistry<NavigationPage>(this));

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -318,7 +318,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var task = GetAppearedOrDisappearedTask(page);
 
 			PushViewController(pack, animated);
-			
+
 			var shown = await task;
 			UpdateToolBarVisible();
 			return shown;

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -318,7 +318,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var task = GetAppearedOrDisappearedTask(page);
 
 			PushViewController(pack, animated);
-
+			
 			var shown = await task;
 			UpdateToolBarVisible();
 			return shown;
@@ -422,7 +422,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateBackgroundColor();
 			else if (e.PropertyName == NavigationPage.CurrentPageProperty.PropertyName)
 				Current = ((NavigationPage)Element).CurrentPage;
-			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.NavigationPage.IsNavigationBarTranslucentProperty.PropertyName)
+			else if (e.PropertyName == NavigationPage.IsNavigationBarTranslucentProperty.PropertyName)
 				UpdateTranslucent();
 		}
 
@@ -433,7 +433,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 			}
 
-			NavigationBar.Translucent = ((NavigationPage)Element).OnThisPlatform().IsNavigationBarTranslucent();
+			NavigationBar.Translucent = ((NavigationPage)Element).IsNavigationBarTranslucent;
 		}
 
 		void InsertPageBefore(Page page, Page before)


### PR DESCRIPTION
### Description of Change ###

At the expense of sounding like a bad architect, I'd like to discuss the way XF is implementing platform specific functionality. While the current implementation works brilliantly, it slows down developer productivity. If we want to create a platform specific feature, then we have to write multiple methods, write documentation for those, and always be exposed to weird-looking extension method syntax. If an element had, say, 10 properties, we are looking at anywhere between 40-60 methods in a single class file!

Also, since the functionality is accessed through methods, there is no way to leverage properties like properties. For example, I cannot do:

```
var np = new NavigationPage
{
	IsNavigationBarTranslucent = true
};
```

I know that extension properties are likely to be implemented in future C#, but a) we don't know when we will see this feature b) it still won't address the issues I listed above.

I'd be okay with defining features in `Core` and ignoring setters if the target OS is not supported. We can also prefix property names with OS names so it becomes more evident that a property applies to a single platform as in `iOS_IsNavigationBarTranslucent`.
