### PR TITLE
[iOS] Tapping on disabled context action cells should not forward touches down

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36573.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36573.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 36573, "[iOS] Selecting Disabled Context Action Fire ListView.ItemSelected", PlatformAffected.iOS)]
+	public class Bugzilla36573 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var items = new List<object> { "", "", "", "" };
+
+			var myListView = new ListView
+			{
+				ItemTemplate = new DataTemplate(typeof(MyCell)),
+				ItemsSource = items,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			myListView.ItemSelected += async (sender, e) => {
+
+				if (e.SelectedItem != null)
+					await DisplayAlert("Item Selected", "List item was selected", "Okay");
+
+				(sender as ListView).SelectedItem = null;
+			};
+
+			Content = myListView;
+		}
+	}
+
+	internal class MyCell : ViewCell
+	{
+		public MyCell()
+		{
+			var downloadItem = new MenuItem
+			{
+				Text = "Download",
+				Command = new Command(async () =>
+				{
+					await Application.Current.MainPage.DisplayAlert("ContextAction", "Download Selected", "Okay");
+				})
+			};
+
+			var deleteItem = new MenuItem
+			{
+				Text = "Disabled",
+				Command = new Command(async () =>
+				{
+					await Application.Current.MainPage.DisplayAlert("ContextAction", "Disabled MenuItem Selected", "Okay");
+				}, () => false),
+
+			};
+
+			ContextActions.Add(downloadItem);
+			ContextActions.Add(deleteItem);
+
+			View = new Label { Text = "List Item" };
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -74,6 +74,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35490.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35738.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36014.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36573.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36559.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36171.cs" />

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -652,7 +652,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					var cell = table.CellAt(_lastPath) as ContextActionsCell;
 
-					return cell != null && !cell.IsTouchInDisabledButton(pos);
+					return cell != null && (!cell.IsOpen || !cell.IsTouchInDisabledButton(pos));
 				};
 			}
 

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Platform.iOS.Resources;
@@ -57,6 +58,13 @@ namespace Xamarin.Forms.Platform.iOS
 		public bool IsOpen
 		{
 			get { return ScrollDelegate.IsOpen; }
+		}
+
+		public bool IsTouchInDisabledButton(PointF pointf)
+		{
+			double totalButtonWidth = _buttons.Aggregate(0.0, (current, uiButton) => current + uiButton.Frame.Width);
+
+			return _buttons.Any(uiButton => !uiButton.Enabled && pointf.X >= uiButton.Frame.X - totalButtonWidth && pointf.X <= uiButton.Frame.X);
 		}
 
 		ContextScrollViewDelegate ScrollDelegate
@@ -644,7 +652,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					var cell = table.CellAt(_lastPath) as ContextActionsCell;
 
-					return cell != null;
+					return cell != null && !cell.IsTouchInDisabledButton(pos);
 				};
 			}
 

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Linq;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Platform.iOS.Resources;
@@ -62,9 +61,19 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public bool IsTouchInDisabledButton(PointF pointf)
 		{
-			double totalButtonWidth = _buttons.Aggregate(0.0, (current, uiButton) => current + uiButton.Frame.Width);
+			var totalButtonWidth = 0.0;
+			foreach (UIButton uiButton in _buttons)
+			{
+				totalButtonWidth += uiButton.Frame.Width;
+			}
 
-			return _buttons.Any(uiButton => !uiButton.Enabled && pointf.X >= uiButton.Frame.X - totalButtonWidth && pointf.X <= uiButton.Frame.X);
+			foreach (UIButton uiButton in _buttons)
+			{
+				if (!uiButton.Enabled && pointf.X >= uiButton.Frame.X - totalButtonWidth && pointf.X <= uiButton.Frame.X)
+					return true;
+			}
+
+			return false;
 		}
 
 		ContextScrollViewDelegate ScrollDelegate


### PR DESCRIPTION
### Description of Change ###

On iOS, if a context action cell is disabled, a tap gesture passes through and is caught by `ListView` which results in a list item being selected. There doesn't seem to be any stack trace triggered when a disabled button is clicked. The first point of entry seems to be `ShouldReceiveTouch` for row selection.

The simplest solution I could think of was checking if the touch point is inside a disabled button so that the touch can be canceled.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=36573

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

