### PR TITLE
[WinRT] Use default background color to ensure InputTransparent functions

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40514.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40514.cs
@@ -1,0 +1,68 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40514, "[WinRT] InputTransparent does not work if the background color not explicitly set")]
+	public class Bugzilla40514 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var parentGrid = new Grid
+			{
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			//Child at back of the UI
+			var btnBack = new Button();
+			btnBack.Text = "Should Not Be Clickable";
+			btnBack.Clicked += BtnBack_Clicked;
+			btnBack.TranslationX = -75;
+			btnBack.HeightRequest = 50;
+			btnBack.VerticalOptions = LayoutOptions.Center;
+			btnBack.HorizontalOptions = LayoutOptions.Center;
+			parentGrid.Children.Add(btnBack);
+
+			//Visual element
+			var rectangle = new Grid();
+			rectangle.Opacity = 0.5;
+			rectangle.InputTransparent = false;
+			parentGrid.Children.Add(rectangle);
+
+			//Child at back of the UI
+			var btnFront = new Button();
+			btnFront.Text = "Toggle Background";
+			btnFront.Command = new Command(() => rectangle.BackgroundColor = rectangle.BackgroundColor == Color.Blue ? Color.Default : Color.Blue);
+			btnFront.TranslationX = 75;
+			btnFront.HeightRequest = 50;
+			btnFront.VerticalOptions = LayoutOptions.Center;
+			btnFront.HorizontalOptions = LayoutOptions.Center;
+			parentGrid.Children.Add(btnFront);
+			
+			Content = new StackLayout
+			{
+				Children =
+				{
+					parentGrid,
+					new Button
+					{
+						Text = "Toggle InputTransparent",
+						Command = new Command(() => rectangle.InputTransparent = !rectangle.InputTransparent)
+					}
+				}
+			};
+		}
+
+		void BtnBack_Clicked(object sender, EventArgs e)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -107,6 +107,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40333.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31806.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40408.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40514.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40858.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40824.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40911.cs" />
@@ -130,7 +131,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43569.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />
-
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44584.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />

--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -342,25 +342,11 @@ namespace Xamarin.Forms.Platform.WinRT
 			var control = Control as Control;
 			if (control != null)
 			{
-				if (!backgroundColor.IsDefault)
-				{
-					control.Background = backgroundColor.ToBrush();
-				}
-				else
-				{
-					control.ClearValue(Windows.UI.Xaml.Controls.Control.BackgroundProperty);
-				}
+				control.Background = !backgroundColor.IsDefault ? backgroundColor.ToBrush() : Color.Default.ToBrush();
 			}
 			else
 			{
-				if (!backgroundColor.IsDefault)
-				{
-					Background = backgroundColor.ToBrush();
-				}
-				else
-				{
-					ClearValue(BackgroundProperty);
-				}
+				Background = !backgroundColor.IsDefault ?  backgroundColor.ToBrush() : Color.Default.ToBrush();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Using no background color whatsoever on an element causes `InputTransparent` to fail due to the clicks going through when using `IsHitTestVisible` natively. Sticking to `Color.Default`'s value instead of calling `ClearValue` lets this function as would be expected.

Note: There are other known issues with `InputTransparent` but are not directly related to this issue.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40514

### API Changes ###

None

### Behavioral Changes ###

It doesn't appear to cause anything different in terms of visual behavior, at least in terms of the control gallery. In a regular Universal Windows application, a similar layout as described in the linked bug appears to utilize a null value for the background (allowing a clickthrough), but for the intentions of cross-platform functionality it would appear reasonable to expect something such as InputTransparent to work the same on each platform.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense