### PR TITLE
[XamlC] use correct filePath for XamlC error reporting

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -141,6 +141,11 @@ namespace Xamarin.Forms.Build.Tasks
 					}
 					Logger.LogLine(2, "");
 
+					CustomAttribute xamlFilePathAttr;
+					var xamlFilePath = typeDef.HasCustomAttributes && (xamlFilePathAttr = typeDef.CustomAttributes.FirstOrDefault(ca => ca.AttributeType.FullName == "Xamarin.Forms.Xaml.XamlFilePathAttribute")) != null ?
+											  (string)xamlFilePathAttr.ConstructorArguments [0].Value :
+											  resource.Name;
+
 					var initCompRuntime = typeDef.Methods.FirstOrDefault(md => md.Name == "__InitComponentRuntime");
 					if (initCompRuntime != null)
 						Logger.LogLine(2, "   __InitComponentRuntime already exists... not duplicating");
@@ -167,7 +172,7 @@ namespace Xamarin.Forms.Build.Tasks
 						success = false;
 						Logger.LogLine(2, "failed.");
 						thrownExceptions?.Add(e);
-						Logger.LogException(null, null, null, resource.Name, e);
+						Logger.LogException(null, null, null, xamlFilePath, e);
 						Logger.LogLine(4, e.StackTrace);
 						continue;
 					}

--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -101,7 +101,7 @@ namespace Xamarin.Forms.Build.Tasks
 		}
 
 		internal static void GenerateCode(string rootType, string rootNs, CodeTypeReference baseType,
-			IDictionary<string, CodeTypeReference> namesAndTypes, string outFile)
+			IDictionary<string, CodeTypeReference> namesAndTypes, string xamlFile, string outFile)
 		{
 			if (rootType == null)
 			{
@@ -113,8 +113,13 @@ namespace Xamarin.Forms.Build.Tasks
 			var declNs = new CodeNamespace(rootNs);
 			ccu.Namespaces.Add(declNs);
 
-			var declType = new CodeTypeDeclaration(rootType);
-			declType.IsPartial = true;
+			var declType = new CodeTypeDeclaration(rootType) {
+				IsPartial = true,
+				CustomAttributes = {
+					new CodeAttributeDeclaration(new CodeTypeReference($"global::{typeof(XamlFilePathAttribute).FullName}"),
+						 new CodeAttributeArgument(new CodePrimitiveExpression(xamlFile)))
+				}
+			};
 			declType.BaseTypes.Add(baseType);
 
 			declNs.Types.Add(declType);
@@ -124,7 +129,7 @@ namespace Xamarin.Forms.Build.Tasks
 				Name = "InitializeComponent",
 				CustomAttributes =
 				{
-					new CodeAttributeDeclaration(new CodeTypeReference(typeof (GeneratedCodeAttribute)),
+					new CodeAttributeDeclaration(new CodeTypeReference($"global::{typeof (GeneratedCodeAttribute).FullName}"),
 						new CodeAttributeArgument(new CodePrimitiveExpression("Xamarin.Forms.Build.Tasks.XamlG")),
 						new CodeAttributeArgument(new CodePrimitiveExpression("0.0.0.0")))
 				}
@@ -132,7 +137,7 @@ namespace Xamarin.Forms.Build.Tasks
 			declType.Members.Add(initcomp);
 
 			initcomp.Statements.Add(new CodeMethodInvokeExpression(
-				new CodeTypeReferenceExpression(new CodeTypeReference("global::Xamarin.Forms.Xaml.Extensions")),
+				new CodeTypeReferenceExpression(new CodeTypeReference($"global::{typeof(Extensions).FullName}")),
 				"LoadFromXaml", new CodeThisReferenceExpression(), new CodeTypeOfExpression(declType.Name)));
 
 			foreach (var entry in namesAndTypes)
@@ -146,7 +151,7 @@ namespace Xamarin.Forms.Build.Tasks
 					Type = type,
 					CustomAttributes =
 					{
-						new CodeAttributeDeclaration(new CodeTypeReference(typeof (GeneratedCodeAttribute)),
+						new CodeAttributeDeclaration(new CodeTypeReference($"global::{typeof (GeneratedCodeAttribute).FullName}"),
 							new CodeAttributeArgument(new CodePrimitiveExpression("Xamarin.Forms.Build.Tasks.XamlG")),
 							new CodeAttributeArgument(new CodePrimitiveExpression("0.0.0.0")))
 					}
@@ -156,7 +161,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 				var find_invoke = new CodeMethodInvokeExpression(
 					new CodeMethodReferenceExpression(
-						new CodeTypeReferenceExpression(new CodeTypeReference("global::Xamarin.Forms.NameScopeExtensions")),
+						new CodeTypeReferenceExpression(new CodeTypeReference($"global::{typeof(NameScopeExtensions).FullName}")),
 						"FindByName", type),
 					new CodeThisReferenceExpression(), new CodePrimitiveExpression(name));
 
@@ -177,9 +182,10 @@ namespace Xamarin.Forms.Build.Tasks
 			string rootType, rootNs;
 			CodeTypeReference baseType;
 			IDictionary<string, CodeTypeReference> namesAndTypes;
+
 			using (StreamReader reader = File.OpenText(xamlFile))
 				ParseXaml(reader, out rootType, out rootNs, out baseType, out namesAndTypes);
-			GenerateCode(rootType, rootNs, baseType, namesAndTypes, outFile);
+			GenerateCode(rootType, rootNs, baseType, namesAndTypes, System.IO.Path.GetFullPath(xamlFile), outFile);
 		}
 
 		static Dictionary<string, CodeTypeReference> GetNamesAndTypes(XmlNode root, XmlNamespaceManager nsmgr)

--- a/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
+++ b/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
@@ -82,6 +82,7 @@
     <Compile Include="XamlCompilationAttribute.cs" />
     <Compile Include="TypeArgumentsParser.cs" />
     <Compile Include="PruneIgnoredNodesVisitor.cs" />
+    <Compile Include="XamlFilePathAttribute.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Xamarin.Forms.Xaml/XamlCompilationAttribute.cs
+++ b/Xamarin.Forms.Xaml/XamlCompilationAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms.Xaml
 {
@@ -36,6 +37,14 @@ namespace Xamarin.Forms.Xaml
 				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
 
 			return false;
+		}
+	}
+
+	[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+	public sealed class XamlFilePathAttribute : Attribute
+	{
+		public XamlFilePathAttribute([CallerFilePath] string filePath = "")
+		{
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml/XamlCompilationAttribute.cs
+++ b/Xamarin.Forms.Xaml/XamlCompilationAttribute.cs
@@ -39,12 +39,4 @@ namespace Xamarin.Forms.Xaml
 			return false;
 		}
 	}
-
-	[AttributeUsage(AttributeTargets.Class, Inherited = false)]
-	public sealed class XamlFilePathAttribute : Attribute
-	{
-		public XamlFilePathAttribute([CallerFilePath] string filePath = "")
-		{
-		}
-	}
 }

--- a/Xamarin.Forms.Xaml/XamlFilePathAttribute.cs
+++ b/Xamarin.Forms.Xaml/XamlFilePathAttribute.cs
@@ -1,19 +1,8 @@
-//
-// XamlFilePathAttribute.cs
-//
-// Author:
-//       Stephane Delcroix <stephane@mi8.be>
-//
-// Copyright (c) 2016 mobile inception
-//
-
 using System;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms.Xaml
 {
-
 	[AttributeUsage(AttributeTargets.Class, Inherited = false)]
 	public sealed class XamlFilePathAttribute : Attribute
 	{

--- a/Xamarin.Forms.Xaml/XamlFilePathAttribute.cs
+++ b/Xamarin.Forms.Xaml/XamlFilePathAttribute.cs
@@ -1,0 +1,24 @@
+//
+// XamlFilePathAttribute.cs
+//
+// Author:
+//       Stephane Delcroix <stephane@mi8.be>
+//
+// Copyright (c) 2016 mobile inception
+//
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Xamarin.Forms.Xaml
+{
+
+	[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+	public sealed class XamlFilePathAttribute : Attribute
+	{
+		public XamlFilePathAttribute([CallerFilePath] string filePath = "")
+		{
+		}
+	}
+}

--- a/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/XamlFilePathAttribute.xml
+++ b/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/XamlFilePathAttribute.xml
@@ -1,0 +1,45 @@
+<Type Name="XamlFilePathAttribute" FullName="Xamarin.Forms.Xaml.XamlFilePathAttribute">
+  <TypeSignature Language="C#" Value="public sealed class XamlFilePathAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit XamlFilePathAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Xaml</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.AttributeUsage(System.AttributeTargets.Class, Inherited=false)</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public XamlFilePathAttribute (string filePath = &quot;&quot;);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string filePath) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="filePath" Type="System.String">
+          <Attributes>
+            <Attribute>
+              <AttributeName>System.Runtime.CompilerServices.CallerFilePath</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+      </Parameters>
+      <Docs>
+        <param name="filePath">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Xaml/index.xml
+++ b/docs/Xamarin.Forms.Xaml/index.xml
@@ -69,6 +69,7 @@
       <Type Name="TypeExtension" Kind="Class" />
       <Type Name="XamlCompilationAttribute" Kind="Class" />
       <Type Name="XamlCompilationOptions" Kind="Enumeration" />
+      <Type Name="XamlFilePathAttribute" Kind="Class" />
       <Type Name="XamlParseException" Kind="Class" />
       <Type Name="XmlLineInfo" Kind="Class" />
     </Namespace>


### PR DESCRIPTION
### Description of Change ###

[XamlC] use correct filePath for XamlC error reporting.

Instead of using the resourceName, report build errors with the file name so you can click on the error on the IDE and get directly to the right xaml file and the faulty position.

### Bugs Fixed ###

- I do not fix bugs, I create them

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - public class XamlFilePathAttribute

### Behavioral Changes ###

Ponies, rainbows, UNICORNS

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
