### PR TITLE
Change MessagingCenter implementation so it becomes testable

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -144,17 +144,17 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			SetPage (FormsApp.GetFormsApp ());
 
-			MessagingCenter.Subscribe<RootPagesGallery, Type> (this, Messages.ChangeRoot, (sender, pageType) => {
+			MessagingCenter.Instance.Subscribe<RootPagesGallery, Type> (this, Messages.ChangeRoot, (sender, pageType) => {
 				var page = ((Page)Activator.CreateInstance (pageType));
 				SetPage (page);
 			});
 
-			MessagingCenter.Subscribe<RootPagesGallery, Type> (this, Messages.ChangeRoot, (sender, pageType) => {
+			MessagingCenter.Instance.Subscribe<RootPagesGallery, Type> (this, Messages.ChangeRoot, (sender, pageType) => {
 				var page = ((Page)Activator.CreateInstance (pageType));
 				SetPage (page);
 			});
 
-			MessagingCenter.Subscribe<HomeButton> (this, Messages.GoHome, (sender) => {
+			MessagingCenter.Instance.Subscribe<HomeButton> (this, Messages.GoHome, (sender) => {
 				var screen = FormsApp.GetFormsApp ();
 				SetPage (screen);
  			});
@@ -206,7 +206,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 			var app = new App ();
 
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
-			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
+			MessagingCenter.Instance.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 
 			LoadApplication (app);
 		}
@@ -321,10 +321,10 @@ namespace Xamarin.Forms.ControlGallery.Android
 			var app = new App();
 
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
-			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
+			MessagingCenter.Instance.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 
 			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
-			MessagingCenter.Subscribe<NativeBindingGalleryPage >(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
+			MessagingCenter.Instance.Subscribe<NativeBindingGalleryPage >(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
 
 			LoadApplication(app);
 		}

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -109,13 +109,13 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			FormsMaps.Init ();
 			window.RootViewController = FormsApp.GetFormsApp ().CreateViewController ();
 		
-			MessagingCenter.Subscribe<RootPagesGallery, Type> (this, Messages.ChangeRoot, (sender, pagetype) => {
+			MessagingCenter.Instance.Subscribe<RootPagesGallery, Type> (this, Messages.ChangeRoot, (sender, pagetype) => {
 				window = new UIWindow (UIScreen.MainScreen.Bounds);
 				window.RootViewController = ((Page) Activator.CreateInstance(pagetype)).CreateViewController();
 				window.MakeKeyAndVisible ();
 			});
 
-			MessagingCenter.Subscribe<HomeButton> (this, Messages.GoHome, (sender) => {
+			MessagingCenter.Instance.Subscribe<HomeButton> (this, Messages.GoHome, (sender) => {
 				window = new UIWindow (UIScreen.MainScreen.Bounds);
 				window.RootViewController = FormsApp.GetFormsApp ().CreateViewController ();
 				window.MakeKeyAndVisible ();
@@ -152,11 +152,11 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			var app = new App();
 
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
-			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
-			MessagingCenter.Subscribe<Bugzilla40911>(this, Bugzilla40911.ReadyToSetUp40911Test, SetUp40911Test);
+			MessagingCenter.Instance.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
+			MessagingCenter.Instance.Subscribe<Bugzilla40911>(this, Bugzilla40911.ReadyToSetUp40911Test, SetUp40911Test);
 
 			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
-			MessagingCenter.Subscribe<NativeBindingGalleryPage>(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
+			MessagingCenter.Instance.Subscribe<NativeBindingGalleryPage>(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
 
 			LoadApplication(app);
 			return base.FinishedLaunching(uiApplication, launchOptions);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla24769.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla24769.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Controls
 			var progressBar = new ProgressBar { Progress = 0.1 };
 
 			btn.Clicked += (sender, arg) => {
-				MessagingCenter.Send (this, "set_progress");
+				MessagingCenter.Instance.Send (this, "set_progress");
 				progressBar.Progress += 0.1;
 			};
 
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Controls
 
 			var progress = new ProgressBar { Progress = 0.1 };
 
-			MessagingCenter.Subscribe<Bugzilla24769> (this, "set_progress", sender => { progress.Progress += 0.1; });
+			MessagingCenter.Instance.Subscribe<Bugzilla24769> (this, "set_progress", sender => { progress.Progress += 0.1; });
 
 			View =
 				new StackLayout {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40911.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40911.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls
 
 			Content = Layout;
 
-			MessagingCenter.Send(this, ReadyToSetUp40911Test);
+			MessagingCenter.Instance.Send(this, ReadyToSetUp40911Test);
 		}
 
 #if UITEST && __IOS__

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1329.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1329.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Controls
 			var navigation = new NavigationPage (GetPage ("root page"));
 			var pageNum = 0;
 
-			MessagingCenter.Subscribe<Button> (
+			MessagingCenter.Instance.Subscribe<Button> (
 				navigation, 
 				"PushPage", 
 				(sender) => navigation.PushAsync (GetPage ("Page #: " + ++pageNum)) 
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Controls
 				Text = name
 			};
 
-			button.Clicked += (sender, e) => MessagingCenter.Send<Button> ((Button)sender, "PushPage");
+			button.Clicked += (sender, e) => MessagingCenter.Instance.Send<Button> ((Button)sender, "PushPage");
 
 			var page = new ContentPage {
 				Content = button

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2964.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2964.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Controls
 					AutomationId = "ModalPagePopButton",
 					Text ="Pop Me",
 					Command = new Command (async () => {
-						MessagingCenter.Send (this, "update");
+						MessagingCenter.Instance.Send (this, "update");
 						await Navigation.PopModalAsync ();
 					})
 				};
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Controls
 			{
 				Title = "Testpage 1";
 
-				MessagingCenter.Subscribe<ModalPage> (this, "update", sender => {
+				MessagingCenter.Instance.Subscribe<ModalPage> (this, "update", sender => {
 					BlowUp ();
 				});
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue892.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue892.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Controls
 			Master = master;
 			Detail = new CustomNavDetailPage ("Initial Page");
 
-			MessagingCenter.Subscribe<NestedNavPageRootView> (this, "PresentMaster", (sender) => {
+			MessagingCenter.Instance.Subscribe<NestedNavPageRootView> (this, "PresentMaster", (sender) => {
 				IsPresented = true;
 			});
 		}
@@ -158,7 +158,7 @@ namespace Xamarin.Forms.Controls
 					new Button {
 						Text = "Present Master",
 						Command = new Command (() => {
-							MessagingCenter.Send<NestedNavPageRootView> (this, "PresentMaster");
+							MessagingCenter.Instance.Send<NestedNavPageRootView> (this, "PresentMaster");
 						})
 					}
 				}

--- a/Xamarin.Forms.Controls/ControlGalleryPages/NativeBindingGalleryPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/NativeBindingGalleryPage.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Controls
 		protected override void OnAppearing()
 		{
 			base.OnAppearing();
-			MessagingCenter.Send(this, ReadyForNativeBindingsMessage);
+			MessagingCenter.Instance.Send(this, ReadyForNativeBindingsMessage);
 		}
 
 		public NativeBindingGalleryPage()

--- a/Xamarin.Forms.Controls/ControlGalleryPages/NestedNativeControlGalleryPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/NestedNativeControlGalleryPage.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Controls
 		protected override void OnAppearing()
 		{
 			base.OnAppearing();
-			MessagingCenter.Send(this, ReadyForNativeControlsMessage);
+			MessagingCenter.Instance.Send(this, ReadyForNativeControlsMessage);
 		}
 
 		public NestedNativeControlGalleryPage ()

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -202,7 +202,7 @@ namespace Xamarin.Forms.Controls
 			ItemsSource = roots;
 
 #if PRE_APPLICATION_CLASS
-			ItemSelected += (sender, args) => MessagingCenter.Send (this, Messages.ChangeRoot, ((CoreViewContainer)args.SelectedItem).PageType);
+			ItemSelected += (sender, args) => MessagingCenter.Instance.Send (this, Messages.ChangeRoot, ((CoreViewContainer)args.SelectedItem).PageType);
 #else			
 			ItemSelected += (sender, args) => {
 				var app = Application.Current as App;

--- a/Xamarin.Forms.Controls/GalleryPages/EditableList.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/EditableList.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Controls
 				return new MessageViewModel { Subject = "Subject Line " + i, MessagePreview = "Lorem ipsum dolorem monkeys bonkers " + i };
 			}));
 
-			MessagingCenter.Subscribe<MessageViewModel, MessageViewModel> (this, "DeleteMessage", (vm, vm2) => {
+			MessagingCenter.Instance.Subscribe<MessageViewModel, MessageViewModel> (this, "DeleteMessage", (vm, vm2) => {
 				Messages.Remove (vm);
 			});
 		}
@@ -30,8 +30,8 @@ namespace Xamarin.Forms.Controls
 	{
 		public MessageViewModel()
 		{
-			Delete = new Command (() => MessagingCenter.Send (this, "DeleteMessage", this));
-			Move = new Command (() => MessagingCenter.Send (this, "MoveMessage", this));
+			Delete = new Command (() => MessagingCenter.Instance.Send (this, "DeleteMessage", this));
+			Move = new Command (() => MessagingCenter.Instance.Send (this, "MoveMessage", this));
 		}
 
 		public string Subject

--- a/Xamarin.Forms.Core.UnitTests/MapTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MapTests.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (null, map.VisibleRegion);
 
 			bool signaled = false;
-			MessagingCenter.Subscribe<Map, MapSpan> (this, "MapMoveToRegion", (s, a) => {
+			MessagingCenter.Instance.Subscribe<Map, MapSpan> (this, "MapMoveToRegion", (s, a) => {
 				signaled = true;
 				map.VisibleRegion = a;
 			}, map);

--- a/Xamarin.Forms.Core.UnitTests/MessagingCenterTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MessagingCenterTests.cs
@@ -11,30 +11,30 @@ namespace Xamarin.Forms.Core.UnitTests
 		public void SingleSubscriber ()
 		{
 			string sentMessage = null;
-			MessagingCenter.Subscribe<MessagingCenterTests, string> (this, "SimpleTest", (sender, args) => sentMessage = args);
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests, string> (this, "SimpleTest", (sender, args) => sentMessage = args);
 
-			MessagingCenter.Send (this, "SimpleTest", "My Message");
+			MessagingCenter.Instance.Send (this, "SimpleTest", "My Message");
 
 			Assert.That (sentMessage, Is.EqualTo ("My Message"));
 
-			MessagingCenter.Unsubscribe<MessagingCenterTests, string> (this, "SimpleTest");
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests, string> (this, "SimpleTest");
 		}
 
 		[Test]
 		public void Filter ()
 		{
 			string sentMessage = null;
-			MessagingCenter.Subscribe<MessagingCenterTests, string> (this, "SimpleTest", (sender, args) => sentMessage = args, this);
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests, string> (this, "SimpleTest", (sender, args) => sentMessage = args, this);
 
-			MessagingCenter.Send (new MessagingCenterTests (), "SimpleTest", "My Message");
+			MessagingCenter.Instance.Send (new MessagingCenterTests (), "SimpleTest", "My Message");
 
 			Assert.That (sentMessage, Is.Null);
 
-			MessagingCenter.Send (this, "SimpleTest", "My Message");
+			MessagingCenter.Instance.Send (this, "SimpleTest", "My Message");
 
 			Assert.That (sentMessage, Is.EqualTo ("My Message"));
 
-			MessagingCenter.Unsubscribe<MessagingCenterTests, string> (this, "SimpleTest");
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests, string> (this, "SimpleTest");
 		}
 
 		[Test]
@@ -44,26 +44,26 @@ namespace Xamarin.Forms.Core.UnitTests
 			var sub2 = new object ();
 			string sentMessage1 = null;
 			string sentMessage2 = null;
-			MessagingCenter.Subscribe<MessagingCenterTests, string> (sub1, "SimpleTest", (sender, args) => sentMessage1 = args);
-			MessagingCenter.Subscribe<MessagingCenterTests, string> (sub2, "SimpleTest", (sender, args) => sentMessage2 = args);
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests, string> (sub1, "SimpleTest", (sender, args) => sentMessage1 = args);
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests, string> (sub2, "SimpleTest", (sender, args) => sentMessage2 = args);
 
-			MessagingCenter.Send (this, "SimpleTest", "My Message");
+			MessagingCenter.Instance.Send (this, "SimpleTest", "My Message");
 
 			Assert.That (sentMessage1, Is.EqualTo ("My Message"));
 			Assert.That (sentMessage2, Is.EqualTo ("My Message"));
 
-			MessagingCenter.Unsubscribe<MessagingCenterTests, string> (sub1, "SimpleTest");
-			MessagingCenter.Unsubscribe<MessagingCenterTests, string> (sub2, "SimpleTest");
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests, string> (sub1, "SimpleTest");
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests, string> (sub2, "SimpleTest");
 		}
 
 		[Test]
 		public void Unsubscribe ()
 		{
 			string sentMessage = null;
-			MessagingCenter.Subscribe<MessagingCenterTests, string> (this, "SimpleTest", (sender, args) => sentMessage = args);
-			MessagingCenter.Unsubscribe<MessagingCenterTests, string> (this, "SimpleTest");
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests, string> (this, "SimpleTest", (sender, args) => sentMessage = args);
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests, string> (this, "SimpleTest");
 
-			MessagingCenter.Send (this, "SimpleTest", "My Message");
+			MessagingCenter.Instance.Send (this, "SimpleTest", "My Message");
 
 			Assert.That (sentMessage, Is.EqualTo (null));
 		}
@@ -71,37 +71,37 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void SendWithoutSubscribers ()
 		{
-			Assert.DoesNotThrow (() => MessagingCenter.Send (this, "SimpleTest", "My Message"));
+			Assert.DoesNotThrow (() => MessagingCenter.Instance.Send (this, "SimpleTest", "My Message"));
 		}
 
 		[Test]
 		public void NoArgSingleSubscriber ()
 		{
 			bool sentMessage = false;
-			MessagingCenter.Subscribe<MessagingCenterTests> (this, "SimpleTest", sender => sentMessage = true);
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests> (this, "SimpleTest", sender => sentMessage = true);
 
-			MessagingCenter.Send (this, "SimpleTest");
+			MessagingCenter.Instance.Send (this, "SimpleTest");
 
 			Assert.That (sentMessage, Is.True);
 
-			MessagingCenter.Unsubscribe<MessagingCenterTests> (this, "SimpleTest");
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests> (this, "SimpleTest");
 		}
 
 		[Test]
 		public void NoArgFilter ()
 		{
 			bool sentMessage = false;
-			MessagingCenter.Subscribe (this, "SimpleTest", (sender) => sentMessage = true, this);
+			MessagingCenter.Instance.Subscribe (this, "SimpleTest", (sender) => sentMessage = true, this);
 
-			MessagingCenter.Send (new MessagingCenterTests (), "SimpleTest");
+			MessagingCenter.Instance.Send (new MessagingCenterTests (), "SimpleTest");
 
 			Assert.That (sentMessage, Is.False);
 
-			MessagingCenter.Send (this, "SimpleTest");
+			MessagingCenter.Instance.Send (this, "SimpleTest");
 
 			Assert.That (sentMessage, Is.True);
 
-			MessagingCenter.Unsubscribe<MessagingCenterTests> (this, "SimpleTest");
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests> (this, "SimpleTest");
 		}
 
 		[Test]
@@ -111,26 +111,26 @@ namespace Xamarin.Forms.Core.UnitTests
 			var sub2 = new object ();
 			bool sentMessage1 = false;
 			bool sentMessage2 = false;
-			MessagingCenter.Subscribe<MessagingCenterTests> (sub1, "SimpleTest", (sender) => sentMessage1 = true);
-			MessagingCenter.Subscribe<MessagingCenterTests> (sub2, "SimpleTest", (sender) => sentMessage2 = true);
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests> (sub1, "SimpleTest", (sender) => sentMessage1 = true);
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests> (sub2, "SimpleTest", (sender) => sentMessage2 = true);
 
-			MessagingCenter.Send (this, "SimpleTest");
+			MessagingCenter.Instance.Send (this, "SimpleTest");
 
 			Assert.That (sentMessage1, Is.True);
 			Assert.That (sentMessage2, Is.True);
 
-			MessagingCenter.Unsubscribe<MessagingCenterTests> (sub1, "SimpleTest");
-			MessagingCenter.Unsubscribe<MessagingCenterTests> (sub2, "SimpleTest");
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests> (sub1, "SimpleTest");
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests> (sub2, "SimpleTest");
 		}
 
 		[Test]
 		public void NoArgUnsubscribe ()
 		{
 			bool sentMessage = false;
-			MessagingCenter.Subscribe<MessagingCenterTests> (this, "SimpleTest", (sender) => sentMessage = true);
-			MessagingCenter.Unsubscribe<MessagingCenterTests> (this, "SimpleTest");
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests> (this, "SimpleTest", (sender) => sentMessage = true);
+			MessagingCenter.Instance.Unsubscribe<MessagingCenterTests> (this, "SimpleTest");
 
-			MessagingCenter.Send (this, "SimpleTest", "My Message");
+			MessagingCenter.Instance.Send (this, "SimpleTest", "My Message");
 
 			Assert.That (sentMessage, Is.False);
 		}
@@ -138,31 +138,31 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void NoArgSendWithoutSubscribers ()
 		{
-			Assert.DoesNotThrow (() => MessagingCenter.Send (this, "SimpleTest"));
+			Assert.DoesNotThrow (() => MessagingCenter.Instance.Send (this, "SimpleTest"));
 		}
 
 		[Test]
 		public void ThrowOnNullArgs ()
 		{
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Subscribe<MessagingCenterTests, string> (null, "Foo", (sender, args) => { }));
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Subscribe<MessagingCenterTests, string> (this, null, (sender, args) => { }));
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Subscribe<MessagingCenterTests, string> (this, "Foo", null));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Subscribe<MessagingCenterTests, string> (null, "Foo", (sender, args) => { }));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Subscribe<MessagingCenterTests, string> (this, null, (sender, args) => { }));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Subscribe<MessagingCenterTests, string> (this, "Foo", null));
 
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Subscribe<MessagingCenterTests> (null, "Foo", (sender) => { }));
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Subscribe<MessagingCenterTests> (this, null, (sender) => { }));
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Subscribe<MessagingCenterTests> (this, "Foo", null));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Subscribe<MessagingCenterTests> (null, "Foo", (sender) => { }));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Subscribe<MessagingCenterTests> (this, null, (sender) => { }));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Subscribe<MessagingCenterTests> (this, "Foo", null));
 
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Send<MessagingCenterTests, string> (null, "Foo", "Bar"));
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Send<MessagingCenterTests, string> (this, null, "Bar"));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Send<MessagingCenterTests, string> (null, "Foo", "Bar"));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Send<MessagingCenterTests, string> (this, null, "Bar"));
 
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Send<MessagingCenterTests> (null, "Foo"));
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Send<MessagingCenterTests> (this, null));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Send<MessagingCenterTests> (null, "Foo"));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Send<MessagingCenterTests> (this, null));
 
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Unsubscribe<MessagingCenterTests> (null, "Foo"));
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Unsubscribe<MessagingCenterTests> (this, null));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Unsubscribe<MessagingCenterTests> (null, "Foo"));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Unsubscribe<MessagingCenterTests> (this, null));
 
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Unsubscribe<MessagingCenterTests, string> (null, "Foo"));
-			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Unsubscribe<MessagingCenterTests, string> (this, null));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Unsubscribe<MessagingCenterTests, string> (null, "Foo"));
+			Assert.Throws<ArgumentNullException> (() => MessagingCenter.Instance.Unsubscribe<MessagingCenterTests, string> (this, null));
 		}
 
 		[Test]
@@ -173,17 +173,17 @@ namespace Xamarin.Forms.Core.UnitTests
 			var subscriber1 = new object ();
 			var subscriber2 = new object ();
 
-			MessagingCenter.Subscribe<MessagingCenterTests> (subscriber1, "SimpleTest", (sender) => {
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests> (subscriber1, "SimpleTest", (sender) => {
 				messageCount++;
-				MessagingCenter.Unsubscribe<MessagingCenterTests> (subscriber2, "SimpleTest");
+				MessagingCenter.Instance.Unsubscribe<MessagingCenterTests> (subscriber2, "SimpleTest");
 			});
 
-			MessagingCenter.Subscribe<MessagingCenterTests> (subscriber2, "SimpleTest", (sender) => {
+			MessagingCenter.Instance.Subscribe<MessagingCenterTests> (subscriber2, "SimpleTest", (sender) => {
 				messageCount++;
-				MessagingCenter.Unsubscribe<MessagingCenterTests> (subscriber1, "SimpleTest");
+				MessagingCenter.Instance.Unsubscribe<MessagingCenterTests> (subscriber1, "SimpleTest");
 			});
 
-			MessagingCenter.Send (this, "SimpleTest");
+			MessagingCenter.Instance.Send (this, "SimpleTest");
 
 			Assert.AreEqual (1, messageCount);
 		}

--- a/Xamarin.Forms.Core.UnitTests/PageTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PageTests.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		public override void TearDown()
 		{
 			base.TearDown ();
-			MessagingCenter.ClearSubscribers();
+			MessagingCenter.Instance.ClearSubscribers();
 		}
 
 		[Test]
@@ -294,7 +294,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		public void BusyNotSentWhenNotVisible ()
 		{
 			var sent = false;
-			MessagingCenter.Subscribe<Page, bool> (this, Page.BusySetSignalName, (p, b) => sent = true);
+			MessagingCenter.Instance.Subscribe<Page, bool> (this, Page.BusySetSignalName, (p, b) => sent = true);
 
 			new ContentPage { IsBusy = true };
 
@@ -305,7 +305,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		public void BusySentWhenBusyPageAppears()
 		{
 			var sent = false;
-			MessagingCenter.Subscribe<Page, bool> (this, Page.BusySetSignalName, (p, b) => {
+			MessagingCenter.Instance.Subscribe<Page, bool> (this, Page.BusySetSignalName, (p, b) => {
 				Assert.That (b, Is.True);
 				sent = true;
 			});
@@ -326,7 +326,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			((IPageController)page).SendAppearing();
 
 			var sent = false;
-			MessagingCenter.Subscribe<Page, bool> (this, Page.BusySetSignalName, (p, b) => {
+			MessagingCenter.Instance.Subscribe<Page, bool> (this, Page.BusySetSignalName, (p, b) => {
 				Assert.That (b, Is.False);
 				sent = true;
 			});
@@ -340,7 +340,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		public void BusySentWhenVisiblePageSetToBusy()
 		{
 			var sent = false;
-			MessagingCenter.Subscribe<Page, bool> (this, Page.BusySetSignalName, (p, b) => sent = true);
+			MessagingCenter.Instance.Subscribe<Page, bool> (this, Page.BusySetSignalName, (p, b) => sent = true);
 
 			var page = new ContentPage();
 			((IPageController)page).SendAppearing();
@@ -358,7 +358,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var page = new ContentPage ();
 
 			AlertArguments args = null;
-			MessagingCenter.Subscribe (this, Page.AlertSignalName, (Page sender, AlertArguments e) => args = e);
+			MessagingCenter.Instance.Subscribe (this, Page.AlertSignalName, (Page sender, AlertArguments e) => args = e);
 
 			var task = page.DisplayAlert ("Title", "Message", "Accept", "Cancel");
 
@@ -381,7 +381,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var page = new ContentPage ();
 
 			ActionSheetArguments args = null;
-			MessagingCenter.Subscribe (this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments e) => args = e);
+			MessagingCenter.Instance.Subscribe (this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments e) => args = e);
 
 			var task = page.DisplayActionSheet ("Title", "Cancel", "Destruction", "Other 1", "Other 2");
 

--- a/Xamarin.Forms.Core/IMessagingCenter.cs
+++ b/Xamarin.Forms.Core/IMessagingCenter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	public interface IMessagingCenter
+	{
+		void Send<TSender, TArgs>(TSender sender, string message, TArgs args) where TSender : class;
+
+		void Send<TSender>(TSender sender, string message) where TSender : class;
+
+		void Subscribe<TSender, TArgs>(object subscriber, string message, Action<TSender, TArgs> callback, TSender source = null) where TSender : class;
+
+		void Subscribe<TSender>(object subscriber, string message, Action<TSender> callback, TSender source = null) where TSender : class;
+
+		void Unsubscribe<TSender, TArgs>(object subscriber, string message) where TSender : class;
+
+		void Unsubscribe<TSender>(object subscriber, string message) where TSender : class;
+	}
+}

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms
 		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons)
 		{
 			var args = new ActionSheetArguments(title, cancel, destruction, buttons);
-			MessagingCenter.Send(this, ActionSheetSignalName, args);
+			MessagingCenter.Instance.Send(this, ActionSheetSignalName, args);
 			return args.Result.Task;
 		}
 
@@ -138,7 +138,7 @@ namespace Xamarin.Forms
 				throw new ArgumentNullException("cancel");
 
 			var args = new AlertArguments(title, message, accept, cancel);
-			MessagingCenter.Send(this, AlertSignalName, args);
+			MessagingCenter.Instance.Send(this, AlertSignalName, args);
 			return args.Result.Task;
 		}
 
@@ -303,7 +303,7 @@ namespace Xamarin.Forms
 			_hasAppeared = true;
 
 			if (IsBusy)
-				MessagingCenter.Send(this, BusySetSignalName, true);
+				MessagingCenter.Instance.Send(this, BusySetSignalName, true);
 
 			OnAppearing();
 			EventHandler handler = Appearing;
@@ -322,7 +322,7 @@ namespace Xamarin.Forms
 			_hasAppeared = false;
 
 			if (IsBusy)
-				MessagingCenter.Send(this, BusySetSignalName, false);
+				MessagingCenter.Instance.Send(this, BusySetSignalName, false);
 
 			var pageContainer = this as IPageContainer<Page>;
 			((IPageController)pageContainer?.CurrentPage)?.SendDisappearing();
@@ -368,7 +368,7 @@ namespace Xamarin.Forms
 			if (!_hasAppeared)
 				return;
 
-			MessagingCenter.Send(this, BusySetSignalName, IsBusy);
+			MessagingCenter.Instance.Send(this, BusySetSignalName, IsBusy);
 		}
 
 		void OnToolbarItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -87,6 +87,7 @@
     <Compile Include="DateChangedEventArgs.cs" />
     <Compile Include="DelegateLogListener.cs" />
     <Compile Include="EnumerableExtensions.cs" />
+    <Compile Include="IMessagingCenter.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\TabbedPage.cs" />

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Maps.Android
 			{
 				if (Element != null)
 				{
-					MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+					MessagingCenter.Instance.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
 					((ObservableCollection<Pin>)Element.Pins).CollectionChanged -= OnCollectionChanged;
 				}
 
@@ -104,7 +104,7 @@ namespace Xamarin.Forms.Maps.Android
 				Map oldMapModel = e.OldElement;
 				((ObservableCollection<Pin>)oldMapModel.Pins).CollectionChanged -= OnCollectionChanged;
 
-				MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+				MessagingCenter.Instance.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
 
 #pragma warning disable 618
 				if (oldMapView.Map != null)
@@ -133,7 +133,7 @@ namespace Xamarin.Forms.Maps.Android
 				SetMapType();
 			}
 
-			MessagingCenter.Subscribe<Map, MapSpan>(this, MoveMessageName, OnMoveToRegionMessage, Map);
+			MessagingCenter.Instance.Subscribe<Map, MapSpan>(this, MoveMessageName, OnMoveToRegionMessage, Map);
 
 			var incc = Map.Pins as INotifyCollectionChanged;
 			if (incc != null)

--- a/Xamarin.Forms.Maps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.UWP/MapRenderer.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Maps.WinRT
 			if (e.OldElement != null)
 			{
 				var mapModel = e.OldElement;
-				MessagingCenter.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
+				MessagingCenter.Instance.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
 				((ObservableCollection<Pin>)mapModel.Pins).CollectionChanged -= OnCollectionChanged;
 			}
 
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Maps.WinRT
 					Control.CenterChanged += async (s, a) => await UpdateVisibleRegion();
 				}
 
-				MessagingCenter.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", async (s, a) => await MoveToRegion(a), mapModel);
+				MessagingCenter.Instance.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", async (s, a) => await MoveToRegion(a), mapModel);
 
 				UpdateMapType();
 				UpdateHasScrollEnabled();
@@ -85,7 +85,7 @@ namespace Xamarin.Forms.Maps.WinRT
 			{
 				_disposed = true;
 
-				MessagingCenter.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
+				MessagingCenter.Instance.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
 
 				if (Element != null)
 					((ObservableCollection<Pin>)Element.Pins).CollectionChanged -= OnCollectionChanged;

--- a/Xamarin.Forms.Maps.WP8/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.WP8/MapRenderer.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Maps.WP8
 			Control.CenterChanged += (s, a) => UpdateVisibleRegion();
 			//Control.ViewChangeOnFrame += (s, a) => UpdateVisibleRegion ();
 
-			MessagingCenter.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", (s, a) => MoveToRegion(a), Element);
+			MessagingCenter.Instance.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", (s, a) => MoveToRegion(a), Element);
 
 			((ObservableCollection<Pin>)Element.Pins).CollectionChanged += OnCollectionChanged;
 

--- a/Xamarin.Forms.Maps.WinRT.Tablet/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.WinRT.Tablet/MapRenderer.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Maps.WinRT
 			if (e.OldElement != null)
 			{
 				var mapModel = e.OldElement;
-				MessagingCenter.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
+				MessagingCenter.Instance.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
 				((ObservableCollection<Pin>)mapModel.Pins).CollectionChanged -= OnCollectionChanged;
 			}
 
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Maps.WinRT
 					Control.ViewChanged += (s, a) => UpdateVisibleRegion();
 				}
 
-				MessagingCenter.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", (s, a) => MoveToRegion(a), mapModel);
+				MessagingCenter.Instance.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", (s, a) => MoveToRegion(a), mapModel);
 
 				UpdateMapType();
 				UpdateHasScrollEnabled();
@@ -76,7 +76,7 @@ namespace Xamarin.Forms.Maps.WinRT
 			{
 				_disposed = true;
 
-				MessagingCenter.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
+				MessagingCenter.Instance.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
 
 				if (Element != null)
 					((ObservableCollection<Pin>)Element.Pins).CollectionChanged -= OnCollectionChanged;

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -122,7 +122,7 @@ namespace Xamarin.Forms.Maps.iOS
 				if (Element != null)
 				{
 					var mapModel = (Map)Element;
-					MessagingCenter.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
+					MessagingCenter.Instance.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
 					((ObservableCollection<Pin>)mapModel.Pins).CollectionChanged -= OnCollectionChanged;
 				}
 
@@ -146,7 +146,7 @@ namespace Xamarin.Forms.Maps.iOS
 			if (e.OldElement != null)
 			{
 				var mapModel = (Map)e.OldElement;
-				MessagingCenter.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
+				MessagingCenter.Instance.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
 				((ObservableCollection<Pin>)mapModel.Pins).CollectionChanged -= OnCollectionChanged;
 			}
 
@@ -163,7 +163,7 @@ namespace Xamarin.Forms.Maps.iOS
 					mkMapView.RegionChanged += MkMapViewOnRegionChanged;
 				}
 
-				MessagingCenter.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", (s, a) => MoveToRegion(a), mapModel);
+				MessagingCenter.Instance.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", (s, a) => MoveToRegion(a), mapModel);
 				if (mapModel.LastMoveToRegion != null)
 					MoveToRegion(mapModel.LastMoveToRegion, false);
 

--- a/Xamarin.Forms.Maps/Map.cs
+++ b/Xamarin.Forms.Maps/Map.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Forms.Maps
 			if (mapSpan == null)
 				throw new ArgumentNullException(nameof(mapSpan));
 			LastMoveToRegion = mapSpan;
-			MessagingCenter.Send(this, "MapMoveToRegion", mapSpan);
+			MessagingCenter.Instance.Send(this, "MapMoveToRegion", mapSpan);
 		}
 
 		void PinsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -187,9 +187,9 @@ namespace Xamarin.Forms.Platform.Android
 			// may never be called
 			base.OnDestroy();
 
-			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
-			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
-			MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
+			MessagingCenter.Instance.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
+			MessagingCenter.Instance.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
+			MessagingCenter.Instance.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
 
 			if (_platform != null)
 				_platform.Dispose();
@@ -364,9 +364,9 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			_busyCount = 0;
-			MessagingCenter.Subscribe<Page, bool>(this, Page.BusySetSignalName, OnPageBusy);
-			MessagingCenter.Subscribe<Page, AlertArguments>(this, Page.AlertSignalName, OnAlertRequested);
-			MessagingCenter.Subscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName, OnActionSheetRequested);
+			MessagingCenter.Instance.Subscribe<Page, bool>(this, Page.BusySetSignalName, OnPageBusy);
+			MessagingCenter.Instance.Subscribe<Page, AlertArguments>(this, Page.AlertSignalName, OnAlertRequested);
+			MessagingCenter.Instance.Subscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName, OnActionSheetRequested);
 
 			_platform = new AppCompat.Platform(this);
 			if (_application != null)

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					return;
 				_navAnimationInProgress = value;
 				if (value)
-					MessagingCenter.Send(this, CloseContextActionsSignalName);
+					MessagingCenter.Instance.Send(this, CloseContextActionsSignalName);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -145,9 +145,9 @@ namespace Xamarin.Forms.Platform.Android
 			// may never be called
 			base.OnDestroy();
 
-			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
-			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
-			MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
+			MessagingCenter.Instance.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
+			MessagingCenter.Instance.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
+			MessagingCenter.Instance.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
 
 			if (_canvas != null)
 				((IDisposable)_canvas).Dispose();
@@ -240,7 +240,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			var busyCount = 0;
-			MessagingCenter.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
+			MessagingCenter.Instance.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
 			{
 				busyCount = Math.Max(0, enabled ? busyCount + 1 : busyCount - 1);
 				UpdateProgressBarVisibility(busyCount > 0);
@@ -248,7 +248,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			UpdateProgressBarVisibility(busyCount > 0);
 
-			MessagingCenter.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
+			MessagingCenter.Instance.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
 			{
 				AlertDialog alert = new AlertDialog.Builder(this).Create();
 				alert.SetTitle(arguments.Title);
@@ -260,7 +260,7 @@ namespace Xamarin.Forms.Platform.Android
 				alert.Show();
 			});
 
-			MessagingCenter.Subscribe(this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments arguments) =>
+			MessagingCenter.Instance.Subscribe(this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments arguments) =>
 			{
 				var builder = new AlertDialog.Builder(this);
 				builder.SetTitle(arguments.Title);

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1070,7 +1070,7 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 				_navAnimationInProgress = value;
 				if (value)
-					MessagingCenter.Send(this, CloseContextActionsSignalName);
+					MessagingCenter.Instance.Send(this, CloseContextActionsSignalName);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -54,9 +54,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			var platform = _listView.Platform;
 			if (platform.GetType() == typeof(AppCompat.Platform))
-				MessagingCenter.Subscribe<AppCompat.Platform>(this, AppCompat.Platform.CloseContextActionsSignalName, p => CloseContextAction());
+				MessagingCenter.Instance.Subscribe<AppCompat.Platform>(this, AppCompat.Platform.CloseContextActionsSignalName, p => CloseContextAction());
 			else
-				MessagingCenter.Subscribe<Platform>(this, Platform.CloseContextActionsSignalName, p => CloseContextAction());
+				MessagingCenter.Instance.Subscribe<Platform>(this, Platform.CloseContextActionsSignalName, p => CloseContextAction());
 		}
 
 		public override int Count
@@ -325,9 +325,9 @@ namespace Xamarin.Forms.Platform.Android
 
 				var platform = _listView.Platform;
 				if (platform.GetType() == typeof(AppCompat.Platform))
-					MessagingCenter.Unsubscribe<AppCompat.Platform>(this, Platform.CloseContextActionsSignalName);
+					MessagingCenter.Instance.Unsubscribe<AppCompat.Platform>(this, Platform.CloseContextActionsSignalName);
 				else
-					MessagingCenter.Unsubscribe<Platform>(this, Platform.CloseContextActionsSignalName);
+					MessagingCenter.Instance.Unsubscribe<Platform>(this, Platform.CloseContextActionsSignalName);
 
 				_realListView.OnItemClickListener = null;
 				_realListView.OnItemLongClickListener = null;

--- a/Xamarin.Forms.Platform.WP8/Forms.cs
+++ b/Xamarin.Forms.Platform.WP8/Forms.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Forms
 
 			public WP8DeviceInfo()
 			{
-				MessagingCenter.Subscribe(this, BWPorientationChangedName, (FormsApplicationPage page, DeviceOrientation orientation) => { CurrentOrientation = orientation; });
+				MessagingCenter.Instance.Subscribe(this, BWPorientationChangedName, (FormsApplicationPage page, DeviceOrientation orientation) => { CurrentOrientation = orientation; });
 
 				Content content = System.Windows.Application.Current.Host.Content;
 
@@ -98,7 +98,7 @@ namespace Xamarin.Forms
 
 			protected override void Dispose(bool disposing)
 			{
-				MessagingCenter.Unsubscribe<FormsApplicationPage, DeviceOrientation>(this, BWPorientationChangedName);
+				MessagingCenter.Instance.Unsubscribe<FormsApplicationPage, DeviceOrientation>(this, BWPorientationChangedName);
 				base.Dispose(disposing);
 			}
 		}

--- a/Xamarin.Forms.Platform.WP8/FormsApplicationPage.cs
+++ b/Xamarin.Forms.Platform.WP8/FormsApplicationPage.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			PhoneApplicationService.Current.Deactivated += OnDeactivated;
 			PhoneApplicationService.Current.Closing += OnClosing;
 
-			MessagingCenter.Send(this, Forms.WP8DeviceInfo.BWPorientationChangedName, Orientation.ToDeviceOrientation());
+			MessagingCenter.Instance.Send(this, Forms.WP8DeviceInfo.BWPorientationChangedName, Orientation.ToDeviceOrientation());
 			OrientationChanged += OnOrientationChanged;
 			//DeserializePropertyStore ();
 		}
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		void OnOrientationChanged(object sender, OrientationChangedEventArgs e)
 		{
-			MessagingCenter.Send(this, Forms.WP8DeviceInfo.BWPorientationChangedName, e.Orientation.ToDeviceOrientation());
+			MessagingCenter.Instance.Send(this, Forms.WP8DeviceInfo.BWPorientationChangedName, e.Orientation.ToDeviceOrientation());
 		}
 
 		void SetMainPage()

--- a/Xamarin.Forms.Platform.WP8/Platform.cs
+++ b/Xamarin.Forms.Platform.WP8/Platform.cs
@@ -51,13 +51,13 @@ namespace Xamarin.Forms.Platform.WinPhone
 			SystemTray.SetProgressIndicator(page, indicator = new ProgressIndicator { IsVisible = false, IsIndeterminate = true });
 
 			var busyCount = 0;
-			MessagingCenter.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
+			MessagingCenter.Instance.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
 			{
 				busyCount = Math.Max(0, enabled ? busyCount + 1 : busyCount - 1);
 				indicator.IsVisible = busyCount > 0;
 			});
 
-			MessagingCenter.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
+			MessagingCenter.Instance.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
 			{
 				var messageBox = new CustomMessageBox { Title = arguments.Title, Message = arguments.Message };
 				if (arguments.Accept != null)
@@ -72,7 +72,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 				};
 			});
 
-			MessagingCenter.Subscribe(this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments arguments) =>
+			MessagingCenter.Instance.Subscribe(this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments arguments) =>
 			{
 				var messageBox = new CustomMessageBox { Title = arguments.Title };
 

--- a/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms
 				typeof (ExportImageSourceHandlerAttribute)
 			});
 
-			MessagingCenter.Subscribe<Page, bool> (Device.PlatformServices, Page.BusySetSignalName, OnPageBusy);
+			MessagingCenter.Instance.Subscribe<Page, bool> (Device.PlatformServices, Page.BusySetSignalName, OnPageBusy);
 
 			HardwareButtons.BackPressed += OnBackPressed;
 

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			_container.SizeChanged += OnRendererSizeChanged;
 
-			MessagingCenter.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
+			MessagingCenter.Instance.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
 			{
 				Windows.UI.Xaml.Controls.ProgressBar indicator = GetBusyIndicator();
 				indicator.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
@@ -74,8 +74,8 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			_toolbarTracker.CollectionChanged += OnToolbarItemsChanged;
 
-			MessagingCenter.Subscribe<Page, AlertArguments>(this, Page.AlertSignalName, OnPageAlert);
-			MessagingCenter.Subscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName, OnPageActionSheet);
+			MessagingCenter.Instance.Subscribe<Page, AlertArguments>(this, Page.AlertSignalName, OnPageAlert);
+			MessagingCenter.Instance.Subscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName, OnPageActionSheet);
 
 			UpdateBounds();
 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_modals = new List<Page>();
 
 			var busyCount = 0;
-			MessagingCenter.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
+			MessagingCenter.Instance.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
 			{
 				if (!PageIsChildOfPlatform(sender))
 					return;
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UIApplication.SharedApplication.NetworkActivityIndicatorVisible = busyCount > 0;
 			});
 
-			MessagingCenter.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
+			MessagingCenter.Instance.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
 			{
 				if (!PageIsChildOfPlatform(sender))
 					return;
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			});
 
-			MessagingCenter.Subscribe(this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments arguments) =>
+			MessagingCenter.Instance.Subscribe(this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments arguments) =>
 			{
 				if (!PageIsChildOfPlatform(sender))
 					return;
@@ -156,9 +156,9 @@ namespace Xamarin.Forms.Platform.iOS
 			_disposed = true;
 
 			Page.DescendantRemoved -= HandleChildRemoved;
-			MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
-			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
-			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
+			MessagingCenter.Instance.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
+			MessagingCenter.Instance.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
+			MessagingCenter.Instance.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
 
 			DisposeModelAndChildrenRenderers(Page);
 			foreach (var modal in _modals)

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public NavigationRenderer()
 		{
-			MessagingCenter.Subscribe<IVisualElementRenderer>(this, UpdateToolbarButtons, sender =>
+			MessagingCenter.Instance.Subscribe<IVisualElementRenderer>(this, UpdateToolbarButtons, sender =>
 			{
 				if (!ViewControllers.Any())
 					return;
@@ -216,7 +216,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (disposing)
 			{
-				MessagingCenter.Unsubscribe<IVisualElementRenderer>(this, UpdateToolbarButtons);
+				MessagingCenter.Instance.Unsubscribe<IVisualElementRenderer>(this, UpdateToolbarButtons);
 
 				foreach (var childViewController in ViewControllers)
 					childViewController.Dispose();

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -219,7 +219,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void HandleMasterPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Page.IconProperty.PropertyName || e.PropertyName == Page.TitleProperty.PropertyName)
-				MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
+				MessagingCenter.Instance.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
 		}
 
 		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -230,7 +230,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			MasterDetailPageController.UpdateMasterBehavior();
-			MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
+			MessagingCenter.Instance.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
 			base.WillRotate(toInterfaceOrientation, duration);
 		}
 
@@ -265,7 +265,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void HandleMasterPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Page.IconProperty.PropertyName || e.PropertyName == Page.TitleProperty.PropertyName)
-				MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
+				MessagingCenter.Instance.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
 		}
 
 		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -279,7 +279,7 @@ namespace Xamarin.Forms.Platform.iOS
 				ToggleMaster();
 			else if (e.PropertyName == MasterDetailPage.IsGestureEnabledProperty.PropertyName)
 				PresentsWithGesture = MasterDetailPage.IsGestureEnabled;
-			MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
+			MessagingCenter.Instance.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
 		}
 
 		void MasterControllerWillAppear(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

This PR changes `MessagingCenter` implementation so that it becomes a non-static class with a static singleton for testability. It uses a `Lazy` implementation so that it's thread-safe. This will be a breaking change for customers, but it is easy to fix.

If this change is okay, I'd like it to be merged sooner than later because it touches many files and could need a rebase several times.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=46601

### API Changes ###

Added:
 - IMessagingCenter
 - public static MessagingCenter Instance

Changed:
 - public static class MessagingCenter => public class MessagingCenter
 - Static methods and fields are marked non-static.

### Behavioral Changes ###

Customers will have to switch to `MessagingCenter.Instance` syntax.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

