### PR TITLE
Bindable picker

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -1,42 +1,119 @@
 using System;
-
 using NUnit.Framework;
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
+	internal class ContextFixture
+	{
+		public class NestedClass
+		{
+			public string Nested { get; set; }
+		}
+
+		public NestedClass Nested { get; set; }
+
+		public string DisplayName { get; set; }
+
+		public string ComplexName { get; set; }
+
+		public ContextFixture(string displayName, string complexName)
+		{
+			DisplayName = displayName;
+			ComplexName = complexName;
+		}
+
+		public ContextFixture()
+		{
+		}
+	}
+
+	internal class BindingContext
+	{
+		public ObservableCollection<object> Items { get; set; }
+
+		public object SelectedItem { get; set; }
+	}
+
+	internal class PickerTestValueConverter : IValueConverter
+	{
+		public bool ConvertCalled { get; private set; }
+
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			ConvertCalled = true;
+			var cf = (ContextFixture)value;
+			return cf.DisplayName;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
 	[TestFixture]
 	public class PickerTests : BaseTestFixture
 	{
 		[Test]
 		public void TestSetSelectedIndexOnNullRows()
 		{
-			var picker = new Picker ();
+			var picker = new Picker();
 
-			Assert.IsEmpty (picker.Items);
-			Assert.AreEqual (-1, picker.SelectedIndex);
+			Assert.IsEmpty(picker.Items);
+			Assert.AreEqual(-1, picker.SelectedIndex);
 
 			picker.SelectedIndex = 2;
 
-			Assert.AreEqual (-1, picker.SelectedIndex);		
+			Assert.AreEqual(-1, picker.SelectedIndex);
 		}
 
 		[Test]
-		public void TestSelectedIndexInRange ()
+		public void TestSelectedIndexInRange()
 		{
-			var picker = new Picker { Items =  { "John", "Paul", "George", "Ringo" } };
+			var picker = new Picker
+			{
+				Items = { "John", "Paul", "George", "Ringo" },
+				SelectedIndex = 2
+			};
 
-			picker.SelectedIndex = 2;
-			Assert.AreEqual (2, picker.SelectedIndex);
+			Assert.AreEqual(2, picker.SelectedIndex);
 
 			picker.SelectedIndex = 42;
-			Assert.AreEqual (3, picker.SelectedIndex);
+			Assert.AreEqual(3, picker.SelectedIndex);
 
 			picker.SelectedIndex = -1;
-			Assert.AreEqual (-1, picker.SelectedIndex);
+			Assert.AreEqual(-1, picker.SelectedIndex);
 
 			picker.SelectedIndex = -42;
-			Assert.AreEqual (-1, picker.SelectedIndex);
+			Assert.AreEqual(-1, picker.SelectedIndex);
+		}
+
+		[Test]
+		public void TestSelectedIndexInRangeDefaultSelectedIndex()
+		{
+			var picker = new Picker
+			{
+				Items = { "John", "Paul", "George", "Ringo" }
+			};
+
+			Assert.AreEqual(-1, picker.SelectedIndex);
+
+			picker.SelectedIndex = -5;
+			Assert.AreEqual(-1, picker.SelectedIndex);
+
+			picker.SelectedIndex = 2;
+			Assert.AreEqual(2, picker.SelectedIndex);
+
+			picker.SelectedIndex = 42;
+			Assert.AreEqual(3, picker.SelectedIndex);
+
+			picker.SelectedIndex = -1;
+			Assert.AreEqual(-1, picker.SelectedIndex);
+
+			picker.SelectedIndex = -42;
+			Assert.AreEqual(-1, picker.SelectedIndex);
 		}
 
 		[Test]
@@ -44,16 +121,387 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var picker = new Picker { Items = { "John", "Paul", "George", "Ringo" }, SelectedIndex = 3 };
 
-			Assert.AreEqual (3, picker.SelectedIndex);
+			Assert.AreEqual(3, picker.SelectedIndex);
 
-			picker.Items.RemoveAt (3);
-			picker.Items.RemoveAt (2);
+			picker.Items.RemoveAt(3);
+			picker.Items.RemoveAt(2);
 
+			Assert.AreEqual(1, picker.SelectedIndex);
 
-			Assert.AreEqual (1, picker.SelectedIndex);
-
-			picker.Items.Clear ();
-			Assert.AreEqual (-1, picker.SelectedIndex);
+			picker.Items.Clear();
+			Assert.AreEqual(-1, picker.SelectedIndex);
 		}
-	}	
+
+		[Test]
+		public void TestSelectedIndexOutOfRangeUpdatesSelectedItem()
+		{
+			var picker = new Picker
+			{
+				ItemsSource = new ObservableCollection<string>
+				{
+					"Monkey",
+					"Banana",
+					"Lemon"
+				},
+				SelectedIndex = 0
+			};
+			Assert.AreEqual("Monkey", picker.SelectedItem);
+			picker.SelectedIndex = 42;
+			Assert.AreEqual("Lemon", picker.SelectedItem);
+			picker.SelectedIndex = -42;
+			Assert.IsNull(picker.SelectedItem);
+		}
+
+		[Test]
+		public void TestUnsubscribeINotifyCollectionChanged()
+		{
+			var list = new ObservableCollection<string>();
+			var picker = new Picker
+			{
+				ItemsSource = list
+			};
+			Assert.AreEqual(0, picker.Items.Count);
+			var newList = new ObservableCollection<string>();
+			picker.ItemsSource = newList;
+			list.Add("item");
+			Assert.AreEqual(0, picker.Items.Count);
+		}
+
+		[Test]
+		public void TestEmptyCollectionResetItems()
+		{
+			var list = new ObservableCollection<string>
+			{
+				"John",
+				"George",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				ItemsSource = list
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			picker.ItemsSource = new ObservableCollection<string>();
+			Assert.AreEqual(0, picker.Items.Count);
+		}
+
+		[Test]
+		public void TestDisplayFunc()
+		{
+			Func<object, string> customDisplayFunc = o =>
+			{
+				var f = (ContextFixture)o;
+				return $"{f.DisplayName} ({f.ComplexName})";
+			};
+			var obj = new ContextFixture("Monkey", "Complex Monkey");
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				DisplayFunc = customDisplayFunc,
+				ItemsSource = new ObservableCollection<object>
+				{
+					obj
+				},
+				SelectedIndex = 1
+			};
+			Assert.AreEqual("Monkey (Complex Monkey)", picker.Items[0]);
+		}
+
+		[Test]
+		public void TestSetItemsSourceProperty()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo",
+				0,
+				new DateTime(1970, 1, 1),
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items
+			};
+			Assert.AreEqual(5, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+			Assert.AreEqual("0", picker.Items[3]);
+		}
+
+		[Test]
+		public void TestDisplayConverter()
+		{
+			var obj = new ContextFixture("John", "John Doe");
+			var converter = new PickerTestValueConverter();
+			var picker = new Picker
+			{
+				DisplayConverter = converter,
+				ItemsSource = new ObservableCollection<object>
+				{
+					obj
+				}
+			};
+			Assert.IsTrue(converter.ConvertCalled);
+			Assert.AreEqual("John", picker.Items[0]);
+		}
+
+		[Test]
+		public void TestDisplayMemberPathShouldThrowArgumentExceptionInvalidPath()
+		{
+			var obj = new ContextFixture("Monkey", "Complex Monkey");
+			Func<Picker> picker = () => new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = new ObservableCollection<object>
+				{
+					obj
+				},
+				SelectedIndex = 1
+			};
+			Assert.Throws<ArgumentException>(() => picker());
+		}
+
+		[Test]
+		public void TestItemsSourceCollectionChangedAppend()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+			items.Add(new { Name = "George" });
+			Assert.AreEqual(4, picker.Items.Count);
+			Assert.AreEqual("George", picker.Items[picker.Items.Count - 1]);
+		}
+
+		[Test]
+		public void TestItemsSourceCollectionChangedClear()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			items.Clear();
+			Assert.AreEqual(0, picker.Items.Count);
+		}
+
+		[Test]
+		public void TestItemsSourceCollectionChangedInsert()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+			items.Insert(1, new { Name = "George" });
+			Assert.AreEqual(4, picker.Items.Count);
+			Assert.AreEqual("George", picker.Items[1]);
+		}
+
+		[Test]
+		public void TestItemsSourceCollectionChangedReAssign()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var bindingContext = new { Items = items };
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				BindingContext = bindingContext
+			};
+			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+			Assert.AreEqual(3, picker.Items.Count);
+			items = new ObservableCollection<object>
+			{
+				"Peach",
+				"Orange"
+			};
+			picker.BindingContext = new { Items = items };
+			Assert.AreEqual(2, picker.Items.Count);
+			Assert.AreEqual("Peach", picker.Items[0]);
+		}
+
+		[Test]
+		public void TestItemsSourceCollectionChangedRemove()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Name",
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+			items.RemoveAt(1);
+			Assert.AreEqual(2, picker.Items.Count);
+			Assert.AreEqual("Ringo", picker.Items[1]);
+		}
+
+		[Test]
+		public void TestItemsSourceCollectionOfStrings()
+		{
+			var items = new ObservableCollection<string>
+			{
+				"John",
+				"Paul",
+				"Ringo"
+			};
+			var picker = new Picker
+			{
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+			Assert.AreEqual(3, picker.Items.Count);
+			Assert.AreEqual("John", picker.Items[0]);
+		}
+
+		[Test]
+		public void TestSelectedItemDefault()
+		{
+			var bindingContext = new BindingContext
+			{
+				Items = new ObservableCollection<object>
+				{
+					new ContextFixture("John", "John")
+				}
+			};
+			var picker = new Picker
+			{
+				BindingContext = bindingContext
+			};
+			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+			picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
+			Assert.AreEqual(1, picker.Items.Count);
+			Assert.AreEqual(-1, picker.SelectedIndex);
+			Assert.AreEqual(bindingContext.SelectedItem, picker.SelectedItem);
+		}
+
+		[Test]
+		public void TestNestedDisplayMemberPathExpression()
+		{
+			var obj = new ContextFixture
+			{
+				Nested = new ContextFixture.NestedClass
+				{
+					Nested = "NestedProperty"
+				}
+			};
+			var picker = new Picker
+			{
+				DisplayMemberPath = "Nested.Nested",
+				ItemsSource = new ObservableCollection<object>
+				{
+					obj
+				},
+				SelectedIndex = 0
+			};
+			Assert.AreEqual("NestedProperty", picker.Items[0]);
+		}
+
+		[Test]
+		public void TestItemsSourceEnums()
+		{
+			var picker = new Picker
+			{
+				ItemsSource = new ObservableCollection<TextAlignment>
+				{
+					TextAlignment.Start,
+					TextAlignment.Center,
+					TextAlignment.End
+				},
+				SelectedIndex = 0
+			};
+			Assert.AreEqual("Start", picker.Items[0]);
+		}
+
+		[Test]
+		public void TestSelectedItemSet()
+		{
+			var obj = new ContextFixture("John", "John");
+			var bindingContext = new BindingContext
+			{
+				Items = new ObservableCollection<object>
+				{
+					obj
+				},
+				SelectedItem = obj
+			};
+			var picker = new Picker
+			{
+				BindingContext = bindingContext,
+				DisplayMemberPath = "DisplayName"
+			};
+			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+			picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
+			Assert.AreEqual(1, picker.Items.Count);
+			Assert.AreEqual(0, picker.SelectedIndex);
+			Assert.AreEqual(obj, picker.SelectedItem);
+		}
+
+		[Test]
+		public void TestSelectedItemChangeSelectedIndex()
+		{
+			var obj = new ContextFixture("John", "John");
+			var bindingContext = new BindingContext
+			{
+				Items = new ObservableCollection<object>
+				{
+					obj
+				},
+			};
+			var picker = new Picker
+			{
+				BindingContext = bindingContext,
+				DisplayMemberPath = "DisplayName"
+			};
+			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
+			picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
+			Assert.AreEqual(1, picker.Items.Count);
+			Assert.AreEqual(-1, picker.SelectedIndex);
+			Assert.AreEqual(null, picker.SelectedItem);
+			picker.SelectedItem = obj;
+			Assert.AreEqual(0, picker.SelectedIndex);
+			Assert.AreEqual(obj, picker.SelectedItem);
+			picker.SelectedIndex = -1;
+			Assert.AreEqual(-1, picker.SelectedIndex);
+			Assert.AreEqual(null, picker.SelectedItem);
+		}
+	}
 }

--- a/Xamarin.Forms.Core.UnitTests/PickerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PickerTests.cs
@@ -5,57 +5,57 @@ using System.Globalization;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
-	internal class ContextFixture
-	{
-		public class NestedClass
-		{
-			public string Nested { get; set; }
-		}
-
-		public NestedClass Nested { get; set; }
-
-		public string DisplayName { get; set; }
-
-		public string ComplexName { get; set; }
-
-		public ContextFixture(string displayName, string complexName)
-		{
-			DisplayName = displayName;
-			ComplexName = complexName;
-		}
-
-		public ContextFixture()
-		{
-		}
-	}
-
-	internal class BindingContext
-	{
-		public ObservableCollection<object> Items { get; set; }
-
-		public object SelectedItem { get; set; }
-	}
-
-	internal class PickerTestValueConverter : IValueConverter
-	{
-		public bool ConvertCalled { get; private set; }
-
-		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-		{
-			ConvertCalled = true;
-			var cf = (ContextFixture)value;
-			return cf.DisplayName;
-		}
-
-		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-		{
-			throw new NotImplementedException();
-		}
-	}
-
 	[TestFixture]
 	public class PickerTests : BaseTestFixture
 	{
+		class PickerTestsContextFixture
+		{
+			public class PickerTestsNestedClass
+			{
+				public string Nested { get; set; }
+			}
+
+			public PickerTestsNestedClass Nested { get; set; }
+
+			public string DisplayName { get; set; }
+
+			public string ComplexName { get; set; }
+
+			public PickerTestsContextFixture(string displayName, string complexName)
+			{
+				DisplayName = displayName;
+				ComplexName = complexName;
+			}
+
+			public PickerTestsContextFixture()
+			{
+			}
+		}
+
+		class PickerTestsBindingContext
+		{
+			public ObservableCollection<object> Items { get; set; }
+
+			public object SelectedItem { get; set; }
+		}
+
+		class PickerTestValueConverter : IValueConverter
+		{
+			public bool ConvertCalled { get; private set; }
+
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				ConvertCalled = true;
+				var cf = (PickerTestsContextFixture)value;
+				return cf.DisplayName;
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
 		[Test]
 		public void TestSetSelectedIndexOnNullRows()
 		{
@@ -186,28 +186,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void TestDisplayFunc()
-		{
-			Func<object, string> customDisplayFunc = o =>
-			{
-				var f = (ContextFixture)o;
-				return $"{f.DisplayName} ({f.ComplexName})";
-			};
-			var obj = new ContextFixture("Monkey", "Complex Monkey");
-			var picker = new Picker
-			{
-				DisplayMemberPath = "Name",
-				DisplayFunc = customDisplayFunc,
-				ItemsSource = new ObservableCollection<object>
-				{
-					obj
-				},
-				SelectedIndex = 1
-			};
-			Assert.AreEqual("Monkey (Complex Monkey)", picker.Items[0]);
-		}
-
-		[Test]
 		public void TestSetItemsSourceProperty()
 		{
 			var items = new ObservableCollection<object>
@@ -220,22 +198,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 			var picker = new Picker
 			{
-				DisplayMemberPath = "Name",
+				ItemDisplayBinding = new Binding("Name"),
 				ItemsSource = items
 			};
 			Assert.AreEqual(5, picker.Items.Count);
 			Assert.AreEqual("John", picker.Items[0]);
-			Assert.AreEqual("0", picker.Items[3]);
+			Assert.AreEqual(null, picker.Items[3]);
 		}
 
 		[Test]
 		public void TestDisplayConverter()
 		{
-			var obj = new ContextFixture("John", "John Doe");
+			var obj = new PickerTestsContextFixture("John", "John Doe");
 			var converter = new PickerTestValueConverter();
 			var picker = new Picker
 			{
-				DisplayConverter = converter,
+				ItemDisplayBinding = new Binding (Binding.SelfPath, converter:converter),
 				ItemsSource = new ObservableCollection<object>
 				{
 					obj
@@ -243,22 +221,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 			Assert.IsTrue(converter.ConvertCalled);
 			Assert.AreEqual("John", picker.Items[0]);
-		}
-
-		[Test]
-		public void TestDisplayMemberPathShouldThrowArgumentExceptionInvalidPath()
-		{
-			var obj = new ContextFixture("Monkey", "Complex Monkey");
-			Func<Picker> picker = () => new Picker
-			{
-				DisplayMemberPath = "Name",
-				ItemsSource = new ObservableCollection<object>
-				{
-					obj
-				},
-				SelectedIndex = 1
-			};
-			Assert.Throws<ArgumentException>(() => picker());
 		}
 
 		[Test]
@@ -272,7 +234,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 			var picker = new Picker
 			{
-				DisplayMemberPath = "Name",
+				ItemDisplayBinding = new Binding("Name"),
 				ItemsSource = items,
 				SelectedIndex = 0
 			};
@@ -294,7 +256,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 			var picker = new Picker
 			{
-				DisplayMemberPath = "Name",
+				ItemDisplayBinding = new Binding("Name"),
 				ItemsSource = items,
 				SelectedIndex = 0
 			};
@@ -314,7 +276,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 			var picker = new Picker
 			{
-				DisplayMemberPath = "Name",
+				ItemDisplayBinding = new Binding("Name"),
 				ItemsSource = items,
 				SelectedIndex = 0
 			};
@@ -337,7 +299,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var bindingContext = new { Items = items };
 			var picker = new Picker
 			{
-				DisplayMemberPath = "Name",
+				ItemDisplayBinding = new Binding("Name"),
 				BindingContext = bindingContext
 			};
 			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
@@ -348,6 +310,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				"Orange"
 			};
 			picker.BindingContext = new { Items = items };
+			picker.ItemDisplayBinding = null;
 			Assert.AreEqual(2, picker.Items.Count);
 			Assert.AreEqual("Peach", picker.Items[0]);
 		}
@@ -358,12 +321,12 @@ namespace Xamarin.Forms.Core.UnitTests
 			var items = new ObservableCollection<object>
 			{
 				new { Name = "John" },
-				"Paul",
-				"Ringo"
+				new { Name = "Paul" },
+				new { Name = "Ringo"},
 			};
 			var picker = new Picker
 			{
-				DisplayMemberPath = "Name",
+				ItemDisplayBinding = new Binding("Name"),
 				ItemsSource = items,
 				SelectedIndex = 0
 			};
@@ -395,11 +358,11 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestSelectedItemDefault()
 		{
-			var bindingContext = new BindingContext
+			var bindingContext = new PickerTestsBindingContext
 			{
 				Items = new ObservableCollection<object>
 				{
-					new ContextFixture("John", "John")
+					new PickerTestsContextFixture("John", "John")
 				}
 			};
 			var picker = new Picker
@@ -414,18 +377,27 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void ThrowsWhenModifyingItemsIfItemsSourceIsSet()
+		{
+			var picker = new Picker {
+				ItemsSource = new System.Collections.Generic.List<object> ()
+			};
+			Assert.Throws<InvalidOperationException>(() => picker.Items.Add("foo"));
+		}
+
+		[Test]
 		public void TestNestedDisplayMemberPathExpression()
 		{
-			var obj = new ContextFixture
+			var obj = new PickerTestsContextFixture
 			{
-				Nested = new ContextFixture.NestedClass
+				Nested = new PickerTestsContextFixture.PickerTestsNestedClass
 				{
 					Nested = "NestedProperty"
 				}
 			};
 			var picker = new Picker
 			{
-				DisplayMemberPath = "Nested.Nested",
+				ItemDisplayBinding = new Binding("Nested.Nested"),
 				ItemsSource = new ObservableCollection<object>
 				{
 					obj
@@ -454,8 +426,8 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestSelectedItemSet()
 		{
-			var obj = new ContextFixture("John", "John");
-			var bindingContext = new BindingContext
+			var obj = new PickerTestsContextFixture("John", "John");
+			var bindingContext = new PickerTestsBindingContext
 			{
 				Items = new ObservableCollection<object>
 				{
@@ -466,7 +438,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var picker = new Picker
 			{
 				BindingContext = bindingContext,
-				DisplayMemberPath = "DisplayName"
+				ItemDisplayBinding = new Binding("DisplayName"),
 			};
 			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
 			picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");
@@ -478,8 +450,8 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestSelectedItemChangeSelectedIndex()
 		{
-			var obj = new ContextFixture("John", "John");
-			var bindingContext = new BindingContext
+			var obj = new PickerTestsContextFixture("John", "John");
+			var bindingContext = new PickerTestsBindingContext
 			{
 				Items = new ObservableCollection<object>
 				{
@@ -489,7 +461,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var picker = new Picker
 			{
 				BindingContext = bindingContext,
-				DisplayMemberPath = "DisplayName"
+				ItemDisplayBinding = new Binding("DisplayName"),
 			};
 			picker.SetBinding(Picker.ItemsSourceProperty, "Items");
 			picker.SetBinding(Picker.SelectedItemProperty, "SelectedItem");

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Globalization;
+using System.Reflection;
 using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
@@ -13,28 +16,81 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
 
 		public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
-			propertyChanged: (bindable, oldvalue, newvalue) =>
-			{
-				EventHandler eh = ((Picker)bindable).SelectedIndexChanged;
-				if (eh != null)
-					eh(bindable, EventArgs.Empty);
-			}, coerceValue: CoerceSelectedIndex);
+			propertyChanged: OnSelectedIndexChanged,
+			coerceValue: CoerceSelectedIndex);
+
+		public static readonly BindableProperty SelectedValueMemberPathProperty = BindableProperty.Create(nameof(SelectedValueMemberPath), typeof(string), typeof(Picker));
+
+		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IList), typeof(Picker), default(IList), propertyChanged: OnItemsSourceChanged);
+
+		public static readonly BindableProperty DisplayMemberPathProperty = BindableProperty.Create(nameof(DisplayMemberPath), typeof(string), typeof(Picker), propertyChanged: OnDisplayMemberPathChanged);
+
+		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay, propertyChanged: OnSelectedItemChanged);
 
 		readonly Lazy<PlatformConfigurationRegistry<Picker>> _platformConfigurationRegistry;
 
+		public static readonly BindableProperty DisplayFuncProperty =
+			BindableProperty.Create(
+				nameof(DisplayFunc),
+				typeof(Func<object, string>),
+				typeof(Picker));
+
+		public static readonly BindableProperty DisplayConverterProperty =
+			BindableProperty.Create(
+				nameof(DisplayConverter),
+				typeof(IValueConverter),
+				typeof(Picker),
+				default(IValueConverter));
+
+		
 		public Picker()
 		{
-			Items = new ObservableList<string>();
 			((ObservableList<string>)Items).CollectionChanged += OnItemsCollectionChanged;
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Picker>>(() => new PlatformConfigurationRegistry<Picker>(this));
 		}
 
-		public IList<string> Items { get; }
+		public string DisplayMemberPath
+		{
+			get { return (string)GetValue(DisplayMemberPathProperty); }
+			set { SetValue(DisplayMemberPathProperty, value); }
+		}
+
+		public Func<object, string> DisplayFunc
+		{
+			get { return (Func<object, string>)GetValue(DisplayFuncProperty); }
+			set { SetValue(DisplayFuncProperty, value); }
+		}
+
+		public IValueConverter DisplayConverter
+		{
+			get { return (IValueConverter)GetValue(DisplayConverterProperty); }
+			set { SetValue(DisplayConverterProperty, value); }
+		}
+
+		public IList<string> Items { get; } = new ObservableList<string>();
+
+		public IList ItemsSource
+		{
+			get { return (IList)GetValue(ItemsSourceProperty); }
+			set { SetValue(ItemsSourceProperty, value); }
+		}
 
 		public int SelectedIndex
 		{
 			get { return (int)GetValue(SelectedIndexProperty); }
 			set { SetValue(SelectedIndexProperty, value); }
+		}
+
+		public object SelectedItem
+		{
+			get { return GetValue(SelectedItemProperty); }
+			set { SetValue(SelectedItemProperty, value); }
+		}
+
+		public string SelectedValueMemberPath
+		{
+			get { return (string)GetValue(SelectedValueMemberPathProperty); }
+			set { SetValue(SelectedValueMemberPathProperty, value); }
 		}
 
 		public Color TextColor
@@ -51,15 +107,182 @@ namespace Xamarin.Forms
 
 		public event EventHandler SelectedIndexChanged;
 
+		protected virtual string GetDisplayMember(object item)
+		{
+			if (DisplayConverter != null)
+			{
+				var display = DisplayConverter.Convert(item, typeof(string), null, CultureInfo.CurrentUICulture) as string;
+				if (display == null)
+				{
+					throw new ArgumentException("value must be converted to string");
+				}
+				return display;
+			}
+			if (DisplayFunc != null)
+			{
+				return DisplayFunc(item);
+			}
+			if (item == null)
+			{
+				return null;
+			}
+			bool isValueType = item.GetType().GetTypeInfo().IsValueType;
+			if (isValueType || string.IsNullOrEmpty(DisplayMemberPath) || item is string)
+			{
+				// For a mix of objects in ItemsSourc to be handled correctly in conjunction with DisplayMemberPath
+				// we need to handle value types and string so that GetPropertyValue doesn't throw exception if the property
+				// doesn't exist on the item object
+				return item.ToString();
+			}
+			return GetPropertyValue(item, DisplayMemberPath) as string;
+		}
+
+		void AddItems(NotifyCollectionChangedEventArgs e)
+		{
+			int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
+			foreach (object newItem in e.NewItems)
+			{
+				Items.Insert(index++, GetDisplayMember(newItem));
+			}
+		}
+
+		void BindItems()
+		{
+			Items.Clear();
+			foreach (object item in ItemsSource)
+			{
+				Items.Add(GetDisplayMember(item));
+			}
+			UpdateSelectedItem();
+		}
+
 		static object CoerceSelectedIndex(BindableObject bindable, object value)
 		{
 			var picker = (Picker)bindable;
 			return picker.Items == null ? -1 : ((int)value).Clamp(-1, picker.Items.Count - 1);
 		}
 
+		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			switch (e.Action)
+			{
+				case NotifyCollectionChangedAction.Move:
+				case NotifyCollectionChangedAction.Replace:
+				case NotifyCollectionChangedAction.Reset:
+					// Clear Items collection and re-populate it with values from ItemsSource
+					BindItems();
+					return;
+				case NotifyCollectionChangedAction.Remove:
+					RemoveItems(e);
+					break;
+				case NotifyCollectionChangedAction.Add:
+					AddItems(e);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
+
+		static object GetPropertyValue(object item, string memberPath)
+		{
+			if (item == null)
+			{
+				throw new ArgumentNullException(nameof(item));
+			}
+			if (string.IsNullOrEmpty(memberPath))
+			{
+				throw new ArgumentNullException(nameof(memberPath));
+			}
+			// Find the property by walking the display member path to find any nested properties
+			string[] propertyPathParts = memberPath.Split('.');
+			object propertyValue = item;
+			foreach (string propertyPathPart in propertyPathParts)
+			{
+				PropertyInfo propInfo = propertyValue.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
+				if (propInfo == null)
+				{
+					throw new ArgumentException(
+						$"No property with name '{propertyPathPart}' was found on '{propertyValue.GetType().FullName}'");
+				}
+				propertyValue = propInfo.GetValue(propertyValue);
+			}
+			return propertyValue;
+		}
+
+		static void OnDisplayMemberPathChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			if (picker.ItemsSource?.Count > 0)
+			{
+				picker.BindItems();
+			}
+		}
+
 		void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
+			UpdateSelectedItem();
+		}
+
+		static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			// Check if the ItemsSource value has changed and if so, unsubscribe from collection changed
+			var observable = oldValue as INotifyCollectionChanged;
+			if (observable != null)
+			{
+				observable.CollectionChanged -= picker.CollectionChanged;
+			}
+			observable = newValue as INotifyCollectionChanged;
+			if (observable != null)
+			{
+				observable.CollectionChanged += picker.CollectionChanged;
+				picker.BindItems();
+			}
+			else
+			{
+				// newValue is null so clear the items collection
+				picker.Items.Clear();
+			}
+		}
+
+		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			EventHandler eh = picker.SelectedIndexChanged;
+			eh?.Invoke(bindable, EventArgs.Empty);
+			picker.UpdateSelectedItem();
+		}
+
+		static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var picker = (Picker)bindable;
+			picker.UpdateSelectedIndex(newValue);
+		}
+
+		void RemoveItems(NotifyCollectionChangedEventArgs e)
+		{
+			int index = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count;
+			// TODO: How do we determine the order of which the items were removed
+			foreach (object _ in e.OldItems)
+			{
+				Items.RemoveAt(index--);
+			}
+		}
+
+		void UpdateSelectedIndex(object selectedItem)
+		{
+			string displayMember = GetDisplayMember(selectedItem);
+			int index = Items.IndexOf(displayMember);
+			// TODO Should we prevent call to FindObject since the object is already known
+			// by setting a flag, or otherwise indicate, that we, internally, forced a SelectedIndex changed
+			SelectedIndex = index;
+		}
+
+		void UpdateSelectedItem()
+		{
+			// coerceSelectedIndex ensures that SelectedIndex is in range [-1,ItemsSource.Count)
+			SelectedItem = SelectedIndex == -1 ? null : ItemsSource?[SelectedIndex];
 		}
 
 		public IPlatformElementConfiguration<T, Picker> On<T>() where T : IConfigPlatform

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -6,6 +6,7 @@ using Android.Content.Res;
 using Android.Text;
 using Android.Widget;
 using Object = Java.Lang.Object;
+using System.Collections.Specialized;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -31,7 +32,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				_disposed = true;
 
-				((ObservableList<string>)Element.Items).CollectionChanged -= RowsCollectionChanged;
+				((INotifyCollectionChanged)Element.Items).CollectionChanged -= RowsCollectionChanged;
 			}
 
 			base.Dispose(disposing);
@@ -40,11 +41,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
 		{
 			if (e.OldElement != null)
-				((ObservableList<string>)e.OldElement.Items).CollectionChanged -= RowsCollectionChanged;
+				((INotifyCollectionChanged)e.OldElement.Items).CollectionChanged -= RowsCollectionChanged;
 
 			if (e.NewElement != null)
 			{
-				((ObservableList<string>)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
+				((INotifyCollectionChanged)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
 				if (Control == null)
 				{
 					EditText textField = CreateNativeControl();

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -9,6 +9,7 @@ using ADatePicker = Android.Widget.DatePicker;
 using ATimePicker = Android.Widget.TimePicker;
 using Object = Java.Lang.Object;
 using Orientation = Android.Widget.Orientation;
+using System.Collections.Specialized;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -30,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (disposing && !_isDisposed)
 			{
 				_isDisposed = true;
-				((ObservableList<string>)Element.Items).CollectionChanged -= RowsCollectionChanged;
+				((INotifyCollectionChanged)Element.Items).CollectionChanged -= RowsCollectionChanged;
 			}
 
 			base.Dispose(disposing);
@@ -44,11 +45,11 @@ namespace Xamarin.Forms.Platform.Android
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
 		{
 			if (e.OldElement != null)
-				((ObservableList<string>)e.OldElement.Items).CollectionChanged -= RowsCollectionChanged;
+				((INotifyCollectionChanged)e.OldElement.Items).CollectionChanged -= RowsCollectionChanged;
 
 			if (e.NewElement != null)
 			{
-				((ObservableList<string>)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
+				((INotifyCollectionChanged)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
 				if (Control == null)
 				{
 					var textField = CreateNativeControl();

--- a/Xamarin.Forms.Platform.WP8/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/PickerRenderer.cs
@@ -27,9 +27,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 			base.OnElementChanged(e);
 
 			if (e.OldElement != null)
-				((ObservableList<string>)Element.Items).CollectionChanged -= ItemsCollectionChanged;
+				((INotifyCollectionChanged)Element.Items).CollectionChanged -= ItemsCollectionChanged;
 
-			((ObservableList<string>)Element.Items).CollectionChanged += ItemsCollectionChanged;
+			((INotifyCollectionChanged)Element.Items).CollectionChanged += ItemsCollectionChanged;
 
 			_listPicker.ItemTemplate = (System.Windows.DataTemplate)System.Windows.Application.Current.Resources["PickerItemTemplate"];
 			_listPicker.FullModeItemTemplate = (System.Windows.DataTemplate)System.Windows.Application.Current.Resources["PickerFullItemTemplate"];

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using UIKit;
 using RectangleF = CoreGraphics.CGRect;
@@ -15,7 +16,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
 		{
 			if (e.OldElement != null)
-				((ObservableList<string>)e.OldElement.Items).CollectionChanged -= RowsCollectionChanged;
+				((INotifyCollectionChanged)e.OldElement.Items).CollectionChanged -= RowsCollectionChanged;
 
 			if (e.NewElement != null)
 			{
@@ -55,7 +56,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdatePicker();
 				UpdateTextColor();
 
-				((ObservableList<string>)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
+				((INotifyCollectionChanged)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
 			}
 
 			base.OnElementChanged(e);

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Picker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Picker.xml
@@ -163,6 +163,22 @@ namespace FormsGallery
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="ItemDisplayBinding">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.BindingBase ItemDisplayBinding { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.BindingBase ItemDisplayBinding" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindingBase</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Items">
       <MemberSignature Language="C#" Value="public System.Collections.Generic.IList&lt;string&gt; Items { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.IList`1&lt;string&gt; Items" />
@@ -183,6 +199,37 @@ namespace FormsGallery
         <summary>Gets the list of choices.</summary>
         <value>An IList&lt;string&gt; representing the Picker choices.</value>
         <remarks>This property is read-only, but exposes the IList&lt;&gt; interface, so items can be added using Add().</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ItemsSource">
+      <MemberSignature Language="C#" Value="public System.Collections.IList ItemsSource { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.IList ItemsSource" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.IList</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ItemsSourceProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ItemsSourceProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ItemsSourceProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -273,6 +320,37 @@ namespace FormsGallery
         <summary>Identifies the SelectedIndex bindable property.</summary>
         <remarks>
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SelectedItem">
+      <MemberSignature Language="C#" Value="public object SelectedItem { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance object SelectedItem" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SelectedItemProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty SelectedItemProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty SelectedItemProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">


### PR DESCRIPTION
### Description of Change ###

This PR includes and replace #296 by @joacar

### Please do not squash merge to preserve authors informations.

### Bugs Fixed ###

None

### API Changes ###

Added:

	public static readonly BindableProperty Picker.ItemsSourceProperty;
	public static readonly BindableProperty Picker.SelectedItemProperty;
	public BindingBase Picker.ItemDisplayBinding { get; set;}
	public IList ItemsSource { get; set; }
	public object SelectedItem { get; set; }

### Behavioral Changes ###

None

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense