### PR TITLE
[C] Track and clear CurrentNavigationTask value

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31171.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31171.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 31171, "Popped page gets held in memory when using NavigationPage")]
+	public class Bugzilla31171 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new Bugzilla31171Page1());
+		}
+
+		public class Bugzilla31171Page1 : ContentPage
+		{
+			Label pageLabel;
+			WeakReference page2Tracker;
+
+			public Bugzilla31171Page1()
+			{
+				var stack = new StackLayout() { VerticalOptions = LayoutOptions.Center };
+
+				pageLabel = new Label
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					Text = "Page 1",
+				};
+				stack.Children.Add(pageLabel);
+
+				Content = stack;
+			}
+
+			protected override async void OnAppearing()
+			{
+				base.OnAppearing();
+
+				if (page2Tracker == null)
+				{
+					var page2 = new Bugzilla31171Page2();
+
+					page2Tracker = new WeakReference(page2);
+
+					await Task.Delay(1000);
+					await Navigation.PushAsync(page2);
+
+					StartTrackPage2();
+				}
+			}
+
+
+			async void StartTrackPage2()
+			{
+				var flag = true;
+				while (flag)
+				{
+					pageLabel.Text = string.Format("Page 1. Page 2 IsAlive = {0}", page2Tracker.IsAlive);
+					if (!page2Tracker.IsAlive)
+					{
+						flag = false;
+						break;
+					}
+					await Task.Delay(1000);
+					GC.Collect();
+				}
+			}
+		}
+
+		class Bugzilla31171Page2 : ContentPage
+		{
+			public Bugzilla31171Page2()
+			{
+				Content = new Label()
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					Text = "Page 2"
+				};
+			}
+
+			protected override async void OnAppearing()
+			{
+				base.OnAppearing();
+
+				await Task.Delay(1000);
+				await Navigation.PopAsync();
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla31171Test()
+		{
+			RunningApp.WaitForElement(q => q.Text("Page 1. Page 2 IsAlive = False"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -463,6 +463,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39489.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36802.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35736.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31171.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var popped = await nav.Navigation.PopAsync ();
 
 			Assert.True (fired);
+			Assert.IsNull(nav.CurrentNavigationTask);
 			Assert.AreSame (childRoot, nav.CurrentPage);
 			Assert.AreEqual (childRoot2, popped);
 
@@ -50,6 +51,30 @@ namespace Xamarin.Forms.Core.UnitTests
 			var last = await nav.Navigation.PopAsync ();
 
 			Assert.IsNull (last);
+		}
+
+		[Test]
+		public async Task TestActiveNavigationTaskCount()
+		{
+			NavigationPage nav = new NavigationPage();
+
+			nav.PushAsync(new ContentPage());
+			Assert.IsNotNull(nav.CurrentNavigationTask);
+			nav.Navigation.PushAsync(new ContentPage());
+			Assert.IsNotNull(nav.CurrentNavigationTask);
+			nav.Navigation.PopAsync();
+			Assert.IsNull(nav.CurrentNavigationTask);
+			nav.Navigation.PushAsync(new ContentPage());
+			Assert.IsNotNull(nav.CurrentNavigationTask);
+			nav.Navigation.PushAsync(new ContentPage());
+			Assert.IsNotNull(nav.CurrentNavigationTask);
+			await nav.Navigation.PopAsync();
+			Assert.IsNull(nav.CurrentNavigationTask);
+			nav.PushAsync(new ContentPage());
+			nav.PushAsync(new ContentPage());
+			Assert.IsNotNull(nav.CurrentNavigationTask);
+			nav.PopToRootAsync(true);
+			Assert.IsNull(nav.CurrentNavigationTask);
 		}
 
 		[Test]


### PR DESCRIPTION
### Description of Change ###

Per a couple reports it appears as if the `CurrentNavigationTask` value was not being cleared when using `PopAsync`.

Update: Added a baseline attempt at a counter and only clear the `CurrentNavigationTask` if the active navigation task count is at 0 and moved the other change to its own PR.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=31171

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

