### PR TITLE
[iOS/Android] Handle item selection highlight when ListView cell is tapped erratically

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32956.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32956.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 32956, "Setting ListView.SelectedItem to null does not remove list item highlight when list item is tapped multiple times quickly", PlatformAffected.Android | PlatformAffected.iOS)]
+	public class Bugzilla32956 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			var list = new List<int>();
+			for(var i=0; i<10; i++)
+				list.Add(i);
+
+			var listView = new ListView
+			{
+				ItemsSource = list
+			};
+			listView.ItemSelected += async (sender, args) =>
+			{
+				if (args.SelectedItem == null)
+					return;
+
+				await Task.Delay(1000);
+				await Navigation.PushAsync(new ContentPage());
+			};
+
+			var contentPage = new ContentPage
+			{
+				Content = listView
+			};
+			contentPage.Appearing += (sender, args) =>
+			{
+				listView.SelectedItem = null;
+			};
+
+			PushAsync(contentPage);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -57,6 +57,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32847.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32956.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33248.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33268.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla33612.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -371,8 +371,9 @@ namespace Xamarin.Forms.Platform.Android
 			if (position < 0 || position >= Count)
 				return;
 
+			if(_lastSelected != view)
+				_fromNative = true;
 			Select(position, view);
-			_fromNative = true;
 			Controller.NotifyRowTapped(position, cell);
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -872,7 +872,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 				SetCellBackgroundColor(cell, UIColor.Clear);
 
-				_selectionFromNative = true;
+				if (!cell.Selected)
+					_selectionFromNative = true;
 
 				tableView.EndEditing(true);
 				Controller.NotifyRowTapped(indexPath.Section, indexPath.Row, formsCell);


### PR DESCRIPTION
### Description of Change ###

On iOS and Android, if you push a page on `ListView` item selected event and when you then go back to the previous page, renderers can't decide if the next selected item change comes from a native tap or some other action. This happens when selected item change is called multiple times with frequent taps and flags fall out of sync. See changes and sample code for a better understanding.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=32956

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
