### PR TITLE
[iOS/Critical] Fix ListView memory leaks

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32206.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32206.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 			PushAsync(new LandingPage32206());
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		public void Bugzilla32206Test()
 		{
@@ -46,14 +46,14 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	public class LandingPage32206 : ContentPage
 	{
-		public static int s_counter;
-		public Label _label;
+		public static int Counter;
+		public Label Label;
 
 		public LandingPage32206()
 		{
-			_label = new Label
+			Label = new Label
 			{
-				Text = "Counter: " + s_counter,
+				Text = "Counter: " + Counter,
 				HorizontalTextAlignment = TextAlignment.Center,
 				VerticalTextAlignment = TextAlignment.Center
 			};
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Controls.Issues
 						Text = "Click Push to show a ListView. When you hit the Back button, Counter will show the number of pages that have not been finalized yet."
 						+ " If you click GC, the counter should be 0."
 					},
-					_label,
+					Label,
 					new Button
 					{
 						Text = "GC",
@@ -81,7 +81,7 @@ namespace Xamarin.Forms.Controls.Issues
 							GC.Collect();
 							GC.WaitForPendingFinalizers();
 							GC.Collect();
-							_label.Text = "Counter: " + s_counter;
+							Label.Text = "Counter: " + Counter;
 						})
 					},
 					new Button
@@ -101,8 +101,8 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			base.OnAppearing();
 
-			if (_label != null)
-				_label.Text = "Counter: " + s_counter;
+			if (Label != null)
+				Label.Text = "Counter: " + Counter;
 		}
 	}
 
@@ -111,8 +111,8 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public ContentPage32206()
 		{
-			Interlocked.Increment(ref LandingPage32206.s_counter);
-			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage32206.s_counter);
+			Interlocked.Increment(ref LandingPage32206.Counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage32206.Counter);
 
 			Content = new ListView
 			{
@@ -124,8 +124,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 		~ContentPage32206()
 		{
-			Interlocked.Decrement(ref LandingPage32206.s_counter);
-			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage32206.s_counter);
+			Interlocked.Decrement(ref LandingPage32206.Counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage32206.Counter);
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32206.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32206.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 32206, "ContextActions cause memory leak: Page is never destroyed", PlatformAffected.iOS)]
+	public class Bugzilla32206 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new LandingPage32206());
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla32206Test()
+		{
+			for (var n = 0; n < 10; n++)
+			{
+				RunningApp.WaitForElement(q => q.Marked("Push"));
+				RunningApp.Tap(q => q.Marked("Push"));
+
+				RunningApp.WaitForElement(q => q.Marked("ListView"));
+				RunningApp.Back();
+			}
+
+			// At this point, the counter can be any value, but it's most likely not zero.
+			// Invoking GC once is enough to clean up all garbage data and set counter to zero
+			RunningApp.WaitForElement(q => q.Marked("GC"));
+			RunningApp.Tap(q => q.Marked("GC"));
+
+			RunningApp.WaitForElement(q => q.Marked("Counter: 0"));
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class LandingPage32206 : ContentPage
+	{
+		public static int s_counter;
+		public Label _label;
+
+		public LandingPage32206()
+		{
+			_label = new Label
+			{
+				Text = "Counter: " + s_counter,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center
+			};
+
+			Content = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Spacing = 15,
+				Children =
+				{
+					new Label
+					{
+						Text = "Click Push to show a ListView. When you hit the Back button, Counter will show the number of pages that have not been finalized yet."
+						+ " If you click GC, the counter should be 0."
+					},
+					_label,
+					new Button
+					{
+						Text = "GC",
+						AutomationId = "GC",
+						Command = new Command(o =>
+						{
+							GC.Collect();
+							GC.WaitForPendingFinalizers();
+							GC.Collect();
+							_label.Text = "Counter: " + s_counter;
+						})
+					},
+					new Button
+					{
+						Text = "Push",
+						AutomationId = "Push",
+						Command = new Command(async o =>
+						{
+							await Navigation.PushAsync(new ContentPage32206());
+						})
+					}
+				}
+			};
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			if (_label != null)
+				_label.Text = "Counter: " + s_counter;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ContentPage32206 : ContentPage
+	{
+		public ContentPage32206()
+		{
+			Interlocked.Increment(ref LandingPage32206.s_counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage32206.s_counter);
+
+			Content = new ListView
+			{
+				ItemsSource = new List<string> { "Apple", "Banana", "Cherry" },
+				ItemTemplate = new DataTemplate(typeof(ViewCell32206)),
+				AutomationId = "ListView"
+			};
+		}
+
+		~ContentPage32206()
+		{
+			Interlocked.Decrement(ref LandingPage32206.s_counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage32206.s_counter);
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewCell32206 : ViewCell
+	{
+		public ViewCell32206()
+		{
+			View = new Label();
+			View.SetBinding(Label.TextProperty, ".");
+			ContextActions.Add(new MenuItem { Text = "Delete" });
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43941.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43941.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43941, "Memory leak with ListView's RecycleElement on iOS", PlatformAffected.iOS)]
+	public class Bugzilla43941 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new LandingPage43941());
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla43941Test()
+		{
+			for (var n = 0; n < 10; n++)
+			{
+				RunningApp.WaitForElement(q => q.Marked("Push"));
+				RunningApp.Tap(q => q.Marked("Push"));
+
+				RunningApp.WaitForElement(q => q.Marked("ListView"));
+				RunningApp.Back();
+			}
+
+			// At this point, the counter can be any value, but it's most likely not zero.
+			// Invoking GC once is enough to clean up all garbage data and set counter to zero
+			RunningApp.WaitForElement(q => q.Marked("GC"));
+			RunningApp.Tap(q => q.Marked("GC"));
+
+			RunningApp.WaitForElement(q => q.Marked("Counter: 0"));
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ContentPage43941 : ContentPage
+	{
+		public ContentPage43941()
+		{
+			Interlocked.Increment(ref LandingPage43941.s_counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage43941.s_counter);
+
+			var list = new List<int>();
+			for (var i = 0; i < 30; i++)
+				list.Add(i);
+
+			Title = "ContentPage43941";
+			Content = new ListView
+			{
+				HasUnevenRows = true,
+				ItemsSource = list,
+				AutomationId = "ListView"
+			};
+		}
+
+		~ContentPage43941()
+		{
+			Interlocked.Decrement(ref LandingPage43941.s_counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage43941.s_counter);
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class LandingPage43941 : ContentPage
+	{
+		public static int s_counter;
+		public Label _label;
+
+		public LandingPage43941()
+		{
+			_label = new Label
+			{
+				Text = "Counter: " + s_counter,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center
+			};
+
+			Content = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Spacing = 15,
+				Children =
+				{
+					new Label
+					{
+						Text = "Click Push to show a ListView. When you hit the Back button, Counter will show the number of pages that have not been finalized yet."
+						+ " If you click GC, the counter should be 0."
+					},
+					_label,
+					new Button
+					{
+						Text = "GC",
+						AutomationId = "GC",
+						Command = new Command(o =>
+						{
+							GC.Collect();
+							GC.WaitForPendingFinalizers();
+							GC.Collect();
+							_label.Text = "Counter: " + s_counter;
+						})
+					},
+					new Button
+					{
+						Text = "Push",
+						AutomationId = "Push",
+						Command = new Command(async o =>
+						{
+							await Navigation.PushAsync(new ContentPage43941());
+						})
+					}
+				}
+			};
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			if (_label != null)
+				_label.Text = "Counter: " + s_counter;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43941.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43941.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 			PushAsync(new LandingPage43941());
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		public void Bugzilla43941Test()
 		{
@@ -48,8 +48,8 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public ContentPage43941()
 		{
-			Interlocked.Increment(ref LandingPage43941.s_counter);
-			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage43941.s_counter);
+			Interlocked.Increment(ref LandingPage43941.Counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage43941.Counter);
 
 			var list = new List<int>();
 			for (var i = 0; i < 30; i++)
@@ -66,22 +66,22 @@ namespace Xamarin.Forms.Controls.Issues
 
 		~ContentPage43941()
 		{
-			Interlocked.Decrement(ref LandingPage43941.s_counter);
-			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage43941.s_counter);
+			Interlocked.Decrement(ref LandingPage43941.Counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage43941.Counter);
 		}
 	}
 
 	[Preserve(AllMembers = true)]
 	public class LandingPage43941 : ContentPage
 	{
-		public static int s_counter;
-		public Label _label;
+		public static int Counter;
+		public Label Label;
 
 		public LandingPage43941()
 		{
-			_label = new Label
+			Label = new Label
 			{
-				Text = "Counter: " + s_counter,
+				Text = "Counter: " + Counter,
 				HorizontalTextAlignment = TextAlignment.Center,
 				VerticalTextAlignment = TextAlignment.Center
 			};
@@ -99,7 +99,7 @@ namespace Xamarin.Forms.Controls.Issues
 						Text = "Click Push to show a ListView. When you hit the Back button, Counter will show the number of pages that have not been finalized yet."
 						+ " If you click GC, the counter should be 0."
 					},
-					_label,
+					Label,
 					new Button
 					{
 						Text = "GC",
@@ -109,7 +109,7 @@ namespace Xamarin.Forms.Controls.Issues
 							GC.Collect();
 							GC.WaitForPendingFinalizers();
 							GC.Collect();
-							_label.Text = "Counter: " + s_counter;
+							Label.Text = "Counter: " + Counter;
 						})
 					},
 					new Button
@@ -129,8 +129,8 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			base.OnAppearing();
 
-			if (_label != null)
-				_label.Text = "Counter: " + s_counter;
+			if (Label != null)
+				Label.Text = "Counter: " + Counter;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -49,6 +49,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31964.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32033.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32034.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32206.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32776.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32842.xaml.cs">
       <DependentUpon>Bugzilla32842.xaml</DependentUpon>
@@ -130,6 +131,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42364.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43941.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43663.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44944.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />

--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -7,8 +7,8 @@ namespace Xamarin.Forms.Platform.iOS
 	public class CellTableViewCell : UITableViewCell, INativeElementView
 	{
 		Cell _cell;
-
 		public Action<object, PropertyChangedEventArgs> PropertyChanged;
+		bool _disposed;
 
 		public CellTableViewCell(UITableViewCellStyle style, string key) : base(style, key)
 		{
@@ -94,6 +94,22 @@ namespace Xamarin.Forms.Platform.iOS
 				cellWithContent.LayoutSubviews();
 
 			return nativeCell;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			if (disposing)
+			{
+				PropertyChanged = null;
+				_cell = null;
+			}
+
+			_disposed = true;
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -48,8 +48,11 @@ namespace Xamarin.Forms.Platform.iOS
 		internal class ViewTableCell : UITableViewCell, INativeElementView
 		{
 			WeakReference<IVisualElementRenderer> _rendererRef;
-
 			ViewCell _viewCell;
+
+			Element INativeElementView.Element => ViewCell;
+			internal bool SupressSeparator { get; set; }
+			bool _disposed;
 
 			public ViewTableCell(string key) : base(UITableViewCellStyle.Default, key)
 			{
@@ -65,10 +68,6 @@ namespace Xamarin.Forms.Platform.iOS
 					UpdateCell(value);
 				}
 			}
-
-			Element INativeElementView.Element => ViewCell;
-
-			internal bool SupressSeparator { get; set; }
 
 			public override void LayoutSubviews()
 			{
@@ -115,6 +114,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			protected override void Dispose(bool disposing)
 			{
+				if (_disposed)
+					return;
+
 				if (disposing)
 				{
 					IVisualElementRenderer renderer;
@@ -126,7 +128,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 						_rendererRef = null;
 					}
+
+					_viewCell = null;
 				}
+
+				_disposed = true;
 
 				base.Dispose(disposing);
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -637,24 +637,25 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					var target = viewCell.View;
 					if (_prototype == null)
-					{
 						_prototype = Platform.CreateRenderer(target);
-						Platform.SetRenderer(target, _prototype);
-					}
 					else
-					{
 						_prototype.SetElement(target);
-						Platform.SetRenderer(target, _prototype);
-					}
+
+					Platform.SetRenderer(target, _prototype);
 
 					var req = target.Measure(tableView.Frame.Width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
 
 					target.ClearValue(Platform.RendererProperty);
-					foreach (var descendant in target.Descendants())
+					foreach (Element descendant in target.Descendants())
+					{
+						IVisualElementRenderer renderer = Platform.GetRenderer(descendant as VisualElement);
 						descendant.ClearValue(Platform.RendererProperty);
+						renderer?.Dispose();
+					}
 
 					return (nfloat)req.Request.Height;
 				}
+
 				var renderHeight = cell.RenderHeight;
 				return renderHeight > 0 ? (nfloat)renderHeight : DefaultRowHeight;
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -664,12 +664,10 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_disposed)
 					return;
 
-				if (disposing)
-				{
-					_prototype = null;
-				}
-
 				_disposed = true;
+
+				if (disposing)
+					_prototype = null;
 
 				base.Dispose(disposing);
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -136,13 +136,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_headerRenderer != null)
 				{
-					var platform = _headerRenderer.Element.Platform as Platform;
+					var platform = _headerRenderer.Element?.Platform as Platform;
 					platform?.DisposeModelAndChildrenRenderers(_headerRenderer.Element);
 					_headerRenderer = null;
 				}
 				if (_footerRenderer != null)
 				{
-					var platform = _footerRenderer.Element.Platform as Platform;
+					var platform = _footerRenderer.Element?.Platform as Platform;
 					platform?.DisposeModelAndChildrenRenderers(_footerRenderer.Element);
 					_footerRenderer = null;
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Platform.iOS
 		IListViewController Controller => Element;
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
 		public override UIViewController ViewController => _tableViewController;
+		bool _disposed;
 
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
@@ -89,27 +90,30 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		void DisposeSubviews(UIView view)
+		{
+			foreach (UIView subView in view.Subviews)
+				DisposeSubviews(subView);
+
+			view.RemoveFromSuperview();
+			view.Dispose();
+		}
+
 		protected override void Dispose(bool disposing)
 		{
-			// check inset tracker for null to 
-			if (disposing && _insetTracker != null)
-			{
-				_insetTracker.Dispose();
-				_insetTracker = null;
+			if (_disposed)
+				return;
 
-				var viewsToLookAt = new Stack<UIView>(Subviews);
-				while (viewsToLookAt.Count > 0)
+			if (disposing)
+			{
+				if (_insetTracker != null)
 				{
-					var view = viewsToLookAt.Pop();
-					var viewCellRenderer = view as ViewCellRenderer.ViewTableCell;
-					if (viewCellRenderer != null)
-						viewCellRenderer.Dispose();
-					else
-					{
-						foreach (var child in view.Subviews)
-							viewsToLookAt.Push(child);
-					}
+					_insetTracker.Dispose();
+					_insetTracker = null;
 				}
+
+				foreach (UIView subview in Subviews)
+					DisposeSubviews(subview);
 
 				if (Element != null)
 				{
@@ -118,27 +122,28 @@ namespace Xamarin.Forms.Platform.iOS
 					templatedItems.GroupedCollectionChanged -= OnGroupedCollectionChanged;
 				}
 
+				if (_dataSource != null)
+				{
+					_dataSource.Dispose();
+					_dataSource = null;
+				}
+
 				if (_tableViewController != null)
 				{
 					_tableViewController.Dispose();
 					_tableViewController = null;
 				}
-			}
 
-			if (disposing)
-			{
 				if (_headerRenderer != null)
 				{
 					var platform = _headerRenderer.Element.Platform as Platform;
-					if (platform != null)
-						platform.DisposeModelAndChildrenRenderers(_headerRenderer.Element);
+					platform?.DisposeModelAndChildrenRenderers(_headerRenderer.Element);
 					_headerRenderer = null;
 				}
 				if (_footerRenderer != null)
 				{
 					var platform = _footerRenderer.Element.Platform as Platform;
-					if (platform != null)
-						platform.DisposeModelAndChildrenRenderers(_footerRenderer.Element);
+					platform?.DisposeModelAndChildrenRenderers(_footerRenderer.Element);
 					_footerRenderer = null;
 				}
 
@@ -152,6 +157,8 @@ namespace Xamarin.Forms.Platform.iOS
 					footerView.MeasureInvalidated -= OnFooterMeasureInvalidated;
 				Control?.TableFooterView?.Dispose();
 			}
+
+			_disposed = true;
 
 			base.Dispose(disposing);
 		}
@@ -597,6 +604,7 @@ namespace Xamarin.Forms.Platform.iOS
 		internal class UnevenListViewDataSource : ListViewDataSource
 		{
 			IVisualElementRenderer _prototype;
+			bool _disposed;
 
 			public UnevenListViewDataSource(ListView list, FormsUITableViewController uiTableViewController) : base(list, uiTableViewController)
 			{
@@ -650,6 +658,21 @@ namespace Xamarin.Forms.Platform.iOS
 				var renderHeight = cell.RenderHeight;
 				return renderHeight > 0 ? (nfloat)renderHeight : DefaultRowHeight;
 			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (_disposed)
+					return;
+
+				if (disposing)
+				{
+					_prototype = null;
+				}
+
+				_disposed = true;
+
+				base.Dispose(disposing);
+			}
 		}
 
 		internal class ListViewDataSource : UITableViewSource
@@ -657,14 +680,15 @@ namespace Xamarin.Forms.Platform.iOS
 			const int DefaultItemTemplateId = 1;
 			static int s_dataTemplateIncrementer = 2; // lets start at not 0 because
 			readonly nfloat _defaultSectionHeight;
-			readonly Dictionary<DataTemplate, int> _templateToId = new Dictionary<DataTemplate, int>();
-			readonly UITableView _uiTableView;
-			readonly FormsUITableViewController _uiTableViewController;
-			protected readonly ListView List;
+			Dictionary<DataTemplate, int> _templateToId = new Dictionary<DataTemplate, int>();
+			UITableView _uiTableView;
+			FormsUITableViewController _uiTableViewController;
+			protected ListView List;
 			IListViewController Controller => List;
 			ITemplatedItemsView<Cell> TemplatedItemsView => List;
 			bool _isDragging;
 			bool _selectionFromNative;
+			bool _disposed;
 
 			public ListViewDataSource(ListViewDataSource source)
 			{
@@ -984,6 +1008,29 @@ namespace Xamarin.Forms.Platform.iOS
 						((INotifyCollectionChanged)templatedList.ShortNames).CollectionChanged -= OnShortNamesCollectionChanged;
 				}
 			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (_disposed)
+					return;
+
+				if (disposing)
+				{
+					if (List != null)
+					{
+						List.ItemSelected -= OnItemSelected;
+						List = null;
+					}
+
+					_templateToId = null;
+					_uiTableView = null;
+					_uiTableViewController = null;
+				}
+
+				_disposed = true;
+
+				base.Dispose(disposing);
+			}
 		}
 	}
 
@@ -999,11 +1046,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 	internal class FormsUITableViewController : UITableViewController
 	{
-		readonly ListView _list;
+		ListView _list;
 		IListViewController Controller => _list;
 		UIRefreshControl _refresh;
 
 		bool _refreshAdded;
+		bool _disposed;
 
 		public FormsUITableViewController(ListView element)
 		{
@@ -1085,15 +1133,25 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
-			base.Dispose(disposing);
+			if (_disposed)
+				return;
 
-			if (disposing && _refresh != null)
+			if (disposing)
 			{
-				_refresh.ValueChanged -= OnRefreshingChanged;
-				_refresh.EndRefreshing();
-				_refresh.Dispose();
-				_refresh = null;
+				if (_refresh != null)
+				{
+					_refresh.ValueChanged -= OnRefreshingChanged;
+					_refresh.EndRefreshing();
+					_refresh.Dispose();
+					_refresh = null;
+				}
+
+				_list = null;
 			}
+
+			_disposed = true;
+
+			base.Dispose(disposing);
 		}
 
 		void CheckContentSize()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -667,7 +667,13 @@ namespace Xamarin.Forms.Platform.iOS
 				_disposed = true;
 
 				if (disposing)
-					_prototype = null;
+				{
+					if (_prototype != null)
+					{
+						_prototype.Dispose();
+						_prototype = null;
+					}
+				}
 
 				base.Dispose(disposing);
 			}


### PR DESCRIPTION
### Description of Change ###

iOS `ListView` is leaking for various reasons. Although the bug description mentions issues with `RecycleElement`, this applies to either caching strategy. Since this seems to be a serious issue, can this PR be given priority?

See comments for details.

P.S. It was mentioned that the same issue occurs on Android, but I wasn't able to reproduce it on AppCompat (at least not with the sample code in this PR).

EDIT: Also included the fix for another bug concerning context actions not being properly disposed.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=43941
- https://bugzilla.xamarin.com/show_bug.cgi?id=32206
- https://bugzilla.xamarin.com/show_bug.cgi?id=27194 (possibly fixes this too. Download links seem to be down.)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
