### PR TITLE
Platform specifics naming adjustments

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/EntryPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/EntryPageiOS.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 					new Button
 					{
 						Text = "Toggle AdjustsFontSizeToFitWidth",
-						Command = new Command(() => entry.On<iOS>().SetAdjustsFontSizeToFitWidth(!entry.On<iOS>().AdjustsFontSizeToFitWidth()))
+						Command = new Command(() => entry.On<iOS>().SetAdjustsFontSizeToFitWidthEnabled(!entry.On<iOS>().IsAdjustsFontSizeToFitWidthEnabled()))
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/TabbedPageAndroid.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/TabbedPageAndroid.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 			Children.Add(CreateAdditonalPage());
 			Children.Add(CreateAdditonalPage());
 			Children.Add(CreateAdditonalPage());
-			On<Android>().SetOffscreenPageLimitProperty(2);
+			On<Android>().SetOffscreenPageLimit(2);
 		}
 
 		ContentPage CreateFirstPage(ICommand restore)

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
@@ -45,24 +45,24 @@
 			BindableProperty.Create("OffscreenPageLimit", typeof(int),
 			typeof(TabbedPage), 3, validateValue: (binding, value) => (int)value >= 0);
 
-		public static int GetOffscreenPageLimitProperty(BindableObject element)
+		public static int GetOffscreenPageLimit(BindableObject element)
 		{
 			return (int)element.GetValue(OffscreenPageLimitProperty);
 		}
 
-		public static void SetOffscreenPageLimitProperty(BindableObject element, int value)
+		public static void SetOffscreenPageLimit(BindableObject element, int value)
 		{
 			element.SetValue(OffscreenPageLimitProperty, value);
 		}
 
 		public static int OffscreenPageLimit(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
-			return GetOffscreenPageLimitProperty(config.Element);
+			return GetOffscreenPageLimit(config.Element);
 		}
 
-		public static IPlatformElementConfiguration<Android, FormsElement> SetOffscreenPageLimitProperty(this IPlatformElementConfiguration<Android, FormsElement> config, int value)
+		public static IPlatformElementConfiguration<Android, FormsElement> SetOffscreenPageLimit(this IPlatformElementConfiguration<Android, FormsElement> config, int value)
 		{
-			SetOffscreenPageLimitProperty(config.Element, value);
+			SetOffscreenPageLimit(config.Element, value);
 			return config;
 		}
 	}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Entry.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Entry.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 	public static class Entry
 	{
 		public static readonly BindableProperty AdjustsFontSizeToFitWidthProperty =
-			BindableProperty.Create("AdjustsFontSizeToFitWidth", typeof(bool),
+			BindableProperty.Create("AdjustsFontSizeToFitWidthEnabled", typeof(bool),
 			typeof(Entry), false);
 
 		public static bool GetAdjustsFontSizeToFitWidth(BindableObject element)
@@ -20,12 +20,12 @@ namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 			element.SetValue(AdjustsFontSizeToFitWidthProperty, value);
 		}
 
-		public static bool AdjustsFontSizeToFitWidth(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		public static bool IsAdjustsFontSizeToFitWidthEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetAdjustsFontSizeToFitWidth(config.Element);
 		}
 
-		public static IPlatformElementConfiguration<iOS, FormsElement> SetAdjustsFontSizeToFitWidth(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetAdjustsFontSizeToFitWidthEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetAdjustsFontSizeToFitWidth(config.Element, value);
 			return config;

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -144,7 +144,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateAdjustsFontSizeToFitWidth()
 		{
-			Control.AdjustsFontSizeToFitWidth = Element.OnThisPlatform().AdjustsFontSizeToFitWidth();
+			Control.AdjustsFontSizeToFitWidth = Element.OnThisPlatform().IsAdjustsFontSizeToFitWidthEnabled();
 		}
 
 		void UpdateFont()

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/TabbedPage.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/TabbedPage.xml
@@ -74,9 +74,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="GetOffscreenPageLimitProperty">
-      <MemberSignature Language="C#" Value="public static int GetOffscreenPageLimitProperty (Xamarin.Forms.BindableObject element);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig int32 GetOffscreenPageLimitProperty(class Xamarin.Forms.BindableObject element) cil managed" />
+    <Member MemberName="GetOffscreenPageLimit">
+      <MemberSignature Language="C#" Value="public static int GetOffscreenPageLimit (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig int32 GetOffscreenPageLimit(class Xamarin.Forms.BindableObject element) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -207,9 +207,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="SetOffscreenPageLimitProperty">
-      <MemberSignature Language="C#" Value="public static void SetOffscreenPageLimitProperty (Xamarin.Forms.BindableObject element, int value);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetOffscreenPageLimitProperty(class Xamarin.Forms.BindableObject element, int32 value) cil managed" />
+    <Member MemberName="SetOffscreenPageLimit">
+      <MemberSignature Language="C#" Value="public static void SetOffscreenPageLimit (Xamarin.Forms.BindableObject element, int value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetOffscreenPageLimit(class Xamarin.Forms.BindableObject element, int32 value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -228,9 +228,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="SetOffscreenPageLimitProperty">
-      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.TabbedPage&gt; SetOffscreenPageLimitProperty (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.TabbedPage&gt; config, int value);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.TabbedPage&gt; SetOffscreenPageLimitProperty(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.TabbedPage&gt; config, int32 value) cil managed" />
+    <Member MemberName="SetOffscreenPageLimit">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.TabbedPage&gt; SetOffscreenPageLimit (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.TabbedPage&gt; config, int value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.TabbedPage&gt; SetOffscreenPageLimit(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.TabbedPage&gt; config, int32 value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Entry.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Entry.xml
@@ -14,26 +14,6 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
-    <Member MemberName="AdjustsFontSizeToFitWidth">
-      <MemberSignature Language="C#" Value="public static bool AdjustsFontSizeToFitWidth (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AdjustsFontSizeToFitWidth(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;" RefType="this" />
-      </Parameters>
-      <Docs>
-        <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="AdjustsFontSizeToFitWidthProperty">
       <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty AdjustsFontSizeToFitWidthProperty;" />
       <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty AdjustsFontSizeToFitWidthProperty" />
@@ -109,6 +89,26 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="IsAdjustsFontSizeToFitWidthEnabled">
+      <MemberSignature Language="C#" Value="public static bool IsAdjustsFontSizeToFitWidthEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsAdjustsFontSizeToFitWidthEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="SetAdjustsFontSizeToFitWidth">
       <MemberSignature Language="C#" Value="public static void SetAdjustsFontSizeToFitWidth (Xamarin.Forms.BindableObject element, bool value);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetAdjustsFontSizeToFitWidth(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
@@ -130,9 +130,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="SetAdjustsFontSizeToFitWidth">
-      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; SetAdjustsFontSizeToFitWidth (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config, bool value);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; SetAdjustsFontSizeToFitWidth(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config, bool value) cil managed" />
+    <Member MemberName="SetAdjustsFontSizeToFitWidthEnabled">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; SetAdjustsFontSizeToFitWidthEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; SetAdjustsFontSizeToFitWidthEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config, bool value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>


### PR DESCRIPTION
### Description of Change ###

Renaming of some platform specifics stuff per @davidbritch's request -- namely `AdjustsFontSizeToFitWidth` to `IsAdjustsFontSizeToFitWidthEnabled` and `SetOffscreenPageLimitProperty`  to `SetOffscreenPageLimit`.

Edit: Updated to only use the latter.

### Bugs Fixed ###

N/A

### API Changes ###

See description changes.

### Behavioral Changes ###

N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

