### PR TITLE
Make CommitAllowingStateLoss the default for FragmentTransactions

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -71,7 +71,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					transaction.DisallowAddToBackStack();
 					transaction.Remove(_currentFragment);
 					transaction.SetTransition((int)FragmentTransit.None);
-					transaction.Commit();
+
+					// This is a removal of a fragment that's not going on the back stack; there's no reason to care
+					// whether its state gets successfully saved, since we'll never restore it. Ergo, CommitAllowingStateLoss
+					transaction.CommitAllowingStateLoss();
 
 					_currentFragment = null;
 				}
@@ -102,7 +105,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				transaction.Add(Id, fragment);
 				transaction.SetTransition((int)FragmentTransit.None);
-				transaction.Commit();
+
+				// We don't currently support fragment restoration 
+				// So we don't need to worry about loss of this fragment's state
+				transaction.CommitAllowingStateLoss();
 
 				_currentFragment = fragment;
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -627,7 +627,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					fragments.Add(fragment);
 				}
 			}
-			transaction.Commit();
+
+			// We don't currently support fragment restoration, so we don't need to worry about
+			// whether the commit loses state
+			transaction.CommitAllowingStateLoss();
 
 			// The fragment transitions don't really SUPPORT telling you when they end
 			// There are some hacks you can do, but they actually are worse than just doing this:


### PR DESCRIPTION
### Description of Change ###

Proposing this as an alternative to [PR 444](https://github.com/xamarin/Xamarin.Forms/pull/444)

PR 444 is adding a Platform Specific to NavigationPage which allows the developer to disable the default Android state loss check when committing a fragment transaction. 

The state loss check prevents unexpected behavior when restoring the state of fragments upon resuming an application. However, XF doesn't support fragment restoration at this time. So rather than add another Platform Specific which we have to maintain, we can simply change from `Commit()` to `CommitAllowingStateLoss()`. 

This PR also addresses a similar issue with MasterDetailPage, which also utilizes fragments (and thus transactions) when setting the master to detail to a NavigationPage or TabbedPage.


