### PR TITLE
[Android] Preserve Toolbar Subtitle on page orientation change

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -795,7 +795,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				bar.SetTitleTextColor(textColor.ToAndroid().ToArgb());
 
 			bar.Title = Element.CurrentPage.Title ?? "";
-            bar.Subtitle = _toolbarBag.Subtitle;
+
+			if (_toolbarBag != null)
+				bar.Subtitle = _toolbarBag.Subtitle;
 		}
 
 		class ClickListener : Object, IOnClickListener

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -40,7 +40,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		AToolbar _toolbar;
 		ToolbarTracker _toolbarTracker;
 		bool _toolbarVisible;
-        ToolbarBag _toolbarBag;
 
         // The following is based on https://android.googlesource.com/platform/frameworks/support/+/refs/heads/master/v4/java/android/support/v4/app/FragmentManager.java#849
         const int TransitionDuration = 220;
@@ -542,10 +541,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
         void ResetToolbar()
         {
-            _toolbarBag = new ToolbarBag
-            {
-                Subtitle = _toolbar.Subtitle
-            };
+	        AToolbar oldToolbar = _toolbar;
 
 			_toolbar.RemoveFromParent();
 			_toolbar.NavigationClick -= BarOnNavigationClick;
@@ -555,7 +551,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			RegisterToolbar();
 			UpdateToolbar();
 			UpdateMenu();
-		}
+
+			// Preserve old values that can't be duplicated by calling methods above
+	        if (_toolbar != null)
+				_toolbar.Subtitle = oldToolbar.Subtitle;
+        }
 
 		void SetupToolbar()
 		{
@@ -795,9 +795,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				bar.SetTitleTextColor(textColor.ToAndroid().ToArgb());
 
 			bar.Title = Element.CurrentPage.Title ?? "";
-
-			if (_toolbarBag != null)
-				bar.Subtitle = _toolbarBag.Subtitle;
 		}
 
 		class ClickListener : Object, IOnClickListener
@@ -844,10 +841,4 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 	}
-
-    // Used when resetting toolbar so that custom values can be preserved.
-    class ToolbarBag
-    {
-        public string Subtitle { get; set; }
-    }
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -41,8 +41,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		ToolbarTracker _toolbarTracker;
 		bool _toolbarVisible;
 
-        // The following is based on https://android.googlesource.com/platform/frameworks/support/+/refs/heads/master/v4/java/android/support/v4/app/FragmentManager.java#849
-        const int TransitionDuration = 220;
+		// The following is based on https://android.googlesource.com/platform/frameworks/support/+/refs/heads/master/v4/java/android/support/v4/app/FragmentManager.java#849
+		const int TransitionDuration = 220;
 
 		public NavigationPageRenderer()
 		{
@@ -539,9 +539,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			});
 		}
 
-        void ResetToolbar()
-        {
-	        AToolbar oldToolbar = _toolbar;
+		void ResetToolbar()
+		{
+			AToolbar oldToolbar = _toolbar;
 
 			_toolbar.RemoveFromParent();
 			_toolbar.NavigationClick -= BarOnNavigationClick;
@@ -553,9 +553,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			UpdateMenu();
 
 			// Preserve old values that can't be duplicated by calling methods above
-	        if (_toolbar != null)
+			if (_toolbar != null)
 				_toolbar.Subtitle = oldToolbar.Subtitle;
-        }
+		}
 
 		void SetupToolbar()
 		{

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -40,9 +40,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		AToolbar _toolbar;
 		ToolbarTracker _toolbarTracker;
 		bool _toolbarVisible;
+        ToolbarBag _toolbarBag;
 
-		// The following is based on https://android.googlesource.com/platform/frameworks/support/+/refs/heads/master/v4/java/android/support/v4/app/FragmentManager.java#849
-		const int TransitionDuration = 220;
+        // The following is based on https://android.googlesource.com/platform/frameworks/support/+/refs/heads/master/v4/java/android/support/v4/app/FragmentManager.java#849
+        const int TransitionDuration = 220;
 
 		public NavigationPageRenderer()
 		{
@@ -539,8 +540,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			});
 		}
 
-		void ResetToolbar()
-		{
+        void ResetToolbar()
+        {
+            _toolbarBag = new ToolbarBag
+            {
+                Subtitle = _toolbar.Subtitle
+            };
+
 			_toolbar.RemoveFromParent();
 			_toolbar.NavigationClick -= BarOnNavigationClick;
 			_toolbar = null;
@@ -789,6 +795,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				bar.SetTitleTextColor(textColor.ToAndroid().ToArgb());
 
 			bar.Title = Element.CurrentPage.Title ?? "";
+            bar.Subtitle = _toolbarBag.Subtitle;
 		}
 
 		class ClickListener : Object, IOnClickListener
@@ -835,4 +842,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 	}
+
+    // Used when resetting toolbar so that custom values can be preserved.
+    class ToolbarBag
+    {
+        public string Subtitle { get; set; }
+    }
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -552,7 +552,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			UpdateToolbar();
 			UpdateMenu();
 
-			// Preserve old values that can't be duplicated by calling methods above
+			// Preserve old values that can't be replicated by calling methods above
 			if (_toolbar != null)
 				_toolbar.Subtitle = oldToolbar.Subtitle;
 		}


### PR DESCRIPTION
### Description of Change ###

When page orientation is changing, AppCompat `Toolbar` is being destroyed and rebuilt. However, this results in old values not being preserved if they cannot be replicated from other elements.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=46938

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
