### PR TITLE
[iOS] TabbedRenderer should set UITabBarItem properly

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -191,22 +191,12 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var page = (Page)sender;
 
-				var renderer = Platform.GetRenderer(page);
-				if (renderer == null)
+				IVisualElementRenderer renderer = Platform.GetRenderer(page);
+
+				if (renderer?.ViewController.TabBarItem == null)
 					return;
 
-				if (renderer.ViewController.TabBarItem == null)
-					return;
-
-				UIImage image = null;
-				if (!string.IsNullOrEmpty(page.Icon))
-					image = new UIImage(page.Icon);
-
-				// the new UITabBarItem forces redraw, setting the UITabBarItem.Image does not
-				renderer.ViewController.TabBarItem = new UITabBarItem(page.Title, image, 0);
-
-				if (image != null)
-					image.Dispose();
+				SetTabBarItem(renderer);
 			}
 		}
 
@@ -267,7 +257,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void SetupPage(Page page, int index)
 		{
-			var renderer = Platform.GetRenderer(page);
+			IVisualElementRenderer renderer = Platform.GetRenderer(page);
 			if (renderer == null)
 			{
 				renderer = Platform.CreateRenderer(page);
@@ -276,15 +266,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			page.PropertyChanged += OnPagePropertyChanged;
 
-			UIImage icon = null;
-			if (page.Icon != null)
-				icon = new UIImage(page.Icon);
-
-			renderer.ViewController.TabBarItem = new UITabBarItem(page.Title, icon, 0);
-			if (icon != null)
-				icon.Dispose();
-
-			renderer.ViewController.TabBarItem.Tag = index;
+			SetTabBarItem(renderer);
 		}
 
 		void TeardownPage(Page page, int index)
@@ -392,6 +374,25 @@ namespace Xamarin.Forms.Platform.iOS
 			var platformEffect = effect as PlatformEffect;
 			if (platformEffect != null)
 				platformEffect.Container = View;
+		}
+
+		void SetTabBarItem(IVisualElementRenderer renderer)
+		{
+			var page = renderer.Element as Page;
+			if(page == null)
+				throw new InvalidCastException($"{nameof(renderer)} must be a {nameof(Page)} renderer.");
+
+			UIImage icon = null;
+			if (!string.IsNullOrEmpty(page.Icon))
+				icon = new UIImage(page.Icon);
+
+			renderer.ViewController.TabBarItem = new UITabBarItem(page.Title, icon, 0)
+			{
+				Tag = Tabbed.Children.IndexOf(page),
+				AccessibilityIdentifier = page.AutomationId
+			};
+
+			icon?.Dispose();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

iOS `TabbedRenderer` is setting `UITabBarItem` in two different places, which introduces multiple points of maintenance and inconsistency. This PR creates a method to set tab bar items consistently. It sets `Tag` (which was being set in one place) and `AccessibilityIdentifier` (enhancement) in each case. 

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=41219

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

