### PR TITLE
Fix UI test for 36788

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36788.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36788.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Controls
 				Spacing = 8
 			};
 
-			var longString = "Very long text in single line to be truncated at tail.  Adding extra text to make sure it gets truncated.";
+			var longString = "Very long text in single line to be truncated at tail. Adding extra text to make sure it gets truncated. And even more extra text because otherwise the test might fail if we're in, say, landscape orientation rather than portrait.";
 
 			var contentView = new ContentView {
 				Padding = 16,


### PR DESCRIPTION
### Description of Change ###

The UI test for 36788 is failing consistently on the first attempt as part of the whole UI test suite, possibly due to a device orientation change or larger screen sizes on some devices. This change makes the test function in both landscape and portrait mode on iPads as well as iPhones.

### Bugs Fixed ###

- Failing UI tests in the iOS lanes.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

