### PR TITLE
Fix possible race conditions in Automation ID tests

### DIFF
--- a/Xamarin.Forms.Core.iOS.UITests/Tests/AutomationIDUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/AutomationIDUITests.cs
@@ -18,8 +18,8 @@ namespace Xamarin.Forms.Core.UITests
 		[Test]
 		public void Test1 ()
 		{
+			App.WaitForElement(c => c.Marked("btnTest1"));
 			App.Tap (c => c.Marked ("btnTest1"));
-			App.WaitForElement (c => c.Marked ("scrollMain"));
 			App.WaitForElement (c => c.Marked ("stckMain"));
 			App.WaitForElement (c => c.Marked ("actHello"));
 			App.WaitForElement (c => c.Marked ("bxvHello"));
@@ -43,6 +43,7 @@ namespace Xamarin.Forms.Core.UITests
 		[Test]
 		public void Test2 ()
 		{
+			App.WaitForElement(c => c.Marked("btnTest2"));
 			App.Tap (c => c.Marked ("btnTest2"));
 			App.WaitForElement (c => c.Marked ("imgHello"));
 			App.WaitForElement (c => c.Marked ("lstView"));


### PR DESCRIPTION
### Description of Change ###

The Automation ID UI tests are failing consistently in a couple of the lanes (notably iOS 8). This change addresses a couple of race conditions which can cause these tests to fail.

### Bugs Fixed ###

- Failing UI tests in iOS 8 lanes (and occasionally others)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

