### PR TITLE
[iOS] Update Editor text from autocorrect when losing focus

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35736.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35736.cs
@@ -1,0 +1,55 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 35736, "[iOS] Editor does not update Text value from autocorrect when losing focus", PlatformAffected.iOS)]
+	public class Bugzilla35736 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var editor = new Editor
+			{
+				AutomationId = "Bugzilla35736Editor"
+			};
+			var label = new Label
+			{
+				AutomationId = "Bugzilla35736Label",
+				Text = ""
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					editor,
+					label,
+					new Button
+					{
+						AutomationId = "Bugzilla35736Button",
+						Text = "Click to set label text",
+						Command = new Command(() => { label.Text = editor.Text; })
+					}
+				}
+			};
+		}
+
+
+#if UITEST
+		[Test]
+		public void Bugzilla35736Test() 
+		{
+			RunningApp.WaitForElement(q => q.Marked("Bugzilla35736Editor"));
+			RunningApp.EnterText(q => q.Marked("Bugzilla35736Editor"), "Testig");
+			RunningApp.Tap(q => q.Marked("Bugzilla35736Button"));
+			Assert.AreEqual("Testing", RunningApp.Query(q => q.Marked("Bugzilla35736Label"))[0].Text);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -461,6 +461,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39908.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39489.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36802.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35736.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -99,6 +99,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
+			if (Control.Text != Element.Text)
+				ElementController.SetValueFromRenderer(Editor.TextProperty, Control.Text);
+
 			Element.SetValue(VisualElement.IsFocusedPropertyKey, false);
 			Element.SendCompleted();
 		}


### PR DESCRIPTION
### Description of Change ###

Setting a similar behavior on `Editor` as with `Entry` for iOS due to the autocorrect suggestions updating the `Control.Text` but not the `Element.Text` value.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=35736

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

