### PR TITLE
ResourceDictionary fixes

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -261,5 +261,36 @@ namespace Xamarin.Forms.Core.UnitTests
 			var ex = Assert.Throws<KeyNotFoundException>(() => { var foo = rd ["test_invalid_key"]; });
 			Assert.That(ex.Message, Is.StringContaining("test_invalid_key"));
 		}
+
+		class MyRD : ResourceDictionary
+		{
+			public MyRD()
+			{
+				CreationCount = CreationCount + 1;
+				Add("foo", "Foo");
+				Add("bar", "Bar");
+			}
+
+			public static int CreationCount { get; set; }
+		}
+
+		[Test]
+		public void MergedWithFailsToMergeAnythingButRDs()
+		{
+			var rd = new ResourceDictionary();
+			Assert.DoesNotThrow(() => rd.MergedWith = typeof(MyRD));
+			Assert.Throws<ArgumentException>(() => rd.MergedWith = typeof(ContentPage));
+		}
+
+		[Test]
+		public void MergedResourcesAreFound()
+		{
+			var rd0 = new ResourceDictionary();
+			rd0.MergedWith = typeof(MyRD);
+
+			object _;
+			Assert.True(rd0.TryGetMergedValue("foo", out _));
+			Assert.AreEqual("Foo", _);
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -253,13 +253,13 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.Fail ();
 		}
 
-        [Test]
-        public void ShowKeyInExceptionIfNotFound()
-        {
-            var rd = new ResourceDictionary();
-            rd.Add("foo", "bar");
-            var ex = Assert.Throws<KeyNotFoundException>(() => { var foo = rd["test_invalid_key"]; });
-            Assert.That(ex.Message, Is.StringContaining("test_invalid_key"));
-        }
-    }
+		[Test]
+		public void ShowKeyInExceptionIfNotFound()
+		{
+			var rd = new ResourceDictionary();
+			rd.Add("foo", "bar");
+			var ex = Assert.Throws<KeyNotFoundException>(() => { var foo = rd ["test_invalid_key"]; });
+			Assert.That(ex.Message, Is.StringContaining("test_invalid_key"));
+		}
+	}
 }

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Forms
 
 		public int Count
 		{
-			get { return _innerDictionary.Count + (_mergedInstance != null ? _mergedInstance.Count: 0); }
+			get { return _innerDictionary.Count; }
 		}
 
 		bool ICollection<KeyValuePair<string, object>>.IsReadOnly
@@ -88,8 +88,6 @@ namespace Xamarin.Forms
 			{
 				if (_innerDictionary.ContainsKey(index))
 					return _innerDictionary[index];
-				if (_mergedInstance != null && _mergedInstance.ContainsKey(index))
-					return _mergedInstance[index];
 				throw new KeyNotFoundException($"The resource '{index}' is not present in the dictionary.");
 			}
 			set
@@ -121,13 +119,25 @@ namespace Xamarin.Forms
 
 		public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
 		{
-			var rd = (IEnumerable<KeyValuePair<string,object>>)_innerDictionary;
-			if (_mergedInstance != null)
-				rd = rd.Concat(_mergedInstance._innerDictionary);
-			return rd.GetEnumerator();
+			return _innerDictionary.GetEnumerator();
+		}
+
+		internal IEnumerable<KeyValuePair<string, object>> MergedResources {
+			get {
+				if (_mergedInstance != null)
+					foreach (var r in _mergedInstance.MergedResources)
+						yield return r;
+				foreach (var r in _innerDictionary)
+					yield return r;
+			}
 		}
 
 		public bool TryGetValue(string key, out object value)
+		{
+			return _innerDictionary.TryGetValue(key, out value);
+		}
+
+		internal bool TryGetMergedValue(string key, out object value)
 		{
 			return _innerDictionary.TryGetValue(key, out value) || (_mergedInstance != null && _mergedInstance.TryGetValue(key, out value));
 		}

--- a/Xamarin.Forms.Core/ResourcesExtensions.cs
+++ b/Xamarin.Forms.Core/ResourcesExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Xamarin.Forms
 {
-	internal static class ResourcesExtensions
+	static class ResourcesExtensions
 	{
 		public static IEnumerable<KeyValuePair<string, object>> GetMergedResources(this IElement element)
 		{
@@ -11,10 +11,10 @@ namespace Xamarin.Forms
 			while (element != null)
 			{
 				var ve = element as IResourcesProvider;
-				if (ve != null && ve.Resources != null && ve.Resources.Count != 0)
+				if (ve != null && ve.Resources != null)
 				{
-					resources = resources ?? new Dictionary<string, object>(ve.Resources.Count);
-					foreach (KeyValuePair<string, object> res in ve.Resources)
+					resources = resources ?? new Dictionary<string, object>();
+					foreach (KeyValuePair<string, object> res in ve.Resources.MergedResources)
 						if (!resources.ContainsKey(res.Key))
 							resources.Add(res.Key, res.Value);
 						else if (res.Key.StartsWith(Style.StyleClassPrefix, StringComparison.Ordinal))

--- a/Xamarin.Forms.Xaml.UnitTests/TestSharedResourceDictionary.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/TestSharedResourceDictionary.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
@@ -16,6 +16,7 @@
 				<ResourceDictionary MergedWith="local:SharedResourceDictionary2"/>
 			</ContentView.Resources>
 			<Label x:Name="label2" Style="{StaticResource sharedStyle2}"/>
+			<Label x:Name="label3" Text="{StaticResource foo}"/>
 		</ContentView>
 	</StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/TestSharedResourceDictionary.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/TestSharedResourceDictionary.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
-
-using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -19,6 +18,23 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		public class Tests
 		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+				Application.Current = new MockApplication {
+					Resources = new ResourceDictionary {
+						MergedWith = typeof(MyRD)
+					}
+				};
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
 			[TestCase (false)]
 			[TestCase (true)]
 			public void MergedResourcesAreFound (bool useCompiledXaml)
@@ -43,6 +59,24 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				var layout = new TestSharedResourceDictionary(useCompiledXaml);
 				Assert.AreEqual(Color.Red, layout.implicitLabel.TextColor);
 			}
+
+			class MyRD : ResourceDictionary
+			{
+				public MyRD()
+				{
+					Add("foo", "Foo");
+					Add("bar", "Bar");
+				}
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void MergedRDAtAppLevel(bool useCompiledXaml)
+			{
+				var layout = new TestSharedResourceDictionary(useCompiledXaml);
+				Assert.AreEqual("Foo", layout.label3.Text);
+			}
+
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -29,14 +29,11 @@ namespace Xamarin.Forms.Xaml
 				var resDict = ve?.Resources ?? p as ResourceDictionary;
 				if (resDict == null)
 					continue;
-				if (resDict.TryGetValue(Key, out resource))
+				if (resDict.TryGetMergedValue(Key, out resource))
 					break;
 			}
-			if (resource == null && Application.Current != null && Application.Current.Resources != null &&
-				Application.Current.Resources.ContainsKey(Key))
-				resource = Application.Current.Resources[Key];
-
-			if (resource == null)
+			if (resource == null && (Application.Current == null || Application.Current.Resources == null ||
+									 !Application.Current.Resources.TryGetMergedValue(Key, out resource)))
 				throw new XamlParseException($"StaticResource not found for key {Key}", xmlLineInfo);
 
 			var bp = valueProvider.TargetProperty as BindableProperty;


### PR DESCRIPTION
### Description of Change ###

Fix the ResourceDictionary interface. Some calls were using the RD values, some others were merging with the merged instance.
Now, all public API only poke the current RD.

StaticResource and implicit styles use an internal API.

This replaces #317.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=42264

### API Changes ###

### Behavioral Changes ###

minor
### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense