### PR TITLE
Use static method syntax to prevent mono compiler error

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -432,23 +432,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateCurrentPagePreferredStatusBarUpdateAnimation()
 		{
-			PageUIStatusBarAnimation animation = ((Page)Element).OnThisPlatform().PreferredStatusBarUpdateAnimation();
-			Current.OnThisPlatform().SetPreferredStatusBarUpdateAnimation(animation);
-		}
-
-		UIKit.UIStatusBarAnimation GetPreferredStatusBarUpdateAnimation()
-		{
-			var animation = Current.OnThisPlatform().PreferredStatusBarUpdateAnimation();
-			switch (animation)
-			{
-				case (PageUIStatusBarAnimation.Fade):
-					return UIKit.UIStatusBarAnimation.Fade;
-				case (PageUIStatusBarAnimation.Slide):
-					return UIKit.UIStatusBarAnimation.Slide;
-				case (PageUIStatusBarAnimation.None):
-				default:
-					return UIKit.UIStatusBarAnimation.None;
-			}
+			// Not using the extension method syntax here because for some reason it confuses the mono compiler
+			// and throws a CS0121 error
+			PageUIStatusBarAnimation animation = PlatformConfiguration.iOSSpecific.Page.PreferredStatusBarUpdateAnimation(((Page)Element).OnThisPlatform());
+			PlatformConfiguration.iOSSpecific.Page.SetPreferredStatusBarUpdateAnimation(Current.OnThisPlatform(), animation);
 		}
 
 		void UpdateTranslucent()


### PR DESCRIPTION
### Description of Change ###

The mono compiler is giving us a CS0121 error where none should exist; switching from extension method syntax to static method syntax for now to work around it.

