### PR TITLE
Run multiple UI tests without restarting ControlGallery

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -22,6 +22,7 @@ using System.IO.IsolatedStorage;
 using Droid = Android;
 using System.Globalization;
 using Java.Interop;
+using Xamarin.Forms.Controls.Issues;
 using Debug = System.Diagnostics.Debug;
 
 [assembly: Dependency (typeof (CacheService))]
@@ -461,6 +462,12 @@ namespace Xamarin.Forms.ControlGallery.Android
 		public bool NavigateToTest(string test)
 		{
 			return _app.NavigateToTestPage(test);
+		}
+
+		[Export("Reset")]
+		public void Reset()
+		{
+			_app.Reset();
 		}
 	}
 #endif

--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -23,7 +23,6 @@ using Droid = Android;
 using System.Globalization;
 using Java.Interop;
 using Xamarin.Forms.Controls.Issues;
-using Debug = System.Diagnostics.Debug;
 
 [assembly: Dependency (typeof (CacheService))]
 [assembly: Dependency (typeof (TestCloudService))]

--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -21,7 +21,8 @@ using System.IO.IsolatedStorage;
 
 using Droid = Android;
 using System.Globalization;
-
+using Java.Interop;
+using Debug = System.Diagnostics.Debug;
 
 [assembly: Dependency (typeof (CacheService))]
 [assembly: Dependency (typeof (TestCloudService))]
@@ -274,6 +275,12 @@ namespace Xamarin.Forms.ControlGallery.Android
 		{
 			base.OnDestroy();
 		}
+
+		[Export("NavigateToTest")]
+		public bool NavigateToTest(string test)
+		{
+			return _app.NavigateToTestPage(test);
+		}
 	}
 #else
 
@@ -297,6 +304,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 	]
 	public class Activity1 : FormsAppCompatActivity
 	{
+		App _app;
+
 		protected override void OnCreate (Bundle bundle)
 		{
 			ToolbarResource = Resource.Layout.Toolbar;
@@ -319,6 +328,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 			//Forms.SetTitleBarVisibility (AndroidTitleBarVisibility.Never);
 
 			var app = new App();
+			_app = app;
 
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
@@ -445,6 +455,12 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 				return null;
 			}
+		}
+
+		[Export("NavigateToTest")]
+		public bool NavigateToTest(string test)
+		{
+			return _app.NavigateToTestPage(test);
 		}
 	}
 #endif

--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -19,6 +19,7 @@ using AButton = Android.Widget.Button;
 using AView = Android.Views.View;
 using Android.OS;
 using System.Reflection;
+using Xamarin.Forms.Controls.Issues;
 
 [assembly: ExportRenderer(typeof(Bugzilla31395.CustomContentView), typeof(CustomContentRenderer))]
 [assembly: ExportRenderer(typeof(NativeListView), typeof(NativeListViewRenderer))]

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -114,6 +114,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />
+    <Reference Include="Mono.Android.Export" />
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -9,6 +9,7 @@ using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.ControlGallery.iOS;
 using Xamarin.Forms.Controls;
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.iOS;
 
 [assembly: Dependency(typeof(TestCloudService))]

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -132,6 +132,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 	[Register("AppDelegate")]
 	public partial class AppDelegate : FormsApplicationDelegate
 	{
+		App _app;
 
 		public override bool FinishedLaunching(UIApplication uiApplication, NSDictionary launchOptions)
 		{
@@ -150,6 +151,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			};
 
 			var app = new App();
+			_app = app;
 
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
@@ -352,6 +354,17 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		}
 
 		#endregion
+
+		[Export("navigateToTest:")]
+		public string NavigateToTest(string test)
+		{
+			var result = _app.NavigateToTestPage(test);
+
+			Console.WriteLine($">>>>>>>> navigateToTest result is {result}");
+			System.Diagnostics.Debug.WriteLine($">>>>>>>> navigateToTest result is {result}");
+
+			return result.ToString();
+		}
 	}
 
 	[Register("KVOUISlider")]

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -362,6 +362,13 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			// this method has to return a string
 			return _app.NavigateToTestPage(test).ToString();
 		}
+
+		[Export("reset:")]
+		public string Reset(string str)
+		{
+			_app.Reset();
+			return String.Empty;
+		}
 	}
 
 	[Register("KVOUISlider")]

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -358,12 +358,9 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		[Export("navigateToTest:")]
 		public string NavigateToTest(string test)
 		{
-			var result = _app.NavigateToTestPage(test);
-
-			Console.WriteLine($">>>>>>>> navigateToTest result is {result}");
-			System.Diagnostics.Debug.WriteLine($">>>>>>>> navigateToTest result is {result}");
-
-			return result.ToString();
+			// According to https://developer.xamarin.com/guides/testcloud/uitest/working-with/backdoors/
+			// this method has to return a string
+			return _app.NavigateToTestPage(test).ToString();
 		}
 	}
 

--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -7,6 +7,7 @@ using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.ControlGallery.iOS;
 using Xamarin.Forms.Controls;
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.iOS;
 using RectangleF = CoreGraphics.CGRect;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AddingMultipleItemsListView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AddingMultipleItemsListView.cs
@@ -16,7 +16,6 @@ using Xamarin.UITest;
 
 namespace Xamarin.Forms.Controls
 {
-
 	public class PropertyChangedBase : INotifyPropertyChanged
 	{
 		Dictionary<string, object> _properties = new Dictionary<string, object>();
@@ -312,11 +311,16 @@ namespace Xamarin.Forms.Controls
 		}
 	}
 
-	[Preserve (AllMembers = true)]
-	[Issue (IssueTracker.None, 0, "Adding Multiple Items to a ListView", PlatformAffected.All)]
+	
+}
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Adding Multiple Items to a ListView", PlatformAffected.All)]
 	public class AddingMultipleItemsListView : TestContentPage
 	{
-		protected override void Init ()
+		protected override void Init()
 		{
 			Title = "Hours";
 			var exampleViewModel = new ExampleViewModel();
@@ -351,18 +355,19 @@ namespace Xamarin.Forms.Controls
 				Children = {
 					listView,
 					addOneJobButton,
-					addTwoJobsButton 
+					addTwoJobsButton
 				}
 			};
 			Content = layout;
 		}
 
-		[Preserve (AllMembers = true)]
+		[Preserve(AllMembers = true)]
 		public class CustomViewCell : ViewCell
 		{
-			public CustomViewCell ()
+			public CustomViewCell()
 			{
-				var jobId = new Label {
+				var jobId = new Label
+				{
 #pragma warning disable 618
 					Font = Font.SystemFontOfSize(20),
 #pragma warning restore 618
@@ -370,17 +375,19 @@ namespace Xamarin.Forms.Controls
 					VerticalOptions = LayoutOptions.Center,
 
 					HorizontalOptions = LayoutOptions.StartAndExpand
-				};                    
+				};
 				jobId.SetBinding(Label.TextProperty, "JobId");
 
-				var jobName = new Label {
+				var jobName = new Label
+				{
 					VerticalOptions = LayoutOptions.Center,
 					WidthRequest = 175,
 					HorizontalOptions = LayoutOptions.CenterAndExpand,
 				};
 				jobName.SetBinding(Label.TextProperty, "JobName");
 
-				var hours = new Label {
+				var hours = new Label
+				{
 					WidthRequest = 45,
 					VerticalOptions = LayoutOptions.Center,
 #pragma warning disable 618
@@ -391,8 +398,9 @@ namespace Xamarin.Forms.Controls
 				};
 				hours.SetBinding(Label.TextProperty, new Binding("Hours", BindingMode.OneWay, new DoubleStringConverter()));
 
-				var hlayout = new StackLayout {
-					Children  = {
+				var hlayout = new StackLayout
+				{
+					Children = {
 						jobId,
 						jobName,
 						hours
@@ -403,44 +411,44 @@ namespace Xamarin.Forms.Controls
 				View = hlayout;
 			}
 		}
-	
+
 #if UITEST
 		[Test]
-		public void AddingMultipleListViewTests1AllElementsPresent ()
+		public void AddingMultipleListViewTests1AllElementsPresent()
 		{
-			RunningApp.WaitForElement (q => q.Marked ("Big Job"));
-			RunningApp.WaitForElement (q => q.Marked ("Smaller Job"));
-			RunningApp.WaitForElement (q => q.Marked ("Add On Job"));
-			RunningApp.WaitForElement (q => q.Marked ("Add One"));
-			RunningApp.WaitForElement (q => q.Marked ("Add Two"));
-			RunningApp.WaitForElement (q => q.Marked ("3672"));
-			RunningApp.WaitForElement (q => q.Marked ("6289"));
-			RunningApp.WaitForElement (q => q.Marked ("3672-41"));
-			RunningApp.WaitForElement (q => q.Marked ("2"));
-			RunningApp.WaitForElement (q => q.Marked ("2"));
-			RunningApp.WaitForElement (q => q.Marked ("23"));
+			RunningApp.WaitForElement(q => q.Marked("Big Job"));
+			RunningApp.WaitForElement(q => q.Marked("Smaller Job"));
+			RunningApp.WaitForElement(q => q.Marked("Add On Job"));
+			RunningApp.WaitForElement(q => q.Marked("Add One"));
+			RunningApp.WaitForElement(q => q.Marked("Add Two"));
+			RunningApp.WaitForElement(q => q.Marked("3672"));
+			RunningApp.WaitForElement(q => q.Marked("6289"));
+			RunningApp.WaitForElement(q => q.Marked("3672-41"));
+			RunningApp.WaitForElement(q => q.Marked("2"));
+			RunningApp.WaitForElement(q => q.Marked("2"));
+			RunningApp.WaitForElement(q => q.Marked("23"));
 
-			RunningApp.Screenshot ("All elements are present");
+			RunningApp.Screenshot("All elements are present");
 		}
 
 		[Test]
-		public void AddingMultipleListViewTests2AddOneElementToList ()
+		public void AddingMultipleListViewTests2AddOneElementToList()
 		{
-			RunningApp.Tap (q => q.Marked ("Add One"));
+			RunningApp.Tap(q => q.Marked("Add One"));
 
-			RunningApp.WaitForElement (q => q.Marked ("1234"), timeout: TimeSpan.FromSeconds (2));
-			RunningApp.Screenshot ("One more element exists");
+			RunningApp.WaitForElement(q => q.Marked("1234"), timeout: TimeSpan.FromSeconds(2));
+			RunningApp.Screenshot("One more element exists");
 		}
 
 		[Test]
-		public void AddingMultipleListViewTests3AddTwoElementToList ()
+		public void AddingMultipleListViewTests3AddTwoElementToList()
 		{
-			RunningApp.Screenshot ("Click 'Add Two'");
-			RunningApp.Tap (q => q.Marked ("Add Two"));
+			RunningApp.Screenshot("Click 'Add Two'");
+			RunningApp.Tap(q => q.Marked("Add Two"));
 
-			RunningApp.WaitForElement (q => q.Marked ("9999"), timeout: TimeSpan.FromSeconds (2));
-			RunningApp.WaitForElement (q => q.Marked ("8888"), timeout: TimeSpan.FromSeconds (2));
-			RunningApp.Screenshot ("Two more element exist");
+			RunningApp.WaitForElement(q => q.Marked("9999"), timeout: TimeSpan.FromSeconds(2));
+			RunningApp.WaitForElement(q => q.Marked("8888"), timeout: TimeSpan.FromSeconds(2));
+			RunningApp.Screenshot("Two more element exist");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla21177.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla21177.cs
@@ -11,7 +11,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 21177, "Using a UICollectionView in a ViewRenderer results in issues with selection")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla22401.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla22401.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla24574.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla24574.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 24574, "Tap Double Tap")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25979.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25979.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 25979, "https://bugzilla.xamarin.com/show_bug.cgi?id=25979")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26032.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26032.xaml
@@ -2,7 +2,7 @@
 <local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
 				 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
  				 xmlns:local="clr-namespace:Xamarin.Forms.Controls"
-				 x:Class="Xamarin.Forms.Controls.Bugzilla26032">
+				 x:Class="Xamarin.Forms.Controls.Issues.Bugzilla26032">
 	<RelativeLayout>
 		<ListView x:Name="List1"
 				  RelativeLayout.XConstraint="{ConstraintExpression Type=Constant, Constant=0}"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26032.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26032.xaml.cs
@@ -10,7 +10,7 @@ using Xamarin.Forms.Core.UITests;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26171.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26171.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 26171, "Xamarin.Forms.Maps is not updating VisibleRegion property when layout is changed")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26233.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26233.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26501.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26501.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls.TestCasesPages
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	public class FamilyViewModel

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 26993, "https://bugzilla.xamarin.com/show_bug.cgi?id=26993")]
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Controls
 		[Preserve (AllMembers = true)]
 		public class Bz26993ViewCell : ViewCell 
 		{
-			static int s_id = 0;
+			public static int s_id = 0;
 
 			public Bz26993ViewCell ()
 			{
@@ -33,6 +33,8 @@ namespace Xamarin.Forms.Controls
 
 		protected override void Init ()
 		{
+			Bz26993ViewCell.s_id = 0;
+
 			var itemSource = new List<string> {
 				"",
 				"",

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27085.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27085.cs
@@ -28,9 +28,5 @@ namespace Xamarin.Forms.Controls
 				
 			Content = tableview;
 		}
-
-#if UITEST
-		
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27779.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27779.cs
@@ -2,6 +2,7 @@
 
 using Xamarin.Forms.CustomAttributes;
 using System.Collections.Generic;
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Internals;
 #if UITEST
 using Xamarin.UITest;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28001.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28001.cs
@@ -6,7 +6,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 28001, "[Android] TabbedPage: invisible tabs are not Disposed", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28240.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28240.cs
@@ -19,20 +19,13 @@ namespace Xamarin.Forms.Controls
 			Master = new NavigationPage( new ContentPage { Title = "MasterPage", BackgroundColor = Color.Blue }) { Title =" Master" };
 		}
 
-		protected override async void OnAppearing ()
+		protected override async void OnAppearing()
 		{
-			var btn = new Button () { Text = "GO Back" };
-			btn.Clicked+= async (object sender, EventArgs e) => await (Master as NavigationPage).PopAsync ();
+			var btn = new Button() { Text = "GO Back" };
+			btn.Clicked += async (object sender, EventArgs e) => await (Master as NavigationPage).PopAsync();
 
-			await (Master as NavigationPage).PushAsync (new ContentPage { Title = "New MasterPage", Content = btn , BackgroundColor = Color.Pink  });
-			base.OnAppearing ();
+			await (Master as NavigationPage).PushAsync(new ContentPage { Title = "New MasterPage", Content = btn, BackgroundColor = Color.Pink });
+			base.OnAppearing();
 		}
-#if UITEST
-		[Test]
-		public void Bugzilla28240Test ()
-		{
-
-		}
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28498.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28498.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 #if UITEST
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 28498, "App crashes when switching between NavigationPages on a MasterDetailPage when In-Call Status Bar is visible")]
@@ -59,11 +59,13 @@ namespace Xamarin.Forms.Controls
 
 #if UITEST
 		[Test]
+		[Ignore("This test doesn't make a lot of sense and crashes 50% of the time; need to re-investigate it.")]
 		public void Bugzilla28498Test ()
 		{
-			RunningApp.SetOrientationPortrait ();
+			RunningApp.SetOrientationPortrait();
 			RunningApp.Tap (q => q.Marked ("btnOpen"));
 			RunningApp.Tap (q => q.Marked ("btnOther"));
+
 			RunningApp.SetOrientationLandscape ();
 			RunningApp.Tap (q => q.Marked ("btnOpen"));
 			RunningApp.Screenshot ("Detail open");
@@ -72,6 +74,12 @@ namespace Xamarin.Forms.Controls
 				Assert.DoesNotThrow (() => RunningApp.Tap (q => q.Marked ("btnCarousel")));
 			else
 				Assert.Inconclusive ("Should be button here, but rotation could take some time on XTC");
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			RunningApp.SetOrientationPortrait ();
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28570.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28570.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 28570, "https://bugzilla.xamarin.com/show_bug.cgi?id=28570")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28575.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28575.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 28575, "listview header set to null")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28709.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28709.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 28709, "Application.Properties saving crash ")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29017.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29017.cs
@@ -70,13 +70,5 @@ namespace Xamarin.Forms.Controls
 		{
 			_lbl.Text = "Click " + DateTime.Now.ToLocalTime ();
 		}
-
-#if UITEST
-		[Test]
-		public void Issue1Test ()
-		{
-
-		}
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29128.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29128.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 29128, "Slider background lays out wrong Android")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params", PlatformAffected.iOS )]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29257.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29257.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 29257, "CarouselPage.CurrentPage Does Not Work Properly When Used Inside a NavigationPage ")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29363.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29363.cs
@@ -10,7 +10,7 @@ using Xamarin.Forms.Core.UITests;
 #endif
 
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.LifeCycle)]
@@ -46,8 +46,9 @@ namespace Xamarin.Forms.Controls
 		public void PushButton ()
 		{
 			RunningApp.Tap (q => q.Marked ("Modal Push Pop Test"));
-			System.Threading.Thread.Sleep (5);
+			System.Threading.Thread.Sleep (2000);
 			// if it didn't crash, yay
+			RunningApp.WaitForElement(q => q.Marked("Modal Push Pop Test"));
 		}
 #endif
     }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29453.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29453.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.LifeCycle)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30317.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30317.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest.Android;
 using System.Collections.Generic;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 30317, "https://bugzilla.xamarin.com/show_bug.cgi?id=30137")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30324.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30324.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 30324, "Detail view of MasterDetailPage does not get appearance events on Android when whole MasterDetailPage disappears/reappears")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 30353, "MasterDetailPage.IsPresentedChanged is not raised")]
@@ -99,6 +99,12 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Screenshot ("Portrait Invisible");
 			RunningApp.WaitForElement (q => q.Marked ("The Master is now invisible"));
 			RunningApp.SetOrientationLandscape ();
+		}
+
+		[TearDown]
+		public void TearDown() 
+		{
+			RunningApp.SetOrientationPortrait ();
 		}
 
 		void Back()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30651.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30651.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using Xamarin.Forms.Internals;
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 30651, "ListView jumps around while scrolling after items are added to its source")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30935.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30935.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 using Xamarin.Forms.CustomAttributes;
-
+using Xamarin.Forms.Internals;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
@@ -9,6 +9,7 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls
 {
+	[Preserve(AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 30935, "NullReferenceException in ViewRenderer<TView, TNativeView> (Xamarin.Forms.Platform.Android)")]
 	public class Bugzilla30935 : TestContentPage
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30935.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30935.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 30935, "NullReferenceException in ViewRenderer<TView, TNativeView> (Xamarin.Forms.Platform.Android)")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
@@ -10,7 +10,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31255.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31255.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 31255, "Master's page Icon cause memory leak after MasterDetailPage is popped out by holding on page")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31330.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31330.cs
@@ -131,7 +131,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla31330Test ()
 		{
-			RunningApp.Tap (c => c.Marked ("Something 2"));
+			RunningApp.WaitForElement (c => c.Marked ("Something 2"));
 			var screenBounds = RunningApp.Query (q => q.Raw ("* index:0"))[0].Rect;
 
 			var cell = RunningApp.Query (c => c.Marked ("Something 1")) [0];

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31330.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31330.cs
@@ -11,7 +11,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 31330, "Disabled context actions appear enabled")]
@@ -131,6 +131,7 @@ namespace Xamarin.Forms.Controls
 		[Test]
 		public void Bugzilla31330Test ()
 		{
+			RunningApp.Tap (c => c.Marked ("Something 2"));
 			var screenBounds = RunningApp.Query (q => q.Raw ("* index:0"))[0].Rect;
 
 			var cell = RunningApp.Query (c => c.Marked ("Something 1")) [0];

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31333.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31333.cs
@@ -12,7 +12,7 @@ using Xamarin.UITest;
 
 #endif
 
-namespace Xamarin.Forms.Controls.TestCasesPages
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Bugzilla, 31333,
@@ -218,6 +218,7 @@ namespace Xamarin.Forms.Controls.TestCasesPages
 			RunningApp.EnterText ("Entry in ListView Success");
 			Assert.True(RunningApp.Query(query => query.Text("Entry in ListView Success")).Length > 0);
 			RunningApp.Screenshot ("Entry in ListView Success");
+			RunningApp.Tap(q => q.Marked("Focus Entry in ListView"));
 		}
 
 		[Test]
@@ -229,6 +230,7 @@ namespace Xamarin.Forms.Controls.TestCasesPages
 			RunningApp.EnterText ("Editor in ListView Success");
 			Assert.True(RunningApp.Query(query => query.Text("Editor in ListView Success")).Length > 0);
 			RunningApp.Screenshot ("Editor in ListView Success");
+			RunningApp.Tap(q => q.Marked("Focus Editor in ListView"));
 		}
 
 		
@@ -241,6 +243,7 @@ namespace Xamarin.Forms.Controls.TestCasesPages
 			RunningApp.EnterText ("Entry in TableView Success");
 			Assert.True(RunningApp.Query(query => query.Text("Entry in TableView Success")).Length > 0);
 			RunningApp.Screenshot ("Entry in TableView Success");
+			RunningApp.Tap(q => q.Marked("Focus Entry in Table"));
 		}
 
 		[Test]
@@ -252,6 +255,7 @@ namespace Xamarin.Forms.Controls.TestCasesPages
 			RunningApp.EnterText ("Editor in TableView Success");
 			Assert.True(RunningApp.Query(query => query.Text("Editor in TableView Success")).Length > 0);
 			RunningApp.Screenshot ("Editor in TableView Success");
+			RunningApp.Tap(q => q.Marked("Focus Editor in Table"));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31366.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31366.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 
 #endif
 
-namespace Xamarin.Forms.Controls.TestCasesPages
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 31366, "Pushing and then popping a page modally causes ArgumentOutOfRangeException",

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31395.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31395.cs
@@ -8,9 +8,8 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
-	// don't forget to update C:\Users\chrisk\Documents\git\DuploBuddy\Xamarin.Forms.ControlGallery.Android\LinkerRoots.cs
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 31395, "Crash when switching MainPage and using a Custom Render")]
 	public class Bugzilla31395 : TestContentPage // or TestMasterDetailPage, etc ...

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31602.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31602.cs
@@ -11,7 +11,7 @@ using Xamarin.UITest.iOS;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.MasterDetailPage)]
@@ -128,6 +128,12 @@ namespace Xamarin.Forms.Controls
 				RunningApp.Tap (q => q.Marked ("Sidemenu Opener"));
 				RunningApp.WaitForElement (q => q.Marked ("SideMenu"));
 			}
+		}
+
+		[TearDown]
+		public void TearDown() 
+		{
+			RunningApp.SetOrientationPortrait ();
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32040.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32040.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.Cells)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32148.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32148.cs
@@ -13,7 +13,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32230.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32230.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 32230, "isPresentedChanged raises multiple times")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32462.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32462.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32615.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32615.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 32615, "OnAppearing is not called on previous page when modal page is popped")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32801.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32801.cs
@@ -85,6 +85,12 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Tap (c => c.Marked ("btnStack"));
 			RunningApp.WaitForElement (c => c.Marked ("Stack 1"));
 		}
+
+		[TearDown]
+		public void TearDown() 
+		{
+			RunningApp.SetOrientationPortrait ();
+		}
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32801.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32801.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Xamarin.UITest.iOS;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 32801, "Memory Leak in TabbedPage + NavigationPage")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32898.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32898.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 32898, "Memory leak when TabbedPage is popped out ")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32902.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32902.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 32902, "[iOS | iPad] App Crashes (without debug log) when Master Detail isPresented and navigation being popped")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33578.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33578.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest.iOS;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 33578, "TableView EntryCell shows DefaultKeyboard, but after scrolling down and back a NumericKeyboard (")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33612.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33612.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 33612,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34007.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34007.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 34007, "Z order drawing of children views are different on Android, iOS, Win", PlatformAffected.Android | PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34061.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34061.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 34061, "RelativeLayout - First child added after page display does not appear")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 using Xamarin.UITest.iOS;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 34561, "[A] Navigation.PushAsync crashes when used in Context Actions (legacy)", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Xamarin.UITest.iOS;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 34632, "Can't change IsPresented when setting SplitOnLandscape ")]
@@ -74,6 +74,12 @@ namespace Xamarin.Forms.Controls
 				RunningApp.Tap (q => q.Marked ("btnDismissModal"));
 				RunningApp.Tap (q => q.Marked ("btnMaster"));
 			}
+		}
+
+		[TearDown]
+		public void TearDown() 
+		{
+			RunningApp.SetOrientationPortrait ();
 		}
 		#endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34912.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34912.cs
@@ -10,7 +10,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35157.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35157.cs
@@ -6,7 +6,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 35157, "CarouselPage inside NavPage inside TabbedPage gets laid out incorrectly", NavigationBehavior.PushModalAsync)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35472.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35472.cs
@@ -10,7 +10,7 @@ using Xamarin.UITest;
 
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 35472, "PopAsync during ScrollToAsync throws NullReferenceException")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35477.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35477.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 using Xamarin.UITest.Queries;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 35477, "Tapped event does not fire when added to Frame in Android AppCompat",

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35733.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35733.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 35733, "iOS WebView crashes when loading an URL with encoded parameters", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35738.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35738.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
     [Preserve (AllMembers = true)]
     public class CustomButton : Button

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36009.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36009.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 36009, "Children of Layouts with data bound IsVisible are not displayed")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36171.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36171.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using Xamarin.UITest.Queries;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 36171, "WinRT Entry UI not updating on TextChanged",

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36393.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36393.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 36393, "[A] Default Entry/Editor/SearchBar Font Size is 14 instead of 18")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36559.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36559.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
     [Preserve(AllMembers = true)]
     [Issue(IssueTracker.Bugzilla, 36559, "[WP] Navigating to a ContentPage with a Grid inside a TableView affects Entry heights")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36681.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36681.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 36681, "[A] NRE when Picker Replaces Page Content (pre-AppCompat only)", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36788.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36788.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 36788, "Truncation Issues with Relative Layouts")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37462.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37462.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 #endif
 
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 37462, "Using App Compat/App Compat theme breaks Navigation.RemovePage on Android ",PlatformAffected.Android )]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37625.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37625.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
     [Preserve (AllMembers = true)]
     [Issue (IssueTracker.Bugzilla, 37625, "App crashes when quickly adding/removing Image views (Windows UWP)")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37841.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37841.cs
@@ -10,7 +10,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 37841, "TableView EntryCells and TextCells cease to update after focus change", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38112.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38112.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 38112, "Switch becomes reenabled when previous ViewCell is removed from TableView", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38658.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38658.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 38658, "Rotation causes app containing CarouselPage to freeze", PlatformAffected.iOS)]
@@ -68,6 +68,12 @@ namespace Xamarin.Forms.Controls
 			RunningApp.SetOrientationPortrait ();
 			RunningApp.Back ();
 			RunningApp.WaitForElement (q => q.Marked ("btn"));
+		}
+
+		[TearDown]
+		public void TearDown() 
+		{
+			RunningApp.SetOrientationPortrait ();
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38978.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38978.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 38978, "Cell.ForceUpdateSize issues with row selection/deselection (ViewCell)", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39331.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39331.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.BoxView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39458.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39458.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 39458, "[UWP/WinRT] Cannot Set CarouselPage.CurrentPage Inside Constructor", PlatformAffected.WinRT)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
@@ -10,7 +10,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 39489, "Memory leak when using NavigationPage with Maps", PlatformAffected.Android)]
@@ -23,6 +23,9 @@ namespace Xamarin.Forms.Controls
 
 #if UITEST
 #if !__IOS__ // Temporarily disabling this test on iOS
+
+		protected override bool Isolate => true;
+
 		[Test]
 		public async Task Bugzilla39489Test()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39530.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39530.cs
@@ -59,6 +59,9 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla39530PanTest()
 		{
+			// Got to wait for the element to be visible to the UI test framework, otherwise we get occasional 
+			// index out of bounds exceptions if the query for the frame and its Rect run quickly enough
+			RunningApp.WaitForElement(q => q.Marked("frame"));
 			AppRect frameBounds = RunningApp.Query (q => q.Marked ("frame"))[0].Rect;
 			RunningApp.Pan (new Drag (frameBounds, frameBounds.X + 10, frameBounds.Y + 10, frameBounds.X + 100, frameBounds.Y + 100, Drag.Direction.LeftToRight));
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39668.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39668.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39829.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39829.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 39829, "RowHeight of ListView is not working for UWP", PlatformAffected.WinRT)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39963.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39963.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 39963, "iOS WebView has wrong scrolling size when loading local html content with images")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40173.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40173.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.BoxView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40333.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40333.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms.Internals;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 40333, "[Android] IllegalStateException: Recursive entry to executePendingTransactions", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40704.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40704.cs
@@ -12,7 +12,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40911.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40911.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms.Internals;
 using Xamarin.UITest;
 using NUnit.Framework;
 #endif
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 40911, "NRE with Facebook Login", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41038.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41038.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 41038, "MasterDetailPage loses menu icon on iOS after reusing NavigationPage as Detail")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41153.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41153.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 41153, "jobject must not be IntPtr.Zero with TabbedPage and ToolbarItems")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41424.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41424.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 41424, "[Android] Clicking cancel on a DatePicker does not cause it to unfocus", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41842.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41842.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 41842, "Set MasterDetailPage.Detail = New Page() twice will crash the application when set MasterBehavior = MasterBehavior.Split", PlatformAffected.WinRT)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42277.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42277.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 42277, "DataTemplate System.InvalidCastException crash in 2.3.1-pre1")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43161.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43161.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44129.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44129.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 44129, "Crash when adding tabbed page after removing all pages using DataTemplates")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44166.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44166.cs
@@ -10,7 +10,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 44166, "MasterDetailPage instances do not get disposed upon GC")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CarouselAsync.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CarouselAsync.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.None, 0, "Carousel Async Add Page Issue", PlatformAffected.All, NavigationBehavior.PushModalAsync)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/IsInvokeRequiredRaceCondition.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/IsInvokeRequiredRaceCondition.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 #endif
 
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 0, "Device.IsInvokeRequired race condition causes crash")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1146.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1146.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls.TestCasesPages
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue(IssueTracker.Github, 1146, "Disabled Switch in Button Gallery not rendering on all devices", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1461.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1461.cs
@@ -12,7 +12,7 @@ using Xamarin.UITest;
 using Xamarin.UITest.iOS;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 
 #if UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1691.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1691.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 using System.Diagnostics;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 1691, "CarouselPage iOS CurrentPage bug")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue181.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue181.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 181, "Color not initialized for Label", PlatformAffected.Android, NavigationBehavior.PushModalAsync)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1891.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1891.cs
@@ -11,7 +11,8 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls {
+namespace Xamarin.Forms.Controls.Issues
+{
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 1891, "Modal dialog scrolls to far when focusing input boxes", PlatformAffected.iOS)]
 	public class Issue1891 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue198.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue198.cs
@@ -64,6 +64,10 @@ namespace Xamarin.Forms.Controls
 			RunningApp.Screenshot ("Clicked Leave");
 
 			RunningApp.WaitForElement (q => q.Marked ("Bug Repro's"));
+
+			RunningApp.ClearText(q => q.Raw("* marked:'SearchBarGo'"));
+			RunningApp.EnterText(q => q.Raw("* marked:'SearchBarGo'"), "G198");
+
 			RunningApp.Tap (q => q.Marked ("SearchButton"));
 			RunningApp.Screenshot ("Navigate into gallery again");
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue198.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue198.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 198, "TabbedPage shouldn't proxy content of NavigationPage", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue206.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue206.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 206, "ViewCell with Label's text does not resize when value is changed", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2222.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2222.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2222, "NavigationBar.ToolbarItems.Add() crashes / breaks app in iOS7. works fine in iOS8", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2241.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2241.cs
@@ -10,7 +10,7 @@ using Xamarin.UITest;
 using Xamarin.UITest.Android;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2241, "ScrollView content can become stuck on orientation change (iOS)", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2259.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2259.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 2259, "ListView.ScrollTo crashes app", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2272.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2272.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Xamarin.UITest.Android;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 2272, "Entry text updating set focus on the beginning of text not the end of it", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2289.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2289.xaml
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
 					   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 					   xmlns:local="clr-namespace:Xamarin.Forms.Controls"
-					   x:Class="Xamarin.Forms.Controls.Issue2289">
+					   x:Class="Xamarin.Forms.Controls.Issues.Issue2289">
 	<local:TestContentPage.Content>
 		<TableView HasUnevenRows="true">
 			<TableView.Root>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2289.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2289.xaml.cs
@@ -13,7 +13,7 @@ using Xamarin.UITest;
 using Xamarin.UITest.iOS;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2289, "TextCell IsEnabled property not disabling element in TableView", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue(IssueTracker.Github, 2354, "ListView, ImageCell and disabled source cache and same image url",PlatformAffected.iOS | PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2411.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2411.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls.TestCasesPages
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 2411, "ListView.ScrollTo not working in TabbedPage", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2414.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2414.cs
@@ -60,9 +60,11 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void TestDoesntCrashShowingContextMenu ()
 		{
+			RunningApp.WaitForElement(c => c.Marked("Swipe ME"));
+
 			var screenBounds = RunningApp.Query (q => q.Raw ("* index:0"))[0].Rect;
 
-			var cell = RunningApp.Query (c => c.Marked ("Swipe ME")) [0];
+			var cell = RunningApp.Query(c => c.Marked("Swipe ME")) [0];
 #if __IOS__
 			RunningApp.DragCoordinates (screenBounds.Width - 10, cell.Rect.CenterY, 0, cell.Rect.CenterY);
 			//TODO: fix this when context menu bug is fixed
@@ -73,11 +75,18 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 			RunningApp.Screenshot ("Didn't crash");
 			RunningApp.TapCoordinates (screenBounds.CenterX, screenBounds.CenterY);
+
+#if __ANDROID__
+			RunningApp.Tap(c => c.Marked("Text0"));
+#endif
+
 		}
 
 		[Test]
 		public void TestShowContextMenuItemsInTheRightOrder ()
 		{
+			RunningApp.WaitForElement(c => c.Marked("Swipe ME"));
+
 			var screenBounds = RunningApp.Query (q => q.Raw ("* index:0"))[0].Rect;
 
 			var cell = RunningApp.Query (c => c.Marked ("Swipe ME")) [0];
@@ -89,10 +98,14 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement (c => c.Marked ("Text0"));
 			RunningApp.Screenshot ("Are the menuitems in the right order?");
 
-		}
+#if __ANDROID__
+			RunningApp.Tap(c => c.Marked("Text0"));
 #endif
 
 		}
+#endif
+
+	}
 }
 
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2414.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2414.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Xamarin.UITest.iOS;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2414, "NullReferenceException when swiping over Context Actions", PlatformAffected.WinPhone)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2470.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2470.xaml
@@ -2,7 +2,7 @@
 <local:TestTabbedPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Xamarin.Forms.Controls"
-             x:Class="Xamarin.Forms.Controls.Issue2470">
+             x:Class="Xamarin.Forms.Controls.Issues.Issue2470">
   <local:TestTabbedPage.Children>
     <ContentPage Title="Generate">
       <StackLayout>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2470.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2470.xaml.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	public class Issue2470ViewModelBase : INotifyPropertyChanged

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue264.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue264.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 264, "PopModal NRE", PlatformAffected.Android | PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2775.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2775.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2775, "ViewCell background conflicts with ListView Semi-Transparent and Transparent backgrounds")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2777.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2777.xaml
@@ -2,7 +2,7 @@
 <local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
 				 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 				 xmlns:local="clr-namespace:Xamarin.Forms.Controls"
-				 x:Class="Xamarin.Forms.Controls.Issue2777">
+				 x:Class="Xamarin.Forms.Controls.Issues.Issue2777">
 	<local:TestContentPage.Content>
 		<ListView x:Name="itemListView" IsGroupingEnabled="true" ItemTapped="OnItemTapped">
 			<ListView.GroupHeaderTemplate>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2777.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2777.xaml.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 #endif
 
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2777, "When add GroupHeaderTemplate in XAML the group header does not show up")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2809.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2809.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using Xamarin.UITest.Android;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 2809, "Secondary ToolbarItems cause app to hang during PushAsync", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2883.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2883.cs
@@ -11,7 +11,7 @@ using Xamarin.UITest.iOS;
 
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2883, "ViewCell IsEnabled set to false does not disable a cell in a TableView")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2923.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2923.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2923, "First tab does not load until navigating", PlatformAffected.WinRT)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2927.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2927.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2927, "ListView item tapped not firing multiple times")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2948.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2948.cs
@@ -217,6 +217,12 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
+		[TearDown]
+		public void TestTearDown()
+		{
+			RunningApp.SetOrientationPortrait();
+		}
+
 		public bool ShouldRunTest() {
 			var isMasterVisible = RunningApp.Query (q => q.Marked ("Leads")).Length > 0;
 			return !isMasterVisible;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2948.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2948.cs
@@ -12,7 +12,7 @@ using Xamarin.UITest.Android;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2948, "MasterDetailPage Detail is interactive even when Master is open when in Landscape")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:controls="clr-namespace:Xamarin.Forms.Controls;assembly=Xamarin.Forms.Controls" x:Name="ThePageIssue2951" x:Class="Xamarin.Forms.Controls.Issue2951">
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:controls="clr-namespace:Xamarin.Forms.Controls;assembly=Xamarin.Forms.Controls" x:Name="ThePageIssue2951" x:Class="Xamarin.Forms.Controls.Issues.Issue2951">
 	<controls:TestContentPage.Resources>
 		<ResourceDictionary>
 			<Style x:Key="ButtonStyle" TargetType="Button">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
@@ -113,32 +113,32 @@ namespace Xamarin.Forms.Controls.Issues
 	
 		#endif
 	}
+}
 
-
-	
-
-	[Preserve (AllMembers = true)]
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
 	public class ButtonExtensions
 	{
 #pragma warning disable 618
-		public static readonly BindableProperty IsPrimaryProperty = BindableProperty.CreateAttached<ButtonExtensions, bool> (
+		public static readonly BindableProperty IsPrimaryProperty = BindableProperty.CreateAttached<ButtonExtensions, bool>(
 #pragma warning restore 618
-			                                                            bindable => GetIsPrimary (bindable),
-			                                                            false,
-			                                                            BindingMode.TwoWay,
-			                                                            null,
-			                                                            null,
-			                                                            null,
-			                                                            null);
+																		bindable => GetIsPrimary(bindable),
+																		false,
+																		BindingMode.TwoWay,
+																		null,
+																		null,
+																		null,
+																		null);
 
-		public static bool GetIsPrimary (BindableObject bo)
+		public static bool GetIsPrimary(BindableObject bo)
 		{
-			return (bool)bo.GetValue (IsPrimaryProperty);
+			return (bool)bo.GetValue(IsPrimaryProperty);
 		}
 
-		public static void SetIsPrimary (BindableObject bo, bool value)
+		public static void SetIsPrimary(BindableObject bo, bool value)
 		{
-			bo.SetValue (IsPrimaryProperty, value);
+			bo.SetValue(IsPrimaryProperty, value);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 #endif
 
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2951, "On Android, button background is not updated when color changes ")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2953.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2953.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2953, "GroupHeaderCells disappear when item is removed from a group in ListView (iOS only) ")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2954.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2954.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2954, "Cell becomes empty after adding a new one with context actions (TableView) ")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2961.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2961.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 using Xamarin.UITest.iOS;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Ignore("This test is looking for an invalid behavior; the second tap *should* keep the drawer open.")] 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2963.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2963.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2963, "Disabling Editor in iOS does not disable entry of text")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2964.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2964.cs
@@ -11,7 +11,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2964, "TabbedPage toolbar item crash")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2965.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2965.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 using Xamarin.UITest.iOS;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2965, "CarouselPage Disappearing event does not fire on Android")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2976.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2976.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2976, "Sample 'WorkingWithListviewNative' throw Exception on Xam.Android project.", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2981.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2981.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2981, "Long Press on ListView causes crash")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2983.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2983.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms.Internals;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls.TestCasesPages
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue(IssueTracker.Github, 2983, "ListView.Footer can cause NullReferenceException", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3276.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3276.cs
@@ -12,7 +12,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 3276, "Crashing Unknown cell parent type on ContextAction Bindings")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3292.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3292.cs
@@ -11,7 +11,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 3292, "TableSection.Title property binding fails in XAML")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3319.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3319.xaml
@@ -2,7 +2,7 @@
 <local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
 				 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
  				 xmlns:local="clr-namespace:Xamarin.Forms.Controls"
-				 x:Class="Xamarin.Forms.Controls.Issue3319">
+				 x:Class="Xamarin.Forms.Controls.Issues.Issue3319">
 	 <StackLayout Orientation="Vertical">
     <ListView x:Name="listView"
           ItemsSource="{Binding FavoriteArticles}"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3319.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3319.xaml.cs
@@ -13,7 +13,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 3319, "[iOS] Clear and adding rows exception")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue342.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue342.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 342, "NRE when Image is not assigned source", PlatformAffected.WinPhone)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue416.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue416.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 416, "NavigationPage in PushModal does not show NavigationBar", PlatformAffected.Android, NavigationBehavior.PushModalAsync)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue417.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue417.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 417, "Navigation.PopToRootAsync does nothing", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue465.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue465.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 465, "Change in Navigation.PushModal", PlatformAffected.All)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue488.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue488.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 488, "Resizing the Label results in wrapped text being cropped on iOS", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue530.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue530.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 530, "ListView does not render if source is async", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue55555.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue55555.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 55555, "Header problem")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue764.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue764.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 764, "Keyboard does not dismiss on SearchBar", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue773.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue773.cs
@@ -8,7 +8,7 @@ using Xamarin.UITest.Queries;
 #endif
 
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 773, "Horizontal ScrollView locks after rotation", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue774.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue774.cs
@@ -54,6 +54,7 @@ namespace Xamarin.Forms.Controls.Issues
 					RunningApp.WaitForNoElement (q => q.Marked ("Destroy"));
 				else
 					RunningApp.WaitForNoElement (q => q.Marked ("Dismiss"));
+
 				RunningApp.Screenshot ("Dismiss ActionSheet");
 
 //				App.SetOrientationPortrait ();
@@ -71,6 +72,16 @@ namespace Xamarin.Forms.Controls.Issues
 //					App.WaitForNoElement (q => q.Marked ("Dismiss"));
 			
 			} 
+			else
+			{
+				RunningApp.Tap(q => q.Marked("Dismiss"));
+			}
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			RunningApp.SetOrientationPortrait();
 		}
 #endif
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue774.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue774.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Xamarin.UITest.iOS;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 774, "ActionSheet won't dismiss after rotation to landscape", PlatformAffected.Android, NavigationBehavior.PushModalAsync)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue852.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue852.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 852, "Async loading of Content causes UI element to be unclickable", PlatformAffected.Android | PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue889.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue889.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 889, "Assigning to MasterDetailPage.Detail after construction doesn't work", PlatformAffected.Android | PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue892.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue892.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 
 	public class NavPageNameObject

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue935.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue935.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	public class Person 
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue968.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue968.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 968, "StackLayout does not relayout on device rotation", PlatformAffected.iOS, NavigationBehavior.PushModalAsync)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue973.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue973.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	internal class PageNameObject
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ListViewViewCellBinding.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ListViewViewCellBinding.cs
@@ -11,28 +11,30 @@ using Xamarin.UITest;
 
 namespace Xamarin.Forms.Controls
 {
-
 	public class GenericValueConverter : IValueConverter
 	{
 		Func<object, object> _convert;
 		Func<object, object> _back;
-		public GenericValueConverter (Func<object, object> convert, Func<object, object> back = null)
+		public GenericValueConverter(Func<object, object> convert, Func<object, object> back = null)
 		{
 			_convert = convert;
 			_back = back;
 		}
 
-		public object Convert (object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
 		{
-			return _convert (value);
+			return _convert(value);
 		}
 
-		public object ConvertBack (object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
 		{
-			return _back (value);
+			return _back(value);
 		}
 	}
+}
 
+namespace Xamarin.Forms.Controls.Issues
+{
 	[Preserve (AllMembers = true)]
 	public class Expense
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/StackLayoutIssue.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/StackLayoutIssue.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.None, 0, "StackLayout issue", PlatformAffected.All, NavigationBehavior.PushModalAsync)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/SwipeBackNavCrash.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/SwipeBackNavCrash.cs
@@ -12,7 +12,7 @@ using Xamarin.UITest.iOS;
 #endif
 
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.None, 0, "Swipe back nav crash", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TabbedPageTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TabbedPageTests.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.None, 0,"TabbedPage nav tests", PlatformAffected.All)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TabbedPageWithList.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TabbedPageWithList.cs
@@ -7,7 +7,7 @@ using Xamarin.UITest;
 #endif
 
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	public class TabbedPageWithListName {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -31,9 +31,19 @@ namespace Xamarin.Forms.Controls
 #if __ANDROID__
 			app = ConfigureApp.Android.ApkFile (AppPaths.ApkPath).Debug ().StartApp ();
 #elif __IOS__ 
-			app = ConfigureApp.iOS.InstalledApp (AppPaths.BundleId).Debug ()
+
+			// TODO EZH Change this back to device 
+			// Running on a device
+			//app = ConfigureApp.iOS.InstalledApp(AppPaths.BundleId).Debug()
 				//Uncomment to run from a specific iOS SIM, get the ID from XCode -> Devices
-				.StartApp ();
+			//	.StartApp();
+
+			// Running on the simulator
+			app = ConfigureApp.iOS
+			                  .PreferIdeSettings()
+			                  .AppBundle("../../../Xamarin.Forms.ControlGallery.iOS/bin/iPhoneSimulator/Debug/XamarinFormsControlGalleryiOS.app")
+			                  .Debug ()
+			                  .StartApp ();
 #endif
 			if (app == null)
 				throw new NullReferenceException ("App was not initialized.");
@@ -66,8 +76,10 @@ namespace Xamarin.Forms.Controls
 				}
 #endif
 #if __IOS__
-				app.Invoke("navigateToTest:", cellName);
-				return;
+				if (bool.Parse(app.Invoke("navigateToTest:", cellName).ToString()))
+				{
+					return;
+				}
 #endif
 			}
 			catch (Exception ex)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Controls
 			// Running on the simulator
 			//var app = ConfigureApp.iOS
 			//				  .PreferIdeSettings()
-			//				  .AppBundle("../../../Xamarin.Forms.ControlGallery.iOS/bin/iPhoneSimulator/Debug/XamarinFormsControlGalleryiOS.app")
+			//		  		  .AppBundle("../../../Xamarin.Forms.ControlGallery.iOS/bin/iPhoneSimulator/Debug/XamarinFormsControlGalleryiOS.app")
 			//				  .Debug()
 			//				  .StartApp();
 
@@ -135,7 +135,7 @@ namespace Xamarin.Forms.Controls
 			{
 				try
 				{
-					RunningApp.TestServer.Get("");
+					RunningApp.TestServer.Get("version");
 					return;
 				}
 				catch (Exception ex)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Controls
 			app = InitializeAndroidApp();
 
 #elif __IOS__
-			//app = InitializeiOSApp();
+
 			app = InitializeiOSApp();
 #endif
 			if (app == null)
@@ -129,6 +129,8 @@ namespace Xamarin.Forms.Controls
 			return runningApp;
 		}
 
+		// Make sure the server on the device is still up and running;
+		// if not, restart the app
 		public static void EnsureConnection()
 		{
 			if (RunningApp != null)
@@ -147,8 +149,10 @@ namespace Xamarin.Forms.Controls
 		}
 
 		static int s_testsrun;
-		const int ConsecutiveTestLimit = 30;
+		const int ConsecutiveTestLimit = 40;
 
+		// Until we get more of our memory leak issues worked out, restart the app 
+		// after a specified number of tests so we don't get bogged down in GC
 		public static void EnsureMemory()
 		{
 			if (RunningApp != null)
@@ -163,6 +167,8 @@ namespace Xamarin.Forms.Controls
 			}
 		}
 
+		// For tests which just don't play well with others, we can ensure
+		// that they run in their own instance of the application
 		public static void BeginIsolate()
 		{
 			if (RunningApp != null && s_testsrun > 0)
@@ -459,6 +465,8 @@ namespace Xamarin.Forms.Controls.Issues
 	using System;
 	using NUnit.Framework;
 
+	// Run setup once for all tests in the Xamarin.Forms.Controls.Issues namespace
+	// (instead of once for each test)
 	[SetUpFixture]
 	public class IssuesSetup
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -33,7 +33,9 @@ namespace Xamarin.Forms.Controls
 #elif __IOS__ 
 			app = ConfigureApp.iOS.InstalledApp (AppPaths.BundleId).Debug ()
 				//Uncomment to run from a specific iOS SIM, get the ID from XCode -> Devices
-				//.DeviceIdentifier("55555555-5555-5555-5555-555555555555")
+.DeviceIdentifier("d8e74947b18cedd091a8ee3c23243e874f1aebbb")
+//          .CodesignIdentity("iPhone Developer: E.Z.Hart(SR9R53YEUX)")
+          //.CodesignIdentity("iPhone Developer")
 				.StartApp ();
 #endif
 			if (app == null)
@@ -56,6 +58,27 @@ namespace Xamarin.Forms.Controls
 				cellName = typeIssueAttribute.Description;
 			}
 
+			try
+			{
+				// Attempt the direct way of navigating to the test page
+#if __ANDROID__
+
+				if (bool.Parse((string)app.Invoke("NavigateToTest", cellName)))
+				{
+					return;
+				}
+#endif
+#if __IOS__
+				app.Invoke("navigateToTest:", cellName);
+				return;
+#endif
+			}
+			catch (Exception ex)
+			{
+				System.Diagnostics.Debug.WriteLine($"Could not directly invoke test, using UI navigation. {ex}");
+			}
+			
+			// Fall back to the "manual" navigation method
 			app.Tap (q => q.Button ("Go to Test Cases"));
 			app.WaitForElement (q => q.Raw ("* marked:'TestCasesIssueList'"));
 
@@ -82,7 +105,7 @@ namespace Xamarin.Forms.Controls
 	}
 #endif
 
-	public abstract class TestPage : Page
+		public abstract class TestPage : Page
 	{
 #if UITEST
 		public IApp RunningApp { get; private set; }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -33,9 +33,6 @@ namespace Xamarin.Forms.Controls
 #elif __IOS__ 
 			app = ConfigureApp.iOS.InstalledApp (AppPaths.BundleId).Debug ()
 				//Uncomment to run from a specific iOS SIM, get the ID from XCode -> Devices
-.DeviceIdentifier("d8e74947b18cedd091a8ee3c23243e874f1aebbb")
-//          .CodesignIdentity("iPhone Developer: E.Z.Hart(SR9R53YEUX)")
-          //.CodesignIdentity("iPhone Developer")
 				.StartApp ();
 #endif
 			if (app == null)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_Template.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_Template.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 [assembly: NUnit.Framework.Category("Issues")]
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 1, "Issue Description", PlatformAffected.Default)]

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -157,8 +157,19 @@ namespace Xamarin.Forms.Controls
 
 		public bool NavigateToTestPage(string test)
 		{
-			SetMainPage(TestCases.GetTestCases());
-			TestCases.TestCaseScreen.PageToAction[test]();
+			try
+			{
+				SetMainPage(TestCases.GetTestCases());
+				TestCases.TestCaseScreen.PageToAction[test]();
+				return true;
+			}
+			catch (Exception ex) 
+			{
+				Log.Warning("UITests", $"Error attempting to navigate directly to {test}: {ex}");
+			}
+
+			// TODO EZH Forcing this to true for now so we can figure out which tests fail using direct nav
+			// once we've fixed them, we can have this properly return false
 			return true;
 		}
 	}

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -154,5 +154,12 @@ namespace Xamarin.Forms.Controls
 				text = await reader.ReadToEndAsync();
 			return text;
 		}
+
+		public bool NavigateToTestPage(string test)
+		{
+			SetMainPage(TestCases.GetTestCases());
+			TestCases.TestCaseScreen.PageToAction[test]();
+			return true;
+		}
 	}
 }

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -159,12 +159,14 @@ namespace Xamarin.Forms.Controls
 		{
 			try
 			{
-				SetMainPage(TestCases.GetTestCases());
+				((MasterDetailPage)Current.MainPage).Detail.Navigation.PushAsync(TestCases.GetTestCases());
+
 				TestCases.TestCaseScreen.PageToAction[test]();
 				return true;
 			}
 			catch (Exception ex) 
 			{
+				Application.Current.MainPage.DisplayAlert("doh", ex.ToString(), "ok");
 				Log.Warning("UITests", $"Error attempting to navigate directly to {test}: {ex}");
 			}
 

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -195,7 +195,6 @@ namespace Xamarin.Forms.Controls
 
 			return false;
 		}
-
 		
 		public void Reset()
 		{

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Controls
 			//});
 		}
 
-		Page CreateDefaultMainPage()
+		public Page CreateDefaultMainPage()
 		{
 			return new MasterDetailPage
 			{
@@ -167,22 +167,37 @@ namespace Xamarin.Forms.Controls
 		{
 			try
 			{
-				SetMainPage(CreateDefaultMainPage());
-				
-				Current.MainPage.Navigation.PushModalAsync(TestCases.GetTestCases());
+				var root = CreateDefaultMainPage();
 
-				TestCases.TestCaseScreen.PageToAction[test]();
+				EventHandler toTestPage = null;
+
+				toTestPage = delegate(object sender, EventArgs e) 
+				{
+					Current.MainPage.Navigation.PushModalAsync(TestCases.GetTestCases());
+					TestCases.TestCaseScreen.PageToAction[test]();
+					Current.MainPage.Appearing -= toTestPage;
+				};
+
+				root.Appearing += toTestPage;
+
+				SetMainPage(root);
+
 				return true;
 			}
 			catch (Exception ex) 
 			{
 				Log.Warning("UITests", $"Error attempting to navigate directly to {test}: {ex}");
+
 			}
 
-			// TODO EZH Forcing this to true for now so we can figure out which tests fail using direct nav
-			// once we've fixed them, we can have this properly return false
 			return true;
 		}
+
+		void Root_Appearing(object sender, EventArgs e)
+		{
+
+		}
+
 
 		public void Reset()
 		{

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -22,16 +22,14 @@ namespace Xamarin.Forms.Controls
 		static Dictionary<string, string> s_config;
 		readonly ITestCloudService _testCloudService;
 
+		public const string DefaultMainPageId = "ControlGalleryMainPage";
+
 		public App()
 		{
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 			InitInsights();
 
-			MainPage = new MasterDetailPage
-			{
-				Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
-				Detail = CoreGallery.GetMainPage()
-			};
+			SetMainPage(CreateDefaultMainPage());
 
 			//// Uncomment to verify that there is no gray screen displayed between the blue splash and red MasterDetailPage.
 			//MainPage = new Bugzilla44596SplashPage(() =>
@@ -44,6 +42,16 @@ namespace Xamarin.Forms.Controls
 			//		Detail = newTabbedPage
 			//	};
 			//});
+		}
+
+		Page CreateDefaultMainPage()
+		{
+			return new MasterDetailPage
+			{
+				AutomationId = DefaultMainPageId,
+				Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
+				Detail = CoreGallery.GetMainPage()
+			};
 		}
 
 		protected override void OnAppLinkRequestReceived(Uri uri)
@@ -159,6 +167,8 @@ namespace Xamarin.Forms.Controls
 		{
 			try
 			{
+				SetMainPage(CreateDefaultMainPage());
+				
 				Current.MainPage.Navigation.PushModalAsync(TestCases.GetTestCases());
 
 				TestCases.TestCaseScreen.PageToAction[test]();
@@ -166,13 +176,17 @@ namespace Xamarin.Forms.Controls
 			}
 			catch (Exception ex) 
 			{
-				Application.Current.MainPage.DisplayAlert("doh", ex.ToString(), "ok");
 				Log.Warning("UITests", $"Error attempting to navigate directly to {test}: {ex}");
 			}
 
 			// TODO EZH Forcing this to true for now so we can figure out which tests fail using direct nav
 			// once we've fixed them, we can have this properly return false
 			return true;
+		}
+
+		public void Reset()
+		{
+			SetMainPage(CreateDefaultMainPage());
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -159,7 +159,7 @@ namespace Xamarin.Forms.Controls
 		{
 			try
 			{
-				((MasterDetailPage)Current.MainPage).Detail.Navigation.PushAsync(TestCases.GetTestCases());
+				Current.MainPage.Navigation.PushModalAsync(TestCases.GetTestCases());
 
 				TestCases.TestCaseScreen.PageToAction[test]();
 				return true;

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -167,8 +167,10 @@ namespace Xamarin.Forms.Controls
 		{
 			try
 			{
+				// Create an instance of the main page
 				var root = CreateDefaultMainPage();
 
+				// Set up a delegate to handle the navigation to the test page
 				EventHandler toTestPage = null;
 
 				toTestPage = delegate(object sender, EventArgs e) 
@@ -178,6 +180,7 @@ namespace Xamarin.Forms.Controls
 					Current.MainPage.Appearing -= toTestPage;
 				};
 
+				// And set that delegate to run once the main page appears
 				root.Appearing += toTestPage;
 
 				SetMainPage(root);
@@ -190,15 +193,10 @@ namespace Xamarin.Forms.Controls
 
 			}
 
-			return true;
+			return false;
 		}
 
-		void Root_Appearing(object sender, EventArgs e)
-		{
-
-		}
-
-
+		
 		public void Reset()
 		{
 			SetMainPage(CreateDefaultMainPage());

--- a/Xamarin.Forms.Controls/ControlGalleryPages/AppearingGalleryPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/AppearingGalleryPage.cs
@@ -69,13 +69,13 @@ namespace Xamarin.Forms.Controls
 			{
 				page.Appearing += (object sender, EventArgs e) => {
 					_isAppearingFired++;
-					App.AppearingMessages.Add ($"Appearing {page.Title}");
+					App.AppearingMessages.Insert (0, $"Appearing {page.Title}");
 					Debug.WriteLine ($"Appearing {page.Title}");
 				};
 
 				page.Disappearing += (object sender, EventArgs e) => {
 					_isDisappearingFired++;
-					App.AppearingMessages.Add ($"Disappearing {page.Title}");
+					App.AppearingMessages.Insert (0, $"Disappearing {page.Title}");
 					Debug.WriteLine( $"Disappearing {page.Title}");
 				};
 			}

--- a/Xamarin.Forms.Controls/GalleryPages/MasterDetailPageTabletPage.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MasterDetailPageTabletPage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Xamarin.Forms.Controls.Issues;
 
 namespace Xamarin.Forms.Controls
 {

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -57,8 +57,9 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.UITest">
-      <HintPath>..\packages\Xamarin.UITest.2.0.0-beta05\lib\Xamarin.UITest.dll</HintPath>
+    <Reference Include="Xamarin.UITest, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.UITest.2.0.0\lib\Xamarin.UITest.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.Android.UITests/packages.config
+++ b/Xamarin.Forms.Core.Android.UITests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="2.0.0-beta05" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -46,8 +46,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Xamarin.UITest">
-      <HintPath>..\packages\Xamarin.UITest.2.0.0-beta05\lib\Xamarin.UITest.dll</HintPath>
+    <Reference Include="Xamarin.UITest, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.UITest.2.0.0\lib\Xamarin.UITest.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.Windows.UITests/packages.config
+++ b/Xamarin.Forms.Core.Windows.UITests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="2.0.0-beta05" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
@@ -16,14 +16,23 @@ namespace Xamarin.Forms.Core.UITests
 	{
 		// TODO: Landscape tests
 
-		public static IApp App { get; private set; }
+		public static IApp App { get; set; }
 		public string PlatformViewType { get; protected set; }
-		public bool ShouldResetPerFixture { get; protected set; }
-		public AppRect ScreenBounds { get; private set; }
+		public static AppRect ScreenBounds { get; set; }
 
-		protected BaseTestFixture()
+		[TestFixtureTearDown]
+		protected virtual void FixtureTeardown()
 		{
-			ShouldResetPerFixture = true;
+		}
+
+		[SetUp]
+		protected virtual void TestSetup()
+		{
+		}
+
+		[TearDown]
+		protected virtual void TestTearDown()
+		{
 		}
 
 		protected abstract void NavigateToGallery();
@@ -33,50 +42,44 @@ namespace Xamarin.Forms.Core.UITests
 #pragma warning restore 618
 		protected virtual void FixtureSetup()
 		{
-			try
-			{
-				if (ShouldResetPerFixture)
-				{
-					RelaunchApp();
-				}
-			}
-			catch (Exception ex)
-			{
-				Debug.WriteLine(ex);
-				throw;
-			}
-		}
-
-#pragma warning disable 618
-		[TestFixtureTearDown]
-#pragma warning restore 618
-		protected virtual void FixtureTeardown()
-		{
-		}
-
-		[SetUp]
-		protected virtual void TestSetup()
-		{
-			if (!ShouldResetPerFixture)
-			{
-
-				RelaunchApp();
-			}
-		}
-
-		[TearDown]
-		protected virtual void TestTearDown()
-		{
-
-		}
-
-		void RelaunchApp()
-		{
-			App = null;
-			App = AppSetup.Setup();
-			App.SetOrientationPortrait();
-			ScreenBounds = App.RootViewRect();
+			ResetApp();
 			NavigateToGallery();
+		}
+
+		void ResetApp()
+		{
+#if __IOS__
+			App.Invoke("reset:", string.Empty);
+#endif
+#if __ANDROID__
+				App.Invoke("Reset");
+#endif
 		}
 	}
 }
+
+#if UITEST
+namespace Xamarin.Forms.Core.UITests
+{
+	using NUnit.Framework;
+
+	[SetUpFixture]
+	public class CoreUITestsSetup
+	{
+		[SetUp]
+		public void RunBeforeAnyTests()
+		{
+			LaunchApp();
+		}
+
+		void LaunchApp()
+		{
+			BaseTestFixture.App = null;
+			BaseTestFixture.App = AppSetup.Setup();
+
+			BaseTestFixture.App.SetOrientationPortrait();
+			BaseTestFixture.ScreenBounds = BaseTestFixture.App.RootViewRect();
+		}
+	}
+}
+#endif

--- a/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
@@ -43,6 +43,8 @@ namespace Xamarin.Forms.Core.UITests
 		protected virtual void FixtureSetup()
 		{
 			ResetApp();
+			// We need to wait for the main page to appear before we navigate to this fixture's gallery
+			App.WaitForElement(q => q.Marked("iOS Core Gallery"));
 			NavigateToGallery();
 		}
 
@@ -52,7 +54,7 @@ namespace Xamarin.Forms.Core.UITests
 			App.Invoke("reset:", string.Empty);
 #endif
 #if __ANDROID__
-				App.Invoke("Reset");
+			App.Invoke("Reset");
 #endif
 		}
 	}

--- a/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Core.UITests
 			NavigateToGallery();
 		}
 
-		void ResetApp()
+		protected void ResetApp()
 		{
 #if __IOS__
 			App.Invoke("reset:", string.Empty);

--- a/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
@@ -25,9 +25,29 @@ namespace Xamarin.Forms.Core.UITests
 		{
 		}
 
+		static int s_testsrun;
+		const int ConsecutiveTestLimit = 40;
+
+		// Until we get more of our memory leak issues worked out, restart the app 
+		// after a specified number of tests so we don't get bogged down in GC
+		public void EnsureMemory()
+		{
+			s_testsrun += 1;
+
+			if (s_testsrun >= ConsecutiveTestLimit)
+			{
+				s_testsrun = 0;
+
+				CoreUITestsSetup.LaunchApp();
+
+				FixtureSetup();
+			}
+		}
+
 		[SetUp]
 		protected virtual void TestSetup()
 		{
+			EnsureMemory();
 		}
 
 		[TearDown]
@@ -43,8 +63,6 @@ namespace Xamarin.Forms.Core.UITests
 		protected virtual void FixtureSetup()
 		{
 			ResetApp();
-			// We need to wait for the main page to appear before we navigate to this fixture's gallery
-			App.WaitForElement(q => q.Marked("iOS Core Gallery"));
 			NavigateToGallery();
 		}
 
@@ -74,7 +92,7 @@ namespace Xamarin.Forms.Core.UITests
 			LaunchApp();
 		}
 
-		void LaunchApp()
+		public static void LaunchApp()
 		{
 			BaseTestFixture.App = null;
 			BaseTestFixture.App = AppSetup.Setup();

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/AppearingUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/AppearingUITests.cs
@@ -8,7 +8,6 @@ namespace Xamarin.Forms.Core.UITests
 	{
 		public AppearingUITests ()
 		{
-			ShouldResetPerFixture = false;
 		}
 
 		protected override void NavigateToGallery ()

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/AppearingUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/AppearingUITests.cs
@@ -6,13 +6,20 @@ namespace Xamarin.Forms.Core.UITests
 	[Category(UITestCategories.LifeCycle)]
 	internal class AppearingUITests : BaseTestFixture
 	{
-		public AppearingUITests ()
+		public AppearingUITests()
 		{
 		}
 
 		protected override void NavigateToGallery ()
 		{
 			App.NavigateToGallery (GalleryQueries.AppearingGallery);
+		}
+
+		protected override void TestTearDown()
+		{
+			base.TestTearDown();
+			ResetApp();
+			NavigateToGallery();
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/ContextActionsUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/ContextActionsUITests.cs
@@ -45,12 +45,12 @@ namespace Xamarin.Forms.Core.UITests
 		public void ContextActionsDelete ()
 		{
 			// mark is an icon on android
-			App.TouchAndHold (q => q.Marked (cell0));
+			App.TouchAndHold (q => q.Marked (cell1));
 			App.WaitForElement (q => q.Marked (delete));
 			App.Screenshot ("I have actions!");
 
 			App.Tap (q => q.Marked (delete));
-			App.WaitForNoElement (q => q.Marked (cell0));
+			App.WaitForNoElement (q => q.Marked (cell1));
 			App.Screenshot ("Deleted cell 0");
 		}
 #endif

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/ContextActionsUITests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/ContextActionsUITests.cs
@@ -16,7 +16,6 @@ namespace Xamarin.Forms.Core.UITests
 
 		public ContextActionsListUITests ()
 		{
-			ShouldResetPerFixture = false;
 		}
 
 		protected override void NavigateToGallery ()
@@ -89,7 +88,6 @@ namespace Xamarin.Forms.Core.UITests
 	{
 		public ContextActionsTableUITests ()
 		{
-			ShouldResetPerFixture = false;
 		}
 
 		protected override void NavigateToGallery ()

--- a/Xamarin.Forms.Core.iOS.UITests/Tests/Legacy-UnevenListTests.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/Tests/Legacy-UnevenListTests.cs
@@ -10,7 +10,6 @@ namespace Xamarin.Forms.Core.UITests
 	{
 		public UnevenListTests ()
 		{
-			ShouldResetPerFixture = false;
 		}
 
 		protected override void NavigateToGallery ()

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -58,8 +58,9 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.UITest">
-      <HintPath>..\packages\Xamarin.UITest.2.0.0-beta05\lib\Xamarin.UITest.dll</HintPath>
+    <Reference Include="Xamarin.UITest, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.UITest.2.0.0\lib\Xamarin.UITest.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.iOS.UITests/packages.config
+++ b/Xamarin.Forms.Core.iOS.UITests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="2.0.0-beta05" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Threading;
+
 using System.Threading.Tasks;
 using Xamarin.Forms.Platform;
 

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Forms.Platform;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -107,7 +107,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewDidDisappear(bool animated)
 		{
 			base.ViewDidDisappear(animated);
-			PageController.SendDisappearing();
+			PageController?.SendDisappearing();
 		}
 
 		public override void ViewDidLayoutSubviews()

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -173,7 +173,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewDidDisappear(bool animated)
 		{
 			base.ViewDidDisappear(animated);
-			PageController.SendDisappearing();
+			PageController?.SendDisappearing();
 		}
 
 		public override void ViewDidLayoutSubviews()


### PR DESCRIPTION
These changes are aimed at running the UI test suite more quickly and efficiently.

- Update the UI Test package to 2.0.0 (from 2.0.0-beta5)
- Remove empty UI tests
- Fix race conditions in some tests which cause intermittent failures
- Consolidate Issues UI tests to the "Issues" namespace
- Update the base test fixtures to launch a single instance of the ControlGallery to run tests against 
- Fix up some tests which don't behave well when run before/after other tests
- Add exported back door method to navigate to Issues tests without going through the "enter text into search box, hit search button" process 

Most of the changed files are simply namespace moves; by putting all of the "issues" under a single namespace, we can run a single NUnit `SetUpFixture` to install and launch the ControlGallery and then run all the "issues" tests against that single instance, rather than shutting down and restarting the ControlGallery between every single test. This drastically shortens the length of a test run.

The rest of the changes to issues are either bug fixes, removal of empty tests, or adjustments to make the tests work well when run in sequence (rather than in complete isolation as they did before).

The main changes are to `TestPages.cs`, `BaseTestFixture.cs`, and `App.cs`.  

