### PR TITLE
[Android] Do not show cell context actions if input views are long clicked

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46630.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46630.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 46630, "Issue Description", PlatformAffected.Android)]
+	public class Bugzilla46630 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new ListView
+			{
+				HasUnevenRows = true,
+				ItemsSource = new List<int> { 0 },
+				ItemTemplate = new DataTemplate(() => new ViewCell
+				{
+					Height = 300,
+					ContextActions =
+					{
+						new MenuItem {Text = "Action1"},
+						new MenuItem {Text = "Action2"}
+					},
+					View = new StackLayout
+					{
+						Orientation = StackOrientation.Vertical,
+						Spacing = 10,
+						HorizontalOptions = LayoutOptions.FillAndExpand,
+						Padding = 10,
+						Children =
+						{
+							new Label { HeightRequest = 50, BackgroundColor = Color.Coral, Text = "Long click each cell. Input views should not display context actions."},
+							new Editor { HeightRequest = 50, BackgroundColor = Color.Bisque, Text = "Editor"},
+							new Entry { HeightRequest = 50, BackgroundColor = Color.Aqua, Text = "Entry"},
+							new SearchBar { HeightRequest = 50, BackgroundColor = Color.CornflowerBlue, Text = "SearchBar"},
+							new Grid { HeightRequest = 50, BackgroundColor = Color.PaleVioletRed}
+						}
+					}
+				})
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -138,6 +138,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46630.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -214,6 +214,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool HandleContextMode(AView view, int position)
 		{
+			if (view is EditorEditText || view is EditText || view is TextView || view is SearchView)
+				return false;
+
 			Cell cell = GetCellForPosition(position);
 
 			if (cell == null)

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -214,7 +214,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool HandleContextMode(AView view, int position)
 		{
-			if (view is EditorEditText || view is EditText || view is TextView || view is SearchView)
+			if (view is EditText || view is TextView || view is SearchView)
 				return false;
 
 			Cell cell = GetCellForPosition(position);


### PR DESCRIPTION
### Description of Change ###

Input views do not trap long clicks to show their editor context menus. Instead, cell context actions are shown. Please let me know if this needs to be a platform specific option or default expected behavior.

P.S. There seems to be an issue with `SearchBar` not getting focus when placed in a cell. When testing the sample code, make sure to give focus to other input views before long clicking `SearchBar`. There should be another bug for this.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=46630

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

