### PR TITLE
[iOS/Android] Move Map camera to correct region on layout change

### DIFF
--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -186,6 +186,7 @@ namespace Xamarin.Forms.Maps.Android
 			else if (changed)
 			{
 				UpdateVisibleRegion(NativeMap.CameraPosition.Target);
+				MoveToRegion(Element.LastMoveToRegion, false);
 			}
 		}
 

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Forms.Maps.iOS
 				UpdateHasScrollEnabled();
 			else if (e.PropertyName == Map.HasZoomEnabledProperty.PropertyName)
 				UpdateHasZoomEnabled();
-			else if ((e.PropertyName == VisualElement.IsVisibleProperty.PropertyName || e.PropertyName == VisualElement.HeightProperty.PropertyName) && ((Map)Element).LastMoveToRegion != null)
+			else if (e.PropertyName == VisualElement.HeightProperty.PropertyName && ((Map)Element).LastMoveToRegion != null)
 				_shouldUpdateRegion = true;
 		}
 

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Forms.Maps.iOS
 				UpdateHasScrollEnabled();
 			else if (e.PropertyName == Map.HasZoomEnabledProperty.PropertyName)
 				UpdateHasZoomEnabled();
-			else if (e.PropertyName == VisualElement.IsVisibleProperty.PropertyName && ((Map)Element).LastMoveToRegion != null)
+			else if ((e.PropertyName == VisualElement.IsVisibleProperty.PropertyName || e.PropertyName == VisualElement.HeightProperty.PropertyName) && ((Map)Element).LastMoveToRegion != null)
 				_shouldUpdateRegion = true;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Move to correct region when `Map` control changes layout. Ref #172.

The repro attached to the bug has two maps in a vertical StackLayout. The second one is invisible on load and made visible on button click. Both maps should have the same camera view when visible; however, the first one is not re-adjusting its view region when control layout changes.

@rmarinho I don't believe checking visibility change on the second map on iOS is the right approach. For now, I removed it. I also ran `Bugzilla38284` on Android device and confirmed that it's not working as it is.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=38284
- https://bugzilla.xamarin.com/show_bug.cgi?id=43639 (possibly. There is no repro there, so I can't decide if it represents the same or a different bug.)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

