### PR TITLE
Fix broken alerts for iPad

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -186,7 +186,7 @@ namespace Xamarin.Forms.Controls
 		}
 
 		static int s_testsrun;
-		const int ConsecutiveTestLimit = 30;
+		const int ConsecutiveTestLimit = 10;
 
 		// Until we get more of our memory leak issues worked out, restart the app 
 		// after a specified number of tests so we don't get bogged down in GC

--- a/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Core.UITests
 		}
 
 		static int s_testsrun;
-		const int ConsecutiveTestLimit = 30;
+		const int ConsecutiveTestLimit = 10;
 
 		// Until we get more of our memory leak issues worked out, restart the app 
 		// after a specified number of tests so we don't get bogged down in GC 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (Forms.IsiOS8OrNewer)
 				{
-					PresentAlert(arguments, pageRenderer);
+					PresentAlert(arguments);
 				}
 				else
 				{
@@ -419,7 +419,7 @@ namespace Xamarin.Forms.Platform.iOS
 			PresentAlert(window, alert);
 		}
 
-		void PresentAlert(ActionSheetArguments arguments, IVisualElementRenderer pageRenderer)
+		void PresentAlert(ActionSheetArguments arguments)
 		{
 			var alert = UIAlertController.Create(arguments.Title, null, UIAlertControllerStyle.ActionSheet);
 			var window = new UIWindow { BackgroundColor = Color.Transparent.ToUIColor() };
@@ -454,7 +454,7 @@ namespace Xamarin.Forms.Platform.iOS
 			window.WindowLevel = UIWindowLevel.Alert + 1;
 			window.MakeKeyAndVisible();
 
-			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad && arguments != null)
 			{
 				UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
 				var observer = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification,

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -444,11 +444,21 @@ namespace Xamarin.Forms.Platform.iOS
 				alert.AddAction(CreateActionWithWindowHide(blabel, UIAlertActionStyle.Default, () => arguments.SetResult(blabel), window));
 			}
 
+			PresentAlert(window, alert, arguments);
+		}
+
+		static void PresentAlert(UIWindow window, UIAlertController alert, ActionSheetArguments arguments = null)
+		{
+			window.RootViewController = new UIViewController();
+			window.RootViewController.View.BackgroundColor = Color.Transparent.ToUIColor();
+			window.WindowLevel = UIWindowLevel.Alert + 1;
+			window.MakeKeyAndVisible();
+
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
 			{
 				UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
 				var observer = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification,
-					n => { alert.PopoverPresentationController.SourceRect = pageRenderer.ViewController.View.Bounds; });
+					n => { alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds; });
 
 				arguments.Result.Task.ContinueWith(t =>
 				{
@@ -456,20 +466,11 @@ namespace Xamarin.Forms.Platform.iOS
 					UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
 				}, TaskScheduler.FromCurrentSynchronizationContext());
 
-				alert.PopoverPresentationController.SourceView = pageRenderer.ViewController.View;
-				alert.PopoverPresentationController.SourceRect = pageRenderer.ViewController.View.Bounds;
+				alert.PopoverPresentationController.SourceView = window.RootViewController.View;
+				alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds;
 				alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
 			}
 
-			PresentAlert(window, alert);
-		}
-
-		static void PresentAlert(UIWindow window, UIAlertController alert)
-		{
-			window.RootViewController = new UIViewController();
-			window.RootViewController.View.BackgroundColor = Color.Transparent.ToUIColor();
-			window.WindowLevel = UIWindowLevel.Alert + 1;
-			window.MakeKeyAndVisible();
 			window.RootViewController.PresentViewController(alert, true, null);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fix the iPad version of the issues addressed with [PR 543](https://github.com/xamarin/Xamarin.Forms/pull/543).

### Bugs Fixed ###

- Can't dismiss action sheets on iPad

