### PR TITLE
Adding some restart logic to the UI tests if navigation fails

### DIFF
--- a/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/BaseTestFixture.cs
@@ -63,7 +63,40 @@ namespace Xamarin.Forms.Core.UITests
 		protected virtual void FixtureSetup()
 		{
 			ResetApp();
-			NavigateToGallery();
+
+			int maxAttempts = 2;
+			int attempts = 0;
+
+			while (attempts < maxAttempts)
+			{
+				attempts += 1;
+				try
+				{
+					NavigateToGallery();
+					return;
+				}
+				catch (Exception ex)
+				{
+					var debugMessage = $"NavigateToGallery failed: {ex}";
+
+					Debug.WriteLine(debugMessage);
+					Console.WriteLine(debugMessage);
+
+					if (attempts < maxAttempts)
+					{
+						// Something has failed and we're stuck in a place where we can't navigate
+						// to the test. Usually this is because we're getting network/HTTP errors 
+						// communicating with the server on the device. So we'll try restarting the app.
+						CoreUITestsSetup.LaunchApp();
+					}
+					else
+					{
+						// But if it's still not working after [maxAttempts], we've got assume this is a legit
+						// problem that restarting won't fix
+						throw;
+					}
+				}
+			}
 		}
 
 		protected void ResetApp()


### PR DESCRIPTION
### Description of Change ###

Restarts the application if the navigation fails because of a Test Cloud issue (e.g., server issues on the device).