### PR TITLE
Clear attached properties when views are being disposed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44074.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44074.cs
@@ -1,0 +1,89 @@
+﻿using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44074, "OnDetachingFrom for Behavior is never called, therefore memory can leak due to event handlers not being unbound", PlatformAffected.All)]
+	public class Bugzilla44074 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var cp = new ContentPage();
+			var sl = new StackLayout { Padding = 20 };
+
+			var label = new Label
+			{
+				Text = "This is the first page with no behaviors",
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center
+			};
+			sl.Children.Add(label);
+
+			var button = new Button
+			{
+				Text = "Open Behavior View",
+				Command = new Command(() => { Navigation.PushAsync(new TestSecondPage()); })
+			};
+			sl.Children.Add(button);
+
+			cp.Content = sl;
+			PushAsync(cp);
+		}
+	}
+
+	public class TestSecondPage : ContentPage
+	{
+		public TestSecondPage()
+		{
+			var sl = new StackLayout { Padding = 20 };
+
+			var label = new Label
+			{
+				Text = "This is the Second Page with a Behavior Attached",
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center
+			};
+			label.Behaviors.Add(new BehaviorTestEvents());
+			sl.Children.Add(label);
+
+			var button = new Button
+			{
+				Text = "Open initial view",
+				Command = new Command(() => { Navigation.PopAsync(); })
+			};
+			sl.Children.Add(button);
+
+			Content = sl;
+		}
+	}
+
+	public class BehaviorTestEvents : Behavior<View>
+	{
+		protected override void OnAttachedTo(View bindable)
+		{
+			base.OnAttachedTo(bindable);
+
+			Debug.WriteLine("OnAttached");
+		}
+
+		protected override void OnDetachingFrom(View bindable)
+		{
+			base.OnDetachingFrom(bindable);
+
+			Debug.WriteLine("OnDetachingFrom");
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -128,6 +128,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43663.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44074.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44944.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />

--- a/Xamarin.Forms.Core/Interactivity/AttachedCollection.cs
+++ b/Xamarin.Forms.Core/Interactivity/AttachedCollection.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 
 namespace Xamarin.Forms
 {
-	internal class AttachedCollection<T> : ObservableCollection<T>, ICollection<T>, IAttachedObject where T : BindableObject, IAttachedObject
+	internal class AttachedCollection<T> : ObservableCollection<T>, IAttachedObject where T : BindableObject, IAttachedObject
 	{
 		readonly List<WeakReference> _associatedObjects = new List<WeakReference>();
 

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -92,10 +92,16 @@ namespace Xamarin.Forms.Platform.Android
 					_container = null;
 				}
 
-				if (Element != null && _focusChangeHandler != null)
+				if (Element != null)
 				{
-					Element.FocusChangeRequested -= _focusChangeHandler;
-					_focusChangeHandler = null;
+					Element.Behaviors?.Clear();
+					Element.Triggers?.Clear();
+
+					if (_focusChangeHandler != null)
+					{
+						Element.FocusChangeRequested -= _focusChangeHandler;
+						_focusChangeHandler = null;
+					}
 				}
 
 				_disposed = true;


### PR DESCRIPTION
### Description of Change ###

When views are being disposed, attached properties are not cleared, which in turn does not raise `DetachFrom` events on behaviors.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44074

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
