### PR TITLE
[C] detach Behaviors and Triggers on VE finalization

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -163,6 +163,14 @@ namespace Xamarin.Forms
 			return bpcontext != null && bpcontext.Binding != null;
 		}
 
+		internal bool GetIsDefault(BindableProperty targetProperty)
+		{
+			if (targetProperty == null)
+				throw new ArgumentNullException(nameof(targetProperty));
+
+			return GetContext(targetProperty) == null;
+		}
+
 		internal object[] GetValues(BindableProperty property0, BindableProperty property1)
 		{
 			var values = new object[2];

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -781,5 +781,18 @@ namespace Xamarin.Forms
 
 			public bool Result { get; set; }
 		}
+
+		~VisualElement()
+		{
+			if (!GetIsDefault(BehaviorsProperty)) {
+				var behaviors = GetValue(BehaviorsProperty) as AttachedCollection<Behavior>;
+				behaviors.DetachFrom(this);
+			}
+
+			if (!GetIsDefault(TriggersProperty)) {
+				var triggers = GetValue(TriggersProperty) as AttachedCollection<Trigger>;
+				triggers.DetachFrom(this);
+			}
+		}
 	}
 }

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
@@ -290,6 +290,22 @@
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="Finalize">
+      <MemberSignature Language="C#" Value="~VisualElement ();" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void Finalize() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Focus">
       <MemberSignature Language="C#" Value="public bool Focus ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance bool Focus() cil managed" />


### PR DESCRIPTION
### Description of Change ###

Detach Triggers and Behaviors on VE finalizer, because they're not IDisposable...

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44074

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
