### PR TITLE
[UWP]Track user location when IsShowingUser enabled

### DIFF
--- a/Xamarin.Forms.Maps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.UWP/MapRenderer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Windows.Devices.Geolocation;
 using Windows.UI;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Maps;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
@@ -85,6 +86,9 @@ namespace Xamarin.Forms.Maps.WinRT
 			{
 				_disposed = true;
 
+				_timer?.Stop();
+				_timer = null;
+
 				MessagingCenter.Unsubscribe<Map, MapSpan>(this, "MapMoveToRegion");
 
 				if (Element != null)
@@ -96,6 +100,7 @@ namespace Xamarin.Forms.Maps.WinRT
 		bool _disposed;
 		bool _firstZoomLevelChangeFired;
 		Ellipse _userPositionCircle;
+		DispatcherTimer _timer;
 
 		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
@@ -155,8 +160,9 @@ namespace Xamarin.Forms.Maps.WinRT
 			Control.Children.Add(new PushPin(pin));
 		}
 
-		async Task UpdateIsShowingUser()
+		async Task UpdateIsShowingUser(bool moveToLocation = true)
 		{
+			
 			if (Element.IsShowingUser)
 			{
 				var myGeolocator = new Geolocator();
@@ -165,11 +171,24 @@ namespace Xamarin.Forms.Maps.WinRT
 				{
 					var userPosition = await myGeolocator.GetGeopositionAsync();
 					if (userPosition?.Coordinate != null)
-						LoadUserPosition(userPosition.Coordinate, true);
+						LoadUserPosition(userPosition.Coordinate, moveToLocation);
 				}
+
+				if (_timer == null)
+				{
+					_timer = new DispatcherTimer();
+					_timer.Tick += async (s, o) => await UpdateIsShowingUser(moveToLocation: false);
+					_timer.Interval = TimeSpan.FromSeconds(15);
+				}
+				
+				if (!_timer.IsEnabled)
+					_timer.Start();
 			}
 			else if (_userPositionCircle != null && Control.Children.Contains(_userPositionCircle))
+			{
+				_timer?.Stop();
 				Control.Children.Remove(_userPositionCircle);
+			}
 		}
 
 		async Task MoveToRegion(MapSpan span, MapAnimationKind animation = MapAnimationKind.Bow)


### PR DESCRIPTION
### Description of Change ###

Add location tracker for UWP maps. Every 15 seconds we will update the users location.

### Bugs Fixed ###

- Private report

### API Changes ###

None

### Behavioral Changes ###

When walking around while using a uwp app the user location dot will now follow the user.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

