### PR TITLE
Fix weak references when getting targets

### DIFF
--- a/Xamarin.Forms.Core/MessagingCenter.cs
+++ b/Xamarin.Forms.Core/MessagingCenter.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Forms
 			List<Tuple<WeakReference, Action<object, object>>> actionsCopy = actions.ToList();
 			foreach (Tuple<WeakReference, Action<object, object>> action in actionsCopy)
 			{
-				if (action.Item1.IsAlive && actions.Contains(action))
+				if (action.Item1.Target != null && actions.Contains(action))
 					action.Item2(sender, args);
 			}
 		}

--- a/Xamarin.Forms.Pages/DataSourceBinding.cs
+++ b/Xamarin.Forms.Pages/DataSourceBinding.cs
@@ -120,11 +120,8 @@ namespace Xamarin.Forms.Pages
 		{
 			base.Unapply();
 
-			if (_dataSourceRef != null && _dataSourceRef.IsAlive)
-			{
-				var dataSourceProviderer = (IDataSourceProvider)_dataSourceRef.Target;
-				dataSourceProviderer?.UnmaskKey(_path);
-			}
+			var dataSourceProviderer = (IDataSourceProvider)_dataSourceRef?.Target;
+			dataSourceProviderer?.UnmaskKey(_path);
 
 			_expression?.Unapply();
 		}

--- a/Xamarin.Forms.Platform.WP8/NavigationMenuRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/NavigationMenuRenderer.cs
@@ -72,8 +72,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 				var weakRef = new WeakReference(hubTile);
 				SizeChanged += (sender, args) =>
 				{
-					if (weakRef.IsAlive)
-						((HubTile)weakRef.Target).Size = GetSize();
+					var hTile = (HubTile)weakRef.Target;
+					if (hTile != null)
+						hTile.Size = GetSize();
 					((IVisualElementController)Element).NativeSizeChanged();
 				};
 


### PR DESCRIPTION
### Description of Change ###

When using `WeakReference`, one should not rely on `IsAlive` when it returns true as it could mean one of two things and we don't know which one. For more info, see bug description as well as the links in it.

It appears that XF is using a mix of `WeakReference` (.NET 1.1) and `WeakReference<T>` (4.5). For future references, `WeakReference` should probably be banned from being used.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=47203

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

