### PR TITLE
[Android] Fix NRE in packager dispose

### DIFF
--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -52,10 +52,13 @@ namespace Xamarin.Forms.Platform.Android
 					_childViews = null;
 				}
 
-				_renderer.Element.ChildAdded -= _childAddedHandler;
-				_renderer.Element.ChildRemoved -= _childRemovedHandler;
+				if (_renderer.Element != null)
+				{
+					_renderer.Element.ChildAdded -= _childAddedHandler;
+					_renderer.Element.ChildRemoved -= _childRemovedHandler;
 
-				_renderer.Element.ChildrenReordered -= _childReorderedHandler;
+					_renderer.Element.ChildrenReordered -= _childReorderedHandler;
+				}
 				_renderer = null;
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

When `VisualElementPackager` is disposing itself, it doesn't check if its element is null. You could run the attached repro in the bug description and see that the user is nullifying `Element` and then disposing the packager.

```
protected override void Dispose(bool disposing)
{
	if (disposing)
	{
		this.SetElement((VisualElement) null);
		if (this.Packager != null) {

			// exception
			this.Packager.Dispose ();
			this.Packager = null;
		}

		this.Tracker.Dispose();
		this.Tracker = (VisualElementTracker) null;
	}

	base.Dispose(disposing);
}
```

This change is in line with the UAP counterpart. iOS side doesn't use `Element` after setting it to null.

P.S. I'm not sure why iOS seems to be the only platform that sets `Element` to null. Was this on purpose?

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=39228

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

