### PR TITLE
[XamlC] support non-generic IMarkup on ABPs

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz47950.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz47950.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Bz47950">
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<Color x:Key="MyColor">#c2d1d3</Color>
+		</ResourceDictionary>
+	</ContentPage.Resources>
+	<Label x:Name="label" local:Bz47950Behavior.ColorTest="{StaticResource MyColor}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz47950.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz47950.xaml.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Bz47950Behavior : Behavior<View>
+	{
+		public static readonly BindableProperty ColorTestProperty =
+			BindableProperty.CreateAttached("ColorTest", typeof(Color), typeof(View), default(Color));
+
+		public static Color GetColorTest(BindableObject bindable) => (Color)bindable.GetValue(ColorTestProperty);
+		public static void SetColorTest(BindableObject bindable, Color value) => bindable.SetValue(ColorTestProperty, value);
+	}
+
+	public partial class Bz47950 : ContentPage
+	{
+		public Bz47950()
+		{
+			InitializeComponent();
+		}
+
+		public Bz47950(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true)]
+			[TestCase(false)]
+			public void BehaviorAndStaticResource(bool useCompiledXaml)
+			{
+				var page = new Bz47950(useCompiledXaml);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported004.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported004.xaml.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TestCase(true), TestCase(false)]
 			public void MultipleGetMethodsAllowed(bool useCompiledXaml)
 			{
-				var page = new Unreported004();
+				var page = new Unreported004(useCompiledXaml);
 				Assert.NotNull(page.label);
 				Assert.AreEqual("foo", GetSomeProperty(page.label));
 			}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported005.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported005.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Unreported005">
+	<RelativeLayout>
+		<Label x:Name="before" />
+		<Button x:Name="after"
+				RelativeLayout.XConstraint="{local:Unreported005RelativeToViewHorizontal ElementName=before, Constant=105}" />
+    
+	</RelativeLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported005.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported005.xaml.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public abstract class Unreported005RelativeToView : IMarkupExtension
+	{
+		protected Unreported005RelativeToView()
+		{
+			Factor = 1;
+		}
+
+		public string ElementName { get; set; }
+
+		public double Factor { get; set; }
+
+		public double Constant { get; set; }
+
+		public object ProvideValue(IServiceProvider serviceProvider)
+		{
+			var element = new ReferenceExtension { Name = ElementName }.ProvideValue(serviceProvider) as View;
+			if (element != null) {
+				var result = Constraint.RelativeToView(element, (layout, view) => DeterminePosition(view) + Constant);
+				return result;
+			}
+			return null;
+		}
+
+		protected virtual double DeterminePosition(VisualElement view)
+		{
+			var result = DetermineStart(view) + DetermineExtent(view) * Factor;
+			return result;
+		}
+
+		protected abstract double DetermineExtent(VisualElement view);
+
+		protected abstract double DetermineStart(VisualElement view);
+	}
+
+	public class Unreported005RelativeToViewHorizontal : Unreported005RelativeToView
+	{
+		protected override double DetermineExtent(VisualElement view)
+		{
+			return view.Width;
+		}
+
+		protected override double DetermineStart(VisualElement view)
+		{
+			return view.X;
+		}
+	}
+
+	//[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Unreported005 : ContentPage
+	{
+		public Unreported005()
+		{
+			InitializeComponent();
+		}
+
+		public Unreported005(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true), TestCase(false)]
+			public void CustomMarkupExtensionWorks(bool useCompiledXaml)
+			{
+				var page = new Unreported005(useCompiledXaml);
+				Assert.That(RelativeLayout.GetXConstraint(page.after), Is.TypeOf<Constraint>());
+				Assert.NotNull(RelativeLayout.GetXConstraint(page.after));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -373,6 +373,9 @@
     <Compile Include="BindingsCompiler.xaml.cs">
       <DependentUpon>BindingsCompiler.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Unreported005.xaml.cs">
+      <DependentUpon>Unreported005.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -665,6 +668,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="BindingsCompiler.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Unreported005.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -376,6 +376,9 @@
     <Compile Include="Issues\Unreported005.xaml.cs">
       <DependentUpon>Unreported005.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz47950.xaml.cs">
+      <DependentUpon>Bz47950.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -671,6 +674,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Unreported005.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz47950.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

see the title, there ^^^

note: this might be a slight regression, but implementing `IMarkupExtension<T>` is a valid workaround

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=47950
- https://forums.xamarin.com/discussion/83236/no-property-bindable-property-or-event-found-for-yconstraint-after-update-to-forms-2-3-3-168

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
