### PR TITLE
[WinRT] Do not store previous page when popping

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -427,7 +427,9 @@ namespace Xamarin.Forms.Platform.WinRT
 				_currentPage.PropertyChanged -= OnCurrentPagePropertyChanged;
 			}
 
-			_previousPage = _currentPage;
+			if (!isPopping)
+				_previousPage = _currentPage;
+
 			_currentPage = page;
 
 			if (page == null)


### PR DESCRIPTION
### Description of Change ###

Moved the change that was in #518 to a separate PR for clarity. On WinRT, the previous page value will no longer be stored when popping.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=45593

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

