### PR TITLE
[XamlC] assigned derived type to generic BP

### DIFF
--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -84,6 +84,9 @@ namespace Xamarin.Forms.Build.Tasks
 
 		public static bool InheritsFromOrImplements(this TypeReference typeRef, TypeReference baseClass)
 		{
+			if (typeRef.FullName == baseClass.FullName)
+				return true;
+
 			var arrayInterfaces = new[]
 			{
 				"System.IEnumerable",

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz48554.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz48554.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Bz48554">
+	<local:Bz48554Slider
+		x:Name="SliderGrades"
+		Values="{x:Static local:Bz48554View.All}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz48554.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz48554.xaml.cs
@@ -58,8 +58,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TestCase(false)]
 			public void XStaticWithXamlC(bool useCompiledXaml)
 			{
-				if (useCompiledXaml)
-					MockCompiler.Compile(typeof(Bz48554));
 				Bz48554 page = null;
 				Assert.DoesNotThrow(()=> page = new Bz48554(useCompiledXaml));
 				Assert.NotNull(page.SliderGrades);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz48554.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz48554.xaml.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Input;
+using NUnit.Framework;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Bz48554View
+	{
+		static List<string> all;
+
+		public static List<string> All {
+			get {
+				if (all == null) {
+					all = new List<string>();
+					all.Add("6b+");
+					all.Add("6c");
+					all.Add("6c+");
+					all.Add("7a");
+					all.Add("7a+");
+				}
+				return all;
+			}
+			set {
+				all = value;
+			}
+		}
+	}
+
+	public class Bz48554Slider : View
+	{
+		public static readonly BindableProperty ValuesProperty =
+			BindableProperty.Create(nameof(Values), typeof(List<string>), typeof(Bz48554Slider), null);
+
+		public List<string> Values {
+			get { return (List<string>)GetValue(ValuesProperty); }
+			set { SetValue(ValuesProperty, value); }
+		}
+	}
+
+	public partial class Bz48554 : ContentPage
+	{
+		public Bz48554()
+		{
+			InitializeComponent();
+		}
+
+		public Bz48554(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true)]
+			[TestCase(false)]
+			public void XStaticWithXamlC(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(Bz48554));
+				Bz48554 page = null;
+				Assert.DoesNotThrow(()=> page = new Bz48554(useCompiledXaml));
+				Assert.NotNull(page.SliderGrades);
+				Assert.AreEqual(5, page.SliderGrades.Values.Count);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported006.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported006.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Unreported006">
+	<local:Unreported006.GenericProperty>
+		<StackLayout/>
+	</local:Unreported006.GenericProperty>
+	<ContentPage.Content>
+	</ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported006.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported006.xaml.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Unreported006 : ContentPage
+	{
+		public Unreported006()
+		{
+			InitializeComponent();
+		}
+
+		public Unreported006(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		public Layout<View> GenericProperty {
+			get { return (Layout<View>)GetValue(GenericPropertyProperty); }
+			set { SetValue(GenericPropertyProperty, value); }
+		}
+
+		public static readonly BindableProperty GenericPropertyProperty =
+			BindableProperty.Create(nameof(GenericProperty), typeof(Layout<View>), typeof(Unreported006));
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true), TestCase(false)]
+			public void CanAssignGenericBP(bool useCompiledXaml)
+			{
+				var page = new Unreported006();
+				Assert.NotNull(page.GenericProperty);
+				Assert.That(page.GenericProperty, Is.TypeOf<StackLayout>());
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -382,6 +382,9 @@
     <Compile Include="Issues\Unreported006.xaml.cs">
       <DependentUpon>Unreported006.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz48554.xaml.cs">
+      <DependentUpon>Bz48554.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -683,6 +686,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Unreported006.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz48554.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -379,6 +379,9 @@
     <Compile Include="Issues\Bz47950.xaml.cs">
       <DependentUpon>Bz47950.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Unreported006.xaml.cs">
+      <DependentUpon>Unreported006.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -677,6 +680,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz47950.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Unreported006.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

[XamlC] assigned derived type to generic BP

This isn't ironclad fix, but does the job for the reported case

Note: possible regression on 2.3.3

### Bugs Fixed ###

- https://forums.xamarin.com/discussion/comment/236161/#Comment_236161
- https://bugzilla.xamarin.com/show_bug.cgi?id=48554

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
