### PR TITLE
[Android] Fix issue with the use of null propagation operator

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ConditionalFocusLayout.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ConditionalFocusLayout.cs
@@ -26,11 +26,11 @@ namespace Xamarin.Forms.Platform.Android
 			(aView as EntryCellView)?.EditText.SetOnTouchListener(this);
 
 			var viewCell = item as ViewCell;
-			if (viewCell == null || viewCell?.View == null)
+			if (viewCell?.View == null)
 				return;
 
 			IVisualElementRenderer renderer = Platform.GetRenderer(viewCell.View);
-			if (renderer?.ViewGroup?.ChildCount != 0)
+			if (renderer?.ViewGroup != null && renderer.ViewGroup.ChildCount != 0)
 				(renderer.ViewGroup.GetChildAt(0) as EditText)?.SetOnTouchListener(this);
 
 			foreach (Element descendant in viewCell.View.Descendants())
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (element == null)
 					continue;
 				renderer = Platform.GetRenderer(element);
-				if (renderer?.ViewGroup?.ChildCount == 0)
+				if (renderer?.ViewGroup == null || renderer.ViewGroup.ChildCount == 0)
 					continue;
 				(renderer.ViewGroup.GetChildAt(0) as EditText)?.SetOnTouchListener(this);
 			}


### PR DESCRIPTION
### Description of Change ###

When propagating null checks using `?` and accessing a property, one should give the expression a default value or else an NRE can be thrown.

`renderer?.ViewGroup?.ChildCount != 0` throws an exception when `renderer` is null. To fix this, we could default the expression to `0` like so:

`(renderer?.ViewGroup?.ChildCount ?? 0) != 0`

or use old-school null checks. I chose the second option because ReSharper isn't smart enough to remove the squiggly line under `renderer`.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=38989

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

