### PR TITLE
[Android] Dismiss context menu when view cell is removed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36846.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36846.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 36846, "ActionBar does not dismiss when content which called it is removed", PlatformAffected.Android)]
+	public class Bugzilla36846 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			PushAsync(new ListWithLongPress());
+		}
+	}
+
+	public class ListWithLongPress : ContentPage
+	{
+		public ObservableCollection<string> MyCollection { get; set; }
+
+		public ListWithLongPress()
+		{
+			MyCollection = new ObservableCollection<string>();
+			PopulateCollection();
+
+			var stackLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical
+			};
+
+			var listView = new ListView
+			{
+				HasUnevenRows = true,
+				ItemsSource = MyCollection,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var viewCell = new ViewCell();
+
+					var grid = new Grid
+					{
+						Padding = new Thickness(0, 5, 0, 5),
+						RowSpacing = 3
+					};
+
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding("."));
+					grid.Children.Add(label);
+
+					viewCell.ContextActions.Add(new MenuItem { Text = "Edit" });
+					viewCell.ContextActions.Add(new MenuItem { Text = "Delete", IsDestructive = true });
+
+					viewCell.View = grid;
+
+					return viewCell;
+				})
+			};
+			stackLayout.Children.Add(listView);
+
+			var button1 = new Button
+			{
+				Text = "Clear list",
+				Command = new Command(() => { MyCollection.Clear(); })
+			};
+			stackLayout.Children.Add(button1);
+
+			var button2 = new Button
+			{
+				Text = "Remove last item",
+				Command = new Command(() =>
+				{
+					if (MyCollection.Count > 0)
+						MyCollection.RemoveAt(MyCollection.Count - 1);
+				})
+			};
+			stackLayout.Children.Add(button2);
+
+			var button3 = new Button
+			{
+				Text = "Load items",
+				Command = new Command(PopulateCollection)
+			};
+			stackLayout.Children.Add(button3);
+
+			Content = stackLayout;
+		}
+
+		void PopulateCollection()
+		{
+			for (var i = 0; i < 10; i++)
+			{
+				MyCollection.Add("This is a Dummy Item #" + i);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -73,6 +73,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36559.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36171.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36846.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37462.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37841.cs" />

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -176,10 +176,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal void CloseContextAction()
 		{
-			if (_actionMode != null)
-				_actionMode.Finish();
-			if (_supportActionMode != null)
-				_supportActionMode.Finish();
+			_actionMode?.Finish();
+			_supportActionMode?.Finish();
 		}
 
 		void CreateContextMenu(IMenu menu)
@@ -226,8 +224,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (!cell.HasContextActions)
 				{
-					_actionMode?.Finish();
-					_supportActionMode?.Finish();
+					CloseContextAction();
 					return false;
 				}
 

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -174,7 +174,7 @@ namespace Xamarin.Forms.Platform.Android
 			view.SetBackgroundResource(0);
 		}
 
-		internal void CloseContextAction()
+		internal void CloseContextActions()
 		{
 			_actionMode?.Finish();
 			_supportActionMode?.Finish();
@@ -224,7 +224,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (!cell.HasContextActions)
 				{
-					CloseContextAction();
+					CloseContextActions();
 					return false;
 				}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -54,9 +54,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			var platform = _listView.Platform;
 			if (platform.GetType() == typeof(AppCompat.Platform))
-				MessagingCenter.Subscribe<AppCompat.Platform>(this, AppCompat.Platform.CloseContextActionsSignalName, p => CloseContextAction());
+				MessagingCenter.Subscribe<AppCompat.Platform>(this, AppCompat.Platform.CloseContextActionsSignalName, p => CloseContextActions());
 			else
-				MessagingCenter.Subscribe<Platform>(this, Platform.CloseContextActionsSignalName, p => CloseContextAction());
+				MessagingCenter.Subscribe<Platform>(this, Platform.CloseContextActionsSignalName, p => CloseContextActions());
 		}
 
 		public override int Count
@@ -321,7 +321,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (disposing)
 			{
-				CloseContextAction();
+				CloseContextActions();
 
 				var platform = _listView.Platform;
 				if (platform.GetType() == typeof(AppCompat.Platform))
@@ -446,7 +446,7 @@ namespace Xamarin.Forms.Platform.Android
 		void OnDataChanged()
 		{
 			if (ActionModeContext != null && !TemplatedItemsView.TemplatedItems.Contains(ActionModeContext))
-				CloseContextAction();
+				CloseContextActions();
 
 			if (IsAttachedToWindow)
 				NotifyDataSetChanged();

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -445,6 +445,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnDataChanged()
 		{
+			if (ActionModeContext != null && !TemplatedItemsView.TemplatedItems.Contains(ActionModeContext))
+				CloseContextAction();
+
 			if (IsAttachedToWindow)
 				NotifyDataSetChanged();
 			else


### PR DESCRIPTION
### Description of Change ###

If a `ListView` cell is removed from the items source and its context menu was visible, the menu stayed visible. This PR will close the context menu when the cell is no longer available.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=36846

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

