### PR TITLE
[iOS] Avoid using DrawRect on base VisualElementRenderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48158.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48158.cs
@@ -6,12 +6,6 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-// Apply the default category of "Issues" to all of the tests in this assembly
-// We use this as a catch-all for tests which haven't been individually categorized
-#if UITEST
-[assembly: NUnit.Framework.Category("Issues")]
-#endif
-
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48158.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48158.cs
@@ -1,0 +1,35 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 48158, "Hidden controls become transparent, needs manual verification", PlatformAffected.iOS)]
+	public class Bugzilla48158 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var grdInner = new Grid { BackgroundColor = Color.Red, IsVisible = false, Padding = new Thickness(10) };
+			var btn = new Button { Text = "Click and verify background is red" };
+			btn.Clicked += (s, e) =>
+			{
+				grdInner.IsVisible = !grdInner.IsVisible;
+			};
+			var grd = new Grid();
+			grd.Children.Add(grdInner);
+			grd.Children.Add(btn);
+			Content = grd;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -463,6 +463,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39489.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36802.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35736.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla48158.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/BoxRenderer.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (_previousSize != Bounds.Size)
 				SetNeedsDisplay();
+
+			base.LayoutSubviews();
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -170,17 +170,16 @@ namespace Xamarin.Forms.Platform.iOS
 			return new SizeF(0, 0);
 		}
 
-		public override void DrawLayer(CoreAnimation.CALayer layer, CoreGraphics.CGContext context)
+		public override void LayoutSubviews()
 		{
-			base.DrawLayer(layer, context);
-			if (_blur != null)
+			base.LayoutSubviews();
+			if (_blur != null && Superview != null)
 			{
 				_blur.Frame = Bounds;
 				if (_blur.Superview == null)
 					Superview.Add(_blur);
 			}
 		}
-
 		protected override void Dispose(bool disposing)
 		{
 			if ((_flags & VisualElementRendererFlags.Disposed) != 0)
@@ -289,7 +288,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			_blur = new UIVisualEffectView(blurEffect);
-			SetNeedsDisplay();
+			LayoutSubviews();
 		}
 
 		protected virtual void UpdateNativeWidget()

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -170,12 +170,12 @@ namespace Xamarin.Forms.Platform.iOS
 			return new SizeF(0, 0);
 		}
 
-		public override void Draw(RectangleF rect)
+		public override void DrawLayer(CoreAnimation.CALayer layer, CoreGraphics.CGContext context)
 		{
-			base.Draw(rect);
+			base.DrawLayer(layer, context);
 			if (_blur != null)
 			{
-				_blur.Frame = rect;
+				_blur.Frame = Bounds;
 				if (_blur.Superview == null)
 					Superview.Add(_blur);
 			}


### PR DESCRIPTION
### Description of Change ###
We shouldn't override DrawRect, this method should only used when we  want to provide full implementation of what we are drawing on the screen. Since we provide a some information to the UIView Layer directly in out tracker update method, overriding this method prevents IOS of passing the info to the Layer properly . 

So this fix avoids that by configuring without overriding any Draw methods.
### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=48158

### API Changes ###
None

### Behavioral Changes ###

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense