### PR TITLE
[Android] Control WebView state on pause/resume

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48195.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48195.cs
@@ -1,0 +1,36 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 48195, "YouTube video plays sound after power button is pressed", PlatformAffected.Android)]
+	public class Bugzilla48195 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			PushAsync(new WebPage());
+		}
+	}
+
+	public class WebPage : ContentPage
+	{
+		public WebPage()
+		{
+			var browser = new WebView { Source = "https://www.youtube.com/watch?v=dQw4w9WgXcQ" };
+
+			Content = browser;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -139,6 +139,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46630.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla48195.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -211,6 +211,8 @@ namespace Xamarin.Forms.Platform.Android
 			// Avoid writing to permanent storage and CPU intensive tasks
 			base.OnPause();
 
+			MessagingCenter.Send(this, WebViewRenderer.ControlWebViewStateSignalName, "Pause");
+
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnPause;
 
@@ -231,6 +233,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			// counterpart to OnPause
 			base.OnResume();
+
+			MessagingCenter.Send(this, WebViewRenderer.ControlWebViewStateSignalName, "Resume");
 
 			if (_application.OnThisPlatform().GetShouldPreserveKeyboardOnResume())
 			{

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -163,6 +163,8 @@ namespace Xamarin.Forms.Platform.Android
 			// Avoid writing to permanent storage and CPU intensive tasks
 			base.OnPause();
 
+			MessagingCenter.Send(this, WebViewRenderer.ControlWebViewStateSignalName, "Pause");
+
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnPause;
 
@@ -183,6 +185,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			// counterpart to OnPause
 			base.OnResume();
+
+			MessagingCenter.Send(this, WebViewRenderer.ControlWebViewStateSignalName, "Resume");
 
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnResume;

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -36,9 +36,9 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					IPlatform platform = Element.Platform;
 					if (platform.GetType() == typeof(AppCompat.Platform))
-						MessagingCenter.Unsubscribe<AppCompat.Platform, string>(this, ControlWebViewStateSignalName);
+						MessagingCenter.Unsubscribe<FormsAppCompatActivity, string>(this, ControlWebViewStateSignalName);
 					else
-						MessagingCenter.Unsubscribe<Platform, string>(this, ControlWebViewStateSignalName);
+						MessagingCenter.Unsubscribe<FormsApplicationActivity, string>(this, ControlWebViewStateSignalName);
 
 					Control?.StopLoading();
 


### PR DESCRIPTION
### Description of Change ###

Unlike iOS, Android `WebView` won't stop playing media if the screen is locked. There doesn't seem to be a direct way to continue playback on resume (could be achieved possibly via html/js parsing), but other necessary code is executed on resume.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=48195

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
