### PR TITLE
Don't run Command CanExecute on incorrect inherited binding context type

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47971.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47971.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 47971, "UWP doesn't display list items when binding a CommandParameter to BindingContext in a DataTemplate and including a CanExecute method", PlatformAffected.WinRT)]
+	public class Bugzilla47971 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var viewModel = new _47971ViewModel();
+
+			var lv = new ListView { BindingContext = viewModel };
+
+			lv.SetBinding(ListView.ItemsSourceProperty, new Binding("Models"));
+			lv.SetBinding(ListView.SelectedItemProperty, new Binding("SelectedModel"));
+
+			lv.ItemTemplate = new DataTemplate(() =>
+			{
+				var tc = new TextCell();
+
+				tc.SetBinding(TextCell.TextProperty, new Binding("Name"));
+				tc.SetBinding(TextCell.CommandParameterProperty, new Binding("."));
+				tc.SetBinding(TextCell.CommandProperty, new Binding("BindingContext.ModelSelectedCommand", source: lv));
+
+				return tc;
+			});
+
+			var layout = new StackLayout { Spacing = 10 };
+			var instructions = new Label {Text = "The ListView below should display three items (Item1, Item2, and Item3). If it does not, this test has failed." };
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(lv);
+
+			Content = layout;
+		}
+
+		[Preserve(AllMembers = true)]
+		internal class _47971ViewModel : INotifyPropertyChanged
+		{
+			_47971ItemModel _selectedModel;
+			Command<_47971ItemModel> _modelSelectedCommand;
+			ObservableCollection<_47971ItemModel> _models;
+
+			public ObservableCollection<_47971ItemModel> Models
+			{
+				get { return _models; }
+				set
+				{
+					_models = value;
+					OnPropertyChanged();
+				}
+			}
+
+			public _47971ItemModel SelectedModel
+			{
+				get { return _selectedModel; }
+				set
+				{
+					_selectedModel = value;
+					OnPropertyChanged();
+				}
+			}
+
+			public Command<_47971ItemModel> ModelSelectedCommand => _modelSelectedCommand ??
+				(_modelSelectedCommand = new Command<_47971ItemModel>(ModelSelectedCommandExecute, CanExecute));
+
+			bool CanExecute(_47971ItemModel itemModel)
+			{
+				return true;
+			}
+
+			void ModelSelectedCommandExecute(_47971ItemModel model)
+			{
+				System.Diagnostics.Debug.WriteLine(model.Name);
+			}
+
+			public _47971ViewModel()
+			{
+				_models = new ObservableCollection<_47971ItemModel>(
+					new List<_47971ItemModel>()
+					{
+						new _47971ItemModel() { Name = "Item 1"},
+						new _47971ItemModel() { Name = "Item 2"},
+						new _47971ItemModel() { Name = "Item 3"}
+					});
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		internal class _47971ItemModel
+		{
+			public string Name { get; set; }
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -139,6 +139,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46630.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47971.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Core.UnitTests/CommandTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/CommandTests.cs
@@ -1,7 +1,6 @@
 using System;
 using NUnit.Framework;
 
-
 namespace Xamarin.Forms.Core.UnitTests
 {
 	[TestFixture]
@@ -150,6 +149,105 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual (expected, cmd.CanExecute ("Foo"));
 			Assert.AreEqual ("Foo", result);
+		}
+
+		class FakeParentContext
+		{
+		}
+
+		// ReSharper disable once ClassNeverInstantiated.Local
+		class FakeChildContext
+		{
+		}
+
+		[Test]
+		public void CanExecuteReturnsFalseIfParameterIsWrongReferenceType()
+		{
+			var command = new Command<FakeChildContext>(context => { }, context => true);
+
+			Assert.IsFalse(command.CanExecute(new FakeParentContext()), "the parameter is of the wrong type");
+		}
+
+		[Test]
+		public void CanExecuteReturnsFalseIfParameterIsWrongValueType()
+		{
+			var command = new Command<int>(context => { }, context => true);
+
+			Assert.IsFalse(command.CanExecute(10.5), "the parameter is of the wrong type");
+		}
+
+		[Test]
+		public void CanExecuteUsesParameterIfReferenceTypeAndSetToNull()
+		{
+			var command = new Command<FakeChildContext>(context => { }, context => true);
+
+			Assert.IsTrue(command.CanExecute(null), "null is a valid value for a reference type");
+		}
+
+		[Test]
+		public void CanExecuteUsesParameterIfNullableAndSetToNull()
+		{
+			var command = new Command<int?>(context => { }, context => true);
+
+			Assert.IsTrue(command.CanExecute(null), "null is a valid value for a Nullable<int> type");
+		}
+
+		[Test]
+		public void CanExecuteIgnoresParameterIfValueTypeAndSetToNull()
+		{
+			var command = new Command<int>(context => { }, context => true);
+
+			Assert.IsFalse(command.CanExecute(null), "null is not a valid valid for int");
+		}
+
+		[Test]
+		public void ExecuteDoesNotRunIfParameterIsWrongReferenceType()
+		{
+			int executions = 0;
+			var command = new Command<FakeChildContext>(context => executions += 1);
+
+			Assert.DoesNotThrow(() => command.Execute(new FakeParentContext()), "the command should not execute, so no exception should be thrown");
+			Assert.IsTrue(executions == 0, "the command should not have executed");
+		}
+
+		[Test]
+		public void ExecuteDoesNotRunIfParameterIsWrongValueType()
+		{
+			int executions = 0;
+			var command = new Command<int>(context => executions += 1);
+
+			Assert.DoesNotThrow(() => command.Execute(10.5), "the command should not execute, so no exception should be thrown");
+			Assert.IsTrue(executions == 0, "the command should not have executed");
+		}
+
+		[Test]
+		public void ExecuteRunsIfReferenceTypeAndSetToNull()
+		{
+			int executions = 0;
+			var command = new Command<FakeChildContext>(context => executions += 1);
+
+			Assert.DoesNotThrow(() => command.Execute(null), "null is a valid value for a reference type");
+			Assert.IsTrue(executions == 1, "the command should have executed");
+		}
+
+		[Test]
+		public void ExecuteRunsIfNullableAndSetToNull()
+		{
+			int executions = 0;
+			var command = new Command<int?>(context => executions += 1);
+
+			Assert.DoesNotThrow(() => command.Execute(null), "null is a valid value for a Nullable<int> type");
+			Assert.IsTrue(executions == 1, "the command should have executed");
+		}
+
+		[Test]
+		public void ExecuteDoesNotRunIfValueTypeAndSetToNull()
+		{
+			int executions = 0;
+			var command = new Command<int>(context => executions += 1);
+
+			Assert.DoesNotThrow(() => command.Execute(null), "null is not a valid value for int");
+			Assert.IsTrue(executions == 0, "the command should not have executed");
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 
 namespace Xamarin.Forms
 {
-	public sealed class Command<T> : Command
+	public sealed class Command<T> : Command 
 	{
 		public Command(Action<T> execute) : base(o => execute((T)o))
 		{
@@ -63,9 +63,9 @@ namespace Xamarin.Forms
 				{
 					return _canExecute(parameter);
 				}
-				catch (InvalidCastException ex)
+				catch (Exception ex)
 				{
-					Log.Warning("Command", $"CanExecute can't run with the current BindingContext; this is probably a temporary inherited context issue: {ex}");
+					Log.Warning("Command", $"Error determining whether the Command can execute: {ex}");
 				}
 
 				return false;

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -11,7 +11,14 @@ namespace Xamarin.Forms
 				throw new ArgumentNullException("execute");
 		}
 
-		public Command(Action<T> execute, Func<T, bool> canExecute) : base(o => execute((T)o), o => canExecute((T)o))
+		public Command(Action<T> execute, Func<T, bool> canExecute) 
+			: base(o =>
+			{
+				if (o is T)
+				{
+					execute((T)o);
+				}
+			}, o => o is T && canExecute((T)o))
 		{
 			if (execute == null)
 				throw new ArgumentNullException("execute");
@@ -58,18 +65,7 @@ namespace Xamarin.Forms
 		public bool CanExecute(object parameter)
 		{
 			if (_canExecute != null)
-			{
-				try
-				{
-					return _canExecute(parameter);
-				}
-				catch (Exception ex)
-				{
-					Log.Warning("Command", $"Error determining whether the Command can execute: {ex}");
-				}
-
-				return false;
-			}
+				return _canExecute(parameter);
 
 			return true;
 		}

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -5,10 +5,19 @@ namespace Xamarin.Forms
 {
 	public sealed class Command<T> : Command 
 	{
-		public Command(Action<T> execute) : base(o => execute((T)o))
+		public Command(Action<T> execute) 
+			: base(o =>
+			{
+				if (o is T)
+				{
+					execute((T)o);
+				}
+			})
 		{
 			if (execute == null)
+			{
 				throw new ArgumentNullException("execute");
+			}
 		}
 
 		public Command(Action<T> execute, Func<T, bool> canExecute) 

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -58,7 +58,18 @@ namespace Xamarin.Forms
 		public bool CanExecute(object parameter)
 		{
 			if (_canExecute != null)
-				return _canExecute(parameter);
+			{
+				try
+				{
+					return _canExecute(parameter);
+				}
+				catch (InvalidCastException ex)
+				{
+					Log.Warning("Command", $"CanExecute can't run with the current BindingContext; this is probably a temporary inherited context issue: {ex}");
+				}
+
+				return false;
+			}
 
 			return true;
 		}

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Windows.Input;
 
 namespace Xamarin.Forms
@@ -8,7 +9,7 @@ namespace Xamarin.Forms
 		public Command(Action<T> execute) 
 			: base(o =>
 			{
-				if (o is T)
+				if (IsValidParameter(o))
 				{
 					execute((T)o);
 				}
@@ -23,16 +24,36 @@ namespace Xamarin.Forms
 		public Command(Action<T> execute, Func<T, bool> canExecute) 
 			: base(o =>
 			{
-				if (o is T)
+				if (IsValidParameter(o))
 				{
 					execute((T)o);
 				}
-			}, o => o is T && canExecute((T)o))
+			}, o => IsValidParameter(o) && canExecute((T)o))
 		{
 			if (execute == null)
 				throw new ArgumentNullException(nameof(execute));
 			if (canExecute == null)
 				throw new ArgumentNullException(nameof(canExecute));
+		}
+
+		static bool IsValidParameter(object o)
+		{
+			if (o != null)
+			{
+				// The parameter isn't null, so we don't have to worry whether null is a valid option
+				return o is T;
+			}
+
+			var t = typeof(T);
+
+			// The parameter is null. Is T Nullable?
+			if (Nullable.GetUnderlyingType(t) != null)
+			{
+				return true;
+			}
+
+			// Not a Nullable, if it's a value type then null is not valid
+			return !t.GetTypeInfo().IsValueType;
 		}
 	}
 

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms
 		{
 			if (execute == null)
 			{
-				throw new ArgumentNullException("execute");
+				throw new ArgumentNullException(nameof(execute));
 			}
 		}
 
@@ -30,9 +30,9 @@ namespace Xamarin.Forms
 			}, o => o is T && canExecute((T)o))
 		{
 			if (execute == null)
-				throw new ArgumentNullException("execute");
+				throw new ArgumentNullException(nameof(execute));
 			if (canExecute == null)
-				throw new ArgumentNullException("canExecute");
+				throw new ArgumentNullException(nameof(canExecute));
 		}
 	}
 
@@ -44,7 +44,7 @@ namespace Xamarin.Forms
 		public Command(Action<object> execute)
 		{
 			if (execute == null)
-				throw new ArgumentNullException("execute");
+				throw new ArgumentNullException(nameof(execute));
 
 			_execute = execute;
 		}
@@ -52,13 +52,13 @@ namespace Xamarin.Forms
 		public Command(Action execute) : this(o => execute())
 		{
 			if (execute == null)
-				throw new ArgumentNullException("execute");
+				throw new ArgumentNullException(nameof(execute));
 		}
 
 		public Command(Action<object> execute, Func<object, bool> canExecute) : this(execute)
 		{
 			if (canExecute == null)
-				throw new ArgumentNullException("canExecute");
+				throw new ArgumentNullException(nameof(canExecute));
 
 			_canExecute = canExecute;
 		}
@@ -66,9 +66,9 @@ namespace Xamarin.Forms
 		public Command(Action execute, Func<bool> canExecute) : this(o => execute(), o => canExecute())
 		{
 			if (execute == null)
-				throw new ArgumentNullException("execute");
+				throw new ArgumentNullException(nameof(execute));
 			if (canExecute == null)
-				throw new ArgumentNullException("canExecute");
+				throw new ArgumentNullException(nameof(canExecute));
 		}
 
 		public bool CanExecute(object parameter)
@@ -89,8 +89,7 @@ namespace Xamarin.Forms
 		public void ChangeCanExecute()
 		{
 			EventHandler changed = CanExecuteChanged;
-			if (changed != null)
-				changed(this, EventArgs.Empty);
+			changed?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

On WinRT/UWP during the process of binding, items in a `ListView` initially inherit the binding context of the `ListView` before getting a more specific binding context. If the `DataTemplate` of the `ListView` includes an item which has both 

- a bound `Command` which includes a `CanExecute` method and
- a bound `CommandParameter`

the initial binding of the item will trigger a check on the `CanExecute` method (to determine if `IsEnabled` should be true). The `CanExecute` method attempts to cast the binding context to the correct type and throws an `InvalidCastException`. The `InvalidCastException` is not fatal, but it causes the rest of the `DataTemplate` binding to fail, and the `ListView` items will appear blank (though in the most recent version of XF they are still tappable). 

This change checks the type before executing the command and does not execute the command if the type is incorrect; it also checks the type before checking `CanExecute` and returns `false` if the type is incorrect.

### Bugs Fixed ###

- [47971 – XF UWP ListView Items no longer display ImageCell is the problem](https://bugzilla.xamarin.com/show_bug.cgi?id=47971)

### API Changes ###

List all API changes here (or just put None), example:

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

