### PR TITLE
[iOS] Enabling TabbedPage More button for content pages

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla22986.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla22986.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 22986, "(iOS) - \"More\" tab on TabbedPage is disabled/does not register the taps", PlatformAffected.iOS)]
+	public class Bugzilla22986 : TestTabbedPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			Children.Add(new NavigationPage(new ContentPage() { BackgroundColor = Color.Red }) { Title = "Page1" });
+			Children.Add(new NavigationPage(new ContentPage() { BackgroundColor = Color.Blue }) { Title = "Page2" });
+			Children.Add(new NavigationPage(new ContentPage() { BackgroundColor = Color.Yellow }) { Title = "Page3" });
+			Children.Add(new NavigationPage(new ContentPage() { BackgroundColor = Color.Green }) { Title = "Page4" });
+			Children.Add(new XTest { Title = "Page5" });
+			Children.Add(new XTest { Title = "Page6" });
+			Children.Add(new XTest { Title = "Page7" });
+			Children.Add(new XTest { Title = "Page8" });
+			Children.Add(new XTest { Title = "Page9" });
+			Children.Add(new XTest { Title = "Page10" });
+		}
+	}
+
+	public class XTest : ContentPage
+	{
+		public XTest()
+		{
+			Content = new StackLayout
+			{
+				Spacing = 10,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Button
+					{
+						HorizontalOptions = LayoutOptions.Center,
+						Text = "Push modal",
+						Command = new Command(async () => { await Navigation.PushModalAsync(new ContentPage { Title = "Modal", Content = new ContentView
+						{
+							Content = new Button
+							{
+								HorizontalOptions = LayoutOptions.Center,
+								VerticalOptions = LayoutOptions.Center,
+								Text = "Go back",
+								Command = new Command(async () => { await Navigation.PopModalAsync(true); })
+							}
+						} }, true); })
+					},
+					new Button
+					{
+						HorizontalOptions = LayoutOptions.Center,
+						Text = "Push non-modal (will error out)",
+						Command = new Command(async () =>
+						{
+							try
+							{
+								await Navigation.PushAsync(new ContentPage { Title = "Non-modal" }, true);
+							}
+							catch(Exception e)
+							{
+								await DisplayAlert("Error", e.Message, "OK");
+							}
+						})
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -18,6 +18,7 @@
       <DependentUpon>Bugzilla22229.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla22401.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla22986.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla23942.xaml.cs">
       <DependentUpon>Bugzilla23942.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -28,7 +28,24 @@ namespace Xamarin.Forms.Platform.iOS
 			get { return base.SelectedViewController; }
 			set
 			{
+				if (ReferenceEquals(value, MoreNavigationController))
+				{
+					if(CustomizableViewControllers != null)
+						throw new NotSupportedException("Editing the order of tab items under the More button is not supported.");
+
+					for(int i=TabBar.Items.Length - 1; i<PageController.InternalChildren.Count; i++)
+					{
+						if(!(PageController.InternalChildren[i] is ContentPage))
+							throw new NotSupportedException($"Nesting pages other than {nameof(ContentPage)} under the More button is not supported.");
+					}
+
+					base.SelectedViewController = value;
+
+					return;
+				}
+
 				base.SelectedViewController = value;
+
 				UpdateCurrentPage();
 			}
 		}
@@ -68,7 +85,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (element != null)
 				element.SendViewInitialized(NativeView);
 
-			//disable edit/reorder of tabs
+			//disable edit/reorder of tabs so that unsupported page types cannot be moved under the More button
 			CustomizableViewControllers = null;
 
 			UpdateBarBackgroundColor();


### PR DESCRIPTION
### Description of Change ###

According to #440, enabling `More` button on a `TabbedPage` creates issues when the tab items under this button are navigation page instances because the controller for `More` is also a navigation controller. This PR will enable the button in a limited way so that only `ContentPage` instances can be packed under it. Using content pages can be handy if trivial information such as about, ToS, basic settings, etc. can be shown on a single page.  

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=22986

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
