### PR TITLE
[Xaml] support non-int enums

### DIFF
--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 			//Obvious Built-in conversions
 			if (targetTypeRef.Resolve().BaseType != null && targetTypeRef.Resolve().BaseType.FullName == "System.Enum")
-				yield return Instruction.Create(OpCodes.Ldc_I4, ParseEnum(targetTypeRef, str, node));
+				yield return PushParsedEnum(targetTypeRef, str, node);
 			else if (targetTypeRef.FullName == "System.Char")
 				yield return Instruction.Create(OpCodes.Ldc_I4, Char.Parse(str));
 			else if (targetTypeRef.FullName == "System.SByte")
@@ -216,29 +216,87 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Instruction.Create(OpCodes.Box, module.Import(originalTypeRef));
 		}
 
-		static int ParseEnum(TypeReference enumRef, string value, IXmlLineInfo lineInfo)
+		static Instruction PushParsedEnum(TypeReference enumRef, string value, IXmlLineInfo lineInfo)
 		{
 			var enumDef = enumRef.Resolve();
 			if (!enumDef.IsEnum)
 				throw new InvalidOperationException();
 
-			int? result = null;
+			// The approved types for an enum are byte, sbyte, short, ushort, int, uint, long, or ulong.
+			// https://msdn.microsoft.com/en-us/library/sbbt4032.aspx
+			byte b = 0; sbyte sb = 0; short s = 0; ushort us = 0;
+			int i = 0; uint ui = 0; long l = 0; ulong ul = 0;
+			bool found = false;
+			TypeReference typeRef = null;
 
-			foreach (var v in value.Split(','))
-			{
-				foreach (var field in enumDef.Fields)
-				{
+			foreach (var field in enumDef.Fields)
+				if (field.Name == "value__")
+					typeRef = field.FieldType;
+
+			if (typeRef == null)
+				throw new ArgumentException();
+
+			foreach (var v in value.Split(',')) {
+				foreach (var field in enumDef.Fields) {
 					if (field.Name == "value__")
 						continue;
-					if (field.Name == v.Trim())
-						result = (result ?? 0) | (int)field.Constant;
+					if (field.Name == v.Trim()) {
+						switch (typeRef.FullName) {
+						case "System.Byte":
+							b |= (byte)field.Constant;
+							break;
+						case "System.SByte":
+							if (found)
+								throw new XamlParseException($"Multi-valued enums are not valid on sbyte enum types", lineInfo);
+							sb = (sbyte)field.Constant;
+							break;
+						case "System.Int16":
+							s |= (short)field.Constant;
+							break;
+						case "System.UInt16":
+							us |= (ushort)field.Constant;
+							break;
+						case "System.Int32":
+							i |= (int)field.Constant;
+							break;
+						case "System.UInt32":
+							ui |= (uint)field.Constant;
+							break;
+						case "System.Int64":
+							l |= (long)field.Constant;
+							break;
+						case "System.UInt64":
+							ul |= (ulong)field.Constant;
+							break;
+						}
+						found = true;
+					}
 				}
 			}
 
-			if (result.HasValue)
-				return result.Value;
-
-			throw new XamlParseException(string.Format("Enum value not found for {0}", value), lineInfo);
+			if (!found)
+				throw new XamlParseException($"Enum value not found for {value}", lineInfo);
+				
+			switch (typeRef.FullName) {
+			case "System.Byte":
+				return Instruction.Create(OpCodes.Ldc_I4, (int)b);
+			case "System.SByte":
+				return Instruction.Create(OpCodes.Ldc_I4, (int)sb);
+			case "System.Int16":
+				return Instruction.Create(OpCodes.Ldc_I4, (int)s);
+			case "System.UInt16":
+				return Instruction.Create(OpCodes.Ldc_I4, (int)us);
+			case "System.Int32":
+				return Instruction.Create(OpCodes.Ldc_I4, (int)i);
+			case "System.UInt32":
+				return Instruction.Create(OpCodes.Ldc_I4, (uint)ui);
+			case "System.Int64":
+				return Instruction.Create(OpCodes.Ldc_I4, (long)l);
+			case "System.UInt64":
+				return Instruction.Create(OpCodes.Ldc_I4, (ulong)ul);
+			default:
+				throw new XamlParseException($"Enum value not found for {value}", lineInfo);
+			}
 		}
 
 		public static IEnumerable<Instruction> PushXmlLineInfo(this INode node, ILContext context)

--- a/Xamarin.Forms.Xaml.UnitTests/SetValue.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/SetValue.xaml
@@ -84,5 +84,6 @@
 			</ContentView.Content>
 		</ContentView>
 		<local:MockViewWithValues x:Name="mockView0" UShort="32" ADecimal="42" />
+		<local:ViewWithEnums x:Name="enums" IntEnum="Foo" ByteEnum="Bar" />
 	</StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/SetValue.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/SetValue.xaml.cs
@@ -20,6 +20,26 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public decimal ADecimal { get; set; }
 	}
 
+	public enum IntEnum
+	{
+		Foo,
+		Bar,
+		Baz
+	}
+
+	public enum ByteEnum : byte
+	{
+		Foo,
+		Bar,
+		Baz
+	}
+
+	public class ViewWithEnums : View
+	{
+		public IntEnum IntEnum { get; set; }
+		public ByteEnum ByteEnum { get; set; }
+	}
+
 	public partial class SetValue : ContentPage
 	{	
 		public SetValue ()
@@ -242,6 +262,19 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				var page = new SetValue(useCompiledXaml);
 				Assert.AreEqual((ushort)32, page.mockView0.UShort);
 				Assert.AreEqual((decimal)42, page.mockView0.ADecimal);
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void NonIntEnums(bool useCompiledXaml)
+			{
+				if (useCompiledXaml) {
+					MockCompiler.Compile(typeof(SetValue));
+					return;
+				}
+				var page = new SetValue(useCompiledXaml);
+				Assert.AreEqual(IntEnum.Foo, page.enums.IntEnum);
+				Assert.AreEqual(ByteEnum.Bar, page.enums.ByteEnum);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

When we did the change to compile the enums, vs parsing them at runtime, we thought that supporting int-based enums was enough. The rationale behind this ? Well, except for interrop or maybe serialization, there's no real reason to use other than ints enums.

### Bugs Fixed ###

- the one @jonathanpeppers reported to me by email. No, not this one. The other below. Yeah, THAT is the one I'm speaking about.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
