### PR TITLE
[iOS] Prevent multiple ListView cells from being swiped simultaneously

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43735.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43735.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43735, "Multiple Swipe on ContextActions", PlatformAffected.iOS)]
+	public class Bugzilla43735 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var list = new List<int>();
+			for (var i = 0; i < 10; i++)
+				list.Add(i);
+
+			var listView = new ListView
+			{
+				ItemsSource = list,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding("."));
+
+					return new ViewCell
+					{
+						View = new ContentView
+						{
+							Content = label,
+						},
+						ContextActions = { new MenuItem
+						{
+							Text = "Action"
+						},
+						new MenuItem
+						{
+							Text = "Delete",
+							IsDestructive = true
+						} }
+					};
+				})
+			};
+
+			Content = listView;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43735.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43735.cs
@@ -7,12 +7,6 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-// Apply the default category of "Issues" to all of the tests in this assembly
-// We use this as a catch-all for tests which haven't been individually categorized
-#if UITEST
-[assembly: NUnit.Framework.Category("Issues")]
-#endif
-
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
@@ -21,8 +15,16 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
+			var stackLayout = new StackLayout();
+
+			var l = new Label
+			{
+				Text = "Swipe multiple cells at the same time. Only one cell should show its context actions."
+			};
+			stackLayout.Children.Add(l);
+
 			var list = new List<int>();
-			for (var i = 0; i < 10; i++)
+			for (var i = 0; i < 20; i++)
 				list.Add(i);
 
 			var listView = new ListView
@@ -51,8 +53,9 @@ namespace Xamarin.Forms.Controls.Issues
 					};
 				})
 			};
+			stackLayout.Children.Add(listView);
 
-			Content = listView;
+			Content = stackLayout;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -137,6 +137,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43469.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43663.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43735.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44944.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />

--- a/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
@@ -68,20 +68,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public Action ClosedCallback { get; set; }
 
-		bool _isOpen;
-		public bool IsOpen
-		{
-			get { return _isOpen; }
-			private set
-			{
-				if (_isOpen == value)
-					return;
-
-				_isOpen = value;
-
-				s_scrollViewBeingScrolled = null;
-			}
-		}
+		public bool IsOpen { get; private set; }
 
 		public override void DraggingStarted(UIScrollView scrollView)
 		{
@@ -137,6 +124,7 @@ namespace Xamarin.Forms.Platform.iOS
 				SetButtonsShowing(false);
 				RestoreHighlight(scrollView);
 
+				s_scrollViewBeingScrolled = null;
 				ClearCloserRecognizer(scrollView);
 				ClosedCallback?.Invoke();
 			}

--- a/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
@@ -88,8 +88,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (ShouldIgnoreScrolling(scrollView))
 				return;
 
-			if (s_scrollViewBeingScrolled == null)
-				s_scrollViewBeingScrolled = new WeakReference<UIScrollView>(scrollView);
+			s_scrollViewBeingScrolled = new WeakReference<UIScrollView>(scrollView);
 			
 			if (!IsOpen)
 				SetButtonsShowing(true);

--- a/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
@@ -72,14 +72,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void DraggingStarted(UIScrollView scrollView)
 		{
+			if (ShouldIgnoreScrolling(scrollView))
+				return;
+
 			if (_scrollViewBeingScrolled == null)
 				_scrollViewBeingScrolled = scrollView;
-			else if(_scrollViewBeingScrolled != null && !ReferenceEquals(_scrollViewBeingScrolled, scrollView))
-			{
-				scrollView.SetContentOffset(new PointF(0,0), false);
-				return;
-			}
-
+			
 			if (!IsOpen)
 				SetButtonsShowing(true);
 
@@ -98,11 +96,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void Scrolled(UIScrollView scrollView)
 		{
-			if (_scrollViewBeingScrolled != null && !ReferenceEquals(_scrollViewBeingScrolled, scrollView))
-			{
-				scrollView.SetContentOffset(new PointF(0, 0), false);
+			if (ShouldIgnoreScrolling(scrollView))
 				return;
-			}
 
 			var width = _finalButtonSize;
 			var count = _buttons.Count;
@@ -144,11 +139,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void WillEndDragging(UIScrollView scrollView, PointF velocity, ref PointF targetContentOffset)
 		{
-			if (_scrollViewBeingScrolled != null && !ReferenceEquals(_scrollViewBeingScrolled, scrollView))
-			{
-				scrollView.SetContentOffset(new PointF(0, 0), false);
+			if (ShouldIgnoreScrolling(scrollView))
 				return;
-			}
 
 			var width = ButtonsWidth;
 			var x = targetContentOffset.X;
@@ -204,6 +196,15 @@ namespace Xamarin.Forms.Platform.iOS
 				if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
 					RestoreHighlight(scrollView);
 			}
+		}
+
+		static bool ShouldIgnoreScrolling(UIScrollView scrollView)
+		{
+			if (_scrollViewBeingScrolled == null || ReferenceEquals(_scrollViewBeingScrolled, scrollView))
+				return false;
+
+			scrollView.SetContentOffset(new PointF(0, 0), false);
+			return true;
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
@@ -68,7 +68,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public Action ClosedCallback { get; set; }
 
-		public bool IsOpen { get; private set; }
+		bool _isOpen;
+		public bool IsOpen
+		{
+			get { return _isOpen; }
+			private set
+			{
+				if (_isOpen == value)
+					return;
+
+				_isOpen = value;
+
+				s_scrollViewBeingScrolled = null;
+			}
+		}
 
 		public override void DraggingStarted(UIScrollView scrollView)
 		{
@@ -126,7 +139,6 @@ namespace Xamarin.Forms.Platform.iOS
 				RestoreHighlight(scrollView);
 
 				ClearCloserRecognizer(scrollView);
-				s_scrollViewBeingScrolled = null;
 				ClosedCallback?.Invoke();
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
@@ -220,7 +220,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
-				s_scrollViewBeingScrolled = null;
 				ClosedCallback = null;
 
 				_table = null;


### PR DESCRIPTION
### Description of Change ###

iOS `ListView` is allowing multiple cells to be swiped to show their context action menus at the same time. This PR will fix that. It seems that each cell has its own dedicated `ScrollView` and they are not aware of each other.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=43735

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
