### PR TITLE
[UWP] Fix CommandBar being clipped when expanded

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47295.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47295.cs
@@ -1,0 +1,39 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 47295, "Toolbar in a NavigationPage is clipped when expanded", PlatformAffected.WinRT)]
+    public class Bugzilla47295 : TestNavigationPage
+    {
+        protected override void Init()
+        {
+            PushAsync(new TestPage47295());
+        }
+    }
+
+    [Preserve(AllMembers = true)]
+    public class TestPage47295 : ContentPage
+    {
+        public TestPage47295()
+        {
+            var descLabel = new Label { Text = "Press '...' to expand the CommandBar. The ToolbarItem's text label should not be clipped." };
+            var pressedLabel = new Label { Text = "ToolbarItem pressed.", IsVisible = false };
+            Content = new StackLayout
+            {
+                Children = {
+                    descLabel,
+                    pressedLabel
+                }
+            };
+
+            ToolbarItems.Add(new ToolbarItem("Test", "toolbar_close", () => pressedLabel.IsVisible = true));
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -140,6 +140,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46630.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47971.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47295.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
@@ -3,7 +3,8 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:uwp="using:Xamarin.Forms.Platform.UWP">
 	<Style TargetType="uwp:MasterDetailControl">
-		<Setter Property="ToolbarForeground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
+        <Setter Property="ToolbarBackground" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"/>
+        <Setter Property="ToolbarForeground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="uwp:MasterDetailControl">
@@ -47,7 +48,7 @@
 									</StackPanel>
 
 									<Border x:Name="TopCommandBarArea" Grid.Column="1" HorizontalAlignment="Stretch">
-										<uwp:FormsCommandBar x:Name="CommandBar" VerticalContentAlignment="Top" Background="{TemplateBinding ToolbarBackground}" Height="{ThemeResource TitleBarHeight}" />
+										<uwp:FormsCommandBar x:Name="CommandBar" VerticalContentAlignment="Top" Background="{TemplateBinding ToolbarBackground}" />
 									</Border>
 								</Grid>
 

--- a/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
@@ -4,7 +4,8 @@
 	xmlns:uwp="using:Xamarin.Forms.Platform.UWP">
 	<Style TargetType="uwp:PageControl">
 		<Setter Property="ContentMargin" Value="0" />
-		<Setter Property="TitleBrush" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
+        <Setter Property="ToolbarBackground" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"/>
+        <Setter Property="TitleBrush" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="uwp:PageControl">
@@ -27,7 +28,7 @@
 							</Border>
 							
 							<Border x:Name="TopCommandBarArea" Grid.Column="1" HorizontalAlignment="Stretch">
-								<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" Height="{ThemeResource TitleBarHeight}" />
+								<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" />
 							</Border>
 						</Grid>
 

--- a/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
@@ -3,7 +3,9 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:uwp="using:Xamarin.Forms.Platform.UWP">
 	<Style x:Key="TabbedPageStyle" TargetType="uwp:FormsPivot">
-		<Setter Property="HeaderTemplate">
+        <Setter Property="ToolbarBackground" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"/>
+
+        <Setter Property="HeaderTemplate">
 			<Setter.Value>
 				<DataTemplate>
 					<TextBlock Name="TabbedPageHeaderTextBlock" Text="{Binding Title}" Style="{ThemeResource BodyTextBlockStyle}" />
@@ -75,7 +77,7 @@
 							</Border>
 							
 							<Border x:Name="TopCommandBarArea" Grid.Column="1" HorizontalAlignment="Stretch">
-								<uwp:FormsCommandBar x:Name="CommandBar" VerticalContentAlignment="Top" Background="{TemplateBinding ToolbarBackground}" Height="{ThemeResource TitleBarHeight}" />
+								<uwp:FormsCommandBar x:Name="CommandBar" VerticalContentAlignment="Top" Background="{TemplateBinding ToolbarBackground}" />
 							</Border>
 						</Grid>
 						


### PR DESCRIPTION
### Description of Change ###

It appears that setting the CommandBar Height was causing it to be clipped when expanded by pressing the "..." button. It also seemed to cause the "..." button to not even appear on Mobile.

This fix also defines the default CommandBar background because by removing the Height in the page styles another issue appeared on some pages where the expanded area of CommandBar was transparent. This was a result of the entire CommandBar being transparent since the default color was not being applied, e.g. in TabbedPageRenderer it was returning [at this line](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs#L297).


### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=47295

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
