### PR TITLE
[iOS] Preserve context menu state on orientation change

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48237.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48237.cs
@@ -1,0 +1,58 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 48237, "ContextAction menu is automatically dismissed when rotating from portrait to landscape mode in a Xamarin.Forms application on iOS.", PlatformAffected.iOS)]
+	public class Bugzilla48237 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var list = new List<int>();
+			for (var i = 0; i < 15; i++)
+				list.Add(i);
+
+			var listView = new ListView
+			{
+				ItemsSource = list,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding("."));
+
+					return new ViewCell
+					{
+						View = new ContentView
+						{
+							Content = label,
+						},
+						ContextActions = { new MenuItem
+						{
+							Text = "Action"
+						},
+						new MenuItem
+						{
+							Text = "Delete",
+							IsDestructive = true
+						} }
+					};
+				})
+			};
+
+			Content = listView;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -140,6 +140,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46630.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla48237.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47971.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public void PrepareForDeselect()
 		{
-			ScrollDelegate.PrepareForDeselect(_scroller);
+			ScrollDelegate.PrepareForDeselect();
 		}
 
 		public override SizeF SizeThatFits(SizeF size)
@@ -177,8 +177,10 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
-				_scroller.Frame = new RectangleF(0, 0, width, height);
+				// Orientation change re-sets Frame which in turn triggers Scrolled event of the scroll view.
+				// Preserve state before Frame changes.
 				isOpen = ScrollDelegate.IsOpen;
+				_scroller.Frame = new RectangleF(0, 0, width, height);
 
 				for (var i = 0; i < _buttons.Count; i++)
 				{
@@ -189,7 +191,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_buttons.Clear();
 
-				ScrollDelegate.Unhook(_scroller);
+				ScrollDelegate.Unhook();
 				ScrollDelegate.Dispose();
 			}
 
@@ -244,7 +246,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			}
 
-			_scroller.Delegate = new ContextScrollViewDelegate(container, _buttons, isOpen);
+			_scroller.Delegate = new ContextScrollViewDelegate(_scroller, container, _buttons, isOpen);
 			_scroller.ContentSize = new SizeF(totalWidth, height);
 
 			if (isOpen)


### PR DESCRIPTION
### Description of Change ###

If a view cell has its context menu open and you change device orientation, this closes the menu. Can you merge this after #578? Both touch the same file and it will be easier to rebase in that order.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=48237

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

