### PR TITLE
Fix potential NRE in ConditionalFocusLayout

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Resources/layout/Layout38989.axml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/layout/Layout38989.axml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+  <ImageView
+      android:id="@+id/coffee"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      android:padding="5dp"
+      android:src="@drawable/icon"
+      android:layout_alignParentLeft="true" />
+</RelativeLayout>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -53,9 +53,7 @@
       </CustomCommands>
     </CustomCommands>
     <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-    <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
-    <AndroidStoreUncompressedFileExtensions />
-    <MandroidI18n />
+    <AndroidSupportedAbis>armeabi;armeabi-v7a;x86</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
     <AndroidEnableMultiDex>False</AndroidEnableMultiDex>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
@@ -176,6 +174,7 @@
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="CustomRenderers.cs" />
     <Compile Include="ColorPicker.cs" />
+    <Compile Include="_38989CustomRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\default.css" />
@@ -254,6 +253,9 @@
       <SubType>Designer</SubType>
     </AndroidResource>
     <AndroidResource Include="Resources\layout\Tabbar.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+    <AndroidResource Include="Resources\layout\Layout38989.axml">
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>

--- a/Xamarin.Forms.ControlGallery.Android/_38989CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_38989CustomRenderer.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Controls.Issues;
+using AView = Android.Views.View;
+
+[assembly: ExportRenderer(typeof(Bugzilla38989._38989CustomViewCell), typeof(_38989CustomViewCellRenderer))]
+
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class _38989CustomViewCellRenderer : Xamarin.Forms.Platform.Android.ViewCellRenderer
+	{
+		protected override AView GetCellCore(Cell item, AView convertView, ViewGroup parent, Context context)
+		{
+			var nativeView = convertView;
+
+			if (nativeView == null)
+				nativeView = (context as Activity).LayoutInflater.Inflate(Resource.Layout.Layout38989, null);
+
+			return nativeView;
+		}
+	}
+
+	
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38989.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38989.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+#if UITEST
+using NUnit.Framework;
+
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 38989, "[Android] NullReferenceException when using a custom ViewCellRenderer ",
+		PlatformAffected.Android)]
+	public class Bugzilla38989 : TestContentPage
+	{
+		const string Success = "If you can see this, the test passed.";
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void Bugzilla38989Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(Success));
+		}
+#endif
+
+		protected override void Init()
+		{
+			var successLabel = new Label { Text = Success };
+
+			var lv = new ListView();
+			var items = new List<string> { "data", "does not", "matter" };
+
+			lv.ItemTemplate = new DataTemplate(typeof(_38989CustomViewCell));
+
+			lv.ItemsSource = items;
+
+			Content = new StackLayout { Children = { successLabel, lv } };
+		}
+
+		[Preserve(AllMembers = true)]
+		public class _38989CustomViewCell : ViewCell
+		{
+			public _38989CustomViewCell()
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+
+				View = label;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -85,6 +85,7 @@
       <DependentUpon>Bugzilla38827.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38989.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39395.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39461.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39483.xaml.cs">

--- a/Xamarin.Forms.Platform.Android/Renderers/ConditionalFocusLayout.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ConditionalFocusLayout.cs
@@ -26,12 +26,11 @@ namespace Xamarin.Forms.Platform.Android
 			(aView as EntryCellView)?.EditText.SetOnTouchListener(this);
 
 			var viewCell = item as ViewCell;
-			if (viewCell == null || viewCell?.View == null)
+			if (viewCell?.View == null)
 				return;
 
 			IVisualElementRenderer renderer = Platform.GetRenderer(viewCell.View);
-			if (renderer?.ViewGroup?.ChildCount != 0)
-				(renderer.ViewGroup.GetChildAt(0) as EditText)?.SetOnTouchListener(this);
+			(renderer?.ViewGroup?.GetChildAt(0) as EditText)?.SetOnTouchListener(this);
 
 			foreach (Element descendant in viewCell.View.Descendants())
 			{
@@ -39,9 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (element == null)
 					continue;
 				renderer = Platform.GetRenderer(element);
-				if (renderer?.ViewGroup?.ChildCount == 0)
-					continue;
-				(renderer.ViewGroup.GetChildAt(0) as EditText)?.SetOnTouchListener(this);
+				(renderer?.ViewGroup?.GetChildAt(0) as EditText)?.SetOnTouchListener(this);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Offering this as an alternative to https://github.com/xamarin/Xamarin.Forms/pull/567

This version is concise and avoids the two potential NRE situations created by checking the nullable result against 0.

### Bugs Fixed ###

- [38989 – [Android] NullReferenceException when using a custom ViewCellRenderer](https://bugzilla.xamarin.com/show_bug.cgi?id=38989)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

