### PR TITLE
Add Tizen to TargetPlatform

### DIFF
--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -58,92 +58,51 @@ namespace Xamarin.Forms
 			return GetNamedSize(size, targetElementType, false);
 		}
 
+		public static void OnPlatform(Action iOS = null, Action Android = null, Action WinPhone = null, Action Default = null)
+		{
+			switch (OS)
+			{
+				case TargetPlatform.iOS:
+					if (iOS != null)
+						iOS();
+					else if (Default != null)
+						Default();
+					break;
+				case TargetPlatform.Android:
+					if (Android != null)
+						Android();
+					else if (Default != null)
+						Default();
+					break;
+				case TargetPlatform.Windows:
+				case TargetPlatform.WinPhone:
+					if (WinPhone != null)
+						WinPhone();
+					else if (Default != null)
+						Default();
+					break;
+				case TargetPlatform.Other:
+					if (Default != null)
+						Default();
+					break;
+			}
+		}
+
 		public static void OnPlatform(Action iOS = null, Action Android = null, Action WinPhone = null, Action Default = null, Action Tizen = null)
 		{
-			switch (OS)
+			if (OS == TargetPlatform.Tizen)
 			{
-				case TargetPlatform.iOS:
-					if (iOS != null)
-						iOS();
-					else if (Default != null)
-						Default();
-					break;
-				case TargetPlatform.Android:
-					if (Android != null)
-						Android();
-					else if (Default != null)
-						Default();
-					break;
-				case TargetPlatform.Windows:
-				case TargetPlatform.WinPhone:
-					if (WinPhone != null)
-						WinPhone();
-					else if (Default != null)
-						Default();
-					break;
-				case TargetPlatform.Tizen:
-					if (Tizen != null)
-						Tizen();
-					else if (Default != null)
-						Default();
-					break;
-				case TargetPlatform.Other:
-					if (Default != null)
-						Default();
-					break;
+				if (Tizen != null)
+					Tizen();
+				else if (Default != null)
+					Default();
+			}
+			else
+			{
+				OnPlatform(iOS, Android, WinPhone, Default);
 			}
 		}
 
-		[Obsolete("OnPlatform is obsolete, please use OnPlatform (Action, Action, Action, Action, Action)")]
-		public static void OnPlatform(Action iOS, Action Android, Action WinPhone, Action Default)
-		{
-			switch (OS)
-			{
-				case TargetPlatform.iOS:
-					if (iOS != null)
-						iOS();
-					else if (Default != null)
-						Default();
-					break;
-				case TargetPlatform.Android:
-					if (Android != null)
-						Android();
-					else if (Default != null)
-						Default();
-					break;
-				case TargetPlatform.Windows:
-				case TargetPlatform.WinPhone:
-					if (WinPhone != null)
-						WinPhone();
-					else if (Default != null)
-						Default();
-					break;
-				case TargetPlatform.Other:
-					if (Default != null)
-						Default();
-					break;
-			}
-		}
-
-		public static T OnPlatform<T>(T iOS, T Android, T WinPhone, T Tizen)
-		{
-			switch (OS)
-			{
-				case TargetPlatform.iOS:
-					return iOS;
-				case TargetPlatform.Android:
-					return Android;
-				case TargetPlatform.Windows:
-				case TargetPlatform.WinPhone:
-					return WinPhone;
-				case TargetPlatform.Tizen:
-					return Tizen;
-			}
-
-			return iOS;
-		}
-
-		[Obsolete("OnPlatform<T> is obsolete, please use OnPlatform<T> (T, T, T, T)")]
 		public static T OnPlatform<T>(T iOS, T Android, T WinPhone)
 		{
 			switch (OS)
@@ -158,6 +117,18 @@ namespace Xamarin.Forms
 			}
 
 			return iOS;
+		}
+
+		public static T OnPlatform<T>(T iOS, T Android, T WinPhone, T Tizen)
+		{
+			if (OS == TargetPlatform.Tizen)
+			{
+				return Tizen;
+			}
+			else
+			{
+				return OnPlatform<T>(iOS, Android, WinPhone);
+			}
 		}
 
 		public static void OpenUri(Uri uri)

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -58,7 +58,44 @@ namespace Xamarin.Forms
 			return GetNamedSize(size, targetElementType, false);
 		}
 
-		public static void OnPlatform(Action iOS = null, Action Android = null, Action WinPhone = null, Action Default = null)
+		public static void OnPlatform(Action iOS = null, Action Android = null, Action WinPhone = null, Action Default = null, Action Tizen = null)
+		{
+			switch (OS)
+			{
+				case TargetPlatform.iOS:
+					if (iOS != null)
+						iOS();
+					else if (Default != null)
+						Default();
+					break;
+				case TargetPlatform.Android:
+					if (Android != null)
+						Android();
+					else if (Default != null)
+						Default();
+					break;
+				case TargetPlatform.Windows:
+				case TargetPlatform.WinPhone:
+					if (WinPhone != null)
+						WinPhone();
+					else if (Default != null)
+						Default();
+					break;
+				case TargetPlatform.Tizen:
+					if (Tizen != null)
+						Tizen();
+					else if (Default != null)
+						Default();
+					break;
+				case TargetPlatform.Other:
+					if (Default != null)
+						Default();
+					break;
+			}
+		}
+
+		[Obsolete("OnPlatform is obsolete, please use OnPlatform (Action, Action, Action, Action, Action)")]
+		public static void OnPlatform(Action iOS, Action Android, Action WinPhone, Action Default)
 		{
 			switch (OS)
 			{
@@ -88,6 +125,25 @@ namespace Xamarin.Forms
 			}
 		}
 
+		public static T OnPlatform<T>(T iOS, T Android, T WinPhone, T Tizen)
+		{
+			switch (OS)
+			{
+				case TargetPlatform.iOS:
+					return iOS;
+				case TargetPlatform.Android:
+					return Android;
+				case TargetPlatform.Windows:
+				case TargetPlatform.WinPhone:
+					return WinPhone;
+				case TargetPlatform.Tizen:
+					return Tizen;
+			}
+
+			return iOS;
+		}
+
+		[Obsolete("OnPlatform<T> is obsolete, please use OnPlatform<T> (T, T, T, T)")]
 		public static T OnPlatform<T>(T iOS, T Android, T WinPhone)
 		{
 			switch (OS)

--- a/Xamarin.Forms.Core/OnPlatform.cs
+++ b/Xamarin.Forms.Core/OnPlatform.cs
@@ -8,6 +8,8 @@ namespace Xamarin.Forms
 
 		public T WinPhone { get; set; }
 
+		public T Tizen { get; set; }
+
 		public static implicit operator T(OnPlatform<T> onPlatform)
 		{
 			switch (Device.OS)
@@ -19,6 +21,8 @@ namespace Xamarin.Forms
 				case TargetPlatform.Windows:
 				case TargetPlatform.WinPhone:
 					return onPlatform.WinPhone;
+				case TargetPlatform.Tizen:
+					return onPlatform.Tizen;
 			}
 
 			return onPlatform.iOS;

--- a/Xamarin.Forms.Core/PlatformConfiguration/ExtensionPoints.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/ExtensionPoints.cs
@@ -4,4 +4,5 @@ namespace Xamarin.Forms.PlatformConfiguration
 	public sealed class Android : IConfigPlatform { }
 	public sealed class iOS : IConfigPlatform { }
 	public sealed class Windows : IConfigPlatform { }
+	public sealed class Tizen : IConfigPlatform { }
 }

--- a/Xamarin.Forms.Core/TargetPlatform.cs
+++ b/Xamarin.Forms.Core/TargetPlatform.cs
@@ -6,6 +6,7 @@ namespace Xamarin.Forms
 		iOS,
 		Android,
 		WinPhone,
-		Windows
+		Windows,
+		Tizen
 	}
 }

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration/Tizen.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration/Tizen.xml
@@ -1,0 +1,35 @@
+<Type Name="Tizen" FullName="Xamarin.Forms.PlatformConfiguration.Tizen">
+  <TypeSignature Language="C#" Value="public sealed class Tizen : Xamarin.Forms.IConfigPlatform" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit Tizen extends System.Object implements class Xamarin.Forms.IConfigPlatform" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IConfigPlatform</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Tizen ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
@@ -130,7 +130,7 @@ Device.BeginInvokeOnMainThread (() => {
       </Docs>
     </Member>
     <Member MemberName="OnPlatform">
-      <MemberSignature Language="C#" Value="public static void OnPlatform (Action iOS = null, Action Android = null, Action WinPhone = null, Action Default = null);" />
+      <MemberSignature Language="C#" Value="public static void OnPlatform (Action iOS, Action Android, Action WinPhone, Action Default);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void OnPlatform(class System.Action iOS, class System.Action Android, class System.Action WinPhone, class System.Action Default) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -142,6 +142,11 @@ Device.BeginInvokeOnMainThread (() => {
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("OnPlatform is obsolete, please use OnPlatform (Action, Action, Action, Action, Action)")</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -168,6 +173,41 @@ Device.OnPlatform (iOS: () => label.Font = Font.OfSize ("HelveticaNeue-UltraLigh
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="OnPlatform">
+      <MemberSignature Language="C#" Value="public static void OnPlatform (Action iOS = null, Action Android = null, Action WinPhone = null, Action Default = null, Action Tizen = null);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void OnPlatform(class System.Action iOS, class System.Action Android, class System.Action WinPhone, class System.Action Default, class System.Action Tizen) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="iOS" Type="System.Action" />
+        <Parameter Name="Android" Type="System.Action" />
+        <Parameter Name="WinPhone" Type="System.Action" />
+        <Parameter Name="Default" Type="System.Action" />
+        <Parameter Name="Tizen" Type="System.Action" />
+      </Parameters>
+      <Docs>
+        <param name="iOS">(optional) The Action to execute on iOS.</param>
+        <param name="Android">(optional) The Action to execute on Android.</param>
+        <param name="WinPhone">(optional) The Action to execute on WinPhone.</param>
+        <param name="Default">(optional) The Action to execute if no Action was provided for the current OS.</param>
+        <param name="Tizen">(optional) The Action to execute on Tizen.</param>
+        <summary>Executes different Actions depending on the <see cref="T:Xamarin.QcuikUI.TargetOS" /> that Xamarin.Forms is working on.</summary>
+        <remarks>
+          <para>This example shows how to change the font of a Label on a single OS.
+          </para>
+          <example>
+            <code lang="C#"><![CDATA[
+Device.OnPlatform (iOS: () => label.Font = Font.OfSize ("HelveticaNeue-UltraLight", NamedSize.Large));
+          ]]></code>
+          </example>
+        </remarks>
+      </Docs>
+    </Member>
     <Member MemberName="OnPlatform&lt;T&gt;">
       <MemberSignature Language="C#" Value="public static T OnPlatform&lt;T&gt; (T iOS, T Android, T WinPhone);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig !!T OnPlatform&lt;T&gt;(!!T iOS, !!T Android, !!T WinPhone) cil managed" />
@@ -181,6 +221,11 @@ Device.OnPlatform (iOS: () => label.Font = Font.OfSize ("HelveticaNeue-UltraLigh
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("OnPlatform&lt;T&gt; is obsolete, please use OnPlatform&lt;T&gt; (T, T, T, T)")</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>T</ReturnType>
       </ReturnValue>
@@ -197,6 +242,44 @@ Device.OnPlatform (iOS: () => label.Font = Font.OfSize ("HelveticaNeue-UltraLigh
         <param name="iOS">The value for iOS.</param>
         <param name="Android">The value for Android.</param>
         <param name="WinPhone">The value for WinPhone.</param>
+        <summary>Returns different values depending on the <see cref="T:Xamarin.Forms.TargetOS" /> Xamarin.Forms is working on.</summary>
+        <returns>The value for the current OS.</returns>
+        <remarks>
+          <para>This example shows how to use different heights for a Button on different OS.
+          </para>
+          <example>
+            <code lang="C#"><![CDATA[
+button.HeightRequest = Device.OnPlatform (20,30,30);
+          ]]></code>
+          </example>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="OnPlatform&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static T OnPlatform&lt;T&gt; (T iOS, T Android, T WinPhone, T Tizen);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig !!T OnPlatform&lt;T&gt;(!!T iOS, !!T Android, !!T WinPhone, !!T Tizen) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>T</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="iOS" Type="T" />
+        <Parameter Name="Android" Type="T" />
+        <Parameter Name="WinPhone" Type="T" />
+        <Parameter Name="Tizen" Type="T" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">The type of the value to be returned.</typeparam>
+        <param name="iOS">The value for iOS.</param>
+        <param name="Android">The value for Android.</param>
+        <param name="WinPhone">The value for WinPhone.</param>
+        <param name="Tizen">The value for Tizen.</param>
         <summary>Returns different values depending on the <see cref="T:Xamarin.Forms.TargetOS" /> Xamarin.Forms is working on.</summary>
         <returns>The value for the current OS.</returns>
         <remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
@@ -130,7 +130,7 @@ Device.BeginInvokeOnMainThread (() => {
       </Docs>
     </Member>
     <Member MemberName="OnPlatform">
-      <MemberSignature Language="C#" Value="public static void OnPlatform (Action iOS, Action Android, Action WinPhone, Action Default);" />
+      <MemberSignature Language="C#" Value="public static void OnPlatform (Action iOS = null, Action Android = null, Action WinPhone = null, Action Default = null);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void OnPlatform(class System.Action iOS, class System.Action Android, class System.Action WinPhone, class System.Action Default) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -142,11 +142,6 @@ Device.BeginInvokeOnMainThread (() => {
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.Obsolete("OnPlatform is obsolete, please use OnPlatform (Action, Action, Action, Action, Action)")</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -221,11 +216,6 @@ Device.OnPlatform (iOS: () => label.Font = Font.OfSize ("HelveticaNeue-UltraLigh
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.Obsolete("OnPlatform&lt;T&gt; is obsolete, please use OnPlatform&lt;T&gt; (T, T, T, T)")</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>T</ReturnType>
       </ReturnValue>
@@ -279,7 +269,7 @@ button.HeightRequest = Device.OnPlatform (20,30,30);
         <param name="iOS">The value for iOS.</param>
         <param name="Android">The value for Android.</param>
         <param name="WinPhone">The value for WinPhone.</param>
-        <param name="Tizen">The value for Tizen.</param>
+        <param name="WinPhone">The value for Tizen.</param>
         <summary>Returns different values depending on the <see cref="T:Xamarin.Forms.TargetOS" /> Xamarin.Forms is working on.</summary>
         <returns>The value for the current OS.</returns>
         <remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/OnPlatform`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/OnPlatform`1.xml
@@ -113,6 +113,22 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Tizen">
+      <MemberSignature Language="C#" Value="public T Tizen { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance !T Tizen" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>T</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>The type as it is implemented on the Tizen platform.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="WinPhone">
       <MemberSignature Language="C#" Value="public T WinPhone { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance !T WinPhone" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/TargetPlatform.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/TargetPlatform.xml
@@ -80,6 +80,20 @@
         <summary>(Unused) Indicates that Forms is running on an undefined platform.</summary>
       </Docs>
     </Member>
+    <Member MemberName="Tizen">
+      <MemberSignature Language="C#" Value="Tizen" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.TargetPlatform Tizen = int32(5)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.TargetPlatform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates that forms is running on the Tizen platform.</summary>
+      </Docs>
+    </Member>
     <Member MemberName="Windows">
       <MemberSignature Language="C#" Value="Windows" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.TargetPlatform Windows = int32(4)" />

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -464,6 +464,7 @@
     <Namespace Name="Xamarin.Forms.PlatformConfiguration">
       <Type Name="Android" Kind="Class" />
       <Type Name="iOS" Kind="Class" />
+      <Type Name="Tizen" Kind="Class" />
       <Type Name="Windows" Kind="Class" />
     </Namespace>
     <Namespace Name="Xamarin.Forms.PlatformConfiguration.AndroidSpecific">


### PR DESCRIPTION
### Description of Change ###

This PR is introduce to Tizen as a TargetPlatform.  `TargetgetPlatform.Tizen` indicates that forms is running on the Tizen Platform.

### Bugs Fixed ###

- None

### API Changes ###

Added:
 - TargetPlatform.Tizen // enum
 - T OnPlatform<T>.Tizen { get; set; }
 - static void Device.OnPlatform (Action iOS, Action Android, Action WinPhone, Action Default, Action Tizen)
 - static T Device.OnPlatform<T> (T iOS, T Android, T WinPhone, T Tizen)
 - sealed class Xamarin.Forms.PlatformConfiguration.Tizen : IConfigPlatform

### Behavioral Changes ###

- None

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

