### PR TITLE
[UWP] Fix CommandBar Overlaying NavigationPage Content

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsPresenter.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsPresenter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	internal class FormsPresenter : Windows.UI.Xaml.Controls.ContentPresenter
+	{
+		public FormsPresenter()
+		{
+			Loaded += FormsPresenter_Loaded;
+			Unloaded += FormsPresenter_Unloaded;
+			SizeChanged += (s, e) =>
+			{
+				if (ActualWidth > 0 && ActualHeight > 0)
+				{
+					var page = (Page)DataContext;
+					((IPageController)page.RealParent).ContainerArea = new Rectangle(0, 0, ActualWidth, ActualHeight);
+				}
+			};
+		}
+
+		void FormsPresenter_Loaded(object sender, RoutedEventArgs e)
+		{
+			var page = (IPageController)DataContext;
+			page.SendAppearing();
+		}
+
+		void FormsPresenter_Unloaded(object sender, RoutedEventArgs e)
+		{
+			var page = (IPageController)DataContext;
+			page.SendDisappearing();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
@@ -26,7 +26,7 @@
                              </uwp:FormsCommandBar>
                         </Border>
 
-                        <ContentPresenter Margin="{TemplateBinding ContentMargin}" ContentTransitions="{TemplateBinding ContentTransitions}" x:Name="presenter" Grid.Row="1" />
+						<uwp:FormsPresenter Margin="{TemplateBinding ContentMargin}" ContentTransitions="{TemplateBinding ContentTransitions}" x:Name="presenter" Grid.Row="1" />
 
 						<Border x:Name="BottomCommandBarArea" Grid.Row="2" HorizontalAlignment="Stretch"></Border>
 					</Grid>

--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -12,35 +12,6 @@ using WGrid = Windows.UI.Xaml.Controls.Grid;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	internal class TabbedPagePresenter : Windows.UI.Xaml.Controls.ContentPresenter
-	{
-		public TabbedPagePresenter()
-		{
-			Loaded += TabbedPagePresenter_Loaded;
-			Unloaded += TabbedPagePresenter_Unloaded;
-			SizeChanged += (s, e) =>
-			{
-				if (ActualWidth > 0 && ActualHeight > 0)
-				{
-					var tab = (Page)DataContext;
-					((IPageController)tab.RealParent).ContainerArea = new Rectangle(0, 0, ActualWidth, ActualHeight);
-				}
-			};
-		}
-
-		void TabbedPagePresenter_Loaded(object sender, RoutedEventArgs e)
-		{
-			var tab = (IPageController)DataContext;
-			tab.SendAppearing();
-		}
-
-		void TabbedPagePresenter_Unloaded(object sender, RoutedEventArgs e)
-		{
-			var tab = (IPageController)DataContext;
-			tab.SendDisappearing();
-		}
-	}
-
     public class TabbedPageRenderer : IVisualElementRenderer, ITitleProvider, IToolbarProvider
     {
         const string TabBarHeaderTextBlockName = "TabbedPageHeaderTextBlock";

--- a/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
@@ -14,7 +14,7 @@
 		<Setter Property="ItemTemplate">
 			<Setter.Value>
 				<DataTemplate>
-					<uwp:TabbedPagePresenter Content="{Binding}" ContentTemplate="{ThemeResource ContainedPageTemplate}" />
+					<uwp:FormsPresenter Content="{Binding}" ContentTemplate="{ThemeResource ContainedPageTemplate}" />
 				</DataTemplate>
 			</Setter.Value>
 		</Setter>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -188,6 +188,7 @@
     <Compile Include="..\Xamarin.Forms.Platform.WinRT\LayoutExtensions.cs">
       <Link>LayoutExtensions.cs</Link>
     </Compile>
+    <Compile Include="FormsPresenter.cs" />
     <Compile Include="IToolBarForegroundBinder.cs" />
     <Compile Include="NativeBindingService.cs" />
     <Compile Include="NativeValueConverterService.cs" />


### PR DESCRIPTION
### Description of Change ###

On mobile, the CommandBar was covering the content inside a NavigationPage because the container area was not being updated after the CommandBar was moved to the bottom of the screen. 

The TabbedPage didn't have this issue as it used a TabbedPagePresenter to respond to the size change so I copied that code to a more generally named FormsPresenter class and used it also for the PageControl used by the NavigationPage renderer.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=48726

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

