### PR TITLE
Restore old Alert/ActionSheet method for iOS 8

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -46,20 +46,17 @@ namespace Xamarin.Forms.Platform.iOS
 				if (!PageIsChildOfPlatform(sender))
 					return;
 
-				if (Forms.IsiOS8OrNewer)
+				if (Forms.IsiOS9OrNewer)
 				{
 					PresentAlert(arguments);
 				}
+				else if (Forms.IsiOS8OrNewer)
+				{
+					Present8Alert(arguments);
+				}
 				else
 				{
-					UIAlertView alertView;
-					if (arguments.Accept != null)
-						alertView = new UIAlertView(arguments.Title, arguments.Message, null, arguments.Cancel, arguments.Accept);
-					else
-						alertView = new UIAlertView(arguments.Title, arguments.Message, null, arguments.Cancel);
-
-					alertView.Dismissed += (o, args) => arguments.SetResult(args.ButtonIndex != 0);
-					alertView.Show();
+					PresentPre8Alert(arguments);
 				}
 			});
 
@@ -73,25 +70,17 @@ namespace Xamarin.Forms.Platform.iOS
 					pageRoot = (Page)pageRoot.RealParent;
 				var pageRenderer = GetRenderer(pageRoot);
 
-				if (Forms.IsiOS8OrNewer)
+				if (Forms.IsiOS9OrNewer)
 				{
 					PresentActionSheet(arguments);
 				}
+				else if (Forms.IsiOS8OrNewer)
+				{
+					Present8ActionSheet(arguments, pageRenderer);
+				}
 				else
 				{
-					var actionSheet = new UIActionSheet(arguments.Title, null, arguments.Cancel, arguments.Destruction, arguments.Buttons.ToArray());
-
-					actionSheet.ShowInView(pageRenderer.NativeView);
-
-					actionSheet.Clicked += (o, args) =>
-					{
-						string title = null;
-						if (args.ButtonIndex != -1)
-							title = actionSheet.ButtonTitle(args.ButtonIndex);
-
-						// iOS 8 always calls WillDismiss twice, once with the real result, and again with -1.
-						arguments.Result.TrySetResult(title);
-					};
+					PresentPre8ActionSheet(arguments, pageRenderer);
 				}
 			});
 		}
@@ -416,7 +405,7 @@ namespace Xamarin.Forms.Platform.iOS
 					() => arguments.SetResult(true), window));
 			}
 
-			PresentAlert(window, alert);
+			PresentPopUp(window, alert);
 		}
 
 		void PresentActionSheet(ActionSheetArguments arguments)
@@ -444,10 +433,10 @@ namespace Xamarin.Forms.Platform.iOS
 				alert.AddAction(CreateActionWithWindowHide(blabel, UIAlertActionStyle.Default, () => arguments.SetResult(blabel), window));
 			}
 
-			PresentAlert(window, alert, arguments);
+			PresentPopUp(window, alert, arguments);
 		}
 
-		static void PresentAlert(UIWindow window, UIAlertController alert, ActionSheetArguments arguments = null)
+		static void PresentPopUp(UIWindow window, UIAlertController alert, ActionSheetArguments arguments = null)
 		{
 			window.RootViewController = new UIViewController();
 			window.RootViewController.View.BackgroundColor = Color.Transparent.ToUIColor();
@@ -502,6 +491,91 @@ namespace Xamarin.Forms.Platform.iOS
 			// would be safe to dismiss the VC). Fortunately this is almost never an issue
 			await _renderer.PresentViewControllerAsync(wrapper, animated);
 			await Task.Delay(5);
+		}
+
+		void PresentPre8Alert(AlertArguments arguments)
+		{
+			UIAlertView alertView;
+			if (arguments.Accept != null)
+				alertView = new UIAlertView(arguments.Title, arguments.Message, null, arguments.Cancel, arguments.Accept);
+			else
+				alertView = new UIAlertView(arguments.Title, arguments.Message, null, arguments.Cancel);
+
+			alertView.Dismissed += (o, args) => arguments.SetResult(args.ButtonIndex != 0);
+			alertView.Show();
+		}
+
+		void PresentPre8ActionSheet(ActionSheetArguments arguments, IVisualElementRenderer pageRenderer)
+		{
+			var actionSheet = new UIActionSheet(arguments.Title, null, arguments.Cancel, arguments.Destruction,
+						arguments.Buttons.ToArray());
+
+			actionSheet.ShowInView(pageRenderer.NativeView);
+
+			actionSheet.Clicked += (o, args) =>
+			{
+				string title = null;
+				if (args.ButtonIndex != -1)
+					title = actionSheet.ButtonTitle(args.ButtonIndex);
+
+				arguments.Result.TrySetResult(title);
+			};
+		}
+
+		void Present8Alert(AlertArguments arguments)
+		{
+			var alert = UIAlertController.Create(arguments.Title, arguments.Message, UIAlertControllerStyle.Alert);
+			var oldFrame = alert.View.Frame;
+			alert.View.Frame = new RectangleF(oldFrame.X, oldFrame.Y, oldFrame.Width, oldFrame.Height - _alertPadding * 2);
+			alert.AddAction(UIAlertAction.Create(arguments.Cancel, UIAlertActionStyle.Cancel, a => arguments.SetResult(false)));
+			if (arguments.Accept != null)
+				alert.AddAction(UIAlertAction.Create(arguments.Accept, UIAlertActionStyle.Default, a => arguments.SetResult(true)));
+			var page = _modals.Any() ? _modals.Last() : Page;
+			var vc = GetRenderer(page).ViewController;
+			vc.PresentViewController(alert, true, null);
+		}
+
+		void Present8ActionSheet(ActionSheetArguments arguments, IVisualElementRenderer pageRenderer)
+		{
+			var alert = UIAlertController.Create(arguments.Title, null, UIAlertControllerStyle.ActionSheet);
+
+			if (arguments.Cancel != null)
+			{
+				alert.AddAction(UIAlertAction.Create(arguments.Cancel, UIAlertActionStyle.Cancel, a => arguments.SetResult(arguments.Cancel)));
+			}
+
+			if (arguments.Destruction != null)
+			{
+				alert.AddAction(UIAlertAction.Create(arguments.Destruction, UIAlertActionStyle.Destructive, a => arguments.SetResult(arguments.Destruction)));
+			}
+
+			foreach (var label in arguments.Buttons)
+			{
+				if (label == null)
+					continue;
+
+				var blabel = label;
+				alert.AddAction(UIAlertAction.Create(blabel, UIAlertActionStyle.Default, a => arguments.SetResult(blabel)));
+			}
+
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+			{
+				UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
+				var observer = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification,
+					n => { alert.PopoverPresentationController.SourceRect = pageRenderer.ViewController.View.Bounds; });
+
+				arguments.Result.Task.ContinueWith(t =>
+				{
+					NSNotificationCenter.DefaultCenter.RemoveObserver(observer);
+					UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
+				}, TaskScheduler.FromCurrentSynchronizationContext());
+
+				alert.PopoverPresentationController.SourceView = pageRenderer.ViewController.View;
+				alert.PopoverPresentationController.SourceRect = pageRenderer.ViewController.View.Bounds;
+				alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
+			}
+
+			pageRenderer.ViewController.PresentViewController(alert, true, null);
 		}
 
 		internal class DefaultRenderer : VisualElementRenderer<VisualElement>

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (Forms.IsiOS8OrNewer)
 				{
-					PresentAlert(arguments);
+					PresentActionSheet(arguments);
 				}
 				else
 				{
@@ -419,7 +419,7 @@ namespace Xamarin.Forms.Platform.iOS
 			PresentAlert(window, alert);
 		}
 
-		void PresentAlert(ActionSheetArguments arguments)
+		void PresentActionSheet(ActionSheetArguments arguments)
 		{
 			var alert = UIAlertController.Create(arguments.Title, null, UIAlertControllerStyle.ActionSheet);
 			var window = new UIWindow { BackgroundColor = Color.Transparent.ToUIColor() };


### PR DESCRIPTION
### Description of Change ###

The method of handling Action Sheets and Alerts introduced by PR 481 doesn't work properly on iOS 8; this change restores the old functionality for iOS 8 while preserving the new functionality for iOS 9 and up.

### Bugs Fixed ###

- Action Sheet and Alerts completely non-functional in iOS 8

### API Changes ###

None

### Behavioral Changes ###

None 

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
