### PR TITLE
[iOS] Fix ItemTapped and ItemSelected event args in Recycle caching strategy

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48271.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48271.cs
@@ -80,14 +80,16 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = listView;
 		}
 
-		void ListViewOnItemTapped(object sender, ItemTappedEventArgs itemTappedEventArgs)
+		async void ListViewOnItemTapped(object sender, ItemTappedEventArgs itemTappedEventArgs)
 		{
-			;
+			var item = (Model48271)itemTappedEventArgs.Item;
+			await DisplayAlert("Alert", item.Text + ", " + item.Detail, "OK");
 		}
 
-		void ListViewOnItemSelected(object sender, SelectedItemChangedEventArgs selectedItemChangedEventArgs)
+		async void ListViewOnItemSelected(object sender, SelectedItemChangedEventArgs selectedItemChangedEventArgs)
 		{
-			;
+			var item = (Model48271)selectedItemChangedEventArgs.SelectedItem;
+			await DisplayAlert("Alert", item.Text + ", " + item.Detail, "OK");
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48271.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla48271.cs
@@ -1,0 +1,157 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 48271, "ListView with custom cell causes selected item to be null", PlatformAffected.iOS)]
+	public class Bugzilla48271 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			PushAsync(new ContentPage
+			{
+				Content = new StackLayout
+				{
+					Spacing = 10,
+					Orientation = StackOrientation.Vertical,
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center,
+					Children =
+					{
+						new Button
+						{
+							Text = "Retain",
+							Command = new Command(async () =>
+							{
+								await Navigation.PushAsync(new ContentPage48271(ListViewCachingStrategy.RetainElement));
+							})
+						},
+						new Button
+						{
+							Text = "Recycle",
+							Command = new Command(async () =>
+							{
+								await Navigation.PushAsync(new ContentPage48271(ListViewCachingStrategy.RecycleElement));
+							})
+						}
+					}
+				}
+			});
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ContentPage48271 : ContentPage
+	{
+		public ContentPage48271(ListViewCachingStrategy cachingStrategy)
+		{
+			BindingContext = new ViewModel48271();
+
+			var listView = new ListView(cachingStrategy)
+			{
+				HasUnevenRows = true,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var customCell = new ViewCell48271();
+					customCell.SetBinding(ViewCell48271.TextProperty, new Binding("Text"));
+					customCell.SetBinding(ViewCell48271.DetailProperty, new Binding("Detail"));
+					return customCell;
+				}),
+				ItemsSource = ((ViewModel48271)BindingContext).ItemList
+			};
+			listView.ItemSelected += ListViewOnItemSelected;
+			listView.ItemTapped += ListViewOnItemTapped;
+
+			Content = listView;
+		}
+
+		void ListViewOnItemTapped(object sender, ItemTappedEventArgs itemTappedEventArgs)
+		{
+			;
+		}
+
+		void ListViewOnItemSelected(object sender, SelectedItemChangedEventArgs selectedItemChangedEventArgs)
+		{
+			;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModel48271 : INotifyPropertyChanged
+	{
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		ObservableCollection<Model48271> _itemList;
+		public ObservableCollection<Model48271> ItemList
+		{
+			get { return _itemList; }
+			set
+			{
+				_itemList = value;
+				OnPropertyChanged();
+			}
+		}
+
+		void OnPropertyChanged([CallerMemberName]string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		public ViewModel48271()
+		{
+			ItemList = new ObservableCollection<Model48271>
+			{
+				new Model48271("1", "Row 1"),
+				new Model48271("2", "Row 2"),
+				new Model48271("3", "Row 3")
+			};
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Model48271
+	{
+		public string Text { get; }
+
+		public string Detail { get; }
+
+		public Model48271(string text, string detail)
+		{
+			Text = text;
+			Detail = detail;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewCell48271 : ViewCell
+	{
+		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(ViewCell48271), "");
+		public string Text
+		{
+			get { return (string)GetValue(TextProperty); }
+			set { SetValue(TextProperty, value); }
+		}
+
+		public static readonly BindableProperty DetailProperty = BindableProperty.Create("Detail", typeof(string), typeof(ViewCell48271), "");
+		public string Detail
+		{
+			get { return (string)GetValue(DetailProperty); }
+			set { SetValue(DetailProperty, value); }
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -140,6 +140,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46630.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47971.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla48271.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -393,23 +393,25 @@ namespace Xamarin.Forms
 
 		internal void NotifyRowTapped(int groupIndex, int inGroupIndex, Cell cell = null)
 		{
-			var group = TemplatedItems.GetGroup(groupIndex);
+			TemplatedItemsList<ItemsView<Cell>, Cell> group = TemplatedItems.GetGroup(groupIndex);
 
 			bool changed = _previousGroupSelected != groupIndex || _previousRowSelected != inGroupIndex;
 
 			_previousRowSelected = inGroupIndex;
 			_previousGroupSelected = groupIndex;
+
+			// Using cell properties is unreliable in the context of RecycleElement
 			if (cell == null)
-			{
 				cell = group[inGroupIndex];
-			}
+
+			object item = group.ListProxy[inGroupIndex];
 
 			// Set SelectedItem before any events so we don't override any changes they may have made.
-			SetValueCore(SelectedItemProperty, cell.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0));
+			SetValueCore(SelectedItemProperty, item, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0));
 
 			cell.OnTapped();
 
-			ItemTapped?.Invoke(this, new ItemTappedEventArgs(group, cell.BindingContext));
+			ItemTapped?.Invoke(this, new ItemTappedEventArgs(group, item));
 		}
 
 		internal void NotifyRowTapped(int index, Cell cell = null)

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -400,16 +400,17 @@ namespace Xamarin.Forms
 			_previousRowSelected = inGroupIndex;
 			_previousGroupSelected = groupIndex;
 
-			// Using cell properties is unreliable in the context of RecycleElement
-			if (cell == null)
-				cell = group[inGroupIndex];
-
 			object item = group.ListProxy[inGroupIndex];
 
 			// Set SelectedItem before any events so we don't override any changes they may have made.
 			SetValueCore(SelectedItemProperty, item, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0));
 
-			cell.OnTapped();
+			// Using cell properties is unreliable in the context of RecycleElement
+			if (cell == null)
+			{
+				cell = group[inGroupIndex];
+				cell.OnTapped();
+			}
 
 			ItemTapped?.Invoke(this, new ItemTappedEventArgs(group, item));
 		}


### PR DESCRIPTION
### Description of Change ###

In `Recycle` caching strategy, `ItemTapped` and `ItemSelected` are returning null for the current item. It appears that the binding context for cells is null. I'm not sure if the fix needs to be fixing the `BindingContext` or if these changes are fine. The sample code tests both caching modes.

There is also another PR for another issue: #461 

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=48271

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

