### PR TITLE
[iOS] Suggested fix for 39908

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39908.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39908.cs
@@ -16,16 +16,16 @@ namespace Xamarin.Forms.Controls
 	{
 		protected override void Init()
 		{
-			PushAsync(new ContentPage39908());
+			PushAsync(new ContentPage39908(1));
 		}
 	}
 
 	[Preserve(AllMembers = true)]
 	public class ContentPage39908 : ContentPage
 	{
-		public ContentPage39908()
+		public ContentPage39908(int count)
 		{
-			string label = "Page " + Navigation.NavigationStack.Count;
+			string label = "Page " + count;
 
 			var button = new Button
 			{
@@ -52,7 +52,8 @@ namespace Xamarin.Forms.Controls
 
 		void AddNewPage(object sender, EventArgs e)
 		{
-			Navigation.PushAsync(new ContentPage39908());
+			int count = (Parent as NavigationPage).Navigation.NavigationStack.Count;
+			Navigation.PushAsync(new ContentPage39908(++count));
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39908.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39908.cs
@@ -11,62 +11,48 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 39908, " Back button hit quickly results in jumbled pages")]
-	public class Bugzilla39908 : TestContentPage // or TestMasterDetailPage, etc ...
+	[Issue(IssueTracker.Bugzilla, 39908, " Back button hit quickly results in jumbled pages", PlatformAffected.iOS)]
+	public class Bugzilla39908 : TestNavigationPage // or TestMasterDetailPage, etc ...
 	{
 		protected override void Init()
 		{
-			var label = "Root Page";
+			PushAsync(new ContentPage39908());
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ContentPage39908 : ContentPage
+	{
+		public ContentPage39908()
+		{
+			string label = "Page " + Navigation.NavigationStack.Count;
+
+			var button = new Button
+			{
+				Text = "Another one",
+				AutomationId = "Another one"
+			};
+			button.Clicked += AddNewPage;
 
 			Title = label;
 			Content = new StackLayout
 			{
 				VerticalOptions = LayoutOptions.Center,
-				Children = {
-					new Label {
-						HorizontalTextAlignment = TextAlignment.Center,
-						Text = label
-					},
-					NewButton ()
-				}
-			};
-		}
-
-
-
-		private Button NewButton()
-		{
-			var newPageButton = new Button();
-			newPageButton.Text = "Another one";
-			newPageButton.Clicked += OnNewPage;
-
-			return newPageButton;
-		}
-
-		private ContentPage NewPage()
-		{
-			var label = Navigation != null ? "Page " + (Navigation.NavigationStack.Count - 1) : "Root Page";
-
-			return new ContentPage
-			{
-				Title = label,
-				Content = new StackLayout
+				Children =
 				{
-					VerticalOptions = LayoutOptions.Center,
-					Children = {
-					new Label {
+					new Label
+					{
 						HorizontalTextAlignment = TextAlignment.Center,
 						Text = label
 					},
-					NewButton ()
-				}
+					button
 				}
 			};
 		}
 
-		private async void OnNewPage(object sender, EventArgs e)
+		void AddNewPage(object sender, EventArgs e)
 		{
-			await Navigation.PushAsync(NewPage());
+			Navigation.PushAsync(new ContentPage39908());
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -110,12 +110,6 @@ namespace Xamarin.Forms.Platform.iOS
 			return OnPopViewAsync(page, animated);
 		}
 
-		public override UIViewController PopViewController(bool animated)
-		{
-			RemoveViewControllers(animated);
-			return base.PopViewController(animated);
-		}
-
 		public Task<bool> PushPageAsync(Page page, bool animated = true)
 		{
 			return OnPushAsync(page, animated);

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -86,20 +86,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (!_appeared || _disposed)
 				return;
-
-			var navigationPage = Element.Parent as NavigationPage;
-			if (navigationPage != null)
-			{
-				int managedStackCount = navigationPage.Navigation.NavigationStack.Count;
-				IVisualElementRenderer renderer = Platform.GetRenderer(navigationPage);
-				var navigationController = renderer as UINavigationController;
-				int? nativeStackCount = navigationController?.ViewControllers.Length;
-				if (managedStackCount > nativeStackCount)
-					await ((INavigationPageController)renderer.Element).PopAsyncInner(animated, true);
-			}
-
 			_appeared = false;
 			PageController.SendDisappearing();
+
+			var navigationPage = Element.Parent as NavigationPage;
+			if (navigationPage == null)
+				return;
+
+			int managedStackCount = navigationPage.Navigation.NavigationStack.Count;
+			IVisualElementRenderer renderer = Platform.GetRenderer(navigationPage);
+			var navigationController = renderer as UINavigationController;
+
+			int? nativeStackCount = navigationController?.ViewControllers.Length;
+			if (nativeStackCount.HasValue && managedStackCount > nativeStackCount.Value)
+				await ((INavigationPageController)renderer.Element).PopAsyncInner(animated, true);
 		}
 
 		public override void ViewDidLoad()

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -96,10 +96,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			int managedStackCount = navigationPage.Navigation.NavigationStack.Count;
 			IVisualElementRenderer renderer = Platform.GetRenderer(navigationPage);
-			var navigationController = renderer as UINavigationController;
 
-			int? nativeStackCount = navigationController?.ViewControllers.Length;
-			if (nativeStackCount.HasValue && managedStackCount > nativeStackCount.Value)
+			var navigationController = renderer as UINavigationController;
+			if (navigationController != null && managedStackCount > navigationController.ViewControllers.Length)
 				await ((INavigationPageController)renderer.Element).PopAsyncInner(animated, true);
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using UIKit;
 using PageUIStatusBarAnimation = Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
@@ -80,7 +81,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateStatusBarPrefersHidden();
 		}
 
-		public override async void ViewDidDisappear(bool animated)
+		public override void ViewDidDisappear(bool animated)
 		{
 			base.ViewDidDisappear(animated);
 
@@ -99,7 +100,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var navigationController = renderer as UINavigationController;
 			if (navigationController != null && managedStackCount > navigationController.ViewControllers.Length)
-				await ((INavigationPageController)renderer.Element).PopAsyncInner(animated, true);
+			{
+				Task<Page> task = ((INavigationPageController)renderer.Element).PopAsyncInner(animated, true);
+				Task.WaitAll(task);
+			}
 		}
 
 		public override void ViewDidLoad()

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -133,7 +133,6 @@ namespace Xamarin.Forms.Platform.iOS
 			base.ViewWillDisappear(animated);
 
 			View.Window?.EndEditing(true);
-			
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -86,6 +86,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (!_appeared || _disposed)
 				return;
+
 			_appeared = false;
 			PageController.SendDisappearing();
 


### PR DESCRIPTION
### Description of Change ###

When you tap the `Back` button on iOS `NavigationPage` rapidly, this will mess up XF's navigation stack because iOS doesn't seem to be calling `PopViewController` for every page being removed.

@rmarinho `ViewDidDisappear` will be called sequentially for every page in `PageRenderer`, so perhaps we can sync the navigation stack there?

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=39908

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

