### PR TITLE
Localized test code to Japanese.

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingBaseUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingBaseUnitTests.cs
@@ -171,10 +171,20 @@ namespace Xamarin.Forms.Core.UnitTests
 			var bo = new MockBindable { BindingContext = vm };
 			bo.SetBinding(property, binding);
 
-			if (System.Threading.Thread.CurrentThread.CurrentCulture.Name == "tr-TR")
-				Assert.That(bo.GetValue(property), Is.EqualTo("%95,00"));
-			else
-				Assert.That(bo.GetValue(property), Is.EqualTo("95.00 %"));
+            switch (System.Threading.Thread.CurrentThread.CurrentCulture.Name)
+            {
+                case "tr-TR":
+                    Assert.That(bo.GetValue(property), Is.EqualTo("%95,00"));
+                    break;
+
+                case "ja-JP":
+                    Assert.That(bo.GetValue(property), Is.EqualTo("95.00%"));
+                    break;
+
+                default:
+                    Assert.That(bo.GetValue(property), Is.EqualTo("95.00 %"));
+                    break;
+            }
 		}
 
 		[Test]


### PR DESCRIPTION
### Description of Change ###
In ja-JP string format convert 0.95d  with "{0:P2}" to "95.00%".
but excepted string format convert to "95.00 %" in test code.
So I modified test code and refactored.
### Bugs Fixed ###
- Nothing.

### API Changes ###
Added:
 - Nothing.

Changed:
 - Nothing.

### Behavioral Changes ###
-Nothing.

### PR Checklist ###

- [x ] Has tests (if omitted, state reason in description)
- [x ] Rebased on top of master at time of PR
- [x ] Changes adhere to coding standard
- [x ] Consolidate commits as makes sense

