### PR TITLE
[WinRT/UWP] Adjust margin for centered Slider

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29110.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29110.cs
@@ -1,0 +1,49 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 29110, "[WinRT/UWP] VerticalOptions = LayoutOptions.Center or CenterAndExpand on Sliders does not result in centered display", PlatformAffected.WinRT)]
+	public class Bugzilla29110 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Children =
+				{
+					new Label
+					{
+						BackgroundColor = Color.CadetBlue,
+						HorizontalOptions = LayoutOptions.Start,
+						VerticalOptions = LayoutOptions.CenterAndExpand,
+						VerticalTextAlignment = TextAlignment.Center,
+						Text = "Label"
+					},
+					new Slider
+					{
+						BackgroundColor = Color.Green,
+						HorizontalOptions = LayoutOptions.FillAndExpand,
+						VerticalOptions = LayoutOptions.CenterAndExpand,
+						Minimum = 0,
+						Maximum = 100
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla29107.xaml.cs">
       <DependentUpon>Bugzilla29107.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla29110.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla29158.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla29363.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla29229.cs" />

--- a/Xamarin.Forms.Platform.WinRT/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/SliderRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Primitives;
 
 #if WINDOWS_UWP
@@ -24,6 +25,25 @@ namespace Xamarin.Forms.Platform.WinRT
 					SetNativeControl(slider);
 
 					slider.ValueChanged += OnNativeValueCHanged;
+
+					// Even when using Center/CenterAndExpand, a Slider has an oddity where it looks
+					// off-center in its layout by a smidge. The default templates are slightly different
+					// between 8.1/UWP; the 8.1 rows are 17/Auto/32 and UWP are 18/Auto/18. The value of
+					// the hardcoded 8.1 rows adds up to 49 (when halved is 24.5) and UWP are 36 (18). Using
+					// a difference of about 6 pixels to correct this oddity seems to make them both center
+					// more correctly.
+					//
+					// The VerticalAlignment needs to be set as well since a control would not actually be
+					// centered if a larger HeightRequest is set.
+					if (Element.VerticalOptions.Alignment == LayoutAlignment.Center && Control.Orientation == Windows.UI.Xaml.Controls.Orientation.Horizontal)
+					{
+						Control.VerticalAlignment = VerticalAlignment.Center;
+#if WINDOWS_UWP
+						slider.Margin = new Windows.UI.Xaml.Thickness(0, 7, 0, 0);
+#else
+						slider.Margin = new Windows.UI.Xaml.Thickness(0, 13, 0, 0);
+#endif
+					}
 				}
 
 				double stepping = Math.Min((e.NewElement.Maximum - e.NewElement.Minimum) / 10, 1);


### PR DESCRIPTION
### Description of Change ###

The Slider control has an odd behavior when centered via `VerticalOptions` and wasn't looking truly centered, like this:

![nofix](https://cloud.githubusercontent.com/assets/1251024/20866990/82af6c54-b9f7-11e6-9754-bf3cb258bb0e.PNG)

Making adjustments to `ArrangeOverride` at an initial glance didn't seem to do enough, even when setting `VerticalAlignment` (although this was needed for cases where a `MinimumHeightRequest` was set, since as it exists it wasn't close to centering at all) so there was always a few pixels' difference as shown above. There is a slight difference in the default template between 8.1 and UWP templates so a slight adjustment using the `Margin` has been added depending on the platform so the result looks like this on each:

![wp81-slider](https://cloud.githubusercontent.com/assets/1251024/20867000/d427ad08-b9f7-11e6-8bcc-da74b3a0d9ad.PNG)

![uwp-slider](https://cloud.githubusercontent.com/assets/1251024/20866995/acd64dd6-b9f7-11e6-88ea-47e2df597129.PNG)

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=29110

### API Changes ###

None

### Behavioral Changes ###

Sliders were not centering as mentioned when a minimum height was specified so in those cases the result might be more obvious.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

