### PR TITLE
[Core] Add CloseContextMenu method to ListView

### DIFF
--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty SeparatorColorProperty = BindableProperty.Create("SeparatorColor", typeof(Color), typeof(ListView), Color.Default);
 
+		internal const string CloseContextMenuSignalName = "Xamarin.CloseContextMenu";
 		readonly Lazy<PlatformConfigurationRegistry<ListView>> _platformConfigurationRegistry;
 
 		BindingBase _groupDisplayBinding;
@@ -594,6 +595,11 @@ namespace Xamarin.Forms
 				return true;
 			var template = (DataTemplate)value;
 			return template.CreateContent() is View;
+		}
+
+		public void CloseContextMenu()
+		{
+			MessagingCenter.Send(this, CloseContextMenuSignalName);
 		}
 
 		public IPlatformElementConfiguration<T, ListView> On<T>() where T : IConfigPlatform

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool _actionModeNeedsUpdates;
 		AView _contextView;
 		global::Android.Support.V7.View.ActionMode _supportActionMode;
+		static WeakReference<CellAdapter> OpenCellAdapter { get; set; }
 
 		protected CellAdapter(Context context)
 		{
@@ -176,10 +177,21 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal void CloseContextAction()
 		{
-			if (_actionMode != null)
-				_actionMode.Finish();
-			if (_supportActionMode != null)
-				_supportActionMode.Finish();
+			_actionMode?.Finish();
+			_supportActionMode?.Finish();
+		}
+
+		internal static void CloseContextMenu()
+		{
+			if (OpenCellAdapter == null)
+				return;
+
+			CellAdapter openCellAdapter;
+			if(!OpenCellAdapter.TryGetTarget(out openCellAdapter))
+				return;
+			
+			openCellAdapter.CloseContextAction();
+			OpenCellAdapter = null;
 		}
 
 		void CreateContextMenu(IMenu menu)
@@ -241,6 +253,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (!cell.HasContextActions)
 					return false;
 
+				OpenCellAdapter = new WeakReference<CellAdapter>(this);
 				ActionModeContext = cell;
 
 				var appCompatActivity = Forms.Context as FormsAppCompatActivity;

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -119,6 +119,7 @@ namespace Xamarin.Forms.Platform.Android
 			OnDestroyActionModeImpl();
 			_supportActionMode.Dispose();
 			_supportActionMode = null;
+			OpenCellAdapter = null;
 		}
 
 		public bool OnPrepareActionMode(ActionMode mode, IMenu menu)

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -177,8 +177,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal void CloseContextAction()
 		{
-			_actionMode?.Finish();
-			_supportActionMode?.Finish();
+			if (_actionMode != null)
+				_actionMode.Finish();
+			if (_supportActionMode != null)
+				_supportActionMode.Finish();
 		}
 
 		internal static void CloseContextMenu()

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -112,6 +112,7 @@ namespace Xamarin.Forms.Platform.Android
 			OnDestroyActionModeImpl();
 			_actionMode.Dispose();
 			_actionMode = null;
+			OpenCellAdapter = null;
 		}
 
 		void global::Android.Support.V7.View.ActionMode.ICallback.OnDestroyActionMode(global::Android.Support.V7.View.ActionMode mode)

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.Android
 		IVisualElementRenderer _footerRenderer;
 		Container _headerView;
 		Container _footerView;
-		bool _isAttached;
+		bool _isAttached, _disposed;
 		ScrollToRequestedEventArgs _pendingScrollTo;
 
 		SwipeRefreshLayout _refresh;
@@ -26,6 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 		public ListViewRenderer()
 		{
 			AutoPackage = false;
+			MessagingCenter.Subscribe<ListView>(this, ListView.CloseContextMenuSignalName, a => { CellAdapter.CloseContextMenu(); });
 		}
 
 		void SwipeRefreshLayout.IOnRefreshListener.OnRefresh()
@@ -36,8 +37,15 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
 			if (disposing)
 			{
+				MessagingCenter.Unsubscribe<ListView>(this, ListView.CloseContextMenuSignalName);
+
 				if (_headerView == null)
 					return;
 

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -191,6 +191,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (FlyoutBase.GetAttachedFlyout(CellContent) == null)
 			{
 				var flyout = new MenuFlyout();
+				flyout.Closed += FlyoutOnClosed;
 				SetupMenuItems(flyout);
 
 				((INotifyCollectionChanged)Cell.ContextActions).CollectionChanged += OnContextActionsChanged;
@@ -201,6 +202,11 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			FlyoutBase.ShowAttachedFlyout(CellContent);
 			OpenCellControl = new WeakReference<CellControl>(this);
+		}
+
+		void FlyoutOnClosed(object sender, object o)
+		{
+			OpenCellControl = null;
 		}
 
 		internal static void CloseContextMenu()
@@ -300,6 +306,10 @@ namespace Xamarin.Forms.Platform.WinRT
 					((INotifyCollectionChanged)_contextActions).CollectionChanged -= OnContextActionsChanged;
 					_contextActions = null;
 				}
+
+				var flyout = FlyoutBase.GetAttachedFlyout(CellContent) as MenuFlyout;
+				if (flyout != null)
+					flyout.Closed -= FlyoutOnClosed;
 
 				FlyoutBase.SetAttachedFlyout(CellContent, null);
 				return;

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -62,10 +62,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			set { SetValue(IsGroupHeaderProperty, value); }
 		}
 
-		protected FrameworkElement CellContent
-		{
-			get { return (FrameworkElement)Content; }
-		}
+		protected FrameworkElement CellContent => (FrameworkElement)Content;
+
+		static WeakReference<FrameworkElement> OpenCellContent { get; set; }
 
 		protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
 		{
@@ -201,6 +200,19 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 
 			FlyoutBase.ShowAttachedFlyout(CellContent);
+			OpenCellContent = new WeakReference<FrameworkElement>(CellContent);
+		}
+
+		internal static void CloseContextMenu()
+		{
+			FrameworkElement openCellContent;
+			if (OpenCellContent == null || !OpenCellContent.TryGetTarget(out openCellContent))
+				return;
+
+			var flyout = FlyoutBase.GetAttachedFlyout(openCellContent) as MenuFlyout;
+			flyout?.Hide();
+
+			OpenCellContent = null;
 		}
 
 		void SetCell(object newContext)

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -214,7 +214,6 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			var flyout = FlyoutBase.GetAttachedFlyout(openCellControl.CellContent) as MenuFlyout;
 			flyout?.Hide();
-
 			OpenCellControl = null;
 		}
 

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		protected FrameworkElement CellContent => (FrameworkElement)Content;
 
-		static WeakReference<FrameworkElement> OpenCellContent { get; set; }
+		static WeakReference<CellControl> OpenCellControl { get; set; }
 
 		protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
 		{
@@ -200,19 +200,22 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 
 			FlyoutBase.ShowAttachedFlyout(CellContent);
-			OpenCellContent = new WeakReference<FrameworkElement>(CellContent);
+			OpenCellControl = new WeakReference<CellControl>(this);
 		}
 
 		internal static void CloseContextMenu()
 		{
-			FrameworkElement openCellContent;
-			if (OpenCellContent == null || !OpenCellContent.TryGetTarget(out openCellContent))
+			if (OpenCellControl == null)
 				return;
 
-			var flyout = FlyoutBase.GetAttachedFlyout(openCellContent) as MenuFlyout;
+			CellControl openCellControl;
+			if (!OpenCellControl.TryGetTarget(out openCellControl))
+				return;
+
+			var flyout = FlyoutBase.GetAttachedFlyout(openCellControl.CellContent) as MenuFlyout;
 			flyout?.Hide();
 
-			OpenCellContent = null;
+			OpenCellControl = null;
 		}
 
 		void SetCell(object newContext)

--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -46,6 +46,13 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		protected WListView List { get; private set; }
 
+		bool _disposed;
+
+		public ListViewRenderer()
+		{
+			MessagingCenter.Subscribe<ListView>(this, ListView.CloseContextMenuSignalName, a => { CellControl.CloseContextMenu(); });
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<ListView> e)
 		{
 			base.OnElementChanged(e);
@@ -138,21 +145,31 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		protected override void Dispose(bool disposing)
 		{
-			if (List != null)
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
 			{
-				List.Tapped -= ListOnTapped;
-				List.KeyUp -= OnKeyPressed;
+				MessagingCenter.Unsubscribe<ListView>(this, ListView.CloseContextMenuSignalName);
 
-				List.SelectionChanged -= OnControlSelectionChanged;
+				if (List != null)
+				{
+					List.Tapped -= ListOnTapped;
+					List.KeyUp -= OnKeyPressed;
 
-				List.DataContext = null;
-				List = null;
-			}
+					List.SelectionChanged -= OnControlSelectionChanged;
 
-			if (_zoom != null)
-			{
-				_zoom.ViewChangeCompleted -= OnViewChangeCompleted;
-				_zoom = null;
+					List.DataContext = null;
+					List = null;
+				}
+
+				if (_zoom != null)
+				{
+					_zoom.ViewChangeCompleted -= OnViewChangeCompleted;
+					_zoom = null;
+				}
 			}
 
 			base.Dispose(disposing);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -27,6 +27,12 @@ namespace Xamarin.Forms.Platform.iOS
 		FormsUITableViewController _tableViewController;
 		IListViewController Controller => Element;
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
+
+		public ListViewRenderer()
+		{
+			MessagingCenter.Subscribe<ListView>(this, ListView.CloseContextMenuSignalName, a => { ContextScrollViewDelegate.CloseContextMenu(); });
+		}
+
 		public override UIViewController ViewController => _tableViewController;
 
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
@@ -127,6 +133,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
+				MessagingCenter.Unsubscribe<ListView>(this, ListView.CloseContextMenuSignalName);
+
 				if (_headerRenderer != null)
 				{
 					var platform = _headerRenderer.Element.Platform as Platform;


### PR DESCRIPTION
### Description of Change ###

Add ability to close cell context menu programmatically as requested [here](https://forums.xamarin.com/discussion/comment/236779#Comment_236779). I'm excluding documentation for now to get feedback first. There doesn't seem to be a dispose method for the classes I used, hence the use of `WeakReference`.

### Bugs Fixed ###

- N/A

### API Changes ###

Added:
- public void CloseContextMenu() in `ListView`

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
