### PR TITLE
[iOS] Fix crash when pushing page on stack on orientation change

### DIFF
--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -167,7 +167,8 @@ namespace Xamarin.Forms
 				area.Height = Math.Max(0, area.Height);
 			}
 
-			foreach (Element element in ElementController.LogicalChildren)
+			List<Element> elements = ElementController.LogicalChildren.ToList();
+			foreach (Element element in elements)
 			{
 				var child = element as VisualElement;
 				if (child == null)

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -175,13 +175,9 @@ namespace Xamarin.Forms
 					continue;
 				var page = child as Page;
 				if (page != null && ((IPageController)page).IgnoresContainerArea)
-				{
 					Forms.Layout.LayoutChildIntoBoundingRegion(child, originalArea);
-				}
 				else
-				{
 					Forms.Layout.LayoutChildIntoBoundingRegion(child, area);
-				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

if you push a page on the navigation stack on device orientation change, this will crash because we are trying to update the element children collection while `foreach` is in progress during a layout cycle. There is a repro attached to the bug description.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=42651

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

