### PR TITLE
[Android] Double tapping on context action should not crash

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 45027, "App crashes when double tapping on ToolbarItem or MenuItem very quickly", PlatformAffected.Android)]
+	public class Bugzilla45027 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var list = new List<int>();
+			for (var i = 0; i < 10; i++)
+				list.Add(i);
+
+			var listView = new ListView
+			{
+				ItemsSource = list,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding("."));
+
+					return new ViewCell
+					{
+						View = new ContentView
+						{
+							Content = label,
+						},
+						ContextActions = { new MenuItem
+						{
+							Text = "Action"
+						},
+						new MenuItem
+						{
+							Text = "Delete",
+							IsDestructive = true
+						} }
+					};
+				})
+			};
+
+			Content = listView;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
@@ -7,12 +7,6 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-// Apply the default category of "Issues" to all of the tests in this assembly
-// We use this as a catch-all for tests which haven't been individually categorized
-#if UITEST
-[assembly: NUnit.Framework.Category("Issues")]
-#endif
-
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
@@ -24,6 +18,19 @@ namespace Xamarin.Forms.Controls.Issues
 			var list = new List<int>();
 			for (var i = 0; i < 10; i++)
 				list.Add(i);
+
+			var stackLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				Children =
+				{
+					new Label
+					{
+						Text = "Long tap list items to display context menu. Double tapping each action rapidly should not crash.",
+						HorizontalTextAlignment = TextAlignment.Center
+					}
+				}
+			};
 
 			var listView = new ListView
 			{
@@ -51,8 +58,9 @@ namespace Xamarin.Forms.Controls.Issues
 					};
 				})
 			};
+			stackLayout.Children.Add(listView);
 
-			Content = listView;
+			Content = stackLayout;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -153,6 +153,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42832.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44338.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45027.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45330.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -82,8 +82,7 @@ namespace Xamarin.Forms.Platform.Android
 		public bool OnActionItemClicked(ActionMode mode, IMenuItem item)
 		{
 			OnActionItemClickedImpl(item);
-			// Disable menu item so it can't be double tapped.
-			item.SetEnabled(false);
+			mode.Menu.Clear();
 			_actionMode?.Finish();
 			return true;
 		}
@@ -91,8 +90,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool global::Android.Support.V7.View.ActionMode.ICallback.OnActionItemClicked(global::Android.Support.V7.View.ActionMode mode, IMenuItem item)
 		{
 			OnActionItemClickedImpl(item);
-			// Disable menu item so it can't be double tapped.
-			item.SetEnabled(false);
+			mode.Menu.Clear();
 			_supportActionMode?.Finish();
 			return true;
 		}

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Forms.Platform.Android
 		public bool OnActionItemClicked(ActionMode mode, IMenuItem item)
 		{
 			OnActionItemClickedImpl(item);
+			// Disable menu item so it can't be double tapped.
 			item.SetEnabled(false);
 			_actionMode?.Finish();
 			return true;
@@ -90,6 +91,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool global::Android.Support.V7.View.ActionMode.ICallback.OnActionItemClicked(global::Android.Support.V7.View.ActionMode mode, IMenuItem item)
 		{
 			OnActionItemClickedImpl(item);
+			// Disable menu item so it can't be double tapped.
 			item.SetEnabled(false);
 			_supportActionMode?.Finish();
 			return true;

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Forms.Platform.Android
 		public bool OnActionItemClicked(ActionMode mode, IMenuItem item)
 		{
 			OnActionItemClickedImpl(item);
+			item.SetEnabled(false);
 			_actionMode?.Finish();
 			return true;
 		}
@@ -89,6 +90,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool global::Android.Support.V7.View.ActionMode.ICallback.OnActionItemClicked(global::Android.Support.V7.View.ActionMode mode, IMenuItem item)
 		{
 			OnActionItemClickedImpl(item);
+			item.SetEnabled(false);
 			_supportActionMode?.Finish();
 			return true;
 		}
@@ -253,9 +255,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnActionItemClickedImpl(IMenuItem item)
 		{
-			if (ActionModeContext == null)
-				return;
-
 			int index = item.ItemId;
 			IMenuItemController action = ActionModeContext.ContextActions[index];
 

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -81,16 +81,16 @@ namespace Xamarin.Forms.Platform.Android
 
 		public bool OnActionItemClicked(ActionMode mode, IMenuItem item)
 		{
-			OnActionItemClickedImpl(item);
 			mode.Menu.Clear();
+			OnActionItemClickedImpl(item);
 			_actionMode?.Finish();
 			return true;
 		}
 
 		bool global::Android.Support.V7.View.ActionMode.ICallback.OnActionItemClicked(global::Android.Support.V7.View.ActionMode mode, IMenuItem item)
 		{
-			OnActionItemClickedImpl(item);
 			mode.Menu.Clear();
+			OnActionItemClickedImpl(item);
 			_supportActionMode?.Finish();
 			return true;
 		}

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -89,7 +89,6 @@ namespace Xamarin.Forms.Platform.Android
 		bool global::Android.Support.V7.View.ActionMode.ICallback.OnActionItemClicked(global::Android.Support.V7.View.ActionMode mode, IMenuItem item)
 		{
 			OnActionItemClickedImpl(item);
-
 			_supportActionMode?.Finish();
 			return true;
 		}
@@ -254,6 +253,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnActionItemClickedImpl(IMenuItem item)
 		{
+			if (ActionModeContext == null)
+				return;
+
 			int index = item.ItemId;
 			IMenuItemController action = ActionModeContext.ContextActions[index];
 


### PR DESCRIPTION
### Description of Change ###

If a cell context menu is open and you double tap an action, it shouldn't crash.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=45027

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
