### PR TITLE
[XamlC] fix loading ulongs, optimize bytecode for longs

### DIFF
--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -128,11 +128,11 @@ namespace Xamarin.Forms.Build.Tasks
 			else if (targetTypeRef.FullName == "System.Byte")
 				yield return Instruction.Create(OpCodes.Ldc_I4, Byte.Parse(str, CultureInfo.InvariantCulture));
 			else if (targetTypeRef.FullName == "System.UInt16")
-				yield return Instruction.Create(OpCodes.Ldc_I4, UInt16.Parse(str, CultureInfo.InvariantCulture));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)UInt16.Parse(str, CultureInfo.InvariantCulture)));
 			else if (targetTypeRef.FullName == "System.UInt32")
 				yield return Instruction.Create(OpCodes.Ldc_I4, UInt32.Parse(str, CultureInfo.InvariantCulture));
 			else if (targetTypeRef.FullName == "System.UInt64")
-				yield return Instruction.Create(OpCodes.Ldc_I8, UInt64.Parse(str, CultureInfo.InvariantCulture));
+				yield return Instruction.Create(OpCodes.Ldc_I8, unchecked((long)UInt64.Parse(str, CultureInfo.InvariantCulture)));
 			else if (targetTypeRef.FullName == "System.Single")
 				yield return Instruction.Create(OpCodes.Ldc_R4, Single.Parse(str, CultureInfo.InvariantCulture));
 			else if (targetTypeRef.FullName == "System.Double")

--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -185,6 +185,7 @@ namespace Xamarin.Forms.Build.Tasks
 					if (OptimizeIL)
 					{
 						Logger.LogString(2, "   Optimizing IL... ");
+						OptimizeLongs(initComp.Body);
 						initComp.Body.OptimizeMacros();
 						Logger.LogLine(2, "done");
 					}
@@ -234,6 +235,28 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 
 			return success;
+		}
+
+		static void ExpandMacro(Instruction instruction, OpCode opcode, object operand)
+		{
+			instruction.OpCode = opcode;
+			instruction.Operand = operand;
+		}
+
+		//this can be removed if/when https://github.com/jbevain/cecil/pull/307 is released in a nuget we consume
+		static void OptimizeLongs(MethodBody self)
+		{
+			var method = self.Method;
+			for (var i = 0; i < self.Instructions.Count; i++) {
+				var instruction = self.Instructions[i];
+				if (instruction.OpCode.Code != Code.Ldc_I8)
+					continue;
+				var l = (long)instruction.Operand;
+				if (l < int.MinValue || l > int.MaxValue)
+					continue;
+				ExpandMacro(instruction, OpCodes.Ldc_I4, unchecked((int)l));
+				self.Instructions.Insert(++i, Instruction.Create(OpCodes.Conv_I8));
+			}
 		}
 
 		bool TryCoreCompile(MethodDefinition initComp, MethodDefinition initCompRuntime, ILRootNode rootnode, out Exception exception)

--- a/Xamarin.Forms.Xaml.UnitTests/I8.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/I8.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.I8"
+		l0="0"
+		l1="2147483647"
+		l2="4294967295"
+		l3="9223372036854775807"
+		l4="-2147483647"
+		l5="-4294967295"
+		l6="-9223372036854775807"
+		l7="256"
+		l8="-256"
+		l9="127"
+		ul0="0"
+		ul1="2147483647"
+		ul2="4294967295"
+		ul3="9223372036854775807"
+		ul4="18446744073709551615"
+		ul5="256">
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/I8.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/I8.xaml.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class I8 : ContentPage
+	{
+		public long l0 { get; set; }
+		public long l1 { get; set; }
+		public long l2 { get; set; }
+		public long l3 { get; set; }
+		public long l4 { get; set; }
+		public long l5 { get; set; }
+		public long l6 { get; set; }
+		public long l7 { get; set; }
+		public long l8 { get; set; }
+		public long l9 { get; set; }
+		public ulong ul0 { get; set; }
+		public ulong ul1 { get; set; }
+		public ulong ul2 { get; set; }
+		public ulong ul3 { get; set; }
+		public ulong ul4 { get; set; }
+		public ulong ul5 { get; set; }
+
+		public I8()
+		{
+			InitializeComponent();
+		}
+
+		public I8(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void I8AreConverted(bool useCompiledXaml)
+			{
+				var p = new I8(useCompiledXaml);
+				Assert.AreEqual(0L, p.l0);
+				Assert.AreEqual((long)int.MaxValue, p.l1);
+				Assert.AreEqual((long)uint.MaxValue, p.l2);
+				Assert.AreEqual(long.MaxValue, p.l3);
+				Assert.AreEqual((long)-int.MaxValue, p.l4);
+				Assert.AreEqual((long)-uint.MaxValue, p.l5);
+				Assert.AreEqual(-long.MaxValue, p.l6);
+				Assert.AreEqual((long)256, p.l7);
+				Assert.AreEqual((long)-256, p.l8);
+				Assert.AreEqual((long)127, p.l9);
+				Assert.AreEqual(0L, p.ul0);
+				Assert.AreEqual((long)int.MaxValue, p.ul1);
+				Assert.AreEqual((long)uint.MaxValue, p.ul2);
+				Assert.AreEqual(long.MaxValue, p.ul3);
+				Assert.AreEqual(ulong.MaxValue, p.ul4);
+				Assert.AreEqual((ulong)256, p.ul5);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/MockCompiler.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MockCompiler.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assembly = assembly,
 				ReferencePath = string.Join(";", refs),
 				KeepXamlResources = true,
+				OptimizeIL = true,
 				Type = type.FullName
 			};
 

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -400,6 +400,9 @@
     <Compile Include="Issues\Bz46921.xaml.cs">
       <DependentUpon>Bz46921.xaml</DependentUpon>
     </Compile>
+     <Compile Include="I8.xaml.cs">
+       <DependentUpon>I8.xaml</DependentUpon>
+     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -719,6 +722,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz46921.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="I8.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

[XamlC] fix loading ulongs, optimize bytecode for longs

The code had a casting issue while generating IL for ulongs.

This patches, in addition to fix the issue, also optimize `ldc.i8` calls by 3 to 7B (from an original 9B) when the [u]long being loaded fits an int.

This optimization has been send to upstream as well https://github.com/jbevain/cecil/pull/307

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense