### PR TITLE
Optimize stlod ldloc

### DIFF
--- a/Xamarin.Forms.Build.Tasks/MethodBodyExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/MethodBodyExtensions.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Build.Tasks
 				throw new ArgumentNullException(nameof(self));
 
 			self.OptimizeLongs();
+			self.OptimizeStLdLoc();
 			self.OptimizeMacros();
 		}
 
@@ -34,6 +35,25 @@ namespace Xamarin.Forms.Build.Tasks
 					continue;
 				ExpandMacro(instruction, OpCodes.Ldc_I4, unchecked((int)l));
 				self.Instructions.Insert(++i, Instruction.Create(OpCodes.Conv_I8));
+			}
+		}
+
+		static void OptimizeStLdLoc(this MethodBody self)
+		{
+			var method = self.Method;
+			for (var i = 0; i < self.Instructions.Count; i++) {
+				var instruction = self.Instructions[i];
+				if (instruction.OpCode.Code != Code.Stloc)
+					continue;
+				if (i + 1 >= self.Instructions.Count)
+					continue;
+				var next = self.Instructions[i + 1];
+				int num = ((VariableDefinition)instruction.Operand).Index;
+				var vardef = instruction.Operand;
+				if (next.OpCode.Code != Code.Ldloc || num != ((VariableDefinition)next.Operand).Index)
+					continue;
+				ExpandMacro(instruction, OpCodes.Dup, null);
+				ExpandMacro(next, OpCodes.Stloc, vardef);
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml.Xamlc/Xamarin.Forms.Xaml.Xamlc.csproj
+++ b/Xamarin.Forms.Xaml.Xamlc/Xamarin.Forms.Xaml.Xamlc.csproj
@@ -17,7 +17,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>-r "../../../Xamarin.Forms.Controls/bin/Debug/" -p "../../../Xamarin.Forms.Xaml.UnitTest/bin/Debug/;/Library/Frameworks/Mono.framework/Versions/3.12.1/lib/mono/4.5;/Library/Frameworks/Mono.framework/Versions/3.12.1/lib/mono/4.5/Facades/" --keep -v 4 ../../../Xamarin.Forms.Xaml.UnitTests/bin/Debug/Xamarin.Forms.Xaml.UnitTests.dll</Commandlineparameters>
+    <Commandlineparameters>-r "../../../Xamarin.Forms.Controls/bin/Debug/" -p "../../../Xamarin.Forms.Xaml.UnitTest/bin/Debug/;/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5;/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5/Facades/" --keep -v 4 ../../../Xamarin.Forms.Xaml.UnitTests/bin/Debug/Xamarin.Forms.Xaml.UnitTests.dll</Commandlineparameters>
     <AssemblyName>xamlc</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
### Description of Change ###

replace (2 to 6B)
```
ldloc x
stloc x
```
by (1 to 4B)
```
dup
stloc x
```

this gain is quite small (~1%)

require #611 and #612 

The current tests are covering this already

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense