### PR TITLE
[XamlC] Compile TypeTypeConverter

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RectangleTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RectangleTypeConverter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/TypeTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/TypeTypeConverter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Xml;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using Xamarin.Forms.Build.Tasks;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Core.XamlC
+{
+	class TypeTypeConverter : ICompiledTypeConverter
+	{
+		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		{
+			if (string.IsNullOrEmpty(value))
+				goto error;
+
+			var split = value.Split(':');
+			if (split.Length > 2)
+				goto error;
+
+			XmlType xmlType;
+			if (split.Length == 2)
+				xmlType = new XmlType(node.NamespaceResolver.LookupNamespace(split[0]), split[1], null);
+			else
+				xmlType = new XmlType(node.NamespaceResolver.LookupNamespace(""), split[0], null);
+
+			var typeRef = xmlType.GetTypeReference(module, (IXmlLineInfo)node);
+			if (typeRef == null)
+				goto error;
+
+			var getTypeFromHandle = module.Import(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
+			yield return Instruction.Create(OpCodes.Ldtoken, module.Import(typeRef));
+			yield return Instruction.Create(OpCodes.Call, module.Import(getTypeFromHandle));
+			yield break;
+
+		error:
+			throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(Type)}", node);
+		}
+	}
+
+}

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -104,6 +104,7 @@
     <Compile Include="CompiledConverters\ConstraintTypeConverter.cs" />
     <Compile Include="CompiledConverters\ThicknessTypeConverter.cs" />
     <Compile Include="MethodBodyExtensions.cs" />
+    <Compile Include="CompiledConverters\TypeTypeConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/Xamarin.Forms.Core/TypeTypeConverter.cs
+++ b/Xamarin.Forms.Core/TypeTypeConverter.cs
@@ -4,6 +4,7 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms
 {
+	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.TypeTypeConverter")]
 	public sealed class TypeTypeConverter : TypeConverter, IExtendedTypeConverter
 	{
 		[Obsolete("Use ConvertFromInvariantString (string, IServiceProvider)")]

--- a/Xamarin.Forms.Xaml.UnitTests/StringLiterals.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/StringLiterals.xaml
@@ -1,15 +1,17 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 x:Class="Xamarin.Forms.Xaml.UnitTests.StringLiterals">
-	<Label x:Name="label0" Text="{}Foo" />
-	<Label x:Name="label1" Text="{}{Foo}" />
-	<Label x:Name="label2">
-		{}Foo
-	</Label>
-	<Label x:Name="label3">
-		<Label.Text>
+	<StackLayout>
+		<Label x:Name="label0" Text="{}Foo" />
+		<Label x:Name="label1" Text="{}{Foo}" />
+		<Label x:Name="label2">
 			{}Foo
-		</Label.Text>
-	</Label>
+		</Label>
+		<Label x:Name="label3">
+			<Label.Text>
+				{}Foo
+			</Label.Text>
+		</Label>
+	</StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/StringLiterals.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/StringLiterals.xaml.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Xamarin.Forms;
 
 using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -22,6 +23,18 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		public class Tests
 		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
 			[TestCase(false)]
 			[TestCase(true)]
 			public void EscapedStringsAreTreatedAsLiterals (bool useCompiledXaml)


### PR DESCRIPTION
### Description of Change ###

[XamlC] Compile TypeTypeConverter

this is a huge improvements it:
- reduce the code size (e.g the StyleTests.InitializeComponent shrunk down to 3545 from 4104)
- do not resolve types at runtime as it's expensive and involve reflection

there's no new tests, this is already covered

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
- [x] Contains a `goto` statement
