### PR TITLE
Fix for 45743 which works with iOS 8

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -50,10 +50,6 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					PresentAlert(arguments);
 				}
-				//else if (Forms.IsiOS8OrNewer)
-				//{
-				//	Present8Alert(arguments);
-				//}
 				else
 				{
 					PresentPre8Alert(arguments);
@@ -74,10 +70,6 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					PresentActionSheet(arguments);
 				}
-				//else if (Forms.IsiOS8OrNewer)
-				//{
-				//	Present8ActionSheet(arguments, pageRenderer);
-				//}
 				else
 				{
 					PresentPre8ActionSheet(arguments, pageRenderer);
@@ -526,62 +518,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 				arguments.Result.TrySetResult(title);
 			};
-		}
-
-		void Present8Alert(AlertArguments arguments)
-		{
-			var alert = UIAlertController.Create(arguments.Title, arguments.Message, UIAlertControllerStyle.Alert);
-			var oldFrame = alert.View.Frame;
-			alert.View.Frame = new RectangleF(oldFrame.X, oldFrame.Y, oldFrame.Width, oldFrame.Height - _alertPadding * 2);
-			alert.AddAction(UIAlertAction.Create(arguments.Cancel, UIAlertActionStyle.Cancel, a => arguments.SetResult(false)));
-			if (arguments.Accept != null)
-				alert.AddAction(UIAlertAction.Create(arguments.Accept, UIAlertActionStyle.Default, a => arguments.SetResult(true)));
-			var page = _modals.Any() ? _modals.Last() : Page;
-			var vc = GetRenderer(page).ViewController;
-			vc.PresentViewController(alert, true, null);
-		}
-
-		void Present8ActionSheet(ActionSheetArguments arguments, IVisualElementRenderer pageRenderer)
-		{
-			var alert = UIAlertController.Create(arguments.Title, null, UIAlertControllerStyle.ActionSheet);
-
-			if (arguments.Cancel != null)
-			{
-				alert.AddAction(UIAlertAction.Create(arguments.Cancel, UIAlertActionStyle.Cancel, a => arguments.SetResult(arguments.Cancel)));
-			}
-
-			if (arguments.Destruction != null)
-			{
-				alert.AddAction(UIAlertAction.Create(arguments.Destruction, UIAlertActionStyle.Destructive, a => arguments.SetResult(arguments.Destruction)));
-			}
-
-			foreach (var label in arguments.Buttons)
-			{
-				if (label == null)
-					continue;
-
-				var blabel = label;
-				alert.AddAction(UIAlertAction.Create(blabel, UIAlertActionStyle.Default, a => arguments.SetResult(blabel)));
-			}
-
-			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
-			{
-				UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
-				var observer = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification,
-					n => { alert.PopoverPresentationController.SourceRect = pageRenderer.ViewController.View.Bounds; });
-
-				arguments.Result.Task.ContinueWith(t =>
-				{
-					NSNotificationCenter.DefaultCenter.RemoveObserver(observer);
-					UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
-				}, TaskScheduler.FromCurrentSynchronizationContext());
-
-				alert.PopoverPresentationController.SourceView = pageRenderer.ViewController.View;
-				alert.PopoverPresentationController.SourceRect = pageRenderer.ViewController.View.Bounds;
-				alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
-			}
-
-			pageRenderer.ViewController.PresentViewController(alert, true, null);
 		}
 
 		internal class DefaultRenderer : VisualElementRenderer<VisualElement>

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -46,14 +46,14 @@ namespace Xamarin.Forms.Platform.iOS
 				if (!PageIsChildOfPlatform(sender))
 					return;
 
-				if (Forms.IsiOS9OrNewer)
+				if (Forms.IsiOS8OrNewer)
 				{
 					PresentAlert(arguments);
 				}
-				else if (Forms.IsiOS8OrNewer)
-				{
-					Present8Alert(arguments);
-				}
+				//else if (Forms.IsiOS8OrNewer)
+				//{
+				//	Present8Alert(arguments);
+				//}
 				else
 				{
 					PresentPre8Alert(arguments);
@@ -70,14 +70,14 @@ namespace Xamarin.Forms.Platform.iOS
 					pageRoot = (Page)pageRoot.RealParent;
 				var pageRenderer = GetRenderer(pageRoot);
 
-				if (Forms.IsiOS9OrNewer)
+				if (Forms.IsiOS8OrNewer)
 				{
 					PresentActionSheet(arguments);
 				}
-				else if (Forms.IsiOS8OrNewer)
-				{
-					Present8ActionSheet(arguments, pageRenderer);
-				}
+				//else if (Forms.IsiOS8OrNewer)
+				//{
+				//	Present8ActionSheet(arguments, pageRenderer);
+				//}
 				else
 				{
 					PresentPre8ActionSheet(arguments, pageRenderer);
@@ -458,6 +458,12 @@ namespace Xamarin.Forms.Platform.iOS
 				alert.PopoverPresentationController.SourceView = window.RootViewController.View;
 				alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds;
 				alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
+			}
+
+			if(!Forms.IsiOS9OrNewer)
+			{
+				// For iOS 8, we need to explicitly set the size of the window
+				window.Frame = new RectangleF(0, 0, UIScreen.MainScreen.Bounds.Width, UIScreen.MainScreen.Bounds.Height);
 			}
 
 			window.RootViewController.PresentViewController(alert, true, null);


### PR DESCRIPTION
### Description of Change ###

The original fix for [45743](https://bugzilla.xamarin.com/show_bug.cgi?id=45743) did not work for iOS 8 - action sheets and alerts were displayed smashed up against the top left corner of the screen (instead of full screen as intended). This fix addresses that bug for iOS 8.

### Bugs Fixed ###

- [45743 – Threading problem with PushAsync() after DisplayAlert() on iOS](https://bugzilla.xamarin.com/show_bug.cgi?id=45743)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
