### PR TITLE
Allow subscriber to be collected if MessagingCenter is the only reference to it

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45926.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45926.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Threading;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 45926, "MessagingCenter prevents subscriber from being collected", PlatformAffected.All)]
+	public class Bugzilla45926 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			Button createPage, sendMessage, doGC;
+
+			Label instanceCount = new Label();
+			Label messageCount = new Label();
+
+			instanceCount.Text = $"Instances: {_45926SecondPage.InstanceCounter.ToString()}";
+			messageCount.Text = $"Messages: {_45926SecondPage.MessageCounter.ToString()}";
+
+			var content = new ContentPage {
+				Title = "Test",
+				Content = new StackLayout {
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+						(createPage = new Button { Text = "New Page" }),
+						(sendMessage = new Button { Text = "Send Message" }),
+						(doGC = new Button { Text = "Do GC" }),
+						instanceCount, messageCount
+					}
+				}
+			};
+
+			createPage.Clicked += (s, e) => PushAsync (new _45926SecondPage ());
+			sendMessage.Clicked += (s, e) =>
+			{
+				MessagingCenter.Send (this, "Test");
+			};
+
+			doGC.Clicked += (sender, e) => {
+				GC.Collect ();
+				GC.WaitForPendingFinalizers();
+				instanceCount.Text = $"Instances: {_45926SecondPage.InstanceCounter.ToString()}";
+				messageCount.Text = $"Messages: {_45926SecondPage.MessageCounter.ToString()}";
+			};
+
+			PushAsync(content);
+		}
+
+		#if UITEST
+		//		[Test]
+		//public void Issue1Test ()
+		//{
+		//	RunningApp.Screenshot ("I am at Issue 1");
+		//	RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
+		//	RunningApp.Screenshot ("I see the Label");
+		//}
+#endif
+	}
+
+	public class _45926SecondPage : ContentPage
+	{
+		public static int InstanceCounter = 0;
+		public static int MessageCounter = 0;
+
+		public _45926SecondPage ()
+		{
+			Interlocked.Increment(ref InstanceCounter);
+
+			Content = new Label {
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Second Page #" + (InstanceCounter)
+			};
+
+			MessagingCenter.Subscribe<Bugzilla45926> (this, "Test", OnMessage);
+		}
+
+		protected override void OnDisappearing ()
+		{
+			base.OnDisappearing ();
+		}
+
+		void OnMessage (Bugzilla45926 app)
+		{
+			System.Diagnostics.Debug.WriteLine ("Got Test message!");
+			Interlocked.Increment(ref MessageCounter);
+		}
+
+		~_45926SecondPage ()
+		{
+			Interlocked.Decrement(ref InstanceCounter);
+			System.Diagnostics.Debug.WriteLine ("~SecondPage: {0}", GetHashCode ());
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45926.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45926.cs
@@ -54,14 +54,21 @@ namespace Xamarin.Forms.Controls.Issues
 			PushAsync(content);
 		}
 
-		#if UITEST
-		//		[Test]
-		//public void Issue1Test ()
-		//{
-		//	RunningApp.Screenshot ("I am at Issue 1");
-		//	RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
-		//	RunningApp.Screenshot ("I see the Label");
-		//}
+#if UITEST
+		[Test]
+		public void Issue1Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked ("New Page"));
+
+			RunningApp.Tap (q => q.Marked ("New Page"));
+			RunningApp.Back();
+			RunningApp.Tap(q => q.Marked("Do GC"));
+			RunningApp.Tap(q => q.Marked("Send Message"));
+			RunningApp.Tap(q => q.Marked("Do GC"));
+
+			RunningApp.WaitForElement (q => q.Marked ("Instances: 0"));
+			RunningApp.WaitForElement (q => q.Marked ("Messages: 0"));
+		}
 #endif
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45926.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45926.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue1Test ()
+		public void Issue45926Test ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("New Page"));
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45926.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45926.cs
@@ -72,6 +72,7 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	}
 
+	[Preserve(AllMembers = true)]
 	public class _45926SecondPage : ContentPage
 	{
 		public static int InstanceCounter = 0;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -468,6 +468,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36802.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35736.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla48158.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45926.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/MessagingCenter.cs
+++ b/Xamarin.Forms.Core/MessagingCenter.cs
@@ -6,31 +6,60 @@ namespace Xamarin.Forms
 {
 	public static class MessagingCenter
 	{
-		static readonly Dictionary<Tuple<string, Type, Type>, List<Tuple<WeakReference, Action<object, object>>>> s_callbacks =
-			new Dictionary<Tuple<string, Type, Type>, List<Tuple<WeakReference, Action<object, object>>>>();
+		class Sender : Tuple<string, Type, Type>
+		{
+			public Sender(string message, Type senderType, Type argType) : base(message, senderType, argType)
+			{
+			}
+
+			public string Message => Item1;
+			public Type SenderType => Item2;
+			public Type ArgType => Item3;
+		}
+
+		delegate void Callback(object sender, object args);
+
+		class Subscription : Tuple<WeakReference, WeakReference<Callback>>
+		{
+			protected Subscription(WeakReference subscriber, WeakReference<Callback> callback) 
+				: base(subscriber, callback)
+			{
+			}
+
+			public Subscription(object subscriber, Callback callback) 
+				: this(new WeakReference(subscriber), new WeakReference<Callback>(callback))
+			{
+			}
+
+			public WeakReference Subscriber => Item1;
+			public WeakReference<Callback> Callback => Item2;
+		}
+
+		static readonly Dictionary<Sender, List<Subscription>> s_subscriptions =
+			new Dictionary<Sender, List<Subscription>>();
 
 		public static void Send<TSender, TArgs>(TSender sender, string message, TArgs args) where TSender : class
 		{
 			if (sender == null)
-				throw new ArgumentNullException("sender");
+				throw new ArgumentNullException(nameof(sender));
 			InnerSend(message, typeof(TSender), typeof(TArgs), sender, args);
 		}
 
 		public static void Send<TSender>(TSender sender, string message) where TSender : class
 		{
 			if (sender == null)
-				throw new ArgumentNullException("sender");
+				throw new ArgumentNullException(nameof(sender));
 			InnerSend(message, typeof(TSender), null, sender, null);
 		}
 
 		public static void Subscribe<TSender, TArgs>(object subscriber, string message, Action<TSender, TArgs> callback, TSender source = null) where TSender : class
 		{
 			if (subscriber == null)
-				throw new ArgumentNullException("subscriber");
+				throw new ArgumentNullException(nameof(subscriber));
 			if (callback == null)
-				throw new ArgumentNullException("callback");
+				throw new ArgumentNullException(nameof(callback));
 
-			Action<object, object> wrap = (sender, args) =>
+			Callback wrap = (sender, args) =>
 			{
 				var send = (TSender)sender;
 				if (source == null || send == source)
@@ -43,11 +72,11 @@ namespace Xamarin.Forms
 		public static void Subscribe<TSender>(object subscriber, string message, Action<TSender> callback, TSender source = null) where TSender : class
 		{
 			if (subscriber == null)
-				throw new ArgumentNullException("subscriber");
+				throw new ArgumentNullException(nameof(subscriber));
 			if (callback == null)
-				throw new ArgumentNullException("callback");
+				throw new ArgumentNullException(nameof(callback));
 
-			Action<object, object> wrap = (sender, args) =>
+			Callback wrap = (sender, args) =>
 			{
 				var send = (TSender)sender;
 				if (source == null || send == source)
@@ -69,18 +98,18 @@ namespace Xamarin.Forms
 
 		internal static void ClearSubscribers()
 		{
-			s_callbacks.Clear();
+			s_subscriptions.Clear();
 		}
 
 		static void InnerSend(string message, Type senderType, Type argType, object sender, object args)
 		{
 			if (message == null)
-				throw new ArgumentNullException("message");
-			var key = new Tuple<string, Type, Type>(message, senderType, argType);
-			if (!s_callbacks.ContainsKey(key))
+				throw new ArgumentNullException(nameof(message));
+			var key = new Sender(message, senderType, argType);
+			if (!s_subscriptions.ContainsKey(key))
 				return;
-			List<Tuple<WeakReference, Action<object, object>>> actions = s_callbacks[key];
-			if (actions == null || !actions.Any())
+			List<Subscription> subcriptions = s_subscriptions[key];
+			if (subcriptions == null || !subcriptions.Any())
 				return; // should not be reachable
 
 			// ok so this code looks a bit funky but here is the gist of the problem. It is possible that in the course
@@ -88,44 +117,50 @@ namespace Xamarin.Forms
 			// the callback. This would invalidate the enumerator. To work around this we make a copy. However if you unsubscribe 
 			// from a message you can fairly reasonably expect that you will therefor not receive a call. To fix this we then
 			// check that the item we are about to send the message to actually exists in the live list.
-			List<Tuple<WeakReference, Action<object, object>>> actionsCopy = actions.ToList();
-			foreach (Tuple<WeakReference, Action<object, object>> action in actionsCopy)
+			List<Subscription> subscriptionsCopy = subcriptions.ToList();
+			foreach (Subscription subscription in subscriptionsCopy)
 			{
-				if (action.Item1.Target != null && actions.Contains(action))
-					action.Item2(sender, args);
+				if (subscription.Subscriber.Target != null && subcriptions.Contains(subscription))
+				{
+					Callback callback;
+					if(subscription.Callback.TryGetTarget(out callback))
+					{
+						callback(sender, args);						
+					}
+				}
 			}
 		}
 
-		static void InnerSubscribe(object subscriber, string message, Type senderType, Type argType, Action<object, object> callback)
+		static void InnerSubscribe(object subscriber, string message, Type senderType, Type argType, Callback callback)
 		{
 			if (message == null)
-				throw new ArgumentNullException("message");
-			var key = new Tuple<string, Type, Type>(message, senderType, argType);
-			var value = new Tuple<WeakReference, Action<object, object>>(new WeakReference(subscriber), callback);
-			if (s_callbacks.ContainsKey(key))
+				throw new ArgumentNullException(nameof(message));
+			var key = new Sender(message, senderType, argType);
+			var value = new Subscription(subscriber, callback);
+			if (s_subscriptions.ContainsKey(key))
 			{
-				s_callbacks[key].Add(value);
+				s_subscriptions[key].Add(value);
 			}
 			else
 			{
-				var list = new List<Tuple<WeakReference, Action<object, object>>> { value };
-				s_callbacks[key] = list;
+				var list = new List<Subscription> { value };
+				s_subscriptions[key] = list;
 			}
 		}
 
 		static void InnerUnsubscribe(string message, Type senderType, Type argType, object subscriber)
 		{
 			if (subscriber == null)
-				throw new ArgumentNullException("subscriber");
+				throw new ArgumentNullException(nameof(subscriber));
 			if (message == null)
-				throw new ArgumentNullException("message");
+				throw new ArgumentNullException(nameof(message));
 
-			var key = new Tuple<string, Type, Type>(message, senderType, argType);
-			if (!s_callbacks.ContainsKey(key))
+			var key = new Sender(message, senderType, argType);
+			if (!s_subscriptions.ContainsKey(key))
 				return;
-			s_callbacks[key].RemoveAll(tuple => !tuple.Item1.IsAlive || tuple.Item1.Target == subscriber);
-			if (!s_callbacks[key].Any())
-				s_callbacks.Remove(key);
+			s_subscriptions[key].RemoveAll(tuple => !tuple.Subscriber.IsAlive || tuple.Subscriber.Target == subscriber);
+			if (!s_subscriptions[key].Any())
+				s_subscriptions.Remove(key);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/MessagingCenter.cs
+++ b/Xamarin.Forms.Core/MessagingCenter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms
 {
@@ -41,7 +42,7 @@ namespace Xamarin.Forms
 					return;
 				}
 
-				var target = DelegateSource.Target;
+				var target = DelegateSource.Target ;
 
 				if (target == null)
 				{

--- a/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
@@ -165,9 +165,11 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			var platformRenderer = (PlatformRenderer)_window.RootViewController;
-			_window.RootViewController = _application.MainPage.CreateViewController();
+
 			if (platformRenderer != null)
 				((IDisposable)platformRenderer.Platform).Dispose();
+
+			_window.RootViewController = _application.MainPage.CreateViewController();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/PageExtensions.cs
@@ -10,13 +10,20 @@ namespace Xamarin.Forms
 			if (!Forms.IsInitialized)
 				throw new InvalidOperationException("call Forms.Init() before this");
 
+			Platform.iOS.Platform currentPlatform = null;
+
+			if (Application.Current.MainPage != null && Application.Current.MainPage.Platform != null)
+			{
+				currentPlatform = Application.Current.MainPage.Platform as Platform.iOS.Platform;
+			}
+
 			if (!(view.RealParent is Application))
 			{
 				Application app = new DefaultApplication();
 				app.MainPage = view;
 			}
 
-			var result = new Platform.iOS.Platform();
+			var result = currentPlatform ?? new Platform.iOS.Platform();
 			result.SetPage(view);
 			return result.ViewController;
 		}

--- a/Xamarin.Forms.Platform.iOS/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/PageExtensions.cs
@@ -10,20 +10,13 @@ namespace Xamarin.Forms
 			if (!Forms.IsInitialized)
 				throw new InvalidOperationException("call Forms.Init() before this");
 
-			Platform.iOS.Platform currentPlatform = null;
-
-			if (Application.Current.MainPage != null && Application.Current.MainPage.Platform != null)
-			{
-				currentPlatform = Application.Current.MainPage.Platform as Platform.iOS.Platform;
-			}
-
 			if (!(view.RealParent is Application))
 			{
 				Application app = new DefaultApplication();
 				app.MainPage = view;
 			}
 
-			var result = currentPlatform ?? new Platform.iOS.Platform();
+			var result = new Platform.iOS.Platform();
 			result.SetPage(view);
 			return result.ViewController;
 		}


### PR DESCRIPTION
### Description of Change ###

If the target of a MessagingCenter callback is the subscriber, keep a weak reference to the subscriber to allow it to be garbage collected.

Also refactored MessagingCenter slightly because I got tired of miscounting the angle brackets.

### Bugs Fixed ###

- [45926 – MessagingCenter prevents subscriber from being collected](https://bugzilla.xamarin.com/show_bug.cgi?id=45926)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
