### PR TITLE
[Core] Register renderers conditionally based on OS version

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ExportRendererTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ExportRendererTests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	public class TestExportRendererAttribute : BaseExportRendererAttribute
+	{
+		public TestExportRendererAttribute(Type handler, Type target) : base(handler, target)
+		{
+			MajorVersion = 8;
+		}
+	}
+
+	[TestFixture]
+	public class ExportRendererTests : BaseTestFixture
+	{
+		[Test]
+		public void InvalidMinimumSdkVersion()
+		{
+			var testExportRendererAttribute = new TestExportRendererAttribute(typeof(Entry), typeof(object));
+
+			Assert.Throws<ArgumentException>(() =>
+			{
+				testExportRendererAttribute.MaximumSdkVersion = 10;
+				testExportRendererAttribute.MinimumSdkVersion = 20;
+			});
+		}
+
+		[Test]
+		public void InvalidMaximumSdkVersion()
+		{
+			var testExportRendererAttribute = new TestExportRendererAttribute(typeof(Entry), typeof(object));
+
+			Assert.Throws<ArgumentException>(() =>
+			{
+				testExportRendererAttribute.MinimumSdkVersion = 20;
+				testExportRendererAttribute.MaximumSdkVersion = 10;
+			});
+		}
+
+		[Test]
+		public void ValidEquality()
+		{
+			var testExportRendererAttribute = new TestExportRendererAttribute(typeof(Entry), typeof(object));
+
+			Assert.DoesNotThrow(() =>
+			{
+				testExportRendererAttribute.MinimumSdkVersion = 10;
+				testExportRendererAttribute.MaximumSdkVersion = 10;
+			});
+		}
+
+		[Test]
+		public void ShouldRegister()
+		{
+			var testExportRendererAttribute = new TestExportRendererAttribute(typeof(Entry), typeof(object))
+			{
+				MinimumSdkVersion = 6,
+				MaximumSdkVersion = 10
+			};
+
+			Assert.True(testExportRendererAttribute.ShouldRegister());
+		}
+
+		[Test]
+		public void ShouldRegister2()
+		{
+			var testExportRendererAttribute = new TestExportRendererAttribute(typeof(Entry), typeof(object))
+			{
+				MinimumSdkVersion = 6,
+				MaximumSdkVersion = 8
+			};
+
+			Assert.True(testExportRendererAttribute.ShouldRegister());
+		}
+
+		[Test]
+		public void ShouldRegister3()
+		{
+			var testExportRendererAttribute = new TestExportRendererAttribute(typeof(Entry), typeof(object))
+			{
+				MinimumSdkVersion = 8,
+				MaximumSdkVersion = 10
+			};
+
+			Assert.True(testExportRendererAttribute.ShouldRegister());
+		}
+
+		[Test]
+		public void ShouldNotRegister()
+		{
+			var testExportRendererAttribute = new TestExportRendererAttribute(typeof(Entry), typeof(object))
+			{
+				MinimumSdkVersion = 4,
+				MaximumSdkVersion = 6
+			};
+
+			Assert.False(testExportRendererAttribute.ShouldRegister());
+		}
+
+		[Test]
+		public void ShouldNotRegister2()
+		{
+			var testExportRendererAttribute = new TestExportRendererAttribute(typeof(Entry), typeof(object))
+			{
+				MinimumSdkVersion = 10,
+				MaximumSdkVersion = 12
+			};
+
+			Assert.False(testExportRendererAttribute.ShouldRegister());
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="ElementTests.cs" />
     <Compile Include="EntryCellTests.cs" />
     <Compile Include="EntryUnitTests.cs" />
+    <Compile Include="ExportRendererTests.cs" />
     <Compile Include="FluentTests.cs" />
     <Compile Include="FontUnitTests.cs" />
     <Compile Include="FormattedStringTests.cs" />

--- a/Xamarin.Forms.Core/BaseExportRendererAttribute.cs
+++ b/Xamarin.Forms.Core/BaseExportRendererAttribute.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	public abstract class BaseExportRendererAttribute : HandlerAttribute
+	{
+		protected int MajorVersion { get; set; }
+
+		#region MinimumSdkVersion
+		int _minimumSdkVersion = int.MinValue;
+		public int MinimumSdkVersion
+		{
+			get { return _minimumSdkVersion; }
+			set
+			{
+				if (_minimumSdkVersion == value)
+					return;
+
+				_minimumSdkVersion = value;
+
+				if (_minimumSdkVersion > MaximumSdkVersion)
+					throw new ArgumentException("Minimum SDK version must be less than or equal to the maximum SDK version.");
+			}
+		}
+		#endregion
+
+		#region MaximumSdkVersion
+		int _maximumSdkVersion = int.MaxValue;
+		public int MaximumSdkVersion
+		{
+			get { return _maximumSdkVersion; }
+			set
+			{
+				if (_maximumSdkVersion == value)
+					return;
+
+				_maximumSdkVersion = value;
+
+				if (_maximumSdkVersion < MinimumSdkVersion)
+					throw new ArgumentException("Maximum SDK version must be greater than or equal to the minimum SDK version.");
+			}
+		}
+		#endregion
+
+		protected BaseExportRendererAttribute(Type handler, Type target) : base(handler, target)
+		{
+		}
+
+		public override bool ShouldRegister()
+		{
+			if (MinimumSdkVersion <= MajorVersion && MajorVersion <= MaximumSdkVersion)
+				return base.ShouldRegister();
+
+			return false;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/HandlerAttribute.cs
+++ b/Xamarin.Forms.Core/HandlerAttribute.cs
@@ -11,9 +11,9 @@ namespace Xamarin.Forms
 			HandlerType = handler;
 		}
 
-		internal Type HandlerType { get; private set; }
+		internal Type HandlerType { get; }
 
-		internal Type TargetType { get; private set; }
+		internal Type TargetType { get; }
 
 		public virtual bool ShouldRegister()
 		{

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -87,6 +87,7 @@
     <Compile Include="DateChangedEventArgs.cs" />
     <Compile Include="DelegateLogListener.cs" />
     <Compile Include="EnumerableExtensions.cs" />
+    <Compile Include="BaseExportRendererAttribute.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\TabbedPage.cs" />

--- a/Xamarin.Forms.Platform.Android/ExportRendererAttribute.cs
+++ b/Xamarin.Forms.Platform.Android/ExportRendererAttribute.cs
@@ -1,12 +1,14 @@
 using System;
+using Android.OS;
 
 namespace Xamarin.Forms
 {
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-	public sealed class ExportRendererAttribute : HandlerAttribute
+	public sealed class ExportRendererAttribute : BaseExportRendererAttribute
 	{
 		public ExportRendererAttribute(Type handler, Type target) : base(handler, target)
 		{
+			MajorVersion = (int)Build.VERSION.SdkInt;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WinRT/ExportRendererAttribute.cs
+++ b/Xamarin.Forms.Platform.WinRT/ExportRendererAttribute.cs
@@ -9,10 +9,13 @@ namespace Xamarin.Forms.Platform.WinRT
 #endif
 {
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-	public sealed class ExportRendererAttribute : HandlerAttribute
+	public sealed class ExportRendererAttribute : BaseExportRendererAttribute
 	{
 		public ExportRendererAttribute(Type handler, Type target) : base(handler, target)
 		{
+#if WINDOWS_UWP
+			MajorVersion = Convert.ToInt32(WindowsDeviceInfo.GetOSVersion().Split('.')[0]);
+#endif
 		}
 	}
 

--- a/Xamarin.Forms.Platform.WinRT/WindowsDeviceInfo.cs
+++ b/Xamarin.Forms.Platform.WinRT/WindowsDeviceInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Windows.Foundation;
 using Windows.Graphics.Display;
+using Windows.System.Profile;
 using Windows.UI.Xaml;
 
 #if WINDOWS_UWP
@@ -109,6 +110,21 @@ namespace Xamarin.Forms.Platform.WinRT
 		void OnOrientationChanged(DisplayInformation sender, object args)
 		{
 			CurrentOrientation = GetDeviceOrientation(sender.CurrentOrientation);
+		}
+
+		internal static string GetOSVersion()
+		{
+#if WINDOWS_UWP
+			string deviceFamilyVersion = AnalyticsInfo.VersionInfo.DeviceFamilyVersion;
+			ulong version = ulong.Parse(deviceFamilyVersion);
+			ulong major = (version & 0xFFFF000000000000L) >> 48;
+			ulong minor = (version & 0x0000FFFF00000000L) >> 32;
+			ulong build = (version & 0x00000000FFFF0000L) >> 16;
+			ulong revision = version & 0x000000000000FFFFL; 
+			return $"{major}.{minor}.{build}.{revision}"; 
+#else
+			throw new NotSupportedException();
+#endif
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/ExportRendererAttribute.cs
+++ b/Xamarin.Forms.Platform.iOS/ExportRendererAttribute.cs
@@ -4,9 +4,9 @@ using UIKit;
 namespace Xamarin.Forms
 {
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-	public sealed class ExportRendererAttribute : HandlerAttribute
+	public sealed class ExportRendererAttribute : BaseExportRendererAttribute
 	{
-		public ExportRendererAttribute(Type handler, Type target, UIUserInterfaceIdiom idiom) : base(handler, target)
+		public ExportRendererAttribute(Type handler, Type target, UIUserInterfaceIdiom idiom) : this(handler, target)
 		{
 			Idiomatic = true;
 			Idiom = idiom;
@@ -14,7 +14,7 @@ namespace Xamarin.Forms
 
 		public ExportRendererAttribute(Type handler, Type target) : base(handler, target)
 		{
-			Idiomatic = false;
+			MajorVersion = Convert.ToInt32(UIDevice.CurrentDevice.SystemVersion.Split('.')[0]);
 		}
 
 		internal UIUserInterfaceIdiom Idiom { get; }
@@ -23,7 +23,10 @@ namespace Xamarin.Forms
 
 		public override bool ShouldRegister()
 		{
-			return !Idiomatic || Idiom == UIDevice.CurrentDevice.UserInterfaceIdiom;
+			if (!(!Idiomatic || Idiom == UIDevice.CurrentDevice.UserInterfaceIdiom))
+				return false;
+
+			return base.ShouldRegister();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

On iOS, `ExportRendererAttribute` allows us to supply two different renderers for MDP on phones and tablets with `UIUserInterfaceIdiom` attribute parameter. We can build upon this to extend the behavior of the exporter such that different renderers can be utilized based on OS version.

We can now do the following:

```
[assembly:ExportRenderer(typeof(Entry), typeof(MyRenderer1), MaximumSdkVersion = 9)]
namespace fgfg789.iOS
{
	public class MyRenderer1 : EntryRenderer
	{
		public MyRenderer1()
		{
			; // Put a breakpoint here. It won't be hit because the renderer 
                          // has not been registered on iOS 10.
		}
	}
}

[assembly: ExportRenderer(typeof(Entry), typeof(MyRenderer2), MinimumSdkVersion = 10)]
namespace fgfg789.iOS
{
	public class MyRenderer2 : EntryRenderer
	{
		public MyRenderer2()
		{
			; // on iOS 10+, This renderer will be registered.
		}
	}
}
```

We can also use more than two renderers if we like so long as we make sure only one renderer is registered per version:

```
[assembly: ExportRenderer(typeof(Entry), typeof(MyRenderer1), MinimumSdkVersion = 6, MaximumSdkVersion = 7)]
[assembly: ExportRenderer(typeof(Entry), typeof(MyRenderer2), MinimumSdkVersion = 8, MaximumSdkVersion = 9]
[assembly: ExportRenderer(typeof(Entry), typeof(MyRenderer3), MinimumSdkVersion = 10)]
```

For further discussion, see [here](https://forums.xamarin.com/discussion/80341/methods-for-registering-renderers-during-runtime-instead-of-using-exportrenderer-attribute#latest).

Note that I do not know how to get OS version in RT (not sure if it's possible either) so I left it out.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
