### PR TITLE
[iOS] Fix IsNavigationBarTranslucent platform-specific not working

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -853,7 +853,7 @@ namespace Xamarin.Forms.Platform.iOS
 			public override void ViewWillAppear(bool animated)
 			{
 				UpdateNavigationBarVisibility(animated);
-				EdgesForExtendedLayout = UIRectEdge.None;
+				EdgesForExtendedLayout = NavigationController.NavigationBar.Translucent ? UIRectEdge.All : UIRectEdge.None;
 				base.ViewWillAppear(animated);
 			}
 


### PR DESCRIPTION
### Description of Change ###

Fixes setting `IsNavigationBarTranslucent = true` not working due to `EdgesForExtendedLayout` always being set to `UIRectEdge.None`.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=49104

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

