### PR TITLE
[XamlC] Allow compilation of IValueProviders

### DIFF
--- a/Xamarin.Forms.Build.Tasks/BindablePropertyReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/BindablePropertyReferenceExtensions.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Build.Tasks
 												md.IsStatic &&
 												md.IsPublic &&
 												md.Parameters.Count == 1 &&
-												md.Parameters [0].ParameterType.FullName == "Xamarin.Forms.BindableObject", module).SingleOrDefault()?.Item1;
+												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.Import(typeof(BindableObject))), module).SingleOrDefault()?.Item1;
 
 			if (getter == null)
 				throw new XamlParseException($"Missing a public static Get{bpName} or a public instance property getter for the attached property \"{bpRef.DeclaringType}.{bpRef.Name}\"", iXmlLineInfo);
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Build.Tasks
 												md.IsStatic &&
 												md.IsPublic &&
 												md.Parameters.Count == 1 &&
-												md.Parameters [0].ParameterType.FullName == "Xamarin.Forms.BindableObject", module).SingleOrDefault()?.Item1;
+												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.Import(typeof(BindableObject))), module).SingleOrDefault()?.Item1;
 
 			var attributes = new List<CustomAttribute>();
 			if (property != null && property.HasCustomAttributes)

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BindablePropertyConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BindablePropertyConverter.cs
@@ -18,7 +18,12 @@ namespace Xamarin.Forms.Core.XamlC
 				yield return Instruction.Create(OpCodes.Ldnull);
 				yield break;
 			}
+			var bpRef = GetBindablePropertyFieldReference(value, module, node);
+			yield return Instruction.Create(OpCodes.Ldsfld, bpRef);
+		}
 
+		public FieldReference GetBindablePropertyFieldReference(string value, ModuleDefinition module, BaseNode node)
+		{
 			FieldReference bpRef = null;
 			string typeName = null, propertyName = null;
 
@@ -49,7 +54,7 @@ namespace Xamarin.Forms.Core.XamlC
 			bpRef = GetBindablePropertyFieldReference(typeRef, propertyName, module);
 			if (bpRef == null)
 				throw new XamlParseException($"Can't resolve {propertyName} on {typeRef.Name}", node);
-			yield return Instruction.Create(OpCodes.Ldsfld, bpRef);
+			return bpRef;
 		}
 
 		public static TypeReference GetTypeReference(string xmlType, ModuleDefinition module, BaseNode iNode)

--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/ICompiledValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/ICompiledValueProvider.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xamarin.Forms.Build.Tasks;
+
+namespace Xamarin.Forms.Xaml
+{
+	interface ICompiledValueProvider
+	{
+		IEnumerable<Instruction> ProvideValue(VariableDefinitionReference vardefref, ModuleDefinition module, BaseNode node, ILContext context);
+	}
+}

--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
+
+namespace Xamarin.Forms.Core.XamlC
+{
+	class SetterValueProvider : ICompiledValueProvider
+	{
+		public IEnumerable<Instruction> ProvideValue(VariableDefinitionReference vardefref, ModuleDefinition module, BaseNode node, ILContext context)
+		{
+			var valueNode = ((IElementNode)node).Properties[new XmlName("", "Value")];
+
+			//if it's an elementNode, there's probably no need to convert it
+			if (valueNode is IElementNode)
+				yield break;
+
+			var value = ((string)((ValueNode)valueNode).Value);
+			var bpNode = ((ValueNode)((IElementNode)node).Properties[new XmlName("", "Property")]);
+			var bpRef = (new BindablePropertyConverter()).GetBindablePropertyFieldReference((string)bpNode.Value, module, bpNode);
+
+			TypeReference _;
+			var setValueRef = module.Import(module.Import(typeof(Setter)).GetProperty(p => p.Name == "Value", out _).SetMethod);
+
+			//push the setter
+			yield return Instruction.Create(OpCodes.Ldloc, vardefref.VariableDefinition);
+
+			//push the value
+			foreach (var instruction in ((ValueNode)valueNode).PushConvertedValue(context, bpRef, valueNode.PushServiceProvider(context, bpRef: bpRef), true, false))
+				yield return instruction;
+
+			//set the value
+			yield return Instruction.Create(OpCodes.Callvirt, setValueRef);
+		}
+	}
+}

--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Core.XamlC
 			yield return Instruction.Create(OpCodes.Ldloc, vardefref.VariableDefinition);
 
 			//push the value
-			foreach (var instruction in ((ValueNode)valueNode).PushConvertedValue(context, bpRef, valueNode.PushServiceProvider(context, bpRef: bpRef), true, false))
+			foreach (var instruction in ((ValueNode)valueNode).PushConvertedValue(context, bpRef, valueNode.PushServiceProvider(context, bpRef: bpRef), boxValueTypes: true, unboxValueTypes: false))
 				yield return instruction;
 
 			//set the value

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -105,6 +105,8 @@
     <Compile Include="CompiledConverters\ThicknessTypeConverter.cs" />
     <Compile Include="MethodBodyExtensions.cs" />
     <Compile Include="CompiledConverters\TypeTypeConverter.cs" />
+    <Compile Include="CompiledValueProviders\SetterValueProvider.cs" />
+    <Compile Include="CompiledValueProviders\ICompiledValueProvider.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
@@ -128,6 +130,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="CompiledMarkupExtensions\" />
+    <Folder Include="CompiledValueProviders\" />
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -8,6 +8,7 @@ using Xamarin.Forms.Xaml;
 namespace Xamarin.Forms
 {
 	[ContentProperty("Value")]
+	[ProvideCompiled("Xamarin.Forms.Core.XamlC.SetterValueProvider")]
 	public sealed class Setter : IValueProvider
 	{
 		readonly ConditionalWeakTable<BindableObject, object> _originalValues = new ConditionalWeakTable<BindableObject, object>();


### PR DESCRIPTION
### Description of Change ###

`IValueProvider`s tagged with the appropriate attribute will be bypassed
and the compiled version, if found, will be used.

This first version contains a compiled version of Setter's
IValueProvider and it already reduces the amount of generated IL by 39%
in, e.g. StyleTests.

It's a huge gain because XamlC no longer have to generate
ServiceProviders for those, so the methodbody is smaller, takes less
time to jit, less time to execute and nothing is invoked at runtime,
which probably saves a tons of time as well, as most IValueProvider
implementation heavily uses reflection.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense