### PR TITLE
Exception clarity in Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs.

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -325,7 +325,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			Children.Add(control);
 
 			if (Element == null)
-				throw new InvalidOperationException("When calling SetNativeControl the Element property must have a non-null value.");
+				throw new InvalidOperationException("Changes to the native control require the Element property must have a non-null value.");
 
 			Element.IsNativeStateConsistent = false;
 			control.Loaded += OnControlLoaded;

--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -324,6 +324,11 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			Children.Add(control);
 
+            if (Element == null)
+            {
+                throw new Exception("When calling SetNativeControl the Element property (of the ViewRenderer) must have a non-null value.");
+            }
+
 			Element.IsNativeStateConsistent = false;
 			control.Loaded += OnControlLoaded;
 

--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -324,10 +324,10 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			Children.Add(control);
 
-            if (Element == null)
-            {
-                throw new Exception("When calling SetNativeControl the Element property (of the ViewRenderer) must have a non-null value.");
-            }
+			if (Element == null)
+			{
+				throw new Exception("When calling SetNativeControl the Element property (of the ViewRenderer) must have a non-null value.");
+			}
 
 			Element.IsNativeStateConsistent = false;
 			control.Loaded += OnControlLoaded;

--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -325,9 +325,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			Children.Add(control);
 
 			if (Element == null)
-			{
-				throw new Exception("When calling SetNativeControl the Element property (of the ViewRenderer) must have a non-null value.");
-			}
+				throw new InvalidOperationException("When calling SetNativeControl the Element property must have a non-null value.");
 
 			Element.IsNativeStateConsistent = false;
 			control.Loaded += OnControlLoaded;


### PR DESCRIPTION
### Description of Change ###

Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs throws a vague NullReferenceException when SetNativeControl is called when the Element property is null. I'm new to GitHub (from Bitbucket) and the first time changing the Xamarin source. Does this require tests?

### Bugs Fixed ###

- None

### API Changes ###

Changed:
 - SetNativeControl in Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs.

### Behavioral Changes ###

Throws an Exception with custom message instead of a runtime induced NullReferenceException.

### PR Checklist ###

- [ ] Has tests (see description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
