### PR TITLE
[XamlC] Box valueTypes on Add()

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -1034,6 +1034,8 @@ namespace Xamarin.Forms.Build.Tasks
 			yield return Instruction.Create(OpCodes.Ldloc, vardef);
 			if (implicitOperator != null)
 				yield return Instruction.Create(OpCodes.Call, module.Import(implicitOperator));
+			if (implicitOperator == null && vardef.VariableType.IsValueType && !childType.IsValueType)
+				yield return Instruction.Create(OpCodes.Box, vardef.VariableType);
 			yield return Instruction.Create(OpCodes.Callvirt, adderRef);
 			if (adderRef.ReturnType.FullName != "System.Void")
 				yield return Instruction.Create(OpCodes.Pop);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz49307.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz49307.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Application xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Bz49307">
+	<Application.Resources>
+		<!-- Application resource dictionary -->
+		<Color x:Key="MyColor">#c2d1d3</Color>
+	</Application.Resources>
+</Application>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz49307.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz49307.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz49307 : Application
+	{
+		public Bz49307()
+		{
+			InitializeComponent();
+		}
+
+		public Bz49307(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void ThrowOnMissingDictionary(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<NullReferenceException>(() => new Bz49307(useCompiledXaml));
+				else
+					Assert.Throws(new XamlParseExceptionConstraint(5, 4), () => new Bz49307(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -403,6 +403,9 @@
      <Compile Include="I8.xaml.cs">
        <DependentUpon>I8.xaml</DependentUpon>
      </Compile>
+    <Compile Include="Issues\Bz49307.xaml.cs">
+      <DependentUpon>Bz49307.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -725,6 +728,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="I8.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz49307.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml.Xamlc/Xamarin.Forms.Xaml.Xamlc.csproj
+++ b/Xamarin.Forms.Xaml.Xamlc/Xamarin.Forms.Xaml.Xamlc.csproj
@@ -17,7 +17,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Commandlineparameters>-r "../../../Xamarin.Forms.Controls/bin/Debug/" -p "../../../Xamarin.Forms.Xaml.UnitTest/bin/Debug/;/Library/Frameworks/Mono.framework/Versions/3.12.1/lib/mono/4.5;/Library/Frameworks/Mono.framework/Versions/3.12.1/lib/mono/4.5/Facades/" --keep -v 4 -d ../../../Xamarin.Forms.Xaml.UnitTests/bin/Debug/Xamarin.Forms.Xaml.UnitTests.dll</Commandlineparameters>
+    <Commandlineparameters>-r "../../../Xamarin.Forms.Controls/bin/Debug/" -p "../../../Xamarin.Forms.Xaml.UnitTest/bin/Debug/;/Library/Frameworks/Mono.framework/Versions/3.12.1/lib/mono/4.5;/Library/Frameworks/Mono.framework/Versions/3.12.1/lib/mono/4.5/Facades/" --keep -v 4 ../../../Xamarin.Forms.Xaml.UnitTests/bin/Debug/Xamarin.Forms.Xaml.UnitTests.dll</Commandlineparameters>
     <AssemblyName>xamlc</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
### Description of Change ###

This doesn't happen often, and I haven't found any valid XAML file out
there requiring this, but in the case of 49307, it at least generates
valid IL, which then fails with a NRE as this is the nature of callvirt.

### Bugs Fixed ###

- generate valid IL for https://bugzilla.xamarin.com/show_bug.cgi?id=49307

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
