### PR TITLE
[Android] NavigationPageRenderer should not create a Fragment unnecessarily

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -584,8 +584,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			FragmentManager.EnableDebugLogging(true);
 #endif
 
-			List<Fragment> fragments = _fragmentStack;
-
 			Current = page;
 
 			((Platform)Element.Platform).NavAnimationInProgress = true;
@@ -596,10 +594,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			transaction.DisallowAddToBackStack();
 
-			if (fragments.Count == 0)
+			if (_fragmentStack.Count == 0)
 			{
 				transaction.Add(Id, fragment);
-				fragments.Add(fragment);
+				_fragmentStack.Add(fragment);
 			}
 			else
 			{
@@ -607,15 +605,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					// pop only one page, or pop everything to the root
 					var popPage = true;
-					while (fragments.Count > 1 && popPage)
+					while (_fragmentStack.Count > 1 && popPage)
 					{
-						Fragment currentToRemove = fragments.Last();
-						fragments.RemoveAt(fragments.Count - 1);
+						Fragment currentToRemove = _fragmentStack.Last();
+						_fragmentStack.RemoveAt(_fragmentStack.Count - 1);
 						transaction.Remove(currentToRemove);
 						popPage = popToRoot;
 					}
 					
-					Fragment toShow = fragments.Last();
+					Fragment toShow = _fragmentStack.Last();
 					// Execute pending transactions so that we can be sure the fragment list is accurate.
 					FragmentManager.ExecutePendingTransactions();
 					if (FragmentManager.Fragments.Contains(toShow))
@@ -626,10 +624,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else
 				{
 					// push
-					Fragment currentToHide = fragments.Last();
+					Fragment currentToHide = _fragmentStack.Last();
 					transaction.Hide(currentToHide);
 					transaction.Add(Id, fragment);
-					fragments.Add(fragment);
+					_fragmentStack.Add(fragment);
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -685,16 +685,16 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		Fragment GetFragment(Page page, bool removed, bool popToRoot)
 		{
-			if (FragmentManager.Fragments == null)
+			// push
+			if (!removed && !popToRoot)
 				return FragmentContainer.CreateInstance(page);
 
+			// pop
 			if (removed)
-				return FragmentManager.Fragments[FragmentManager.Fragments.Count - 2];
+				return _fragmentStack[_fragmentStack.Count - 2];
 
-			if (popToRoot)
-				return FragmentManager.Fragments[0];
-
-			throw new NotSupportedException();
+			// pop to root
+			return _fragmentStack[0];
 		}
 
 		void ToolbarTrackerOnCollectionChanged(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 
-		FragmentManager FragmentManager => _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
+		FragmentManager FragmentManager	=> _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
 
 		IPageController PageController => Element as IPageController;
 
@@ -324,7 +324,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			else
 				transaction.SetTransition((int)FragmentTransit.FragmentClose);
 		}
-
+		
 		internal int GetNavBarHeight()
 		{
 			if (!ToolbarVisible)
@@ -584,6 +584,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			FragmentManager.EnableDebugLogging(true);
 #endif
 
+			List<Fragment> fragments = _fragmentStack;
+
 			Current = page;
 
 			((Platform)Element.Platform).NavAnimationInProgress = true;
@@ -594,10 +596,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			transaction.DisallowAddToBackStack();
 
-			if (_fragmentStack.Count == 0)
+			if (fragments.Count == 0)
 			{
 				transaction.Add(Id, fragment);
-				_fragmentStack.Add(fragment);
+				fragments.Add(fragment);
 			}
 			else
 			{
@@ -605,15 +607,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					// pop only one page, or pop everything to the root
 					var popPage = true;
-					while (_fragmentStack.Count > 1 && popPage)
+					while (fragments.Count > 1 && popPage)
 					{
-						Fragment currentToRemove = _fragmentStack.Last();
-						_fragmentStack.RemoveAt(_fragmentStack.Count - 1);
+						Fragment currentToRemove = fragments.Last();
+						fragments.RemoveAt(fragments.Count - 1);
 						transaction.Remove(currentToRemove);
 						popPage = popToRoot;
 					}
-
-					Fragment toShow = _fragmentStack.Last();
+					
+					Fragment toShow = fragments.Last();
 					// Execute pending transactions so that we can be sure the fragment list is accurate.
 					FragmentManager.ExecutePendingTransactions();
 					if (FragmentManager.Fragments.Contains(toShow))
@@ -624,10 +626,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else
 				{
 					// push
-					Fragment currentToHide = _fragmentStack.Last();
+					Fragment currentToHide = fragments.Last();
 					transaction.Hide(currentToHide);
 					transaction.Add(Id, fragment);
-					_fragmentStack.Add(fragment);
+					fragments.Add(fragment);
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -683,16 +683,16 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		Fragment GetFragment(Page page, bool removed, bool popToRoot)
 		{
-			// push
-			if (!removed && !popToRoot)
-				return FragmentContainer.CreateInstance(page);
-
 			// pop
 			if (removed)
 				return _fragmentStack[_fragmentStack.Count - 2];
 
 			// pop to root
-			return _fragmentStack[0];
+			if(popToRoot)
+				return _fragmentStack[0];
+
+			// push
+			return FragmentContainer.CreateInstance(page);
 		}
 
 		void ToolbarTrackerOnCollectionChanged(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 
-		FragmentManager FragmentManager	=> _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
+		FragmentManager FragmentManager => _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
 
 		IPageController PageController => Element as IPageController;
 
@@ -324,7 +324,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			else
 				transaction.SetTransition((int)FragmentTransit.FragmentClose);
 		}
-		
+
 		internal int GetNavBarHeight()
 		{
 			if (!ToolbarVisible)
@@ -584,8 +584,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			FragmentManager.EnableDebugLogging(true);
 #endif
 
-			List<Fragment> fragments = _fragmentStack;
-
 			Current = page;
 
 			((Platform)Element.Platform).NavAnimationInProgress = true;
@@ -596,10 +594,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			transaction.DisallowAddToBackStack();
 
-			if (fragments.Count == 0)
+			if (_fragmentStack.Count == 0)
 			{
 				transaction.Add(Id, fragment);
-				fragments.Add(fragment);
+				_fragmentStack.Add(fragment);
 			}
 			else
 			{
@@ -607,15 +605,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					// pop only one page, or pop everything to the root
 					var popPage = true;
-					while (fragments.Count > 1 && popPage)
+					while (_fragmentStack.Count > 1 && popPage)
 					{
-						Fragment currentToRemove = fragments.Last();
-						fragments.RemoveAt(fragments.Count - 1);
+						Fragment currentToRemove = _fragmentStack.Last();
+						_fragmentStack.RemoveAt(_fragmentStack.Count - 1);
 						transaction.Remove(currentToRemove);
 						popPage = popToRoot;
 					}
-					
-					Fragment toShow = fragments.Last();
+
+					Fragment toShow = _fragmentStack.Last();
 					// Execute pending transactions so that we can be sure the fragment list is accurate.
 					FragmentManager.ExecutePendingTransactions();
 					if (FragmentManager.Fragments.Contains(toShow))
@@ -626,10 +624,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else
 				{
 					// push
-					Fragment currentToHide = fragments.Last();
+					Fragment currentToHide = _fragmentStack.Last();
 					transaction.Hide(currentToHide);
 					transaction.Add(Id, fragment);
-					fragments.Add(fragment);
+					_fragmentStack.Add(fragment);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

`NavigationPageRenderer` is creating a new `Fragment` every time we push, pop, or pop to root. While it makes sense to do this in the first case, it doesn't in other cases. Instead, we can re-use existing fragments from `_fragmentStack`. Not sure what this means for performance, but there is no need to instantiate a `Fragment` object unnecessarily. 

Also removed two local variables.

### Bugs Fixed ###

- N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
