### PR TITLE
[iOS] Dispose Entry and Editor properly and automate GC checks

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1024.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1024.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 1024, "Entry is leaking when used in ViewCell", PlatformAffected.iOS)]
+	public class Bugzilla1024 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new LandingPage1024());
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void Bugzilla1024Test()
+		{
+			for (var n = 0; n < 10; n++)
+			{
+				RunningApp.WaitForElement(q => q.Marked("Push"));
+				RunningApp.Tap(q => q.Marked("Push"));
+
+				RunningApp.WaitForElement(q => q.Marked("ListView"));
+				RunningApp.Back();
+			}
+
+			// At this point, the counter can be any value, but it's most likely not zero.
+			// Invoking GC once is enough to clean up all garbage data and set counter to zero
+			RunningApp.WaitForElement(q => q.Marked("GC"));
+			RunningApp.Tap(q => q.Marked("GC"));
+
+			RunningApp.WaitForElement(q => q.Marked("Counter: 0"));
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class LandingPage1024 : ContentPage
+	{
+		public static int Counter;
+		public Label Label;
+
+		public LandingPage1024()
+		{
+			Label = new Label
+			{
+				Text = "Counter: " + Counter,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center
+			};
+
+			Content = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Spacing = 15,
+				Children =
+				{
+					new Label
+					{
+						Text = "Click Push to show a ListView. When you hit the Back button, Counter will show the number of pages that have not been finalized yet."
+						+ " If you click GC, the counter should be 0."
+					},
+					Label,
+					new Button
+					{
+						Text = "GC",
+						AutomationId = "GC",
+						Command = new Command(o =>
+						{
+							GC.Collect();
+							GC.WaitForPendingFinalizers();
+							GC.Collect();
+							Label.Text = "Counter: " + Counter;
+						})
+					},
+					new Button
+					{
+						Text = "Push",
+						AutomationId = "Push",
+						Command = new Command(async o =>
+						{
+							await Navigation.PushAsync(new ContentPage1024());
+						})
+					}
+				}
+			};
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			if (Label != null)
+				Label.Text = "Counter: " + Counter;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ContentPage1024 : ContentPage
+	{
+		public ContentPage1024()
+		{
+			Interlocked.Increment(ref LandingPage1024.Counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage1024.Counter);
+
+			Content = new ListView
+			{
+				HasUnevenRows = true,
+				ItemsSource = new List<int> { 1, 2, 3 },
+				ItemTemplate = new DataTemplate(typeof(ViewCell1024)),
+				AutomationId = "ListView"
+			};
+		}
+
+		~ContentPage1024()
+		{
+			Interlocked.Decrement(ref LandingPage1024.Counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage1024.Counter);
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewCell1024 : ViewCell
+	{
+		public ViewCell1024()
+		{
+			View = new Entry
+			{
+				Text = "Entry",
+				BackgroundColor = Color.Beige,
+				HeightRequest = 50
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1024.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1024.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.None, 1024, "Entry is leaking when used in ViewCell", PlatformAffected.iOS)]
+	[Issue(IssueTracker.None, 1024, "Entry and Editor are leaking when used in ViewCell", PlatformAffected.iOS)]
 	public class Bugzilla1024 : TestNavigationPage
 	{
 		protected override void Init()
@@ -117,8 +117,8 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = new ListView
 			{
 				HasUnevenRows = true,
-				ItemsSource = new List<int> { 1, 2, 3 },
-				ItemTemplate = new DataTemplate(typeof(ViewCell1024)),
+				ItemsSource = new List<string> { "Entry", "Editor"},
+				ItemTemplate = new InputViewDataTemplateSelector(),
 				AutomationId = "ListView"
 			};
 		}
@@ -131,16 +131,28 @@ namespace Xamarin.Forms.Controls.Issues
 	}
 
 	[Preserve(AllMembers = true)]
-	public class ViewCell1024 : ViewCell
+	public class InputViewDataTemplateSelector : DataTemplateSelector
 	{
-		public ViewCell1024()
+		public DataTemplate EntryTemplate { get; set; }
+		public DataTemplate EditorTemplate { get; set; }
+
+		public InputViewDataTemplateSelector()
 		{
-			View = new Entry
+			EntryTemplate = new DataTemplate(() => new ViewCell { View = new Entry { BackgroundColor = Color.DarkGoldenrod, Text = "Entry" } });
+			EditorTemplate = new DataTemplate(() => new ViewCell { View = new Editor { BackgroundColor = Color.Bisque, Text = "Editor" } });
+		}
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			switch (item as string)
 			{
-				Text = "Entry",
-				BackgroundColor = Color.Beige,
-				HeightRequest = 50
-			};
+				case "Entry":
+					return EntryTemplate;
+				case "Editor":
+					return EditorTemplate;
+			}
+
+			return null;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -173,6 +173,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)InputTransparentIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsInvokeRequiredRaceCondition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsPasswordToggleTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1024.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1025.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1026.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1691.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -27,9 +27,6 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementChanged(e);
 
-			if (e.NewElement == null)
-				return;
-
 			if (Control == null)
 			{
 				SetNativeControl(new UITextView(RectangleF.Empty));
@@ -55,11 +52,14 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.Ended += OnEnded;
 			}
 
-			UpdateText();
-			UpdateFont();
-			UpdateTextColor();
-			UpdateKeyboard();
-			UpdateEditable();
+			if (e.NewElement != null)
+			{
+				UpdateText();
+				UpdateFont();
+				UpdateTextColor();
+				UpdateKeyboard();
+				UpdateEditable();
+			}
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -27,6 +27,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementChanged(e);
 
+			if (e.NewElement == null)
+				return;
+
 			if (Control == null)
 			{
 				SetNativeControl(new UITextView(RectangleF.Empty));
@@ -52,14 +55,11 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.Ended += OnEnded;
 			}
 
-			if (e.NewElement != null)
-			{
-				UpdateText();
-				UpdateFont();
-				UpdateTextColor();
-				UpdateKeyboard();
-				UpdateEditable();
-			}
+			UpdateText();
+			UpdateFont();
+			UpdateTextColor();
+			UpdateKeyboard();
+			UpdateEditable();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -7,17 +7,24 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class EditorRenderer : ViewRenderer<Editor, UITextView>
 	{
-		UIToolbar _accessoryView;
-
+		bool _disposed;
 		IElementController ElementController => Element as IElementController;
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
 			if (disposing)
 			{
-				Control.Changed -= HandleChanged;
-				Control.Started -= OnStarted;
-				Control.Ended -= OnEnded;
+				if (Control != null)
+				{
+					Control.Changed -= HandleChanged;
+					Control.Started -= OnStarted;
+					Control.Ended -= OnEnded;
+				}
 			}
 
 			base.Dispose(disposing);
@@ -27,6 +34,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementChanged(e);
 
+			if (e.NewElement == null)
+				return;
+
 			if (Control == null)
 			{
 				SetNativeControl(new UITextView(RectangleF.Empty));
@@ -35,7 +45,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					// iPhone does not have a dismiss keyboard button
 					var keyboardWidth = UIScreen.MainScreen.Bounds.Width;
-					_accessoryView = new UIToolbar(new RectangleF(0, 0, keyboardWidth, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
+					var accessoryView = new UIToolbar(new RectangleF(0, 0, keyboardWidth, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
 
 					var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);
 					var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) =>
@@ -43,8 +53,8 @@ namespace Xamarin.Forms.Platform.iOS
 						Control.ResignFirstResponder();
 						Element.SendCompleted();
 					});
-					_accessoryView.SetItems(new[] { spacer, doneButton }, false);
-					Control.InputAccessoryView = _accessoryView;
+					accessoryView.SetItems(new[] { spacer, doneButton }, false);
+					Control.InputAccessoryView = accessoryView;
 				}
 
 				Control.Changed += HandleChanged;
@@ -52,14 +62,11 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.Ended += OnEnded;
 			}
 
-			if (e.NewElement != null)
-			{
-				UpdateText();
-				UpdateFont();
-				UpdateTextColor();
-				UpdateKeyboard();
-				UpdateEditable();
-			}
+			UpdateText();
+			UpdateFont();
+			UpdateTextColor();
+			UpdateKeyboard();
+			UpdateEditable();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Forms.Platform.iOS
 	public class EntryRenderer : ViewRenderer<Entry, UITextField>
 	{
 		UIColor _defaultTextColor;
+		bool _disposed;
 
 		public EntryRenderer()
 		{
@@ -20,8 +21,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
 			if (disposing)
 			{
+				_defaultTextColor = null;
+
 				if (Control != null)
 				{
 					Control.EditingDidBegin -= OnEditingBegan;
@@ -37,26 +45,25 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementChanged(e);
 
-			var textField = Control;
-
-			if (Control == null)
-			{
-				SetNativeControl(textField = new UITextField(RectangleF.Empty));
-
-				_defaultTextColor = textField.TextColor;
-				textField.BorderStyle = UITextBorderStyle.RoundedRect;
-				textField.ClipsToBounds = true;
-
-				textField.EditingChanged += OnEditingChanged;
-
-				textField.ShouldReturn = OnShouldReturn;
-
-				textField.EditingDidBegin += OnEditingBegan;
-				textField.EditingDidEnd += OnEditingEnded;
-			}
-
 			if (e.NewElement != null)
 			{
+				if (Control == null)
+				{
+					UITextField textField;
+					SetNativeControl(textField = new UITextField(RectangleF.Empty));
+
+					_defaultTextColor = textField.TextColor;
+					textField.BorderStyle = UITextBorderStyle.RoundedRect;
+					textField.ClipsToBounds = true;
+
+					textField.EditingChanged += OnEditingChanged;
+
+					textField.ShouldReturn = OnShouldReturn;
+
+					textField.EditingDidBegin += OnEditingBegan;
+					textField.EditingDidEnd += OnEditingEnded;
+				}
+
 				UpdatePlaceholder();
 				UpdatePassword();
 				UpdateText();

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -49,8 +49,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (Control == null)
 				{
-					UITextField textField;
-					SetNativeControl(textField = new UITextField(RectangleF.Empty));
+					var textField = new UITextField(RectangleF.Empty);
+					SetNativeControl(textField);
 
 					_defaultTextColor = textField.TextColor;
 					textField.BorderStyle = UITextBorderStyle.RoundedRect;

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -45,34 +45,34 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementChanged(e);
 
-			if (e.NewElement != null)
+			if (e.NewElement == null)
+				return;
+
+			if (Control == null)
 			{
-				if (Control == null)
-				{
-					var textField = new UITextField(RectangleF.Empty);
-					SetNativeControl(textField);
+				var textField = new UITextField(RectangleF.Empty);
+				SetNativeControl(textField);
 
-					_defaultTextColor = textField.TextColor;
-					textField.BorderStyle = UITextBorderStyle.RoundedRect;
-					textField.ClipsToBounds = true;
+				_defaultTextColor = textField.TextColor;
+				textField.BorderStyle = UITextBorderStyle.RoundedRect;
+				textField.ClipsToBounds = true;
 
-					textField.EditingChanged += OnEditingChanged;
+				textField.EditingChanged += OnEditingChanged;
 
-					textField.ShouldReturn = OnShouldReturn;
+				textField.ShouldReturn = OnShouldReturn;
 
-					textField.EditingDidBegin += OnEditingBegan;
-					textField.EditingDidEnd += OnEditingEnded;
-				}
-
-				UpdatePlaceholder();
-				UpdatePassword();
-				UpdateText();
-				UpdateColor();
-				UpdateFont();
-				UpdateKeyboard();
-				UpdateAlignment();
-				UpdateAdjustsFontSizeToFitWidth();
+				textField.EditingDidBegin += OnEditingBegan;
+				textField.EditingDidEnd += OnEditingEnded;
 			}
+
+			UpdatePlaceholder();
+			UpdatePassword();
+			UpdateText();
+			UpdateColor();
+			UpdateFont();
+			UpdateKeyboard();
+			UpdateAlignment();
+			UpdateAdjustsFontSizeToFitWidth();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -74,6 +74,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (disposing && Control != null && ManageNativeControlLifetime)
 			{
+				Control.RemoveFromSuperview();
 				Control.Dispose();
 				Control = null;
 			}


### PR DESCRIPTION
### Description of Change ###

When you have a `ListView` where each `ViewCell` contains an `Entry`, popping the current page does not release it because `EntryRenderer` is missing `if (e.NewElement != null)` in `OnElementChanged`. I have a UI test case that could be automated. Let me know if you want me to push it as well. Since I haven't created a bug, I do not know what to name the test class.

Please run this on top of #524.

### Bugs Fixed ###

- N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

