### PR TITLE
Deprecate versions of iOS older than 8

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -169,9 +169,8 @@ namespace Xamarin.Forms.Platform.iOS
 				_scroller = new UIScrollView(new RectangleF(0, 0, width, height));
 				_scroller.ScrollsToTop = false;
 				_scroller.ShowsHorizontalScrollIndicator = false;
-
-				if (Forms.IsiOS8OrNewer)
-					_scroller.PreservesSuperviewLayoutMargins = true;
+				
+				_scroller.PreservesSuperviewLayoutMargins = true;
 
 				ContentView.AddSubview(_scroller);
 			}
@@ -299,11 +298,6 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			var frame = _moreButton.Frame;
-			if (!Forms.IsiOS8OrNewer)
-			{
-				var container = _moreButton.Superview;
-				frame = new RectangleF(container.Frame.X, 0, frame.Width, frame.Height);
-			}
 
 			var x = frame.X - _scroller.ContentOffset.X;
 

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -24,10 +24,6 @@ namespace Xamarin.Forms
 		//Preserve GetCallingAssembly
 		static readonly bool nevertrue = false;
 
-		static bool? s_isiOS7OrNewer;
-
-		static bool? s_isiOS8OrNewer;
-
 		static bool? s_isiOS9OrNewer;
 
 		static Forms()
@@ -37,26 +33,6 @@ namespace Xamarin.Forms
 		}
 
 		public static bool IsInitialized { get; private set; }
-
-		internal static bool IsiOS7OrNewer
-		{
-			get
-			{
-				if (!s_isiOS7OrNewer.HasValue)
-					s_isiOS7OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(7, 0);
-				return s_isiOS7OrNewer.Value;
-			}
-		}
-
-		internal static bool IsiOS8OrNewer
-		{
-			get
-			{
-				if (!s_isiOS8OrNewer.HasValue)
-					s_isiOS8OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(8, 0);
-				return s_isiOS8OrNewer.Value;
-			}
-		}
 
 		internal static bool IsiOS9OrNewer
 		{

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -45,15 +45,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (!PageIsChildOfPlatform(sender))
 					return;
-
-				if (Forms.IsiOS8OrNewer)
-				{
-					PresentAlert(arguments);
-				}
-				else
-				{
-					PresentPre8Alert(arguments);
-				}
+				PresentAlert(arguments);
 			});
 
 			MessagingCenter.Subscribe(this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments arguments) =>
@@ -64,16 +56,8 @@ namespace Xamarin.Forms.Platform.iOS
 				var pageRoot = sender;
 				while (!Application.IsApplicationOrNull(pageRoot.RealParent))
 					pageRoot = (Page)pageRoot.RealParent;
-				var pageRenderer = GetRenderer(pageRoot);
 
-				if (Forms.IsiOS8OrNewer)
-				{
-					PresentActionSheet(arguments);
-				}
-				else
-				{
-					PresentPre8ActionSheet(arguments, pageRenderer);
-				}
+				PresentActionSheet(arguments);
 			});
 		}
 
@@ -489,35 +473,6 @@ namespace Xamarin.Forms.Platform.iOS
 			// would be safe to dismiss the VC). Fortunately this is almost never an issue
 			await _renderer.PresentViewControllerAsync(wrapper, animated);
 			await Task.Delay(5);
-		}
-
-		void PresentPre8Alert(AlertArguments arguments)
-		{
-			UIAlertView alertView;
-			if (arguments.Accept != null)
-				alertView = new UIAlertView(arguments.Title, arguments.Message, null, arguments.Cancel, arguments.Accept);
-			else
-				alertView = new UIAlertView(arguments.Title, arguments.Message, null, arguments.Cancel);
-
-			alertView.Dismissed += (o, args) => arguments.SetResult(args.ButtonIndex != 0);
-			alertView.Show();
-		}
-
-		void PresentPre8ActionSheet(ActionSheetArguments arguments, IVisualElementRenderer pageRenderer)
-		{
-			var actionSheet = new UIActionSheet(arguments.Title, null, arguments.Cancel, arguments.Destruction,
-						arguments.Buttons.ToArray());
-
-			actionSheet.ShowInView(pageRenderer.NativeView);
-
-			actionSheet.Clicked += (o, args) =>
-			{
-				string title = null;
-				if (args.ButtonIndex != -1)
-					title = actionSheet.ButtonTitle(args.ButtonIndex);
-
-				arguments.Result.TrySetResult(title);
-			};
 		}
 
 		internal class DefaultRenderer : VisualElementRenderer<VisualElement>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
@@ -82,8 +82,6 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateFont();
 			else if (e.PropertyName == Button.BorderWidthProperty.PropertyName || e.PropertyName == Button.BorderRadiusProperty.PropertyName || e.PropertyName == Button.BorderColorProperty.PropertyName)
 				UpdateBorder();
-			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
-				UpdateBackgroundVisibility();
 			else if (e.PropertyName == Button.ImageProperty.PropertyName)
 				UpdateImage();
 		}
@@ -91,18 +89,6 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnButtonTouchUpInside(object sender, EventArgs eventArgs)
 		{
 			((IButtonController)Element)?.SendClicked();
-		}
-
-		void UpdateBackgroundVisibility()
-		{
-			if (Forms.IsiOS7OrNewer)
-				return;
-
-			var model = Element;
-			var shouldDrawImage = model.BackgroundColor == Color.Default;
-
-			foreach (var control in Control.Subviews.Where(sv => !(sv is UILabel)))
-				control.Alpha = shouldDrawImage ? 1.0f : 0.0f;
 		}
 
 		void UpdateBorder()
@@ -115,8 +101,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			uiButton.Layer.BorderWidth = Math.Max(0f, (float)button.BorderWidth);
 			uiButton.Layer.CornerRadius = button.BorderRadius;
-
-			UpdateBackgroundVisibility();
 		}
 
 		void UpdateFont()
@@ -142,10 +126,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UIButton button = Control;
 				if (button != null && uiimage != null)
 				{
-					if (Forms.IsiOS7OrNewer)
-						button.SetImage(uiimage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal), UIControlState.Normal);
-					else
-						button.SetImage(uiimage, UIControlState.Normal);
+					button.SetImage(uiimage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal), UIControlState.Normal);
 
 					button.ImageView.ContentMode = UIViewContentMode.ScaleAspectFit;
 
@@ -184,9 +165,8 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.SetTitleColor(Element.TextColor.ToUIColor(), UIControlState.Normal);
 				Control.SetTitleColor(Element.TextColor.ToUIColor(), UIControlState.Highlighted);
 				Control.SetTitleColor(_buttonTextColorDefaultDisabled, UIControlState.Disabled);
-
-				if (Forms.IsiOS7OrNewer)
-					Control.TintColor = Element.TextColor.ToUIColor();
+				
+				Control.TintColor = Element.TextColor.ToUIColor();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
@@ -22,8 +22,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public CarouselPageRenderer()
 		{
-			if (!Forms.IsiOS7OrNewer)
-				WantsFullScreenLayout = true;
 		}
 
 		IElementController ElementController => Element as IElementController;

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -11,16 +11,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		IElementController ElementController => Element as IElementController;
 
-		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
-		{
-			if (!Forms.IsiOS7OrNewer)
-			{
-				// Avoid crash iOS 6. iOS 6, I hate you. Why you no like Infinite size?
-				return base.GetDesiredSize(Math.Min(widthConstraint, 2000), Math.Min(heightConstraint, 2000));
-			}
-			return base.GetDesiredSize(widthConstraint, heightConstraint);
-		}
-
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)

--- a/Xamarin.Forms.Platform.iOS/Renderers/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FontExtensions.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				try
 				{
-					if (UIFont.FamilyNames.Contains(self.FontFamily) && Forms.IsiOS7OrNewer)
+					if (UIFont.FamilyNames.Contains(self.FontFamily))
 					{
 						var descriptor = new UIFontDescriptor().CreateWithFamily(self.FontFamily);
 
@@ -67,12 +67,6 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			if (bold && italic)
 			{
-				if (!Forms.IsiOS7OrNewer)
-				{
-					// not sure how to make a font both bold and italic in iOS 6, default to bold
-					return UIFont.BoldSystemFontOfSize(size);
-				}
-
 				var defaultFont = UIFont.SystemFontOfSize(size);
 				var descriptor = defaultFont.FontDescriptor.CreateWithTraits(UIFontDescriptorSymbolicTraits.Bold | UIFontDescriptorSymbolicTraits.Italic);
 				return UIFont.FromDescriptor(descriptor, 0);
@@ -110,7 +104,7 @@ namespace Xamarin.Forms.Platform.iOS
 				try
 				{
 					UIFont result;
-					if (UIFont.FamilyNames.Contains(family) && Forms.IsiOS7OrNewer)
+					if (UIFont.FamilyNames.Contains(family))
 					{
 						var descriptor = new UIFontDescriptor().CreateWithFamily(family);
 
@@ -142,12 +136,6 @@ namespace Xamarin.Forms.Platform.iOS
 			if (bold && italic)
 			{
 				var defaultFont = UIFont.SystemFontOfSize(size);
-
-				if (!Forms.IsiOS7OrNewer)
-				{
-					// not sure how to make a font both bold and italic in iOS 6, default to bold
-					return UIFont.BoldSystemFontOfSize(size);
-				}
 
 				var descriptor = defaultFont.FontDescriptor.CreateWithTraits(UIFontDescriptorSymbolicTraits.Bold | UIFontDescriptorSymbolicTraits.Italic);
 				return UIFont.FromDescriptor(descriptor, 0);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -370,8 +370,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
-				if (Forms.IsiOS7OrNewer)
-					Control.EstimatedRowHeight = 0;
+				Control.EstimatedRowHeight = 0;
 				_estimatedRowHeight = true;
 			}
 		}
@@ -560,10 +559,9 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateRowHeight()
 		{
 			var rowHeight = Element.RowHeight;
-			if (Element.HasUnevenRows && rowHeight == -1 && Forms.IsiOS7OrNewer)
+			if (Element.HasUnevenRows && rowHeight == -1)
 			{
-				if (Forms.IsiOS8OrNewer)
-					Control.RowHeight = UITableView.AutomaticDimension;
+				Control.RowHeight = UITableView.AutomaticDimension;
 			}
 			else
 				Control.RowHeight = rowHeight <= 0 ? DefaultRowHeight : rowHeight;
@@ -612,10 +610,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (List.RowHeight == -1 && cell.Height == -1 && cell is ViewCell)
 				{
-					// only doing ViewCell because its the only one that matters (the others dont adjust ANYWAY)
-					if (Forms.IsiOS8OrNewer)
-						return UITableView.AutomaticDimension;
-					return CalculateHeightForCell(tableView, cell);
+					return UITableView.AutomaticDimension;
 				}
 
 				var renderHeight = cell.RenderHeight;
@@ -681,7 +676,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				_uiTableViewController = uiTableViewController;
 				_uiTableView = uiTableViewController.TableView;
-				_defaultSectionHeight = Forms.IsiOS8OrNewer ? DefaultRowHeight : _uiTableView.SectionHeaderHeight;
+				_defaultSectionHeight = DefaultRowHeight;
 				List = list;
 				List.ItemSelected += OnItemSelected;
 				UpdateShortNameListener();

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -182,13 +182,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidLoad();
 
-			if (Forms.IsiOS7OrNewer)
-			{
-				
-				UpdateTranslucent();
-			}
-			else
-				WantsFullScreenLayout = false;
+			UpdateTranslucent();
 
 			_secondaryToolbar = new SecondaryToolbar { Frame = new RectangleF(0, 0, 320, 44) };
 			View.Add(_secondaryToolbar);
@@ -454,11 +448,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateTranslucent()
 		{
-			if (!Forms.IsiOS7OrNewer)
-			{
-				return;
-			}
-
 			NavigationBar.Translucent = ((NavigationPage)Element).OnThisPlatform().IsNavigationBarTranslucent();
 		}
 
@@ -571,18 +560,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var barBackgroundColor = ((NavigationPage)Element).BarBackgroundColor;
 			// Set navigation bar background color
-			if (Forms.IsiOS7OrNewer)
-			{
-				NavigationBar.BarTintColor = barBackgroundColor == Color.Default
-					? UINavigationBar.Appearance.BarTintColor
-					: barBackgroundColor.ToUIColor();
-			}
-			else
-			{
-				NavigationBar.TintColor = barBackgroundColor == Color.Default
-					? UINavigationBar.Appearance.TintColor
-					: barBackgroundColor.ToUIColor();
-			}
+			NavigationBar.BarTintColor = barBackgroundColor == Color.Default
+				? UINavigationBar.Appearance.BarTintColor
+				: barBackgroundColor.ToUIColor();
 		}
 
 		void UpdateBarTextColor()
@@ -616,12 +596,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var statusBarColorMode = (Element as NavigationPage).OnThisPlatform().GetStatusBarTextColorMode();
 
 			// set Tint color (i. e. Back Button arrow and Text)
-			if (Forms.IsiOS7OrNewer)
-			{
-				NavigationBar.TintColor = barTextColor == Color.Default || statusBarColorMode == StatusBarTextColorMode.DoNotAdjust
-					? UINavigationBar.Appearance.TintColor
-					: barTextColor.ToUIColor();
-			}
+			NavigationBar.TintColor = barTextColor == Color.Default || statusBarColorMode == StatusBarTextColorMode.DoNotAdjust
+				? UINavigationBar.Appearance.TintColor
+				: barTextColor.ToUIColor();
 
 			if (statusBarColorMode == StatusBarTextColorMode.DoNotAdjust || barTextColor.Luminosity <= 0.5)
 			{
@@ -679,18 +656,13 @@ namespace Xamarin.Forms.Platform.iOS
 #pragma warning disable 0618 //retaining legacy call to obsolete code
 			var tintColor = ((NavigationPage)Element).Tint;
 #pragma warning restore 0618
-			if (Forms.IsiOS7OrNewer)
-			{
-				NavigationBar.BarTintColor = tintColor == Color.Default
-					? UINavigationBar.Appearance.BarTintColor
-					: tintColor.ToUIColor();
-				if (tintColor == Color.Default)
-					NavigationBar.TintColor = UINavigationBar.Appearance.TintColor;
-				else
-					NavigationBar.TintColor = tintColor.Luminosity > 0.5 ? UIColor.Black : UIColor.White;
-			}
+			NavigationBar.BarTintColor = tintColor == Color.Default
+				? UINavigationBar.Appearance.BarTintColor
+				: tintColor.ToUIColor();
+			if (tintColor == Color.Default)
+				NavigationBar.TintColor = UINavigationBar.Appearance.TintColor;
 			else
-				NavigationBar.TintColor = tintColor == Color.Default ? null : tintColor.ToUIColor();
+				NavigationBar.TintColor = tintColor.Luminosity > 0.5 ? UIColor.Black : UIColor.White;
 		}
 
 		void UpdateToolBarVisible()
@@ -776,8 +748,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public ParentingViewController(NavigationRenderer navigation)
 			{
-				if (Forms.IsiOS7OrNewer)
-					AutomaticallyAdjustsScrollViewInsets = false;
+				AutomaticallyAdjustsScrollViewInsets = false;
 
 				_navigation = new WeakReference<NavigationRenderer>(navigation);
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -19,8 +19,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public PageRenderer()
 		{
-			if (!Forms.IsiOS7OrNewer)
-				WantsFullScreenLayout = true;
 		}
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -28,8 +28,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public PhoneMasterDetailRenderer()
 		{
-			if (!Forms.IsiOS7OrNewer)
-				WantsFullScreenLayout = true;
 		}
 
 		IMasterDetailPageController MasterDetailPageController => Element as IMasterDetailPageController;

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -107,16 +107,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (_defaultTintColor == null)
 			{
-				if (Forms.IsiOS7OrNewer)
-					_defaultTintColor = Control.BarTintColor;
-				else
-					_defaultTintColor = Control.TintColor;
+				_defaultTintColor = Control.BarTintColor;
 			}
-
-			if (Forms.IsiOS7OrNewer)
-				Control.BarTintColor = color.ToUIColor(_defaultTintColor);
-			else
-				Control.TintColor = color.ToUIColor(_defaultTintColor);
+			
+			Control.BarTintColor = color.ToUIColor(_defaultTintColor);
 
 			if (color.A < 1)
 				Control.SetBackgroundImage(new UIImage(), UIBarPosition.Any, UIBarMetrics.Default);

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -134,14 +134,6 @@ namespace Xamarin.Forms.Platform.iOS
 			_loaded = true;
 		}
 
-		public override void ViewDidLoad()
-		{
-			base.ViewDidLoad();
-
-			if (!Forms.IsiOS7OrNewer)
-				WantsFullScreenLayout = false;
-		}
-
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
@@ -314,25 +306,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (!_defaultBarColorSet)
 			{
-				if (Forms.IsiOS7OrNewer)
-					_defaultBarColor = TabBar.BarTintColor;
-				else
-					_defaultBarColor = TabBar.TintColor;
+				_defaultBarColor = TabBar.BarTintColor;
 
 				_defaultBarColorSet = true;
 			}
 
 			if (!isDefaultColor)
 				_barBackgroundColorWasSet = true;
-
-			if (Forms.IsiOS7OrNewer)
-			{
-				TabBar.BarTintColor = isDefaultColor ? _defaultBarColor : barBackgroundColor.ToUIColor();
-			}
-			else
-			{
-				TabBar.TintColor = isDefaultColor ? _defaultBarColor : barBackgroundColor.ToUIColor();
-			}
+			
+			TabBar.BarTintColor = isDefaultColor ? _defaultBarColor : barBackgroundColor.ToUIColor();
 		}
 
 		void UpdateBarTextColor()
@@ -369,10 +351,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// set TintColor for selected icon
 			// setting the unselected icon tint is not supported by iOS
-			if (Forms.IsiOS7OrNewer)
-			{
-				TabBar.TintColor = isDefaultColor ? _defaultBarTextColor : barTextColor.ToUIColor();
-			}
+			TabBar.TintColor = isDefaultColor ? _defaultBarTextColor : barTextColor.ToUIColor();
 		}
 
 		void UpdateChildrenOrderIndex(UIViewController[] viewControllers)

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
@@ -137,7 +137,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var cell = View.Model.GetCell(indexPath.Section, indexPath.Row);
 			var h = cell.Height;
 
-			if (View.RowHeight == -1 && h == -1 && cell is ViewCell && Forms.IsiOS8OrNewer) {
+			if (View.RowHeight == -1 && h == -1 && cell is ViewCell) {
 				return UITableView.AutomaticDimension;
 			} else if (h == -1)
 				return tableView.RowHeight;

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
@@ -134,9 +134,8 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateRowHeight()
 		{
 			var rowHeight = Element.RowHeight;
-			if (Element.HasUnevenRows && rowHeight == -1 && Forms.IsiOS7OrNewer) {
-				if (Forms.IsiOS8OrNewer)
-					Control.RowHeight = UITableView.AutomaticDimension;
+			if (Element.HasUnevenRows && rowHeight == -1) {
+				Control.RowHeight = UITableView.AutomaticDimension;
 			} else
 				Control.RowHeight = rowHeight <= 0 ? DefaultRowHeight : rowHeight;
 		}
@@ -147,8 +146,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element.HasUnevenRows && rowHeight == -1) {
 				Control.EstimatedRowHeight = DefaultRowHeight;
 			} else {
-				if (Forms.IsiOS7OrNewer)
-					Control.EstimatedRowHeight = 0;
+				Control.EstimatedRowHeight = 0;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -223,11 +223,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!MasterDetailPageController.ShouldShowSplitMode && _masterVisible)
 			{
 				MasterDetailPageController.CanChangeIsPresented = true;
-				if (Forms.IsiOS8OrNewer)
-				{
-					PreferredDisplayMode = UISplitViewControllerDisplayMode.PrimaryHidden;
-					PreferredDisplayMode = UISplitViewControllerDisplayMode.Automatic;
-				}
+				PreferredDisplayMode = UISplitViewControllerDisplayMode.PrimaryHidden;
+				PreferredDisplayMode = UISplitViewControllerDisplayMode.Automatic;
 			}
 
 			MasterDetailPageController.UpdateMasterBehavior();
@@ -307,10 +304,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void PerformButtonSelector()
 		{
-			if (Forms.IsiOS8OrNewer)
-				DisplayModeButtonItem.Target.PerformSelector(DisplayModeButtonItem.Action, DisplayModeButtonItem, 0);
-			else
-				PresentButton.Target.PerformSelector(PresentButton.Action, PresentButton, 0);
+			DisplayModeButtonItem.Target.PerformSelector(DisplayModeButtonItem.Action, DisplayModeButtonItem, 0);
 		}
 
 		void ToggleMaster()

--- a/Xamarin.Forms.Platform.iOS/ResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.iOS/ResourcesProvider.cs
@@ -8,8 +8,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public ResourcesProvider()
 		{
-			if (Forms.IsiOS7OrNewer)
-				UIApplication.Notifications.ObserveContentSizeCategoryChanged((sender, args) => UpdateStyles());
+			UIApplication.Notifications.ObserveContentSizeCategoryChanged((sender, args) => UpdateStyles());
 		}
 
 		public IResourceDictionary GetSystemResources()
@@ -45,20 +44,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateStyles()
 		{
-			if (Forms.IsiOS7OrNewer)
-			{
-				_dictionary[Device.Styles.TitleStyleKey] = GenerateStyle(UIFont.PreferredHeadline);
-				_dictionary[Device.Styles.SubtitleStyleKey] = GenerateStyle(UIFont.PreferredSubheadline);
-				_dictionary[Device.Styles.BodyStyleKey] = GenerateStyle(UIFont.PreferredBody);
-				_dictionary[Device.Styles.CaptionStyleKey] = GenerateStyle(UIFont.PreferredCaption1);
-			}
-			else
-			{
-				_dictionary[Device.Styles.TitleStyleKey] = GenerateStyle(UIFont.BoldSystemFontOfSize(17));
-				_dictionary[Device.Styles.SubtitleStyleKey] = GenerateStyle(UIFont.SystemFontOfSize(15));
-				_dictionary[Device.Styles.BodyStyleKey] = GenerateStyle(UIFont.SystemFontOfSize(17));
-				_dictionary[Device.Styles.CaptionStyleKey] = GenerateStyle(UIFont.SystemFontOfSize(12));
-			}
+			
+			_dictionary[Device.Styles.TitleStyleKey] = GenerateStyle(UIFont.PreferredHeadline);
+			_dictionary[Device.Styles.SubtitleStyleKey] = GenerateStyle(UIFont.PreferredSubheadline);
+			_dictionary[Device.Styles.BodyStyleKey] = GenerateStyle(UIFont.PreferredBody);
+			_dictionary[Device.Styles.CaptionStyleKey] = GenerateStyle(UIFont.PreferredCaption1);
 
 			_dictionary[Device.Styles.ListItemTextStyleKey] = GenerateListItemTextStyle();
 			_dictionary[Device.Styles.ListItemDetailTextStyleKey] = GenerateListItemDetailTextStyle();


### PR DESCRIPTION
### Description of Change ###

Same as last pr, but leaves iOS 9 checks in place and fixes some if statements that were improperly resolved.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

Older iOS versions continue to be unsupported.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

