### PR TITLE
[Android] Fix NavigationPage.BarTextColorProperty on API 21+ with FormsApplicationActivity

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -846,9 +846,21 @@ namespace Xamarin.Forms.Platform.Android
 			Color navigationBarTextColor = CurrentNavigationPage == null ? Color.Default : CurrentNavigationPage.BarTextColor;
 			TextView actionBarTitleTextView = null;
 
-			int actionBarTitleId = _context.Resources.GetIdentifier("action_bar_title", "id", "android");
-			if (actionBarTitleId > 0)
-				actionBarTitleTextView = ((Activity)_context).FindViewById<TextView>(actionBarTitleId);
+			if(Forms.IsLollipopOrNewer)
+			{
+				int actionbarId = _context.Resources.GetIdentifier("action_bar", "id", "android");
+				if(actionbarId > 0)
+				{
+					var toolbar = (Toolbar)((Activity)_context).FindViewById(actionbarId);
+					actionBarTitleTextView = (TextView)toolbar.GetChildAt(0);
+				}
+			}
+			else
+			{
+				int actionBarTitleId = _context.Resources.GetIdentifier("action_bar_title", "id", "android");
+				if (actionBarTitleId > 0)
+					actionBarTitleTextView = ((Activity)_context).FindViewById<TextView>(actionBarTitleId);
+			}
 
 			if (actionBarTitleTextView != null && navigationBarTextColor != Color.Default)
 				actionBarTitleTextView.SetTextColor(navigationBarTextColor.ToAndroid());


### PR DESCRIPTION
### Description of Change ###

On Lollipop and above `NavigationPage.BarTextColorProperty` was not working when using `FormsApplicationActivity` because getting a reference to the title `TextView` with the `action_bar_title` resource Id returns null. Instead you have to get a reference to the view indirectly via the Toolbar.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=49384

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense