### PR TITLE
[iOS] Dispose pickers properly and automate GC checks

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1023.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1023.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				HasUnevenRows = true,
 				ItemsSource = new List<string> { "DatePicker", "Picker", "TimePicker" },
-				ItemTemplate = new PickerDataTemplateSelector(),
+				ItemTemplate = new DataTemplateSelector1023(),
 				AutomationId = "ListView"
 			};
 		}
@@ -131,13 +131,13 @@ namespace Xamarin.Forms.Controls.Issues
 	}
 
 	[Preserve(AllMembers = true)]
-	public class PickerDataTemplateSelector : DataTemplateSelector
+	public class DataTemplateSelector1023 : DataTemplateSelector
 	{
 		public DataTemplate DatePickerTemplate { get; set; }
 		public DataTemplate PickerTemplate { get; set; }
 		public DataTemplate TimePickerTemplate { get; set; }
 
-		public PickerDataTemplateSelector()
+		public DataTemplateSelector1023()
 		{
 			DatePickerTemplate = new DataTemplate(() => new ViewCell { View = new DatePicker() });
 			PickerTemplate = new DataTemplate(() => new ViewCell { View = new Picker() });

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1023.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1023.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 1023, "Automate GC checks of picker disposals", PlatformAffected.iOS)]
+	public class Bugzilla1023 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new LandingPage1023());
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void Bugzilla1023Test()
+		{
+			for (var n = 0; n < 10; n++)
+			{
+				RunningApp.WaitForElement(q => q.Marked("Push"));
+				RunningApp.Tap(q => q.Marked("Push"));
+
+				RunningApp.WaitForElement(q => q.Marked("ListView"));
+				RunningApp.Back();
+			}
+
+			// At this point, the counter can be any value, but it's most likely not zero.
+			// Invoking GC once is enough to clean up all garbage data and set counter to zero
+			RunningApp.WaitForElement(q => q.Marked("GC"));
+			RunningApp.Tap(q => q.Marked("GC"));
+
+			RunningApp.WaitForElement(q => q.Marked("Counter: 0"));
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class LandingPage1023 : ContentPage
+	{
+		public static int Counter;
+		public Label Label;
+
+		public LandingPage1023()
+		{
+			Label = new Label
+			{
+				Text = "Counter: " + Counter,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center
+			};
+
+			Content = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Spacing = 15,
+				Children =
+				{
+					new Label
+					{
+						Text = "Click Push to show a ListView. When you hit the Back button, Counter will show the number of pages that have not been finalized yet."
+						+ " If you click GC, the counter should be 0."
+					},
+					Label,
+					new Button
+					{
+						Text = "GC",
+						AutomationId = "GC",
+						Command = new Command(o =>
+						{
+							GC.Collect();
+							GC.WaitForPendingFinalizers();
+							GC.Collect();
+							Label.Text = "Counter: " + Counter;
+						})
+					},
+					new Button
+					{
+						Text = "Push",
+						AutomationId = "Push",
+						Command = new Command(async o =>
+						{
+							await Navigation.PushAsync(new ContentPage1023());
+						})
+					}
+				}
+			};
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			if (Label != null)
+				Label.Text = "Counter: " + Counter;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ContentPage1023 : ContentPage
+	{
+		public ContentPage1023()
+		{
+			Interlocked.Increment(ref LandingPage1023.Counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage1023.Counter);
+
+			Content = new ListView
+			{
+				HasUnevenRows = true,
+				ItemsSource = new List<string> { "DatePicker", "Picker", "TimePicker" },
+				ItemTemplate = new PickerDataTemplateSelector(),
+				AutomationId = "ListView"
+			};
+		}
+
+		~ContentPage1023()
+		{
+			Interlocked.Decrement(ref LandingPage1023.Counter);
+			System.Diagnostics.Debug.WriteLine("Page: " + LandingPage1023.Counter);
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class PickerDataTemplateSelector : DataTemplateSelector
+	{
+		public DataTemplate DatePickerTemplate { get; set; }
+		public DataTemplate PickerTemplate { get; set; }
+		public DataTemplate TimePickerTemplate { get; set; }
+
+		public PickerDataTemplateSelector()
+		{
+			DatePickerTemplate = new DataTemplate(() => new ViewCell { View = new DatePicker() });
+			PickerTemplate = new DataTemplate(() => new ViewCell { View = new Picker() });
+			TimePickerTemplate = new DataTemplate(() => new ViewCell { View = new TimePicker() });
+		}
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			switch (item as string)
+			{
+				case "DatePicker":
+					return DatePickerTemplate;
+				case "Picker":
+					return PickerTemplate;
+				case "TimePicker":
+					return TimePickerTemplate;
+			}
+
+			return null;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -173,6 +173,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)InputTransparentIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsInvokeRequiredRaceCondition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsPasswordToggleTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1023.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1024.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1025.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1026.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		UIDatePicker _picker;
 		UIColor _defaultTextColor;
+		bool _disposed;
 
 		IElementController ElementController => Element as IElementController;
 
@@ -29,7 +30,10 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementChanged(e);
 
-			if (e.OldElement == null)
+			if (e.NewElement == null)
+				return;
+
+			if (Control == null)
 			{
 				var entry = new NoCaretField { BorderStyle = UITextBorderStyle.RoundedRect };
 
@@ -55,13 +59,10 @@ namespace Xamarin.Forms.Platform.iOS
 				SetNativeControl(entry);
 			}
 
-			if (e.NewElement != null)
-			{
-				UpdateDateFromModel(false);
-				UpdateMaximumDate();
-				UpdateMinimumDate();
-				UpdateTextColor();
-			}
+			UpdateDateFromModel(false);
+			UpdateMaximumDate();
+			UpdateMinimumDate();
+			UpdateTextColor();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -119,6 +120,35 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.TextColor = _defaultTextColor;
 			else
 				Control.TextColor = textColor.ToUIColor();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				_defaultTextColor = null;
+
+				if (_picker != null)
+				{
+					_picker.RemoveFromSuperview();
+					_picker.ValueChanged -= HandleValueChanged;
+					_picker.Dispose();
+					_picker = null;
+				}
+
+				if (Control != null)
+				{
+					Control.EditingDidBegin -= OnStarted;
+					Control.EditingDidEnd -= OnEnded;
+				}
+			}
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		UIPickerView _picker;
 		UIColor _defaultTextColor;
+		bool _disposed;
 
 		IElementController ElementController => Element as IElementController;
 
@@ -137,6 +138,37 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.TextColor = _defaultTextColor;
 			else
 				Control.TextColor = textColor.ToUIColor();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				_defaultTextColor = null;
+
+				if (_picker != null)
+				{
+					_picker.RemoveFromSuperview();
+					_picker.Dispose();
+					_picker = null;
+				}
+
+				if (Control != null)
+				{
+					Control.EditingDidBegin -= OnStarted;
+					Control.EditingDidEnd -= OnEnded;
+				}
+
+				if(Element != null)
+					((INotifyCollectionChanged)Element.Items).CollectionChanged -= RowsCollectionChanged;
+			}
+
+			base.Dispose(disposing);
 		}
 
 		class PickerSource : UIPickerViewModel

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -153,6 +153,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_picker != null)
 				{
+					if (_picker.Model != null)
+					{
+						_picker.Model.Dispose();
+						_picker.Model = null;
+					}
+
 					_picker.RemoveFromSuperview();
 					_picker.Dispose();
 					_picker = null;
@@ -173,11 +179,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 		class PickerSource : UIPickerViewModel
 		{
-			readonly PickerRenderer _renderer;
+			PickerRenderer _renderer;
+			bool _disposed;
 
-			public PickerSource(PickerRenderer model)
+			public PickerSource(PickerRenderer renderer)
 			{
-				_renderer = model;
+				_renderer = renderer;
 			}
 
 			public int SelectedIndex { get; internal set; }
@@ -214,6 +221,19 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if(_renderer.Element.On<PlatformConfiguration.iOS>().UpdateMode() == UpdateMode.Immediately)
 					_renderer.UpdatePickerFromModel(this);
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (_disposed)
+					return;
+
+				_disposed = true;
+
+				if (disposing)
+					_renderer = null;
+
+				base.Dispose(disposing);
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -10,17 +10,34 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		UIDatePicker _picker;
 		UIColor _defaultTextColor;
+		bool _disposed;
 
 		IElementController ElementController => Element as IElementController;
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
 			if (disposing)
 			{
-				Control.EditingDidBegin -= OnStarted;
-				Control.EditingDidEnd -= OnEnded;
+				_defaultTextColor = null;
 
-				_picker.ValueChanged -= OnValueChanged;
+				if (_picker != null)
+				{
+					_picker.RemoveFromSuperview();
+					_picker.ValueChanged -= OnValueChanged;
+					_picker.Dispose();
+					_picker = null;
+				}
+
+				if (Control != null)
+				{
+					Control.EditingDidBegin -= OnStarted;
+					Control.EditingDidEnd -= OnEnded;
+				}
 			}
 
 			base.Dispose(disposing);


### PR DESCRIPTION
### Description of Change ###

Went through renderers for `Picker`, `TimePicker`, and `DatePicker` to add/enhance dispose methods. Also added a UI test to automate GC checks. This should be run on top of #524.

### Bugs Fixed ###

- N/A

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
