### PR TITLE
[Suggestion] Set Control directly instead of going through SetNativeControl

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -39,7 +39,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (Control == null)
 			{
-				SetNativeControl(new UITextView(RectangleF.Empty));
+				//SetNativeControl(new UITextView(RectangleF.Empty));
+				Control = new UITextView(RectangleF.Empty);
 
 				if (Device.Idiom == TargetIdiom.Phone)
 				{

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -130,15 +130,7 @@ namespace Xamarin.Forms.Platform.iOS
 		[Obsolete("Set Control directly instead.")]
 		protected void SetNativeControl(TNativeView uiview)
 		{
-			_defaultColor = uiview.BackgroundColor;
 			Control = uiview;
-
-			if (Element.BackgroundColor != Color.Default)
-				SetBackgroundColor(Element.BackgroundColor);
-
-			UpdateIsEnabled();
-
-			AddSubview(uiview);
 		}
 
 		internal override void SendVisualElementInitialized(VisualElement element, UIView nativeView)

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -13,8 +13,28 @@ namespace Xamarin.Forms.Platform.iOS
 	public abstract class ViewRenderer<TView, TNativeView> : VisualElementRenderer<TView> where TView : View where TNativeView : UIView
 	{
 		UIColor _defaultColor;
+		TNativeView _control;
 
-		public TNativeView Control { get; private set; }
+		public TNativeView Control
+		{
+			get { return _control; }
+			protected set
+			{
+				if (ReferenceEquals(_control, value))
+					return;
+
+				_control = value;
+
+				_defaultColor = _control.BackgroundColor;
+
+				if (Element.BackgroundColor != Color.Default)
+					SetBackgroundColor(Element.BackgroundColor);
+
+				UpdateIsEnabled();
+
+				AddSubview(_control);
+			}
+		}
 
 		public override void LayoutSubviews()
 		{
@@ -107,6 +127,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.BackgroundColor = color.ToUIColor();
 		}
 
+		[Obsolete("Set Control directly instead.")]
 		protected void SetNativeControl(TNativeView uiview)
 		{
 			_defaultColor = uiview.BackgroundColor;


### PR DESCRIPTION
### Description of Change ###

When we use `SetNativeControl`, ReSharper issues a `Possible System.NullReferenceException` in derived renderers because it does not know for sure that `SetNativeControl` sets `Control`. Is it acceptable to mark this method obsolete and set `Control` in a protected manner?

I have not gone through making adjustments everywhere. Let me know if this is OK so I can complete the PR.


