### PR TITLE
[UWP] Fix Navigate/Switch to exist page performance and lost state problem in real phone

### DIFF
--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -791,7 +791,8 @@ namespace Xamarin.Forms
 
 			if (!GetIsDefault(TriggersProperty)) {
 				var triggers = GetValue(TriggersProperty) as AttachedCollection<Trigger>;
-				triggers.DetachFrom(this);
+				if (null != triggers)
+                    triggers.DetachFrom(this);
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -120,22 +120,26 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			get
 			{
-				double height = ActualHeight;
-				double width = ActualWidth;
+                //double height = ActualHeight;
+                //double width = ActualWidth;
 
-				if (_commandBar != null)
-					height -= _commandBar.ActualHeight;
+                //if (_commandBar != null)
+                //	height -= _commandBar.ActualHeight;
 
-				if (ShouldShowSplitMode && IsPaneOpen)
-				{
-					if (_split != null)
-						width -= _split.OpenPaneLength;
-					else if (_detailPresenter != null)
-						width -= _masterPresenter.ActualWidth;
-				}
+                //if (ShouldShowSplitMode && IsPaneOpen)
+                //{
+                //	if (_split != null)
+                //		width -= _split.OpenPaneLength;
+                //	else if (_detailPresenter != null)
+                //		width -= _masterPresenter.ActualWidth;
+                //}
 
-				return new Windows.Foundation.Size(width, height);
-			}
+                //return new Windows.Foundation.Size(width, height);
+
+                // This is more clean and good way, if use the old way, it will failed calculate the details size after resize
+                return new Windows.Foundation.Size(this.DetailContent.ActualWidth, this.DetailContent.ActualHeight);
+
+            }
 		}
 
 		public string DetailTitle

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -315,7 +315,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (_split == null)
 			{
-				return;
+                return;
 			}
 
 			_split.DisplayMode = ShouldShowSplitMode 
@@ -324,18 +324,24 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_split.CompactPaneLength = CollapsedPaneWidth;
 
-			if (_split.DisplayMode == SplitViewDisplayMode.Inline)
-			{
-				// If we've determined that the pane will always be open, then there's no
-				// reason to display the show/hide pane button in the master
-				MasterToolbarVisibility = Visibility.Collapsed;
-			}
+            if (_split.DisplayMode == SplitViewDisplayMode.Inline)
+            {
+                // If we've determined that the pane will always be open, then there's no
+                // reason to display the show/hide pane button in the master
+                MasterToolbarVisibility = Visibility.Collapsed;
+            }
 
-			// If we're in compact mode or the pane is always open,
-			// we don't need to display the content pane's toggle button
-			ContentTogglePaneButtonVisibility = _split.DisplayMode == SplitViewDisplayMode.Overlay 
+            // If we're in compact mode or the pane is always open,
+            // we don't need to display the content pane's toggle button
+            ContentTogglePaneButtonVisibility = _split.DisplayMode == SplitViewDisplayMode.Overlay 
 				? Visibility.Visible 
 				: Visibility.Collapsed;
-		}
-	}
+
+            // if panel default mode is always open, but we set IsPresented = false
+            if (!IsPaneOpen)
+            {
+                ContentTogglePaneButtonVisibility = Visibility.Visible;
+            }
+        }
+    }
 }

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
@@ -48,7 +48,7 @@
                                     </uwp:FormsCommandBar>
                                 </Border>
 
-                                <ContentPresenter x:Name="DetailPresenter" Grid.Row="1" Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Detail}" />
+                                <ContentPresenter x:Name="DetailPresenter" Grid.Row="1" Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DetailContent}" />
 
 								<Border x:Name="BottomCommandBarArea" Grid.Row="2" HorizontalAlignment="Stretch"></Border>
 							</Grid>

--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -306,7 +306,17 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateIsPresented()
 		{
-			Control.IsPaneOpen = Element.IsPresented;
+            if (Control.IsPaneOpen != Element.IsPresented)
+			{
+                Control.IsPaneOpen = Element.IsPresented;
+
+                // Fix in PC mode, the split change, but the detail content width not changed
+                if (Control.ShouldShowSplitMode)
+                {
+                    Control.UpdateLayout();
+                    UpdateBounds();
+                }
+            }
 		}
 
 		void UpdateMaster()

--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -304,20 +304,19 @@ namespace Xamarin.Forms.Platform.UWP
 			(this as ITitleProvider).ShowTitle = !string.IsNullOrEmpty(Control.DetailTitle);
 		}
 
-		void UpdateIsPresented()
-		{
-            if (Control.IsPaneOpen != Element.IsPresented)
-			{
-                Control.IsPaneOpen = Element.IsPresented;
+        void UpdateIsPresented()
+        {
+            Control.IsPaneOpen = Element.IsPresented;
 
-                // Fix in PC mode, the split change, but the detail content width not changed
-                if (Control.ShouldShowSplitMode)
-                {
+            // Fix in PC mode, the split change, but the detail content width not changed
+            if (Control.ShouldShowSplitMode)
+            {
+                if (Control.Width != MasterDetailPageController.DetailBounds.Width)
                     Control.UpdateLayout();
-                    UpdateBounds();
-                }
+                UpdateBounds();
+                UpdateMode();
             }
-		}
+        }
 
 		void UpdateMaster()
 		{

--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -245,11 +245,13 @@ namespace Xamarin.Forms.Platform.UWP
 		void UpdateBounds()
 		{
 			Windows.Foundation.Size masterSize = Control.MasterSize;
-			Windows.Foundation.Size detailSize = Control.DetailSize;
+            Windows.Foundation.Size detailSize = Control.DetailSize;
+
 
 			MasterDetailPageController.MasterBounds = new Rectangle(0, 0, masterSize.Width, masterSize.Height);
 			MasterDetailPageController.DetailBounds = new Rectangle(0, 0, detailSize.Width, detailSize.Height);
-		}
+            RefreshInsidePagesSize();
+            }
 
 		void UpdateDetail()
 		{
@@ -272,13 +274,28 @@ namespace Xamarin.Forms.Platform.UWP
             if (null != _previousDetail)
                 ((IPageController)_previousDetail)?.SendDisappearing();
             Control.Detail = element;
+            
             if (Control.CheckContentIfExist(element))
                 ((IPageController)_detail)?.SendAppearing();
             
 			UpdateDetailTitle();
-		}
 
-		void UpdateDetailTitle()
+            // avoid other page size not right after switch back
+            RefreshInsidePagesSize();
+
+        }
+
+
+        private void RefreshInsidePagesSize()
+        {
+            if (null != _detail)
+            ((IPageController)_detail).ContainerArea = new Rectangle(0, 0, MasterDetailPageController.DetailBounds.Width, MasterDetailPageController.DetailBounds.Height);
+            
+        }
+
+
+
+        void UpdateDetailTitle()
 		{
 			if (_detail == null)
 				return;

--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -477,7 +477,7 @@ namespace Xamarin.Forms.Platform.WinRT
             RefreshInsidePagesSize();
         }
 
-		void UpdateBackButton()
+		internal void UpdateBackButton()
 		{
 			bool showBackButton = PageController.InternalChildren.Count > 1 && NavigationPage.GetHasBackButton(_currentPage);
 			_container.ShowBackButton = showBackButton;

--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -473,7 +473,8 @@ namespace Xamarin.Forms.Platform.WinRT
             UpdateTitleVisible();
             UpdateTitleOnParents();
 
-            
+            // update the inside pages size, if first page change size(because phone orientation changed), navigate to (exist) second page, the page size must resize again
+            RefreshInsidePagesSize();
         }
 
 		void UpdateBackButton()
@@ -498,12 +499,27 @@ namespace Xamarin.Forms.Platform.WinRT
 			_container.BackButtonTitle = title;
 		}
 
-		void UpdateContainerArea()
-		{
-			PageController.ContainerArea = new Rectangle(0, 0, _container.ContentWidth, _container.ContentHeight);
-		}
+        void UpdateContainerArea()
+        {
+            PageController.ContainerArea = new Rectangle(0, 0, _container.ContentWidth, _container.ContentHeight);
+            
+            // Resize the inside pages
+            RefreshInsidePagesSize();
+            // Rechange visibility again(avoid after change phone orientation, the first page will show up)
+            IVisualElementRenderer renderer = _currentPage.GetOrCreateRenderer();
+            _container.RecalcVisiblitiy(renderer.ContainerElement);
+            
+        }
 
-		void UpdateNavigationBarBackground()
+        private void RefreshInsidePagesSize() {
+            foreach (IPageController item in PageController.InternalChildren)
+            {
+                if (item == _currentPage)
+                    item.ContainerArea = new Rectangle(0, 0, _container.ContentWidth, _container.ContentHeight);
+            }
+        }
+
+        void UpdateNavigationBarBackground()
 		{
 			(this as ITitleProvider).BarBackgroundBrush = GetBarBackgroundBrush();
 		}

--- a/Xamarin.Forms.Platform.WinRT/PageControl.xaml.cs
+++ b/Xamarin.Forms.Platform.WinRT/PageControl.xaml.cs
@@ -5,6 +5,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
+using System.Linq;
 
 #if WINDOWS_UWP
 
@@ -46,12 +47,19 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		TaskCompletionSource<CommandBar> _commandBarTcs;
 		Windows.UI.Xaml.Controls.ContentPresenter _presenter;
-	    
 
-	    public PageControl()
+        Canvas ContentController;
+
+
+
+        public PageControl()
 		{
 			InitializeComponent();
-		}
+            ContentController = new Canvas();
+            base.Content = ContentController;
+
+
+        }
 
 		public string BackButtonTitle
 		{
@@ -184,5 +192,40 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			_backButton.Opacity = ShowBackButton ? 1 : 0;
 		}
+
+        /*** Every time display a element, that's take too much performance, especially for some exist page, That's why
+        I changed the original lotic, replace it with visibility, next time navigate exist page or switch exists content page(For NavigationPage) it will be fast displayed, even there are too much element in target page ***/
+        public new object Content
+        {
+            get
+            {
+                return this.ContentController.Children.Where(x => x.Visibility == Visibility.Visible).FirstOrDefault();
+            }
+            set
+            {
+                UIElement newElement = value as UIElement;
+                UIElement oldElement = this.Content as UIElement;
+
+
+                if (newElement != oldElement)
+                {
+                    if (null != oldElement)
+                        oldElement.Visibility = Visibility.Collapsed;
+
+
+                    if (null != newElement)
+                    {
+                        if (this.ContentController.Children.Any(x => x == newElement))
+                            newElement.Visibility = Visibility.Visible;
+                        else
+                            this.ContentController.Children.Add(newElement);
+                    }
+                }
+            }
+        }
+
+        internal bool CheckContentIfExist(UIElement element) {
+            return this.ContentController.Children.Any(x => x == element);
+        }
     }
 }

--- a/Xamarin.Forms.Platform.WinRT/PageControl.xaml.cs
+++ b/Xamarin.Forms.Platform.WinRT/PageControl.xaml.cs
@@ -227,5 +227,18 @@ namespace Xamarin.Forms.Platform.WinRT
         internal bool CheckContentIfExist(UIElement element) {
             return this.ContentController.Children.Any(x => x == element);
         }
+
+
+        internal void RecalcVisiblitiy(UIElement element)
+        {
+            foreach (var item in this.ContentController.Children)
+            {
+                if (element == item && element.Visibility != item.Visibility)
+                    item.Visibility = element.Visibility;
+                else if (element != item && element.Visibility != Visibility.Collapsed)
+                    item.Visibility = Visibility.Collapsed;
+            }
+        }
+
     }
 }

--- a/Xamarin.Forms.Platform.WinRT/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/PageRenderer.cs
@@ -48,7 +48,10 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				if (e.OldElement == null)
 				{
-					Loaded += OnLoaded;
+                    // In the previous version not remove it before, This might be cause a add multiple even problem and cause some performance and memory or other problems wehen keep navigate exist page.
+                    Loaded -= OnLoaded;
+                    Unloaded -= OnUnloaded;
+                    Loaded += OnLoaded;
 					Unloaded += OnUnloaded;
 
 					Tracker = new BackgroundTracker<FrameworkElement>(BackgroundProperty);

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -225,13 +225,17 @@ namespace Xamarin.Forms.Platform.WinRT
 				return;
 			foreach (Page root in _navModel.Roots)
 			{
-				root.Layout(bounds);
-				IVisualElementRenderer renderer = GetRenderer(root);
-				if (renderer != null)
-				{
-					renderer.ContainerElement.Width = _container.ActualWidth;
-					renderer.ContainerElement.Height = _container.ActualHeight;
-				}
+                // Don't resize every page, it will let previous page visible in new design page display mode
+                if (root == _currentPage)
+                {
+                    root.Layout(bounds);
+                    IVisualElementRenderer renderer = GetRenderer(root);
+                    if (renderer != null)
+                    {
+                        renderer.ContainerElement.Width = _container.ActualWidth;
+                        renderer.ContainerElement.Height = _container.ActualHeight;
+                    }
+                }
 			}
 		}
 
@@ -356,7 +360,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		Rectangle _bounds;
 		readonly Canvas _container;
-        List<FrameworkElement> RenderHistory = new List<FrameworkElement>();
+
 		readonly Windows.UI.Xaml.Controls.Page _page;
 		Windows.UI.Xaml.Controls.ProgressBar _busyIndicator;
 		Page _currentPage;

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -228,11 +228,14 @@ namespace Xamarin.Forms.Platform.WinRT
                 // Don't resize every page, it will let previous page visible in new design page display mode
                 if (root == _currentPage)
                 {
-                    root.Layout(bounds);
+                    if (root.Width != bounds.Width || root.Height != bounds.Height)
+                        root.Layout(bounds);
                     IVisualElementRenderer renderer = GetRenderer(root);
                     if (renderer != null)
                     {
-                        renderer.ContainerElement.Width = _container.ActualWidth;
+                        if (renderer.ContainerElement.Width != _container.ActualWidth)
+                            renderer.ContainerElement.Width = _container.ActualWidth;
+                        if (renderer.ContainerElement.Height != _container.ActualHeight)
                         renderer.ContainerElement.Height = _container.ActualHeight;
                     }
                 }
@@ -519,11 +522,16 @@ namespace Xamarin.Forms.Platform.WinRT
 
             UpdateToolbarTracker();
             UpdateToolbarTitle(newPage);
+
+            UpdatePageSizes();
+
             await UpdateToolbarItems();
 
         }
 
-		void UpdateToolbarTitle(Page page)
+        
+
+        void UpdateToolbarTitle(Page page)
 		{
 			if (_toolbarProvider == null)
 				return;

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -525,6 +525,10 @@ namespace Xamarin.Forms.Platform.WinRT
 
             UpdatePageSizes();
 
+            // When App.MainPage navigate to exist navigation page, maybe in UWP Desktop App lose Back button on the top, That's why I add it
+            if (pageRenderer is NavigationPageRenderer)
+                ((NavigationPageRenderer)pageRenderer).UpdateBackButton();
+
             await UpdateToolbarItems();
 
         }


### PR DESCRIPTION
### Description of Change ###

When we navigate to some page and navigate to other page and back or switch exist Details page, or change App.MainPage to exist page, the page last state fill lost, like ScrollViewer position...etc, and also the navigate/switch speed still very slow. This will fix that problem.
(Note: **Navigate animation unable to use currently after apply this**, but I think temporarily it's fine, the navigate animation too ugly, I think no one will use animation for now)

The basic idea is that use Canvas, put pages to the canvas, and when navigate to new page, hide the old page, navigate back just show it again. It will  more faster navigate or switch to the exist page now, especially when the page has a a lot of controls or ListView, Because the Phone is using ARM, it would be a big performance problem if every time navigate/switch will unload and load exist page such like a new page. So I just change the idea

Currently improved type of pages:
1.App.MainPage
2.NavigationPage
3.MasterDetailPage



### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=46856
https://bugzilla.xamarin.com/show_bug.cgi?id=48682
https://bugzilla.xamarin.com/show_bug.cgi?id=38260


### API Changes ###

None

Added:
 - Xamarin.Forms.Platform.UWP.MasterDetailControl Add Detail , its' a  Canvas. also add internal method CheckContentIfExist
 - Xamarin.Forms.Platform.UWP.MasterDetailControl Add Detail , its' a  Canvas. also add internal method CheckContentIfExist
 - Xamarin.Forms.Platform.WinRT/PageControl.xaml Add Canvas in the content, replace Content and add internal method CheckContentIfExist


Changed:
 - Xamarin.Forms.Platform.UWP.MasterDetailControl Detail rename to DetailContent
 - Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer change logic: do not clear the page every time switch pages(for that manually fire SendDisappearing and SendAppearing)
 - Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs change logic: do not clear the page every time switch pages(for that manually fire SendDisappearing and SendAppearing)
 - Xamarin.Forms.Platform.WinRT/Platform change logic: do not clear the page every time switch pages

### Behavioral Changes ###

In the original mode: every time when use these:
App.MainPage = existPage;
NavigationPage.push(existPage) or pop();
MasterDetailPage.Detail = existPage;

it will always clean and dispose the old page, when user want to switch back the last page, it need to reload all things, that's a really bad design, **we should recommend developer always should use exist page more now**, because every open or display a page unload and load it will cause to much performance, also last page state will lose(Like ListView or ScrollViever scroll position will reset)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
