### PR TITLE
[UWP] Allow for proper dismissal of soft keyboard

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45067.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45067.cs
@@ -1,0 +1,48 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 45067, "[UWP] No way of cleanly dismissing soft keyboard", PlatformAffected.Default)]
+	public class Bugzilla45067 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var username = new Entry
+			{
+				Placeholder = "Username"
+			};
+			var password = new Entry
+			{
+				Placeholder = "Password",
+				IsPassword = true
+			};
+			username.Completed += (s, e) => password.Focus();
+			password.Completed += (s, e) => password.Unfocus();
+			Content = new StackLayout
+			{
+				Children =
+				{
+					username,
+					password,
+					new Button
+					{
+						Text = "Submit"
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -155,6 +155,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45330.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45067.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />

--- a/Xamarin.Forms.Platform.WinRT/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/EntryRenderer.cs
@@ -84,6 +84,10 @@ namespace Xamarin.Forms.Platform.WinRT
 				UpdateAlignment();
 			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
 				UpdatePlaceholderColor();
+#if WINDOWS_UWP
+			else if (e.PropertyName == VisualElement.IsFocusedProperty.PropertyName)
+				UpdateFocus();
+#endif
 		}
 
 		protected override void UpdateBackgroundColor()
@@ -117,6 +121,16 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			Control.TextAlignment = Element.HorizontalTextAlignment.ToNativeTextAlignment();
 		}
+
+#if WINDOWS_UWP
+		void UpdateFocus()
+		{
+			if (Element.IsFocused)
+				Windows.UI.ViewManagement.InputPane.GetForCurrentView().TryShow();
+			else
+				Windows.UI.ViewManagement.InputPane.GetForCurrentView().TryHide();
+		}
+#endif
 
 		void UpdateFont()
 		{


### PR DESCRIPTION
### Description of Change ###

As mentioned in the below bug report, a page with entries on it suffer from a situation where the soft keyboard can't be dismissed. This can be resolved by utilizing the `InputPane` class to show or hide the soft keyboard when the focus changes. The soft keyboard is also utilized in situations such as tablet mode on devices like the Surface.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=45067

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

