### PR TITLE
Make UWP toolbar visibility consistent with other platforms

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40073.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40073.cs
@@ -1,0 +1,35 @@
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40073, "Toolbar items are not not functioning properly on UWP", PlatformAffected.WinRT)]
+	public class Bugzilla40073 : TestNavigationPage
+	{
+		ContentPage _theContent;
+
+		protected override void Init()
+		{
+			_theContent = new ContentPage
+			{
+				Content = new StackLayout
+				{
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+						new Label {
+							HorizontalTextAlignment = TextAlignment.Center,
+							Text = "This page should have a toolbar. If it does not, the test has failed."
+						}
+					}
+				}
+			};
+
+			var thePage = new TabbedPage();
+			thePage.Children.Add(_theContent);
+			thePage.ToolbarItems.Add(new ToolbarItem() { Text = "Refresh", Icon = "coffee.png" });
+
+			PushAsync(thePage);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -103,6 +103,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39702.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40005.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40073.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40173.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39821.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40185.cs" />

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/TabbedPageWindows.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/TabbedPageWindows.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 		{
 			Children.Add(CreateFirstPage(restore));
 			Children.Add(CreateSecondPage());
-			WindowsPlatformSpecificsGalleryHelpers.AddToolBarItems(this);
+			Children.Add(CreateThirdPage());
 		}
 
 		ContentPage CreateFirstPage(ICommand restore)
@@ -38,6 +38,16 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 			page.Content = content;
 
 			return page;
+		}
+
+		NavigationPage CreateThirdPage()
+		{
+			var content = CreateSecondPage();
+			content.Title = "Content in a Nav Page";
+			var navpage = new NavigationPage(content);
+			navpage.Title = "Nav Page";
+			WindowsPlatformSpecificsGalleryHelpers.AddToolBarItems(navpage);
+			return navpage;
 		}
 
 		static Page CreateSecondPage()

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -51,6 +51,12 @@ namespace Xamarin.Forms.Platform.UWP
 		CommandBar _commandBar;
 		readonly ToolbarPlacementHelper _toolbarPlacementHelper = new ToolbarPlacementHelper();
 
+		public bool ShouldShowToolbar
+		{
+			get { return _toolbarPlacementHelper.ShouldShowToolBar; }
+			set { _toolbarPlacementHelper.ShouldShowToolBar = value; }
+		}
+
 		TaskCompletionSource<CommandBar> _commandBarTcs;
 		FrameworkElement _masterPresenter;
 		FrameworkElement _detailPresenter;

--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -261,6 +261,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 				IVisualElementRenderer renderer = _detail.GetOrCreateRenderer();
 				element = renderer.ContainerElement;
+
+				// Enforce consistency rules on toolbar (show toolbar if Detail is Navigation Page)
+				Control.ShouldShowToolbar = _detail is NavigationPage; 
 			}
 
 			Control.Detail = element;
@@ -297,6 +300,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 			Control.Master = element;
 			Control.MasterTitle = _master?.Title;
+
+			// Enforce consistency rules on toolbar (show toolbar if Master is Navigation Page)
+			Control.ShouldShowToolbar = _master is NavigationPage;
 		}
 
 		void UpdateMode()

--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -317,6 +317,9 @@ namespace Xamarin.Forms.Platform.UWP
             var nav = page as NavigationPage;
             TitleProvider.ShowTitle = nav != null;
 
+			// Enforce consistency rules on toolbar (show toolbar if visible Tab is Navigation Page)
+			Control.ShouldShowToolbar = nav != null;
+
             if (page == null)
                 return;
 

--- a/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
@@ -68,7 +68,7 @@
                             <uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" MinHeight="{ThemeResource TitleBarHeight}">
                                 <uwp:FormsCommandBar.Content>
                                     <Border x:Name="TitleArea" Visibility="{TemplateBinding TitleVisibility}" Height="{ThemeResource TitleBarHeight}">
-                                        <TextBlock Text="{Binding Title}" VerticalAlignment="Center" Padding="10,0,0,0" Foreground="Red" Style="{ThemeResource TitleTextBlockStyle}" />
+                                        <TextBlock Text="{TemplateBinding Title}" TextWrapping="NoWrap" VerticalAlignment="Center" Margin="10,0,0,0" Foreground="{TemplateBinding ToolbarForeground}" Style="{ThemeResource TitleTextBlockStyle}" />
                                     </Border>
                                 </uwp:FormsCommandBar.Content>
                             </uwp:FormsCommandBar>

--- a/Xamarin.Forms.Platform.UAP/ToolbarPlacementHelper.cs
+++ b/Xamarin.Forms.Platform.UAP/ToolbarPlacementHelper.cs
@@ -26,7 +26,11 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				// We have to wait for the command bar to load so that it'll be in the control hierarchy
 				// otherwise we can't properly move it to wherever the toolbar is supposed to be
-				_commandBar.Loaded += (sender, args) => UpdateToolbarPlacement();
+				_commandBar.Loaded += (sender, args) =>
+				{
+					UpdateToolbarPlacement();
+					UpdateIsInValidLocation();
+				};
 			}
 		}
 
@@ -88,6 +92,29 @@ namespace Xamarin.Forms.Platform.UWP
 					// Put the title back into the command bar
 					toolbar.Content = titleArea;
 				}
+			}
+		}
+
+		// For the time being, keeping this logic for dealing with consistency between the platforms
+		// re: toolbar visibility here; at some point we should be separating toolbars from navigation bars,
+		// and this won't be necessary
+		bool _shouldShowToolBar;
+		public bool ShouldShowToolBar
+		{
+			get { return _shouldShowToolBar; }
+			set
+			{
+				_shouldShowToolBar = value;
+				UpdateIsInValidLocation();
+			}
+		}
+
+		void UpdateIsInValidLocation()
+		{
+			var formsCommandBar = _commandBar as FormsCommandBar;
+			if (formsCommandBar != null)
+			{
+				formsCommandBar.IsInValidLocation = ShouldShowToolBar;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/FormsPivot.cs
@@ -23,11 +23,18 @@ namespace Xamarin.Forms.Platform.WinRT
 		CommandBar _commandBar;
 #if WINDOWS_UWP
 		readonly ToolbarPlacementHelper _toolbarPlacementHelper = new ToolbarPlacementHelper();
+
+		public bool ShouldShowToolbar
+		{
+			get { return _toolbarPlacementHelper.ShouldShowToolBar; }
+			set { _toolbarPlacementHelper.ShouldShowToolBar = value; }
+		}
 #endif
 		TaskCompletionSource<CommandBar> _commandBarTcs;
 	    ToolbarPlacement _toolbarPlacement;
+		
 
-	    public Brush ToolbarBackground
+		public Brush ToolbarBackground
 		{
 			get { return (Brush)GetValue(ToolbarBackgroundProperty); }
 			set { SetValue(ToolbarBackgroundProperty, value); }

--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -177,6 +177,11 @@ namespace Xamarin.Forms.Platform.WinRT
 
 					Tracker = new BackgroundTracker<PageControl>(Control.BackgroundProperty) { Element = (Page)element, Container = _container };
 
+#if WINDOWS_UWP
+					// Enforce consistency rules on toolbar (show toolbar if top-level page is Navigation Page)
+					_container.ShouldShowToolbar = _parentMasterDetailPage == null && _parentMasterDetailPage == null;
+#endif
+
 					SetPage(Element.CurrentPage, false, false);
 
 					_container.Loaded += OnLoaded;
@@ -304,6 +309,8 @@ namespace Xamarin.Forms.Platform.WinRT
 				_parentMasterDetailPage.PropertyChanged += MultiPagePropertyChanged;
 #if WINDOWS_UWP
 			((ITitleProvider)this).ShowTitle = _parentTabbedPage == null && _parentMasterDetailPage == null;
+
+			
 #else
 			if (Device.Idiom == TargetIdiom.Phone && _parentTabbedPage != null)
 				((ITitleProvider)this).ShowTitle = false;

--- a/Xamarin.Forms.Platform.WinRT/PageControl.xaml.cs
+++ b/Xamarin.Forms.Platform.WinRT/PageControl.xaml.cs
@@ -42,6 +42,12 @@ namespace Xamarin.Forms.Platform.WinRT
 #if WINDOWS_UWP
         ToolbarPlacement _toolbarPlacement;
 	    readonly ToolbarPlacementHelper _toolbarPlacementHelper = new ToolbarPlacementHelper();
+
+		public bool ShouldShowToolbar
+		{
+			get { return _toolbarPlacementHelper.ShouldShowToolBar; }
+			set { _toolbarPlacementHelper.ShouldShowToolBar = value; }
+		}
 #endif
 
 		TaskCompletionSource<CommandBar> _commandBarTcs;


### PR DESCRIPTION
### Description of Change ###

Makes the UWP toolbar consistent with Android/iOS with regard to visibility.

### Bugs Fixed ###

- [40073 – Toolbar items are not not functioning properly on UWP](https://bugzilla.xamarin.com/show_bug.cgi?id=40073)
- [51142 – Toolbar not showing when using PushAsync on UWP](https://bugzilla.xamarin.com/show_bug.cgi?id=51142)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
