### PR TITLE
[UWP] Use toolbar foreground color on primary items

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44453.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44453.cs
@@ -1,0 +1,55 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44453, "[UWP] ToolbarItem Text hard to see when BarTextColor is light", PlatformAffected.WinRT)]
+	public class Bugzilla44453 : TestMasterDetailPage
+	{
+		protected override void Init()
+		{
+			var content = new ContentPage
+			{
+				Title = "UWPToolbarItemColor",
+				Content = new StackLayout
+				{
+					VerticalOptions = LayoutOptions.Center,
+					Children =
+					{
+						new Label
+						{
+							LineBreakMode = LineBreakMode.WordWrap,
+							HorizontalTextAlignment = TextAlignment.Center,
+							Text = "The toolbar secondary items should not have white text on a light background"
+						}
+					}
+				}
+			};
+			
+			MasterBehavior = MasterBehavior.Popover;
+			Master = new ContentPage
+			{
+				Title = "Master"
+			};
+			Detail = new NavigationPage(content)
+			{
+				BarBackgroundColor = Color.Green,
+				BarTextColor = Color.White
+			};
+
+			Detail.ToolbarItems.Add(new ToolbarItem("Test Secondary Item", null, delegate { }, ToolbarItemOrder.Secondary));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -131,6 +131,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43663.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44944.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -296,13 +296,16 @@ namespace Xamarin.Forms.Platform.WinRT
 				button.Command = new MenuItemCommand(item);
 				button.DataContext = item;
 
-#if WINDOWS_UWP
-				toolBarProvider?.BindForegroundColor(button);
-#endif
 
 				ToolbarItemOrder order = item.Order == ToolbarItemOrder.Default ? ToolbarItemOrder.Primary : item.Order;
+
 				if (order == ToolbarItemOrder.Primary)
+				{
+#if WINDOWS_UWP
+					toolBarProvider?.BindForegroundColor(button);
+#endif
 					commandBar.PrimaryCommands.Add(button);
+				}
 				else
 					commandBar.SecondaryCommands.Add(button);
 			}


### PR DESCRIPTION
### Description of Change ###

Secondary toolbar items on UWP were being given the same foreground color as those in the bar itself. Shifting the call to `BindForegroundColor` after checking the order to see if it's a primary item prevents this from happening. The light drop down menu appears to be in line with a standard UWP app, as applying the background on a `CommandBar` only applies it to the bar itself.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=44453

### API Changes ###

None

### Behavioral Changes ###

This only specifically deals with the foreground color being set on the secondary items, potentially making them difficult to read.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

