### PR TITLE
Update NameScope.cs

### DIFF
--- a/Xamarin.Forms.Core/Internals/NameScope.cs
+++ b/Xamarin.Forms.Core/Internals/NameScope.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Internals
 		void INameScope.RegisterName(string name, object scopedElement)
 		{
 			if (_names.ContainsKey(name))
-				throw new ArgumentException("An element with the same key already exists in NameScope", "name");
+				throw new ArgumentException($"An element with the same key '{name}' already exists in NameScope", name);
 
 			_names[name] = scopedElement;
 		}


### PR DESCRIPTION
### Description of Change ###

Debug message corrected (parameter named passed instead of parameter value).

### Bugs Fixed ###

```
Exception:

System.ArgumentException: An element with the same key already exists in NameScope
Parameter name: name

```

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

Debug message corrected