### PR TITLE
[Xaml] support short Properties for PropertyCondition

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BindablePropertyConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BindablePropertyConverter.cs
@@ -30,7 +30,8 @@ namespace Xamarin.Forms.Core.XamlC
 			var parts = value.Split('.');
 			if (parts.Length == 1) {
 				var parent = node.Parent?.Parent as IElementNode;
-				if ((node.Parent as ElementNode)?.XmlType.NamespaceUri == "http://xamarin.com/schemas/2014/forms" && (node.Parent as ElementNode)?.XmlType.Name == "Setter") {
+				if ((node.Parent as ElementNode)?.XmlType.NamespaceUri == "http://xamarin.com/schemas/2014/forms" &&
+				    ((node.Parent as ElementNode)?.XmlType.Name == "Setter" || (node.Parent as ElementNode)?.XmlType.Name == "PropertyCondition")) {
 					if (parent.XmlType.NamespaceUri == "http://xamarin.com/schemas/2014/forms" &&
 						(parent.XmlType.Name == "Trigger" || parent.XmlType.Name == "DataTrigger" || parent.XmlType.Name == "MultiTrigger" || parent.XmlType.Name == "Style")) {
 						var ttnode = (parent as ElementNode).Properties [new XmlName("", "TargetType")];
@@ -46,6 +47,9 @@ namespace Xamarin.Forms.Core.XamlC
 				typeName = parts [0];
 				propertyName = parts [1];
 			} else
+				throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(BindableProperty)}", node);
+
+			if (typeName == null || propertyName == null)
 				throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(BindableProperty)}", node);
 
 			var typeRef = GetTypeReference(typeName, module, node);

--- a/Xamarin.Forms.Core/BindablePropertyConverter.cs
+++ b/Xamarin.Forms.Core/BindablePropertyConverter.cs
@@ -50,6 +50,8 @@ namespace Xamarin.Forms
 				}
 				else if (parentValuesProvider.TargetObject is Trigger)
 					type = (parentValuesProvider.TargetObject as Trigger).TargetType;
+				else if (parentValuesProvider.TargetObject is PropertyCondition && (parent as TriggerBase) != null)
+					type = (parent as TriggerBase).TargetType;
 
 				if (type == null)
 					throw new XamlParseException($"Can't resolve {parts [0]}", lineinfo);

--- a/Xamarin.Forms.Core/IValueConverterProvider.cs
+++ b/Xamarin.Forms.Core/IValueConverterProvider.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Xamarin.Forms.Xaml
 {
-	internal interface IValueConverterProvider
+	interface IValueConverterProvider
 	{
 		object Convert(object value, Type toType, Func<MemberInfo> minfoRetriever, IServiceProvider serviceProvider);
 	}

--- a/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms
 
 		public BindingCondition()
 		{
-			_boundProperty = BindableProperty.CreateAttached("Bound", typeof(object), typeof(DataTrigger), null, propertyChanged: OnBoundPropertyChanged);
+			_boundProperty = BindableProperty.CreateAttached("Bound", typeof(object), typeof(BindingCondition), null, propertyChanged: OnBoundPropertyChanged);
 		}
 
 		public BindingBase Binding
@@ -23,7 +23,7 @@ namespace Xamarin.Forms
 				if (_binding == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Binding once the Trigger has been applied.");
+					throw new InvalidOperationException("Can not change Binding once the Condition has been applied.");
 				_binding = value;
 			}
 		}
@@ -36,7 +36,7 @@ namespace Xamarin.Forms
 				if (_triggerValue == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Value once the Trigger has been applied.");
+					throw new InvalidOperationException("Can not change Value once the Condition has been applied.");
 				_triggerValue = value;
 			}
 		}

--- a/Xamarin.Forms.Core/Interactivity/MultiCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/MultiCondition.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms
 
 		public MultiCondition()
 		{
-			_aggregatedStateProperty = BindableProperty.CreateAttached("AggregatedState", typeof(bool), typeof(DataTrigger), false, propertyChanged: OnAggregatedStatePropertyChanged);
+			_aggregatedStateProperty = BindableProperty.CreateAttached("AggregatedState", typeof(bool), typeof(MultiCondition), false, propertyChanged: OnAggregatedStatePropertyChanged);
 			Conditions = new TriggerBase.SealedList<Condition>();
 		}
 

--- a/Xamarin.Forms.Xaml.UnitTests/TriggerTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/TriggerTests.xaml
@@ -1,12 +1,24 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.TriggerTests">
 	<ContentPage.Content>
-		<Entry x:Name="entry">
-			<Entry.Triggers>
-				<Trigger Property="IsPassword" Value="true" TargetType="Entry">
-					<Setter Property="Scale" Value="1.2" />
-				</Trigger>
-			</Entry.Triggers>
-		</Entry>
+		<StackLayout>
+			<Entry x:Name="entry">
+				<Entry.Triggers>
+					<Trigger Property="IsPassword" Value="true" TargetType="Entry">
+						<Setter Property="Scale" Value="1.2" />
+					</Trigger>
+				</Entry.Triggers>
+			</Entry>
+			<Entry x:Name="entry1">
+				<Entry.Triggers>
+					<MultiTrigger TargetType="Entry">
+						<MultiTrigger.Conditions>
+							<PropertyCondition Value="True" Property="IsPassword" />
+						</MultiTrigger.Conditions>
+						<Setter Property="Scale" Value="1.2" />
+					</MultiTrigger>
+				</Entry.Triggers>
+			</Entry>
+		</StackLayout>
 	</ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/TriggerTests.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/TriggerTests.xaml.cs
@@ -47,6 +47,22 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.AreEqual (Entry.IsPasswordProperty, pwTrigger.Property);
 				Assert.AreEqual (true, pwTrigger.Value);
 			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void ValueIsConvertedWithPropertyCondition(bool useCompiledXaml)
+			{
+				var layout = new TriggerTests(useCompiledXaml);
+				Entry entry = layout.entry1;
+				Assert.NotNull(entry);
+
+				var triggers = entry.Triggers;
+				Assert.IsNotEmpty(triggers);
+				var pwTrigger = triggers[0] as MultiTrigger;
+				var pwCondition = pwTrigger.Conditions[0] as PropertyCondition;
+				Assert.AreEqual(Entry.IsPasswordProperty, pwCondition.Property);
+				Assert.AreEqual(true, pwCondition.Value);
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml/ValueConverterProvider.cs
+++ b/Xamarin.Forms.Xaml/ValueConverterProvider.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Xamarin.Forms.Xaml
 {
-	internal class ValueConverterProvider : IValueConverterProvider
+	class ValueConverterProvider : IValueConverterProvider
 	{
 		public object Convert(object value, Type toType, Func<MemberInfo> minfoRetriever, IServiceProvider serviceProvider)
 		{


### PR DESCRIPTION
### Description of Change ###

Support short version of Property (`IsPassword` instead of `Entry.IsPassword`) 
```
<MultiTrigger TargetType="Entry">
	<MultiTrigger.Conditions>
		<PropertyCondition Value="True" Property="IsPassword" />
	</MultiTrigger.Conditions>
	<Setter Property="Scale" Value="1.2" />
</MultiTrigger>
```
### Bugs Fixed ###

- The one I found out earlier this week while doing somewhat related stuffs, you know which one

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
