### PR TITLE
[UWP] Set SearchBar's AutoMaximizeSuggestionArea to false

### DIFF
--- a/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
@@ -26,6 +26,7 @@ namespace Xamarin.Forms.Platform.UWP
 					Control.QuerySubmitted += OnQuerySubmitted;
 					Control.TextChanged += OnTextChanged;
 					Control.Loaded += OnControlLoaded;
+					Control.AutoMaximizeSuggestionArea = false;
 				}
 
 				UpdateText();


### PR DESCRIPTION
### Description of Change ###

The feature in #499 was deemed as something that be moved into an effect, but there is one element of it that is actually a fix via setting `AutoMaximizeSuggestionArea` to false to prevent the SearchBar from shifting up awkwardly to accommodate a suggestion area which doesn't exist (explained and displayed in that PR).

(I had been meaning to get around to extracting this)

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=45924

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

