### PR TITLE
Xamlc compile data triggers

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/PassthroughValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/PassthroughValueProvider.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
+
+namespace Xamarin.Forms.Core.XamlC
+{
+	class PassthroughValueProvider : ICompiledValueProvider
+	{
+		public IEnumerable<Instruction> ProvideValue(VariableDefinitionReference vardefref, ModuleDefinition module, BaseNode node, ILContext context)
+		{
+			yield break;
+		}
+	}
+}

--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/TriggerValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/TriggerValueProvider.cs
@@ -8,7 +8,6 @@ using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Core.XamlC
 {
-	
 	class TriggerValueProvider : ICompiledValueProvider
 	{
 		public IEnumerable<Instruction> ProvideValue(VariableDefinitionReference vardefref, ModuleDefinition module, BaseNode node, ILContext context)

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -108,6 +108,7 @@
     <Compile Include="CompiledValueProviders\SetterValueProvider.cs" />
     <Compile Include="CompiledValueProviders\ICompiledValueProvider.cs" />
     <Compile Include="CompiledValueProviders\TriggerValueProvider.cs" />
+    <Compile Include="CompiledValueProviders\PassthroughValueProvider.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/Xamarin.Forms.Core.UnitTests/DataTriggerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DataTriggerTests.cs
@@ -6,6 +6,20 @@ namespace Xamarin.Forms.Core.UnitTests
 	[TestFixture]
 	public class DataTriggerTests : BaseTestFixture
 	{
+		[SetUp]
+		public override void Setup()
+		{
+			Device.PlatformServices = new MockPlatformServices();
+			base.Setup();
+		}
+
+		[TearDown]
+		public override void TearDown()
+		{
+			base.TearDown();
+			Device.PlatformServices = null;
+		}
+
 		class MockElement : VisualElement
 		{
 		}

--- a/Xamarin.Forms.Core.UnitTests/MultiTriggerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MultiTriggerTests.cs
@@ -5,6 +5,20 @@ namespace Xamarin.Forms.Core.UnitTests
 	[TestFixture]
 	public class MultiTriggerTests : BaseTestFixture
 	{
+		[SetUp]
+		public override void Setup()
+		{
+			Device.PlatformServices = new MockPlatformServices();
+			base.Setup();
+		}
+
+		[TearDown]
+		public override void TearDown()
+		{
+			base.TearDown();
+			Device.PlatformServices = null;
+		}
+
 		class MockElement : VisualElement
 		{
 		}

--- a/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
@@ -41,15 +41,9 @@ namespace Xamarin.Forms
 			}
 		}
 
-		internal IServiceProvider ServiceProvider { get; set; }
-
-		internal IValueConverterProvider ValueConverter { get; set; }
-
 		object IValueProvider.ProvideValue(IServiceProvider serviceProvider)
 		{
-			ValueConverter = serviceProvider.GetService(typeof(IValueConverterProvider)) as IValueConverterProvider;
-			ServiceProvider = serviceProvider;
-
+			//This is no longer required
 			return this;
 		}
 
@@ -71,14 +65,16 @@ namespace Xamarin.Forms
 			bindable.ClearValue(_boundProperty);
 		}
 
+		static IValueConverterProvider s_valueConverter = DependencyService.Get<IValueConverterProvider>();
+
 		bool EqualsToValue(object other)
 		{
 			if ((other == Value) || (other != null && other.Equals(Value)))
 				return true;
 
 			object converted = null;
-			if (ValueConverter != null)
-				converted = ValueConverter.Convert(Value, other != null ? other.GetType() : typeof(object), null, ServiceProvider);
+			if (s_valueConverter != null)
+				converted = s_valueConverter.Convert(Value, other != null ? other.GetType() : typeof(object), null, null);
 			else
 				return false;
 

--- a/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
@@ -3,6 +3,7 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms
 {
+	[ProvideCompiled("Xamarin.Forms.Core.XamlC.PassthroughValueProvider")]
 	public sealed class BindingCondition : Condition, IValueProvider
 	{
 		readonly BindableProperty _boundProperty;

--- a/Xamarin.Forms.Core/Interactivity/DataTrigger.cs
+++ b/Xamarin.Forms.Core/Interactivity/DataTrigger.cs
@@ -5,6 +5,7 @@ using Xamarin.Forms.Xaml;
 namespace Xamarin.Forms
 {
 	[ContentProperty("Setters")]
+	[ProvideCompiled("Xamarin.Forms.Core.XamlC.PassthroughValueProvider")]
 	public sealed class DataTrigger : TriggerBase, IValueProvider
 	{
 		public DataTrigger([TypeConverter(typeof(TypeTypeConverter))] [Parameter("TargetType")] Type targetType) : base(new BindingCondition(), targetType)

--- a/Xamarin.Forms.Core/Interactivity/DataTrigger.cs
+++ b/Xamarin.Forms.Core/Interactivity/DataTrigger.cs
@@ -48,9 +48,7 @@ namespace Xamarin.Forms
 
 		object IValueProvider.ProvideValue(IServiceProvider serviceProvider)
 		{
-			var valueconverter = serviceProvider.GetService(typeof(IValueConverterProvider)) as IValueConverterProvider;
-			(Condition as BindingCondition).ValueConverter = valueconverter;
-
+			//This is no longer required
 			return this;
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz28719.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz28719.xaml.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using NUnit.Framework;
 
-using Xamarin.Forms;
-using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -21,6 +19,18 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		class Tests
 		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
 			[TestCase(true)]
 			[TestCase(false)]
 			public void DataTriggerInTemplates (bool useCompiledXaml)

--- a/Xamarin.Forms.Xaml/ValueConverterProvider.cs
+++ b/Xamarin.Forms.Xaml/ValueConverterProvider.cs
@@ -1,6 +1,11 @@
 using System;
 using System.Reflection;
 
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+[assembly:Dependency(typeof(ValueConverterProvider))]
+
 namespace Xamarin.Forms.Xaml
 {
 	class ValueConverterProvider : IValueConverterProvider


### PR DESCRIPTION
### Description of Change ###

Or better, avoid compiling DataTrigger, and avoid generating ServiceProvider for (now) unused ProvideValue

I feel there's something not-quite-right in the way the compiled value providers are invoked but can't put my finger on it. This isn't an issue as we control, and test, 100% of the compiled value providers.

I guess I'll refine this when I'll compile (the remaining) markup extensions

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense