### PR TITLE
Update NameScope.cs throwing more precise except

### DIFF
--- a/Xamarin.Forms.Core/Internals/NameScope.cs
+++ b/Xamarin.Forms.Core/Internals/NameScope.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Internals
 		void INameScope.RegisterName(string name, object scopedElement)
 		{
 			if (_names.ContainsKey(name))
-				throw new ArgumentException("An element with the same key already exists in NameScope", "name");
+                		throw new XamlParseException(string.Format("An element with the name \"{0}\" already exists in this NameScope", name), new XmlLineInfo());
 
 			_names[name] = scopedElement;
 		}
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Internals
 			{
 				((INameScope)this).RegisterName(name, scopedElement);
 			}
-			catch (ArgumentException)
+			catch (XamlParseException)
 			{
 				throw new XamlParseException(string.Format("An element with the name \"{0}\" already exists in this NameScope", name), xmlLineInfo);
 			}

--- a/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
+++ b/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
@@ -31,17 +31,7 @@ namespace Xamarin.Forms.Xaml
 		{
 			if (!IsXNameProperty(node, parentNode))
 				return;
-			try
-			{
-				((IElementNode)parentNode).Namescope.RegisterName((string)node.Value, Values[parentNode]);
-			}
-			catch (ArgumentException ae)
-			{
-				if (ae.ParamName != "name")
-					throw ae;
-				throw new XamlParseException(
-					string.Format("An element with the name \"{0}\" already exists in this NameScope", (string)node.Value), node);
-			}
+			((IElementNode)parentNode).Namescope.RegisterName((string)node.Value, Values[parentNode]);
 		}
 
 		public void Visit(MarkupNode node, INode parentNode)


### PR DESCRIPTION
### Description of Change ###

Update to give a more comprehensive exception and a consistent behavior among methods (same kind of exception thrown, with relevant information for developers)

### Bugs Fixed ###

The following exception message is not very helpful for developers:

    Exception:
    
    System.ArgumentException: An element with the same key already exists in NameScope
    Parameter name: name

### API Changes ###

Changes the type of Exception thrown by the method INameScope.RegisterName(string name, object scopedElement)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense

Update to give a more comprehensive exception and a consistent behavior among methods (same kind of exception thrown, with relevant information for developers)

Adjustment to the PR https://github.com/xamarin/Xamarin.Forms/pull/643