### PR TITLE
Enable 24-hr formatting for Android TimePicker

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using Android.App;
 using Android.Content.Res;
 using Android.Widget;
+using Android.Text.Format;
 using ADatePicker = Android.Widget.DatePicker;
 using ATimePicker = Android.Widget.TimePicker;
 using Object = Java.Lang.Object;
@@ -92,7 +93,8 @@ namespace Xamarin.Forms.Platform.Android
 			TimePicker view = Element;
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 
-			_dialog = new TimePickerDialog(Context, this, view.Time.Hours, view.Time.Minutes, false);
+			bool is24HourFormat = DateFormat.Is24HourFormat(Context);
+			_dialog = new TimePickerDialog(Context, this, view.Time.Hours, view.Time.Minutes, is24HourFormat);
 
 			if (Forms.IsLollipopOrNewer)
 				_dialog.CancelEvent += OnCancelButtonClicked;


### PR DESCRIPTION
### Description of Change ###

The renderer for the Android time picker opens the time picker dialog with a hardcoded 12-hr setting despite the fact the the platform allows to determine whether 24 hr time formatting was configured or not.

### Bugs Fixed ###

Time picker should respect the 12hr/24hr setting of the user on Android.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

Enable 24-hr time formatting depending on Android system settings instead of the hard coded 12-hour setting.