### PR TITLE
Fixed property name

### DIFF
--- a/Xamarin.Forms.Xaml/XmlName.cs
+++ b/Xamarin.Forms.Xaml/XmlName.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Xaml
 		public static readonly XmlName xName = new XmlName("x", "Name");
 		public static readonly XmlName xTypeArguments = new XmlName("x", "TypeArguments");
 		public static readonly XmlName xArguments = new XmlName("x", "Arguments");
-		public static readonly XmlName xFactoryMethod = new XmlName("x", "xFactoryMethod");
+		public static readonly XmlName xFactoryMethod = new XmlName("x", "FactoryMethod");
 		public static readonly XmlName xDataType = new XmlName("x", "DataType");
 		public static readonly XmlName Empty = new XmlName();
 


### PR DESCRIPTION
Not sure if wrong or intended. This edit was proposed just by looking at the surrounding code. It seems like a typo.

The unit tests suggest this was a working fixture in spite of the name being seemingly wrong. I just want to discuss the code, not actually make a PR, but GitHub won't let me.

Please verify if this breaks or fixes something, and if the latter, why the unit tests for the FactoryMethods work although the name was wrong.

### Description of Change ###

The name of the static XmlName object for the FactoryMethod property seems to contain the x prefix of the namespace, too. I removed the x.

Maybe the Xaml parser breaks for x:FactoryMethod attribute (although I'd rather expect it to not have worked before)?

No additional unit test because the existing ones should cover.

### Bugs Fixed ###

I don't see an issue tracker here, so none?

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
