### PR TITLE
[Android] Hide Fragments before removing them to allow custom animations

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Resources/anim/enter_from_left.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/anim/enter_from_left.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+  <translate 
+      android:fromXDelta="-100%" android:toXDelta="0%"
+      android:fromYDelta="0%" android:toYDelta="0%"
+      android:duration="500"/>
+</set>

--- a/Xamarin.Forms.ControlGallery.Android/Resources/anim/enter_from_right.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/anim/enter_from_right.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+  <translate
+     android:fromXDelta="100%" android:toXDelta="0%"
+     android:fromYDelta="0%" android:toYDelta="0%"
+     android:duration="500" />
+</set>

--- a/Xamarin.Forms.ControlGallery.Android/Resources/anim/exit_to_left.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/anim/exit_to_left.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+  <translate 
+      android:fromXDelta="0%" android:toXDelta="-100%"
+      android:fromYDelta="0%" android:toYDelta="0%"
+      android:duration="500"/>
+</set>

--- a/Xamarin.Forms.ControlGallery.Android/Resources/anim/exit_to_right.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/anim/exit_to_right.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+  <translate
+     android:fromXDelta="0%" android:toXDelta="100%"
+     android:fromYDelta="0%" android:toYDelta="0%"
+     android:duration="500" />
+</set>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -176,6 +176,7 @@
     <Compile Include="CustomRenderers.cs" />
     <Compile Include="ColorPicker.cs" />
     <Compile Include="_38989CustomRenderer.cs" />
+    <Compile Include="_50787CustomRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\default.css" />
@@ -262,6 +263,18 @@
   </ItemGroup>
   <ItemGroup>
     <TransformFile Include="Properties\AndroidManifest.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\anim\enter_from_right.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\anim\exit_to_left.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\anim\exit_to_right.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\anim\enter_from_left.xml" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\error.xml" />

--- a/Xamarin.Forms.ControlGallery.Android/_50787CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_50787CustomRenderer.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Platform.Android.AppCompat;
+using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
+
+[assembly: ExportRenderer(typeof(NavigationPage), typeof(_50787CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class _50787CustomRenderer : NavigationPageRenderer
+	{
+		protected override int TransitionDuration { get; set; } = 500;
+
+		protected override void SetupPageTransition(FragmentTransaction transaction, bool isPush)
+		{
+			if (isPush)
+				transaction.SetCustomAnimations(Resource.Animation.enter_from_right, Resource.Animation.exit_to_left);
+			else
+				transaction.SetCustomAnimations(Resource.Animation.enter_from_left, Resource.Animation.exit_to_right);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
@@ -7,12 +7,6 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-// Apply the default category of "Issues" to all of the tests in this assembly
-// We use this as a catch-all for tests which haven't been individually categorized
-#if UITEST
-[assembly: NUnit.Framework.Category("Issues")]
-#endif
-
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
@@ -54,5 +54,17 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			System.Diagnostics.Debug.WriteLine("appearing");
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+			System.Diagnostics.Debug.WriteLine("disappearing");
+		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 50787, "Can\'t animate Fragment transition when it\'s being removed from the stack", PlatformAffected.Android)]
+	public class Bugzilla50787 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			PushAsync(new ContentPage50787());
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ContentPage50787 : ContentPage
+	{
+		public ContentPage50787()
+		{
+			BackgroundColor = Color.FromRgb(Guid.NewGuid().GetHashCode() % 255, Guid.NewGuid().GetHashCode() % 255, Guid.NewGuid().GetHashCode() % 255);
+
+			var b = new Button
+			{
+				Text = "Push",
+				Command = new Command(async () => { await Navigation.PushAsync(new ContentPage50787()); })
+			};
+
+			var b2 = new Button
+			{
+				Text = "Pop to root",
+				Command = new Command(async () => { await Navigation.PopToRootAsync(); })
+			};
+
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					b,
+					b2
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
@@ -43,6 +43,11 @@ namespace Xamarin.Forms.Controls.Issues
 				VerticalOptions = LayoutOptions.Center,
 				Children =
 				{
+					new Label
+					{
+						Text = "Take note of the background color of the root page. As you push, a new page should slide in from the right. If you hit the back button, it should be the reverse. Popping to root should slide in only the root page.",
+						TextColor = Color.White
+					},
 					b,
 					b2
 				}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -183,6 +183,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47923.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla48236.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47971.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla50787.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52318.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37290.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51553.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -651,7 +651,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			// We don't currently support fragment restoration, so we don't need to worry about
 			// whether the commit loses state
 			transaction.CommitAllowingStateLoss();
-		
+
 			// The fragment transitions don't really SUPPORT telling you when they end
 			// There are some hacks you can do, but they actually are worse than just doing this:
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -624,10 +624,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					while (_fragmentStack.Count > 1 && popPage)
 					{
 						Fragment currentToRemove = _fragmentStack.Last();
-                        _fragmentStack.RemoveAt(_fragmentStack.Count - 1);
-                        transaction.Hide(currentToRemove);
-                        fragmentsToRemove.Add(currentToRemove);
-                        popPage = popToRoot;
+						_fragmentStack.RemoveAt(_fragmentStack.Count - 1);
+						transaction.Hide(currentToRemove);
+						fragmentsToRemove.Add(currentToRemove);
+						popPage = popToRoot;
 					}
 					
 					Fragment toShow = _fragmentStack.Last();

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -666,11 +666,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else if (_drawerToggle != null && ((INavigationPageController)Element).StackDepth == 2)
 					AnimateArrowOut();
 
-				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, removed);
-
+				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, TransitionDuration, removed);
 			}
 			else
-				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, true);
+				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, 1, true);
 
 			Context.HideKeyboard(this);
 			((Platform)Element.Platform).NavAnimationInProgress = false;
@@ -808,9 +807,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			bar.Title = Element.CurrentPage.Title ?? "";
 		}
 
-		void AddTransitionTimer(TaskCompletionSource<bool> tcs, Fragment fragment, FragmentManager fm, IReadOnlyCollection<Fragment> fragmentsToRemove, bool shouldUpdateToolbar)
+		void AddTransitionTimer(TaskCompletionSource<bool> tcs, Fragment fragment, FragmentManager fm, IReadOnlyCollection<Fragment> fragmentsToRemove, int duration, bool shouldUpdateToolbar)
 		{
-			Device.StartTimer(TimeSpan.FromMilliseconds(TransitionDuration), () =>
+			Device.StartTimer(TimeSpan.FromMilliseconds(duration), () =>
 			{
 				tcs.TrySetResult(true);
 				fragment.UserVisibleHint = true;

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -665,12 +665,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 				else if (_drawerToggle != null && ((INavigationPageController)Element).StackDepth == 2)
 					AnimateArrowOut();
-
-				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, removed);
-
 			}
-			else
-				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, true);
+
+			AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, !animated || removed);
 
 			Context.HideKeyboard(this);
 			((Platform)Element.Platform).NavAnimationInProgress = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -665,9 +665,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 				else if (_drawerToggle != null && ((INavigationPageController)Element).StackDepth == 2)
 					AnimateArrowOut();
-			}
 
-			AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, !animated || removed);
+				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, removed);
+
+			}
+			else
+				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, true);
 
 			Context.HideKeyboard(this);
 			((Platform)Element.Platform).NavAnimationInProgress = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -666,10 +666,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else if (_drawerToggle != null && ((INavigationPageController)Element).StackDepth == 2)
 					AnimateArrowOut();
 
-				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, TransitionDuration, removed);
+				AddTransitionTimer(tcs, fragment, FragmentManager, fragmentsToRemove, TransitionDuration, removed);
 			}
 			else
-				AddTransitionTimer(tcs, fragment, fm, fragmentsToRemove, 1, true);
+				AddTransitionTimer(tcs, fragment, FragmentManager, fragmentsToRemove, 1, true);
 
 			Context.HideKeyboard(this);
 			((Platform)Element.Platform).NavAnimationInProgress = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -807,7 +807,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			bar.Title = Element.CurrentPage.Title ?? "";
 		}
 
-		void AddTransitionTimer(TaskCompletionSource<bool> tcs, Fragment fragment, FragmentManager fm, IReadOnlyCollection<Fragment> fragmentsToRemove, int duration, bool shouldUpdateToolbar)
+		void AddTransitionTimer(TaskCompletionSource<bool> tcs, Fragment fragment, FragmentManager fragmentManager, IReadOnlyCollection<Fragment> fragmentsToRemove, int duration, bool shouldUpdateToolbar)
 		{
 			Device.StartTimer(TimeSpan.FromMilliseconds(duration), () =>
 			{
@@ -816,10 +816,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (shouldUpdateToolbar)
 					UpdateToolbar();
 
-				FragmentTransaction fragmentTransaction = fm.BeginTransaction();
+				FragmentTransaction fragmentTransaction = fragmentManager.BeginTransaction();
 				fragmentTransaction.DisallowAddToBackStack();
-				foreach (Fragment fragment1 in fragmentsToRemove)
-					fragmentTransaction.Remove(fragment1);
+				foreach (Fragment frag in fragmentsToRemove)
+					fragmentTransaction.Remove(frag);
 
 				fragmentTransaction.CommitAllowingStateLoss();
 


### PR DESCRIPTION
### Description of Change ###

As of now, when the navigation stack is being navigated back, Fragments are being removed which does not allow for custom transition animations. This change attempts to hide them first and remove them when the transition is done.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=50787

### API Changes ###

Added:
 - `protected virtual int TransitionDuration { get; set; } = 220;`
 This seems to be the time interval before the transition timer triggers. By default, it's set to 220ms but the custom animations I provided use 500ms.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
