### PR TITLE
[All] Implement IFontElement on Picker, DatePicker, and TimePicker

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/DatePickerCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/DatePickerCoreGalleryPage.cs
@@ -24,6 +24,27 @@ namespace Xamarin.Forms.Controls
 				new DatePicker { MaximumDate = new DateTime(2087, 9, 13) });
 			var textColorContainer = new ViewContainer<DatePicker>(Test.DatePicker.TextColor,
 				new DatePicker { Date = new DateTime(1978, 12, 24), TextColor = Color.Lime });
+			var fontAttributesContainer = new ViewContainer<DatePicker>(Test.DatePicker.FontAttributes,
+				new DatePicker { FontAttributes = FontAttributes.Bold });
+
+			var fontFamilyContainer = new ViewContainer<DatePicker>(Test.DatePicker.FontFamily,
+				new DatePicker());
+			// Set font family based on available fonts per platform
+			switch(Device.RuntimePlatform)
+			{
+				case Device.Android:
+					fontFamilyContainer.View.FontFamily = "sans-serif-thin";
+					break;
+				case Device.iOS:
+					fontFamilyContainer.View.FontFamily = "Courier";
+					break;
+				default:
+					fontFamilyContainer.View.FontFamily = "Garamond";
+					break;
+			}
+
+			var fontSizeContainer = new ViewContainer<DatePicker>(Test.DatePicker.FontSize, 
+				new DatePicker { FontSize = 24 });
 
 			Add(dateContainer);
 			Add(dateSelectedContainer);
@@ -31,6 +52,9 @@ namespace Xamarin.Forms.Controls
 			Add(minimumDateContainer);
 			Add(maximumDateContainer);
 			Add(textColorContainer);
+			Add(fontAttributesContainer);
+			Add(fontFamilyContainer);
+			Add(fontSizeContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
@@ -28,10 +28,44 @@ namespace Xamarin.Forms.Controls
 			textColorContainer.View.Items.Add("Item 2");
 			textColorContainer.View.Items.Add("Item 3");
 
+			var fontAttributesContainer = new ViewContainer<Picker>(Test.Picker.FontAttributes,
+				new Picker { FontAttributes = FontAttributes.Bold });
+			fontAttributesContainer.View.Items.Add("Item 1");
+			fontAttributesContainer.View.Items.Add("Item 2");
+			fontAttributesContainer.View.Items.Add("Item 3");
+
+			var fontFamilyContainer = new ViewContainer<Picker>(Test.Picker.FontFamily,
+				new Picker());
+			// Set font family based on available fonts per platform
+			switch(Device.RuntimePlatform)
+			{
+				case Device.Android:
+					fontFamilyContainer.View.FontFamily = "sans-serif-thin";
+					break;
+				case Device.iOS:
+					fontFamilyContainer.View.FontFamily = "Courier";
+					break;
+				default:
+					fontFamilyContainer.View.FontFamily = "Garamond";
+					break;
+			}
+			fontFamilyContainer.View.Items.Add("Item 1");
+			fontFamilyContainer.View.Items.Add("Item 2");
+			fontFamilyContainer.View.Items.Add("Item 3");
+
+			var fontSizeContainer = new ViewContainer<Picker>(Test.Picker.FontSize,
+				new Picker { FontSize = 24 });
+			fontSizeContainer.View.Items.Add("Item 1");
+			fontSizeContainer.View.Items.Add("Item 2");
+			fontSizeContainer.View.Items.Add("Item 3");
+
 			Add(itemsContainer);
 			Add(selectedIndexContainer);
 			Add(titleContainer);
 			Add(textColorContainer);
+			Add(fontAttributesContainer);
+			Add(fontFamilyContainer);
+			Add(fontSizeContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/CoreGalleryPages/TimePickerCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/TimePickerCoreGalleryPage.cs
@@ -15,10 +15,34 @@ namespace Xamarin.Forms.Controls
 				new TimePicker { Time = new TimeSpan(14, 45, 50) });
 			var textColorContainer = new ViewContainer<TimePicker>(Test.TimePicker.TextColor,
 				new TimePicker { Time = new TimeSpan(14, 45, 50), TextColor = Color.Lime });
+			var fontAttributesContainer = new ViewContainer<TimePicker>(Test.TimePicker.FontAttributes,
+				new TimePicker { FontAttributes = FontAttributes.Bold });
+
+			var fontFamilyContainer = new ViewContainer<TimePicker>(Test.TimePicker.FontFamily,
+				new TimePicker());
+			// Set font family based on available fonts per platform
+			switch(Device.RuntimePlatform)
+			{
+				case Device.Android:
+					fontFamilyContainer.View.FontFamily = "sans-serif-thin";
+					break;
+				case Device.iOS:
+					fontFamilyContainer.View.FontFamily = "Courier";
+					break;
+				default:
+					fontFamilyContainer.View.FontFamily = "Garamond";
+					break;
+			}
+
+			var fontSizeContainer = new ViewContainer<TimePicker>(Test.TimePicker.FontSize,
+				new TimePicker { FontSize = 24 });
 
 			Add(formatContainer);
 			Add(timeContainer);
 			Add(textColorContainer);
+			Add(fontAttributesContainer);
+			Add(fontFamilyContainer);
+			Add(fontSizeContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -84,25 +84,21 @@ namespace Xamarin.Forms
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
-		{
-		}
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
-		{
-		}
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-		void IFontElement.OnFontChanged(Font oldValue, Font newValue)
-		{
-		}
+		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			Device.GetNamedSize(NamedSize.Default, (DatePicker)this);
 
-		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
-		{
-		}
-		
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+
 		public event EventHandler<DateChangedEventArgs> DateSelected;
 
 		static object CoerceDate(BindableObject bindable, object value)

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -1,10 +1,11 @@
 using System;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_DatePickerRenderer))]
-	public class DatePicker : View, ITextElement,IElementConfiguration<DatePicker>
+	public class DatePicker : View, IFontElement, ITextElement,IElementConfiguration<DatePicker>
 	{
 		public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(DatePicker), "d");
 
@@ -20,6 +21,12 @@ namespace Xamarin.Forms
 			validateValue: ValidateMaximumDate, coerceValue: CoerceMaximumDate);
 
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
+		
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
+
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
+
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<DatePicker>> _platformConfigurationRegistry;
 
@@ -58,6 +65,44 @@ namespace Xamarin.Forms
 			set { SetValue(TextElement.TextColorProperty, value); }
 		}
 
+		public FontAttributes FontAttributes
+		{
+			get { return (FontAttributes)GetValue(FontAttributesProperty); }
+			set { SetValue(FontAttributesProperty, value); }
+		}
+
+		public string FontFamily
+		{
+			get { return (string)GetValue(FontFamilyProperty); }
+			set { SetValue(FontFamilyProperty, value); }
+		}
+
+		[TypeConverter(typeof(FontSizeConverter))]
+		public double FontSize
+		{
+			get { return (double)GetValue(FontSizeProperty); }
+			set { SetValue(FontSizeProperty, value); }
+		}
+
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
+		{
+		}
+
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
+		{
+		}
+
+		void IFontElement.OnFontChanged(Font oldValue, Font newValue)
+		{
+		}
+
+		double IFontElement.FontSizeDefaultValueCreator() =>
+			Device.GetNamedSize(NamedSize.Default, (DatePicker)this);
+
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
+		{
+		}
+		
 		public event EventHandler<DateChangedEventArgs> DateSelected;
 
 		static object CoerceDate(BindableObject bindable, object value)

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -62,25 +62,21 @@ namespace Xamarin.Forms
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
-		{
-		}
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
-		{
-		}
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+
+		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			Device.GetNamedSize(NamedSize.Default, (Picker)this);
 
-		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
-		{
-		}
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-		void IFontElement.OnFontChanged(Font oldValue, Font newValue)
-		{
-		}
-		
 		public IList<string> Items { get; } = new LockableObservableListWrapper();
 
 		public IList ItemsSource

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -11,7 +11,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_PickerRenderer))]
-	public class Picker : View, ITextElement, IElementConfiguration<Picker>
+	public class Picker : View, IFontElement, ITextElement, IElementConfiguration<Picker>
 	{
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
@@ -30,6 +30,12 @@ namespace Xamarin.Forms
 			BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay,
 									propertyChanged: OnSelectedItemChanged);
 
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
+
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
+
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
+		
 		readonly Lazy<PlatformConfigurationRegistry<Picker>> _platformConfigurationRegistry;
 
 		public Picker()
@@ -37,7 +43,44 @@ namespace Xamarin.Forms
 			((INotifyCollectionChanged)Items).CollectionChanged += OnItemsCollectionChanged;
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Picker>>(() => new PlatformConfigurationRegistry<Picker>(this));
 		}
+		public FontAttributes FontAttributes
+		{
+			get { return (FontAttributes)GetValue(FontAttributesProperty); }
+			set { SetValue(FontAttributesProperty, value); }
+		}
 
+		public string FontFamily
+		{
+			get { return (string)GetValue(FontFamilyProperty); }
+			set { SetValue(FontFamilyProperty, value); }
+		}
+
+		[TypeConverter(typeof(FontSizeConverter))]
+		public double FontSize
+		{
+			get { return (double)GetValue(FontSizeProperty); }
+			set { SetValue(FontSizeProperty, value); }
+		}
+
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
+		{
+		}
+
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
+		{
+		}
+
+		double IFontElement.FontSizeDefaultValueCreator() =>
+			Device.GetNamedSize(NamedSize.Default, (Picker)this);
+
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
+		{
+		}
+
+		void IFontElement.OnFontChanged(Font oldValue, Font newValue)
+		{
+		}
+		
 		public IList<string> Items { get; } = new LockableObservableListWrapper();
 
 		public IList ItemsSource

--- a/Xamarin.Forms.Core/TimePicker.cs
+++ b/Xamarin.Forms.Core/TimePicker.cs
@@ -67,25 +67,21 @@ namespace Xamarin.Forms
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
-		{
-		}
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
-		{
-		}
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-		void IFontElement.OnFontChanged(Font oldValue, Font newValue)
-		{
-		}
+		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			Device.GetNamedSize(NamedSize.Default, (TimePicker)this);
 
-		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
-		{
-		}
-		
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+
 		public IPlatformElementConfiguration<T, TimePicker> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();

--- a/Xamarin.Forms.Core/TimePicker.cs
+++ b/Xamarin.Forms.Core/TimePicker.cs
@@ -1,10 +1,11 @@
 using System;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_TimePickerRenderer))]
-	public class TimePicker : View, ITextElement, IElementConfiguration<TimePicker>
+	public class TimePicker : View, IFontElement, ITextElement, IElementConfiguration<TimePicker>
 	{
 		public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(TimePicker), "t");
 
@@ -15,6 +16,12 @@ namespace Xamarin.Forms
 			var time = (TimeSpan)value;
 			return time.TotalHours < 24 && time.TotalMilliseconds >= 0;
 		});
+
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
+
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
+
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<TimePicker>> _platformConfigurationRegistry;
 
@@ -41,6 +48,44 @@ namespace Xamarin.Forms
 			set { SetValue(TimeProperty, value); }
 		}
 
+		public FontAttributes FontAttributes
+		{
+			get { return (FontAttributes)GetValue(FontAttributesProperty); }
+			set { SetValue(FontAttributesProperty, value); }
+		}
+
+		public string FontFamily
+		{
+			get { return (string)GetValue(FontFamilyProperty); }
+			set { SetValue(FontFamilyProperty, value); }
+		}
+
+		[TypeConverter(typeof(FontSizeConverter))]
+		public double FontSize
+		{
+			get { return (double)GetValue(FontSizeProperty); }
+			set { SetValue(FontSizeProperty, value); }
+		}
+
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
+		{
+		}
+
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
+		{
+		}
+
+		void IFontElement.OnFontChanged(Font oldValue, Font newValue)
+		{
+		}
+
+		double IFontElement.FontSizeDefaultValueCreator() =>
+			Device.GetNamedSize(NamedSize.Default, (TimePicker)this);
+
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
+		{
+		}
+		
 		public IPlatformElementConfiguration<T, TimePicker> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -478,7 +478,10 @@ namespace Xamarin.Forms.CustomAttributes
 			MaximumDate,
 			Focus,
 			IsVisible,
-			TextColor
+			TextColor,
+			FontAttributes,
+			FontFamily,
+			FontSize
 		}
 
 		public enum InputView
@@ -667,7 +670,10 @@ namespace Xamarin.Forms.CustomAttributes
 			Format,
 			Time,
 			Focus,
-			TextColor
+			TextColor,
+			FontAttributes,
+			FontFamily,
+			FontSize
 		}
 
 		public enum WebView {
@@ -706,7 +712,10 @@ namespace Xamarin.Forms.CustomAttributes
 			Items,
 			SelectedIndex,
 			Focus,
-			TextColor
+			TextColor,
+			FontAttributes,
+			FontFamily,
+			FontSize
 		}
 
 		public enum FileImageSource {

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -1,13 +1,14 @@
-using System;
-using System.ComponentModel;
-using System.Linq;
 using Android.App;
 using Android.Content.Res;
 using Android.Text;
+using Android.Util;
 using Android.Widget;
-using Object = Java.Lang.Object;
+using System;
 using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
 using Android.Content;
+using Object = Java.Lang.Object;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -64,6 +65,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors);
 					SetNativeControl(textField);
 				}
+				UpdateFont();
 				UpdatePicker();
 				UpdateTextColor();
 			}
@@ -77,10 +79,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (e.PropertyName == Picker.TitleProperty.PropertyName)
 				UpdatePicker();
-			if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
+			else if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 				UpdatePicker();
-			if (e.PropertyName == Picker.TextColorProperty.PropertyName)
+			else if (e.PropertyName == Picker.TextColorProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == Picker.FontAttributesProperty.PropertyName || e.PropertyName == Picker.FontFamilyProperty.PropertyName || e.PropertyName == Picker.FontSizeProperty.PropertyName)
+				UpdateFont();
 		}
 
 		internal override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
@@ -130,6 +134,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void RowsCollectionChanged(object sender, EventArgs e)
 		{
 			UpdatePicker();
+		}
+
+		void UpdateFont()
+		{
+			Control.Typeface = Element.ToTypeface();
+			Control.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
 		}
 
 		void UpdatePicker()

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using Android.App;
 using Android.Content;
 using Android.Content.Res;
+using Android.Util;
 using Android.Widget;
 using AView = Android.Views.View;
 using Object = Java.Lang.Object;
@@ -71,6 +72,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			SetDate(Element.Date);
 
+			UpdateFont();
 			UpdateMinimumDate();
 			UpdateMaximumDate();
 			UpdateTextColor();
@@ -86,8 +88,10 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateMinimumDate();
 			else if (e.PropertyName == DatePicker.MaximumDateProperty.PropertyName)
 				UpdateMaximumDate();
-			if (e.PropertyName == DatePicker.TextColorProperty.PropertyName)
+			else if (e.PropertyName == DatePicker.TextColorProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == DatePicker.FontAttributesProperty.PropertyName || e.PropertyName == DatePicker.FontFamilyProperty.PropertyName || e.PropertyName == DatePicker.FontSizeProperty.PropertyName)
+				UpdateFont();
 		}
 
 		internal override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
@@ -163,6 +167,12 @@ namespace Xamarin.Forms.Platform.Android
 		void SetDate(DateTime date)
 		{
 			Control.Text = date.ToString(Element.Format);
+		}
+
+		void UpdateFont()
+		{
+			Control.Typeface = Element.ToTypeface();
+			Control.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
 		}
 
 		void UpdateMaximumDate()

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -1,15 +1,16 @@
-using System;
-using System.ComponentModel;
-using System.Linq;
 using Android.App;
 using Android.Content.Res;
+using Android.Util;
 using Android.Views;
 using Android.Widget;
+using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
 using ADatePicker = Android.Widget.DatePicker;
 using ATimePicker = Android.Widget.TimePicker;
 using Object = Java.Lang.Object;
 using Orientation = Android.Widget.Orientation;
-using System.Collections.Specialized;
 using Android.Content;
 
 namespace Xamarin.Forms.Platform.Android
@@ -64,6 +65,8 @@ namespace Xamarin.Forms.Platform.Android
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors);
 					SetNativeControl(textField);
 				}
+				
+				UpdateFont();
 				UpdatePicker();
 				UpdateTextColor();
 			}
@@ -77,10 +80,12 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (e.PropertyName == Picker.TitleProperty.PropertyName)
 				UpdatePicker();
-			if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
+			else if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 				UpdatePicker();
-			if (e.PropertyName == Picker.TextColorProperty.PropertyName)
+			else if (e.PropertyName == Picker.TextColorProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == Picker.FontAttributesProperty.PropertyName || e.PropertyName == Picker.FontFamilyProperty.PropertyName || e.PropertyName == Picker.FontSizeProperty.PropertyName)
+				UpdateFont();
 		}
 
 		internal override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
@@ -157,6 +162,12 @@ namespace Xamarin.Forms.Platform.Android
 		void RowsCollectionChanged(object sender, EventArgs e)
 		{
 			UpdatePicker();
+		}
+
+		void UpdateFont()
+		{
+			Control.Typeface = Element.ToTypeface();
+			Control.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
 		}
 
 		void UpdatePicker()

--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using Android.App;
 using Android.Content;
 using Android.Content.Res;
+using Android.Util;
 using Android.Widget;
 using Android.Text.Format;
 using ADatePicker = Android.Widget.DatePicker;
@@ -79,9 +80,10 @@ namespace Xamarin.Forms.Platform.Android
 			if (e.PropertyName == TimePicker.TimeProperty.PropertyName ||
 				e.PropertyName == TimePicker.FormatProperty.PropertyName)
 				SetTime(Element.Time);
-
-			if (e.PropertyName == TimePicker.TextColorProperty.PropertyName)
+			else if (e.PropertyName == TimePicker.TextColorProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == TimePicker.FontAttributesProperty.PropertyName || e.PropertyName == TimePicker.FontFamilyProperty.PropertyName || e.PropertyName == TimePicker.FontSizeProperty.PropertyName)
+				UpdateFont();
 		}
 
 		internal override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
@@ -124,6 +126,12 @@ namespace Xamarin.Forms.Platform.Android
 		void SetTime(TimeSpan time)
 		{
 			Control.Text = DateTime.Today.Add(time).ToString(_timeFormat);
+		}
+
+		void UpdateFont()
+		{
+			Control.Typeface = Element.ToTypeface();
+			Control.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
 		}
 
 		void UpdateTextColor()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
@@ -40,6 +40,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			UpdateDateFromModel();
 			UpdateMaximumDate();
 			UpdateMinimumDate();
+			UpdateFont();
 			UpdateTextColor();
 		}
 
@@ -57,6 +58,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			else if (e.PropertyName == DatePicker.TextColorProperty.PropertyName ||
 					e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == Picker.FontSizeProperty.PropertyName ||
+				e.PropertyName == Picker.FontFamilyProperty.PropertyName ||
+				e.PropertyName == Picker.FontAttributesProperty.PropertyName)
+				UpdateFont();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -107,6 +112,14 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 			if (_picker.DateValue.ToDateTime().Date != Element.Date.Date)
 				_picker.DateValue = Element.Date.ToNSDate();
+		}
+
+		void UpdateFont()
+		{
+			if (Control == null || Element == null)
+				return;
+			
+			Control.Font = Element.ToNSFont();
 		}
 
 		void UpdateMaximumDate()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PickerRenderer.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				Control.SelectionChanged += ComboBoxSelectionChanged;
 
 				UpdatePicker();
+				UpdateFont();
 				UpdateTextColor();
 			}
 
@@ -43,8 +44,13 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 				UpdatePicker();
 			if (e.PropertyName == Picker.TextColorProperty.PropertyName ||
-				e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+			    e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateTextColor();
+			if (e.PropertyName == Picker.FontSizeProperty.PropertyName ||
+				e.PropertyName == Picker.FontFamilyProperty.PropertyName ||
+				e.PropertyName == Picker.FontAttributesProperty.PropertyName)
+				UpdateFont();
+				
 		}
 
 		protected override void SetBackgroundColor(Color color)
@@ -95,6 +101,14 @@ namespace Xamarin.Forms.Platform.MacOS
 		void RowsCollectionChanged(object sender, EventArgs e)
 		{
 			UpdatePicker();
+		}
+
+		void UpdateFont()
+		{
+			if (Control == null || Element == null)
+				return;
+
+			Control.Font = Element.ToNSFont();
 		}
 
 		void UpdatePicker()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				}
 
 				UpdateTime();
+				UpdateFont();
 				UpdateTextColor();
 			}
 		}
@@ -50,6 +51,11 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (e.PropertyName == TimePicker.TextColorProperty.PropertyName ||
 				e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateTextColor();
+
+			if (e.PropertyName == Picker.FontSizeProperty.PropertyName ||
+				e.PropertyName == Picker.FontFamilyProperty.PropertyName ||
+				e.PropertyName == Picker.FontAttributesProperty.PropertyName)
+					UpdateFont();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -77,6 +83,14 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			ElementController?.SetValueFromRenderer(TimePicker.TimeProperty,
 				Control.DateValue.ToDateTime() - new DateTime(2001, 1, 1));
+		}
+
+		void UpdateFont()
+		{
+			if (Control == null || Element == null)
+				return;
+
+			Control.Font = Element.ToNSFont();	
 		}
 
 		void UpdateTime()

--- a/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Forms.Platform.UWP
 	public class DatePickerRenderer : ViewRenderer<DatePicker, Windows.UI.Xaml.Controls.DatePicker>
 	{
 		Brush _defaultBrush;
+		bool _fontApplied;
+		FontFamily _defaultFontFamily;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -48,6 +50,8 @@ namespace Xamarin.Forms.Platform.UWP
 			// The defaults from the control template won't be available
 			// right away; we have to wait until after the template has been applied
 			_defaultBrush = Control.Foreground;
+			_defaultFontFamily = Control.FontFamily;
+			UpdateFont();
 			UpdateTextColor();
 		}
 
@@ -65,6 +69,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTextColor();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
+			else if (e.PropertyName == DatePicker.FontAttributesProperty.PropertyName || e.PropertyName == DatePicker.FontFamilyProperty.PropertyName || e.PropertyName == DatePicker.FontSizeProperty.PropertyName)
+				UpdateFont();
 		}
 
 		protected override bool PreventGestureBubbling { get; set; } = true;
@@ -87,6 +93,39 @@ namespace Xamarin.Forms.Platform.UWP
 		void UpdateFlowDirection()
 		{
 			Control.UpdateFlowDirection(Element);
+		}
+		
+		void UpdateFont()
+		{
+			if (Control == null)
+				return;
+
+			DatePicker datePicker = Element;
+
+			if (datePicker == null)
+				return;
+
+			bool datePickerIsDefault = datePicker.FontFamily == null && datePicker.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(DatePicker), true) && datePicker.FontAttributes == FontAttributes.None;
+
+			if (datePickerIsDefault && !_fontApplied)
+				return;
+
+			if (datePickerIsDefault)
+			{
+				// ReSharper disable AccessToStaticMemberViaDerivedType
+				Control.ClearValue(ComboBox.FontStyleProperty);
+				Control.ClearValue(ComboBox.FontSizeProperty);
+				Control.ClearValue(ComboBox.FontFamilyProperty);
+				Control.ClearValue(ComboBox.FontWeightProperty);
+				Control.ClearValue(ComboBox.FontStretchProperty);
+				// ReSharper restore AccessToStaticMemberViaDerivedType
+			}
+			else
+			{
+				Control.ApplyFont(datePicker);
+			}
+
+			_fontApplied = true;
 		}
 
 		void UpdateMaximumDate()

--- a/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
@@ -11,8 +11,10 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public class PickerRenderer : ViewRenderer<Picker, FormsComboBox>
 	{
+		bool _fontApplied;
 		bool _isAnimating;
 		Brush _defaultBrush;
+		FontFamily _defaultFontFamily;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -66,6 +68,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTitle();
 			else if (e.PropertyName == Picker.TextColorProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == Picker.FontAttributesProperty.PropertyName || e.PropertyName == Picker.FontFamilyProperty.PropertyName || e.PropertyName == Picker.FontSizeProperty.PropertyName)
+				UpdateFont();
 		}
 
 		void ControlOnLoaded(object sender, RoutedEventArgs routedEventArgs)
@@ -73,6 +77,8 @@ namespace Xamarin.Forms.Platform.UWP
 			// The defaults from the control template won't be available
 			// right away; we have to wait until after the template has been applied
 			_defaultBrush = Control.Foreground;
+			_defaultFontFamily = Control.FontFamily;
+			UpdateFont();
 			UpdateTextColor();
 		}
 
@@ -142,6 +148,39 @@ namespace Xamarin.Forms.Platform.UWP
 					await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => ((IVisualElementController)Element)?.InvalidateMeasure(InvalidationTrigger.MeasureChanged));
 				}
 			});
+		}
+
+		void UpdateFont()
+		{
+			if (Control == null)
+				return;
+
+			Picker picker = Element;
+
+			if (picker == null)
+				return;
+
+			bool pickerIsDefault = picker.FontFamily == null && picker.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Picker), true) && picker.FontAttributes == FontAttributes.None;
+
+			if (pickerIsDefault && !_fontApplied)
+				return;
+
+			if (pickerIsDefault)
+			{
+				// ReSharper disable AccessToStaticMemberViaDerivedType
+				Control.ClearValue(ComboBox.FontStyleProperty);
+				Control.ClearValue(ComboBox.FontSizeProperty);
+				Control.ClearValue(ComboBox.FontFamilyProperty);
+				Control.ClearValue(ComboBox.FontWeightProperty);
+				Control.ClearValue(ComboBox.FontStretchProperty);
+				// ReSharper restore AccessToStaticMemberViaDerivedType
+			}
+			else
+			{
+				Control.ApplyFont(picker);
+			}
+
+			_fontApplied = true;
 		}
 
 		void UpdateSelectedIndex()

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -60,6 +60,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			UpdateDateFromModel(false);
+			UpdateFont();
 			UpdateMaximumDate();
 			UpdateMinimumDate();
 			UpdateTextColor();
@@ -80,6 +81,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateTextColor();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
+			else if (e.PropertyName == DatePicker.FontAttributesProperty.PropertyName || e.PropertyName == DatePicker.FontFamilyProperty.PropertyName || e.PropertyName == DatePicker.FontSizeProperty.PropertyName)
+				UpdateFont();
 		}
 
 		void HandleValueChanged(object sender, EventArgs e)
@@ -108,6 +111,11 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateFlowDirection()
 		{
 			(Control as UITextField).UpdateTextAlignment(Element);
+		}
+		
+		void UpdateFont()
+		{
+			Control.Font = Element.ToUIFont();
 		}
 
 		void UpdateMaximumDate()

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -56,6 +56,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_picker.Model = new PickerSource(this);
 
+				UpdateFont();
 				UpdatePicker();
 				UpdateTextColor();
 
@@ -70,10 +71,12 @@ namespace Xamarin.Forms.Platform.iOS
 			base.OnElementPropertyChanged(sender, e);
 			if (e.PropertyName == Picker.TitleProperty.PropertyName)
 				UpdatePicker();
-			if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
+			else if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 				UpdatePicker();
-			if (e.PropertyName == Picker.TextColorProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+			else if (e.PropertyName == Picker.TextColorProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == Picker.FontAttributesProperty.PropertyName || e.PropertyName == Picker.FontFamilyProperty.PropertyName || e.PropertyName == Picker.FontSizeProperty.PropertyName)
+				UpdateFont();
 		}
 
 		void OnEditing(object sender, EventArgs eventArgs)
@@ -104,6 +107,11 @@ namespace Xamarin.Forms.Platform.iOS
 		void RowsCollectionChanged(object sender, EventArgs e)
 		{
 			UpdatePicker();
+		}
+
+		void UpdateFont()
+		{
+			Control.Font = Element.ToUIFont();
 		}
 
 		void UpdatePicker()

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -73,6 +73,7 @@ namespace Xamarin.Forms.Platform.iOS
 					SetNativeControl(entry);
 				}
 
+				UpdateFont();
 				UpdateTime();
 				UpdateTextColor();
 				UpdateFlowDirection();
@@ -87,9 +88,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (e.PropertyName == TimePicker.TimeProperty.PropertyName || e.PropertyName == TimePicker.FormatProperty.PropertyName)
 				UpdateTime();
-
-			if (e.PropertyName == TimePicker.TextColorProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+			else if (e.PropertyName == TimePicker.TextColorProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == TimePicker.FontAttributesProperty.PropertyName || e.PropertyName == TimePicker.FontFamilyProperty.PropertyName || e.PropertyName == TimePicker.FontSizeProperty.PropertyName)
+				UpdateFont();
 
 			if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
@@ -113,6 +115,11 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateFlowDirection()
 		{
 			(Control as UITextField).UpdateTextAlignment(Element);
+		}
+		
+		void UpdateFont()
+		{
+			Control.Font = Element.ToUIFont();
 		}
 
 		void UpdateTextColor()

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/DatePicker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/DatePicker.xml
@@ -185,6 +185,104 @@ DatePicker datePicker = new DatePicker
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="FontAttributes">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.FontAttributes FontAttributes { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.FontAttributes FontAttributes" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FontAttributes</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontAttributesProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontAttributesProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontAttributesProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontFamily">
+      <MemberSignature Language="C#" Value="public string FontFamily { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string FontFamily" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontFamilyProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontFamilyProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontFamilyProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontSize">
+      <MemberSignature Language="C#" Value="public double FontSize { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float64 FontSize" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FontSizeConverter))</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontSizeProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontSizeProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontSizeProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Format">
       <MemberSignature Language="C#" Value="public string Format { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Format" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/DatePicker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/DatePicker.xml
@@ -1,6 +1,6 @@
 <Type Name="DatePicker" FullName="Xamarin.Forms.DatePicker">
-  <TypeSignature Language="C#" Value="public class DatePicker : Xamarin.Forms.View, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.DatePicker&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit DatePicker extends Xamarin.Forms.View implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.DatePicker&gt;" />
+  <TypeSignature Language="C#" Value="public class DatePicker : Xamarin.Forms.View, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.DatePicker&gt;, Xamarin.Forms.Internals.IFontElement" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit DatePicker extends Xamarin.Forms.View implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.DatePicker&gt;, class Xamarin.Forms.Internals.IFontElement" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -17,6 +17,9 @@
   <Interfaces>
     <Interface>
       <InterfaceName>Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.DatePicker&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.Internals.IFontElement</InterfaceName>
     </Interface>
   </Interfaces>
   <Attributes>
@@ -470,6 +473,107 @@ DatePicker datePicker = new DatePicker
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Xamarin.Forms.DatePicker.TextColor" /> property.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.FontSizeDefaultValueCreator">
+      <MemberSignature Language="C#" Value="double IFontElement.FontSizeDefaultValueCreator ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance float64 Xamarin.Forms.Internals.IFontElement.FontSizeDefaultValueCreator() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontAttributesChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontAttributesChanged (Xamarin.Forms.FontAttributes oldValue, Xamarin.Forms.FontAttributes newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontAttributesChanged(valuetype Xamarin.Forms.FontAttributes oldValue, valuetype Xamarin.Forms.FontAttributes newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="Xamarin.Forms.FontAttributes" />
+        <Parameter Name="newValue" Type="Xamarin.Forms.FontAttributes" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontChanged (Xamarin.Forms.Font oldValue, Xamarin.Forms.Font newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontChanged(valuetype Xamarin.Forms.Font oldValue, valuetype Xamarin.Forms.Font newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="Xamarin.Forms.Font" />
+        <Parameter Name="newValue" Type="Xamarin.Forms.Font" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontFamilyChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontFamilyChanged (string oldValue, string newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontFamilyChanged(string oldValue, string newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="System.String" />
+        <Parameter Name="newValue" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontSizeChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontSizeChanged (double oldValue, double newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontSizeChanged(float64 oldValue, float64 newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="System.Double" />
+        <Parameter Name="newValue" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Picker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Picker.xml
@@ -1,6 +1,6 @@
 <Type Name="Picker" FullName="Xamarin.Forms.Picker">
-  <TypeSignature Language="C#" Value="public class Picker : Xamarin.Forms.View, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.Picker&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Picker extends Xamarin.Forms.View implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.Picker&gt;" />
+  <TypeSignature Language="C#" Value="public class Picker : Xamarin.Forms.View, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.Picker&gt;, Xamarin.Forms.Internals.IFontElement" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Picker extends Xamarin.Forms.View implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.Picker&gt;, class Xamarin.Forms.Internals.IFontElement" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -17,6 +17,9 @@
   <Interfaces>
     <Interface>
       <InterfaceName>Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.Picker&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.Internals.IFontElement</InterfaceName>
     </Interface>
   </Interfaces>
   <Attributes>
@@ -524,6 +527,107 @@ namespace FormsGallery
         <summary>Identifies the Title bindable property.</summary>
         <remarks>
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.FontSizeDefaultValueCreator">
+      <MemberSignature Language="C#" Value="double IFontElement.FontSizeDefaultValueCreator ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance float64 Xamarin.Forms.Internals.IFontElement.FontSizeDefaultValueCreator() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontAttributesChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontAttributesChanged (Xamarin.Forms.FontAttributes oldValue, Xamarin.Forms.FontAttributes newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontAttributesChanged(valuetype Xamarin.Forms.FontAttributes oldValue, valuetype Xamarin.Forms.FontAttributes newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="Xamarin.Forms.FontAttributes" />
+        <Parameter Name="newValue" Type="Xamarin.Forms.FontAttributes" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontChanged (Xamarin.Forms.Font oldValue, Xamarin.Forms.Font newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontChanged(valuetype Xamarin.Forms.Font oldValue, valuetype Xamarin.Forms.Font newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="Xamarin.Forms.Font" />
+        <Parameter Name="newValue" Type="Xamarin.Forms.Font" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontFamilyChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontFamilyChanged (string oldValue, string newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontFamilyChanged(string oldValue, string newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="System.String" />
+        <Parameter Name="newValue" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontSizeChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontSizeChanged (double oldValue, double newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontSizeChanged(float64 oldValue, float64 newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="System.Double" />
+        <Parameter Name="newValue" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Picker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Picker.xml
@@ -163,6 +163,104 @@ namespace FormsGallery
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="FontAttributes">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.FontAttributes FontAttributes { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.FontAttributes FontAttributes" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FontAttributes</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontAttributesProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontAttributesProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontAttributesProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontFamily">
+      <MemberSignature Language="C#" Value="public string FontFamily { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string FontFamily" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontFamilyProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontFamilyProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontFamilyProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontSize">
+      <MemberSignature Language="C#" Value="public double FontSize { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float64 FontSize" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FontSizeConverter))</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontSizeProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontSizeProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontSizeProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="ItemDisplayBinding">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.BindingBase ItemDisplayBinding { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.BindingBase ItemDisplayBinding" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/TimePicker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/TimePicker.xml
@@ -1,6 +1,6 @@
 <Type Name="TimePicker" FullName="Xamarin.Forms.TimePicker">
-  <TypeSignature Language="C#" Value="public class TimePicker : Xamarin.Forms.View, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.TimePicker&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit TimePicker extends Xamarin.Forms.View implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.TimePicker&gt;" />
+  <TypeSignature Language="C#" Value="public class TimePicker : Xamarin.Forms.View, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.TimePicker&gt;, Xamarin.Forms.Internals.IFontElement" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit TimePicker extends Xamarin.Forms.View implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.TimePicker&gt;, class Xamarin.Forms.Internals.IFontElement" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -17,6 +17,9 @@
   <Interfaces>
     <Interface>
       <InterfaceName>Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.TimePicker&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.Internals.IFontElement</InterfaceName>
     </Interface>
   </Interfaces>
   <Attributes>
@@ -302,6 +305,107 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <summary>Identifies the Time bindable property.</summary>
         <remarks>
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.FontSizeDefaultValueCreator">
+      <MemberSignature Language="C#" Value="double IFontElement.FontSizeDefaultValueCreator ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance float64 Xamarin.Forms.Internals.IFontElement.FontSizeDefaultValueCreator() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontAttributesChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontAttributesChanged (Xamarin.Forms.FontAttributes oldValue, Xamarin.Forms.FontAttributes newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontAttributesChanged(valuetype Xamarin.Forms.FontAttributes oldValue, valuetype Xamarin.Forms.FontAttributes newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="Xamarin.Forms.FontAttributes" />
+        <Parameter Name="newValue" Type="Xamarin.Forms.FontAttributes" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontChanged (Xamarin.Forms.Font oldValue, Xamarin.Forms.Font newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontChanged(valuetype Xamarin.Forms.Font oldValue, valuetype Xamarin.Forms.Font newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="Xamarin.Forms.Font" />
+        <Parameter Name="newValue" Type="Xamarin.Forms.Font" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontFamilyChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontFamilyChanged (string oldValue, string newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontFamilyChanged(string oldValue, string newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="System.String" />
+        <Parameter Name="newValue" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Internals.IFontElement.OnFontSizeChanged">
+      <MemberSignature Language="C#" Value="void IFontElement.OnFontSizeChanged (double oldValue, double newValue);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.Internals.IFontElement.OnFontSizeChanged(float64 oldValue, float64 newValue) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="oldValue" Type="System.Double" />
+        <Parameter Name="newValue" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="oldValue">To be added.</param>
+        <param name="newValue">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/TimePicker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/TimePicker.xml
@@ -62,6 +62,104 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="FontAttributes">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.FontAttributes FontAttributes { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.FontAttributes FontAttributes" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FontAttributes</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontAttributesProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontAttributesProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontAttributesProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontFamily">
+      <MemberSignature Language="C#" Value="public string FontFamily { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string FontFamily" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontFamilyProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontFamilyProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontFamilyProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontSize">
+      <MemberSignature Language="C#" Value="public double FontSize { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float64 FontSize" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FontSizeConverter))</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FontSizeProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty FontSizeProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty FontSizeProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Format">
       <MemberSignature Language="C#" Value="public string Format { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Format" />


### PR DESCRIPTION
### Description of Change ###

As discussed [here](https://forums.xamarin.com/discussion/84742/add-ability-to-change-font-family-of-picker); this implements `IFontElement` on `Picker`, `DatePicker`, and `TimePicker`. The core gallery pages were updated to include these types.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=50098

### API Changes ###

`IFontElement` is applied on the above three controls which includes:

- public static readonly BindableProperty FontAttributesProperty
- public static readonly BindableProperty FontFamilyProperty
- public static readonly BindableProperty FontSizeProperty
- public FontAttributes FontAttributes
- public string FontFamily
- public double FontSize

### Behavioral Changes ###

N/A

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense