### PR TITLE
[Android] Keyboard should not change layout while dismissing on Entry and Editor

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43867.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43867.cs
@@ -26,19 +26,21 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					new Label
 					{
-						Text = "Focus and unfocus each element 10 times. Observe that the soft keyboard does not show different characters while hiding."
+						Text = "Focus and unfocus each element 10 times using the Back button. Observe that the soft keyboard does not show different characters while hiding. Now repeat the test by tapping off of the element."
 					},
 					new Entry
 					{
 						WidthRequest = 250,
 						HeightRequest = 50,
-						BackgroundColor = Color.AntiqueWhite
+						BackgroundColor = Color.AntiqueWhite,
+						Keyboard = Keyboard.Numeric
 					},
 					new Editor
 					{
 						WidthRequest = 250,
 						HeightRequest = 50,
-						BackgroundColor = Color.BurlyWood
+						BackgroundColor = Color.BurlyWood,
+						Keyboard = Keyboard.Numeric
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43867.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43867.cs
@@ -1,0 +1,47 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43867, "Numeric keyboard shows text / default keyboard when back button is hit", PlatformAffected.Android)]
+	public class Bugzilla43867 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			Application.Current.On<Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize);
+
+			Content = new StackLayout
+			{
+				Spacing = 10,
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Label
+					{
+						Text = "Focus and unfocus each element 10 times. Observe that the soft keyboard does not change layout while hiding."
+					},
+					new Entry
+					{
+						WidthRequest = 250,
+						HeightRequest = 50,
+						BackgroundColor = Color.AntiqueWhite
+					},
+					new Editor
+					{
+						WidthRequest = 250,
+						HeightRequest = 50,
+						BackgroundColor = Color.BurlyWood
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43867.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43867.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					new Label
 					{
-						Text = "Focus and unfocus each element 10 times. Observe that the soft keyboard does not change layout while hiding."
+						Text = "Focus and unfocus each element 10 times. Observe that the soft keyboard does not show different characters while hiding."
 					},
 					new Entry
 					{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -139,6 +139,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43469.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43663.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43867.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43735.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44944.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorEditText.cs
@@ -23,12 +23,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override bool OnKeyPreIme(Keycode keyCode, KeyEvent e)
 		{
-			if (keyCode == Keycode.Back && e.Action == KeyEventActions.Down)
-			{
-				this.HideKeyboard();
-				OnBackKeyboardPressed?.Invoke(this, EventArgs.Empty);
-			}
+			if (keyCode != Keycode.Back || e.Action != KeyEventActions.Down)
+				return base.OnKeyPreIme(keyCode, e);
 
+			this.HideKeyboard();
+			OnBackKeyboardPressed?.Invoke(this, EventArgs.Empty);
 			return true;
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorEditText.cs
@@ -25,11 +25,11 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (keyCode == Keycode.Back && e.Action == KeyEventActions.Down)
 			{
-				EventHandler handler = OnBackKeyboardPressed;
-				if (handler != null)
-					handler(this, EventArgs.Empty);
+				this.HideKeyboard();
+				OnBackKeyboardPressed?.Invoke(this, EventArgs.Empty);
 			}
-			return base.OnKeyPreIme(keyCode, e);
+
+			return true;
 		}
 
 		public override bool RequestFocus(FocusSearchDirection direction, Rect previouslyFocusedRect)

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryEditText.cs
@@ -23,12 +23,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override bool OnKeyPreIme(Keycode keyCode, KeyEvent e)
 		{
-			if (keyCode == Keycode.Back && e.Action == KeyEventActions.Down)
-			{
-				this.HideKeyboard();
-				OnKeyboardBackPressed?.Invoke(this, EventArgs.Empty);
-			}
+			if (keyCode != Keycode.Back || e.Action != KeyEventActions.Down)
+				return base.OnKeyPreIme(keyCode, e);
 
+			this.HideKeyboard();
+			OnKeyboardBackPressed?.Invoke(this, EventArgs.Empty);
 			return true;
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryEditText.cs
@@ -25,18 +25,16 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (keyCode == Keycode.Back && e.Action == KeyEventActions.Down)
 			{
-				EventHandler handler = OnKeyboardBackPressed;
-				if (handler != null)
-					handler(this, EventArgs.Empty);
+				this.HideKeyboard();
+				ClearFocus();
 			}
-			return base.OnKeyPreIme(keyCode, e);
+
+			return true;
 		}
 
 		public override bool RequestFocus(FocusSearchDirection direction, Rect previouslyFocusedRect)
 		{
 			return (this as IDescendantFocusToggler).RequestFocus(this, () => base.RequestFocus(direction, previouslyFocusedRect));
 		}
-
-		internal event EventHandler OnKeyboardBackPressed;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryEditText.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (keyCode == Keycode.Back && e.Action == KeyEventActions.Down)
 			{
 				this.HideKeyboard();
-				ClearFocus();
+				OnKeyboardBackPressed?.Invoke(this, EventArgs.Empty);
 			}
 
 			return true;
@@ -36,5 +36,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			return (this as IDescendantFocusToggler).RequestFocus(this, () => base.RequestFocus(direction, previouslyFocusedRect));
 		}
+
+		internal event EventHandler OnKeyboardBackPressed;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -66,7 +66,6 @@ namespace Xamarin.Forms.Platform.Android
 				_textView.ImeOptions = ImeAction.Done;
 				_textView.AddTextChangedListener(this);
 				_textView.SetOnEditorActionListener(this);
-				_textView.OnKeyboardBackPressed += (sender, args) => _textView.ClearFocus();
 				SetNativeControl(_textView);
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -66,6 +66,7 @@ namespace Xamarin.Forms.Platform.Android
 				_textView.ImeOptions = ImeAction.Done;
 				_textView.AddTextChangedListener(this);
 				_textView.SetOnEditorActionListener(this);
+				_textView.OnKeyboardBackPressed += (sender, args) => _textView.ClearFocus();
 				SetNativeControl(_textView);
 			}
 


### PR DESCRIPTION
### Description of Change ###

When the soft keyboard is dismissing on `Entry` and `Editor`, it changes characters. This seems to happen randomly instead of following a consistent pattern unless you use a Google keyboard (tested on S6) in which case it seems to happen every time.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=43867

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
