### PR TITLE
TargetNullValue & FallbackValue implemented

### DIFF
--- a/Xamarin.Forms.Core/Binding.cs
+++ b/Xamarin.Forms.Core/Binding.cs
@@ -82,9 +82,11 @@ namespace Xamarin.Forms
 			}
 		}
 
-		internal string UpdateSourceEventName {
+		internal string UpdateSourceEventName
+		{
 			get { return _updateSourceEventName; }
-			set {
+			set
+			{
 				ThrowIfApplied();
 				_updateSourceEventName = value;
 			}
@@ -116,7 +118,7 @@ namespace Xamarin.Forms
 			object src = _source;
 			base.Apply(src ?? newContext, bindObj, targetProperty);
 
-			object bindingContext = src ?? Context ?? newContext;
+			object bindingContext = src ?? Context ?? newContext ?? TargetNullValue;
 			if (_expression == null && bindingContext != null)
 				_expression = new BindingExpression(this, SelfPath);
 
@@ -125,7 +127,7 @@ namespace Xamarin.Forms
 
 		internal override BindingBase Clone()
 		{
-			return new Binding(Path, Mode) { Converter = Converter, ConverterParameter = ConverterParameter, StringFormat = StringFormat, Source = Source, UpdateSourceEventName = UpdateSourceEventName };
+			return new Binding(Path, Mode) { Converter = Converter, ConverterParameter = ConverterParameter, StringFormat = StringFormat, Source = Source, UpdateSourceEventName = UpdateSourceEventName, TargetNullValue = TargetNullValue, FallbackValue = FallbackValue };
 		}
 
 		internal override object GetSourceValue(object value, Type targetPropertyType)

--- a/Xamarin.Forms.Core/Binding.cs
+++ b/Xamarin.Forms.Core/Binding.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Forms
 			object src = _source;
 			base.Apply(src ?? newContext, bindObj, targetProperty);
 
-			object bindingContext = src ?? Context ?? newContext ?? TargetNullValue;
+			object bindingContext = src ?? Context ?? newContext;
 			if (_expression == null && bindingContext != null)
 				_expression = new BindingExpression(this, SelfPath);
 

--- a/Xamarin.Forms.Core/BindingBase.cs
+++ b/Xamarin.Forms.Core/BindingBase.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Forms
 
 		BindingMode _mode = BindingMode.Default;
 		string _stringFormat;
+		object _targetNullValue;
+		object _fallbackValue;
 
 		internal BindingBase()
 		{
@@ -37,6 +39,28 @@ namespace Xamarin.Forms
 				ThrowIfApplied();
 
 				_stringFormat = value;
+			}
+		}
+
+		public object TargetNullValue
+		{
+			get { return _targetNullValue; }
+			set
+			{
+				ThrowIfApplied();
+
+				_targetNullValue = value;
+			}
+		}
+
+		public object FallbackValue
+		{
+			get { return _fallbackValue; }
+			set
+			{
+				ThrowIfApplied();
+
+				_fallbackValue = value;
 			}
 		}
 

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -176,7 +176,7 @@ namespace Xamarin.Forms
 					return;
 				}
 
-				object bindingValue = (hasValidBinding) ? value : Binding.FallbackValue;
+				object bindingValue = (hasValidBinding) ? value ?? Binding.TargetNullValue : Binding.FallbackValue;
 
 				target.SetValueCore(property, bindingValue, BindableObject.SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);
 			}

--- a/Xamarin.Forms.Core/TemplateBinding.cs
+++ b/Xamarin.Forms.Core/TemplateBinding.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Forms
 
 		internal override BindingBase Clone()
 		{
-			return new TemplateBinding(Path, Mode) { Converter = Converter, ConverterParameter = ConverterParameter, StringFormat = StringFormat };
+			return new TemplateBinding(Path, Mode) { Converter = Converter, ConverterParameter = ConverterParameter, StringFormat = StringFormat, TargetNullValue = TargetNullValue, FallbackValue = FallbackValue };
 		}
 
 		internal override object GetSourceValue(object value, Type targetPropertyType)

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -135,6 +135,8 @@ namespace Xamarin.Forms.Internals
 				StringFormat = StringFormat,
 				Source = Source,
 				UpdateSourceEventName = UpdateSourceEventName,
+				TargetNullValue = TargetNullValue,
+				FallbackValue = FallbackValue,
 			};
 		}
 

--- a/Xamarin.Forms.Xaml/MarkupExtensions/BindingExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/BindingExtension.cs
@@ -22,6 +22,10 @@ namespace Xamarin.Forms.Xaml
 
 		public string StringFormat { get; set; }
 
+		public object TargetNullValue { get; set; }
+
+		public object FallbackValue { get; set; }
+
 		public object Source { get; set; }
 
 		public string UpdateSourceEventName { get; set; }
@@ -31,7 +35,7 @@ namespace Xamarin.Forms.Xaml
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
 			if (TypedBinding == null)
-				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source) { UpdateSourceEventName = UpdateSourceEventName };
+				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source) { UpdateSourceEventName = UpdateSourceEventName, TargetNullValue = TargetNullValue, FallbackValue = FallbackValue };
 
 			TypedBinding.Mode = Mode;
 			TypedBinding.Converter = Converter;
@@ -39,6 +43,8 @@ namespace Xamarin.Forms.Xaml
 			TypedBinding.StringFormat = StringFormat;
 			TypedBinding.Source = Source;
 			TypedBinding.UpdateSourceEventName = UpdateSourceEventName;
+			TypedBinding.TargetNullValue = TargetNullValue;
+			TypedBinding.FallbackValue = FallbackValue;
 			return TypedBinding;
 		}
 


### PR DESCRIPTION
### TargetNullValue & FallbackValue features added to Binding class ###


**TargetNullValue**: The value that is used in the target when the value of the source is null.
(This feature exists on Windows platforms. [See more ](https://msdn.microsoft.com/en-us/library/system.windows.data.bindingbase.targetnullvalue(v=vs.110).aspx))

**FallbackValue:** Gets or sets the value to use when the binding is unable to return a value.
(This feature exists on Windows platforms. [See more](https://msdn.microsoft.com/en-us/library/system.windows.data.bindingbase.fallbackvalue%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396))

Usage: 
`<Label Text="{Binding User.Name, TargetNullValue='Unknown', FallbackValue='-'}"/>`

- **Unknown**: when User.Name is `null`
- **-** : If `BindingContext `does not have property such `User` or `Name`

### Bugs Fixed ###

- 

### API Changes ###

Added:
 - object : FallbackValue Property in BindingBase
 - object : TargetNullValue  property in BindingBase

### Behavioral Changes ###
-None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
