### PR TITLE
[WinRT/UWP] Handle Button click routing via Tapped

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46632.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46632.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 46632, "[WinRT/UWP] Clicking button in ListView ViewCell triggers both button clicked and cell ItemTapped", PlatformAffected.WinRT)]
+	public class Bugzilla46632 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var items = new List<string>() { "ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX" };
+			var listView = new ListView
+			{
+				HasUnevenRows = true,
+				SeparatorColor = Color.Black,
+				ItemsSource = items,
+				ItemTemplate = new DataTemplate(typeof(Bugzilla46632Cell))
+			};
+
+			listView.ItemTapped += async (sender, args) =>
+			{
+				listView.IsEnabled = false;
+
+				await Application.Current.MainPage.DisplayAlert("Tap", "ListItem Tapped", "OK");
+
+				listView.SelectedItem = null;
+				listView.IsEnabled = true;
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = "When clicking/tapping a cell button below, only the alert for the button should pop up. Likewise, clicking/tapping the cell itself should only show the alert for the cell."
+					},
+					listView
+				}
+			};
+		}
+		class Bugzilla46632Cell : ViewCell
+		{
+			public Bugzilla46632Cell()
+			{
+				var entry = new Entry
+				{
+					Placeholder = "Test"
+				};
+				var button = new Button
+				{
+					Text = "Click Me!",
+					BackgroundColor = Color.Green,
+				};
+				button.Clicked += async (s, e) => await Application.Current.MainPage.DisplayAlert("Click", "Button Clicked", "OK");
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+
+				View = new StackLayout
+				{
+					Orientation = StackOrientation.Horizontal,
+					Children =
+					{
+						button,
+						label,
+						entry
+					},
+					Padding = 20,
+				};
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -152,6 +152,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46630.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46632.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla48236.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47971.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />

--- a/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using Xamarin.Forms.Internals;
@@ -30,7 +31,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				if (Control == null)
 				{
 					var button = new FormsButton();
-					button.Click += OnButtonClick;
+					button.Tapped += OnButtonTapped;
 					SetNativeControl(button);
 				}
 
@@ -97,11 +98,11 @@ namespace Xamarin.Forms.Platform.WinRT
 			return;
 		}
 
-		void OnButtonClick(object sender, RoutedEventArgs e)
+		void OnButtonTapped(object sender, TappedRoutedEventArgs args)
 		{
 			Button buttonView = Element;
-			if (buttonView != null)
-				((IButtonController)buttonView).SendClicked();
+			((IButtonController)buttonView)?.SendClicked();
+			args.Handled = true;
 		}
 
 		void UpdateBackground()


### PR DESCRIPTION
### Description of Change ###

A Button being used inside of a ListView cell on WinRT/UWP will presently trigger a click/tap event for the button and the cell it belongs to due to the routing not being handled. Because the `Click` event can't handle routing itself, the `Tapped` event can be used in place of it to perform the same function while also setting the `TappedRoutedEventArgs`'s `Handled` property to true, preventing the unintended second tap from occurring. If the Button is not enabled, the taps on the button will instead go through to the cell.

Per the [MSDN docs](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.uielement.tapped.aspx):

> The input system processes an action where the user clicks the left mouse button while over the element as a *Tapped* action. The event doesn't fire until the left mouse button is released. Mouse input doesn't produce Holding events by default, no matter how long a mouse button is held down, or which button is held.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=46632

### API Changes ###

None

### Behavioral Changes ###

Per the MSDN docs it seems like Tapped is the newer and more preferable way to handle click/tap events. I assume that as the button exists on WinRT/UWP now, if someone had a part of the screen that could be tapped and the button was on top of it, the tap would go through as it does with the ListView cells, but it seems like an edge case since I believe it's reasonable to want the button to stop bubbling routing events when it's the focal point of a click/tap.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense