### PR TITLE
Fix for nullreferenceexception in TabbedRenderer on iOS when it has are no children (yet)

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -233,7 +233,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override UIViewController ChildViewControllerForStatusBarHidden()
 		{
-			return GetViewController(Tabbed.CurrentPage);
+			var current = Tabbed.CurrentPage;
+			if (current == null)
+				return null;
+
+			return GetViewController(current);
 		}
 
 		void UpdateCurrentPagePreferredStatusBarUpdateAnimation()


### PR DESCRIPTION
When a TabbedPage is rendered on iOS with no set CurrentPage (i.e. CurrentPage = null), this results in a NullReferenceRxception. 

This occurs for example when the children are loaded/added async.

### Description of Change ###

Add null check in ChildViewControllerForStatusBarHidden() in TabbedRenderer

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [NO] Has tests (if omitted, state reason in description) I don't know how to write automated integration tests.
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
