### PR TITLE
[Android] Add OffscreenPageLimit to CarouselPage

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/CarouselPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/CarouselPage.cs
@@ -1,0 +1,36 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using FormsElement = Forms.CarouselPage;
+
+	public static class CarouselPage
+    {
+		public static readonly BindableProperty IsSwipePagingEnabledProperty =
+			BindableProperty.Create("IsSwipePagingEnabled", typeof(bool),
+			typeof(CarouselPage), true);
+
+		public static readonly BindableProperty OffscreenPageLimitProperty =
+			BindableProperty.Create("OffscreenPageLimit", typeof(int),
+			typeof(CarouselPage), 3, validateValue: (binding, value) => (int)value >= 0);
+
+		public static int GetOffscreenPageLimit(BindableObject element)
+		{
+			return (int)element.GetValue(OffscreenPageLimitProperty);
+		}
+
+		public static void SetOffscreenPageLimit(BindableObject element, int value)
+		{
+			element.SetValue(OffscreenPageLimitProperty, value);
+		}
+
+		public static int OffscreenPageLimit(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetOffscreenPageLimit(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetOffscreenPageLimit(this IPlatformElementConfiguration<Android, FormsElement> config, int value)
+		{
+			SetOffscreenPageLimit(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -90,6 +90,7 @@
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\Application.cs" />
+    <Compile Include="PlatformConfiguration\AndroidSpecific\CarouselPage.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\TabbedPage.cs" />
     <Compile Include="PlatformConfiguration\ExtensionPoints.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using Android.Content;
 using Android.Support.V4.View;
 using Android.Views;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -103,7 +104,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					ScrollToCurrentPage();
 
 				((IPageController)carouselPage).InternalChildren.CollectionChanged += OnChildrenCollectionChanged;
+
+			    UpdateOffscreenPageLimit();
 			}
+
+
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -144,5 +149,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			_viewPager.SetCurrentItem(Element.Children.IndexOf(Element.CurrentPage), true);
 		}
-	}
+
+        void UpdateOffscreenPageLimit()
+        {
+            _viewPager.OffscreenPageLimit = Element.OnThisPlatform().OffscreenPageLimit();
+        }
+    }
 }


### PR DESCRIPTION
### Description of Change ###

Add OffscreenPageLimit to platform specific CarouselPage options

### Bugs Fixed ###

None

### API Changes ###

List all API changes here (or just put None), example:

Extended:
 - CarouselPage.On&lt;Android&gt;()
     - With:
         - SetOffscreenPageLimit(int);

### Behavioral Changes ###

AppCompat CarousellPageRenderer sets OffscreenPageLimit based on this value

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description) just not done
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
