### PR TITLE
Defer initialization of Application.Properties until first use

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms
 	public class Application : Element, IResourcesProvider, IApplicationController, IElementConfiguration<Application>
 	{
 		static Application s_current;
-		readonly Task<IDictionary<string, object>> _propertiesTask;
+		Task<IDictionary<string, object>> _propertiesTask;
 		readonly Lazy<PlatformConfigurationRegistry<Application>> _platformConfigurationRegistry;
 
 		IAppIndexingProvider _appIndexProvider;
@@ -30,7 +30,6 @@ namespace Xamarin.Forms
 				Loader.Load();
 			NavigationProxy = new NavigationImpl(this);
 			Current = this;
-			_propertiesTask = GetPropertiesAsync();
 
 			SystemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
 			SystemResources.ValuesChanged += OnParentResourcesChanged;
@@ -94,7 +93,15 @@ namespace Xamarin.Forms
 
 		public IDictionary<string, object> Properties
 		{
-			get { return _propertiesTask.Result; }
+			get
+			{
+				if (_propertiesTask == null)
+				{
+					_propertiesTask = GetPropertiesAsync();
+				}
+
+				return _propertiesTask.Result;
+			}
 		}
 
 		internal override ReadOnlyCollection<Element> LogicalChildrenInternal


### PR DESCRIPTION
### Description of Change ###

Currently the built-in Application.Properties dictionary is initialized as part of the Application constructor, which adds overhead to application startup even if the application doesn't use the feature. 

This change defers the initialization of the Properties feature until first use.

No new tests.

### Bugs Fixed ###

- None

### API Changes ###

- None

### Behavioral Changes ###

- Slightly faster application startup
- Slight delay on first access of Properties

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
