### PR TITLE
Make ExpressionSearch for RelativeLayouts lazy

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/RelativeLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RelativeLayoutTests.cs
@@ -41,14 +41,14 @@ namespace Xamarin.Forms.Core.UnitTests
 		public override void Setup()
 		{
 			base.Setup ();
-			ExpressionSearch.Default = new UnitExpressionSearch ();
+			ExpressionSearch.Default = new Lazy<IExpressionSearch> (() => new UnitExpressionSearch());
 		}
 
 		[TearDown]
 		public override void TearDown()
 		{
 			base.TearDown ();
-			ExpressionSearch.Default = new UnitExpressionSearch ();
+			ExpressionSearch.Default = new Lazy<IExpressionSearch>(() => new UnitExpressionSearch());
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/BoundsConstraint.cs
+++ b/Xamarin.Forms.Core/BoundsConstraint.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms
 			var result = new BoundsConstraint
 			{
 				_measureFunc = compiled,
-				RelativeTo = parents ?? ExpressionSearch.Default.FindObjects<View>(expression).ToArray() // make sure we have our own copy
+				RelativeTo = parents ?? ExpressionSearch.Default.Value.FindObjects<View>(expression).ToArray() // make sure we have our own copy
 			};
 
 			return result;

--- a/Xamarin.Forms.Core/Constraint.cs
+++ b/Xamarin.Forms.Core/Constraint.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms
 			var result = new Constraint
 			{
 				_measureFunc = layout => compiled(),
-				RelativeTo = ExpressionSearch.Default.FindObjects<View>(expression).ToArray() // make sure we have our own copy
+				RelativeTo = ExpressionSearch.Default.Value.FindObjects<View>(expression).ToArray() // make sure we have our own copy
 			};
 
 			return result;

--- a/Xamarin.Forms.Core/ExpressionSearch.cs
+++ b/Xamarin.Forms.Core/ExpressionSearch.cs
@@ -1,7 +1,9 @@
+using System;
+
 namespace Xamarin.Forms
 {
 	internal abstract class ExpressionSearch
 	{
-		internal static IExpressionSearch Default { get; set; }
+		internal static Lazy<IExpressionSearch> Default { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/RelativeLayout.cs
+++ b/Xamarin.Forms.Core/RelativeLayout.cs
@@ -294,10 +294,10 @@ namespace Xamarin.Forms
 				Func<double> heightCompiled = height != null ? height.Compile() : () => view.Measure(Parent.Width, Parent.Height, MeasureFlags.IncludeMargins).Request.Height;
 
 				var parents = new List<View>();
-				parents.AddRange(ExpressionSearch.Default.FindObjects<View>(x));
-				parents.AddRange(ExpressionSearch.Default.FindObjects<View>(y));
-				parents.AddRange(ExpressionSearch.Default.FindObjects<View>(width));
-				parents.AddRange(ExpressionSearch.Default.FindObjects<View>(height));
+				parents.AddRange(ExpressionSearch.Default.Value.FindObjects<View>(x));
+				parents.AddRange(ExpressionSearch.Default.Value.FindObjects<View>(y));
+				parents.AddRange(ExpressionSearch.Default.Value.FindObjects<View>(width));
+				parents.AddRange(ExpressionSearch.Default.Value.FindObjects<View>(height));
 
 				BoundsConstraint bounds = BoundsConstraint.FromExpression(() => new Rectangle(xCompiled(), yCompiled(), widthCompiled(), heightCompiled()), parents.Distinct().ToArray());
 

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -147,7 +147,7 @@ namespace Xamarin.Forms
 			Device.Idiom = minWidthDp >= TabletCrossover ? TargetIdiom.Tablet : TargetIdiom.Phone;
 
 			if (ExpressionSearch.Default == null)
-				ExpressionSearch.Default = new AndroidExpressionSearch();
+				ExpressionSearch.Default = new Lazy<IExpressionSearch>(() => new AndroidExpressionSearch()); 
 
 			IsInitialized = true;
 		}

--- a/Xamarin.Forms.Platform.WP8/Forms.cs
+++ b/Xamarin.Forms.Platform.WP8/Forms.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Forms
 
 			Device.Idiom = TargetIdiom.Phone;
 
-			ExpressionSearch.Default = new WinPhoneExpressionSearch();
+			ExpressionSearch.Default = new Lazy<IExpressionSearch>(() => new WinPhoneExpressionSearch()); 
 
 			s_isInitialized = true;
 		}

--- a/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms
 			
 			Ticker.Default = new WindowsTicker();
 
-			ExpressionSearch.Default = new WindowsExpressionSearch();
+			ExpressionSearch.Default = new Lazy<IExpressionSearch>(() => new WindowsExpressionSearch()); 
 
 			Registrar.RegisterAll (new[] {
 				typeof (ExportRendererAttribute),

--- a/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Forms
 					break;
 			}
 #endif
-			ExpressionSearch.Default = new WindowsExpressionSearch();
+			ExpressionSearch.Default = new Lazy<IExpressionSearch>(() => new WindowsExpressionSearch());
 
 #if WINDOWS_UWP
 			Registrar.ExtraAssemblies = rendererAssemblies?.ToArray();

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Forms
 
 			Device.Idiom = UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad ? TargetIdiom.Tablet : TargetIdiom.Phone;
 
-			ExpressionSearch.Default = new iOSExpressionSearch();
+			ExpressionSearch.Default = new Lazy<IExpressionSearch>(() => new iOSExpressionSearch());
 		}
 
 		public static event EventHandler<ViewInitializedEventArgs> ViewInitialized;


### PR DESCRIPTION
### Description of Change ###

Currently Forms intializes the ExpressionSearch at application startup, even if the application doesn't use RelativeLayout anywhere.

This change makes the initialization of ExpressionSearch occur on first use of a RelativeLayout.

### Bugs Fixed ###

- None

### API Changes ###

- None

### Behavioral Changes ###

- None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
