### PR TITLE
Improve registry startup and lookup performance

### DIFF
--- a/Xamarin.Forms.Core/DependencyService.cs
+++ b/Xamarin.Forms.Core/DependencyService.cs
@@ -70,6 +70,16 @@ namespace Xamarin.Forms
 				assemblies = assemblies.Union(Registrar.ExtraAssemblies).ToArray();
 			}
 
+			Initialize(assemblies);
+		}
+
+		internal static void Initialize(Assembly[] assemblies)
+		{
+			if (s_initialized)
+			{
+				return;
+			}
+
 			Type targetAttrType = typeof(DependencyAttribute);
 
 			// Don't use LINQ for performance reasons

--- a/Xamarin.Forms.Core/DependencyService.cs
+++ b/Xamarin.Forms.Core/DependencyService.cs
@@ -14,8 +14,7 @@ namespace Xamarin.Forms
 
 		public static T Get<T>(DependencyFetchTarget fetchTarget = DependencyFetchTarget.GlobalInstance) where T : class
 		{
-			if (!s_initialized)
-				Initialize();
+			Initialize();
 
 			Type targetType = typeof(T);
 
@@ -64,6 +63,11 @@ namespace Xamarin.Forms
 
 		static void Initialize()
 		{
+			if (s_initialized)
+			{
+				return;
+			}
+
 			Assembly[] assemblies = Device.GetAssemblies();
 			if (Registrar.ExtraAssemblies != null)
 			{

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -31,15 +31,18 @@ namespace Xamarin.Forms
 
 		internal Type GetHandlerType(Type viewType)
 		{
-			Type type = LookupHandlerType(viewType);
-			if (type != null)
+			Type type;
+			if(LookupHandlerType(viewType, out type))
 				return type;
 
 			// lazy load render-view association with RenderWithAttribute (as opposed to using ExportRenderer)
-			// TODO: change Registrar to a LazyImmutableDictionary and pass this logic to ctor as a delegate.
 			var attribute = viewType.GetTypeInfo().GetCustomAttribute<RenderWithAttribute>();
 			if (attribute == null)
+			{
+				Register(viewType, null); // Cache this result so we don't have to do GetCustomAttribute again
 				return null;
+			}
+
 			type = attribute.Type;
 
 			if (type.Name.StartsWith("_"))
@@ -51,30 +54,33 @@ namespace Xamarin.Forms
 
 				if (type.Name.StartsWith("_"))
 				{
-					//var attrs = type.GetTypeInfo ().GetCustomAttributes ().ToArray ();
+					Register(viewType, null); // Cache this result so we don't work through this chain again
 					return null;
 				}
 			}
 
-			Register(viewType, type);
-			return LookupHandlerType(viewType);
+			Register(viewType, type); // Register this so we don't have to look for the RenderWith Attibute again in the future
+
+			return type;
 		}
 
-		Type LookupHandlerType(Type viewType)
+		bool LookupHandlerType(Type viewType, out Type handlerType)
 		{
 			Type type = viewType;
 
-			while (true)
+			while (type != null)
 			{
 				if (_handlers.ContainsKey(type))
-					return _handlers[type];
+				{
+					handlerType = _handlers[type];
+					return true;
+				}
 
 				type = type.GetTypeInfo().BaseType;
-				if (type == null)
-					break;
 			}
 
-			return null;
+			handlerType = null;
+			return false;
 		}
 	}
 
@@ -126,15 +132,16 @@ namespace Xamarin.Forms
 				}
 
 				string resolutionName = assembly.FullName;
-				var resolutionNameAttribute = (ResolutionGroupNameAttribute)assembly.GetCustomAttribute(typeof(ResolutionGroupNameAttribute));
-				if (resolutionNameAttribute != null)
-				{
-					resolutionName = resolutionNameAttribute.ShortName;
-				}
 
 				Attribute[] effectAttributes = assembly.GetCustomAttributes(typeof(ExportEffectAttribute)).ToArray();
 				if (effectAttributes.Length > 0)
 				{
+					var resolutionNameAttribute = (ResolutionGroupNameAttribute)assembly.GetCustomAttribute(typeof(ResolutionGroupNameAttribute));
+					if (resolutionNameAttribute != null)
+					{
+						resolutionName = resolutionNameAttribute.ShortName;
+					}
+
 					foreach (Attribute attribute in effectAttributes)
 					{
 						var effect = (ExportEffectAttribute)attribute;
@@ -142,6 +149,8 @@ namespace Xamarin.Forms
 					}
 				}
 			}
+
+			DependencyService.Initialize(assemblies);
 		}
 	}
 }


### PR DESCRIPTION
Optimize search for Effect resolution name
Avoid multiple collection of assemblies during startup
Cache handler lookups

### Description of Change ###

Don't resolve Effect resolution short name unless the assembly actually has effects.

If the Dependency Service hasn't already been initialized, pass the assembly list to it for initialization (so the Dependency Service doesn't have to compile that list again for itself).

When  looking up handler types, cache null results to avoid traversing the class hierarchy on subsequent lookups.

### Bugs Fixed ###

- None

### API Changes ###

- None

### Behavioral Changes ###

- None 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
