### PR TITLE
Don't create FontExtensions Regex unless/until necessary

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FontExtensions.cs
@@ -10,7 +10,10 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		static readonly Dictionary<Tuple<string, FontAttributes>, Typeface> Typefaces = new Dictionary<Tuple<string, FontAttributes>, Typeface>();
 
-		static readonly Lazy<Regex> s_loadFromAssets = new Lazy<Regex>(() => new Regex(@"\w+\.((ttf)|(otf))\#\w*"));
+		// We don't create and cache a Regex object here because we may not ever need it, and creating Regexes is surprisingly expensive (especially on older hardware)
+		// Instead, we'll use the static Regex.IsMatch below, which will create and cache the regex internally as needed. It's the equivalent of Lazy<Regex> with less code.
+		// See https://msdn.microsoft.com/en-us/library/sdx2bds0(v=vs.110).aspx#Anchor_2
+		const string LoadFromAssetsRegex = @"\w+\.((ttf)|(otf))\#\w*";
 
 		static Typeface s_defaultTypeface;
 
@@ -56,7 +59,7 @@ namespace Xamarin.Forms.Platform.Android
 				var style = ToTypefaceStyle(self.FontAttributes);
 				result = Typeface.Create(Typeface.Default, style);
 			}
-			else if (s_loadFromAssets.Value.IsMatch(self.FontFamily))
+			else if (Regex.IsMatch(self.FontFamily, LoadFromAssetsRegex))
 			{
 				result = Typeface.CreateFromAsset(AApplication.Context.Assets, FontNameToFontFile(self.FontFamily));
 			}
@@ -88,7 +91,7 @@ namespace Xamarin.Forms.Platform.Android
 				var style = ToTypefaceStyle(self.FontAttributes);
 				result = Typeface.Create(Typeface.Default, style);
 			}
-			else if (s_loadFromAssets.Value.IsMatch(self.FontFamily))
+			else if (Regex.IsMatch(self.FontFamily, LoadFromAssetsRegex))
 			{
 				result = Typeface.CreateFromAsset(AApplication.Context.Assets, FontNameToFontFile(self.FontFamily));
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FontExtensions.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		static readonly Dictionary<Tuple<string, FontAttributes>, Typeface> Typefaces = new Dictionary<Tuple<string, FontAttributes>, Typeface>();
 
-		static readonly Regex LoadFromAssets = new Regex(@"\w+\.((ttf)|(otf))\#\w*");
+		static readonly Lazy<Regex> s_loadFromAssets = new Lazy<Regex>(() => new Regex(@"\w+\.((ttf)|(otf))\#\w*"));
 
 		static Typeface s_defaultTypeface;
 
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Platform.Android
 				var style = ToTypefaceStyle(self.FontAttributes);
 				result = Typeface.Create(Typeface.Default, style);
 			}
-			else if (LoadFromAssets.IsMatch(self.FontFamily))
+			else if (s_loadFromAssets.Value.IsMatch(self.FontFamily))
 			{
 				result = Typeface.CreateFromAsset(AApplication.Context.Assets, FontNameToFontFile(self.FontFamily));
 			}
@@ -88,7 +88,7 @@ namespace Xamarin.Forms.Platform.Android
 				var style = ToTypefaceStyle(self.FontAttributes);
 				result = Typeface.Create(Typeface.Default, style);
 			}
-			else if (LoadFromAssets.IsMatch(self.FontFamily))
+			else if (s_loadFromAssets.Value.IsMatch(self.FontFamily))
 			{
 				result = Typeface.CreateFromAsset(AApplication.Context.Assets, FontNameToFontFile(self.FontFamily));
 			}


### PR DESCRIPTION
### Description of Change ###

Defers the creation of the regex used to determine whether the font needs to be loaded from an assset. Reduces overhead if no font with a FontFamily property is ever used in the application.

### Bugs Fixed ###

- None

### API Changes ###

- None

### Behavioral Changes ###

- None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
