### PR TITLE
[WinRT/UWP] Enable selection in password entry

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45277.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45277.cs
@@ -1,0 +1,50 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 45277, "[WinRT/UWP] Entry with IsPassword = true does not allow selection of characters", PlatformAffected.WinRT)]
+	public class Bugzilla45277 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var passwordTextLabel = new Label
+			{
+				Text = "[No Password Text Yet]"
+			};
+			var passwordEntry = new Entry
+			{
+				IsPassword = true,
+				Placeholder = "Enter password"
+			};
+			passwordEntry.Completed += (sender, args) => DisplayAlert("Enter pressed", "OK", "Cancel");
+			passwordEntry.TextChanged += (sender, args) =>
+			{
+				passwordTextLabel.Text = passwordEntry.Text;
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = "The below label should allow Paste and Select All commands; however, copying via keyboard should not work."
+					},
+					passwordEntry,
+					new Entry
+					{
+						Placeholder = "Entry for easily testing your paste functionality"
+					},
+					passwordTextLabel
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -167,6 +167,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45027.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45330.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44955.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45277.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />

--- a/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -44,6 +45,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		bool _cachedSpellCheckSetting;
 		CancellationTokenSource _cts;
 		bool _internalChangeFlag;
+		int _cachedSelectionLength;
 
 		public FormsTextBox()
 		{
@@ -237,19 +239,65 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnSelectionChanged(object sender, RoutedEventArgs routedEventArgs)
 		{
-			if (!IsPassword)
-			{
-				return;
-			}
+			// Cache this value for later use as explained in OnKeyDown below
+			_cachedSelectionLength = SelectionLength;
+		}
 
-			// Prevent the user from selecting any text in the password box by forcing all selection
-			// to zero-length at the end of the Text
-			// This simulates the "do not allow clipboard copy" behavior the PasswordBox control has
-			if (SelectionLength > 0 || SelectionStart < Text.Length)
+		// Because the implementation of a password entry is based around inheriting from TextBox (via FormsTextBox), there
+		// are some inaccuracies in the behavior. OnKeyDown is what needs to be used for a workaround in this case because 
+		// there's no easy way to disable specific keyboard shortcuts in a TextBox, so key presses are being intercepted and 
+		// handled accordingly.
+		protected override void OnKeyDown(KeyRoutedEventArgs e)
+		{
+			if (IsPassword)
 			{
-				SelectionLength = 0;
-				SelectionStart = Text.Length;
+				// The ctrlDown flag is used to track if the Ctrl key is pressed; if it's actively being used and the most recent
+				// key to trigger OnKeyDown, then treat it as handled.
+				var ctrlDown = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+
+				if (ctrlDown && e.Key == VirtualKey.Control)
+				{
+					e.Handled = true;
+				}
+				// The shift, tab, and directional (Home/End/PgUp/PgDown included) keys can be used to select text and should otherwise
+				// be ignored.
+				else if (
+					e.Key == VirtualKey.Shift ||
+					e.Key == VirtualKey.Tab ||
+					e.Key == VirtualKey.Left ||
+					e.Key == VirtualKey.Right ||
+					e.Key == VirtualKey.Up ||
+					e.Key == VirtualKey.Down ||
+					e.Key == VirtualKey.Home ||
+					e.Key == VirtualKey.End ||
+					e.Key == VirtualKey.PageUp ||
+					e.Key == VirtualKey.PageDown)
+				{
+					base.OnKeyDown(e);
+					return;
+				}
+				// For anything else, continue on (calling base.OnKeyDown) and then if Ctrl is still being pressed, do nothing about it.
+				// The tricky part here is that the SelectionLength value needs to be cached because in an example where the user entered
+				// '123' into the field and selects all of it, the moment that any character key is pressed to replace the entire string,
+				// the SelectionLength is equal to zero, which is not what's desired. Entering a key will thus remove the selected number
+				// of characters from the Text value. OnKeyDown is fortunately called before OnSelectionChanged which enables this.
+				else
+				{
+					// If the C or X keys (copy/cut) are pressed while Ctrl is active, ignore handing them at all. Undo and Redo (Z/Y) should 
+					// be ignored as well as this emulates the regular behavior of a PasswordBox.
+					if ((e.Key == VirtualKey.C || e.Key == VirtualKey.X || e.Key == VirtualKey.Z || e.Key == VirtualKey.Y) && ctrlDown)
+					{
+						e.Handled = false;
+						return;
+					}
+
+					base.OnKeyDown(e);
+					if (_cachedSelectionLength > 0 && !ctrlDown)
+						Text = Text.Remove(SelectionStart, _cachedSelectionLength);
+				}
 			}
+			else
+				base.OnKeyDown(e);
 		}
 
 		void OnTextChanged(object sender, Windows.UI.Xaml.Controls.TextChangedEventArgs textChangedEventArgs)

--- a/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
@@ -255,13 +255,9 @@ namespace Xamarin.Forms.Platform.WinRT
 				// key to trigger OnKeyDown, then treat it as handled.
 				var ctrlDown = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
 
-				if (ctrlDown && e.Key == VirtualKey.Control)
-				{
-					e.Handled = true;
-				}
 				// The shift, tab, and directional (Home/End/PgUp/PgDown included) keys can be used to select text and should otherwise
 				// be ignored.
-				else if (
+				if (
 					e.Key == VirtualKey.Shift ||
 					e.Key == VirtualKey.Tab ||
 					e.Key == VirtualKey.Left ||


### PR DESCRIPTION
### Description of Change ###

There is presently an issue in WinRT/UWP where entries with `Password = true` do not allow selection of text. This is a larger issue on the desktop than mobile, but is an issue for both. What this PR changes in particular is that selection is allowed, but also handles a variety of other inputs. The code is appropriately commented due to being a process that involves

- Caching the size of the selection of text for deletion purposes
- Caching whether the Ctrl key is in a pressed state and handling the key routing
- Handling any use of the Shift key, Tab key, arrow keys, or Home/End/PgUp/PgDown keys (which can be used to select text or leave the entry)
- Handle any use of the Copy (C), Cut (X), Undo (Z), or Redo (Y) keys in the instance that the Ctrl key is in being actively pressed to prevent those shortcuts from working (which emulates the behavior of a `PasswordBox`)
- Remove any text if the aforementioned cached selection size is greater than 0 (in other instances a backspace will simply remove the single character)

Note that this should fix the core problem with being unable to select the text, but does not fix three issues:
- If the back button is pressed with the cursor mid-password, the trailing character gets removed.
- Inserting a character/pasting into in the middle of the password causes unintended results.
- The context menu still permits use those keyboard shortcuts which are otherwise disabled. An issue is that WinRT does not support the use of `Clipboard` so this makes things more difficult. If the text is copied, however, it is only copied as obfuscation characters. This can possibly be revisited in the future.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=45277

### API Changes ###

None

### Behavioral Changes ###

The only one that was very clearly visible was the fact that the password characters can be copied, but again, those are only the obfuscation characters (●).

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
