### PR TITLE
Add MonoAndroid70 to Forms/Map .nuspec 

### DIFF
--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -22,6 +22,12 @@
         <dependency id="Xamarin.Android.Support.v7.AppCompat" version="[23.3.0]"/>
         <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
       </group>
+      <group targetFramework="MonoAndroid70">
+        <dependency id="Xamarin.GooglePlayServices.Maps" version="29.0.0.1"/>
+        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0"/>
+        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0"/>
+        <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
+      </group>
     </dependencies>
     <references>
       <group targetFramework="portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10">

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -23,6 +23,13 @@
         <dependency id="Xamarin.Android.Support.v7.CardView" version="[23.3.0]"/>
         <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="[23.3.0]"/>
       </group>
+      <group targetFramework="MonoAndroid70">
+        <dependency id="Xamarin.Android.Support.v4" version="23.3.0"/>
+        <dependency id="Xamarin.Android.Support.Design" version="23.3.0"/>
+        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0"/>
+        <dependency id="Xamarin.Android.Support.v7.CardView" version="23.3.0"/>
+        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0"/>
+      </group>
     </dependencies>
     <references>
        <group targetFramework="portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20">

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -23,10 +23,11 @@ using Fragment = Android.Support.V4.App.Fragment;
 using FragmentManager = Android.Support.V4.App.FragmentManager;
 using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
 using Object = Java.Lang.Object;
+using static Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
-	public class NavigationPageRenderer : VisualElementRenderer<NavigationPage>, IManageFragments
+	public class NavigationPageRenderer : VisualElementRenderer<NavigationPage>, IManageFragments, IOnClickListener
 	{
 		readonly List<Fragment> _fragmentStack = new List<Fragment>();
 
@@ -144,7 +145,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				if (_toolbar != null)
 				{
-					_toolbar.NavigationClick -= BarOnNavigationClick;
+					_toolbar.SetNavigationOnClickListener(null);
 					_toolbar.Dispose();
 					_toolbar = null;
 				}
@@ -392,7 +393,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			valueAnim.Start();
 		}
 
-		void BarOnNavigationClick(object sender, AToolbar.NavigationClickEventArgs navigationClickEventArgs)
+		public void OnClick(AView v)
 		{
 			Element?.PopAsync();
 		}
@@ -558,7 +559,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AToolbar oldToolbar = _toolbar;
 
 			_toolbar.RemoveFromParent();
-			_toolbar.NavigationClick -= BarOnNavigationClick;
+			_toolbar.SetNavigationOnClickListener(null);
 			_toolbar = null;
 
 			SetupToolbar();
@@ -582,7 +583,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			else
 				bar = new AToolbar(context);
 
-			bar.NavigationClick += BarOnNavigationClick;
+			bar.SetNavigationOnClickListener(this);
 
 			AddView(bar);
 			_toolbar = bar;


### PR DESCRIPTION
Users want to upgrade to Xamarin.Support.* v25 but cannot because XF locks its version at v23 (in .nuspec, see version="[23.3.0]"). If we simply unlocked the version then they can reference v25 however those assemblies reference Android SDK API 25 which if not installed will break their build. So we have to make sure that by default, when they upgrade, API 25 is present. The VS SDK installer is not owned by Xamarin's division so are forced to wait till May for the installer to add API 25 during a VS upgrade. That upgrade will also include Xamarin.Android (XA) which will support MonoAndroid70. XA will automatically update Android csproj files at load time to MonoAndroid71. Hence, for users that simply upgrade VS in May, XF knows that if referring project is MonoAndroid70 or greater than API 25 is present and XS.* v25 can be referenced hence the change in the .nuspec.

XS v25 also removed an event signature so we changed to using the java methods to hook and unhook hence the source code changes.