### PR TITLE
Pool and reuse MKMapView instances on iOS 9 as well as iOS 10

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Xamarin.Forms.Maps;
 
 #if UITEST
+using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
 using NUnit.Framework;
 #endif
@@ -14,6 +15,9 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
+#if UITEST
+	[Category(UITestCategories.Maps)]
+#endif
 	[Issue(IssueTracker.Bugzilla, 39489, "Memory leak when using NavigationPage with Maps", PlatformAffected.Android | PlatformAffected.iOS)]
 	public class Bugzilla39489 : TestNavigationPage
 	{

--- a/Xamarin.Forms.Core.iOS.UITests/UITestCategories.cs
+++ b/Xamarin.Forms.Core.iOS.UITests/UITestCategories.cs
@@ -29,6 +29,7 @@
 		public const string TimePicker = "TimePicker";
 		public const string ToolbarItem = "ToolbarItem";
 		public const string WebView = "WebView";
+		public const string Maps = "Maps";
 
 		public const string ManualReview = "ManualReview";
 	}

--- a/Xamarin.Forms.Maps.iOS/FormsMaps.cs
+++ b/Xamarin.Forms.Maps.iOS/FormsMaps.cs
@@ -7,6 +7,7 @@ namespace Xamarin
 	{
 		static bool s_isInitialized;
 		static bool? s_isiOs8OrNewer;
+		static bool? s_isiOs9OrNewer;
 		static bool? s_isiOs10OrNewer;
 
 		internal static bool IsiOs8OrNewer
@@ -16,6 +17,16 @@ namespace Xamarin
 				if (!s_isiOs8OrNewer.HasValue)
 					s_isiOs8OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(8, 0);
 				return s_isiOs8OrNewer.Value;
+			}
+		}
+
+		internal static bool IsiOs9OrNewer
+		{
+			get
+			{
+				if (!s_isiOs9OrNewer.HasValue)
+					s_isiOs9OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(9, 0);
+				return s_isiOs9OrNewer.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -137,13 +137,13 @@ namespace Xamarin.Forms.Maps.iOS
 			return Control.GetSizeRequest(widthConstraint, heightConstraint);
 		}
 
-		// iOS 10 has some issues with releasing memory from map views; each one we create allocates
+		// iOS 9/10 have some issues with releasing memory from map views; each one we create allocates
 		// a bunch of memory we can never get back. Until that's fixed, we'll just reuse MKMapViews
 		// as much as possible to prevent creating new ones and losing more memory
 
 		// For the time being, we don't want ViewRenderer handling disposal of the MKMapView
-		// if we're on iOS 10; during Dispose we'll be putting the MKMapView in a pool instead
-		protected override bool ManageNativeControlLifetime => !FormsMaps.IsiOs10OrNewer;
+		// if we're on iOS 9 or 10; during Dispose we'll be putting the MKMapView in a pool instead
+		protected override bool ManageNativeControlLifetime => !FormsMaps.IsiOs9OrNewer;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -170,14 +170,14 @@ namespace Xamarin.Forms.Maps.iOS
 				mkMapView.Delegate = null;
 				mkMapView.RemoveFromSuperview();
 
-				if (FormsMaps.IsiOs10OrNewer)
+				if (FormsMaps.IsiOs9OrNewer)
 				{
 					// This renderer is done with the MKMapView; we can put it in the pool
 					// for other rendererers to use in the future
 					MapPool.Add(mkMapView);
 				}
 
-				// For iOS versions < 10, the MKMapView will be disposed in ViewRenderer's Dispose method
+				// For iOS versions < 9, the MKMapView will be disposed in ViewRenderer's Dispose method
 
 				if (_locationManager != null)
 				{
@@ -208,7 +208,7 @@ namespace Xamarin.Forms.Maps.iOS
 				{
 					MKMapView mapView = null;
 
-					if (FormsMaps.IsiOs10OrNewer)
+					if (FormsMaps.IsiOs9OrNewer)
 					{
 						// See if we've got an MKMapView available in the pool; if so, use it
 						mapView = MapPool.Get();
@@ -216,7 +216,7 @@ namespace Xamarin.Forms.Maps.iOS
 
 					if (mapView == null)
 					{
-						// If this is iOS 9 or lower, or if there weren't any MKMapViews in the pool,
+						// If this is iOS 8 or lower, or if there weren't any MKMapViews in the pool,
 						// create a new one
 						mapView = new MKMapView(RectangleF.Empty);
 					}


### PR DESCRIPTION
### Description of Change ###

This is the same fix as [PR 467](https://github.com/xamarin/Xamarin.Forms/pull/467), but applied to iOS 9. MKMapView instances are pooled and reused to avoid leaking memory.

### Bugs Fixed ###

- Failing test 39489 on iOS 9

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
