### PR TITLE
Update the mismatch of Pink Color value

### DIFF
--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -461,7 +461,7 @@ namespace Xamarin.Forms
 		public static readonly Color PapayaWhip = FromRgb(255, 239, 213);
 		public static readonly Color PeachPuff = FromRgb(255, 218, 185);
 		public static readonly Color Peru = FromRgb(205, 133, 63);
-		public static readonly Color Pink = FromRgb(255, 192, 203);
+		public static readonly Color Pink = FromRgb(255, 102, 255);
 		public static readonly Color Plum = FromRgb(221, 160, 221);
 		public static readonly Color PowderBlue = FromRgb(176, 224, 230);
 		public static readonly Color Purple = FromRgb(128, 0, 128);


### PR DESCRIPTION
Color Pink value is set to different from what Xamarin spec document says on the following link  https://developer.xamarin.com/api/type/Xamarin.Forms.Color/
On the spec, it says Color.Pink is (255, 102, 255), not (255, 192, 203).

### Description of Change ###

Change the Pink color value to what Xamarin API Spec document says

### Bugs Fixed ###

N/A

### API Changes ###

No API Changes

### Behavioral Changes ###

The color of Pink will be changed

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
