### PR TITLE
[XamlC] allow xml-elements as Setter/Trigger Values

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
@@ -5,6 +5,7 @@ using Mono.Cecil.Cil;
 
 using Xamarin.Forms.Xaml;
 using Xamarin.Forms.Build.Tasks;
+using System.Xml;
 
 namespace Xamarin.Forms.Core.XamlC
 {
@@ -12,7 +13,12 @@ namespace Xamarin.Forms.Core.XamlC
 	{
 		public IEnumerable<Instruction> ProvideValue(VariableDefinitionReference vardefref, ModuleDefinition module, BaseNode node, ILContext context)
 		{
-			var valueNode = ((IElementNode)node).Properties[new XmlName("", "Value")];
+			INode valueNode = null;
+			if (!((IElementNode)node).Properties.TryGetValue(new XmlName("", "Value"), out valueNode) && ((IElementNode)node).CollectionItems.Count == 1)
+				valueNode = ((IElementNode)node).CollectionItems[0];
+
+			if (valueNode == null)
+				throw new XamlParseException("Missing Value for Setter", (IXmlLineInfo)node);
 
 			//if it's an elementNode, there's probably no need to convert it
 			if (valueNode is IElementNode)

--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/TriggerValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/TriggerValueProvider.cs
@@ -5,6 +5,7 @@ using Mono.Cecil.Cil;
 
 using Xamarin.Forms.Xaml;
 using Xamarin.Forms.Build.Tasks;
+using System.Xml;
 
 namespace Xamarin.Forms.Core.XamlC
 {
@@ -12,7 +13,12 @@ namespace Xamarin.Forms.Core.XamlC
 	{
 		public IEnumerable<Instruction> ProvideValue(VariableDefinitionReference vardefref, ModuleDefinition module, BaseNode node, ILContext context)
 		{
-			var valueNode = ((IElementNode)node).Properties[new XmlName("", "Value")];
+			INode valueNode = null;
+			if (!((IElementNode)node).Properties.TryGetValue(new XmlName("", "Value"), out valueNode) && ((IElementNode)node).CollectionItems.Count == 1)
+				valueNode = ((IElementNode)node).CollectionItems[0];
+
+			if (valueNode == null)
+				throw new XamlParseException("Missing Value for Trigger", (IXmlLineInfo)node);
 
 			//if it's an elementNode, there's probably no need to convert it
 			if (valueNode is IElementNode)

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz51567.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz51567.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Bz51567">
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<Style x:Key="ListText" TargetType="Label">
+				<Setter Property="TextColor" Value="Black" />
+				<Setter Property="FontSize">
+					<OnPlatform x:TypeArguments="x:Double" iOS="17" Android="17" WinPhone="20" />
+				</Setter>
+			</Style>
+		</ResourceDictionary>
+	</ContentPage.Resources>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz51567.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz51567.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz51567 : ContentPage
+	{
+		public Bz51567()
+		{
+			InitializeComponent();
+		}
+
+		public Bz51567(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void SetterWithElementValue(bool useCompiledXaml)
+			{
+				var page = new Bz51567(useCompiledXaml);
+				var style = page.Resources["ListText"] as Style;
+				var setter = style.Setters[1];
+				Assert.NotNull(setter);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -409,6 +409,9 @@
     <Compile Include="Issues\Bz45179.xaml.cs">
       <DependentUpon>Bz45179.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz51567.xaml.cs">
+      <DependentUpon>Bz51567.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -737,6 +740,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz45179.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz51567.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

[XamlC] allow xml-elements as Setter/Trigger Values

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=51567

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense