### PR TITLE
[iOS] Remove "Enabled" usage on AdjustsFontSizeToFitWidth

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/EntryPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/EntryPageiOS.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 					new Button
 					{
 						Text = "Toggle AdjustsFontSizeToFitWidth",
-						Command = new Command(() => entry.On<iOS>().SetAdjustsFontSizeToFitWidthEnabled(!entry.On<iOS>().IsAdjustsFontSizeToFitWidthEnabled()))
+						Command = new Command(() => entry.On<iOS>().SetAdjustsFontSizeToFitWidth(!entry.On<iOS>().AdjustsFontSizeToFitWidth()))
 					}
 				}
 			};

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Entry.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Entry.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 	public static class Entry
 	{
 		public static readonly BindableProperty AdjustsFontSizeToFitWidthProperty =
-			BindableProperty.Create("AdjustsFontSizeToFitWidthEnabled", typeof(bool),
+			BindableProperty.Create("AdjustsFontSizeToFitWidth", typeof(bool),
 			typeof(Entry), false);
 
 		public static bool GetAdjustsFontSizeToFitWidth(BindableObject element)
@@ -20,12 +20,12 @@ namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 			element.SetValue(AdjustsFontSizeToFitWidthProperty, value);
 		}
 
-		public static bool IsAdjustsFontSizeToFitWidthEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		public static bool AdjustsFontSizeToFitWidth(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetAdjustsFontSizeToFitWidth(config.Element);
 		}
 
-		public static IPlatformElementConfiguration<iOS, FormsElement> SetAdjustsFontSizeToFitWidthEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetAdjustsFontSizeToFitWidth(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetAdjustsFontSizeToFitWidth(config.Element, value);
 			return config;

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -144,7 +144,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateAdjustsFontSizeToFitWidth()
 		{
-			Control.AdjustsFontSizeToFitWidth = Element.OnThisPlatform().IsAdjustsFontSizeToFitWidthEnabled();
+			Control.AdjustsFontSizeToFitWidth = Element.OnThisPlatform().AdjustsFontSizeToFitWidth();
 		}
 
 		void UpdateFont()

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Entry.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.iOSSpecific/Entry.xml
@@ -14,6 +14,26 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
+    <Member MemberName="AdjustsFontSizeToFitWidth">
+      <MemberSignature Language="C#" Value="public static bool AdjustsFontSizeToFitWidth (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AdjustsFontSizeToFitWidth(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="AdjustsFontSizeToFitWidthProperty">
       <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty AdjustsFontSizeToFitWidthProperty;" />
       <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty AdjustsFontSizeToFitWidthProperty" />
@@ -89,26 +109,6 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="IsAdjustsFontSizeToFitWidthEnabled">
-      <MemberSignature Language="C#" Value="public static bool IsAdjustsFontSizeToFitWidthEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsAdjustsFontSizeToFitWidthEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt;" RefType="this" />
-      </Parameters>
-      <Docs>
-        <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="SetAdjustsFontSizeToFitWidth">
       <MemberSignature Language="C#" Value="public static void SetAdjustsFontSizeToFitWidth (Xamarin.Forms.BindableObject element, bool value);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetAdjustsFontSizeToFitWidth(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
@@ -130,9 +130,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="SetAdjustsFontSizeToFitWidthEnabled">
-      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; SetAdjustsFontSizeToFitWidthEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config, bool value);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; SetAdjustsFontSizeToFitWidthEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config, bool value) cil managed" />
+    <Member MemberName="SetAdjustsFontSizeToFitWidth">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; SetAdjustsFontSizeToFitWidth (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.iOS,Xamarin.Forms.Entry&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; SetAdjustsFontSizeToFitWidth(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.iOS, class Xamarin.Forms.Entry&gt; config, bool value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>


### PR DESCRIPTION
### Description of Change ###

There was lingering usage of "Enabled" in naming from #526. This corrects those names while we should still be able to since this is only in 2.3.4-pre1.

### Bugs Fixed ###

N/A

### API Changes ###

See changes

### Behavioral Changes ###

N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
