### PR TITLE
[A]Fix potential crash when calling ClearFocus in SearchBarRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool SearchView.IOnQueryTextListener.OnQueryTextSubmit(string query)
 		{
 			((ISearchBarController)Element).OnSearchButtonPressed();
-			Control.ClearFocus();
+			ClearFocus(Control);
 			return true;
 		}
 
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Platform.Android
 				_inputType = InputTypes.ClassText | InputTypes.TextFlagAutoComplete | InputTypes.TextFlagNoSuggestions;
 			}
 
-			searchView.ClearFocus();
+			ClearFocus(searchView);
 			UpdatePlaceholder();
 			UpdateText();
 			UpdateEnabled();
@@ -113,7 +113,7 @@ namespace Xamarin.Forms.Platform.Android
 		internal override void OnNativeFocusChanged(bool hasFocus)
 		{
 			if (hasFocus && !Element.IsEnabled)
-				Control.ClearFocus();
+				ClearFocus(Control);
 		}
 
 		void UpdateAlignment()
@@ -148,12 +148,24 @@ namespace Xamarin.Forms.Platform.Android
 			SearchView control = Control;
 			if (!model.IsEnabled)
 			{
-				control.ClearFocus();
+				ClearFocus(control);
 				// removes cursor in SearchView
 				control.SetInputType(InputTypes.Null);
 			}
 			else
 				control.SetInputType(_inputType);
+		}
+
+		void ClearFocus(SearchView view)
+		{
+			try
+			{
+				view.ClearFocus();
+			}
+			catch (Java.Lang.UnsupportedOperationException)
+			{
+				// silently catch these as they happen in the previewer due to some bugs in upstread android
+			}
 		}
 
 		void UpdateFont()


### PR DESCRIPTION
### Description of Change ###

Adds a try/catch around API that fails in previewer specific situation.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

Works now with previewer

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
