### PR TITLE
[Core] Fix NullReferenceException in VisualElement finalizer.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51503.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51503.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 51503, "NullReferenceException on VisualElement Finalize", PlatformAffected.All)]
+	public class Bugzilla51503 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			PushAsync(new RootPage());
+		}
+
+		[Preserve(AllMembers = true)]
+		class RootPage : ContentPage
+		{
+			public RootPage()
+			{
+				Button button = new Button
+				{
+					AutomationId = "Button",
+					Text = "Open"					
+				};
+
+				button.Clicked += Button_Clicked;
+
+				Content = button;
+			}
+
+			async void Button_Clicked(object sender, EventArgs e)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+
+				await Navigation.PushAsync(new ChildPage());
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class ChildPage : ContentPage
+		{
+			public ChildPage()
+			{
+				Content = new Label
+				{
+					AutomationId = "VisualElement",
+					Text = "Navigate 3 times to this page",
+					Triggers = 
+					{
+						new EventTrigger()
+					}
+				};
+			}
+		}
+
+#if UITEST
+[Test]
+		public void Issue51503Test()
+		{
+			for (int i = 0; i < 3; i++)
+			{
+				RunningApp.WaitForElement(q => q.Marked("Button"));
+				
+				RunningApp.Tap(q => q.Marked("Button"));
+
+				RunningApp.WaitForElement(q => q.Marked("VisualElement"));
+
+				RunningApp.Back();
+			}
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -222,6 +222,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla28650.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37431.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44777.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51503.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -790,7 +790,7 @@ namespace Xamarin.Forms
 			}
 
 			if (!GetIsDefault(TriggersProperty)) {
-				var triggers = GetValue(TriggersProperty) as AttachedCollection<Trigger>;
+				var triggers = GetValue(TriggersProperty) as AttachedCollection<TriggerBase>;
 				triggers.DetachFrom(this);
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

When `EventTrigger`, `DataTrigger` or `MultiTrigger` are attached to a `VisualElement`, the finalizer throw a `NullReferenceException` which crash the application after the page disappear. 
It's because these inherit from `TriggerBase` and not `Trigger`.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=51503

### API Changes ###
Nothing

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
