### PR TITLE
[iOS] Fix NRE when re-adding header/footer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -414,6 +414,8 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (_footerRenderer != null)
 			{
 				Control.TableFooterView = null;
+				_footerRenderer.Element.MeasureInvalidated -= OnFooterMeasureInvalidated;
+
 				var platform = _footerRenderer.Element.Platform as Platform;
 				if (platform != null)
 					platform.DisposeModelAndChildrenRenderers(_footerRenderer.Element);
@@ -458,6 +460,8 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (_headerRenderer != null)
 			{
 				Control.TableHeaderView = null;
+				_headerRenderer.Element.MeasureInvalidated -= OnHeaderMeasureInvalidated;
+				
 				var platform = _headerRenderer.Element.Platform as Platform;
 				if (platform != null)
 					platform.DisposeModelAndChildrenRenderers(_headerRenderer.Element);


### PR DESCRIPTION
### Description of Change ###

In the case where the footer view was removed, the event handler for `_footerRenderer.Element.MeasureInvalidated` was not removed so re-adding a footer would fire off the event while `_footerRenderer` was still null and [cause an NRE](https://github.com/jimmgarrido/Xamarin.Forms/blob/a4ba715083a4b1545f44f6bacd6c8699076ac172/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs#L296).

The same thing would also happen with a header.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=51652

### API Changes ###

None

### Behavioral Changes ###


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
