### PR TITLE
Use a prototype TextBlock to resolve theme resources on Windows

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43783.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43783.cs
@@ -1,0 +1,30 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 43783, "[WP8.1] Most Device Styles do not render correctly in Windows Phone 8.1 (RT) applications", PlatformAffected.WinPhone)]
+	public class Bugzilla43783 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Device";
+
+			Content = new StackLayout
+			{
+				Children = {
+					new Label { Margin = new Thickness(10), Text = "The Labels for Body, Caption, List Item, List Item Detail, and No Style should not all look the same. If all of them look the same, this test has failed."},
+					new Label { Text = "Title style", Style = Device.Styles.TitleStyle },
+					new Label { Text = "Subtitle style", Style = Device.Styles.SubtitleStyle },
+					new Label { Text = "Body style", Style = Device.Styles.BodyStyle },
+					new Label { Text = "Caption style", Style = Device.Styles.CaptionStyle },
+					new Label { Text = "List item text style", Style = Device.Styles.ListItemTextStyle },
+					new Label { Text = "List item detail text style", Style = Device.Styles.ListItemDetailTextStyle },
+					new Label { Text = "No style" }
+				}
+			};
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -141,6 +141,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43663.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43735.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43783.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44944.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />

--- a/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
@@ -8,6 +8,8 @@ namespace Xamarin.Forms.Platform.WinRT
 	internal sealed class WindowsPhoneResourcesProvider
 		: ISystemResourcesProvider
 	{
+		readonly TextBlock _prototype = new TextBlock();
+
 		public IResourceDictionary GetSystemResources()
 		{
 			return new ResourceDictionary
@@ -36,8 +38,6 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			return formsStyle;
 		}
-
-		readonly TextBlock _prototype = new TextBlock();
 
 		static FontAttributes ToAttributes(FontWeight fontWeight)
 		{

--- a/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
@@ -8,33 +8,33 @@ namespace Xamarin.Forms.Platform.WinRT
 	internal sealed class WindowsPhoneResourcesProvider
 		: ISystemResourcesProvider
 	{
-		readonly TextBlock _prototype = new TextBlock();
-
 		public IResourceDictionary GetSystemResources()
 		{
+			var prototype = new TextBlock();
+			
 			return new ResourceDictionary
 			{
-				[Device.Styles.TitleStyleKey] = GetStyle("HeaderTextBlockStyle"),
-				[Device.Styles.SubtitleStyleKey] = GetStyle("SubheaderTextBlockStyle"),
-				[Device.Styles.BodyStyleKey] = GetStyle("BodyTextBlockStyle"),
-				[Device.Styles.CaptionStyleKey] = GetStyle("BodyTextBlockStyle"),
-				[Device.Styles.ListItemTextStyleKey] = GetStyle("ListViewItemTextBlockStyle"),
-				[Device.Styles.ListItemDetailTextStyleKey] = GetStyle("ListViewItemContentTextBlockStyle")
+				[Device.Styles.TitleStyleKey] = GetStyle("HeaderTextBlockStyle", prototype),
+				[Device.Styles.SubtitleStyleKey] = GetStyle("SubheaderTextBlockStyle", prototype),
+				[Device.Styles.BodyStyleKey] = GetStyle("BodyTextBlockStyle", prototype),
+				[Device.Styles.CaptionStyleKey] = GetStyle("BodyTextBlockStyle", prototype),
+				[Device.Styles.ListItemTextStyleKey] = GetStyle("ListViewItemTextBlockStyle", prototype),
+				[Device.Styles.ListItemDetailTextStyleKey] = GetStyle("ListViewItemContentTextBlockStyle", prototype)
 			};
 		}
 
-		Style GetStyle(object nativeKey)
+		static Style GetStyle(object nativeKey, TextBlock prototype)
 		{
 			var style = (WStyle)Windows.UI.Xaml.Application.Current.Resources[nativeKey];
 
-			_prototype.Style = style;
+			prototype.Style = style;
 
 			var formsStyle = new Style(typeof(Label));
 
-			formsStyle.Setters.Add(Label.FontSizeProperty, _prototype.FontSize);
-			formsStyle.Setters.Add(Label.FontFamilyProperty, _prototype.FontFamily.Source);
-			formsStyle.Setters.Add(Label.FontAttributesProperty, ToAttributes(_prototype.FontWeight));
-			formsStyle.Setters.Add(Label.LineBreakModeProperty, ToLineBreakMode(_prototype.TextWrapping));
+			formsStyle.Setters.Add(Label.FontSizeProperty, prototype.FontSize);
+			formsStyle.Setters.Add(Label.FontFamilyProperty, prototype.FontFamily.Source);
+			formsStyle.Setters.Add(Label.FontAttributesProperty, ToAttributes(prototype.FontWeight));
+			formsStyle.Setters.Add(Label.LineBreakModeProperty, ToLineBreakMode(prototype.TextWrapping));
 
 			return formsStyle;
 		}

--- a/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/WindowsPhoneResourcesProvider.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Windows.UI.Text;
+﻿using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using WStyle = Windows.UI.Xaml.Style;
 
 namespace Xamarin.Forms.Platform.WinRT
 {
@@ -12,89 +10,50 @@ namespace Xamarin.Forms.Platform.WinRT
 	{
 		public IResourceDictionary GetSystemResources()
 		{
-			var windowsResources = Windows.UI.Xaml.Application.Current.Resources;
-
-			var resources = new ResourceDictionary ();
-			resources[Device.Styles.TitleStyleKey] = GetStyle ("HeaderTextBlockStyle");
-			resources[Device.Styles.SubtitleStyleKey] = GetStyle ("SubheaderTextBlockStyle");
-			resources[Device.Styles.BodyStyleKey] = GetStyle ("BodyTextBlockStyle");
-			resources[Device.Styles.CaptionStyleKey] = GetStyle ("BodyTextBlockStyle");
-			resources[Device.Styles.ListItemTextStyleKey] = GetStyle ("ListViewItemTextBlockStyle");
-			resources[Device.Styles.ListItemDetailTextStyleKey] = GetStyle ("ListViewItemContentTextBlockStyle");
-			return resources;
+			return new ResourceDictionary
+			{
+				[Device.Styles.TitleStyleKey] = GetStyle("HeaderTextBlockStyle"),
+				[Device.Styles.SubtitleStyleKey] = GetStyle("SubheaderTextBlockStyle"),
+				[Device.Styles.BodyStyleKey] = GetStyle("BodyTextBlockStyle"),
+				[Device.Styles.CaptionStyleKey] = GetStyle("BodyTextBlockStyle"),
+				[Device.Styles.ListItemTextStyleKey] = GetStyle("ListViewItemTextBlockStyle"),
+				[Device.Styles.ListItemDetailTextStyleKey] = GetStyle("ListViewItemContentTextBlockStyle")
+			};
 		}
 
-		Style GetStyle (object nativeKey)
+		Style GetStyle(object nativeKey)
 		{
-			var style = (Windows.UI.Xaml.Style) Windows.UI.Xaml.Application.Current.Resources[nativeKey];
-			style = GetAncestorSetters(style);
+			var style = (WStyle)Windows.UI.Xaml.Application.Current.Resources[nativeKey];
 
-			var formsStyle = new Style (typeof (Label));
-			foreach (var b in style.Setters) {
-				var setter = b as Windows.UI.Xaml.Setter;
-				if (setter == null)
-					continue;
+			_prototype.Style = style;
 
-				// TODO: Need to implement a stealth pass-through for things we don't support
+			var formsStyle = new Style(typeof(Label));
 
-				if (setter.Property == TextBlock.FontSizeProperty)
-					formsStyle.Setters.Add (Label.FontSizeProperty, setter.Value);
-				else if (setter.Property == TextBlock.FontFamilyProperty)
-					formsStyle.Setters.Add (Label.FontFamilyProperty, setter.Value);
-				else if (setter.Property == TextBlock.FontWeightProperty)
-					formsStyle.Setters.Add (Label.FontAttributesProperty, ToAttributes (Convert.ToUInt16 (setter.Value)));
-				else if (setter.Property == TextBlock.TextWrappingProperty)
-					formsStyle.Setters.Add (Label.LineBreakModeProperty, ToLineBreakMode ((TextWrapping) setter.Value));
-			}
+			formsStyle.Setters.Add(Label.FontSizeProperty, _prototype.FontSize);
+			formsStyle.Setters.Add(Label.FontFamilyProperty, _prototype.FontFamily.Source);
+			formsStyle.Setters.Add(Label.FontAttributesProperty, ToAttributes(_prototype.FontWeight));
+			formsStyle.Setters.Add(Label.LineBreakModeProperty, ToLineBreakMode(_prototype.TextWrapping));
 
 			return formsStyle;
 		}
 
-		static Windows.UI.Xaml.Style GetAncestorSetters (Windows.UI.Xaml.Style value)
+		readonly TextBlock _prototype = new TextBlock();
+
+		static FontAttributes ToAttributes(FontWeight fontWeight)
 		{
-			var style = new Windows.UI.Xaml.Style (value.TargetType)
+			if (fontWeight.Weight == FontWeights.Bold.Weight || fontWeight.Weight == FontWeights.SemiBold.Weight 
+				|| fontWeight.Weight == FontWeights.ExtraBold.Weight)
 			{
-				BasedOn = value.BasedOn
-			};
-			foreach (var valSetter in value.Setters)
-			{
-				style.Setters.Add(valSetter);
+				return FontAttributes.Bold;
 			}
 
-			var ancestorStyles = new List<Windows.UI.Xaml.Style> ();
-
-			Windows.UI.Xaml.Style currStyle = style;
-			while (currStyle.BasedOn != null)
-			{
-				ancestorStyles.Add(currStyle.BasedOn);
-				currStyle = currStyle.BasedOn;
-			}
-
-			foreach (var styleParent in ancestorStyles)
-			{
-				foreach (var b in styleParent.Setters)
-				{
-					var parentSetter = b as Windows.UI.Xaml.Setter;
-					if (parentSetter == null)
-						continue;
-
-					var derviedSetter = style.Setters
-						.OfType<Windows.UI.Xaml.Setter> ()
-						.FirstOrDefault (x => x.Property == parentSetter.Property);
-
-					//Ignore any ancestor setters which a child setter has already overridden
-					if (derviedSetter != null)
-						continue;
-					else
-						style.Setters.Add (parentSetter);
-				}
-			}
-			return style;
+			return FontAttributes.None;
 		}
 
-		static LineBreakMode ToLineBreakMode (TextWrapping value)
+		static LineBreakMode ToLineBreakMode(TextWrapping value)
 		{
-			switch (value) {
+			switch (value)
+			{
 				case TextWrapping.Wrap:
 					return LineBreakMode.CharacterWrap;
 				case TextWrapping.WrapWholeWords:
@@ -103,15 +62,6 @@ namespace Xamarin.Forms.Platform.WinRT
 				case TextWrapping.NoWrap:
 					return LineBreakMode.NoWrap;
 			}
-		}
-
-		static FontAttributes ToAttributes (ushort uweight)
-		{
-			if (uweight == FontWeights.Bold.Weight || uweight == FontWeights.SemiBold.Weight || uweight == FontWeights.ExtraBold.Weight) {
-				return FontAttributes.Bold;
-			}
-
-			return FontAttributes.None;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WinRT.Tablet/WindowsResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/WindowsResourcesProvider.cs
@@ -13,38 +13,38 @@ namespace Xamarin.Forms.Platform.WinRT
 {
 	internal sealed class WindowsResourcesProvider : ISystemResourcesProvider
 	{
-		readonly TextBlock _prototype = new TextBlock();
-
 		public IResourceDictionary GetSystemResources()
 		{
+			var prototype = new TextBlock();
+
 			return new ResourceDictionary
 			{
-				[Device.Styles.TitleStyleKey] = GetStyle("HeaderTextBlockStyle"),
-				[Device.Styles.SubtitleStyleKey] = GetStyle("SubheaderTextBlockStyle"),
-				[Device.Styles.BodyStyleKey] = GetStyle("BodyTextBlockStyle"),
-				[Device.Styles.CaptionStyleKey] = GetStyle("CaptionTextBlockStyle"),
-				[Device.Styles.ListItemDetailTextStyleKey] = GetStyle("BodyTextBlockStyle"),
+				[Device.Styles.TitleStyleKey] = GetStyle("HeaderTextBlockStyle", prototype),
+				[Device.Styles.SubtitleStyleKey] = GetStyle("SubheaderTextBlockStyle", prototype),
+				[Device.Styles.BodyStyleKey] = GetStyle("BodyTextBlockStyle", prototype),
+				[Device.Styles.CaptionStyleKey] = GetStyle("CaptionTextBlockStyle", prototype),
+				[Device.Styles.ListItemDetailTextStyleKey] = GetStyle("BodyTextBlockStyle", prototype),
 
 #if WINDOWS_UWP
-				[Device.Styles.ListItemTextStyleKey] = GetStyle("BaseTextBlockStyle"),
+				[Device.Styles.ListItemTextStyleKey] = GetStyle("BaseTextBlockStyle", prototype),
 #else
-				[Device.Styles.ListItemTextStyleKey] = GetStyle("TitleTextBlockStyle"),
+				[Device.Styles.ListItemTextStyleKey] = GetStyle("TitleTextBlockStyle", prototype),
 #endif
 			};
 		}
 
-		Style GetStyle(object nativeKey)
+		Style GetStyle(object nativeKey, TextBlock prototype)
 		{
 			var style = (WStyle)Windows.UI.Xaml.Application.Current.Resources[nativeKey];
 
-			_prototype.Style = style;
+			prototype.Style = style;
 
 			var formsStyle = new Style(typeof(Label));
 
-			formsStyle.Setters.Add(Label.FontSizeProperty, _prototype.FontSize);
-			formsStyle.Setters.Add(Label.FontFamilyProperty, _prototype.FontFamily.Source);
-			formsStyle.Setters.Add(Label.FontAttributesProperty, ToAttributes(_prototype.FontWeight));
-			formsStyle.Setters.Add(Label.LineBreakModeProperty, ToLineBreakMode(_prototype.TextWrapping));
+			formsStyle.Setters.Add(Label.FontSizeProperty, prototype.FontSize);
+			formsStyle.Setters.Add(Label.FontFamilyProperty, prototype.FontFamily.Source);
+			formsStyle.Setters.Add(Label.FontAttributesProperty, ToAttributes(prototype.FontWeight));
+			formsStyle.Setters.Add(Label.LineBreakModeProperty, ToLineBreakMode(prototype.TextWrapping));
 
 			return formsStyle;
 		}

--- a/Xamarin.Forms.Platform.WinRT.Tablet/WindowsResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/WindowsResourcesProvider.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using Windows.UI.Text;
+﻿using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using WStyle = Windows.UI.Xaml.Style;
 
 #if WINDOWS_UWP
 
@@ -15,60 +15,47 @@ namespace Xamarin.Forms.Platform.WinRT
 	{
 		public IResourceDictionary GetSystemResources()
 		{
-			Windows.UI.Xaml.ResourceDictionary windowsResources = Windows.UI.Xaml.Application.Current.Resources;
+			return new ResourceDictionary
+			{
+				[Device.Styles.TitleStyleKey] = GetStyle("HeaderTextBlockStyle"),
+				[Device.Styles.SubtitleStyleKey] = GetStyle("SubheaderTextBlockStyle"),
+				[Device.Styles.BodyStyleKey] = GetStyle("BodyTextBlockStyle"),
+				[Device.Styles.CaptionStyleKey] = GetStyle("CaptionTextBlockStyle"),
+				[Device.Styles.ListItemDetailTextStyleKey] = GetStyle("BodyTextBlockStyle"),
 
-			var resources = new ResourceDictionary();
-			resources[Device.Styles.TitleStyleKey] = GetStyle("HeaderTextBlockStyle");
-			resources[Device.Styles.SubtitleStyleKey] = GetStyle("SubheaderTextBlockStyle");
-			resources[Device.Styles.BodyStyleKey] = GetStyle("BodyTextBlockStyle");
-			resources[Device.Styles.CaptionStyleKey] = GetStyle("CaptionTextBlockStyle");
 #if WINDOWS_UWP
-			resources[Device.Styles.ListItemTextStyleKey] = GetStyle("BaseTextBlockStyle");
+				[Device.Styles.ListItemTextStyleKey] = GetStyle("BaseTextBlockStyle"),
 #else
-			resources[Device.Styles.ListItemTextStyleKey] = GetStyle("TitleTextBlockStyle");
+				[Device.Styles.ListItemTextStyleKey] = GetStyle("TitleTextBlockStyle"),
 #endif
-			resources[Device.Styles.ListItemDetailTextStyleKey] = GetStyle("BodyTextBlockStyle");
-			return resources;
+			};
 		}
 
 		Style GetStyle(object nativeKey)
 		{
-			var style = (Windows.UI.Xaml.Style)Windows.UI.Xaml.Application.Current.Resources[nativeKey];
+			var style = (WStyle)Windows.UI.Xaml.Application.Current.Resources[nativeKey];
+
+			_prototype.Style = style;
 
 			var formsStyle = new Style(typeof(Label));
-			foreach (SetterBase b in style.Setters)
-			{
-				var setter = b as Windows.UI.Xaml.Setter;
-				if (setter == null)
-					continue;
 
-				// TODO: Need to implement a stealth pass-through for things we don't support
-
-				try
-				{
-					if (setter.Property == TextBlock.FontSizeProperty)
-						formsStyle.Setters.Add(Label.FontSizeProperty, setter.Value);
-					else if (setter.Property == TextBlock.FontFamilyProperty)
-						formsStyle.Setters.Add(Label.FontFamilyProperty, setter.Value);
-					else if (setter.Property == TextBlock.FontWeightProperty)
-						formsStyle.Setters.Add(Label.FontAttributesProperty, ToAttributes(Convert.ToUInt16(setter.Value)));
-					else if (setter.Property == TextBlock.TextWrappingProperty)
-						formsStyle.Setters.Add(Label.LineBreakModeProperty, ToLineBreakMode((TextWrapping)setter.Value));
-				}
-				catch (NotImplementedException)
-				{
-					// see https://bugzilla.xamarin.com/show_bug.cgi?id=33135
-					// WinRT implementation of Windows.UI.Xaml.Setter.get_Value is not implemented.
-				}
-			}
+			formsStyle.Setters.Add(Label.FontSizeProperty, _prototype.FontSize);
+			formsStyle.Setters.Add(Label.FontFamilyProperty, _prototype.FontFamily.Source);
+			formsStyle.Setters.Add(Label.FontAttributesProperty, ToAttributes(_prototype.FontWeight));
+			formsStyle.Setters.Add(Label.LineBreakModeProperty, ToLineBreakMode(_prototype.TextWrapping));
 
 			return formsStyle;
 		}
 
-		static FontAttributes ToAttributes(ushort uweight)
+		readonly TextBlock _prototype = new TextBlock();
+
+		static FontAttributes ToAttributes(FontWeight fontWeight)
 		{
-			if (uweight == FontWeights.Bold.Weight || uweight == FontWeights.SemiBold.Weight || uweight == FontWeights.ExtraBold.Weight)
+			if (fontWeight.Weight == FontWeights.Bold.Weight || fontWeight.Weight == FontWeights.SemiBold.Weight 
+				|| fontWeight.Weight == FontWeights.ExtraBold.Weight)
+			{
 				return FontAttributes.Bold;
+			}
 
 			return FontAttributes.None;
 		}

--- a/Xamarin.Forms.Platform.WinRT.Tablet/WindowsResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/WindowsResourcesProvider.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Forms.Platform.WinRT
 {
 	internal sealed class WindowsResourcesProvider : ISystemResourcesProvider
 	{
+		readonly TextBlock _prototype = new TextBlock();
+
 		public IResourceDictionary GetSystemResources()
 		{
 			return new ResourceDictionary
@@ -46,8 +48,6 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			return formsStyle;
 		}
-
-		readonly TextBlock _prototype = new TextBlock();
 
 		static FontAttributes ToAttributes(FontWeight fontWeight)
 		{


### PR DESCRIPTION
### Description of Change ###

On the Windows platforms, the device styles were being retrieved and copied into the Forms resource dictionary by walking up the style tree and retrieving the Setter values. However, this fails when the walk up the style tree encounters a Setter whose value is a binding expression (e.g., to ThemeResource). Because of this, most of the built-in device styles do not render at all on the Windows platforms.

Rather than walk the tree, this change creates a TextBlock, applies the style to it, and retrieves the resolved values for use in the Forms resource dictionary. This allows it to retrieve values which come from ThemeResource bindings. The rendered device styles now match more closely with the values in WinRT apps created in Blend:

[Windows Phone 8.1 Styles before](https://www.dropbox.com/s/4vvwoi32uk6jemp/wp81_before.png?raw=1) 
[Windows Phone 8.1 Styles from Blend](https://www.dropbox.com/s/posfbze82rnqpb5/wp81_blend.png?raw=1)
[Windows Phone 8.1 Styles after](https://www.dropbox.com/s/kbaf7r3y8rrz2zr/wp81_after.png?raw=1)

[Windows 8.1 Styles Before](https://www.dropbox.com/s/nz7ehlve3kgpj45/w81_before.PNG?raw=1)
[Windows 8.1 Styles from Blend](https://www.dropbox.com/s/jif9imaqijbp6fg/w81_blend.PNG?raw=1)
[Windows 8.1 Styles After](https://www.dropbox.com/s/gix3zqy7vksetdi/w81_after.PNG?raw=1)

This also applies to UWP, but I got tired of taking screenshots.

### Bugs Fixed ###

- [43783 – [WP8.1] Most Device Styles do not render correctly in Windows Phone 8.1 (RT) applications](https://bugzilla.xamarin.com/show_bug.cgi?id=43783)

### API Changes ###

- None

### Behavioral Changes ###

- Anyone who previously relied on the incorrect device styles would need to update their code (though the updates would mostly consist of simply removing the device style). 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
