### PR TITLE
[macOS] Fixed Tab NSImage crash in TabbedPageRenderer

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
@@ -192,14 +192,23 @@ namespace Xamarin.Forms.Platform.MacOS
 		protected virtual NSTabViewItem GetTabViewItem(Page page, IVisualElementRenderer pageRenderer)
 		{
 			var tvi = new NSTabViewItem { ViewController = pageRenderer.ViewController, Label = page.Title ?? "" };
-			if (!string.IsNullOrEmpty(page.Icon))
-				tvi.Image = GetTabViewItemIcon(page.Icon);
+            if (!string.IsNullOrEmpty (page.Icon)) {
+                var image = GetTabViewItemIcon (page.Icon);
+                if (image != null)
+                    tvi.Image = image;
+            }
 			return tvi;
 		}
 
 		protected virtual NSImage GetTabViewItemIcon(string imageName)
 		{
-			var image = NSImage.ImageNamed(imageName);
+            var image = NSImage.ImageNamed (imageName);
+            if(image == null)
+                image = new NSImage (imageName);
+
+            if (image == null)
+                return null;
+
 			bool shouldResize = TabStyle == NSTabViewControllerTabStyle.SegmentedControlOnTop ||
 								TabStyle == NSTabViewControllerTabStyle.SegmentedControlOnBottom;
 			if (shouldResize)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
@@ -193,21 +193,21 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			var tvi = new NSTabViewItem { ViewController = pageRenderer.ViewController, Label = page.Title ?? "" };
             if (!string.IsNullOrEmpty (page.Icon)) {
-                var image = GetTabViewItemIcon (page.Icon);
-                if (image != null)
-                    tvi.Image = image;
+				var image = GetTabViewItemIcon (page.Icon);
+				if (image != null)
+					tvi.Image = image;
             }
 			return tvi;
 		}
 
 		protected virtual NSImage GetTabViewItemIcon(string imageName)
 		{
-            var image = NSImage.ImageNamed (imageName);
-            if(image == null)
-                image = new NSImage (imageName);
+			var image = NSImage.ImageNamed (imageName);
+			if(image == null)
+				image = new NSImage (imageName);
 
-            if (image == null)
-                return null;
+			if (image == null)
+				return null;
 
 			bool shouldResize = TabStyle == NSTabViewControllerTabStyle.SegmentedControlOnTop ||
 								TabStyle == NSTabViewControllerTabStyle.SegmentedControlOnBottom;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
@@ -192,11 +192,11 @@ namespace Xamarin.Forms.Platform.MacOS
 		protected virtual NSTabViewItem GetTabViewItem(Page page, IVisualElementRenderer pageRenderer)
 		{
 			var tvi = new NSTabViewItem { ViewController = pageRenderer.ViewController, Label = page.Title ?? "" };
-            if (!string.IsNullOrEmpty (page.Icon)) {
+			if (!string.IsNullOrEmpty (page.Icon)) {
 				var image = GetTabViewItemIcon (page.Icon);
 				if (image != null)
 					tvi.Image = image;
-            }
+			}
 			return tvi;
 		}
 


### PR DESCRIPTION
### Description of Change ###

`GetTabViewItemIcon` uses NSImage.ImageNamed, which supports only named images or images in the root directory of the bundle. This PR adds support for images in a subdirectory. It also prevents the app from crashing, if the image is not found.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
