### PR TITLE
Add default parameter value of zero to INavigationPageController.Peek()

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
@@ -248,6 +248,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			await nav.PushAsync(child2);
 
 			Assert.AreEqual(((INavigationPageController)nav).Peek(0), child2);
+			Assert.AreEqual(((INavigationPageController)nav).Peek(), child2);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/INavigationPageController.cs
+++ b/Xamarin.Forms.Core/INavigationPageController.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms
 {
 	public interface INavigationPageController
 	{
-		Page Peek(int depth);
+		Page Peek(int depth = 0);
 
 		IEnumerable<Page> Pages { get; }
 


### PR DESCRIPTION
### Description of Change ###

Adds default parameter value of zero to `Peek()` method. Because Rui's right, it's a lot nicer that way.

### API Changes ###

- Adds default parameter value of zero to `Peek()` method.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
