### PR TITLE
[Xaml[C]] cast to BindingBase before SetBinding()

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz44213.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz44213.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Bz44213">
+	<Label x:Name="label">
+		<Label.Text>
+			<OnPlatform x:TypeArguments="BindingBase" Android="{Binding Bar}">
+				<OnPlatform.iOS>
+					<Binding Path="Foo"/>
+				</OnPlatform.iOS>
+			</OnPlatform>
+		</Label.Text>
+	</Label>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz44213.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz44213.xaml.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz44213 : ContentPage
+	{
+		public Bz44213()
+		{
+			InitializeComponent();
+		}
+
+		public Bz44213(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void BindingInOnPlatform(bool useCompiledXaml)
+			{
+				((MockPlatformServices)Device.PlatformServices).RuntimePlatform = Device.iOS;
+				var p = new Bz44213(useCompiledXaml);
+				p.BindingContext = new { Foo = "Foo", Bar = "Bar" };
+				Assert.AreEqual("Foo", p.label.Text);
+				((MockPlatformServices)Device.PlatformServices).RuntimePlatform = Device.Android;
+				p = new Bz44213(useCompiledXaml);
+				p.BindingContext = new { Foo = "Foo", Bar = "Bar" };
+				Assert.AreEqual("Bar", p.label.Text);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -424,6 +424,9 @@
     <Compile Include="Issues\Bz43733.xaml.cs">
       <DependentUpon>Bz43733.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz44213.xaml.cs">
+      <DependentUpon>Bz44213.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -767,6 +770,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz43733.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz44213.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -361,7 +361,7 @@ namespace Xamarin.Forms.Xaml
 			exception = null;
 
 			var elementType = element.GetType();
-			var binding = value as BindingBase;
+			var binding = value.ConvertTo(typeof(BindingBase),pinfoRetriever:null,serviceProvider:null) as BindingBase;
 			var bindable = element as BindableObject;
 			var nativeBindingService = DependencyService.Get<INativeBindingService>();
 


### PR DESCRIPTION
### Description of Change ###

Use the `op_Implicit` operator on the value to cast to `BindingBase` before calling `SetBinding()`. This allows scenarios like this to work:

```
<Label x:Name="label">
  <Label.Text>
    <OnPlatform x:TypeArguments="BindingBase" Android="{Binding Bar}">
      <OnPlatform.iOS>
        <Binding Path="Foo"/>
      </OnPlatform.iOS>
    </OnPlatform>
  </Label.Text>
</Label>
```

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44213
- http://stackoverflow.com/questions/41760510/xamarin-forms-xaml-onplatform-not-working-on-bindings

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense