### PR TITLE
[XamlC] use TypeRefComparer to compare TypeRef from different assemblies

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
@@ -40,25 +40,25 @@ namespace Xamarin.Forms.Build.Tasks
 					return new [] { Instruction.Create(OpCodes.Ldsfld, fieldRef) };
 
 				//Constants can be numbers, Boolean values, strings, or a null reference. (https://msdn.microsoft.com/en-us/library/e6w8fe1b.aspx)
-				if (memberRef == module.TypeSystem.Boolean)
+				if (TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.Boolean))
 					return new [] { Instruction.Create(((bool)fieldDef.Constant) ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0) };
-				if (memberRef == module.TypeSystem.String)
+				if (TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.String))
 					return new [] { Instruction.Create(OpCodes.Ldstr, (string)fieldDef.Constant) };
 				if (fieldDef.Constant == null)
 					return new [] { Instruction.Create(OpCodes.Ldnull) };
-				if (memberRef == module.TypeSystem.Char)
+				if (TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.Char))
 					return new [] { Instruction.Create(OpCodes.Ldc_I4, (char)fieldDef.Constant) };
-				if (memberRef == module.TypeSystem.Single)
+				if (TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.Single))
 					return new [] { Instruction.Create(OpCodes.Ldc_R4, (float)fieldDef.Constant) };
-				if (memberRef == module.TypeSystem.Double)
+				if (TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.Double))
 					return new [] { Instruction.Create(OpCodes.Ldc_R8, (double)fieldDef.Constant) };
-				if (memberRef == module.TypeSystem.Byte || memberRef == module.TypeSystem.Int16 || memberRef == module.TypeSystem.Int32)
+				if (TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.Byte) || TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.Int16) || TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.Int32))
 					return new [] { Instruction.Create(OpCodes.Ldc_I4, (int)fieldDef.Constant) };
-				if (memberRef == module.TypeSystem.SByte || memberRef == module.TypeSystem.UInt16 || memberRef == module.TypeSystem.UInt32)
+				if (TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.SByte) || TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.UInt16) || TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.UInt32))
 					return new [] { Instruction.Create(OpCodes.Ldc_I4, (uint)fieldDef.Constant) };
-				if (memberRef == module.TypeSystem.Int64)
+				if (TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.Int64))
 					return new [] { Instruction.Create(OpCodes.Ldc_I8, (long)fieldDef.Constant) };
-				if (memberRef == module.TypeSystem.UInt64)
+				if (TypeRefComparer.Default.Equals(memberRef, module.TypeSystem.UInt64))
 					return new [] { Instruction.Create(OpCodes.Ldc_I8, (ulong)fieldDef.Constant) };
 
 				//enum values

--- a/Xamarin.Forms.Xaml.UnitTests/XStatic.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/XStatic.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+			 xmlns:remote="clr-namespace:Xamarin.Forms.Controls;assembly=Xamarin.Forms.Controls"
 			 x:Class="Xamarin.Forms.Xaml.UnitTests.XStatic">
 	<ContentPage.ToolbarItems>
 		<ToolbarItem Icon="{x:Static local:MockxStatic.MockFieldRef}" />
@@ -15,6 +16,8 @@
 			   TextColor="{x:Static local:MockxStatic.BackgroundColor}" />
 		<Label x:Name="constant"
 				Text="{x:Static local:MockxStatic.MockConstant}"/>
+		<Label x:Name="remoteConstant"
+				Text="{x:Static remote:App.AppName}"/>
 		<Label x:Name="field"
 				Text="{x:Static local:MockxStatic.MockField}"/>
 		<ScrollView x:Name="enuM"

--- a/Xamarin.Forms.Xaml.UnitTests/XStatic.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XStatic.xaml.cs
@@ -96,6 +96,15 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			[TestCase(false)]
 			[TestCase(true)]
+			//https://bugzilla.xamarin.com/show_bug.cgi?id=49228
+			public void ConstantInARemoteAssembly(bool useCompiledXaml)
+			{
+				var layout = new XStatic(useCompiledXaml);
+				Assert.AreEqual("XamarinFormsControls", layout.remoteConstant.Text);
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
 			public void Field(bool useCompiledXaml)
 			{
 				var layout = new XStatic(useCompiledXaml);


### PR DESCRIPTION
### Description of Change ###

[XamlC] use TypeRefComparer to compare TypeRef from different assemblies

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=49228

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense