### PR TITLE
Fix overeager subscription cleanup

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/MessagingCenterTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MessagingCenterTests.cs
@@ -319,6 +319,24 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True(success); // TestCallbackSource.SuccessCallback() should be invoked to make success == true
 		}
 
+		[Test]
+		public void MultipleSubscribersOfTheSameClass()
+		{
+			var sub1 = new object();
+			var sub2 = new object();
+
+			string args2 = null;
+
+			const string message = "message";
+
+			MessagingCenter.Subscribe<MessagingCenterTests, string>(sub1, message, (sender, args) => { });
+			MessagingCenter.Subscribe<MessagingCenterTests, string>(sub2, message, (sender, args) => args2 = args);
+			MessagingCenter.Unsubscribe<MessagingCenterTests, string>(sub1, message);
+
+			MessagingCenter.Send(this, message, "Testing");
+			Assert.That(args2, Is.EqualTo("Testing"), "unsubscribing sub1 should not unsubscribe sub2");
+		}
+
 		class TestSubcriber
 		{
 			public void SetSuccess()

--- a/Xamarin.Forms.Core/MessagingCenter.cs
+++ b/Xamarin.Forms.Core/MessagingCenter.cs
@@ -205,7 +205,7 @@ namespace Xamarin.Forms
 			var key = new Sender(message, senderType, argType);
 			if (!s_subscriptions.ContainsKey(key))
 				return;
-			s_subscriptions[key].RemoveAll(sub => !sub.CanBeRemoved() || sub.Subscriber.Target == subscriber);
+			s_subscriptions[key].RemoveAll(sub => sub.CanBeRemoved() || sub.Subscriber.Target == subscriber);
 			if (!s_subscriptions[key].Any())
 				s_subscriptions.Remove(key);
 		}


### PR DESCRIPTION
### Description of Change ###

Fixes incorrect subscription cleanup logic which removed subscriptions which were not eligible for removal. Adds unit test to catch the problem in the future.

### Bugs Fixed ###

- [51703 – MessagingCenter.Unsubscribe unsubbs ALL instances that has subscribed to the message](https://bugzilla.xamarin.com/show_bug.cgi?id=51703)

### API Changes ###

- None 

### Behavioral Changes ###

- None 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
