### PR TITLE
[Xaml[C]] check for compatible types on op_implicit

### DIFF
--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -157,7 +157,10 @@ namespace Xamarin.Forms.Build.Tasks
 			var typeDef = typeRef.Resolve();
 			if (TypeRefComparer.Default.Equals(typeDef, baseClass.Resolve()))
 				return true;
-			if (typeDef.Interfaces.Any(ir => TypeRefComparer.Default.Equals(ir, baseClass)))
+			if (typeDef.Interfaces.Any(ir => {
+				ir = ir.ResolveGenericParameters(typeRef);
+				return TypeRefComparer.Default.Equals(ir, baseClass);
+			}))
 				return true;
 			if (typeDef.BaseType == null)
 				return false;
@@ -257,10 +260,8 @@ namespace Xamarin.Forms.Build.Tasks
 					var returnType = castDef.ReturnType;
 					if (returnType.IsGenericParameter)
 						returnType = ((GenericInstanceType)opDeclTypeRef).GenericArguments [((GenericParameter)returnType).Position];
-					if (returnType.FullName == toType.FullName &&
-					    cast.Parameters [0].ParameterType.Name == fromType.Name) {
+					if (returnType.InheritsFromOrImplements(toType))
 						return castDef;
-					}
 				}
 			}
 			return null;

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz45891.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz45891.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:sys="clr-namespace:System;assembly=mscorlib"
+	xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"
+	xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+	x:Class="Xamarin.Forms.Xaml.UnitTests.Bz45891">
+	<local:Bz45891.List>
+		<OnPlatform x:TypeArguments="scg:List(sys:String)">
+			<OnPlatform.iOS>
+				<scg:List x:TypeArguments="sys:String">
+					<x:String>Foo</x:String>
+				</scg:List>
+			</OnPlatform.iOS>
+		</OnPlatform>
+	</local:Bz45891.List>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz45891.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz45891.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz45891 : ContentPage
+	{
+		public Bz45891()
+		{
+			InitializeComponent();
+		}
+
+		public Bz45891(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		public static readonly BindableProperty ListProperty =
+			BindableProperty.Create("List", typeof(IEnumerable<string>), typeof(Bz45891), default(IEnumerable<string>));
+
+		public IEnumerable<string> List {
+			get { return (IEnumerable<string>)GetValue(ListProperty); }
+			set { SetValue(ListProperty, value); }
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void LookForInheritanceOnOpImplicit(bool useCompiledXaml)
+			{
+				var p = new Bz45891(useCompiledXaml);
+				Assert.AreEqual("Foo", p.List.First());
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -406,6 +406,9 @@
     <Compile Include="Issues\Unreported008.xaml.cs">
       <DependentUpon>Unreported008.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz45891.xaml.cs">
+      <DependentUpon>Bz45891.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -731,6 +734,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Unreported008.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz45891.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Xaml.XamlcUnitTests
 		[TestCase(typeof(bool), typeof(BindableObject), ExpectedResult = false)]
 		[TestCase(typeof(Dictionary<string, string>), typeof(BindableObject), ExpectedResult = false)]
 		[TestCase(typeof(List<string>), typeof(BindableObject), ExpectedResult = false)]
+		[TestCase(typeof(List<string>), typeof(IEnumerable<string>), ExpectedResult = true)]
 		[TestCase(typeof(List<Button>), typeof(BindableObject), ExpectedResult = false)]
 		[TestCase(typeof(Queue<KeyValuePair<string, string>>), typeof(BindableObject), ExpectedResult = false)]
 		[TestCase(typeof(double), typeof(double), ExpectedResult = true)]

--- a/Xamarin.Forms.Xaml/TypeConversionExtensions.cs
+++ b/Xamarin.Forms.Xaml/TypeConversionExtensions.cs
@@ -176,7 +176,7 @@ namespace Xamarin.Forms.Xaml
 					if (!mi.IsSpecialName) continue;
 					if (mi.Name != "op_Implicit") continue;
 					if (!mi.IsPublic) continue;
-					if (mi.ReturnType != toType) continue;
+					if (!toType.IsAssignableFrom(mi.ReturnType)) continue;
 					var parameters = mi.GetParameters();
 					if (parameters.Length != 1) continue;
 					if (parameters[0].ParameterType != value.GetType()) continue;
@@ -188,7 +188,7 @@ namespace Xamarin.Forms.Xaml
 						if (!mi.IsSpecialName) continue;
 						if (mi.Name != "op_Implicit") continue;
 						if (!mi.IsPublic) continue;
-						if (mi.ReturnType != toType) continue;
+						if (!toType.IsAssignableFrom(mi.ReturnType)) continue;
 						var parameters = mi.GetParameters();
 						if (parameters.Length != 1) continue;
 						if (parameters[0].ParameterType != value.GetType()) continue;


### PR DESCRIPTION
### Description of Change ###

[Xaml[C]] check for compatible types on op_implicit, and not only for type equality. this allows assigning the value from a OnPlatform<foo> to a property of type IFoo.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=45891

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense