### PR TITLE
[C] throw meaningful exception on duplicate RD key

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -292,5 +292,19 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True(rd0.TryGetMergedValue("foo", out _));
 			Assert.AreEqual("Foo", _);
 		}
+
+		[Test]
+		public void ThrowOnDuplicateKey()
+		{
+			var rd0 = new ResourceDictionary();
+			rd0.Add("foo", "Foo");
+			try {
+				rd0.Add("foo", "Bar");
+			} catch (ArgumentException ae) {
+				Assert.AreEqual("A resource with the key 'foo' is already present in the ResourceDictionary.", ae.Message);
+				Assert.Pass();
+			}
+			Assert.Fail();
+		}
 	}
 }

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -72,6 +72,8 @@ namespace Xamarin.Forms
 
 		public void Add(string key, object value)
 		{
+			if (ContainsKey(key))
+				throw new ArgumentException($"A resource with the key '{key}' is already present in the ResourceDictionary.");
 			_innerDictionary.Add(key, value);
 			OnValueChanged(key, value);
 		}


### PR DESCRIPTION
### Description of Change ###

[C] throw meaningful exception on duplicate RD key
### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=45678

### API Changes ###

None: the argument has the same type, the message is different.

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense