### PR TITLE
[Xaml] do not set properties with private setters

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz44216.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz44216.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+	x:Class="Xamarin.Forms.Xaml.UnitTests.Bz44216">
+	<ContentPage.Behaviors>
+		<local:Bz44216Behavior MinLengh="5" />
+	</ContentPage.Behaviors>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz44216.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz44216.xaml.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Bz44216Behavior : Behavior<ContentPage>
+	{
+		static readonly BindableProperty MinLenghProperty = BindableProperty.Create("MinLengh", typeof(int), typeof(Bz44216Behavior), 1);
+
+		public int MinLengh {
+			get { return (int)base.GetValue(MinLenghProperty); }
+			private set { base.SetValue(MinLenghProperty, value > 0 ? value : 1); }
+		}
+	}
+
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Bz44216 : ContentPage
+	{
+		public Bz44216()
+		{
+			InitializeComponent();
+		}
+
+		public Bz44216(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void DonSetValueOnPrivateBP(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws(new XamlParseExceptionConstraint(7, 26, s => s.StartsWith("No property,", StringComparison.Ordinal)), () => MockCompiler.Compile(typeof(Bz44216)));
+				else
+					Assert.Throws(new XamlParseExceptionConstraint(7, 26, s=> s.StartsWith("Cannot assign property", StringComparison.Ordinal)), () => new Bz44216(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -439,6 +439,9 @@
     <Compile Include="Issues\Bz45891.xaml.cs">
       <DependentUpon>Bz45891.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz44216.xaml.cs">
+      <DependentUpon>Bz44216.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -797,6 +800,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz45891.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz44216.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

[Xaml] do not set properties with private setters

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44216

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense