### PR TITLE
[iOS] Fix extra tab icon appearing in iOS for TabbedPage (was #448)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45284.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45284.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TabbedPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             Title="Repro"
+             ItemsSource="{Binding Tabs}"
+             x:Class="Xamarin.Forms.Controls.Issues.Bugzilla45284">
+  <TabbedPage.ItemTemplate>
+    <DataTemplate>
+      <ContentPage Title="{Binding Title}" Icon="{Binding Icon}">
+        <Label>Hello</Label>
+      </ContentPage>
+    </DataTemplate>
+  </TabbedPage.ItemTemplate>
+</TabbedPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45284.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45284.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 45284, "[iOS10] Extra tab icons display in iOS when binding Title on TabbedPage", PlatformAffected.iOS)]
+	public partial class Bugzilla45284 : TabbedPage
+	{
+		public Bugzilla45284()
+		{
+			var model = new Bugzilla45284Model();
+			InitializeComponent();
+			BindingContext = model;
+			model.Change();
+		}
+	}
+
+	public class Bugzilla45284Model : INotifyPropertyChanged
+	{
+		public List<Bugzilla45284TabModel> Tabs => new List<Bugzilla45284TabModel> { 
+			new Bugzilla45284TabModel(),
+			new Bugzilla45284TabModel(),
+			new Bugzilla45284TabModel(),
+			new Bugzilla45284TabModel(),
+			new Bugzilla45284TabModel(),
+			new Bugzilla45284TabModel(),
+			new Bugzilla45284TabModel(),
+		};
+
+		public event PropertyChangedEventHandler PropertyChanged;
+		public void Change()
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Tabs)));
+		}
+	}
+
+	public class Bugzilla45284TabModel
+	{
+		public string Title { get; set; } = "Title";
+		public string Icon { get; set; } = "bank.png";
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45284.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45284.xaml.cs
@@ -7,6 +7,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if APP
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 45284, "[iOS10] Extra tab icons display in iOS when binding Title on TabbedPage", PlatformAffected.iOS)]
 	public partial class Bugzilla45284 : TabbedPage
@@ -44,4 +45,5 @@ namespace Xamarin.Forms.Controls.Issues
 		public string Title { get; set; } = "Title";
 		public string Icon { get; set; } = "bank.png";
 	}
+#endif
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -484,6 +484,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla35736.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla48158.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45926.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45284.xaml.cs">
+      <DependentUpon>Bugzilla45284.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -591,6 +594,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla39378.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla45284.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Forms
 
 		static bool? s_isiOS9OrNewer;
 
+		static bool? s_isiOS10OrNewer;
+
 		static Forms()
 		{
 			if (nevertrue)
@@ -41,6 +43,16 @@ namespace Xamarin.Forms
 				if (!s_isiOS9OrNewer.HasValue)
 					s_isiOS9OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(9, 0);
 				return s_isiOS9OrNewer.Value;
+			}
+		}
+
+		internal static bool IsiOS10OrNewer
+		{
+			get
+			{
+				if (!s_isiOS10OrNewer.HasValue)
+					s_isiOS10OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(10, 0);
+				return s_isiOS10OrNewer.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -171,7 +171,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == Page.TitleProperty.PropertyName)
+			// Setting TabBarItem.Title in iOS 10 causes rendering bugs
+			// Work around this by creating a new UITabBarItem on each change
+			if (e.PropertyName == Page.TitleProperty.PropertyName && !Forms.IsiOS10OrNewer)
 			{
 				var page = (Page)sender;
 				var renderer = Platform.GetRenderer(page);
@@ -181,7 +183,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (renderer.ViewController.TabBarItem != null)
 					renderer.ViewController.TabBarItem.Title = page.Title;
 			}
-			else if (e.PropertyName == Page.IconProperty.PropertyName)
+			else if (e.PropertyName == Page.IconProperty.PropertyName || e.PropertyName == Page.TitleProperty.PropertyName && Forms.IsiOS10OrNewer)
 			{
 				var page = (Page)sender;
 


### PR DESCRIPTION
### Description of Change ###

[iOS] Fix extra tab icon appearing in iOS for TabbedPage

This branch pull #448 along, and add a test.

## DO NOT SQUASH-MERGE TO PRESERVE AUTHOR ATTRIBUTION

This adds a workaround for an iOS 10 bug that displays extra icons in a UITabBarController when the UITabBarItem.Title property is changed. More info here: http://stackoverflow.com/questions/38776978/ios-10-uitabbar-more-items-visible-after-setting-title

### Bugs Fixed

- https://bugzilla.xamarin.com/show_bug.cgi?id=45284

### API Changes

Added:
- internal Forms.IsiOS10OrNewer { get; }

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense