### PR TITLE
Make MessagingCenter testable

### DIFF
--- a/Xamarin.Forms.Core/MessagingCenter.cs
+++ b/Xamarin.Forms.Core/MessagingCenter.cs
@@ -22,9 +22,7 @@ namespace Xamarin.Forms
 
 	public class MessagingCenter : IMessagingCenter
 	{
-		static readonly MessagingCenter s_instance = new MessagingCenter();
-
-		public static IMessagingCenter Instance => s_instance;
+		public static IMessagingCenter Instance { get; } = new MessagingCenter();
 
 		class Sender : Tuple<string, Type, Type>
 		{

--- a/Xamarin.Forms.Core/MessagingCenter.cs
+++ b/Xamarin.Forms.Core/MessagingCenter.cs
@@ -2,12 +2,30 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms
 {
-	public static class MessagingCenter
+	public interface IMessagingCenter
 	{
+		void Send<TSender, TArgs>(TSender sender, string message, TArgs args) where TSender : class;
+
+		void Send<TSender>(TSender sender, string message) where TSender : class;
+
+		void Subscribe<TSender, TArgs>(object subscriber, string message, Action<TSender, TArgs> callback, TSender source = null) where TSender : class;
+
+		void Subscribe<TSender>(object subscriber, string message, Action<TSender> callback, TSender source = null) where TSender : class;
+
+		void Unsubscribe<TSender, TArgs>(object subscriber, string message) where TSender : class;
+
+		void Unsubscribe<TSender>(object subscriber, string message) where TSender : class;
+	}
+
+	public class MessagingCenter : IMessagingCenter
+	{
+		static readonly Lazy<MessagingCenter> s_instance = new Lazy<MessagingCenter>(() => new MessagingCenter());
+
+		public static IMessagingCenter Instance => s_instance.Value;
+
 		class Sender : Tuple<string, Type, Type>
 		{
 			public Sender(string message, Type senderType, Type argType) : base(message, senderType, argType)
@@ -19,8 +37,8 @@ namespace Xamarin.Forms
 
 		class MaybeWeakReference
 		{
-			WeakReference DelegateWeakReference { get; set; }
-			object DelegateStrongReference { get; set; }
+			WeakReference DelegateWeakReference { get; }
+			object DelegateStrongReference { get; }
 
 			readonly bool _isStrongReference;
 
@@ -84,10 +102,15 @@ namespace Xamarin.Forms
 			}
 		}
 
-		static readonly Dictionary<Sender, List<Subscription>> s_subscriptions =
+		readonly Dictionary<Sender, List<Subscription>> _subscriptions =
 			new Dictionary<Sender, List<Subscription>>();
 
 		public static void Send<TSender, TArgs>(TSender sender, string message, TArgs args) where TSender : class
+		{
+			Instance.Send(sender, message, args);
+		}
+
+		void IMessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args)
 		{
 			if (sender == null)
 				throw new ArgumentNullException(nameof(sender));
@@ -96,12 +119,22 @@ namespace Xamarin.Forms
 
 		public static void Send<TSender>(TSender sender, string message) where TSender : class
 		{
+			Instance.Send(sender, message);
+		}
+
+		void IMessagingCenter.Send<TSender>(TSender sender, string message)
+		{
 			if (sender == null)
 				throw new ArgumentNullException(nameof(sender));
 			InnerSend(message, typeof(TSender), null, sender, null);
 		}
 
 		public static void Subscribe<TSender, TArgs>(object subscriber, string message, Action<TSender, TArgs> callback, TSender source = null) where TSender : class
+		{
+			Instance.Subscribe(subscriber, message, callback, source);
+		}
+
+		void IMessagingCenter.Subscribe<TSender, TArgs>(object subscriber, string message, Action<TSender, TArgs> callback, TSender source)
 		{
 			if (subscriber == null)
 				throw new ArgumentNullException(nameof(subscriber));
@@ -121,6 +154,11 @@ namespace Xamarin.Forms
 
 		public static void Subscribe<TSender>(object subscriber, string message, Action<TSender> callback, TSender source = null) where TSender : class
 		{
+			Instance.Subscribe(subscriber, message, callback, source);
+		}
+
+		void IMessagingCenter.Subscribe<TSender>(object subscriber, string message, Action<TSender> callback, TSender source)
+		{
 			if (subscriber == null)
 				throw new ArgumentNullException(nameof(subscriber));
 			if (callback == null)
@@ -139,27 +177,32 @@ namespace Xamarin.Forms
 
 		public static void Unsubscribe<TSender, TArgs>(object subscriber, string message) where TSender : class
 		{
+			Instance.Unsubscribe<TSender, TArgs>(subscriber, message);
+		}
+
+		void IMessagingCenter.Unsubscribe<TSender, TArgs>(object subscriber, string message)
+		{
 			InnerUnsubscribe(message, typeof(TSender), typeof(TArgs), subscriber);
 		}
 
 		public static void Unsubscribe<TSender>(object subscriber, string message) where TSender : class
 		{
+			Instance.Unsubscribe<TSender>(subscriber, message);
+		}
+
+		void IMessagingCenter.Unsubscribe<TSender>(object subscriber, string message)
+		{
 			InnerUnsubscribe(message, typeof(TSender), null, subscriber);
 		}
 
-		internal static void ClearSubscribers()
-		{
-			s_subscriptions.Clear();
-		}
-
-		static void InnerSend(string message, Type senderType, Type argType, object sender, object args)
+		void InnerSend(string message, Type senderType, Type argType, object sender, object args)
 		{
 			if (message == null)
 				throw new ArgumentNullException(nameof(message));
 			var key = new Sender(message, senderType, argType);
-			if (!s_subscriptions.ContainsKey(key))
+			if (!_subscriptions.ContainsKey(key))
 				return;
-			List<Subscription> subcriptions = s_subscriptions[key];
+			List<Subscription> subcriptions = _subscriptions[key];
 			if (subcriptions == null || !subcriptions.Any())
 				return; // should not be reachable
 
@@ -178,24 +221,24 @@ namespace Xamarin.Forms
 			}
 		}
 
-		static void InnerSubscribe(object subscriber, string message, Type senderType, Type argType, object target, MethodInfo methodInfo, Filter filter)
+		void InnerSubscribe(object subscriber, string message, Type senderType, Type argType, object target, MethodInfo methodInfo, Filter filter)
 		{
 			if (message == null)
 				throw new ArgumentNullException(nameof(message));
 			var key = new Sender(message, senderType, argType);
 			var value = new Subscription(subscriber, target, methodInfo, filter);
-			if (s_subscriptions.ContainsKey(key))
+			if (_subscriptions.ContainsKey(key))
 			{
-				s_subscriptions[key].Add(value);
+				_subscriptions[key].Add(value);
 			}
 			else
 			{
 				var list = new List<Subscription> { value };
-				s_subscriptions[key] = list;
+				_subscriptions[key] = list;
 			}
 		}
 
-		static void InnerUnsubscribe(string message, Type senderType, Type argType, object subscriber)
+		void InnerUnsubscribe(string message, Type senderType, Type argType, object subscriber)
 		{
 			if (subscriber == null)
 				throw new ArgumentNullException(nameof(subscriber));
@@ -203,11 +246,19 @@ namespace Xamarin.Forms
 				throw new ArgumentNullException(nameof(message));
 
 			var key = new Sender(message, senderType, argType);
-			if (!s_subscriptions.ContainsKey(key))
+			if (!_subscriptions.ContainsKey(key))
 				return;
-			s_subscriptions[key].RemoveAll(sub => sub.CanBeRemoved() || sub.Subscriber.Target == subscriber);
-			if (!s_subscriptions[key].Any())
-				s_subscriptions.Remove(key);
+			_subscriptions[key].RemoveAll(sub => sub.CanBeRemoved() || sub.Subscriber.Target == subscriber);
+			if (!_subscriptions[key].Any())
+				_subscriptions.Remove(key);
+		}
+
+		// This is a bit gross; it only exists to support the unit tests in PageTests
+		// because the implementations of ActionSheet, Alert, and IsBusy are all very
+		// tightly coupled to the MessagingCenter singleton 
+		internal static void ClearSubscribers()
+		{
+			(Instance as MessagingCenter)?._subscriptions.Clear();
 		}
 	}
 }

--- a/Xamarin.Forms.Core/MessagingCenter.cs
+++ b/Xamarin.Forms.Core/MessagingCenter.cs
@@ -22,9 +22,9 @@ namespace Xamarin.Forms
 
 	public class MessagingCenter : IMessagingCenter
 	{
-		static readonly Lazy<MessagingCenter> s_instance = new Lazy<MessagingCenter>(() => new MessagingCenter());
+		static readonly MessagingCenter s_instance = new MessagingCenter();
 
-		public static IMessagingCenter Instance => s_instance.Value;
+		public static IMessagingCenter Instance => s_instance;
 
 		class Sender : Tuple<string, Type, Type>
 		{

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/IMessagingCenter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/IMessagingCenter.xml
@@ -1,0 +1,205 @@
+<Type Name="IMessagingCenter" FullName="Xamarin.Forms.IMessagingCenter">
+  <TypeSignature Language="C#" Value="public interface IMessagingCenter" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IMessagingCenter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Send&lt;TSender&gt;">
+      <MemberSignature Language="C#" Value="public void Send&lt;TSender&gt; (TSender sender, string message) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Send&lt;class TSender&gt;(!!TSender sender, string message) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="sender" Type="TSender" />
+        <Parameter Name="message" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <param name="sender">To be added.</param>
+        <param name="message">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Send&lt;TSender,TArgs&gt;">
+      <MemberSignature Language="C#" Value="public void Send&lt;TSender,TArgs&gt; (TSender sender, string message, TArgs args) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Send&lt;class TSender, TArgs&gt;(!!TSender sender, string message, !!TArgs args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+        <TypeParameter Name="TArgs" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="sender" Type="TSender" />
+        <Parameter Name="message" Type="System.String" />
+        <Parameter Name="args" Type="TArgs" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <typeparam name="TArgs">To be added.</typeparam>
+        <param name="sender">To be added.</param>
+        <param name="message">To be added.</param>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Subscribe&lt;TSender&gt;">
+      <MemberSignature Language="C#" Value="public void Subscribe&lt;TSender&gt; (object subscriber, string message, Action&lt;TSender&gt; callback, TSender source = null) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Subscribe&lt;class TSender&gt;(object subscriber, string message, class System.Action`1&lt;!!TSender&gt; callback, !!TSender source) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="subscriber" Type="System.Object" />
+        <Parameter Name="message" Type="System.String" />
+        <Parameter Name="callback" Type="System.Action&lt;TSender&gt;" />
+        <Parameter Name="source" Type="TSender" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <param name="subscriber">To be added.</param>
+        <param name="message">To be added.</param>
+        <param name="callback">To be added.</param>
+        <param name="source">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Subscribe&lt;TSender,TArgs&gt;">
+      <MemberSignature Language="C#" Value="public void Subscribe&lt;TSender,TArgs&gt; (object subscriber, string message, Action&lt;TSender,TArgs&gt; callback, TSender source = null) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Subscribe&lt;class TSender, TArgs&gt;(object subscriber, string message, class System.Action`2&lt;!!TSender, !!TArgs&gt; callback, !!TSender source) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+        <TypeParameter Name="TArgs" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="subscriber" Type="System.Object" />
+        <Parameter Name="message" Type="System.String" />
+        <Parameter Name="callback" Type="System.Action&lt;TSender,TArgs&gt;" />
+        <Parameter Name="source" Type="TSender" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <typeparam name="TArgs">To be added.</typeparam>
+        <param name="subscriber">To be added.</param>
+        <param name="message">To be added.</param>
+        <param name="callback">To be added.</param>
+        <param name="source">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Unsubscribe&lt;TSender&gt;">
+      <MemberSignature Language="C#" Value="public void Unsubscribe&lt;TSender&gt; (object subscriber, string message) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Unsubscribe&lt;class TSender&gt;(object subscriber, string message) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="subscriber" Type="System.Object" />
+        <Parameter Name="message" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <param name="subscriber">To be added.</param>
+        <param name="message">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Unsubscribe&lt;TSender,TArgs&gt;">
+      <MemberSignature Language="C#" Value="public void Unsubscribe&lt;TSender,TArgs&gt; (object subscriber, string message) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Unsubscribe&lt;class TSender, TArgs&gt;(object subscriber, string message) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+        <TypeParameter Name="TArgs" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="subscriber" Type="System.Object" />
+        <Parameter Name="message" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <typeparam name="TArgs">To be added.</typeparam>
+        <param name="subscriber">To be added.</param>
+        <param name="message">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/MessagingCenter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/MessagingCenter.xml
@@ -1,6 +1,6 @@
 <Type Name="MessagingCenter" FullName="Xamarin.Forms.MessagingCenter">
-  <TypeSignature Language="C#" Value="public static class MessagingCenter" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit MessagingCenter extends System.Object" />
+  <TypeSignature Language="C#" Value="public class MessagingCenter : Xamarin.Forms.IMessagingCenter" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MessagingCenter extends System.Object implements class Xamarin.Forms.IMessagingCenter" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -14,7 +14,11 @@
   <Base>
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
-  <Interfaces />
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IMessagingCenter</InterfaceName>
+    </Interface>
+  </Interfaces>
   <Docs>
     <summary>Associates a callback on subscribers with a specific message name.</summary>
     <remarks>
@@ -40,6 +44,35 @@ Assert.AreEqual(2, subscriber.IntProperty);
     </remarks>
   </Docs>
   <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MessagingCenter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Instance">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IMessagingCenter Instance { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property class Xamarin.Forms.IMessagingCenter Instance" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IMessagingCenter</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Send&lt;TSender&gt;">
       <MemberSignature Language="C#" Value="public static void Send&lt;TSender&gt; (TSender sender, string message) where TSender : class;" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Send&lt;class TSender&gt;(!!TSender sender, string message) cil managed" />
@@ -256,6 +289,196 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="subscriber">To be added.</param>
         <param name="message">To be added.</param>
         <summary>Unsubscribes from the specified parameterless subscriber messages.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IMessagingCenter.Send&lt;TSender&gt;">
+      <MemberSignature Language="C#" Value="void IMessagingCenter.Send&lt;TSender&gt; (TSender sender, string message) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IMessagingCenter.Send&lt;class TSender&gt;(!!TSender sender, string message) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="sender" Type="TSender" />
+        <Parameter Name="message" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <param name="sender">To be added.</param>
+        <param name="message">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IMessagingCenter.Send&lt;TSender,TArgs&gt;">
+      <MemberSignature Language="C#" Value="void IMessagingCenter.Send&lt;TSender,TArgs&gt; (TSender sender, string message, TArgs args) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IMessagingCenter.Send&lt;class TSender, TArgs&gt;(!!TSender sender, string message, !!TArgs args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+        <TypeParameter Name="TArgs" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="sender" Type="TSender" />
+        <Parameter Name="message" Type="System.String" />
+        <Parameter Name="args" Type="TArgs" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <typeparam name="TArgs">To be added.</typeparam>
+        <param name="sender">To be added.</param>
+        <param name="message">To be added.</param>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IMessagingCenter.Subscribe&lt;TSender&gt;">
+      <MemberSignature Language="C#" Value="void IMessagingCenter.Subscribe&lt;TSender&gt; (object subscriber, string message, Action&lt;TSender&gt; callback, TSender source) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IMessagingCenter.Subscribe&lt;class TSender&gt;(object subscriber, string message, class System.Action`1&lt;!!TSender&gt; callback, !!TSender source) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="subscriber" Type="System.Object" />
+        <Parameter Name="message" Type="System.String" />
+        <Parameter Name="callback" Type="System.Action&lt;TSender&gt;" />
+        <Parameter Name="source" Type="TSender" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <param name="subscriber">To be added.</param>
+        <param name="message">To be added.</param>
+        <param name="callback">To be added.</param>
+        <param name="source">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IMessagingCenter.Subscribe&lt;TSender,TArgs&gt;">
+      <MemberSignature Language="C#" Value="void IMessagingCenter.Subscribe&lt;TSender,TArgs&gt; (object subscriber, string message, Action&lt;TSender,TArgs&gt; callback, TSender source) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IMessagingCenter.Subscribe&lt;class TSender, TArgs&gt;(object subscriber, string message, class System.Action`2&lt;!!TSender, !!TArgs&gt; callback, !!TSender source) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+        <TypeParameter Name="TArgs" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="subscriber" Type="System.Object" />
+        <Parameter Name="message" Type="System.String" />
+        <Parameter Name="callback" Type="System.Action&lt;TSender,TArgs&gt;" />
+        <Parameter Name="source" Type="TSender" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <typeparam name="TArgs">To be added.</typeparam>
+        <param name="subscriber">To be added.</param>
+        <param name="message">To be added.</param>
+        <param name="callback">To be added.</param>
+        <param name="source">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IMessagingCenter.Unsubscribe&lt;TSender&gt;">
+      <MemberSignature Language="C#" Value="void IMessagingCenter.Unsubscribe&lt;TSender&gt; (object subscriber, string message) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IMessagingCenter.Unsubscribe&lt;class TSender&gt;(object subscriber, string message) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="subscriber" Type="System.Object" />
+        <Parameter Name="message" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <param name="subscriber">To be added.</param>
+        <param name="message">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IMessagingCenter.Unsubscribe&lt;TSender,TArgs&gt;">
+      <MemberSignature Language="C#" Value="void IMessagingCenter.Unsubscribe&lt;TSender,TArgs&gt; (object subscriber, string message) where TSender : class;" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IMessagingCenter.Unsubscribe&lt;class TSender, TArgs&gt;(object subscriber, string message) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TSender">
+          <Constraints>
+            <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+          </Constraints>
+        </TypeParameter>
+        <TypeParameter Name="TArgs" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="subscriber" Type="System.Object" />
+        <Parameter Name="message" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TSender">To be added.</typeparam>
+        <typeparam name="TArgs">To be added.</typeparam>
+        <param name="subscriber">To be added.</param>
+        <param name="message">To be added.</param>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
### Description of Change ###

Proposing this as an alternative to [PR 541](https://github.com/xamarin/Xamarin.Forms/pull/541). This change is designed to allow for easier testing of components which utilize `MessagingCenter` by introducing an interface (`IMessagingCenter`) which can be faked/mocked/substituted in automated tests (see the `TestMessagingCenterSubstitute()` method in `MessagingCenterTests` for an example). 

This is essentially the same interface proposed in 541, but built on top of the changes from [PR 617](https://github.com/xamarin/Xamarin.Forms/pull/617). Also, this version allows the continued use of the original `MessagingCenter` API without deprecation; the static methods on `MessagingCenter` simply call through to the new singleton instance, allowing the code to be shared rather than duplicated.

### Bugs Fixed ###

- [46601 – MessagingCenter is static](https://bugzilla.xamarin.com/show_bug.cgi?id=46601)

### API Changes ###

Added:
```
public interface IMessagingCenter
{
	void Send<TSender, TArgs>(TSender sender, string message, TArgs args) where TSender : class;
	void Send<TSender>(TSender sender, string message) where TSender : class;
	void Subscribe<TSender, TArgs>(object subscriber, string message, Action<TSender, TArgs> callback, TSender source = null) where TSender : class;
	void Subscribe<TSender>(object subscriber, string message, Action<TSender> callback, TSender source = null) where TSender : class;
	void Unsubscribe<TSender, TArgs>(object subscriber, string message) where TSender : class;
	void Unsubscribe<TSender>(object subscriber, string message) where TSender : class;
}
```

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
