### PR TITLE
[XamlC] support portable pdb

### DIFF
--- a/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Build.Tasks
 			using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(Assembly, new ReaderParameters {
 				ReadWrite = true,
 				ReadSymbols = DebugSymbols,
-				SymbolReaderProvider = System.Type.GetType("Mono.Runtime") != null ? ((ISymbolReaderProvider)(new MdbReaderProvider())) : ((ISymbolReaderProvider)new PdbReaderProvider()),
+				SymbolReaderProvider = GetSymbolReaderProvider(Assembly, DebugSymbols),
 				AssemblyResolver = resolver
 			})) {
 				foreach (var module in assemblyDefinition.Modules) {
@@ -146,7 +146,7 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 				Logger.LogString(1, "Writing the assembly... ");
 				assemblyDefinition.Write(new WriterParameters {
-					SymbolWriterProvider = System.Type.GetType("Mono.Runtime") != null ? ((ISymbolWriterProvider)(new MdbWriterProvider())) : ((ISymbolWriterProvider)new MdbWriterProvider()),
+					SymbolWriterProvider = GetSymbolWriterProvider(Assembly, DebugSymbols),
 					WriteSymbols = DebugSymbols
 				});
 			}

--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -5,8 +5,6 @@ using System.Linq;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using Mono.Cecil.Mdb;
-using Mono.Cecil.Pdb;
 
 using Xamarin.Forms.Xaml;
 
@@ -74,7 +72,7 @@ namespace Xamarin.Forms.Build.Tasks
 				AssemblyResolver = resolver,
 				ReadWrite = !ReadOnly,
 				ReadSymbols = DebugSymbols,
-				SymbolReaderProvider = DebugSymbols ? (System.Type.GetType("Mono.Runtime") != null ? ((ISymbolReaderProvider)(new MdbReaderProvider())) : ((ISymbolReaderProvider)new PdbReaderProvider())) : null,
+				SymbolReaderProvider = GetSymbolReaderProvider(Assembly, DebugSymbols),
 			};
 
 			using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(Path.GetFullPath(Assembly),readerParameters)) {
@@ -228,7 +226,7 @@ namespace Xamarin.Forms.Build.Tasks
 				try {
 					assemblyDefinition.Write(new WriterParameters {
 						WriteSymbols = DebugSymbols,
-						SymbolWriterProvider = DebugSymbols ? (System.Type.GetType("Mono.Runtime") != null ? ((ISymbolWriterProvider)(new MdbWriterProvider())) : ((ISymbolWriterProvider)new MdbWriterProvider())): null,
+						SymbolWriterProvider = GetSymbolWriterProvider(Assembly, DebugSymbols),
 					});
 					Logger.LogLine(1, "done.");
 				} catch (Exception e) {

--- a/Xamarin.Forms.Build.Tasks/XamlTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlTask.cs
@@ -11,6 +11,8 @@ using Mono.Cecil;
 
 using Xamarin.Forms.Xaml;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Pdb;
+using Mono.Cecil.Mdb;
 
 namespace Xamarin.Forms.Build.Tasks
 {
@@ -57,6 +59,56 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 			}
 			return rootnode;
+		}
+
+		protected static ISymbolReaderProvider GetSymbolReaderProvider(string moduleFileName, bool debugSymbols)
+		{
+			if (!debugSymbols)
+				return null;
+
+			var pdb_name = GetPdbFileName(moduleFileName);
+			if (File.Exists(pdb_name)) {
+				// TODO: check mvid match
+				return new PdbReaderProvider();
+			}
+
+			var mdb_name = GetMdbFileName(moduleFileName);
+			if (File.Exists(mdb_name)) {
+				// TODO: check mvid match
+				return new MdbReaderProvider();
+			}
+
+			return null;
+		}
+
+		protected static ISymbolWriterProvider GetSymbolWriterProvider(string moduleFileName, bool debugSymbols)
+		{
+			if (!debugSymbols)
+				return null;
+
+			var pdb_name = GetPdbFileName(moduleFileName);
+			if (File.Exists(pdb_name)) {
+				// TODO: check mvid match
+				return new PdbWriterProvider();
+			}
+
+			var mdb_name = GetMdbFileName(moduleFileName);
+			if (File.Exists(mdb_name)) {
+				// TODO: check mvid match
+				return new MdbWriterProvider();
+			}
+
+			return null;
+		}
+
+		static string GetPdbFileName(string assemblyFileName)
+		{
+			return Path.ChangeExtension(assemblyFileName, ".pdb");
+		}
+
+		static string GetMdbFileName(string assemblyFileName)
+		{
+			return assemblyFileName + ".mdb";
 		}
 	}
 


### PR DESCRIPTION
### Description of Change ###

[XamlC] support portable pdb. Reuse Cecil logic (https://github.com/mono/cecil/commit/898fb6b8cb03319937448d93bdf6eaa3dd2c6008#diff-d60c9973465fb52c71c5ba9af324992aR687) based on file availability to pick between Pdb (portable or native) or Mdb.

Portable Pdb will be the default symbol format for mono in Cycle10. We HAVE to support this.

~~This PR actually contains a single commit but is built on top of #699. Merge that one before.~~

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=51778

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense