### PR TITLE
[WinRT/UWP] Fix Slider binding value incorrectly

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41619.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41619.cs
@@ -1,0 +1,62 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41619, "[WinRT/UWP] Slider binding works incorrectly", PlatformAffected.WinRT)]
+	public class Bugzilla41619 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var vm = new Bugzilla41619ViewModel { SliderValue = 5 };
+			BindingContext = vm;
+			var label = new Label();
+			label.SetBinding(Label.TextProperty, "SliderValue");
+			var slider = new Slider
+			{
+				Maximum = 10,
+				Minimum = 1,
+			};
+			slider.SetBinding(Slider.ValueProperty, "SliderValue", BindingMode.TwoWay);
+			Content = new StackLayout
+			{
+				Children =
+				{
+					label,
+					slider,
+					new Label { Text = "The initial slider value above should be 5." }
+				}
+			};
+		}
+
+		class Bugzilla41619ViewModel : INotifyPropertyChanged
+		{
+			private double _sliderValue;
+
+			public double SliderValue
+			{
+				get { return _sliderValue; }
+				set
+				{
+					_sliderValue = value;
+					OnPropertyChanged();
+				}
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -127,6 +127,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41415.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41418.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41619.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42069.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42069_Page.xaml.cs">
       <DependentUpon>Bugzilla42069_Page.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.WinRT/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/SliderRenderer.cs
@@ -24,7 +24,11 @@ namespace Xamarin.Forms.Platform.WinRT
 					var slider = new Windows.UI.Xaml.Controls.Slider();
 					SetNativeControl(slider);
 
-					slider.ValueChanged += OnNativeValueCHanged;
+					Control.Minimum = e.NewElement.Minimum;
+					Control.Maximum = e.NewElement.Maximum;
+					Control.Value = e.NewElement.Value;
+
+					slider.ValueChanged += OnNativeValueChanged;
 
 					// Even when using Center/CenterAndExpand, a Slider has an oddity where it looks
 					// off-center in its layout by a smidge. The default templates are slightly different
@@ -49,10 +53,6 @@ namespace Xamarin.Forms.Platform.WinRT
 				double stepping = Math.Min((e.NewElement.Maximum - e.NewElement.Minimum) / 10, 1);
 				Control.StepFrequency = stepping;
 				Control.SmallChange = stepping;
-
-				Control.Minimum = e.NewElement.Minimum;
-				Control.Maximum = e.NewElement.Maximum;
-				Control.Value = e.NewElement.Value;
 			}
 		}
 
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 		}
 
-		void OnNativeValueCHanged(object sender, RangeBaseValueChangedEventArgs e)
+		void OnNativeValueChanged(object sender, RangeBaseValueChangedEventArgs e)
 		{
 			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, e.NewValue);
 		}


### PR DESCRIPTION
### Description of Change ###

A bound initial value on a slider was not working on WinRT/UWP if the `Minimum` value was not set to 0. it appears that not setting these values on the control prior to assigning `OnNativeValueChanged` is incorrectly setting `Element.Value` to `Minimum`. Adjusting the sequence allows the behavior to function as expected. 

(While it was noticed, a small adjustment was made to remove an unnecessarily extra capital letter in OnNativeValueChanged.)

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41619

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
