### PR TITLE
Add TV to TargetIdiom

### DIFF
--- a/Xamarin.Forms.Core/OnIdiom.cs
+++ b/Xamarin.Forms.Core/OnIdiom.cs
@@ -1,4 +1,4 @@
-﻿namespace Xamarin.Forms
+namespace Xamarin.Forms
 {
 	public class OnIdiom<T>
 	{
@@ -7,6 +7,8 @@
 		public T Tablet { get; set; }
 		
 		public T Desktop { get; set; }
+
+		public T TV { get; set; }
 
 		public static implicit operator T(OnIdiom<T> onIdiom)
 		{
@@ -19,6 +21,8 @@
 					return onIdiom.Tablet;
 				case TargetIdiom.Desktop:
 					return onIdiom.Desktop;
+				case TargetIdiom.TV:
+					return onIdiom.TV;
 			}
 		}
 	}

--- a/Xamarin.Forms.Core/TargetIdiom.cs
+++ b/Xamarin.Forms.Core/TargetIdiom.cs
@@ -5,6 +5,7 @@ namespace Xamarin.Forms
 		Unsupported,
 		Phone,
 		Tablet,
-		Desktop
+		Desktop,
+		TV
 	}
 }

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/OnIdiom`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/OnIdiom`1.xml
@@ -139,5 +139,22 @@
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="TV">
+      <MemberSignature Language="C#" Value="public T TV { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance !T TV" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>T</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets the value applied on TV-like devices.</summary>
+        <value>A T.</value>
+        <remarks>
+        </remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/TargetIdiom.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/TargetIdiom.xml
@@ -80,6 +80,20 @@
         <summary>Indicates that the width of the iPad, Windows 8.1, or Android device on which Forms is running is wider than 600 dips.</summary>
       </Docs>
     </Member>
+    <Member MemberName="TV">
+      <MemberSignature Language="C#" Value="TV" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.TargetIdiom TV = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.TargetIdiom</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates that Forms is running on a Tizen app on Tizen TV.</summary>
+      </Docs>
+    </Member>
     <Member MemberName="Unsupported">
       <MemberSignature Language="C#" Value="Unsupported" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.TargetIdiom Unsupported = int32(0)" />


### PR DESCRIPTION
### Description of Change ###

Add TV to TargetIdiom. `TargetIdiom.TV` indicates that Forms is running on a Tizen app on Tizen TV devices.

### Bugs Fixed ###

- None

### API Changes ###

Added:
 - TargetIdiom.TV //  enum
 - T OnIdiom<T>.TV { get; set; }

### Behavioral Changes ###

- None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
