### PR TITLE
[A] Do not throw error for first param in ScrollTo

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41600.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41600.cs
@@ -1,0 +1,51 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 41600, "[Android] Invalid item param value for ScrollTo throws an error", PlatformAffected.Android)]
+	public class Bugzilla41600 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var items = new List<string>();
+			for (var i = 0; i <= 30; i++)
+				items.Add(i.ToString());
+
+			var listView = new ListView
+			{
+				ItemsSource = items
+			};
+			Content = new StackLayout
+			{
+				Children =
+				{
+					listView,
+					new Button
+					{
+						Text = "Click for ScrollTo (should do nothing)",
+						Command = new Command(() =>
+						{
+							listView.ScrollTo("Hello", ScrollToPosition.Start, true);
+						})
+					},
+					new Button
+					{
+						Text = "Click for ScrollTo (should go to 15)",
+						Command = new Command(() =>
+						{
+							listView.ScrollTo(items[15], ScrollToPosition.Start, false);
+						})
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -128,6 +128,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41415.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41418.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41424.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41600.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41619.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42069.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42069_Page.xaml.cs">

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -206,6 +206,9 @@ namespace Xamarin.Forms.Platform.Android
 			else
 			{
 				position = templatedItems.GetGlobalIndexOfItem(scrollArgs.Item);
+				if (position == -1)
+					return;
+
 				cell = templatedItems[position];
 			}
 


### PR DESCRIPTION
### Description of Change ###

As it presently exists, using a `ListView`'s `ScrollTo` while passing in an invalid value (such as `listView.ScrollTo("Test", ScrollToPosition.Start, false)` will result in the application crashing opposed to silently returning from the method when running on Android. iOS and RT/UWP do not crash, so the inclination is to bring Android's behavior in line with the other platforms and make certain that this is documented. This behavior already existed when `IsGroupingEnabled` is set to true, and was only applying to situation where it was false.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41600

### API Changes ###

None

### Behavioral Changes ###

Aside from a crash not occurring, this behavior should be documented somewhere.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
