### PR TITLE
Split Windows RuntimePlatform into UWP and WinRT

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla22229.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla22229.xaml.cs
@@ -26,7 +26,8 @@ namespace Xamarin.Forms.Controls
 			case Device.Android:
 				_prefix = "";
 				break;
-			case Device.Windows:
+			case Device.WinRT:
+			case Device.UWP:
 			case Device.WinPhone:
 				_prefix = "Assets/";
 				break;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init ()
 		{
-			if (Device.RuntimePlatform == Device.Windows)
+			if (Device.RuntimePlatform == Device.UWP || Device.RuntimePlatform == Device.WinRT)
 				MasterBehavior = MasterBehavior.Split;
 			else
 				MasterBehavior = MasterBehavior.SplitOnLandscape;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42069.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42069.cs
@@ -25,7 +25,8 @@ namespace Xamarin.Forms.Controls
 					smallImage = "coffee.png";
 					break;
 				case Device.WinPhone:
-				case Device.Windows:
+				case Device.WinRT:
+				case Device.UWP:
 					smallImage = "bank.png";
 					break;
 				}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ImageLoadingErrorHandling.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ImageLoadingErrorHandling.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Controls
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.None, 0, "Image Loading Error Handling", PlatformAffected.WinRT)]
+	[Issue(IssueTracker.None, 0, "Image Loading Error Handling", PlatformAffected.WinRT | PlatformAffected.UWP)]
 	public class ImageLoadingErrorHandling : TestContentPage
 	{
 		protected override void Init()
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Controls
 
 			Grid fakeUri = CreateTest(() => image.Source = ImageSource.FromUri(new Uri("http://not.real")),
 				"Non-existent URI",
-				Device.RuntimePlatform == Device.Windows && Device.Idiom == TargetIdiom.Phone
+				(Device.RuntimePlatform == Device.UWP || Device.RuntimePlatform == Device.WinRT) && Device.Idiom == TargetIdiom.Phone
 				? "Clicking this button should display an alert dialog. The error message should include the text 'NotFound'."
 				: "Clicking this button should display an alert dialog. The error message should include the text 'the server name or address could not be resolved'.");
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue773.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue773.cs
@@ -165,7 +165,7 @@ namespace Xamarin.Forms.Controls.Issues
 			layout.Children.Add(new ScrollView {
 				BackgroundColor = Color.Aqua,
 				Orientation = ScrollOrientation.Horizontal,
-				HeightRequest = Device.RuntimePlatform == Device.Windows || Device.RuntimePlatform == Device.WinPhone ? 80 : 44,
+				HeightRequest = Device.RuntimePlatform == Device.WinRT || Device.RuntimePlatform == Device.UWP || Device.RuntimePlatform == Device.WinPhone ? 80 : 44,
 				Content = buttonStack
 			});
 

--- a/Xamarin.Forms.Controls/ControlGalleryPages/AccessibilityGallery.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/AccessibilityGallery.cs
@@ -25,7 +25,8 @@ namespace Xamarin.Forms.Controls
 					scrollFingers = "two fingers";
 					explore = "Drag one finger across the screen to read each element on the page.";
 					break;
-				case Device.Windows:
+				case Device.WinRT:
+				case Device.UWP:
 				case Device.WinPhone:
 					screenReader = "Narrator";
 					scrollFingers = "two fingers";

--- a/Xamarin.Forms.Controls/GalleryPages/ButtonGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ButtonGallery.cs
@@ -41,7 +41,8 @@ namespace Xamarin.Forms.Controls
 				fontName = "sans-serif-light";
 				break;
 			case Device.WinPhone:
-			case Device.Windows:
+			case Device.WinRT:
+			case Device.UWP:
 				fontName = "Comic Sans MS";
 				break;
 			}

--- a/Xamarin.Forms.Controls/GalleryPages/CellsGalleries/ProductViewCell.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CellsGalleries/ProductViewCell.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls
 
 			var frame = new Frame {
 				Content = _stack,
-				BackgroundColor = new[] { Device.Android, Device.Windows, Device.WinPhone }.Contains(Device.RuntimePlatform) ? new Color(0.2) : new Color(1)
+				BackgroundColor = new[] { Device.Android, Device.WinRT, Device.UWP, Device.WinPhone }.Contains(Device.RuntimePlatform) ? new Color(0.2) : new Color(1)
 			};
 			_timeLabel = new Label {
 				Text = text

--- a/Xamarin.Forms.Controls/GalleryPages/FrameGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/FrameGallery.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Controls
 				Content = new Button {
 					Text = "Framous!"
 				},
-				BackgroundColor = new[] { Device.Android, Device.Windows, Device.WinPhone }.Contains(Device.RuntimePlatform) ? new Color(0) : new Color(1),
+				BackgroundColor = new[] { Device.Android, Device.WinRT, Device.UWP, Device.WinPhone }.Contains(Device.RuntimePlatform) ? new Color(0) : new Color(1),
 				VerticalOptions = LayoutOptions.FillAndExpand
 			};
 

--- a/Xamarin.Forms.Controls/GalleryPages/LabelGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/LabelGallery.cs
@@ -82,7 +82,8 @@ namespace Xamarin.Forms.Controls
 				fontName = "sans-serif-light";
 				break;
 			case Device.WinPhone:
-			case Device.Windows:
+			case Device.WinRT:
+			case Device.UWP:
 				fontName = "Comic Sans MS";
 				break;
 			}

--- a/Xamarin.Forms.Controls/TestCases.cs
+++ b/Xamarin.Forms.Controls/TestCases.cs
@@ -212,7 +212,8 @@ namespace Xamarin.Forms.Controls
 				page.Title = "Test Cases";
 				break;
 			case Device.WinPhone:
-			case Device.Windows:
+			case Device.UWP:
+			case Device.WinRT:
 				page.Title = "Tests";
 				break;
 			}

--- a/Xamarin.Forms.Core.UnitTests/ListViewTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ListViewTests.cs
@@ -1474,7 +1474,8 @@ namespace Xamarin.Forms.Core.UnitTests
 
 		[TestCase (Device.Android, ListViewCachingStrategy.RecycleElement)]
 		[TestCase (Device.iOS, ListViewCachingStrategy.RecycleElement)]
-		[TestCase (Device.Windows, ListViewCachingStrategy.RetainElement)]
+		[TestCase (Device.WinRT, ListViewCachingStrategy.RetainElement)]
+		[TestCase(Device.UWP, ListViewCachingStrategy.RetainElement)]
 		[TestCase ("Other", ListViewCachingStrategy.RetainElement)]
 		[TestCase (Device.WinPhone, ListViewCachingStrategy.RetainElement)]
 		public void EnforcesCachingStrategy (string platform, ListViewCachingStrategy expected)

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -11,7 +11,8 @@ namespace Xamarin.Forms
 		public const string iOS = "iOS";
 		public const string Android = "Android";
 		public const string WinPhone = "WinPhone";
-		public const string Windows = "Windows";
+		public const string UWP = "UWP";
+		public const string WinRT = "WinRT";
 		public const string macOS = "macOS";
 
 		internal static DeviceInfo info;
@@ -29,6 +30,13 @@ namespace Xamarin.Forms
 				TargetPlatform platform;
 				if (Enum.TryParse(RuntimePlatform, out platform))
 					return platform;
+
+				// In the old TargetPlatform, there was no distinction between WinRT/UWP
+				if (RuntimePlatform == UWP || RuntimePlatform == WinRT)
+				{
+					return TargetPlatform.Windows;
+				}
+
 				return TargetPlatform.Other;
 			}
 		}

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -135,6 +135,7 @@ namespace Xamarin.Forms.CustomAttributes
 		Android = 1 << 1,
 		WinPhone = 1 << 2,
 		WinRT = 1 << 3,
+		UWP = 1 << 4,
 		All = ~0,
 		Default = 0
 	}

--- a/Xamarin.Forms.Platform.WinRT/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.WinRT/WindowsBasePlatformServices.cs
@@ -116,7 +116,11 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		public bool IsInvokeRequired => !CoreApplication.MainView.CoreWindow.Dispatcher.HasThreadAccess;
 
-		public string RuntimePlatform => Device.Windows;
+#if WINDOWS_UWP
+		public string RuntimePlatform => Device.UWP;
+#else
+		public string RuntimePlatform => Device.WinRT;
+#endif
 
 		public void OpenUriAction(Uri uri)
 		{

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -269,7 +269,14 @@ namespace Xamarin.Forms.Xaml
 					continue;
 				try {
 					if (targetPlatform != Device.RuntimePlatform)
+					{
+						// Special case for Windows backward compatibility
+						if (targetPlatform == "Windows" &&
+						    (Device.RuntimePlatform == Device.UWP || Device.RuntimePlatform == Device.WinRT))
+							continue;
+						
 						prefixes.Add(prefix);
+					}
 				} catch (InvalidOperationException) {
 					prefixes.Add(prefix);
 				}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
@@ -361,9 +361,9 @@ button.HeightRequest = Device.OnPlatform (20,30,30);
         <remarks>While the callback returns <see langword="true" />, the timer will keep recurring.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Windows">
-      <MemberSignature Language="C#" Value="public const string Windows;" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal string Windows" />
+    <Member MemberName="UWP">
+      <MemberSignature Language="C#" Value="public const string UWP;" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal string UWP" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -379,6 +379,21 @@ button.HeightRequest = Device.OnPlatform (20,30,30);
     <Member MemberName="WinPhone">
       <MemberSignature Language="C#" Value="public const string WinPhone;" />
       <MemberSignature Language="ILAsm" Value=".field public static literal string WinPhone" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="WinRT">
+      <MemberSignature Language="C#" Value="public const string WinRT;" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal string WinRT" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>


### PR DESCRIPTION
### Description of Change ###

Splits the `Windows` option for `RuntimePlatform` into separate `WinRT` and `UWP` values, allowing for separate `OnPlatform` values for each platform (and distinguishing between the two anywhere else it might be called for).

Also added long-overdue `UWP` option to `PlatformAffected`.

### Bugs Fixed ###

None

### API Changes ###

Anywhere which previously checked for a `Device.RuntimePlatform` of `Windows` will now need to check `WinRT` and `UWP` individually.

### Behavioral Changes ###

`Device.RuntimePlatform` now returns `WinRT` on WinRT and `UWP` on UWP.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
