### PR TITLE
[WinRT/UWP] Make TextBox better respect background color changes via behaviors

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44955.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44955.cs
@@ -1,0 +1,81 @@
+﻿using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44955, "[WinRT/UWP] Setting Entry BackgroundColor via Behavior results in sticky unfocused background color", PlatformAffected.WinRT)]
+	public class Bugzilla44955 : TestContentPage
+	{
+		Entry _validationEntry;
+		protected override void Init()
+		{
+			_validationEntry = new Entry();
+			_validationEntry.Behaviors.Add(new NonEmptyStringValidator());
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = "The first entry should have a red background only when it is empty, regardless of focus (due to an attached behavior). The second has a set background color, the third is default, and the last is default, but disabled."
+					},
+					_validationEntry,
+					new Entry
+					{
+						BackgroundColor = Color.MediumPurple
+					},
+					new Entry(),
+					new Entry
+					{
+						IsEnabled = false
+					},
+					new Button
+					{
+						Text = "Change background of first label to yellow",
+						Command = new Command(() => _validationEntry.BackgroundColor = Color.Yellow)
+					}
+				}
+			};
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+			_validationEntry.Behaviors.Clear();
+		}
+
+		class NonEmptyStringValidator : Behavior<Entry>
+		{
+			protected override void OnAttachedTo(Entry bindable)
+			{
+				bindable.TextChanged += HandleTextChanged;
+				Validate(bindable, bindable.Text);
+			}
+
+			protected override void OnDetachingFrom(Entry bindable)
+			{
+				bindable.TextChanged -= HandleTextChanged;
+			}
+
+			void HandleTextChanged(object sender, TextChangedEventArgs e)
+			{
+				Validate((Entry)sender, e.NewTextValue);
+			}
+
+			void Validate(Entry entry, string text)
+			{
+				if (text == null)
+					entry.BackgroundColor = Color.Red;
+				else
+					entry.BackgroundColor = text.Trim() != "" ? Color.Default : Color.Red;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -157,6 +157,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44044.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45330.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />

--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -166,7 +166,7 @@
 						<Border x:Name="BackgroundElement" Background="{TemplateBinding Background}" Grid.ColumnSpan="2"
 						        Margin="{TemplateBinding BorderThickness}" Opacity="{ThemeResource TextControlBackgroundRestOpacity}"
 						        Grid.Row="1" Grid.RowSpan="1" />
-						<Border x:Name="BorderElement" BorderBrush="{TemplateBinding BorderBrush}"
+						<Border x:Name="BorderElement" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
 						        BorderThickness="{TemplateBinding BorderThickness}" Grid.ColumnSpan="2" Grid.Row="1" Grid.RowSpan="1" />
 						<ContentPresenter x:Name="HeaderContentPresenter" Grid.ColumnSpan="2"
 						                  ContentTemplate="{TemplateBinding HeaderTemplate}" Content="{TemplateBinding Header}"

--- a/Xamarin.Forms.Platform.WinRT.Phone/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.WinRT.Phone/FormsTextBoxStyle.xaml
@@ -48,7 +48,10 @@
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="ContentElement">
 											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextBoxDisabledForegroundThemeBrush}"/>
 										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="PlaceholderTextContentPresenter">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background" Storyboard.TargetName="ContentElement">
+                                            <DiscreteObjectKeyFrame KeyTime="0"  Value="{ThemeResource TextBoxDisabledBackgroundThemeBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="PlaceholderTextContentPresenter">
 											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextBoxDisabledForegroundThemeBrush}"/>
 										</ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="HeaderContentPresenter">
@@ -90,6 +93,7 @@
                                           Grid.Row="0" Style="{StaticResource HeaderContentPresenterStyle}"/>
 						<ScrollViewer x:Name="ContentElement" 
                                       AutomationProperties.AccessibilityView="Raw" 
+                                      Background="{Binding BackgroundFocusBrush, RelativeSource={RelativeSource TemplatedParent}}"
                                       HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}" 
                                       HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" 
                                       IsTabStop="False" 

--- a/Xamarin.Forms.Platform.WinRT.Tablet/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/FormsTextBoxStyle.xaml
@@ -123,12 +123,22 @@
 											<DiscreteObjectKeyFrame KeyTime="0"
 											                        Value="{ThemeResource TextBoxDisabledBackgroundThemeBrush}" />
 										</ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement"
+										                               Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+											                        Value="{ThemeResource TextBoxDisabledBackgroundThemeBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement"
 										                               Storyboard.TargetProperty="BorderBrush">
 											<DiscreteObjectKeyFrame KeyTime="0"
 											                        Value="{ThemeResource TextBoxDisabledBorderThemeBrush}" />
 										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement"
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement"
+										                               Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+											                        Value="{ThemeResource TextBoxDisabledBackgroundThemeBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement"
 										                               Storyboard.TargetProperty="Foreground">
 											<DiscreteObjectKeyFrame KeyTime="0"
 											                        Value="{ThemeResource TextBoxDisabledForegroundThemeBrush}" />
@@ -198,6 +208,7 @@
 						        Grid.ColumnSpan="2"
 						        Grid.RowSpan="1" />
 						<Border x:Name="BorderElement"
+                                Background="{Binding Background, RelativeSource={RelativeSource TemplatedParent}}"
 						        Grid.Row="1"
 						        BorderBrush="{TemplateBinding BorderBrush}"
 						        BorderThickness="{TemplateBinding BorderThickness}"
@@ -212,6 +223,7 @@
 						                  ContentTemplate="{TemplateBinding HeaderTemplate}"
 						                  FontWeight="Semilight" />
 						<ScrollViewer x:Name="ContentElement"
+                                      Background="{Binding Background, RelativeSource={RelativeSource TemplatedParent}}"
 						              Grid.Row="1"
 						              HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
 						              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"


### PR DESCRIPTION
### Description of Change ###

Similar to #618, there's an issue with behaviors and the background color. This is an older fix that was sitting around that was most of the way there for WinRT, but is better than the current situation where the entry background color isn't updating correctly. The only lingering issue is that the border on WinRT (tablet) has a very faint tint to it when the background changes to white (in the repro, it'll be a very light red), but nothing in the template stood out and I wanted to avoid modifying it too much. The phone template is simpler and doesn't seem to have the same problem. If anything stands out on the former, feel free to point it out.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=44955

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
