### PR TITLE
Null compiled markup

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/NullExtension.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/NullExtension.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Build.Tasks
+{
+	class NullExtension : ICompiledMarkupExtension
+	{
+
+		public IEnumerable<Instruction> ProvideValue(IElementNode node, ModuleDefinition module, ILContext context, out TypeReference typeRef)
+		{
+			typeRef = module.TypeSystem.Object;
+			return new[] { Instruction.Create(OpCodes.Ldnull) };
+		}
+	}
+}

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -111,6 +111,7 @@
     <Compile Include="CompiledValueProviders\PassthroughValueProvider.cs" />
     <Compile Include="CompiledConverters\ListStringTypeConverter.cs" />
     <Compile Include="CompiledMarkupExtensions\TypeExtension.cs" />
+    <Compile Include="CompiledMarkupExtensions\NullExtension.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/Xamarin.Forms.Xaml/MarkupExtensions/NullExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/NullExtension.cs
@@ -2,6 +2,7 @@
 
 namespace Xamarin.Forms.Xaml
 {
+	[ProvideCompiled("Xamarin.Forms.Build.Tasks.NullExtension")]
 	public class NullExtension : IMarkupExtension
 	{
 		public object ProvideValue(IServiceProvider serviceProvider)


### PR DESCRIPTION
### Description of Change ###

do not call ProvideValue on `{x:Null}` but push `ldnull` on the stack instead. Reduce Il size and computation time.

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
