### PR TITLE
[WinRT/UWP] Insert missing SendScrollFinished call

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44940.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44940.cs
@@ -1,0 +1,94 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44940, "[WinRT/UWP] ScrollView.ScrollToAsync does not return from await", PlatformAffected.WinRT)]
+	public class Bugzilla44940 : TestContentPage
+	{
+		Label _statusLabel;
+		Entry _firstEntry;
+		Entry _secondEntry;
+		StackLayout _verticalStackLayout;
+		ScrollView _scrollView;
+
+		protected override void Init()
+		{
+			_statusLabel = new Label
+			{
+				Text = "With focus on first Entry, hit Return key",
+				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				LineBreakMode = LineBreakMode.WordWrap
+			};
+
+			_firstEntry = new Entry
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+			};
+
+			_secondEntry = new Entry
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+			};
+
+			_firstEntry.Completed += FirstEntryCompleted;
+
+			_verticalStackLayout = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				Padding = new Thickness(0, 0, 0, 0),
+				Margin = new Thickness(0, 0, 0, 0),
+				Spacing = 5,
+				Children =
+				{
+					_statusLabel,
+					_firstEntry,
+					_secondEntry
+				}
+			};
+
+			_scrollView = new ScrollView
+			{
+				Orientation = ScrollOrientation.Vertical,
+				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				Margin = new Thickness(10, 5, 10, 0),
+				Padding = new Thickness(0, 0, 0, 0),
+				Content = _verticalStackLayout
+			};
+
+			Content = _scrollView;
+			
+			Device.BeginInvokeOnMainThread(async () =>
+			{
+				await Task.Delay(100);
+				_firstEntry.Focus();
+			});
+		}
+
+		async void FirstEntryCompleted(object sender, System.EventArgs e)
+		{
+			_firstEntry?.Unfocus();
+			_statusLabel.Text = "Attempting scroll. Return from await pending...";
+			await _scrollView.ScrollToAsync(_secondEntry, ScrollToPosition.MakeVisible, false);
+			_statusLabel.Text = "This should be visible on WinRT/UWP";
+			_secondEntry?.Focus();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -149,6 +149,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43735.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43783.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44940.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44944.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44166.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44461.cs" />

--- a/Xamarin.Forms.Platform.WinRT/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ScrollViewRenderer.cs
@@ -146,6 +146,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				Control.ChangeView(x, y, null, !e.ShouldAnimate);
 			}
+			Controller.SendScrollFinished();
 		}
 
 		void OnViewChanged(object sender, ScrollViewerViewChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

`SendScrollFinished` was not being called inside of `OnScrollToRequested` on WinRT/UWP which would cause an `await` to not be returned.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=44940

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
