### PR TITLE
Throw InvalidOperationException when ViewCell View is null

### DIFF
--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -2,6 +2,7 @@ using Android.Content;
 using Android.Views;
 using AView = Android.Views.View;
 using Xamarin.Forms.Internals;
+using System;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -31,6 +32,9 @@ namespace Xamarin.Forms.Platform.Android
 				unevenRows = ListView.HasUnevenRowsProperty;
 				rowHeight = ListView.RowHeightProperty;
 			}
+
+			if (cell.View == null)
+				throw new InvalidOperationException($"ViewCell must have a {nameof(cell.View)}");
 
 			IVisualElementRenderer view = Platform.CreateRenderer(cell.View);
 			Platform.SetRenderer(cell.View, view);

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -139,6 +139,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			IVisualElementRenderer GetNewRenderer()
 			{
+				if (_viewCell.View == null)
+					throw new InvalidOperationException($"ViewCell must have a {nameof(_viewCell.View)}");
+
 				var newRenderer = Platform.CreateRenderer(_viewCell.View);
 				_rendererRef = new WeakReference<IVisualElementRenderer>(newRenderer);
 				ContentView.AddSubview(newRenderer.NativeView);


### PR DESCRIPTION
### Description of Change ###

Currently, a generic unhandled exception will be thrown during runtime if `ViewCell.View == null`. This fix adds a null check which throws an `InvalidOperationException` with a more descriptive exception message.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
