### PR TITLE
Fixes unlimited Image sizing in UWP ImageCell and aligns lack of styling …

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -375,7 +375,7 @@
 	</DataTemplate>
 
 	<DataTemplate x:Key="ImageCell">
-		<Grid>
+		<Grid Margin="10,0,10,1">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition />
@@ -389,9 +389,12 @@
 			<Image Grid.Column="0" Grid.RowSpan="2"
 				DataContext="{Binding ImageSource, Converter={StaticResource ImageConverter}}"
 				Source="{Binding Value}"
-				VerticalAlignment="Center" />
+				VerticalAlignment="Center" 
+				Height="60"
+				Margin="0,0,20,0"/>
 
 			<TextBlock Grid.Column="1" Grid.Row="0"
+				Margin="0,10,0,0"
 				Text="{Binding Text}"
 				Style="{ThemeResource BaseTextBlockStyle}"
 				Visibility="{Binding Text,RelativeSource={RelativeSource Self}, Converter={StaticResource CollapseWhenEmpty}}"


### PR DESCRIPTION
…to be similar to Android ImageCell.

### Description of Change ###

Added a fixed height to the `Image` element of `ImageCell`.  This stops large images from expanding the `Grid` container.  Also, added some styling changes to the overall `ImageCell` using `Margin` so that there is a 1 pixel gap between items and centering of the two text fields.

No tests as these are just UI property value changes.

### Bugs Fixed ###

[https://bugzilla.xamarin.com/show_bug.cgi?id=47962](https://bugzilla.xamarin.com/show_bug.cgi?id=47962)

### API Changes ###

None

### Behavioral Changes ###

NA

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X ] Rebased on top of master at time of PR
- [X ] Changes adhere to coding standard
- [X ] Consolidate commits as makes sense
