### PR TITLE
[WinRT/UWP] Open Picker dropdown when calling Focus

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52266.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52266.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 52266, "[WinRT/UWP] Picker.Focus() does not open the dropdown", PlatformAffected.WinRT)]
+	public class Bugzilla52266 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var picker = new Picker
+			{
+				ItemsSource = new string[] { "A", "B", "C" }
+			};
+			Content = new StackLayout
+			{
+				Children =
+				{
+					picker,
+					new Button
+					{
+						Text = "Click to focus the picker",
+						Command = new Command(() =>
+						{
+							picker.Focus();
+						})
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -184,6 +184,7 @@
       <DependentUpon>Bugzilla51642.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52266.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.WinRT/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/PickerRenderer.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Platform.WinRT
 	{
 		bool _isAnimating;
 		Brush _defaultBrush;
+		bool _dropDownWasOpened;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -32,6 +33,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					Control.DropDownClosed -= OnDropDownOpenStateChanged;
 					Control.OpenAnimationCompleted -= ControlOnOpenAnimationCompleted;
 					Control.Loaded -= ControlOnLoaded;
+					Control.GotFocus -= ControlOnGotFocus;
 				}
 			}
 
@@ -51,6 +53,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					Control.OpenAnimationCompleted += ControlOnOpenAnimationCompleted;
 					Control.ClosedAnimationStarted += ControlOnClosedAnimationStarted;
 					Control.Loaded += ControlOnLoaded;
+					Control.GotFocus += ControlOnGotFocus;
 				}
 
 				Control.ItemsSource = ((LockableObservableListWrapper)Element.Items)._list;
@@ -102,6 +105,19 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 		}
 
+		void ControlOnGotFocus(object sender, RoutedEventArgs routedEventArgs)
+		{
+			// The FormsComboBox is separate from the Popup/dropdown that it uses to select an item,
+			// and the behavior here is changed to be similar to the other platforms where focusing the
+			// Picker opens the dropdown (with the exception where if focus was given via keyboard, such
+			// as tabbing through controls). The _dropDownWasOpened flag is reset to false in the case that
+			// the FormsComboBox regained focus after the dropdown closed.
+			if (!_dropDownWasOpened && Control.FocusState != FocusState.Keyboard)
+				Control.IsDropDownOpen = true;
+			else
+				_dropDownWasOpened = false;
+		}
+
 		void OnControlSelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 			if (Element != null)
@@ -129,6 +145,9 @@ namespace Xamarin.Forms.Platform.WinRT
 				_isAnimating = false;
 				// and force the final redraw
 				((IVisualElementController)Element)?.InvalidateMeasure(InvalidationTrigger.MeasureChanged);
+
+				// Related to ControlOnGotFocus, _dropDownWasOpened is set to true
+				_dropDownWasOpened = true;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

The Picker presently focuses the `ComboBox` but doesn't open the dropdown when `Focus()` is called on it. The dropdown itself (essentially a `Popup`) is separate from the `ComboBox` (`FormsComboBox`) that is used. Hooking into `GotFocus` and tracking whether the dropdown was just closed lets this function in line with what the other platforms do.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=52266

### API Changes ###

None

### Behavioral Changes ###

The unfortunate side effect here is that this is a behavior change from what presently occurs which appears in line with the default behavior of the platform (focusing the `ComboBox` only focuses the `ComboBox` and does not open the dropdown). We could alternatively implement a platform specific behavior which allows the user to define if this focus behavior opens the popup (or vice versa).

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
