### PR TITLE
IEditorController

### DIFF
--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -68,8 +68,7 @@ namespace Xamarin.Forms
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		void IEditorController.SendCompleted() => SendCompleted();
-		internal void SendCompleted()
+		void IEditorController.SendCompleted()
 		{
 			EventHandler handler = Completed;
 			if (handler != null)

--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_EditorRenderer))]
-	public class Editor : InputView, IFontElement, IElementConfiguration<Editor>
+	public class Editor : InputView, IEditorController, IFontElement, IElementConfiguration<Editor>
 	{
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(Editor), null, BindingMode.TwoWay, propertyChanged: (bindable, oldValue, newValue) =>
 		{
@@ -68,6 +68,7 @@ namespace Xamarin.Forms
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
+		void IEditorController.SendCompleted() => SendCompleted();
 		internal void SendCompleted()
 		{
 			EventHandler handler = Completed;

--- a/Xamarin.Forms.Core/IEditorController.cs
+++ b/Xamarin.Forms.Core/IEditorController.cs
@@ -1,0 +1,7 @@
+namespace Xamarin.Forms
+{
+	public interface IEditorController : IViewController
+	{
+		void SendCompleted();
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -87,6 +87,7 @@
     <Compile Include="DataTemplateSelector.cs" />
     <Compile Include="DateChangedEventArgs.cs" />
     <Compile Include="DelegateLogListener.cs" />
+    <Compile Include="IEditorController.cs" />
     <Compile Include="Internals\EffectUtilities.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
+        IEditorController ElementController => Element;
+
 		void ITextWatcher.AfterTextChanged(IEditable s)
 		{
 		}
@@ -53,7 +55,7 @@ namespace Xamarin.Forms.Platform.Android
 				edit.AddTextChangedListener(this);
 				edit.OnBackKeyboardPressed += (sender, args) =>
 				{
-					Element.SendCompleted();
+                    ElementController.SendCompleted();
 					edit.ClearFocus();
 				};
 			}
@@ -89,7 +91,7 @@ namespace Xamarin.Forms.Platform.Android
 		internal override void OnNativeFocusChanged(bool hasFocus)
 		{
 			if (Element.IsFocused && !hasFocus) // Editor has requested an unfocus, fire completed event
-				Element.SendCompleted();
+                ElementController.SendCompleted();
 		}
 
 		void UpdateFont()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EditorRenderer.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		const string NewLineSelector = "insertNewline";
 		bool _disposed;
 
-		IElementController ElementController => Element;
+		IEditorController ElementController => Element;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
 		{
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		void OnEditingEnded(object sender, EventArgs eventArgs)
 		{
 			Element.SetValue(VisualElement.IsFocusedPropertyKey, false);
-			Element.SendCompleted();
+            ElementController.SendCompleted();
 		}
 
 		void OnEditingBegan(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.WP8/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/EditorRenderer.cs
@@ -9,7 +9,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 	{
 		bool _fontApplied;
 
-		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
+        IEditorController ElementController => Element;
+
+        protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
 		{
 			base.OnElementChanged(e);
 
@@ -21,7 +23,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			UpdateInputScope();
 			UpdateTextColor();
 
-			Control.LostFocus += (sender, args) => Element.SendCompleted();
+			Control.LostFocus += (sender, args) => ElementController.SendCompleted();
 
 			textBox.TextChanged += TextBoxOnTextChanged;
 		}

--- a/Xamarin.Forms.Platform.WinRT/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/EditorRenderer.cs
@@ -16,7 +16,9 @@ namespace Xamarin.Forms.Platform.WinRT
 		bool _fontApplied;
 		Brush _backgroundColorFocusedDefaultBrush;
 
-		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
+        IEditorController ElementController => Element;
+
+        protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
 		{
 			if (e.NewElement != null)
 			{
@@ -83,7 +85,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnLostFocus(object sender, RoutedEventArgs e)
 		{
-			Element.SendCompleted();
+            ElementController.SendCompleted();
 		}
 
 		protected override void UpdateBackgroundColor()

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -8,9 +8,9 @@ namespace Xamarin.Forms.Platform.iOS
 	public class EditorRenderer : ViewRenderer<Editor, UITextView>
 	{
 		bool _disposed;
-		IElementController ElementController => Element as IElementController;
+        IEditorController ElementController => Element;
 
-		protected override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
 		{
 			if (_disposed)
 				return;
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.iOS
 					var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) =>
 					{
 						Control.ResignFirstResponder();
-						Element.SendCompleted();
+                        ElementController.SendCompleted();
 					});
 					accessoryView.SetItems(new[] { spacer, doneButton }, false);
 					Control.InputAccessoryView = accessoryView;
@@ -100,7 +100,7 @@ namespace Xamarin.Forms.Platform.iOS
 				ElementController.SetValueFromRenderer(Editor.TextProperty, Control.Text);
 
 			Element.SetValue(VisualElement.IsFocusedPropertyKey, false);
-			Element.SendCompleted();
+			ElementController.SendCompleted();
 		}
 
 		void OnStarted(object sender, EventArgs eventArgs)

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Editor.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Editor.xml
@@ -1,6 +1,6 @@
 <Type Name="Editor" FullName="Xamarin.Forms.Editor">
-  <TypeSignature Language="C#" Value="public class Editor : Xamarin.Forms.InputView, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.Editor&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Editor extends Xamarin.Forms.InputView implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.Editor&gt;" />
+  <TypeSignature Language="C#" Value="public class Editor : Xamarin.Forms.InputView, Xamarin.Forms.IEditorController, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.Editor&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Editor extends Xamarin.Forms.InputView implements class Xamarin.Forms.IEditorController, class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.Editor&gt;, class Xamarin.Forms.IElementController, class Xamarin.Forms.IViewController, class Xamarin.Forms.IVisualElementController" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -15,6 +15,9 @@
     <BaseTypeName>Xamarin.Forms.InputView</BaseTypeName>
   </Base>
   <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IEditorController</InterfaceName>
+    </Interface>
     <Interface>
       <InterfaceName>Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.Editor&gt;</InterfaceName>
     </Interface>
@@ -323,6 +326,22 @@ var editor = new Editor {
         <summary>Identifies the Text bindable property.</summary>
         <remarks>
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IEditorController.SendCompleted">
+      <MemberSignature Language="C#" Value="void IEditorController.SendCompleted ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IEditorController.SendCompleted() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/IEditorController.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/IEditorController.xml
@@ -1,0 +1,35 @@
+<Type Name="IEditorController" FullName="Xamarin.Forms.IEditorController">
+  <TypeSignature Language="C#" Value="public interface IEditorController : Xamarin.Forms.IViewController" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IEditorController implements class Xamarin.Forms.IElementController, class Xamarin.Forms.IViewController, class Xamarin.Forms.IVisualElementController" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IViewController</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="SendCompleted">
+      <MemberSignature Language="C#" Value="public void SendCompleted ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendCompleted() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -264,6 +264,7 @@
       <Type Name="IConfigElement`1" DisplayName="IConfigElement&lt;T&gt;" Kind="Interface" />
       <Type Name="IConfigPlatform" Kind="Interface" />
       <Type Name="IDefinition" Kind="Interface" />
+      <Type Name="IEditorController" Kind="Interface" />
       <Type Name="IEffectControlProvider" Kind="Interface" />
       <Type Name="IElementConfiguration`1" DisplayName="IElementConfiguration&lt;TElement&gt;" Kind="Interface" />
       <Type Name="IElementController" Kind="Interface" />


### PR DESCRIPTION
### Description of Change ###

3ed parties are adding platforms and their renderers need access to internal XF members that are exposed internally via InternalVisibleToAttribute. To expose those internal members we're adding IViewControllers to all renderers; We're making the internal members public but as explicit implementations of an interface to hide them from isense. 

### API Changes ###

Added Editor.SendCompleted as explicit implementation of IEditorController.
