### PR TITLE
IWebViewController

### DIFF
--- a/Xamarin.Forms.Core/IWebViewController.cs
+++ b/Xamarin.Forms.Core/IWebViewController.cs
@@ -1,0 +1,16 @@
+using System;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms
+{
+	public interface IWebViewController : IViewController
+	{
+		bool CanGoBack { get; set; }
+		bool CanGoForward { get; set; }
+		event EventHandler<EvalRequested> EvalRequested;
+		event EventHandler GoBackRequested;
+		event EventHandler GoForwardRequested;
+		void SendNavigated(WebNavigatedEventArgs args);
+		void SendNavigating(WebNavigatingEventArgs args);
+	}
+}

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -41,24 +41,22 @@ namespace Xamarin.Forms
 
 		bool IWebViewController.CanGoBack {
 			get { return CanGoBack; }
-			set { CanGoBack = value; }
+			set { SetValue(CanGoBackPropertyKey, value); }
 		}
 
 		public bool CanGoBack
 		{
 			get { return (bool)GetValue(CanGoBackProperty); }
-			internal set { SetValue(CanGoBackPropertyKey, value); }
 		}
 
 		bool IWebViewController.CanGoForward {
 			get { return CanGoForward; }
-			set { CanGoForward = value; }
+			set { SetValue(CanGoForwardPropertyKey, value); }
 		}
 
 		public bool CanGoForward
 		{
 			get { return (bool)GetValue(CanGoForwardProperty); }
-			internal set { SetValue(CanGoForwardPropertyKey, value); }
 		}
 
 		[TypeConverter(typeof(WebViewSourceTypeConverter))]
@@ -125,38 +123,30 @@ namespace Xamarin.Forms
 			remove { EvalRequested -= value; }
 		}
 
-		internal event EventHandler<EvalRequested> EvalRequested;
+		event EventHandler<EvalRequested> EvalRequested;
 
 		event EventHandler IWebViewController.GoBackRequested {
 			add { GoBackRequested += value; }
 			remove { GoBackRequested -= value; }
 		}
 
-		internal event EventHandler GoBackRequested;
+		event EventHandler GoBackRequested;
 
 		event EventHandler IWebViewController.GoForwardRequested {
 			add { GoForwardRequested += value; }
 			remove { GoForwardRequested -= value; }
 		}
 
-		internal event EventHandler GoForwardRequested;
+		event EventHandler GoForwardRequested;
 
-		void IWebViewController.SendNavigated(WebNavigatedEventArgs args) => SendNavigated(args);
-
-		internal void SendNavigated(WebNavigatedEventArgs args)
+		void IWebViewController.SendNavigated(WebNavigatedEventArgs args)
 		{
-			EventHandler<WebNavigatedEventArgs> handler = Navigated;
-			if (handler != null)
-				handler(this, args);
+			Navigated?.Invoke(this, args);
 		}
 
-		void IWebViewController.SendNavigating(WebNavigatingEventArgs args) => SendNavigating(args);
-
-		internal void SendNavigating(WebNavigatingEventArgs args)
+		void IWebViewController.SendNavigating(WebNavigatingEventArgs args)
 		{
-			EventHandler<WebNavigatingEventArgs> handler = Navigating;
-			if (handler != null)
-				handler(this, args);
+			Navigating?.Invoke(this, args);
 		}
 
 		public IPlatformElementConfiguration<T, WebView> On<T>() where T : IConfigPlatform

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_WebViewRenderer))]
-	public class WebView : View, IElementConfiguration<WebView>
+	public class WebView : View, IWebViewController, IElementConfiguration<WebView>
 	{
 		public static readonly BindableProperty SourceProperty = BindableProperty.Create("Source", typeof(WebViewSource), typeof(WebView), default(WebViewSource),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
@@ -39,10 +39,20 @@ namespace Xamarin.Forms
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<WebView>>(() => new PlatformConfigurationRegistry<WebView>(this));
 		}
 
+		bool IWebViewController.CanGoBack {
+			get { return CanGoBack; }
+			set { CanGoBack = value; }
+		}
+
 		public bool CanGoBack
 		{
 			get { return (bool)GetValue(CanGoBackProperty); }
 			internal set { SetValue(CanGoBackPropertyKey, value); }
+		}
+
+		bool IWebViewController.CanGoForward {
+			get { return CanGoForward; }
+			set { CanGoForward = value; }
 		}
 
 		public bool CanGoForward
@@ -110,11 +120,28 @@ namespace Xamarin.Forms
 			OnPropertyChanged(SourceProperty.PropertyName);
 		}
 
+		event EventHandler<EvalRequested> IWebViewController.EvalRequested {
+			add { EvalRequested += value; }
+			remove { EvalRequested -= value; }
+		}
+
 		internal event EventHandler<EvalRequested> EvalRequested;
+
+		event EventHandler IWebViewController.GoBackRequested {
+			add { GoBackRequested += value; }
+			remove { GoBackRequested -= value; }
+		}
 
 		internal event EventHandler GoBackRequested;
 
+		event EventHandler IWebViewController.GoForwardRequested {
+			add { GoForwardRequested += value; }
+			remove { GoForwardRequested -= value; }
+		}
+
 		internal event EventHandler GoForwardRequested;
+
+		void IWebViewController.SendNavigated(WebNavigatedEventArgs args) => SendNavigated(args);
 
 		internal void SendNavigated(WebNavigatedEventArgs args)
 		{
@@ -122,6 +149,8 @@ namespace Xamarin.Forms
 			if (handler != null)
 				handler(this, args);
 		}
+
+		void IWebViewController.SendNavigating(WebNavigatingEventArgs args) => SendNavigating(args);
 
 		internal void SendNavigating(WebNavigatingEventArgs args)
 		{

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -88,6 +88,7 @@
     <Compile Include="DateChangedEventArgs.cs" />
     <Compile Include="DelegateLogListener.cs" />
     <Compile Include="IEditorController.cs" />
+    <Compile Include="IWebViewController.cs" />
     <Compile Include="Internals\EffectUtilities.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -12,6 +12,8 @@ namespace Xamarin.Forms.Platform.Android
 		bool _ignoreSourceChanges;
 		FormsWebChromeClient _webChromeClient;
 
+        IWebViewController ElementController => Element;
+
 		public WebViewRenderer()
 		{
 			AutoPackage = false;
@@ -35,9 +37,9 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					if (Control != null)
 						Control.StopLoading();
-					Element.EvalRequested -= OnEvalRequested;
-					Element.GoBackRequested -= OnGoBackRequested;
-					Element.GoForwardRequested -= OnGoForwardRequested;
+					ElementController.EvalRequested -= OnEvalRequested;
+					ElementController.GoBackRequested -= OnGoBackRequested;
+					ElementController.GoForwardRequested -= OnGoForwardRequested;
 
 					_webChromeClient?.Dispose();
 				}
@@ -84,16 +86,18 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (e.OldElement != null)
 			{
-				e.OldElement.EvalRequested -= OnEvalRequested;
-				e.OldElement.GoBackRequested -= OnGoBackRequested;
-				e.OldElement.GoForwardRequested -= OnGoForwardRequested;
+				var oldElementController = e.OldElement as IWebViewController;
+				oldElementController.EvalRequested -= OnEvalRequested;
+				oldElementController.GoBackRequested -= OnGoBackRequested;
+				oldElementController.GoForwardRequested -= OnGoForwardRequested;
 			}
 
 			if (e.NewElement != null)
 			{
-				e.NewElement.EvalRequested += OnEvalRequested;
-				e.NewElement.GoBackRequested += OnGoBackRequested;
-				e.NewElement.GoForwardRequested += OnGoForwardRequested;
+				var newElementController = e.NewElement as IWebViewController;
+				newElementController.EvalRequested += OnEvalRequested;
+				newElementController.GoBackRequested += OnGoBackRequested;
+				newElementController.GoForwardRequested += OnGoForwardRequested;
 			}
 
 			Load();
@@ -147,8 +151,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (Element == null || Control == null)
 				return;
-			Element.CanGoBack = Control.CanGoBack();
-			Element.CanGoForward = Control.CanGoForward();
+			ElementController.CanGoBack = Control.CanGoBack();
+			ElementController.CanGoForward = Control.CanGoForward();
 		}
 
 		class WebClient : WebViewClient
@@ -170,12 +174,12 @@ namespace Xamarin.Forms.Platform.Android
 
 				var source = new UrlWebViewSource { Url = url };
 				_renderer._ignoreSourceChanges = true;
-				((IElementController)_renderer.Element).SetValueFromRenderer(WebView.SourceProperty, source);
+				_renderer.ElementController.SetValueFromRenderer(WebView.SourceProperty, source);
 				_renderer._ignoreSourceChanges = false;
 
 				var args = new WebNavigatedEventArgs(WebNavigationEvent.NewPage, source, url, _navigationResult);
 
-				_renderer.Element.SendNavigated(args);
+				_renderer.ElementController.SendNavigated(args);
 
 				_renderer.UpdateCanGoBackForward();
 
@@ -209,7 +213,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				var args = new WebNavigatingEventArgs(WebNavigationEvent.NewPage, new UrlWebViewSource { Url = url }, url);
 
-				_renderer.Element.SendNavigating(args);
+				_renderer.ElementController.SendNavigating(args);
 				_navigationResult = WebNavigationResult.Success;
 
 				_renderer.UpdateCanGoBackForward();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		WebNavigationEvent _lastBackForwardEvent;
 		WebNavigationEvent _lastEvent;
 
-		IElementController ElementController => Element;
+		IWebViewController ElementController => Element;
 
 		void IWebViewDelegate.LoadHtml(string html, string baseUrl)
 		{
@@ -43,9 +43,9 @@ namespace Xamarin.Forms.Platform.MacOS
 					Control.OnFinishedLoading += OnNSWebViewFinishedLoad;
 					Control.OnFailedLoading += OnNSWebViewFailedLoadWithError;
 
-					Element.EvalRequested += OnEvalRequested;
-					Element.GoBackRequested += OnGoBackRequested;
-					Element.GoForwardRequested += OnGoForwardRequested;
+					ElementController.EvalRequested += OnEvalRequested;
+					ElementController.GoBackRequested += OnGoBackRequested;
+					ElementController.GoForwardRequested += OnGoForwardRequested;
 
 					Layer.BackgroundColor = NSColor.Clear.CGColor;
 				}
@@ -69,9 +69,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				_disposed = true;
 				Control.OnFinishedLoading -= OnNSWebViewFinishedLoad;
 				Control.OnFailedLoading -= OnNSWebViewFailedLoadWithError;
-				Element.EvalRequested -= OnEvalRequested;
-				Element.GoBackRequested -= OnGoBackRequested;
-				Element.GoForwardRequested -= OnGoForwardRequested;
+				ElementController.EvalRequested -= OnEvalRequested;
+				ElementController.GoBackRequested -= OnGoBackRequested;
+				ElementController.GoForwardRequested -= OnGoForwardRequested;
 			}
 			base.Dispose(disposing);
 		}
@@ -90,8 +90,8 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (Element == null)
 				return;
-			Element.CanGoBack = Control.CanGoBack();
-			Element.CanGoForward = Control.CanGoForward();
+			ElementController.CanGoBack = Control.CanGoBack();
+			ElementController.CanGoForward = Control.CanGoForward();
 		}
 
 		void OnEvalRequested(object sender, EvalRequested eventArg)
@@ -124,7 +124,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		void OnNSWebViewFailedLoadWithError(object sender, WebKit.WebResourceErrorEventArgs e)
 		{
 			_lastEvent = _lastBackForwardEvent;
-			Element?.SendNavigated(new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = Control.MainFrameUrl },
+			ElementController?.SendNavigated(new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = Control.MainFrameUrl },
 				Control.MainFrameUrl, WebNavigationResult.Failure));
 
 			UpdateCanGoBackForward();
@@ -140,7 +140,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			_ignoreSourceChanges = false;
 
 			_lastEvent = _lastBackForwardEvent;
-			Element?.SendNavigated(new WebNavigatedEventArgs(_lastEvent, Element?.Source, Control.MainFrameUrl,
+			ElementController?.SendNavigated(new WebNavigatedEventArgs(_lastEvent, Element?.Source, Control.MainFrameUrl,
 				WebNavigationResult.Success));
 
 			UpdateCanGoBackForward();

--- a/Xamarin.Forms.Platform.WP8/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/WebViewRenderer.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Forms.Platform.WinPhone
 		WebNavigationEvent _eventState;
 		bool _updating;
 
+		IWebViewController ElementController => Element;
+
 		public async void LoadHtml(string html, string baseUrl)
 		{
 			string fileName = string.Format("formslocal_{0}.html", DateTime.Now.Ticks);
@@ -43,17 +45,19 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 			if (e.OldElement != null)
 			{
-				e.OldElement.EvalRequested -= OnEvalRequested;
-				e.OldElement.GoBackRequested -= OnGoBackRequested;
-				e.OldElement.GoForwardRequested -= OnGoForwardRequested;
+				var oldElementController = e.OldElement as IWebViewController;
+				oldElementController.EvalRequested -= OnEvalRequested;
+				oldElementController.GoBackRequested -= OnGoBackRequested;
+				oldElementController.GoForwardRequested -= OnGoForwardRequested;
 				Control.DataContext = null;
 			}
 
 			if (e.NewElement != null)
 			{
-				e.NewElement.EvalRequested += OnEvalRequested;
-				e.NewElement.GoBackRequested += OnGoBackRequested;
-				e.NewElement.GoForwardRequested += OnGoForwardRequested;
+				var newElementController = e.NewElement as IWebViewController;
+				newElementController.EvalRequested += OnEvalRequested;
+				newElementController.GoBackRequested += OnGoBackRequested;
+				newElementController.GoForwardRequested += OnGoForwardRequested;
 				Control.DataContext = e.NewElement;
 			}
 
@@ -123,7 +127,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			((IElementController)Element).SetValueFromRenderer(WebView.SourceProperty, source);
 			_updating = false;
 
-			Element.SendNavigated(new WebNavigatedEventArgs(evnt, source, source.Url, result));
+			ElementController.SendNavigated(new WebNavigatedEventArgs(evnt, source, source.Url, result));
 
 			UpdateCanGoBackForward();
 			_eventState = WebNavigationEvent.NewPage;
@@ -132,8 +136,8 @@ namespace Xamarin.Forms.Platform.WinPhone
 		// Nasty hack because we cant bind this because OneWayToSource isn't a thing in WP8, yay
 		void UpdateCanGoBackForward()
 		{
-			Element.CanGoBack = Control.CanGoBack;
-			Element.CanGoForward = Control.CanGoForward;
+			ElementController.CanGoBack = Control.CanGoBack;
+			ElementController.CanGoForward = Control.CanGoForward;
 		}
 
 		void WebBrowserOnNavigated(object sender, System.Windows.Navigation.NavigationEventArgs navigationEventArgs)
@@ -149,7 +153,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			string url = navigatingEventArgs.Uri.IsAbsoluteUri ? navigatingEventArgs.Uri.AbsoluteUri : navigatingEventArgs.Uri.OriginalString;
 			var args = new WebNavigatingEventArgs(_eventState, new UrlWebViewSource { Url = url }, url);
 
-			Element.SendNavigating(args);
+			ElementController.SendNavigating(args);
 
 			navigatingEventArgs.Cancel = args.Cancel;
 

--- a/Xamarin.Forms.Platform.WinRT/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/WebViewRenderer.cs
@@ -31,6 +31,7 @@ var bases = head.getElementsByTagName('base');
 if(bases.length == 0){
     head.innerHTML = 'baseTag' + head.innerHTML;
 }";
+		IWebViewController ElementController => Element;
 
 		public void LoadHtml(string html, string baseUrl)
 		{
@@ -98,9 +99,10 @@ if(bases.length == 0){
 
 			if (e.OldElement != null)
 			{
-				e.OldElement.EvalRequested -= OnEvalRequested;
-				e.OldElement.GoBackRequested -= OnGoBackRequested;
-				e.OldElement.GoForwardRequested -= OnGoForwardRequested;
+				var oldElementController = e.OldElement as IWebViewController;
+				oldElementController.EvalRequested -= OnEvalRequested;
+				oldElementController.GoBackRequested -= OnGoBackRequested;
+				oldElementController.GoForwardRequested -= OnGoForwardRequested;
 			}
 
 			if (e.NewElement != null)
@@ -114,9 +116,10 @@ if(bases.length == 0){
 					SetNativeControl(webView);
 				}
 
-				e.NewElement.EvalRequested += OnEvalRequested;
-				e.NewElement.GoForwardRequested += OnGoForwardRequested;
-				e.NewElement.GoBackRequested += OnGoBackRequested;
+				var newElementController = e.NewElement as IWebViewController;
+				newElementController.EvalRequested += OnEvalRequested;
+				newElementController.GoForwardRequested += OnGoForwardRequested;
+				newElementController.GoBackRequested += OnGoBackRequested;
 
 				Load();
 			}
@@ -190,7 +193,7 @@ if(bases.length == 0){
 			{
 				var args = new WebNavigatingEventArgs(_eventState, new UrlWebViewSource { Url = uri.AbsoluteUri }, uri.AbsoluteUri);
 
-				Element.SendNavigating(args);
+				ElementController.SendNavigating(args);
 				e.Cancel = args.Cancel;
 
 				// reset in this case because this is the last event we will get
@@ -205,7 +208,7 @@ if(bases.length == 0){
 			((IElementController)Element).SetValueFromRenderer(WebView.SourceProperty, source);
 			_updating = false;
 
-			Element.SendNavigated(new WebNavigatedEventArgs(evnt, source, source.Url, result));
+			ElementController.SendNavigated(new WebNavigatedEventArgs(evnt, source, source.Url, result));
 
 			UpdateCanGoBackForward();
 			_eventState = WebNavigationEvent.NewPage;
@@ -213,8 +216,8 @@ if(bases.length == 0){
 
 		void UpdateCanGoBackForward()
 		{
-			Element.CanGoBack = Control.CanGoBack;
-			Element.CanGoForward = Control.CanGoForward;
+			ElementController.CanGoBack = Control.CanGoBack;
+			ElementController.CanGoForward = Control.CanGoForward;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -20,6 +20,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 		}
 
+		IWebViewController ElementController => Element as IWebViewController;
+
 		public VisualElement Element { get; private set; }
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
@@ -34,9 +36,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var oldElement = Element;
 			Element = element;
 			Element.PropertyChanged += HandlePropertyChanged;
-			((WebView)Element).EvalRequested += OnEvalRequested;
-			((WebView)Element).GoBackRequested += OnGoBackRequested;
-			((WebView)Element).GoForwardRequested += OnGoForwardRequested;
+			ElementController.EvalRequested += OnEvalRequested;
+			ElementController.GoBackRequested += OnGoBackRequested;
+			ElementController.GoForwardRequested += OnGoForwardRequested;
 			Delegate = new CustomWebViewDelegate(this);
 
 			BackgroundColor = UIColor.Clear;
@@ -96,9 +98,9 @@ namespace Xamarin.Forms.Platform.iOS
 					StopLoading();
 
 				Element.PropertyChanged -= HandlePropertyChanged;
-				((WebView)Element).EvalRequested -= OnEvalRequested;
-				((WebView)Element).GoBackRequested -= OnGoBackRequested;
-				((WebView)Element).GoForwardRequested -= OnGoForwardRequested;
+				ElementController.EvalRequested -= OnEvalRequested;
+				ElementController.GoBackRequested -= OnGoBackRequested;
+				ElementController.GoForwardRequested -= OnGoForwardRequested;
 
 				_tracker?.Dispose();
 				_packager?.Dispose();
@@ -160,8 +162,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateCanGoBackForward()
 		{
-			((WebView)Element).CanGoBack = CanGoBack;
-			((WebView)Element).CanGoForward = CanGoForward;
+			ElementController.CanGoBack = CanGoBack;
+			ElementController.CanGoForward = CanGoForward;
 		}
 
 		class CustomWebViewDelegate : UIWebViewDelegate
@@ -176,6 +178,8 @@ namespace Xamarin.Forms.Platform.iOS
 				_renderer = renderer;
 			}
 
+			IWebViewController WebViewController => WebView;
+
 			WebView WebView
 			{
 				get { return (WebView)_renderer.Element; }
@@ -184,7 +188,7 @@ namespace Xamarin.Forms.Platform.iOS
 			public override void LoadFailed(UIWebView webView, NSError error)
 			{
 				var url = GetCurrentUrl();
-				WebView.SendNavigated(new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = url }, url, WebNavigationResult.Failure));
+				WebViewController.SendNavigated(new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = url }, url, WebNavigationResult.Failure));
 
 				_renderer.UpdateCanGoBackForward();
 			}
@@ -200,7 +204,7 @@ namespace Xamarin.Forms.Platform.iOS
 				_renderer._ignoreSourceChanges = false;
 
 				var args = new WebNavigatedEventArgs(_lastEvent, WebView.Source, url, WebNavigationResult.Success);
-				WebView.SendNavigated(args);
+				WebViewController.SendNavigated(args);
 
 				_renderer.UpdateCanGoBackForward();
 			}
@@ -238,7 +242,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var lastUrl = request.Url.ToString();
 				var args = new WebNavigatingEventArgs(navEvent, new UrlWebViewSource { Url = lastUrl }, lastUrl);
 
-				WebView.SendNavigating(args);
+				WebViewController.SendNavigating(args);
 				_renderer.UpdateCanGoBackForward();
 				return !args.Cancel;
 			}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/IWebViewController.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/IWebViewController.xml
@@ -1,0 +1,134 @@
+<Type Name="IWebViewController" FullName="Xamarin.Forms.IWebViewController">
+  <TypeSignature Language="C#" Value="public interface IWebViewController : Xamarin.Forms.IViewController" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IWebViewController implements class Xamarin.Forms.IElementController, class Xamarin.Forms.IViewController, class Xamarin.Forms.IVisualElementController" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IViewController</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="CanGoBack">
+      <MemberSignature Language="C#" Value="public bool CanGoBack { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool CanGoBack" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CanGoForward">
+      <MemberSignature Language="C#" Value="public bool CanGoForward { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool CanGoForward" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="EvalRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.EvalRequested&gt; EvalRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.EvalRequested&gt; EvalRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.EvalRequested&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GoBackRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler GoBackRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler GoBackRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.EventHandler</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GoForwardRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler GoForwardRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler GoForwardRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.EventHandler</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendNavigated">
+      <MemberSignature Language="C#" Value="public void SendNavigated (Xamarin.Forms.WebNavigatedEventArgs args);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendNavigated(class Xamarin.Forms.WebNavigatedEventArgs args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="args" Type="Xamarin.Forms.WebNavigatedEventArgs" />
+      </Parameters>
+      <Docs>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendNavigating">
+      <MemberSignature Language="C#" Value="public void SendNavigating (Xamarin.Forms.WebNavigatingEventArgs args);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendNavigating(class Xamarin.Forms.WebNavigatingEventArgs args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="args" Type="Xamarin.Forms.WebNavigatingEventArgs" />
+      </Parameters>
+      <Docs>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/WebView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/WebView.xml
@@ -1,6 +1,6 @@
 <Type Name="WebView" FullName="Xamarin.Forms.WebView">
-  <TypeSignature Language="C#" Value="public class WebView : Xamarin.Forms.View, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.WebView&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit WebView extends Xamarin.Forms.View implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.WebView&gt;" />
+  <TypeSignature Language="C#" Value="public class WebView : Xamarin.Forms.View, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.WebView&gt;, Xamarin.Forms.IWebViewController" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit WebView extends Xamarin.Forms.View implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.WebView&gt;, class Xamarin.Forms.IElementController, class Xamarin.Forms.IViewController, class Xamarin.Forms.IVisualElementController, class Xamarin.Forms.IWebViewController" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -17,6 +17,9 @@
   <Interfaces>
     <Interface>
       <InterfaceName>Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.WebView&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IWebViewController</InterfaceName>
     </Interface>
   </Interfaces>
   <Attributes>
@@ -403,6 +406,76 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Xamarin.Forms.WebView.Source" /> property.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IWebViewController.CanGoBack">
+      <MemberSignature Language="C#" Value="bool Xamarin.Forms.IWebViewController.CanGoBack { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool Xamarin.Forms.IWebViewController.CanGoBack" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IWebViewController.CanGoForward">
+      <MemberSignature Language="C#" Value="bool Xamarin.Forms.IWebViewController.CanGoForward { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool Xamarin.Forms.IWebViewController.CanGoForward" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IWebViewController.SendNavigated">
+      <MemberSignature Language="C#" Value="void IWebViewController.SendNavigated (Xamarin.Forms.WebNavigatedEventArgs args);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IWebViewController.SendNavigated(class Xamarin.Forms.WebNavigatedEventArgs args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="args" Type="Xamarin.Forms.WebNavigatedEventArgs" />
+      </Parameters>
+      <Docs>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IWebViewController.SendNavigating">
+      <MemberSignature Language="C#" Value="void IWebViewController.SendNavigating (Xamarin.Forms.WebNavigatingEventArgs args);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IWebViewController.SendNavigating(class Xamarin.Forms.WebNavigatingEventArgs args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="args" Type="Xamarin.Forms.WebNavigatingEventArgs" />
+      </Parameters>
+      <Docs>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -316,6 +316,7 @@
       <Type Name="IViewContainer`1" DisplayName="IViewContainer&lt;T&gt;" Kind="Interface" />
       <Type Name="IViewController" Kind="Interface" />
       <Type Name="IVisualElementController" Kind="Interface" />
+      <Type Name="IWebViewController" Kind="Interface" />
       <Type Name="IWebViewDelegate" Kind="Interface" />
       <Type Name="Keyboard" Kind="Class" />
       <Type Name="KeyboardFlags" Kind="Enumeration" />


### PR DESCRIPTION
3ed parties are adding platforms and their renderers need access to internal XF members that are exposed internally via InternalVisibleToAttribute. To expose those internal members we're adding IViewControllers to all renderers; We're making the internal members public but as explicit implementations of an interface to hide them from isense.

Describe your changes here.

None

### API Changes ###

List all API changes here (or just put None), example:

Added IWebViewController which contains internal members of WebView. Explicitly implemented IWebViewController on WebView with implementations delegating to their corresponding internal members.

### Behavioral Changes ###

None

### PR Checklist ###

Want to rebase onto https://github.com/xamarin/Xamarin.Forms/pull/766 before generating docs.
