### PR TITLE
INavigationMenuController

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/NavigationMenuGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationMenuGallery.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls
 {

--- a/Xamarin.Forms.Core.UnitTests/NavigationMenuUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationMenuUnitTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 
 using System.Collections.Generic;
 using System.Linq;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -182,7 +183,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 			menu.Add (child);
 
-			menu.SendTargetSelected (child);
+			((INavigationMenuController)menu).SendTargetSelected (child);
 
 			Assert.True (pushed);
 			Assert.AreEqual (child, navForm.CurrentPage);

--- a/Xamarin.Forms.Core/INavigationMenuController.cs
+++ b/Xamarin.Forms.Core/INavigationMenuController.cs
@@ -1,0 +1,7 @@
+namespace Xamarin.Forms
+{
+	public interface INavigationMenuController : IViewController
+	{
+		void SendTargetSelected(Page target);
+	}
+}

--- a/Xamarin.Forms.Core/NavigationMenu.cs
+++ b/Xamarin.Forms.Core/NavigationMenu.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Xamarin.Forms.Platform;
 
-namespace Xamarin.Forms
+namespace Xamarin.Forms.Internals
 {
 	// Mark as internal until renderers are ready for release after 1.0
 	[RenderWith(typeof(_NavigationMenuRenderer))]
-	internal class NavigationMenu : View, INavigationMenuController, IElementConfiguration<NavigationMenu>
+	public class NavigationMenu : View, INavigationMenuController, IElementConfiguration<NavigationMenu>
 	{
 		readonly List<Page> _targets = new List<Page>();
 
@@ -64,14 +64,7 @@ namespace Xamarin.Forms
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		void INavigationMenuController.SendTargetSelected(Page target) => SendTargetSelected(target);
-
-		internal void SendTargetSelected(Page target)
-		{
-			TargetSelected(target);
-		}
-
-		void TargetSelected(Page target)
+		void INavigationMenuController.SendTargetSelected(Page target)
 		{
 			Navigation.PushAsync(target);
 		}

--- a/Xamarin.Forms.Core/NavigationMenu.cs
+++ b/Xamarin.Forms.Core/NavigationMenu.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms
 {
 	// Mark as internal until renderers are ready for release after 1.0
 	[RenderWith(typeof(_NavigationMenuRenderer))]
-	internal class NavigationMenu : View, IElementConfiguration<NavigationMenu>
+	internal class NavigationMenu : View, INavigationMenuController, IElementConfiguration<NavigationMenu>
 	{
 		readonly List<Page> _targets = new List<Page>();
 
@@ -63,6 +63,8 @@ namespace Xamarin.Forms
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
+
+		void INavigationMenuController.SendTargetSelected(Page target) => SendTargetSelected(target);
 
 		internal void SendTargetSelected(Page target)
 		{

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -88,6 +88,7 @@
     <Compile Include="DateChangedEventArgs.cs" />
     <Compile Include="DelegateLogListener.cs" />
     <Compile Include="IEditorController.cs" />
+    <Compile Include="INavigationMenuController.cs" />
     <Compile Include="Internals\EffectUtilities.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationMenuRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationMenuRenderer.cs
@@ -6,6 +6,7 @@ using Android.Graphics;
 using Android.Views;
 using Android.Widget;
 using AView = Android.Views.View;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -115,6 +116,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			readonly NavigationMenu _menu;
 
+			INavigationMenuController MenuController => _menu;
+
 			public MenuAdapter(NavigationMenu menu)
 			{
 				_menu = menu;
@@ -135,7 +138,7 @@ namespace Xamarin.Forms.Platform.Android
 				Page item = this[position];
 				menuItem.Icon = item.Icon;
 				menuItem.Name = item.Title;
-				menuItem.OnSelected = () => _menu.SendTargetSelected(item);
+				menuItem.OnSelected = () => MenuController.SendTargetSelected(item);
 				return menuItem;
 			}
 

--- a/Xamarin.Forms.Platform.WP8/NavigationMenuRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/NavigationMenuRenderer.cs
@@ -2,12 +2,15 @@
 using System.ComponentModel;
 using System.Windows.Media.Imaging;
 using Microsoft.Phone.Controls;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.WinPhone
 {
 	internal class NavigationMenuRenderer : ViewRenderer<NavigationMenu, System.Windows.Controls.Grid>
 	{
 		const int Spacing = 12;
+
+		INavigationMenuController ElementController => Element;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<NavigationMenu> e)
 		{
@@ -63,7 +66,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 					hubTile.Background = target.BackgroundColor.ToBrush();
 
 				Page tmp = target;
-				hubTile.Tap += (sender, args) => Element.SendTargetSelected(tmp);
+				hubTile.Tap += (sender, args) => ElementController.SendTargetSelected(tmp);
 
 				hubTile.SetValue(System.Windows.Controls.Grid.RowProperty, y);
 				hubTile.SetValue(System.Windows.Controls.Grid.ColumnProperty, x);

--- a/Xamarin.Forms.Platform.WP8/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.WP8/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@ using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.WinPhone;
 using TableView = Xamarin.Forms.TableView;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationMenuRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationMenuRenderer.cs
@@ -4,6 +4,7 @@ using Foundation;
 using UIKit;
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -109,6 +110,8 @@ namespace Xamarin.Forms.Platform.iOS
 				_menu = menu;
 			}
 
+			INavigationMenuController MenuController => _menu;
+
 			public override UICollectionViewCell GetCell(UICollectionView collectionView, NSIndexPath indexPath)
 			{
 				var cell = (NavigationCell)collectionView.DequeueReusableCell(new NSString("NavigationCell"), indexPath);
@@ -118,7 +121,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					cell.Name = target.Title;
 					cell.Icon = target.Icon;
-					cell.Selected = () => _menu.SendTargetSelected(target);
+					cell.Selected = () => MenuController.SendTargetSelected(target);
 				}
 				else
 				{

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/INavigationMenuController.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/INavigationMenuController.xml
@@ -1,0 +1,38 @@
+<Type Name="INavigationMenuController" FullName="Xamarin.Forms.INavigationMenuController">
+  <TypeSignature Language="C#" Value="public interface INavigationMenuController : Xamarin.Forms.IViewController" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract INavigationMenuController implements class Xamarin.Forms.IElementController, class Xamarin.Forms.IViewController, class Xamarin.Forms.IVisualElementController" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IViewController</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="SendTargetSelected">
+      <MemberSignature Language="C#" Value="public void SendTargetSelected (Xamarin.Forms.Page target);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendTargetSelected(class Xamarin.Forms.Page target) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="target" Type="Xamarin.Forms.Page" />
+      </Parameters>
+      <Docs>
+        <param name="target">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -291,6 +291,7 @@
       <Type Name="IMessagingCenter" Kind="Interface" />
       <Type Name="INativeElementView" Kind="Interface" />
       <Type Name="INavigation" Kind="Interface" />
+      <Type Name="INavigationMenuController" Kind="Interface" />
       <Type Name="INavigationPageController" Kind="Interface" />
       <Type Name="InputView" Kind="Class" />
       <Type Name="IOpenGlViewController" Kind="Interface" />


### PR DESCRIPTION
3ed parties are adding platforms and their renderers need access to internal XF members that are exposed internally via InternalVisibleToAttribute. To expose those internal members we're adding IViewControllers to all renderers; We're making the internal members public but as explicit implementations of an interface to hide them from isense.

### Describe your changes here.

None

### API Changes

List all API changes here (or just put None), example:

Added INavigationMenuController which contains internal members of NavigationMenu. Explicitly implemented INavigationMenuController on NavigationMenu with implementations delegating to their corresponding internal members.

### Behavioral Changes

None

### PR Checklist

Want to rebase onto #766 before generating docs.