### PR TITLE
Checkout docs using unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,6 @@
 *.png binary
 *.jpg binary
 *.jpeg binary
+
+# Always checkout docs using unix line endings because mdoc uses unix line endings even on windows
+/docs/**/*.xml text eol=lf


### PR DESCRIPTION
### Description of Change ###

On a clean master branch I expect to be able to run update-docs-windows.bat and have git detect no changes. What actually happens is (1) the line endings are changed from windows to unix by mdoc and (2) non-white spaces changes are made because the build does not always detect that doc changes were made (it checks for "Members Added: 0, Members Deleted: 0" but that is buggy and reports 0 when changes were actually made). To fix (1) we can force all doc files to be checked out by git using unix line endings regardless of dev os by updating .gitattributes. To fix (2), after this change goes through, we can update our build to fail on account of missing docs whenever after running update-docs-windows.bat git detects any changes.

To force git to re-checkout the docs with unix line endings delete the docs folder and run `git reset --hard`.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

None
