### PR TITLE
[Xaml] decorate markup and value providers to speed up inflating

### DIFF
--- a/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
@@ -4,6 +4,7 @@ using Xamarin.Forms.Xaml;
 namespace Xamarin.Forms
 {
 	[ProvideCompiled("Xamarin.Forms.Core.XamlC.PassthroughValueProvider")]
+	[AcceptEmptyServiceProvider]
 	public sealed class BindingCondition : Condition, IValueProvider
 	{
 		readonly BindableProperty _boundProperty;

--- a/Xamarin.Forms.Core/Interactivity/DataTrigger.cs
+++ b/Xamarin.Forms.Core/Interactivity/DataTrigger.cs
@@ -6,6 +6,7 @@ namespace Xamarin.Forms
 {
 	[ContentProperty("Setters")]
 	[ProvideCompiled("Xamarin.Forms.Core.XamlC.PassthroughValueProvider")]
+	[AcceptEmptyServiceProvider]
 	public sealed class DataTrigger : TriggerBase, IValueProvider
 	{
 		public DataTrigger([TypeConverter(typeof(TypeTypeConverter))] [Parameter("TargetType")] Type targetType) : base(new BindingCondition(), targetType)

--- a/Xamarin.Forms.Pages/DataSourceBindingExtension.cs
+++ b/Xamarin.Forms.Pages/DataSourceBindingExtension.cs
@@ -4,6 +4,7 @@ using Xamarin.Forms.Xaml;
 namespace Xamarin.Forms.Pages
 {
 	[ContentProperty("Path")]
+	[AcceptEmptyServiceProvider]
 	public sealed class DataSourceBindingExtension : IMarkupExtension<BindingBase>
 	{
 		public DataSourceBindingExtension()

--- a/Xamarin.Forms.Xaml/MarkupExtensions/ArrayExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/ArrayExtension.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 namespace Xamarin.Forms.Xaml
 {
 	[ContentProperty("Items")]
+	[AcceptEmptyServiceProvider]
 	public class ArrayExtension : IMarkupExtension<Array>
 	{
 		public ArrayExtension()

--- a/Xamarin.Forms.Xaml/MarkupExtensions/BindingExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/BindingExtension.cs
@@ -4,6 +4,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Xaml
 {
 	[ContentProperty("Path")]
+	[AcceptEmptyServiceProvider]
 	public sealed class BindingExtension : IMarkupExtension<BindingBase>
 	{
 		public BindingExtension()

--- a/Xamarin.Forms.Xaml/MarkupExtensions/NullExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/NullExtension.cs
@@ -3,6 +3,7 @@
 namespace Xamarin.Forms.Xaml
 {
 	[ProvideCompiled("Xamarin.Forms.Build.Tasks.NullExtension")]
+	[AcceptEmptyServiceProvider]
 	public class NullExtension : IMarkupExtension
 	{
 		public object ProvideValue(IServiceProvider serviceProvider)

--- a/Xamarin.Forms.Xaml/MarkupExtensions/TemplateBindingExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/TemplateBindingExtension.cs
@@ -3,6 +3,7 @@ using System;
 namespace Xamarin.Forms.Xaml
 {
 	[ContentProperty("Path")]
+	[AcceptEmptyServiceProvider]
 	public sealed class TemplateBindingExtension : IMarkupExtension<BindingBase>
 	{
 		public TemplateBindingExtension()

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/BindingCondition.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/BindingCondition.xml
@@ -16,6 +16,11 @@
       <InterfaceName>Xamarin.Forms.Xaml.IValueProvider</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.AcceptEmptyServiceProvider</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Class that represents a value comparison with the target of an arbitrary binding.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/DataTrigger.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/DataTrigger.xml
@@ -20,6 +20,9 @@
     <Attribute>
       <AttributeName>Xamarin.Forms.ContentProperty("Setters")</AttributeName>
     </Attribute>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.AcceptEmptyServiceProvider</AttributeName>
+    </Attribute>
   </Attributes>
   <Docs>
     <summary>Class that represents a binding condition and a list of <see cref="T:Xamarin.Forms.Setter" /> objects that will be applied when the condition is met.</summary>

--- a/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/ArrayExtension.xml
+++ b/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/ArrayExtension.xml
@@ -22,6 +22,9 @@
     <Attribute>
       <AttributeName>Xamarin.Forms.ContentProperty("Items")</AttributeName>
     </Attribute>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.AcceptEmptyServiceProvider</AttributeName>
+    </Attribute>
   </Attributes>
   <Docs>
     <summary>For internal use by the XAML infrastructure.</summary>

--- a/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/BindingExtension.xml
+++ b/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/BindingExtension.xml
@@ -19,6 +19,9 @@
     <Attribute>
       <AttributeName>Xamarin.Forms.ContentProperty("Path")</AttributeName>
     </Attribute>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.AcceptEmptyServiceProvider</AttributeName>
+    </Attribute>
   </Attributes>
   <Docs>
     <summary>For internal use by the XAML infrastructure.</summary>

--- a/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/NullExtension.xml
+++ b/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/NullExtension.xml
@@ -20,10 +20,10 @@
   </Interfaces>
   <Attributes>
     <Attribute>
-      <AttributeName>Xamarin.Forms.Xaml.ProvideCompiled("Xamarin.Forms.Build.Tasks.NullExtension")</AttributeName>
+      <AttributeName>Xamarin.Forms.Xaml.AcceptEmptyServiceProvider</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Xamarin.Forms.Xaml.AcceptEmptyServiceProvider</AttributeName>
+      <AttributeName>Xamarin.Forms.Xaml.ProvideCompiled("Xamarin.Forms.Build.Tasks.NullExtension")</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/NullExtension.xml
+++ b/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/NullExtension.xml
@@ -22,6 +22,9 @@
     <Attribute>
       <AttributeName>Xamarin.Forms.Xaml.ProvideCompiled("Xamarin.Forms.Build.Tasks.NullExtension")</AttributeName>
     </Attribute>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.AcceptEmptyServiceProvider</AttributeName>
+    </Attribute>
   </Attributes>
   <Docs>
     <summary>Extension class that differentiates between null values and empty strings.</summary>

--- a/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/TemplateBindingExtension.xml
+++ b/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/TemplateBindingExtension.xml
@@ -17,6 +17,9 @@
     <Attribute>
       <AttributeName>Xamarin.Forms.ContentProperty("Path")</AttributeName>
     </Attribute>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.AcceptEmptyServiceProvider</AttributeName>
+    </Attribute>
   </Attributes>
   <Docs>
     <summary>For internal use by the XAML infrastructure.</summary>


### PR DESCRIPTION
### Description of Change ###

[Xaml][XamlC] decorate IMarkupExtnesion and IValueProvider with `[AcceptEmptyServiceProvider]` when the service provider isn't used. This speeds up inflating as the loader doesn't have to create a service provider. In case of XamlC, it further reduces IL size.

### Bugs Fixed ###

### API Changes ###

### Behavioral Changes ###

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense