### PR TITLE
Robust doc change detection

### DIFF
--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -839,7 +839,7 @@
           <typeparam name="TView">To be added.</typeparam>
           <typeparam name="TItem">To be added.</typeparam>
           <param name="cell">To be added.</param>
-          <summary>To be added.</summary>
+          <summary>For internal use by platform renderers.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.Internals.CellExtensions" Member="M:Xamarin.Forms.Internals.CellExtensions.GetGroup``2(``1)" />
       </Member>
@@ -875,7 +875,7 @@
           <typeparam name="TView">To be added.</typeparam>
           <typeparam name="TItem">To be added.</typeparam>
           <param name="cell">To be added.</param>
-          <summary>To be added.</summary>
+          <summary>For internal use by platform renderers.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.Internals.CellExtensions" Member="M:Xamarin.Forms.Internals.CellExtensions.GetGroupHeaderContent``2(``1)" />
       </Member>
@@ -911,7 +911,7 @@
           <typeparam name="TView">To be added.</typeparam>
           <typeparam name="TItem">To be added.</typeparam>
           <param name="cell">To be added.</param>
-          <summary>To be added.</summary>
+          <summary>For internal use by platform renderers.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.Internals.CellExtensions" Member="M:Xamarin.Forms.Internals.CellExtensions.GetIndex``2(``1)" />
       </Member>
@@ -947,7 +947,7 @@
           <typeparam name="TView">To be added.</typeparam>
           <typeparam name="TItem">To be added.</typeparam>
           <param name="cell">To be added.</param>
-          <summary>To be added.</summary>
+          <summary>For internal use by platform renderers.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.Internals.CellExtensions" Member="M:Xamarin.Forms.Internals.CellExtensions.GetIsGroupHeader``2(``1)" />
       </Member>
@@ -968,7 +968,7 @@
         </Parameters>
         <Docs>
           <param name="cell">To be added.</param>
-          <summary>To be added.</summary>
+          <summary>For internal use by platform renderers.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.Internals.CellExtensions" Member="M:Xamarin.Forms.Internals.CellExtensions.GetPath(Xamarin.Forms.Cell)" />
       </Member>
@@ -1006,7 +1006,7 @@
           <typeparam name="TItem">To be added.</typeparam>
           <param name="cell">To be added.</param>
           <param name="value">To be added.</param>
-          <summary>To be added.</summary>
+          <summary>For internal use by platform renderers.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.Internals.CellExtensions" Member="M:Xamarin.Forms.Internals.CellExtensions.SetIsGroupHeader``2(``1,System.Boolean)" />
       </Member>
@@ -1033,7 +1033,7 @@
           <param name="insert">To be added.</param>
           <param name="removeAt">To be added.</param>
           <param name="reset">To be added.</param>
-          <summary>To be added.</summary>
+          <summary>For internal use by platform renderers.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.Internals.NotifyCollectionChangedEventArgsExtensions" Member="M:Xamarin.Forms.Internals.NotifyCollectionChangedEventArgsExtensions.Apply(System.Collections.Specialized.NotifyCollectionChangedEventArgs,System.Action{System.Object,System.Int32,System.Boolean},System.Action{System.Object,System.Int32},System.Action)" />
       </Member>
@@ -1062,7 +1062,7 @@
           <param name="self">To be added.</param>
           <param name="from">To be added.</param>
           <param name="to">To be added.</param>
-          <summary>To be added.</summary>
+          <summary>For internal use by platform renderers.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.Internals.NotifyCollectionChangedEventArgsExtensions" Member="M:Xamarin.Forms.Internals.NotifyCollectionChangedEventArgsExtensions.Apply``1(System.Collections.Specialized.NotifyCollectionChangedEventArgs,System.Collections.Generic.IList{``0},System.Collections.Generic.IList{System.Object})" />
       </Member>
@@ -1085,7 +1085,7 @@
         <Docs>
           <param name="e">To be added.</param>
           <param name="count">To be added.</param>
-          <summary>To be added.</summary>
+          <summary>For internal use by platform renderers.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.Internals.NotifyCollectionChangedEventArgsExtensions" Member="M:Xamarin.Forms.Internals.NotifyCollectionChangedEventArgsExtensions.WithCount(System.Collections.Specialized.NotifyCollectionChangedEventArgs,System.Int32)" />
       </Member>

--- a/update-docs-windows.bat
+++ b/update-docs-windows.bat
@@ -5,36 +5,20 @@ IF EXIST docs.xml (erase docs.xml)
 for /r docs %%i in (*.xml) do type %%i >> docs.xml
 
 echo "Updating Xamarin.Forms.Core"
-tools\mdoc\mdoc update --delete Xamarin.Forms.Core\bin\Debug\Xamarin.Forms.Core.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Core | findstr /r "^Members.Added:..," > tmpFile
-set /p RESULT= < tmpFile
-echo "%RESULT%"
-del tmpFile
-
-IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (goto fail)
+tools\mdoc\mdoc update --delete Xamarin.Forms.Core\bin\Debug\Xamarin.Forms.Core.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Core > nul
+IF %ERRORLEVEL% NEQ 0 (goto fail)
 
 echo "Updating Xamarin.Forms.Xaml"
-tools\mdoc\mdoc update --delete Xamarin.Forms.Xaml\bin\Debug\Xamarin.Forms.Xaml.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Xaml | findstr /r "^Members.Added:..," > tmpFile
-set /p RESULT= < tmpFile
-echo "%RESULT%"
-del tmpFile
-
-IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (goto fail)
+tools\mdoc\mdoc update --delete Xamarin.Forms.Xaml\bin\Debug\Xamarin.Forms.Xaml.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Xaml > nul
+IF %ERRORLEVEL% NEQ 0 (goto fail)
 
 echo "Updating Xamarin.Forms.Maps"
-tools\mdoc\mdoc update --delete Xamarin.Forms.Maps\bin\Debug\Xamarin.Forms.Maps.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Maps | findstr /r "^Members.Added:..," > tmpFile
-set /p RESULT= < tmpFile
-echo "%RESULT%"
-del tmpFile
-
-IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (goto fail)
+tools\mdoc\mdoc update --delete Xamarin.Forms.Maps\bin\Debug\Xamarin.Forms.Maps.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Maps > nul
+IF %ERRORLEVEL% NEQ 0 (goto fail)
 
 echo "Updating Xamarin.Forms.Pages"
-tools\mdoc\mdoc update --delete Xamarin.Forms.Pages\bin\Debug\Xamarin.Forms.Pages.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Pages | findstr /r "^Members.Added:..," > tmpFile
-set /p RESULT= < tmpFile
-echo "%RESULT%"
-del tmpFile
-
-IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (goto fail)
+tools\mdoc\mdoc update --delete Xamarin.Forms.Pages\bin\Debug\Xamarin.Forms.Pages.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Pages > nul
+IF %ERRORLEVEL% NEQ 0 (goto fail)
 
 IF EXIST _docs.xml (erase _docs.xml)
 for /r docs %%i in (*.xml) do type %%i >> _docs.xml

--- a/update-docs-windows.bat
+++ b/update-docs-windows.bat
@@ -1,13 +1,16 @@
 @echo off
 PATH="C:\Program Files (x86)\Mono\bin";%PATH%
 
+IF EXIST docs.xml (erase docs.xml)
+for /r docs %%i in (*.xml) do type %%i >> docs.xml
+
 echo "Updating Xamarin.Forms.Core"
 tools\mdoc\mdoc update --delete Xamarin.Forms.Core\bin\Debug\Xamarin.Forms.Core.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Core | findstr /r "^Members.Added:..," > tmpFile
 set /p RESULT= < tmpFile
 echo "%RESULT%"
 del tmpFile
 
-IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (exit 1)
+IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (goto fail)
 
 echo "Updating Xamarin.Forms.Xaml"
 tools\mdoc\mdoc update --delete Xamarin.Forms.Xaml\bin\Debug\Xamarin.Forms.Xaml.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Xaml | findstr /r "^Members.Added:..," > tmpFile
@@ -15,7 +18,7 @@ set /p RESULT= < tmpFile
 echo "%RESULT%"
 del tmpFile
 
-IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (exit 1)
+IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (goto fail)
 
 echo "Updating Xamarin.Forms.Maps"
 tools\mdoc\mdoc update --delete Xamarin.Forms.Maps\bin\Debug\Xamarin.Forms.Maps.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Maps | findstr /r "^Members.Added:..," > tmpFile
@@ -23,7 +26,7 @@ set /p RESULT= < tmpFile
 echo "%RESULT%"
 del tmpFile
 
-IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (exit 1)
+IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (goto fail)
 
 echo "Updating Xamarin.Forms.Pages"
 tools\mdoc\mdoc update --delete Xamarin.Forms.Pages\bin\Debug\Xamarin.Forms.Pages.dll -L "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile259" --out docs\Xamarin.Forms.Pages | findstr /r "^Members.Added:..," > tmpFile
@@ -31,7 +34,19 @@ set /p RESULT= < tmpFile
 echo "%RESULT%"
 del tmpFile
 
-IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (exit 1)
+IF NOT "%RESULT%" == "Members Added: 0, Members Deleted: 0" (goto fail)
 
+IF EXIST _docs.xml (erase _docs.xml)
+for /r docs %%i in (*.xml) do type %%i >> _docs.xml
+fc docs.xml _docs.xml > nul 2> nul
+IF %ERRORLEVEL% NEQ 0 (goto fail)
+
+erase docs.xml _docs.xml
+echo No changes detected.
 exit /B 0
+
+:fail
+erase docs.xml _docs.xml
+echo Changes detected!
+exit /B 1
 


### PR DESCRIPTION
### Description of Change ###

I expect that when I run update-docs-windows.bat on a clean master no files change. What actually happens is that sometime doc files change. This happens because the build fails to detect changes to the docs. The build runs `update-docs-windows.bat` which returns a success exit code if mdoc returns `"Members Added: 0, Members Deleted: 0"` and a failure exit code otherwise. This doesn't work because mdoc may return that string when docs are non-trivially changed.

To make the change check more robust, I concat all *.xml doc files into a `doc.xml` before running mdoc and then again into `_doc.xml` after running mdoc. I fail the build if `fc` detects those two files are different.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

None
