### PR TITLE
[UWP] Adjust AutoSuggestBox's TextBoxStyle style name to prevent possible crash

### DIFF
--- a/Xamarin.Forms.Platform.UAP/AutoSuggestStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/AutoSuggestStyle.xaml
@@ -7,7 +7,7 @@
 	<Style TargetType="AutoSuggestBox">
 		<Setter Property="VerticalAlignment" Value="Top" />
 		<Setter Property="IsTabStop" Value="False" />
-		<Setter Property="TextBoxStyle" Value="{StaticResource AutoSuggestBoxTextBoxStyle}" />
+		<Setter Property="TextBoxStyle" Value="{StaticResource AutoSuggestBoxFormsTextBoxStyle}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="AutoSuggestBox">
@@ -58,7 +58,7 @@
 		</Setter>
 	</Style>
 
-	<Style TargetType="uwp:FormsTextBox" x:Key="AutoSuggestBoxTextBoxStyle">
+	<Style TargetType="uwp:FormsTextBox" x:Key="AutoSuggestBoxFormsTextBoxStyle">
 		<Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
 		<Setter Property="MinHeight" Value="{ThemeResource TextControlThemeMinHeight}" />
 		<Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />


### PR DESCRIPTION
### Description of Change ###

Presently trying to set the AutoSuggestBox style like the following for UWP causes a crash:

    <Style TargetType="AutoSuggestBox">
        <Setter Property="FontFamily" Value="Comic Sans MS"/>
    </Style>

Although setting this property in a native UWP app would not work (the style should be applied as a value on `TextBoxStyle`), it wouldn't crash. The crash here appears due to a naming conflict on the `AutoSuggestBoxTextBoxStyle` key being used; renaming this appears to prevent this crash from occurring. The `App.xaml` in the UWP gallery project was not modified for this PR to keep global styles the same, but would reproduce the issue if added.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=41919

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
