### PR TITLE
[iOS] Prevent "NaN is not a valid value for width" exception

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52533.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52533.cs
@@ -1,0 +1,64 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 52533, "System.ArgumentException: NaN is not a valid value for width", PlatformAffected.iOS)]
+	public class Bugzilla52533 : TestContentPage
+	{
+		const string LabelId = "label";
+
+		protected override void Init()
+		{
+			Content = new ListView { ItemTemplate = new DataTemplate(typeof(GridViewCell)), ItemsSource = Enumerable.Range(0, 10) };
+		}
+
+		[Preserve(AllMembers = true)]
+		class GridViewCell : ViewCell
+		{
+
+			public GridViewCell()
+			{
+				var grid = new Grid
+				{
+					// Multiple rows
+					RowDefinitions = {
+						new RowDefinition { Height = new GridLength(20, GridUnitType.Absolute) },
+						new RowDefinition { Height = new GridLength(150, GridUnitType.Absolute) }
+					},
+					// Dynamic width
+					ColumnDefinitions = {
+						new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }
+					}
+				};
+
+				// Infinitely wide + Label
+				var horStack = new StackLayout { Orientation = StackOrientation.Horizontal, Children = { new Label { Text = "If this does not crash, this test has passed.", AutomationId = LabelId } } };
+				grid.Children.Add(horStack, 0, 0);
+
+				View = grid;
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla52533Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(LabelId));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -240,6 +240,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37431.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44777.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51503.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52533.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -37,8 +37,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			result.Minimum = new Size(Math.Min(10, result.Request.Width), result.Request.Height);
 			if (Element.LineBreakMode != LineBreakMode.NoWrap)
 			{
-				if (result.Request.Width > widthConstraint || Element.LineBreakMode == LineBreakMode.WordWrap || Element.LineBreakMode == LineBreakMode.CharacterWrap)
-					result.Request = new Size(Math.Max(result.Minimum.Width, widthConstraint), result.Request.Height);
+				if (!double.IsInfinity(result.Request.Width) && !double.IsInfinity(widthConstraint))
+					if (result.Request.Width > widthConstraint || Element.LineBreakMode == LineBreakMode.WordWrap || Element.LineBreakMode == LineBreakMode.CharacterWrap)
+						result.Request = new Size(Math.Max(result.Minimum.Width, widthConstraint), result.Request.Height);
 			}
 
 			return result;


### PR DESCRIPTION
### Description of Change ###

Fix regression introduced in #529 allowing an infinite width to be returned for `Label's on iOS, which led to an exception in nested and potentially horizontally infinite layouts. 

### Bugs Fixed ###

- [Bug 52533 - Xamarin.Forms v2.3.4.192-pre2 Regression: System.ArgumentException: NaN is not a valid value for width](https://bugzilla.xamarin.com/show_bug.cgi?id=52533)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
