### PR TITLE
[Core] Share BP across IFontElement implementors

### DIFF
--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -25,13 +25,11 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty FontProperty = BindableProperty.Create("Font", typeof(Font), typeof(Button), default(Font), propertyChanged: FontStructPropertyChanged);
 
-		public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create("FontFamily", typeof(string), typeof(Button), default(string), propertyChanged: SpecificFontPropertyChanged);
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		public static readonly BindableProperty FontSizeProperty = BindableProperty.Create("FontSize", typeof(double), typeof(Button), -1.0, propertyChanged: SpecificFontPropertyChanged,
-			defaultValueCreator: bindable => Device.GetNamedSize(NamedSize.Default, (Button)bindable));
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(Button), FontAttributes.None,
-			propertyChanged: SpecificFontPropertyChanged);
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
 		public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create("BorderWidth", typeof(double), typeof(Button), -1d);
 
@@ -214,18 +212,26 @@ namespace Xamarin.Forms
 			{
 				button.FontFamily = button.Font.FontFamily;
 				if (button.Font.UseNamedSize)
-				{
 					button.FontSize = Device.GetNamedSize(button.Font.NamedSize, button.GetType(), true);
-				}
 				else
-				{
 					button.FontSize = button.Font.FontSize;
-				}
 				button.FontAttributes = button.Font.FontAttributes;
 			}
 
 			button._cancelEvents = false;
 		}
+
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
+			SpecificFontPropertyChanged();
+
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
+			SpecificFontPropertyChanged();
+
+		double IFontElement.FontSizeDefaultValueCreator() =>
+			Device.GetNamedSize(NamedSize.Default, (Button)this);
+
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			SpecificFontPropertyChanged();
 
 		void OnCommandChanged()
 		{
@@ -260,27 +266,21 @@ namespace Xamarin.Forms
 				oldvalue.SourceChanged -= OnSourceChanged;
 		}
 
-		static void SpecificFontPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		void SpecificFontPropertyChanged()
 		{
-			var button = (Button)bindable;
-
-			if (button._cancelEvents)
+			if (_cancelEvents)
 				return;
 
-			button.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-			button._cancelEvents = true;
+			_cancelEvents = true;
 
-			if (button.FontFamily != null)
-			{
-				button.Font = Font.OfSize(button.FontFamily, button.FontSize).WithAttributes(button.FontAttributes);
-			}
+			if (FontFamily != null)
+				Font = Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
 			else
-			{
-				button.Font = Font.SystemFontOfSize(button.FontSize, button.FontAttributes);
-			}
+				Font = Font.SystemFontOfSize(FontSize, FontAttributes);
 
-			button._cancelEvents = false;
+			_cancelEvents = false;
 		}
 
 		[DebuggerDisplay("Image Position = {Position}, Spacing = {Spacing}")]

--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -13,12 +13,11 @@ namespace Xamarin.Forms
 				editor.TextChanged(editor, new TextChangedEventArgs((string)oldValue, (string)newValue));
 		});
 
-		public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create("FontFamily", typeof(string), typeof(Editor), default(string));
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		public static readonly BindableProperty FontSizeProperty = BindableProperty.Create("FontSize", typeof(double), typeof(Editor), -1.0,
-			defaultValueCreator: bindable => Device.GetNamedSize(NamedSize.Default, (Editor)bindable));
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(Editor), FontAttributes.None);
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
 		public static readonly BindableProperty TextColorProperty = BindableProperty.Create("TextColor", typeof(Color), typeof(Editor), Color.Default);
 		readonly Lazy<PlatformConfigurationRegistry<Editor>> _platformConfigurationRegistry;
@@ -52,6 +51,21 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(FontSizeProperty); }
 			set { SetValue(FontSizeProperty, value); }
+		}
+
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
+		{
+		}
+
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
+		{
+		}
+
+		double IFontElement.FontSizeDefaultValueCreator() =>
+			Device.GetNamedSize(NamedSize.Default, (Editor)this);
+
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
+		{
 		}
 
 		public event EventHandler Completed;

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -18,12 +18,11 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty PlaceholderColorProperty = BindableProperty.Create("PlaceholderColor", typeof(Color), typeof(Entry), Color.Default);
 
-		public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create("FontFamily", typeof(string), typeof(Entry), default(string));
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		public static readonly BindableProperty FontSizeProperty = BindableProperty.Create("FontSize", typeof(double), typeof(Entry), -1.0,
-			defaultValueCreator: bindable => Device.GetNamedSize(NamedSize.Default, (Entry)bindable));
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(Entry), FontAttributes.None);
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<Entry>> _platformConfigurationRegistry;
 
@@ -85,6 +84,21 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(FontSizeProperty); }
 			set { SetValue(FontSizeProperty, value); }
+		}
+
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
+		{
+		}
+
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
+		{
+		}
+
+		double IFontElement.FontSizeDefaultValueCreator() =>
+			Device.GetNamedSize(NamedSize.Default, (Entry)this);
+
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
+		{
 		}
 
 		public event EventHandler Completed;

--- a/Xamarin.Forms.Core/FontElement.cs
+++ b/Xamarin.Forms.Core/FontElement.cs
@@ -1,0 +1,38 @@
+namespace Xamarin.Forms
+{
+	static class FontElement
+	{
+		public static readonly BindableProperty FontFamilyProperty =
+			BindableProperty.Create("FontFamily", typeof(string), typeof(FontElement), default(string),
+									propertyChanged: OnFontFamilyChanged);
+
+		public static readonly BindableProperty FontSizeProperty =
+			BindableProperty.Create("FontSize", typeof(double), typeof(FontElement), -1.0,
+									propertyChanged: OnFontSizeChanged,
+									defaultValueCreator: FontSizeDefaultValueCreator);
+
+		public static readonly BindableProperty FontAttributesProperty =
+			BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(FontElement), FontAttributes.None,
+									propertyChanged: OnFontAttributesChanged);
+
+		static void OnFontFamilyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			((IFontElement)bindable).OnFontFamilyChanged((string)oldValue, (string)newValue);
+		}
+
+		static void OnFontSizeChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			((IFontElement)bindable).OnFontSizeChanged((double)oldValue, (double)newValue);
+		}
+
+		static object FontSizeDefaultValueCreator(BindableObject bindable)
+		{
+			return ((IFontElement)bindable).FontSizeDefaultValueCreator();
+		}
+
+		static void OnFontAttributesChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			((IFontElement)bindable).OnFontAttributesChanged((FontAttributes)oldValue, (FontAttributes)newValue);
+		}
+	}
+}

--- a/Xamarin.Forms.Core/FontElement.cs
+++ b/Xamarin.Forms.Core/FontElement.cs
@@ -3,16 +3,16 @@ namespace Xamarin.Forms
 	static class FontElement
 	{
 		public static readonly BindableProperty FontFamilyProperty =
-			BindableProperty.Create("FontFamily", typeof(string), typeof(FontElement), default(string),
+			BindableProperty.Create("FontFamily", typeof(string), typeof(IFontElement), default(string),
 									propertyChanged: OnFontFamilyChanged);
 
 		public static readonly BindableProperty FontSizeProperty =
-			BindableProperty.Create("FontSize", typeof(double), typeof(FontElement), -1.0,
+			BindableProperty.Create("FontSize", typeof(double), typeof(IFontElement), -1.0,
 									propertyChanged: OnFontSizeChanged,
 									defaultValueCreator: FontSizeDefaultValueCreator);
 
 		public static readonly BindableProperty FontAttributesProperty =
-			BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(FontElement), FontAttributes.None,
+			BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(IFontElement), FontAttributes.None,
 									propertyChanged: OnFontAttributesChanged);
 
 		static void OnFontFamilyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/Xamarin.Forms.Core/IFontElement.cs
+++ b/Xamarin.Forms.Core/IFontElement.cs
@@ -1,11 +1,16 @@
 namespace Xamarin.Forms
 {
-	internal interface IFontElement
+	interface IFontElement
 	{
+		//note to implementor: implement the properties publicly
 		FontAttributes FontAttributes { get; }
-
 		string FontFamily { get; }
-
 		double FontSize { get; }
+
+		//note to implementor: but implement the methods explicitly
+		void OnFontFamilyChanged(string oldValue, string newValue);
+		void OnFontSizeChanged(double oldValue, double newValue);
+		double FontSizeDefaultValueCreator();
+		void OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue);
 	}
 }

--- a/Xamarin.Forms.Core/IFontElement.cs
+++ b/Xamarin.Forms.Core/IFontElement.cs
@@ -5,6 +5,8 @@ namespace Xamarin.Forms
 		//note to implementor: implement the properties publicly
 		FontAttributes FontAttributes { get; }
 		string FontFamily { get; }
+
+		[TypeConverter(typeof(FontSizeConverter))]
 		double FontSize { get; }
 
 		//note to implementor: but implement the methods explicitly

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -27,13 +27,11 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(Label), default(string), propertyChanged: OnTextPropertyChanged);
 
-		public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create("FontFamily", typeof(string), typeof(Label), default(string), propertyChanged: OnFontFamilyChanged);
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		public static readonly BindableProperty FontSizeProperty = BindableProperty.Create("FontSize", typeof(double), typeof(Label), -1.0, propertyChanged: OnFontSizeChanged,
-			defaultValueCreator: bindable => Device.GetNamedSize(NamedSize.Default, (Label)bindable));
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(Label), FontAttributes.None,
-			propertyChanged: OnFontAttributesChanged);
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
 		public static readonly BindableProperty FormattedTextProperty = BindableProperty.Create("FormattedText", typeof(FormattedString), typeof(Label), default(FormattedString),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
@@ -171,93 +169,72 @@ namespace Xamarin.Forms
 			label.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
-		static void OnFontAttributesChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			var label = (Label)bindable;
+		double IFontElement.FontSizeDefaultValueCreator() =>
+			Device.GetNamedSize(NamedSize.Default, (Label)this);
 
-			if (label._cancelEvents)
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
+		{
+			if (_cancelEvents)
 				return;
 
-			label._cancelEvents = true;
+			_cancelEvents = true;
 
-			var attributes = (FontAttributes)newValue;
+			var attributes = newValue;
 
-			object[] values = label.GetValues(FontFamilyProperty, FontSizeProperty);
+#pragma warning disable 0618 // retain until Font removed
+			object[] values = GetValues(FontFamilyProperty, FontSizeProperty);
 			var family = (string)values[0];
 			if (family != null)
-			{
-#pragma warning disable 0618 // retain until Font removed
-				label.Font = Font.OfSize(family, (double)values[1]).WithAttributes(attributes);
-#pragma warning restore 0618
-			}
+				Font = Font.OfSize(family, (double)values[1]).WithAttributes(attributes);
 			else
-			{
-#pragma warning disable 0618 // retain until Font removed
-				label.Font = Font.SystemFontOfSize((double)values[1], attributes);
+				Font = Font.SystemFontOfSize((double)values[1], attributes);
 #pragma warning restore 0618
-			}
 
-			label._cancelEvents = false;
+			_cancelEvents = false;
 
-			label.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
-		static void OnFontFamilyChanged(BindableObject bindable, object oldValue, object newValue)
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
 		{
-			var label = (Label)bindable;
-			if (label._cancelEvents)
+			if (_cancelEvents)
 				return;
 
-			label._cancelEvents = true;
+			_cancelEvents = true;
 
-			object[] values = label.GetValues(FontSizeProperty, FontAttributesProperty);
-
-			var family = (string)newValue;
+#pragma warning disable 0618 // retain until Font removed
+			object[] values = GetValues(FontSizeProperty, FontAttributesProperty);
+			var family = newValue;
 			if (family != null)
-			{
-#pragma warning disable 0618 // retain until Font removed
-				label.Font = Font.OfSize(family, (double)values[0]).WithAttributes((FontAttributes)values[1]);
-#pragma warning restore 0618
-			}
+				Font = Font.OfSize(family, (double)values[0]).WithAttributes((FontAttributes)values[1]);
 			else
-			{
-#pragma warning disable 0618 // retain until Font removed
-				label.Font = Font.SystemFontOfSize((double)values[0], (FontAttributes)values[1]);
+				Font = Font.SystemFontOfSize((double)values[0], (FontAttributes)values[1]);
 #pragma warning restore 0618
-			}
 
-			label._cancelEvents = false;
-			label.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			_cancelEvents = false;
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
-		static void OnFontSizeChanged(BindableObject bindable, object oldValue, object newValue)
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
 		{
-			var label = (Label)bindable;
-			if (label._cancelEvents)
+			if (_cancelEvents)
 				return;
 
-			label._cancelEvents = true;
+			_cancelEvents = true;
 
-			object[] values = label.GetValues(FontFamilyProperty, FontAttributesProperty);
-
-			var size = (double)newValue;
+#pragma warning disable 0618 // retain until Font removed
+			object[] values = GetValues(FontFamilyProperty, FontAttributesProperty);
+			var size = newValue;
 			var family = (string)values[0];
 			if (family != null)
-			{
-#pragma warning disable 0618 // retain until Font removed
-				label.Font = Font.OfSize(family, size).WithAttributes((FontAttributes)values[1]);
-#pragma warning restore 0618
-			}
+				Font = Font.OfSize(family, size).WithAttributes((FontAttributes)values[1]);
 			else
-			{
-#pragma warning disable 0618 // retain until Font removed
-				label.Font = Font.SystemFontOfSize(size, (FontAttributes)values[1]);
+				Font = Font.SystemFontOfSize(size, (FontAttributes)values[1]);
 #pragma warning restore 0618
-			}
 
-			label._cancelEvents = false;
+			_cancelEvents = false;
 
-			label.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
 		void OnFormattedTextChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Core/SearchBar.cs
+++ b/Xamarin.Forms.Core/SearchBar.cs
@@ -24,12 +24,11 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create("Placeholder", typeof(string), typeof(SearchBar), null);
 
-		public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create("FontFamily", typeof(string), typeof(SearchBar), default(string));
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		public static readonly BindableProperty FontSizeProperty = BindableProperty.Create("FontSize", typeof(double), typeof(SearchBar), -1.0,
-			defaultValueCreator: bindable => Device.GetNamedSize(NamedSize.Default, (SearchBar)bindable));
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create("FontAttributes", typeof(FontAttributes), typeof(SearchBar), FontAttributes.None);
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = BindableProperty.Create("HorizontalTextAlignment", typeof(TextAlignment), typeof(SearchBar), TextAlignment.Start);
 
@@ -109,6 +108,21 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(FontSizeProperty); }
 			set { SetValue(FontSizeProperty, value); }
+		}
+
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
+		{
+		}
+
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
+		{
+		}
+
+		double IFontElement.FontSizeDefaultValueCreator() =>
+			Device.GetNamedSize(NamedSize.Default, (SearchBar)this);
+
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
+		{
 		}
 
 		public event EventHandler SearchButtonPressed;

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -84,9 +84,11 @@ namespace Xamarin.Forms
 			{
 				if (_fontAttributes == value)
 					return;
+				var oldValue = _fontAttributes;
 				_fontAttributes = value;
 				OnPropertyChanged();
-				UpdateStructFromFontProperties();
+
+				((IFontElement)this).OnFontAttributesChanged(oldValue, value);
 			}
 		}
 
@@ -97,9 +99,10 @@ namespace Xamarin.Forms
 			{
 				if (_fontFamily == value)
 					return;
+				var oldValue = _fontFamily;
 				_fontFamily = value;
 				OnPropertyChanged();
-				UpdateStructFromFontProperties();
+				((IFontElement)this).OnFontFamilyChanged(oldValue, value);
 			}
 		}
 
@@ -111,9 +114,10 @@ namespace Xamarin.Forms
 			{
 				if (_fontSize == value)
 					return;
+				var oldValue = _fontSize;
 				_fontSize = value;
 				OnPropertyChanged();
-				UpdateStructFromFontProperties();
+				((IFontElement)this).OnFontSizeChanged(oldValue, value);
 			}
 		}
 
@@ -149,23 +153,34 @@ namespace Xamarin.Forms
 			_inUpdate = false;
 		}
 
-		void UpdateStructFromFontProperties()
+		void OnSomeFontPropertyChanged()
 		{
-			if (_inUpdate)
-				return;
-			_inUpdate = true;
-
-			if (FontFamily != null)
 			{
-				Font = Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
-			}
-			else
-			{
-				Font = Font.SystemFontOfSize(FontSize).WithAttributes(FontAttributes);
-			}
+				if (_inUpdate)
+					return;
+				_inUpdate = true;
 
-			_inUpdate = false;
+				if (FontFamily != null)
+					Font = Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+				else
+					Font = Font.SystemFontOfSize(FontSize).WithAttributes(FontAttributes);
+
+				_inUpdate = false;
+			}
 		}
-	}
+
 #pragma warning restore
+
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
+			OnSomeFontPropertyChanged();
+
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
+			OnSomeFontPropertyChanged();
+
+		double IFontElement.FontSizeDefaultValueCreator() =>
+			Device.GetNamedSize(NamedSize.Default, typeof(Label));
+
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			OnSomeFontPropertyChanged();
+	}
 }

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -449,6 +449,7 @@
     <Compile Include="XmlnsDefinitionAttribute.cs" />
     <Compile Include="PlatformConfiguration\macOSSpecific\TabbedPage.cs" />
     <Compile Include="PlatformConfiguration\macOSSpecific\TabsStyle.cs" />
+    <Compile Include="FontElement.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Reuse the same BPs for IFontElement properties. The advantage is that it's now possible to set the FontSizeProperty to any IFontElement property without knowing what it is, and make sure the property will apply.

no api change => no new tests.

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

None, ideally

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense