### PR TITLE
Fix for Android Visibility/Opacity crash 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51238.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51238.cs
@@ -1,6 +1,10 @@
-﻿using NUnit.Framework;
-using Xamarin.Forms.CustomAttributes;
+﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51238.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51238.cs
@@ -2,44 +2,17 @@
 using Xamarin.Forms.Internals;
 
 #if UITEST
-using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 51238, "Transparent Grid causes Java.Lang.IllegalStateException: Unable to create layer for Platform_DefaultRenderer", PlatformAffected.Android)]
+	[Issue(IssueTracker.Bugzilla, 51238,
+		"Transparent Grid causes Java.Lang.IllegalStateException: Unable to create layer for Platform_DefaultRenderer",
+		PlatformAffected.Android)]
 	public class Bugzilla51238 : TestContentPage
 	{
-		protected override void Init()
-		{
-			var grid = new Grid();
-			grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Star });
-			grid.RowDefinitions.Add(new RowDefinition() { Height = 50 });
-
-			var transparentLayer = new Grid();
-			transparentLayer.IsVisible = false;
-			transparentLayer.BackgroundColor = Color.Lime;
-			transparentLayer.Opacity = 0.5;
-
-			Grid.SetRow(transparentLayer, 0);
-
-			var button = new Button() { Text = "Tap Me!", HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
-
-			Grid.SetRow(button, 0);
-
-			button.Clicked += (sender, args) =>
-			{
-				transparentLayer.IsVisible = !transparentLayer.IsVisible;
-			};
-
-			grid.Children.Add(transparentLayer);
-			grid.Children.Add(button);
-
-			Content = grid;
-		}
-
 #if UITEST
 		[Test]
 		public void Issue1Test()
@@ -49,5 +22,44 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("Tap Me!");
 		}
 #endif
+
+		protected override void Init()
+		{
+			var grid = new Grid();
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+			grid.RowDefinitions.Add(new RowDefinition { Height = 50 });
+
+			var transparentLayer = new Grid();
+			transparentLayer.IsVisible = false;
+			transparentLayer.BackgroundColor = Color.Lime;
+			transparentLayer.Opacity = 0.5;
+
+			var label = new Label
+			{
+				Text = "Foo",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			Grid.SetRow(label, 0);
+			Grid.SetRow(transparentLayer, 0);
+
+			var button = new Button
+			{
+				Text = "Tap Me!",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			Grid.SetRow(button, 1);
+
+			button.Clicked += (sender, args) => { transparentLayer.IsVisible = !transparentLayer.IsVisible; };
+
+			grid.Children.Add(label);
+			grid.Children.Add(transparentLayer);
+			grid.Children.Add(button);
+
+			Content = grid;
+		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51238.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51238.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 51238, "Transparent Grid causes Java.Lang.IllegalStateException: Unable to create layer for Platform_DefaultRenderer", PlatformAffected.Android)]
+	public class Bugzilla51238 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var grid = new Grid();
+			grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Star });
+			grid.RowDefinitions.Add(new RowDefinition() { Height = 50 });
+
+			var transparentLayer = new Grid();
+			transparentLayer.IsVisible = false;
+			transparentLayer.BackgroundColor = Color.Lime;
+			transparentLayer.Opacity = 0.5;
+
+			Grid.SetRow(transparentLayer, 0);
+
+			var button = new Button() { Text = "Tap Me!", HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
+
+			Grid.SetRow(button, 0);
+
+			button.Clicked += (sender, args) =>
+			{
+				transparentLayer.IsVisible = !transparentLayer.IsVisible;
+			};
+
+			grid.Children.Add(transparentLayer);
+			grid.Children.Add(button);
+
+			Content = grid;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1Test()
+		{
+			RunningApp.WaitForElement("Tap Me!");
+			RunningApp.Tap("Tap Me!"); // Crashes the app if the issue isn't fixed
+			RunningApp.WaitForElement("Tap Me!");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -171,6 +171,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47923.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla48236.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47971.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51238.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51642.xaml.cs">
       <DependentUpon>Bugzilla51642.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -477,51 +477,5 @@ namespace Xamarin.Forms.Platform.Android
 
 			UpdateClickable(forceClick);
 		}
-
-		[SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
-		public override ViewStates Visibility
-		{
-			get { return base.Visibility; }
-			set
-			{
-				if (Alpha == 0 || Alpha == 1)
-				{
-					// Business as usual
-					base.Visibility = value;
-				}
-				else
-				{
-					// For some reason, restoring the visibility of Views which have an 
-					// Alpha value between 0 and 1 causes a crash. We can avoid the problem
-					// by forcing the Alpha value to 0 while we restore the visibility, then
-					// restoring the original value. This solution should be removed as soon
-					// as we can figure out the underlying renderer error
-
-					// Track the current alpha setting
-					var alpha = Alpha;
-
-					var currentVisibility = base.Visibility;
-
-					// Are we making this visible?
-					if ((currentVisibility == ViewStates.Invisible || currentVisibility == ViewStates.Gone) &&
-					    value == ViewStates.Visible)
-					{
-						// Set the alpha to zero so we don't get a mysterious rendering crash
-						Alpha = 0;
-					}
-
-					base.Visibility = value;
-
-					// Queue up the restoration of the alpha setting
-					// ReSharper disable once CompareOfFloatsByEqualityOperator
-					if (Alpha != alpha)
-					{
-						Looper looper = Context.MainLooper;
-						var handler = new Handler(looper);
-						handler.Post(() => { Alpha = alpha; });
-					}
-				}
-			}
-		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using Android.OS;
 using Android.Support.V4.View;
 using Android.Views;
 using Xamarin.Forms.Internals;
@@ -474,6 +476,52 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			UpdateClickable(forceClick);
+		}
+
+		[SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
+		public override ViewStates Visibility
+		{
+			get { return base.Visibility; }
+			set
+			{
+				if (Alpha == 0 || Alpha == 1)
+				{
+					// Business as usual
+					base.Visibility = value;
+				}
+				else
+				{
+					// For some reason, restoring the visibility of Views which have an 
+					// Alpha value between 0 and 1 causes a crash. We can avoid the problem
+					// by forcing the Alpha value to 0 while we restore the visibility, then
+					// restoring the original value. This solution should be removed as soon
+					// as we can figure out the underlying renderer error
+
+					// Track the current alpha setting
+					var alpha = Alpha;
+
+					var currentVisibility = base.Visibility;
+
+					// Are we making this visible?
+					if ((currentVisibility == ViewStates.Invisible || currentVisibility == ViewStates.Gone) &&
+					    value == ViewStates.Visible)
+					{
+						// Set the alpha to zero so we don't get a mysterious rendering crash
+						Alpha = 0;
+					}
+
+					base.Visibility = value;
+
+					// Queue up the restoration of the alpha setting
+					// ReSharper disable once CompareOfFloatsByEqualityOperator
+					if (Alpha != alpha)
+					{
+						Looper looper = Context.MainLooper;
+						var handler = new Handler(looper);
+						handler.Post(() => { Alpha = alpha; });
+					}
+				}
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using Android.OS;
 using Android.Support.V4.View;
 using Android.Views;
 using Xamarin.Forms.Internals;

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -79,8 +79,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			var x = (int)_context.ToPixels(view.X);
 			var y = (int)_context.ToPixels(view.Y);
-			var width = (int)_context.ToPixels(view.Width);
-			var height = (int)_context.ToPixels(view.Height);
+			var width = Math.Max(0, (int)_context.ToPixels(view.Width));
+			var height = Math.Max(0, (int)_context.ToPixels(view.Height));
 
 			var formsViewGroup = aview as FormsViewGroup;
 			if (formsViewGroup == null)


### PR DESCRIPTION
### Description of Change ###

Restoring the visibility of Views which have an Alpha value between 0 and 1 causes a crash due to a negative width/height in `VisualElementTracker`'s `UpdateLayout` method.

### Bugs Fixed ###

- [51238 – Transparent Grid causes Java.Lang.IllegalStateException: Unable to create layer for Platform_DefaultRenderer](https://bugzilla.xamarin.com/show_bug.cgi?id=51238)

### API Changes ###

None

### Behavioral Changes ###

None 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
