### PR TITLE
Fixed issue where Android Hints were causing a "." to be placed on al…

### DIFF
--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -223,7 +223,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_defaultHint == null)
 				_defaultHint = textView.Hint;
 
-			var elemValue = string.Join(". ", (string)Element.GetValue(Accessibility.NameProperty), (string)Element.GetValue(Accessibility.HintProperty));
+            var elemValue = string.Join((String.IsNullOrWhiteSpace((string)(Element.GetValue(Accessibility.NameProperty))) || String.IsNullOrWhiteSpace((string)(Element.GetValue(Accessibility.HintProperty)))) ? "" : ". ", (string)Element.GetValue(Accessibility.NameProperty), (string)Element.GetValue(Accessibility.HintProperty));
 
 			if (!string.IsNullOrWhiteSpace(elemValue))
 				textView.Hint = elemValue;


### PR DESCRIPTION
Fixed issue where Android Hints were causing a "." to be placed on all entry controls.

### Description of Change ###

Accessibility support on Android caused a ". " to be place on every control.

No tests believe to be needed.  If there is another issue where certain hints are not being defaulted on certain setups then tests will probably be needed.

### Bugs Fixed ###

### API Changes ###

None

### Behavioral Changes ###

Android will now have errant ". " replaced with "" in the UI where Hint and Name are non existent.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense