### PR TITLE
Fixed a redundant check that caused a massive slowdown on UWP.

### DIFF
--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -332,12 +332,11 @@ namespace Xamarin.Forms
 					return true;
 
 				Element parent = RealParent;
-				while (parent != null)
+				if (parent != null)
 				{
 					var visualElement = parent as VisualElement;
 					if (visualElement != null && visualElement.IsInNativeLayout)
 						return true;
-					parent = parent.RealParent;
 				}
 
 				return false;

--- a/Xamarin.Forms.Platform.WP8/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WP8/VisualElementTracker.cs
@@ -272,9 +272,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		void MaybeInvalidate()
 		{
-			if (Model.IsInNativeLayout)
-				return;
-			var parent = (FrameworkElement)Element.Parent;
+           if (Model.IsInNativeLayout)
+            	return;
+            var parent = (FrameworkElement)Element.Parent;
 			parent?.InvalidateMeasure();
 			Element.InvalidateMeasure();
 		}

--- a/Xamarin.Forms.Platform.WP8/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WP8/VisualElementTracker.cs
@@ -272,9 +272,10 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		void MaybeInvalidate()
 		{
-           if (Model.IsInNativeLayout)
-            	return;
-            var parent = (FrameworkElement)Element.Parent;
+			if (Model.IsInNativeLayout)
+				return;
+
+			var parent = (FrameworkElement)Element.Parent;
 			parent?.InvalidateMeasure();
 			Element.InvalidateMeasure();
 		}

--- a/Xamarin.Forms.Platform.WP8/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WP8/VisualElementTracker.cs
@@ -272,9 +272,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		void MaybeInvalidate()
 		{
-           if (Model.IsInNativeLayout)
-            	return;
-            var parent = (FrameworkElement)Element.Parent;
+			if (Model.IsInNativeLayout)
+				return;
+			var parent = (FrameworkElement)Element.Parent;
 			parent?.InvalidateMeasure();
 			Element.InvalidateMeasure();
 		}

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -272,9 +272,10 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void MaybeInvalidate()
 		{
-            	if (Element.IsInNativeLayout)
-            		return;
-            var parent = (FrameworkElement)Container.Parent;
+			if (Element.IsInNativeLayout)
+				return;
+
+			var parent = (FrameworkElement)Container.Parent;
 			parent?.InvalidateMeasure();
 			Container.InvalidateMeasure();
 		}

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -274,7 +274,6 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			if (Element.IsInNativeLayout)
 				return;
-
 			var parent = (FrameworkElement)Container.Parent;
 			parent?.InvalidateMeasure();
 			Container.InvalidateMeasure();

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -274,6 +274,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			if (Element.IsInNativeLayout)
 				return;
+
 			var parent = (FrameworkElement)Container.Parent;
 			parent?.InvalidateMeasure();
 			Container.InvalidateMeasure();

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -272,9 +272,9 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void MaybeInvalidate()
 		{
-			if (Element.IsInNativeLayout)
-				return;
-			var parent = (FrameworkElement)Container.Parent;
+            	if (Element.IsInNativeLayout)
+            		return;
+            var parent = (FrameworkElement)Container.Parent;
 			parent?.InvalidateMeasure();
 			Container.InvalidateMeasure();
 		}


### PR DESCRIPTION
### Description of Change ###

Our views on UWP can take anywhere from 30 seconds to 10 minutes to render.  This fix takes all those views down to milliseconds.  I would rather have just removed all the IsInNativeLayout and also the MaybeInvalidate() function because they seem to not really do anything.  InvalidateLayout shouldnt cause a layout cycle unless something else was wrong.  So even though we are checking the tree once per control now instead of multiple times, I believe its still too much and shouldnt be needed.

No Tests needed as this is for performance only.  I did see some performance functions in the master code if that is something that can be used on UWP then it would be interesting to see the differences on complex trees.

### Bugs Fixed ###

#52507

### API Changes ###

None

### Behavioral Changes ###

UWP views should load extremely fast now, especially in release.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
