### PR TITLE
[XamlC] update to cecil 0.10.0-b4 for better symbol detection

### DIFF
--- a/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
@@ -46,7 +46,6 @@ namespace Xamarin.Forms.Build.Tasks
 			using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(Assembly, new ReaderParameters {
 				ReadWrite = true,
 				ReadSymbols = DebugSymbols,
-				SymbolReaderProvider = GetSymbolReaderProvider(Assembly, DebugSymbols),
 				AssemblyResolver = resolver
 			})) {
 				foreach (var module in assemblyDefinition.Modules) {
@@ -146,7 +145,6 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 				Logger.LogString(1, "Writing the assembly... ");
 				assemblyDefinition.Write(new WriterParameters {
-					SymbolWriterProvider = GetSymbolWriterProvider(Assembly, DebugSymbols),
 					WriteSymbols = DebugSymbols
 				});
 			}

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -52,16 +52,16 @@
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Mono.Cecil">
-      <HintPath>..\packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.dll</HintPath>
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -72,7 +72,6 @@ namespace Xamarin.Forms.Build.Tasks
 				AssemblyResolver = resolver,
 				ReadWrite = !ReadOnly,
 				ReadSymbols = DebugSymbols,
-				SymbolReaderProvider = GetSymbolReaderProvider(Assembly, DebugSymbols),
 			};
 
 			using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(Path.GetFullPath(Assembly),readerParameters)) {
@@ -226,7 +225,6 @@ namespace Xamarin.Forms.Build.Tasks
 				try {
 					assemblyDefinition.Write(new WriterParameters {
 						WriteSymbols = DebugSymbols,
-						SymbolWriterProvider = GetSymbolWriterProvider(Assembly, DebugSymbols),
 					});
 					Logger.LogLine(1, "done.");
 				} catch (Exception e) {

--- a/Xamarin.Forms.Build.Tasks/XamlTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlTask.cs
@@ -60,56 +60,6 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 			return rootnode;
 		}
-
-		protected static ISymbolReaderProvider GetSymbolReaderProvider(string moduleFileName, bool debugSymbols)
-		{
-			if (!debugSymbols)
-				return null;
-
-			var pdb_name = GetPdbFileName(moduleFileName);
-			if (File.Exists(pdb_name)) {
-				// TODO: check mvid match
-				return new PdbReaderProvider();
-			}
-
-			var mdb_name = GetMdbFileName(moduleFileName);
-			if (File.Exists(mdb_name)) {
-				// TODO: check mvid match
-				return new MdbReaderProvider();
-			}
-
-			return null;
-		}
-
-		protected static ISymbolWriterProvider GetSymbolWriterProvider(string moduleFileName, bool debugSymbols)
-		{
-			if (!debugSymbols)
-				return null;
-
-			var pdb_name = GetPdbFileName(moduleFileName);
-			if (File.Exists(pdb_name)) {
-				// TODO: check mvid match
-				return new PdbWriterProvider();
-			}
-
-			var mdb_name = GetMdbFileName(moduleFileName);
-			if (File.Exists(mdb_name)) {
-				// TODO: check mvid match
-				return new MdbWriterProvider();
-			}
-
-			return null;
-		}
-
-		static string GetPdbFileName(string assemblyFileName)
-		{
-			return Path.ChangeExtension(assemblyFileName, ".pdb");
-		}
-
-		static string GetMdbFileName(string assemblyFileName)
-		{
-			return assemblyFileName + ".mdb";
-		}
 	}
 
 	static class CecilExtensions

--- a/Xamarin.Forms.Build.Tasks/packages.config
+++ b/Xamarin.Forms.Build.Tasks/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.10.0-beta2" targetFramework="net451" />
+  <package id="Mono.Cecil" version="0.10.0-beta4" targetFramework="net451" />
 </packages>

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -57,16 +57,16 @@
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Mono.Cecil">
-      <HintPath>..\packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.dll</HintPath>
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\packages\Mono.Cecil.0.10.0-beta2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/packages.config
+++ b/Xamarin.Forms.Xaml.UnitTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.10.0-beta2" targetFramework="net451" />
+  <package id="Mono.Cecil" version="0.10.0-beta4" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
### Description of Change ###

[XamlC] update to cecil 0.10.0-b4 for better symbol detection.

since -beta4 Cecil uses a different `snk` than mono, so the one we build against and deploy will no longer be mismatched with the one installed in the GAC

this is an enhanced version of #726 

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense