### PR TITLE
[Xaml] Fallback to App.Current for DynResources (Previewer)

### DIFF
--- a/Xamarin.Forms.Controls/SdxApp.xaml
+++ b/Xamarin.Forms.Controls/SdxApp.xaml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Controls.SdxApp">
+	<ContentPage.Content>
+	</ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/SdxApp.xaml.cs
+++ b/Xamarin.Forms.Controls/SdxApp.xaml.cs
@@ -1,0 +1,22 @@
+﻿//
+// SdxApp.xaml.cs
+//
+// Author:
+//       Stephane Delcroix <stdelc@microsoft.com>
+//
+// Copyright (c) 2017 
+using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Controls
+{
+	public partial class SdxApp : ContentPage
+	{
+		public SdxApp()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/SdxPage.xaml
+++ b/Xamarin.Forms.Controls/SdxPage.xaml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Controls.SdxPage">
+	<ContentPage.Content>
+	</ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/SdxPage.xaml.cs
+++ b/Xamarin.Forms.Controls/SdxPage.xaml.cs
@@ -1,0 +1,22 @@
+﻿//
+// SdxPage.xaml.cs
+//
+// Author:
+//       Stephane Delcroix <stdelc@microsoft.com>
+//
+// Copyright (c) 2017 
+using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Controls
+{
+	public partial class SdxPage : ContentPage
+	{
+		public SdxPage()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/DynamicResourceTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DynamicResourceTests.cs
@@ -10,6 +10,13 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			base.Setup ();
 			Device.PlatformServices = new MockPlatformServices ();
+			Application.Current = new MockApplication();
+		}
+
+		[TearDown]
+		public override void TearDown()
+		{
+			Application.Current = null;
 		}
 
 		[Test]
@@ -143,11 +150,24 @@ namespace Xamarin.Forms.Core.UnitTests
 			label.SetDynamicResource (Label.TextProperty, "foo");
 			label.Resources = new ResourceDictionary { {"foo","FOO"}};
 
-			Assert.AreEqual ("FOO", label.Text);
+			Assume.That(label.Text, Is.EqualTo("FOO"));
 
 			label.Resources ["foo"] = "BAR";
 
 			Assert.AreEqual ("BAR", label.Text);
+		}
+
+		[Test]
+		public void FallbackToApplicationCurrent()
+		{
+			Application.Current.Resources = new ResourceDictionary { { "foo", "FOO" } };
+
+			var label = new Label();
+			label.BindingContext = new MockViewModel();
+			label.SetBinding(Label.TextProperty, "Text", BindingMode.TwoWay);
+			label.SetDynamicResource(Label.TextProperty, "foo");
+
+			Assert.That(label.Text, Is.EqualTo("FOO"));
 		}
 	}
 }

--- a/Xamarin.Forms.Core/MergedStyle.cs
+++ b/Xamarin.Forms.Core/MergedStyle.cs
@@ -125,12 +125,11 @@ namespace Xamarin.Forms
 			void RegisterImplicitStyles()
 			{
 				Type type = TargetType;
-				while (true)
-				{
+				while (true) {
 					BindableProperty implicitStyleProperty = BindableProperty.Create("ImplicitStyle", typeof(Style), typeof(VisualElement), default(Style),
-						propertyChanged: (bindable, oldvalue, newvalue) => ((VisualElement)bindable)._mergedStyle.OnImplicitStyleChanged());
-					Target.SetDynamicResource(implicitStyleProperty, type.FullName);
+						 propertyChanged: (bindable, oldvalue, newvalue) => OnImplicitStyleChanged());
 					_implicitStyles.Add(implicitStyleProperty);
+					Target.SetDynamicResource(implicitStyleProperty, type.FullName);
 					type = type.GetTypeInfo().BaseType;
 					if (s_stopAtTypes.Contains(type))
 						return;

--- a/Xamarin.Forms.Core/ResourcesExtensions.cs
+++ b/Xamarin.Forms.Core/ResourcesExtensions.cs
@@ -55,6 +55,11 @@ namespace Xamarin.Forms
 					return true;
 				element = element.Parent;
 			}
+
+			//Fallback for the XF previewer
+			if (Application.Current != null && Application.Current.Resources != null && Application.Current.Resources.TryGetValue(key, out value))
+				return true;
+
 			value = null;
 			return false;
 		}


### PR DESCRIPTION
### Description of Change ###

[Xaml] Fallback to App.Current for DynamicResources so the previewer can resolve them even if the displayed control is not parented back to Application.Current.MainPage.

this needs to be backported to 2.3.4 once merged

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=52706

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense