### PR TITLE
[Android] Small performance fixes to ListViewRenderer, PlatformSpecific IsFastScrollEnabled 

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
@@ -9,9 +9,12 @@ using System.Threading;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+
 namespace Xamarin.Forms.Controls
 {
-	[Preserve (AllMembers = true)]
+	[Preserve(AllMembers = true)]
 	internal class ListViewCoreGalleryPage : CoreGalleryPage<ListView>
 	{
 		internal class Employee : INotifyPropertyChanged
@@ -22,10 +25,11 @@ namespace Xamarin.Forms.Controls
 				get { return _name; }
 				set
 				{
-					if (value != null && value != _name) {
+					if (value != null && value != _name)
+					{
 						_name = value;
-						OnPropertyChanged ();
-					}	
+						OnPropertyChanged();
+					}
 				}
 			}
 
@@ -35,10 +39,11 @@ namespace Xamarin.Forms.Controls
 				get { return _daysWorked; }
 				set
 				{
-					if (value != null && value != _daysWorked) {
+					if (value != null && value != _daysWorked)
+					{
 						_daysWorked = value;
-						OnPropertyChanged ();
-					}	
+						OnPropertyChanged();
+					}
 				}
 			}
 
@@ -48,14 +53,15 @@ namespace Xamarin.Forms.Controls
 				get { return _rowHeight; }
 				set
 				{
-					if (value != null && value != _rowHeight) {
+					if (value != null && value != _rowHeight)
+					{
 						_rowHeight = value;
-						OnPropertyChanged ();
+						OnPropertyChanged();
 					}
 				}
 			}
 
-			public Employee (string name, TimeSpan daysWorked, int rowHeight)
+			public Employee(string name, TimeSpan daysWorked, int rowHeight)
 			{
 				_name = name;
 				_daysWorked = daysWorked;
@@ -64,61 +70,65 @@ namespace Xamarin.Forms.Controls
 
 			public event PropertyChangedEventHandler PropertyChanged;
 
-			protected virtual void OnPropertyChanged ([CallerMemberName] string propertyName = null)
+			protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
 			{
 				PropertyChangedEventHandler handler = PropertyChanged;
 				if (handler != null)
-					handler (this, new PropertyChangedEventArgs (propertyName));
+					handler(this, new PropertyChangedEventArgs(propertyName));
 			}
 		}
 
-		[Preserve (AllMembers = true)]
+		[Preserve(AllMembers = true)]
 		internal class Grouping<K, T> : ObservableCollection<T>
 		{
 			public K Key { get; private set; }
 
-			public Grouping (K key, IEnumerable<T> items)
+			public Grouping(K key, IEnumerable<T> items)
 			{
 				Key = key;
-				foreach (T item in items) {
-					Items.Add (item);
+				foreach (T item in items)
+				{
+					Items.Add(item);
 				}
 			}
 		}
 
-		[Preserve (AllMembers = true)]
+		[Preserve(AllMembers = true)]
 		public class HeaderCell : ViewCell
 		{
-			public HeaderCell ()
+			public HeaderCell()
 			{
 				Height = 60;
-				var title = new Label {
+				var title = new Label
+				{
 					HeightRequest = 60,
 					BackgroundColor = Color.Navy,
 					TextColor = Color.White
 				};
 
-				title.SetBinding (Label.TextProperty, new Binding ("Key"));
+				title.SetBinding(Label.TextProperty, new Binding("Key"));
 
-				View = new StackLayout {
+				View = new StackLayout
+				{
 					BackgroundColor = Color.Pink,
 					Children = { title }
 				};
 			}
 		}
 
-		[Preserve (AllMembers = true)]
+		[Preserve(AllMembers = true)]
 		class UnevenCell : ViewCell
 		{
-			public UnevenCell ()
+			public UnevenCell()
 			{
-	
-				SetBinding (HeightProperty, new Binding("RowHeight"));
 
-				var label = new Label ();
-				label.SetBinding (Label.TextProperty, new Binding("Name"));
+				SetBinding(HeightProperty, new Binding("RowHeight"));
 
-				var layout = new StackLayout {
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, new Binding("Name"));
+
+				var layout = new StackLayout
+				{
 					BackgroundColor = Color.Red,
 					Children = {
 						label
@@ -129,17 +139,17 @@ namespace Xamarin.Forms.Controls
 			}
 		}
 
-		[Preserve (AllMembers = true)]
+		[Preserve(AllMembers = true)]
 		internal class ListViewViewModel
 		{
 			public ObservableCollection<Grouping<string, Employee>> CategorizedEmployees { get; private set; }
-			public ObservableCollection<Employee> Employees { get; private set; } 
+			public ObservableCollection<Employee> Employees { get; private set; }
 
-			public ListViewViewModel ()
+			public ListViewViewModel()
 			{
 				CategorizedEmployees = new ObservableCollection<Grouping<string, Employee>> {
 					new Grouping<string, Employee> (
-						"Engineer", 
+						"Engineer",
 						new [] {
 							new Employee ("Seth", TimeSpan.FromDays (10), 60),
 							new Employee ("Jason", TimeSpan.FromDays (100), 100),
@@ -147,7 +157,7 @@ namespace Xamarin.Forms.Controls
 						}
 					),
  					new Grouping<string, Employee> (
-						"Sales", 
+						"Sales",
 						new [] {
 							new Employee ("Andrew 1", TimeSpan.FromDays (10), 160),
 							new Employee ("Andrew 2", TimeSpan.FromDays (100), 100),
@@ -165,7 +175,7 @@ namespace Xamarin.Forms.Controls
 					new Employee ("Andrew 3", TimeSpan.FromDays (1000), 60),
 				};
 
-				Enumerable.Range (0, 9000).Select (e => new Employee (e.ToString (), TimeSpan.FromDays (1), 60)).ForEach (e => Employees.Add (e));
+				Enumerable.Range(0, 9000).Select(e => new Employee(e.ToString(), TimeSpan.FromDays(1), 60)).ForEach(e => Employees.Add(e));
 			}
 		}
 
@@ -174,96 +184,102 @@ namespace Xamarin.Forms.Controls
 			get { return false; }
 		}
 
-		protected override void InitializeElement (ListView element)
+		protected override void InitializeElement(ListView element)
 		{
 			element.HeightRequest = 350;
 			element.RowHeight = 60;
 
-			var viewModel = new ListViewViewModel ();
+			var viewModel = new ListViewViewModel();
 			element.BindingContext = viewModel;
 
 			element.ItemsSource = viewModel.Employees;
 
-			var template = new DataTemplate (typeof(TextCell));
-			template.SetBinding (TextCell.TextProperty, "Name");
-			template.SetBinding (TextCell.DetailProperty, new Binding("DaysWorked", converter: new GenericValueConverter (time => time.ToString ())));
+			var template = new DataTemplate(typeof(TextCell));
+			template.SetBinding(TextCell.TextProperty, "Name");
+			template.SetBinding(TextCell.DetailProperty, new Binding("DaysWorked", converter: new GenericValueConverter(time => time.ToString())));
 
 			element.ItemTemplate = template;
 		}
 
-		protected override void Build (StackLayout stackLayout)
+		protected override void Build(StackLayout stackLayout)
 		{
-			base.Build (stackLayout);
+			base.Build(stackLayout);
 
-			var viewModel = new ListViewViewModel ();
+			var viewModel = new ListViewViewModel();
 
-			var groupDisplayBindingContainer = new ViewContainer<ListView> (Test.ListView.GroupDisplayBinding, new ListView ());
-			InitializeElement (groupDisplayBindingContainer.View);
+			var groupDisplayBindingContainer = new ViewContainer<ListView>(Test.ListView.GroupDisplayBinding, new ListView());
+			InitializeElement(groupDisplayBindingContainer.View);
 			groupDisplayBindingContainer.View.ItemsSource = viewModel.CategorizedEmployees;
 			groupDisplayBindingContainer.View.IsGroupingEnabled = true;
-			groupDisplayBindingContainer.View.GroupDisplayBinding = new Binding ("Key");
+			groupDisplayBindingContainer.View.GroupDisplayBinding = new Binding("Key");
 
 
-			var groupHeaderTemplateContainer = new ViewContainer<ListView> (Test.ListView.GroupHeaderTemplate, new ListView ());
-			InitializeElement (groupHeaderTemplateContainer.View);
+			var groupHeaderTemplateContainer = new ViewContainer<ListView>(Test.ListView.GroupHeaderTemplate, new ListView());
+			InitializeElement(groupHeaderTemplateContainer.View);
 			groupHeaderTemplateContainer.View.ItemsSource = viewModel.CategorizedEmployees;
 			groupHeaderTemplateContainer.View.IsGroupingEnabled = true;
-			groupHeaderTemplateContainer.View.GroupHeaderTemplate = new DataTemplate (typeof (HeaderCell));
+			groupHeaderTemplateContainer.View.GroupHeaderTemplate = new DataTemplate(typeof(HeaderCell));
 
-			var groupShortNameContainer = new ViewContainer<ListView> (Test.ListView.GroupShortNameBinding, new ListView ());
-			InitializeElement (groupShortNameContainer.View);
+			var groupShortNameContainer = new ViewContainer<ListView>(Test.ListView.GroupShortNameBinding, new ListView());
+			InitializeElement(groupShortNameContainer.View);
 			groupShortNameContainer.View.ItemsSource = viewModel.CategorizedEmployees;
 			groupShortNameContainer.View.IsGroupingEnabled = true;
 			groupShortNameContainer.View.GroupShortNameBinding = new Binding("Key");
 
 			// TODO - not sure how to do this
-			var hasUnevenRowsContainer = new ViewContainer<ListView> (Test.ListView.HasUnevenRows, new ListView ());
-			InitializeElement (hasUnevenRowsContainer.View);
+			var hasUnevenRowsContainer = new ViewContainer<ListView>(Test.ListView.HasUnevenRows, new ListView());
+			InitializeElement(hasUnevenRowsContainer.View);
 			hasUnevenRowsContainer.View.HasUnevenRows = true;
-			hasUnevenRowsContainer.View.ItemTemplate = new DataTemplate (typeof(UnevenCell));
+			hasUnevenRowsContainer.View.ItemTemplate = new DataTemplate(typeof(UnevenCell));
 
-			var isGroupingEnabledContainer = new StateViewContainer<ListView> (Test.ListView.IsGroupingEnabled, new ListView ());
-			InitializeElement (isGroupingEnabledContainer.View);
+			var isGroupingEnabledContainer = new StateViewContainer<ListView>(Test.ListView.IsGroupingEnabled, new ListView());
+			InitializeElement(isGroupingEnabledContainer.View);
 			isGroupingEnabledContainer.View.ItemsSource = viewModel.CategorizedEmployees;
 			isGroupingEnabledContainer.View.IsGroupingEnabled = true;
 			isGroupingEnabledContainer.StateChangeButton.Clicked += (sender, args) => isGroupingEnabledContainer.View.IsGroupingEnabled = !isGroupingEnabledContainer.View.IsGroupingEnabled;
 
 
-			var itemAppearingContainer = new EventViewContainer<ListView> (Test.ListView.ItemAppearing, new ListView ());
-			InitializeElement (itemAppearingContainer.View);
-			itemAppearingContainer.View.ItemAppearing += (sender, args) => itemAppearingContainer.EventFired ();
+			var itemAppearingContainer = new EventViewContainer<ListView>(Test.ListView.ItemAppearing, new ListView());
+			InitializeElement(itemAppearingContainer.View);
+			itemAppearingContainer.View.ItemAppearing += (sender, args) => itemAppearingContainer.EventFired();
 
-			var itemDisappearingContainer = new EventViewContainer<ListView> (Test.ListView.ItemDisappearing, new ListView ());
-			InitializeElement (itemDisappearingContainer.View);
-			itemDisappearingContainer.View.ItemDisappearing += (sender, args) => itemDisappearingContainer.EventFired ();
+			var itemDisappearingContainer = new EventViewContainer<ListView>(Test.ListView.ItemDisappearing, new ListView());
+			InitializeElement(itemDisappearingContainer.View);
+			itemDisappearingContainer.View.ItemDisappearing += (sender, args) => itemDisappearingContainer.EventFired();
 
-			var itemSelectedContainer = new EventViewContainer<ListView> (Test.ListView.ItemSelected, new ListView ());
-			InitializeElement (itemSelectedContainer.View);
-			itemSelectedContainer.View.ItemSelected += (sender, args) => itemSelectedContainer.EventFired ();
+			var itemSelectedContainer = new EventViewContainer<ListView>(Test.ListView.ItemSelected, new ListView());
+			InitializeElement(itemSelectedContainer.View);
+			itemSelectedContainer.View.ItemSelected += (sender, args) => itemSelectedContainer.EventFired();
 
-			var itemTappedContainer = new EventViewContainer<ListView> (Test.ListView.ItemTapped, new ListView ());
-			InitializeElement (itemTappedContainer.View);
-			itemTappedContainer.View.ItemTapped += (sender, args) => itemTappedContainer.EventFired ();
+			var itemTappedContainer = new EventViewContainer<ListView>(Test.ListView.ItemTapped, new ListView());
+			InitializeElement(itemTappedContainer.View);
+			itemTappedContainer.View.ItemTapped += (sender, args) => itemTappedContainer.EventFired();
 
 			// TODO
-			var rowHeightContainer = new ViewContainer<ListView> (Test.ListView.RowHeight, new ListView ());
-			InitializeElement (rowHeightContainer.View);
+			var rowHeightContainer = new ViewContainer<ListView>(Test.ListView.RowHeight, new ListView());
+			InitializeElement(rowHeightContainer.View);
 
-			var selectedItemContainer = new ViewContainer<ListView> (Test.ListView.SelectedItem, new ListView ());
-			InitializeElement (selectedItemContainer.View);
+			var selectedItemContainer = new ViewContainer<ListView>(Test.ListView.SelectedItem, new ListView());
+			InitializeElement(selectedItemContainer.View);
 			selectedItemContainer.View.SelectedItem = viewModel.Employees[2];
 
-			Add (groupDisplayBindingContainer);
-			Add (groupHeaderTemplateContainer);
-			Add (groupShortNameContainer);
-			Add (hasUnevenRowsContainer);
-			Add (isGroupingEnabledContainer);
-			Add (itemAppearingContainer);
-			Add (itemDisappearingContainer);
-			Add (itemSelectedContainer);
-			Add (itemTappedContainer);
-			Add (rowHeightContainer);
-			Add (selectedItemContainer);
+			var fastScrollItemContainer = new ViewContainer<ListView>(Test.ListView.FastScroll, new ListView());
+			InitializeElement(fastScrollItemContainer.View);
+			fastScrollItemContainer.View.On<Android>().SetIsFastScrollEnabled(true);
+			fastScrollItemContainer.View.ItemsSource = viewModel.CategorizedEmployees;
+
+			Add(groupDisplayBindingContainer);
+			Add(groupHeaderTemplateContainer);
+			Add(groupShortNameContainer);
+			Add(hasUnevenRowsContainer);
+			Add(isGroupingEnabledContainer);
+			Add(itemAppearingContainer);
+			Add(itemDisappearingContainer);
+			Add(itemSelectedContainer);
+			Add(itemTappedContainer);
+			Add(rowHeightContainer);
+			Add(selectedItemContainer);
+			Add(fastScrollItemContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/ListView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/ListView.cs
@@ -1,0 +1,32 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using FormsElement = Forms.ListView;
+
+	public static class ListView
+	{
+		public static readonly BindableProperty IsFastScrollEnabledProperty =
+				BindableProperty.Create("IsFastScrollEnabled", typeof(bool),
+				typeof(ListView), true);
+
+		public static bool GetIsFastScrollEnabled(BindableObject element)
+		{
+			return (bool)element.GetValue(IsFastScrollEnabledProperty);
+		}
+
+		public static void SetIsFastScrollEnabled(BindableObject element, bool value)
+		{
+			element.SetValue(IsFastScrollEnabledProperty, value);
+		}
+
+		public static bool IsFastScrollEnabled(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetIsFastScrollEnabled(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetIsFastScrollEnabled(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
+		{
+			SetIsFastScrollEnabled(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/ListView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/ListView.cs
@@ -4,9 +4,7 @@
 
 	public static class ListView
 	{
-		public static readonly BindableProperty IsFastScrollEnabledProperty =
-				BindableProperty.Create("IsFastScrollEnabled", typeof(bool),
-				typeof(ListView), true);
+		public static readonly BindableProperty IsFastScrollEnabledProperty = BindableProperty.Create("IsFastScrollEnabled", typeof(bool), typeof(ListView), false);
 
 		public static bool GetIsFastScrollEnabled(BindableObject element)
 		{

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -450,6 +450,7 @@
     <Compile Include="PlatformConfiguration\macOSSpecific\TabbedPage.cs" />
     <Compile Include="PlatformConfiguration\macOSSpecific\TabsStyle.cs" />
     <Compile Include="FontElement.cs" />
+    <Compile Include="PlatformConfiguration\AndroidSpecific\ListView.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -414,7 +414,8 @@ namespace Xamarin.Forms.CustomAttributes
 			IsGroupingEnabled,
 			GroupDisplayBinding,
 			GroupShortNameBinding,
-			ScrollTo
+			ScrollTo,
+			FastScroll
 		}
 
 		public enum TableView

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -395,7 +395,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				for (var x = 0; x < take; x++)
 				{
-					if (position + x >= templatedItems.Count)
+					if (position + x >= _listCount)
 						return cells;
 
 					cells.Add(templatedItems[x + position]);
@@ -406,7 +406,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			var i = 0;
 			var global = 0;
-			for (; i < templatedItems.Count; i++)
+			for (; i < _listCount; i++)
 			{
 				var group = templatedItems.GetGroup(i);
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -26,6 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 		readonly AListView _realListView;
 		readonly Dictionary<DataTemplate, int> _templateToId = new Dictionary<DataTemplate, int>();
 		int _dataTemplateIncrementer = 2; // lets start at not 0 because
+		int _listCount = -1; // -1 we need to get count from the list
 		Cell _enabledCheckCell;
 
 		bool _fromNative;
@@ -63,16 +64,20 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			get
 			{
-				var templatedItems = TemplatedItemsView.TemplatedItems;
-				int count = templatedItems.Count;
-
-				if (_listView.IsGroupingEnabled)
+				if (_listCount == -1)
 				{
-					for (var i = 0; i < templatedItems.Count; i++)
-						count += templatedItems.GetGroup(i).Count;
-				}
+					var templatedItems = TemplatedItemsView.TemplatedItems;
+					int count = templatedItems.Count;
 
-				return count;
+					if (_listView.IsGroupingEnabled)
+					{
+						for (var i = 0; i < templatedItems.Count; i++)
+							count += templatedItems.GetGroup(i).Count;
+					}
+
+					_listCount = count;
+				}
+				return _listCount;
 			}
 		}
 
@@ -371,7 +376,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (position < 0 || position >= Count)
 				return;
 
-			if(_lastSelected != view)
+			if (_lastSelected != view)
 				_fromNative = true;
 			Select(position, view);
 			Controller.NotifyRowTapped(position, cell);
@@ -446,6 +451,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnDataChanged()
 		{
+			InvalidateCount();
 			if (ActionModeContext != null && !TemplatedItemsView.TemplatedItems.Contains(ActionModeContext))
 				CloseContextActions();
 
@@ -585,6 +591,11 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Row,
 			Header
+		}
+
+		void InvalidateCount()
+		{
+			_listCount = -1;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -58,6 +58,7 @@ namespace Xamarin.Forms.Platform.Android
 				MessagingCenter.Subscribe<AppCompat.Platform>(this, AppCompat.Platform.CloseContextActionsSignalName, p => CloseContextActions());
 			else
 				MessagingCenter.Subscribe<Platform>(this, Platform.CloseContextActionsSignalName, p => CloseContextActions());
+			InvalidateCount();
 		}
 
 		public override int Count
@@ -391,11 +392,12 @@ namespace Xamarin.Forms.Platform.Android
 				return cells;
 
 			var templatedItems = TemplatedItemsView.TemplatedItems;
+			var templatedItemsCount = templatedItems.Count;
 			if (!_listView.IsGroupingEnabled)
 			{
 				for (var x = 0; x < take; x++)
 				{
-					if (position + x >= _listCount)
+					if (position + x >= templatedItemsCount)
 						return cells;
 
 					cells.Add(templatedItems[x + position]);
@@ -406,7 +408,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			var i = 0;
 			var global = 0;
-			for (; i < _listCount; i++)
+			for (; i < templatedItemsCount; i++)
 			{
 				var group = templatedItems.GetGroup(i);
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -135,6 +135,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				((IListViewController)e.NewElement).ScrollToRequested += OnScrollToRequested;
 
+				nativeListView.FastScrollEnabled = true;
 				nativeListView.DividerHeight = 0;
 				nativeListView.Focusable = false;
 				nativeListView.DescendantFocusability = DescendantFocusability.AfterDescendants;

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -6,6 +6,8 @@ using Android.Views;
 using AListView = Android.Widget.ListView;
 using AView = Android.Views.View;
 using Xamarin.Forms.Internals;
+using System;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -135,7 +137,6 @@ namespace Xamarin.Forms.Platform.Android
 
 				((IListViewController)e.NewElement).ScrollToRequested += OnScrollToRequested;
 
-				nativeListView.FastScrollEnabled = true;
 				nativeListView.DividerHeight = 0;
 				nativeListView.Focusable = false;
 				nativeListView.DescendantFocusability = DescendantFocusability.AfterDescendants;
@@ -148,6 +149,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateHeader();
 				UpdateFooter();
 				UpdateIsSwipeToRefreshEnabled();
+				UpdateFastScrollEnabled();
 			}
 		}
 
@@ -167,6 +169,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateIsRefreshing();
 			else if (e.PropertyName == ListView.SeparatorColorProperty.PropertyName || e.PropertyName == ListView.SeparatorVisibilityProperty.PropertyName)
 				_adapter.NotifyDataSetChanged();
+			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.ListView.IsFastScrollEnabledProperty.PropertyName)
+				UpdateFastScrollEnabled();
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
@@ -327,6 +331,12 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (_refresh != null)
 				_refresh.Enabled = Element.IsPullToRefreshEnabled && (Element as IListViewController).RefreshAllowed;
+		}
+
+		void UpdateFastScrollEnabled()
+		{
+			if (Control != null)
+				Control.FastScrollEnabled = Element.OnThisPlatform().IsFastScrollEnabled();
 		}
 
 		internal class Container : ViewGroup

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/ListView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/ListView.xml
@@ -1,0 +1,116 @@
+<Type Name="ListView" FullName="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ListView">
+  <TypeSignature Language="C#" Value="public static class ListView" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit ListView extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetIsFastScrollEnabled">
+      <MemberSignature Language="C#" Value="public static bool GetIsFastScrollEnabled (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetIsFastScrollEnabled(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsFastScrollEnabled">
+      <MemberSignature Language="C#" Value="public static bool IsFastScrollEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsFastScrollEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.ListView&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsFastScrollEnabledProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty IsFastScrollEnabledProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty IsFastScrollEnabledProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetIsFastScrollEnabled">
+      <MemberSignature Language="C#" Value="public static void SetIsFastScrollEnabled (Xamarin.Forms.BindableObject element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetIsFastScrollEnabled(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetIsFastScrollEnabled">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt; SetIsFastScrollEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.ListView&gt; SetIsFastScrollEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.ListView&gt; config, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -477,6 +477,7 @@
     </Namespace>
     <Namespace Name="Xamarin.Forms.PlatformConfiguration.AndroidSpecific">
       <Type Name="Application" Kind="Class" />
+      <Type Name="ListView" Kind="Class" />
       <Type Name="TabbedPage" Kind="Class" />
       <Type Name="WindowSoftInputModeAdjust" Kind="Enumeration" />
     </Namespace>
@@ -1295,6 +1296,50 @@
           <summary>Sets a value that controls whether the soft input mode of the provided platform configuration pans or resizes its content to allow the display of the on-screen input UI.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Application" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Application.UseWindowSoftInputModeAdjust(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application},Xamarin.Forms.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="IsFastScrollEnabled">
+        <MemberSignature Language="C#" Value="public static bool IsFastScrollEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsFastScrollEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.ListView&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ListView" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ListView.IsFastScrollEnabled(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetIsFastScrollEnabled">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt; SetIsFastScrollEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt; config, bool value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.ListView&gt; SetIsFastScrollEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.ListView&gt; config, bool value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView&gt;" RefType="this" />
+          <Parameter Name="value" Type="System.Boolean" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ListView" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ListView.SetIsFastScrollEnabled(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.ListView},System.Boolean)" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>


### PR DESCRIPTION
### Description of Change ###

Work on some feedback from @Clancey  for ListViewRenderer ,

- Add Platform specific for IsFastScrollEnabled 
- Cache count

### API Changes ###

Added:
 - Platform specific `IsFastScrollEnabled `

Usage:
- `listView.On<Android>().SetIsFastScrollEnabled(true);`

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
