### PR TITLE
Fix obsolete constructor in ContextActionCell

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -347,7 +347,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var d = new MoreActionSheetDelegate { Scroller = _scroller, Items = new List<MenuItem>() };
 
-				var actionSheet = new UIActionSheet(null, d);
+				var actionSheet = new UIActionSheet(null, (IUIActionSheetDelegate)d);
 
 				for (var i = 0; i < _cell.ContextActions.Count; i++)
 				{


### PR DESCRIPTION
### Description of Change ###

Fix a build error in upcoming versions; an overload of the ActionSheet constructor we use is [being obsoleted](https://github.com/xamarin/xamarin-macios/blob/master/src/UIKit/UIActionSheet.cs#L51). This updates to the non-obsolete constructor. 


