### PR TITLE
[Android] Add null checks to ActivityIndicator

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ActivityIndicatorRenderer.cs
@@ -45,16 +45,22 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateColor()
 		{
+			if (Element == null || Control == null)
+				return;
+
 			Color color = Element.Color;
 
 			if (!color.IsDefault)
-				Control.IndeterminateDrawable.SetColorFilter(color.ToAndroid(), PorterDuff.Mode.SrcIn);
+				Control.IndeterminateDrawable?.SetColorFilter(color.ToAndroid(), PorterDuff.Mode.SrcIn);
 			else
-				Control.IndeterminateDrawable.ClearColorFilter();
+				Control.IndeterminateDrawable?.ClearColorFilter();
 		}
 
 		void UpdateVisibility()
 		{
+			if (Element == null || Control == null)
+				return;
+
 			Control.Visibility = Element.IsRunning ? ViewStates.Visible : ViewStates.Invisible;
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Null check all the things to prevent the XF Previewer from crashing. No tests added, but did verify that this stops the crash in https://github.com/xamarin/app-crm on `SplashPage.xaml`.

### Bugs Fixed ###

- [Bug 52885 - ActivityIndicatorView does not null check the IndeterminateDrawable](https://bugzilla.xamarin.com/show_bug.cgi?id=52885)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
