### PR TITLE
Add EditorBrowsableAttribute to public classes/interfaces in XF.Internals

### DIFF
--- a/Xamarin.Forms.Core/ActionSheetArguments.cs
+++ b/Xamarin.Forms.Core/ActionSheetArguments.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ActionSheetArguments
 	{
 		public ActionSheetArguments(string title, string cancel, string destruction, IEnumerable<string> buttons)

--- a/Xamarin.Forms.Core/AlertArguments.cs
+++ b/Xamarin.Forms.Core/AlertArguments.cs
@@ -1,7 +1,9 @@
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class AlertArguments
 	{
 		public AlertArguments(string title, string message, string accept, string cancel)

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -648,6 +648,7 @@ namespace Xamarin.Forms
 	namespace Internals
 	{
 		[Flags]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public enum SetValueFlags
 		{
 			None = 0,

--- a/Xamarin.Forms.Core/CustomKeyboard.cs
+++ b/Xamarin.Forms.Core/CustomKeyboard.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public sealed class CustomKeyboard : Keyboard
 	{
 		internal CustomKeyboard(KeyboardFlags flags)
@@ -10,7 +11,6 @@ namespace Xamarin.Forms.Internals
 		}
 
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public KeyboardFlags Flags { get; private set; }
 	}
 }

--- a/Xamarin.Forms.Core/DataTemplateExtensions.cs
+++ b/Xamarin.Forms.Core/DataTemplateExtensions.cs
@@ -2,9 +2,9 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class DataTemplateExtensions
 	{
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static object CreateContent(this DataTemplate self, object item, BindableObject container)
 		{
 			var selector = self as DataTemplateSelector;

--- a/Xamarin.Forms.Core/DelegateLogListener.cs
+++ b/Xamarin.Forms.Core/DelegateLogListener.cs
@@ -1,8 +1,10 @@
 using System;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class DelegateLogListener : LogListener
 	{
 		readonly Action<string, string> _log;

--- a/Xamarin.Forms.Core/DeviceInfo.cs
+++ b/Xamarin.Forms.Core/DeviceInfo.cs
@@ -4,12 +4,12 @@ using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public abstract class DeviceInfo : INotifyPropertyChanged, IDisposable
 	{
 		DeviceOrientation _currentOrientation;
 		bool _disposed;
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public DeviceOrientation CurrentOrientation
 		{
 			get { return _currentOrientation; }

--- a/Xamarin.Forms.Core/DeviceOrientation.cs
+++ b/Xamarin.Forms.Core/DeviceOrientation.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public enum DeviceOrientation
 	{
 		Portrait,

--- a/Xamarin.Forms.Core/DeviceOrientationExtensions.cs
+++ b/Xamarin.Forms.Core/DeviceOrientationExtensions.cs
@@ -2,15 +2,14 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class DeviceOrientationExtensions
 	{
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool IsLandscape(this DeviceOrientation orientation)
 		{
 			return orientation == DeviceOrientation.Landscape || orientation == DeviceOrientation.LandscapeLeft || orientation == DeviceOrientation.LandscapeRight;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool IsPortrait(this DeviceOrientation orientation)
 		{
 			return orientation == DeviceOrientation.Portrait || orientation == DeviceOrientation.PortraitDown || orientation == DeviceOrientation.PortraitUp;

--- a/Xamarin.Forms.Core/EnumerableExtensions.cs
+++ b/Xamarin.Forms.Core/EnumerableExtensions.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class EnumerableExtensions
 	{
 		public static IEnumerable<T> GetGesturesFor<T>(this IEnumerable<IGestureRecognizer> gestures, Func<T, bool> predicate = null) where T : GestureRecognizer
@@ -32,7 +33,6 @@ namespace Xamarin.Forms.Internals
 			yield return item;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void ForEach<T>(this IEnumerable<T> enumeration, Action<T> action)
 		{
 			foreach (T item in enumeration)
@@ -41,7 +41,6 @@ namespace Xamarin.Forms.Internals
 			}
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static int IndexOf<T>(this IEnumerable<T> enumerable, T item)
 		{
 			if (enumerable == null)
@@ -59,7 +58,6 @@ namespace Xamarin.Forms.Internals
 			return -1;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static int IndexOf<T>(this IEnumerable<T> enumerable, Func<T, bool> predicate)
 		{
 			var i = 0;
@@ -74,7 +72,6 @@ namespace Xamarin.Forms.Internals
 			return -1;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IEnumerable<T> Prepend<T>(this IEnumerable<T> enumerable, T item)
 		{
 			yield return item;

--- a/Xamarin.Forms.Core/EventArg.cs
+++ b/Xamarin.Forms.Core/EventArg.cs
@@ -1,7 +1,9 @@
 using System;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class EventArg<T> : EventArgs
 	{
 		// Property variable

--- a/Xamarin.Forms.Core/ExpressionSearch.cs
+++ b/Xamarin.Forms.Core/ExpressionSearch.cs
@@ -2,9 +2,9 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public abstract class ExpressionSearch
 	{
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IExpressionSearch Default { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/FileAccess.cs
+++ b/Xamarin.Forms.Core/FileAccess.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public enum FileAccess
 	{
 		Read = 0x00000001,

--- a/Xamarin.Forms.Core/FileMode.cs
+++ b/Xamarin.Forms.Core/FileMode.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public enum FileMode
 	{
 		CreateNew = 1,

--- a/Xamarin.Forms.Core/FileShare.cs
+++ b/Xamarin.Forms.Core/FileShare.cs
@@ -1,8 +1,10 @@
 using System;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
 	[Flags]
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public enum FileShare
 	{
 		None = 0,

--- a/Xamarin.Forms.Core/IDeserializer.cs
+++ b/Xamarin.Forms.Core/IDeserializer.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IDeserializer
 	{
 		Task<IDictionary<string, object>> DeserializePropertiesAsync();

--- a/Xamarin.Forms.Core/IExpressionSearch.cs
+++ b/Xamarin.Forms.Core/IExpressionSearch.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq.Expressions;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IExpressionSearch
 	{
 		List<T> FindObjects<T>(Expression expression) where T : class;

--- a/Xamarin.Forms.Core/IFontElement.cs
+++ b/Xamarin.Forms.Core/IFontElement.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IFontElement
 	{
 		//note to implementor: implement the properties publicly

--- a/Xamarin.Forms.Core/IIsolatedStorageFile.cs
+++ b/Xamarin.Forms.Core/IIsolatedStorageFile.cs
@@ -1,9 +1,11 @@
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IIsolatedStorageFile
 	{
 		Task CreateDirectoryAsync(string path);

--- a/Xamarin.Forms.Core/IPlatform.cs
+++ b/Xamarin.Forms.Core/IPlatform.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IPlatform
 	{
 		SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint);

--- a/Xamarin.Forms.Core/IPlatformServices.cs
+++ b/Xamarin.Forms.Core/IPlatformServices.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -7,6 +8,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IPlatformServices
 	{
 		bool IsInvokeRequired { get; }

--- a/Xamarin.Forms.Core/IResourceDictionary.cs
+++ b/Xamarin.Forms.Core/IResourceDictionary.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IResourceDictionary : IEnumerable<KeyValuePair<string, object>>
 	{
 		bool TryGetValue(string key, out object value);

--- a/Xamarin.Forms.Core/ISystemResourcesProvider.cs
+++ b/Xamarin.Forms.Core/ISystemResourcesProvider.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface ISystemResourcesProvider
 	{
 		IResourceDictionary GetSystemResources();

--- a/Xamarin.Forms.Core/Internals/CellExtensions.cs
+++ b/Xamarin.Forms.Core/Internals/CellExtensions.cs
@@ -1,7 +1,9 @@
 using System;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class CellExtensions
 	{
 		public static bool GetIsGroupHeader<TView, TItem>(this TItem cell) where TView : BindableObject, ITemplatedItemsView<TItem> where TItem : BindableObject

--- a/Xamarin.Forms.Core/Internals/DynamicResource.cs
+++ b/Xamarin.Forms.Core/Internals/DynamicResource.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class DynamicResource
 	{
 		public DynamicResource(string key)

--- a/Xamarin.Forms.Core/Internals/EffectUtilities.cs
+++ b/Xamarin.Forms.Core/Internals/EffectUtilities.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class EffectUtilities
 	{
 		public static void RegisterEffectControlProvider(IEffectControlProvider self, IElementController oldElement, IElementController newElement)

--- a/Xamarin.Forms.Core/Internals/EvalRequested.cs
+++ b/Xamarin.Forms.Core/Internals/EvalRequested.cs
@@ -1,7 +1,9 @@
 using System;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class EvalRequested : EventArgs
 	{
 		public string Script { get; }

--- a/Xamarin.Forms.Core/Internals/IDataTemplate.cs
+++ b/Xamarin.Forms.Core/Internals/IDataTemplate.cs
@@ -1,8 +1,10 @@
 using System;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
 	[Obsolete]
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IDataTemplate
 	{
 		Func<object> LoadTemplate { get; set; }

--- a/Xamarin.Forms.Core/Internals/IDynamicResourceHandler.cs
+++ b/Xamarin.Forms.Core/Internals/IDynamicResourceHandler.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IDynamicResourceHandler
 	{
 		void SetDynamicResource(BindableProperty property, string key);

--- a/Xamarin.Forms.Core/Internals/INameScope.cs
+++ b/Xamarin.Forms.Core/Internals/INameScope.cs
@@ -1,8 +1,10 @@
 using System;
+using System.ComponentModel;
 using System.Xml;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface INameScope
 	{
 		object FindByName(string name);

--- a/Xamarin.Forms.Core/Internals/InvalidationTrigger.cs
+++ b/Xamarin.Forms.Core/Internals/InvalidationTrigger.cs
@@ -1,8 +1,10 @@
 using System;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
 	[Flags]
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public enum InvalidationTrigger
 	{
 		Undefined = 0,

--- a/Xamarin.Forms.Core/Internals/NameScope.cs
+++ b/Xamarin.Forms.Core/Internals/NameScope.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Xml;
 using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NameScope : INameScope
 	{
 		public static readonly BindableProperty NameScopeProperty = BindableProperty.CreateAttached("NameScope", typeof(INameScope), typeof(NameScope), default(INameScope));

--- a/Xamarin.Forms.Core/Internals/NavigationRequestedEventArgs.cs
+++ b/Xamarin.Forms.Core/Internals/NavigationRequestedEventArgs.cs
@@ -1,7 +1,9 @@
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NavigationRequestedEventArgs : NavigationEventArgs
 	{
 		public NavigationRequestedEventArgs(Page page, bool animated, bool realize = true) : base(page)

--- a/Xamarin.Forms.Core/Internals/NotifyCollectionChangedEventArgsEx.cs
+++ b/Xamarin.Forms.Core/Internals/NotifyCollectionChangedEventArgsEx.cs
@@ -1,8 +1,10 @@
 using System.Collections;
 using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NotifyCollectionChangedEventArgsEx : NotifyCollectionChangedEventArgs
 	{
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action) : base(action)

--- a/Xamarin.Forms.Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
+++ b/Xamarin.Forms.Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class NotifyCollectionChangedEventArgsExtensions
 	{
 		public static void Apply<TFrom>(this NotifyCollectionChangedEventArgs self, IList<TFrom> from, IList<object> to)

--- a/Xamarin.Forms.Core/Internals/PreserveAttribute.cs
+++ b/Xamarin.Forms.Core/Internals/PreserveAttribute.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
 	[AttributeUsage(AttributeTargets.All)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PreserveAttribute : Attribute
 	{
 		public bool AllMembers;

--- a/Xamarin.Forms.Core/Internals/Ticker.cs
+++ b/Xamarin.Forms.Core/Internals/Ticker.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public abstract class Ticker
 	{
 		static Ticker s_ticker;
@@ -23,7 +24,6 @@ namespace Xamarin.Forms.Internals
 			_stopwatch = new Stopwatch();
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetDefault(Ticker ticker) => Default = ticker;
 		public static Ticker Default
 		{

--- a/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
+++ b/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
@@ -7,6 +7,7 @@ using System.Linq;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ToolbarTracker
 	{
 		int _masterDetails;

--- a/Xamarin.Forms.Core/LockableObservableListWrapper.cs
+++ b/Xamarin.Forms.Core/LockableObservableListWrapper.cs
@@ -10,6 +10,7 @@ using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class LockableObservableListWrapper : IList<string>, ICollection<string>, INotifyCollectionChanged, INotifyPropertyChanged, IReadOnlyList<string>, IReadOnlyCollection<string>, IEnumerable<string>, IEnumerable
 	{
 		public readonly ObservableCollection<string> _list = new ObservableCollection<string>();

--- a/Xamarin.Forms.Core/Log.cs
+++ b/Xamarin.Forms.Core/Log.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class Log
 	{
 		static Log()

--- a/Xamarin.Forms.Core/LogListener.cs
+++ b/Xamarin.Forms.Core/LogListener.cs
@@ -1,5 +1,8 @@
+using System.ComponentModel;
+
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public abstract class LogListener
 	{
 		public abstract void Warning(string category, string message);

--- a/Xamarin.Forms.Core/NativeBindingHelpers.cs
+++ b/Xamarin.Forms.Core/NativeBindingHelpers.cs
@@ -10,9 +10,9 @@ using static System.String;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class NativeBindingHelpers
 	{
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetBinding<TNativeView>(TNativeView target, string targetProperty, BindingBase bindingBase, string updateSourceEventName = null) where TNativeView : class
 		{
 			var binding = bindingBase as Binding;
@@ -26,7 +26,6 @@ namespace Xamarin.Forms.Internals
 			SetBinding(target, targetProperty, bindingBase, eventWrapper);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetBinding<TNativeView>(TNativeView target, string targetProperty, BindingBase bindingBase, INotifyPropertyChanged propertyChanged) where TNativeView : class
 		{
 			if (target == null)
@@ -95,7 +94,6 @@ namespace Xamarin.Forms.Internals
 			bindable.SetValueCore(property, value);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetBinding<TNativeView>(TNativeView target, BindableProperty targetProperty, BindingBase binding) where TNativeView : class
 		{
 			if (target == null)
@@ -109,7 +107,6 @@ namespace Xamarin.Forms.Internals
 			proxy.BindingsBackpack.Add(new KeyValuePair<BindableProperty, BindingBase>(targetProperty, binding));
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetValue<TNativeView>(TNativeView target, BindableProperty targetProperty, object value) where TNativeView : class
 		{
 			if (target == null)
@@ -121,7 +118,6 @@ namespace Xamarin.Forms.Internals
 			proxy.ValuesBackpack.Add(new KeyValuePair<BindableProperty, object>(targetProperty, value));
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetBindingContext<TNativeView>(TNativeView target, object bindingContext, Func<TNativeView, IEnumerable<TNativeView>> getChild = null) where TNativeView : class
 		{
 			if (target == null)
@@ -139,7 +135,6 @@ namespace Xamarin.Forms.Internals
 					SetBindingContext(child, bindingContext, getChild);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void TransferBindablePropertiesToWrapper<TNativeView, TNativeWrapper>(TNativeView nativeView, TNativeWrapper wrapper)
 			where TNativeView : class
 			where TNativeWrapper : View

--- a/Xamarin.Forms.Core/NavigationMenu.cs
+++ b/Xamarin.Forms.Core/NavigationMenu.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Xamarin.Forms.Platform;
 
@@ -7,6 +8,7 @@ namespace Xamarin.Forms.Internals
 {
 	// Mark as internal until renderers are ready for release after 1.0
 	[RenderWith(typeof(_NavigationMenuRenderer))]
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NavigationMenu : View, INavigationMenuController, IElementConfiguration<NavigationMenu>
 	{
 		readonly List<Page> _targets = new List<Page>();

--- a/Xamarin.Forms.Core/NavigationModel.cs
+++ b/Xamarin.Forms.Core/NavigationModel.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NavigationModel
 	{
 		readonly List<Page> _modalStack = new List<Page>();

--- a/Xamarin.Forms.Core/NavigationProxy.cs
+++ b/Xamarin.Forms.Core/NavigationProxy.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NavigationProxy : INavigation
 	{
 		INavigation _inner;
@@ -13,7 +14,6 @@ namespace Xamarin.Forms.Internals
 
 		Lazy<List<Page>> _pushStack = new Lazy<List<Page>>(() => new List<Page>());
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public INavigation Inner
 		{
 			get { return _inner; }
@@ -54,67 +54,56 @@ namespace Xamarin.Forms.Internals
 			}
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void InsertPageBefore(Page page, Page before)
 		{
 			OnInsertPageBefore(page, before);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public IReadOnlyList<Page> ModalStack
 		{
 			get { return GetModalStack(); }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public IReadOnlyList<Page> NavigationStack
 		{
 			get { return GetNavigationStack(); }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task<Page> PopAsync()
 		{
 			return OnPopAsync(true);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task<Page> PopAsync(bool animated)
 		{
 			return OnPopAsync(animated);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task<Page> PopModalAsync()
 		{
 			return OnPopModal(true);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task<Page> PopModalAsync(bool animated)
 		{
 			return OnPopModal(animated);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task PopToRootAsync()
 		{
 			return OnPopToRootAsync(true);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task PopToRootAsync(bool animated)
 		{
 			return OnPopToRootAsync(animated);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task PushAsync(Page root)
 		{
 			return PushAsync(root, true);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task PushAsync(Page root, bool animated)
 		{
 			if (root.RealParent != null)
@@ -122,13 +111,11 @@ namespace Xamarin.Forms.Internals
 			return OnPushAsync(root, animated);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task PushModalAsync(Page modal)
 		{
 			return PushModalAsync(modal, true);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task PushModalAsync(Page modal, bool animated)
 		{
 			if (modal.RealParent != null)
@@ -136,7 +123,6 @@ namespace Xamarin.Forms.Internals
 			return OnPushModal(modal, animated);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void RemovePage(Page page)
 		{
 			OnRemovePage(page);

--- a/Xamarin.Forms.Core/NumericExtensions.cs
+++ b/Xamarin.Forms.Core/NumericExtensions.cs
@@ -3,16 +3,15 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class NumericExtensions
 	{
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static double Clamp(this double self, double min, double max)
 		{
 			return Math.Min(max, Math.Max(self, min));
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static int Clamp(this int self, int min, int max)
 		{
 			return Math.Min(max, Math.Max(self, min));

--- a/Xamarin.Forms.Core/Performance.cs
+++ b/Xamarin.Forms.Core/Performance.cs
@@ -8,18 +8,17 @@ using System.Text;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class Performance
 	{
 		static readonly Dictionary<string, Stats> Statistics = new Dictionary<string, Stats>();
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Conditional("PERF")]
 		public static void Clear()
 		{
 			Statistics.Clear();
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void Count(string tag = null, [CallerFilePath] string path = null, [CallerMemberName] string member = null)
 		{
 			string id = path + ":" + member + (tag != null ? "-" + tag : string.Empty);
@@ -31,14 +30,12 @@ namespace Xamarin.Forms.Internals
 			stats.CallCount++;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Conditional("PERF")]
 		public static void DumpStats()
 		{
 			Debug.WriteLine(GetStats());
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static string GetStats()
 		{
 			var b = new StringBuilder();
@@ -54,7 +51,6 @@ namespace Xamarin.Forms.Internals
 			return b.ToString();
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Conditional("PERF")]
 		public static void Start(string tag = null, [CallerFilePath] string path = null, [CallerMemberName] string member = null)
 		{
@@ -68,7 +64,6 @@ namespace Xamarin.Forms.Internals
 			stats.StartTimes.Push(Stopwatch.GetTimestamp());
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Conditional("PERF")]
 		public static void Stop(string tag = null, [CallerFilePath] string path = null, [CallerMemberName] string member = null)
 		{

--- a/Xamarin.Forms.Core/ReflectionExtensions.cs
+++ b/Xamarin.Forms.Core/ReflectionExtensions.cs
@@ -6,33 +6,29 @@ using System.Reflection;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class ReflectionExtensions
 	{
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static FieldInfo GetField(this Type type, Func<FieldInfo, bool> predicate)
 		{
 			return GetFields(type).FirstOrDefault(predicate);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static FieldInfo GetField(this Type type, string name)
 		{
 			return type.GetField(fi => fi.Name == name);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IEnumerable<FieldInfo> GetFields(this Type type)
 		{
 			return GetParts(type, i => i.DeclaredFields);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IEnumerable<PropertyInfo> GetProperties(this Type type)
 		{
 			return GetParts(type, ti => ti.DeclaredProperties);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static PropertyInfo GetProperty(this Type type, string name)
 		{
 			Type t = type;
@@ -49,13 +45,11 @@ namespace Xamarin.Forms.Internals
 			return null;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool IsAssignableFrom(this Type self, Type c)
 		{
 			return self.GetTypeInfo().IsAssignableFrom(c.GetTypeInfo());
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool IsInstanceOfType(this Type self, object o)
 		{
 			return self.GetTypeInfo().IsAssignableFrom(o.GetType().GetTypeInfo());

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class Registrar<TRegistrable> where TRegistrable : class
 	{
 		readonly Dictionary<Type, Type> _handlers = new Dictionary<Type, Type>();
@@ -26,13 +27,11 @@ namespace Xamarin.Forms.Internals
 			return (TRegistrable)handler;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public TOut GetHandler<TOut>(Type type) where TOut : TRegistrable
 		{
 			return (TOut)GetHandler(type);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Type GetHandlerType(Type viewType)
 		{
 			Type type;
@@ -88,6 +87,7 @@ namespace Xamarin.Forms.Internals
 		}
 	}
 
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class Registrar
 	{
 		static Registrar()
@@ -97,13 +97,10 @@ namespace Xamarin.Forms.Internals
 
 		internal static Dictionary<string, Type> Effects { get; } = new Dictionary<string, Type>();
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IEnumerable<Assembly> ExtraAssemblies { get; set; }
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static Registrar<IRegisterable> Registered { get; }
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void RegisterAll(Type[] attrTypes)
 		{
 			Assembly[] assemblies = Device.GetAssemblies();

--- a/Xamarin.Forms.Core/ResourcesChangedEventArgs.cs
+++ b/Xamarin.Forms.Core/ResourcesChangedEventArgs.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ResourcesChangedEventArgs : EventArgs
 	{
 		public ResourcesChangedEventArgs(IEnumerable<KeyValuePair<string, object>> values)

--- a/Xamarin.Forms.Core/TableModel.cs
+++ b/Xamarin.Forms.Core/TableModel.cs
@@ -4,9 +4,9 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public abstract class TableModel: ITableModel
 	{
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public virtual Cell GetCell(int section, int row)
 		{
 			object item = GetItem(section, row);
@@ -17,46 +17,36 @@ namespace Xamarin.Forms.Internals
 			return new TextCell { Text = item.ToString() };
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public virtual Cell GetHeaderCell(int section)
 		{
 			return null;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public abstract object GetItem(int section, int row);
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public abstract int GetRowCount(int section);
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public abstract int GetSectionCount();
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public virtual string[] GetSectionIndexTitles()
 		{
 			return null;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public virtual string GetSectionTitle(int section)
 		{
 			return null;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event EventHandler<EventArg<object>> ItemLongPressed;
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event EventHandler<EventArg<object>> ItemSelected;
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void RowLongPressed(int section, int row)
 		{
 			RowLongPressed(GetItem(section, row));
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void RowLongPressed(object item)
 		{
 			if (ItemLongPressed != null)
@@ -65,13 +55,11 @@ namespace Xamarin.Forms.Internals
 			OnRowLongPressed(item);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void RowSelected(int section, int row)
 		{
 			RowSelected(GetItem(section, row));
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void RowSelected(object item)
 		{
 			if (ItemSelected != null)

--- a/Xamarin.Forms.Core/TemplatedItemsList.cs
+++ b/Xamarin.Forms.Core/TemplatedItemsList.cs
@@ -11,14 +11,13 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Internals
 {
 
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public sealed class TemplatedItemsList<TView, TItem> : BindableObject, ITemplatedItemsList<TItem>, IList, IDisposable
 												where TView : BindableObject, IItemsView<TItem>
 												where TItem : BindableObject
 	{
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly BindableProperty NameProperty = BindableProperty.Create("Name", typeof(string), typeof(TemplatedItemsList<TView, TItem>), null);
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly BindableProperty ShortNameProperty = BindableProperty.Create("ShortName", typeof(string), typeof(TemplatedItemsList<TView, TItem>), null);
 
 		static readonly BindablePropertyKey HeaderContentPropertyKey = BindableProperty.CreateReadOnly("HeaderContent", typeof(TItem), typeof(TemplatedItemsList<TView, TItem>), null);
@@ -96,7 +95,6 @@ namespace Xamarin.Forms.Internals
 			remove { PropertyChanged -= value; }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public BindingBase GroupDisplayBinding
 		{
 			get { return _groupDisplayBinding; }
@@ -107,7 +105,6 @@ namespace Xamarin.Forms.Internals
 			}
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public DataTemplate GroupHeaderTemplate
 		{
 			get
@@ -129,10 +126,8 @@ namespace Xamarin.Forms.Internals
 			}
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public BindableProperty GroupHeaderTemplateProperty { get; set; }
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public BindingBase GroupShortNameBinding
 		{
 			get { return _groupShortNameBinding; }
@@ -143,49 +138,40 @@ namespace Xamarin.Forms.Internals
 			}
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public TItem HeaderContent
 		{
 			get { return (TItem)GetValue(HeaderContentPropertyKey.BindableProperty); }
 			private set { SetValue(HeaderContentPropertyKey, value); }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public bool IsGroupingEnabled
 		{
 			get { return (IsGroupingEnabledProperty != null) && (bool)_itemsView.GetValue(IsGroupingEnabledProperty); }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public BindableProperty IsGroupingEnabledProperty { get; set; }
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public IEnumerable ItemsSource
 		{
 			get { return ListProxy.ProxiedEnumerable; }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public string Name
 		{
 			get { return (string)GetValue(NameProperty); }
 			set { SetValue(NameProperty, value); }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public TemplatedItemsList<TView, TItem> Parent { get; }
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public BindableProperty ProgressiveLoadingProperty { get; set; }
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public string ShortName
 		{
 			get { return (string)GetValue(ShortNameProperty); }
 			set { SetValue(ShortNameProperty, value); }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public IReadOnlyList<string> ShortNames
 		{
 			get { return _shortNames; }
@@ -339,22 +325,18 @@ namespace Xamarin.Forms.Internals
 			throw new NotSupportedException();
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event NotifyCollectionChangedEventHandler CollectionChanged;
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int Count
 		{
 			get { return ListProxy.Count; }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public TItem this[int index]
 		{
 			get { return GetOrCreateContent(index, ListProxy[index]); }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int GetDescendantCount()
 		{
 			if (!IsGroupingEnabled)
@@ -370,7 +352,6 @@ namespace Xamarin.Forms.Internals
 			return count;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int GetGlobalIndexForGroup(ITemplatedItemsList<TItem> group)
 		{
 			if (group == null)
@@ -385,7 +366,6 @@ namespace Xamarin.Forms.Internals
 			return index;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int GetGlobalIndexOfGroup(object item)
 		{
 			var count = 0;
@@ -402,7 +382,6 @@ namespace Xamarin.Forms.Internals
 			return -1;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int GetGlobalIndexOfItem(object item)
 		{
 			if (!IsGroupingEnabled)
@@ -426,7 +405,6 @@ namespace Xamarin.Forms.Internals
 			return -1;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int GetGlobalIndexOfItem(object group, object item)
 		{
 			if (!IsGroupingEnabled)
@@ -453,7 +431,6 @@ namespace Xamarin.Forms.Internals
 			return -1;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Tuple<int, int> GetGroupAndIndexOfItem(object item)
 		{
 			if (item == null)
@@ -477,7 +454,6 @@ namespace Xamarin.Forms.Internals
 			return new Tuple<int, int>(-1, -1);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Tuple<int, int> GetGroupAndIndexOfItem(object group, object item)
 		{
 			if (!IsGroupingEnabled)
@@ -506,7 +482,6 @@ namespace Xamarin.Forms.Internals
 			return new Tuple<int, int>(-1, -1);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int GetGroupIndexFromGlobal(int globalIndex, out int leftOver)
 		{
 			leftOver = 0;
@@ -532,7 +507,6 @@ namespace Xamarin.Forms.Internals
 			return -1;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event NotifyCollectionChangedEventHandler GroupedCollectionChanged;
 		event NotifyCollectionChangedEventHandler ITemplatedItemsList<TItem>.GroupedCollectionChanged
 		{
@@ -540,7 +514,6 @@ namespace Xamarin.Forms.Internals
 			remove { GroupedCollectionChanged -= value; }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int IndexOf(TItem item)
 		{
 			TemplatedItemsList<TView, TItem> group = GetGroup(item);
@@ -550,7 +523,6 @@ namespace Xamarin.Forms.Internals
 			return GetIndex(item);
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public TItem CreateContent(int index, object item, bool insert = false)
 		{
 			TItem content = ItemTemplate != null ? (TItem)ItemTemplate.CreateContent(item, _itemsView) : _itemsView.CreateDefault(item);

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -9,6 +9,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Internals
 {
 	//FIXME: need a better name for this, and share with Binding, so we can share more unittests
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public abstract class TypedBindingBase : BindingBase
 	{
 		IValueConverter _converter;
@@ -53,6 +54,7 @@ namespace Xamarin.Forms.Internals
 		}
 	}
 
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public sealed class TypedBinding<TSource, TProperty> : TypedBindingBase
 	{
 		readonly Func<TSource, TProperty> _getter;

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ActionSheetArguments.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ActionSheetArguments.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/AlertArguments.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/AlertArguments.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/CellExtensions.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/CellExtensions.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/CustomKeyboard.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/CustomKeyboard.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>Xamarin.Forms.Keyboard</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -21,11 +26,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.KeyboardFlags</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DataTemplateExtensions.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DataTemplateExtensions.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -21,11 +26,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DelegateLogListener.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DelegateLogListener.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>Xamarin.Forms.Internals.LogListener</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DeviceInfo.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DeviceInfo.xml
@@ -16,6 +16,11 @@
       <InterfaceName>System.IDisposable</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -41,11 +46,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Internals.DeviceOrientation</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DeviceOrientation.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DeviceOrientation.xml
@@ -8,6 +8,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DeviceOrientationExtensions.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DeviceOrientationExtensions.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -21,11 +26,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -46,11 +46,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DynamicResource.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DynamicResource.xml
@@ -10,6 +10,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EffectUtilities.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EffectUtilities.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EnumerableExtensions.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EnumerableExtensions.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -21,11 +26,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -86,11 +86,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -117,11 +112,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -149,9 +139,6 @@
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
         <Attribute>
           <AttributeName>System.Runtime.CompilerServices.IteratorStateMachine(typeof(Xamarin.Forms.Internals.EnumerableExtensions/&lt;Prepend&gt;d__5`1))</AttributeName>
         </Attribute>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EvalRequested.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EvalRequested.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.EventArgs</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EventArg`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EventArg`1.xml
@@ -12,6 +12,11 @@
     <BaseTypeName>System.EventArgs</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <typeparam name="T">To be added.</typeparam>
     <summary>To be added.</summary>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ExpressionSearch.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ExpressionSearch.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -34,11 +39,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Internals.IExpressionSearch</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/FileAccess.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/FileAccess.xml
@@ -8,6 +8,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/FileMode.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/FileMode.xml
@@ -8,6 +8,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/FileShare.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/FileShare.xml
@@ -10,6 +10,9 @@
   </Base>
   <Attributes>
     <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+    <Attribute>
       <AttributeName>System.Flags</AttributeName>
     </Attribute>
   </Attributes>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IDataTemplate.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IDataTemplate.xml
@@ -9,6 +9,9 @@
   <Interfaces />
   <Attributes>
     <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+    <Attribute>
       <AttributeName>System.Obsolete</AttributeName>
     </Attribute>
   </Attributes>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IDeserializer.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IDeserializer.xml
@@ -6,6 +6,11 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IDynamicResourceHandler.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IDynamicResourceHandler.xml
@@ -7,6 +7,11 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IExpressionSearch.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IExpressionSearch.xml
@@ -6,6 +6,11 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IFontElement.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IFontElement.xml
@@ -6,6 +6,11 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IIsolatedStorageFile.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IIsolatedStorageFile.xml
@@ -6,6 +6,11 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/INameScope.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/INameScope.xml
@@ -7,6 +7,11 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IPlatform.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IPlatform.xml
@@ -6,6 +6,11 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IPlatformServices.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IPlatformServices.xml
@@ -6,6 +6,11 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IResourceDictionary.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/IResourceDictionary.xml
@@ -10,6 +10,11 @@
       <InterfaceName>System.Collections.Generic.IEnumerable&lt;System.Collections.Generic.KeyValuePair&lt;System.String,System.Object&gt;&gt;</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ISystemResourcesProvider.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ISystemResourcesProvider.xml
@@ -6,6 +6,11 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/InvalidationTrigger.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/InvalidationTrigger.xml
@@ -10,6 +10,9 @@
   </Base>
   <Attributes>
     <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+    <Attribute>
       <AttributeName>System.Flags</AttributeName>
     </Attribute>
   </Attributes>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/LockableObservableListWrapper.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/LockableObservableListWrapper.xml
@@ -31,6 +31,11 @@
       <InterfaceName>System.ComponentModel.INotifyPropertyChanged</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Log.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Log.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/LogListener.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/LogListener.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NameScope.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NameScope.xml
@@ -14,6 +14,11 @@
       <InterfaceName>Xamarin.Forms.Internals.INameScope</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NativeBindingHelpers.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NativeBindingHelpers.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -21,11 +26,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -57,11 +57,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -95,11 +90,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -133,11 +123,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -169,11 +154,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -205,11 +185,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationMenu.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationMenu.xml
@@ -18,6 +18,9 @@
   </Interfaces>
   <Attributes>
     <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+    <Attribute>
       <AttributeName>Xamarin.Forms.RenderWith(typeof(Xamarin.Forms.Platform._NavigationMenuRenderer))</AttributeName>
     </Attribute>
   </Attributes>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationModel.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationModel.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationProxy.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationProxy.xml
@@ -13,6 +13,11 @@
       <InterfaceName>Xamarin.Forms.INavigation</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -72,11 +77,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.INavigation</ReturnType>
       </ReturnValue>
@@ -93,11 +93,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -119,11 +114,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.Generic.IReadOnlyList&lt;Xamarin.Forms.Page&gt;</ReturnType>
       </ReturnValue>
@@ -140,11 +130,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.Generic.IReadOnlyList&lt;Xamarin.Forms.Page&gt;</ReturnType>
       </ReturnValue>
@@ -305,11 +290,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task&lt;Xamarin.Forms.Page&gt;</ReturnType>
       </ReturnValue>
@@ -327,11 +307,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task&lt;Xamarin.Forms.Page&gt;</ReturnType>
       </ReturnValue>
@@ -352,11 +327,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task&lt;Xamarin.Forms.Page&gt;</ReturnType>
       </ReturnValue>
@@ -374,11 +344,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task&lt;Xamarin.Forms.Page&gt;</ReturnType>
       </ReturnValue>
@@ -399,11 +364,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task</ReturnType>
       </ReturnValue>
@@ -421,11 +381,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task</ReturnType>
       </ReturnValue>
@@ -446,11 +401,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task</ReturnType>
       </ReturnValue>
@@ -471,11 +421,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task</ReturnType>
       </ReturnValue>
@@ -498,11 +443,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task</ReturnType>
       </ReturnValue>
@@ -523,11 +463,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Threading.Tasks.Task</ReturnType>
       </ReturnValue>
@@ -550,11 +485,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationRequestedEventArgs.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationRequestedEventArgs.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>Xamarin.Forms.NavigationEventArgs</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NotifyCollectionChangedEventArgsEx.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NotifyCollectionChangedEventArgsEx.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Collections.Specialized.NotifyCollectionChangedEventArgs</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NotifyCollectionChangedEventArgsExtensions.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NotifyCollectionChangedEventArgsExtensions.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NumericExtensions.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NumericExtensions.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -21,11 +26,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
@@ -50,11 +50,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Performance.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Performance.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -22,9 +27,6 @@
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
         <Attribute>
           <AttributeName>System.Diagnostics.Conditional("PERF")</AttributeName>
         </Attribute>
@@ -45,11 +47,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -87,9 +84,6 @@
       </AssemblyInfo>
       <Attributes>
         <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-        <Attribute>
           <AttributeName>System.Diagnostics.Conditional("PERF")</AttributeName>
         </Attribute>
       </Attributes>
@@ -109,11 +103,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
@@ -132,9 +121,6 @@
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
         <Attribute>
           <AttributeName>System.Diagnostics.Conditional("PERF")</AttributeName>
         </Attribute>
@@ -175,9 +161,6 @@
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
         <Attribute>
           <AttributeName>System.Diagnostics.Conditional("PERF")</AttributeName>
         </Attribute>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/PreserveAttribute.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/PreserveAttribute.xml
@@ -13,6 +13,9 @@
     <Attribute>
       <AttributeName>System.AttributeUsage(System.AttributeTargets.All)</AttributeName>
     </Attribute>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ReflectionExtensions.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ReflectionExtensions.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -21,11 +26,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Reflection.FieldInfo</ReturnType>
       </ReturnValue>
@@ -48,11 +48,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Reflection.FieldInfo</ReturnType>
       </ReturnValue>
@@ -75,11 +70,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Reflection.FieldInfo&gt;</ReturnType>
       </ReturnValue>
@@ -100,11 +90,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Reflection.PropertyInfo&gt;</ReturnType>
       </ReturnValue>
@@ -125,11 +110,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Reflection.PropertyInfo</ReturnType>
       </ReturnValue>
@@ -152,11 +132,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -179,11 +154,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -21,11 +26,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Reflection.Assembly&gt;</ReturnType>
       </ReturnValue>
@@ -42,11 +42,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -66,11 +61,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Internals.Registrar&lt;Xamarin.Forms.IRegisterable&gt;</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
@@ -16,6 +16,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <typeparam name="TRegistrable">To be added.</typeparam>
     <summary>To be added.</summary>
@@ -42,11 +47,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>TOut</ReturnType>
       </ReturnValue>
@@ -75,11 +75,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Type</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ResourcesChangedEventArgs.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ResourcesChangedEventArgs.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.EventArgs</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/SetValueFlags.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/SetValueFlags.xml
@@ -10,6 +10,9 @@
   </Base>
   <Attributes>
     <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+    <Attribute>
       <AttributeName>System.Flags</AttributeName>
     </Attribute>
   </Attributes>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TableModel.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TableModel.xml
@@ -13,6 +13,11 @@
       <InterfaceName>Xamarin.Forms.ITableModel</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -38,11 +43,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Cell</ReturnType>
       </ReturnValue>
@@ -65,11 +65,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Cell</ReturnType>
       </ReturnValue>
@@ -90,11 +85,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
@@ -117,11 +107,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -142,11 +127,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -164,11 +144,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.String[]</ReturnType>
       </ReturnValue>
@@ -186,11 +161,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
@@ -211,11 +181,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.EventArg&lt;System.Object&gt;&gt;</ReturnType>
       </ReturnValue>
@@ -231,11 +196,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.EventArg&lt;System.Object&gt;&gt;</ReturnType>
       </ReturnValue>
@@ -289,11 +249,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -313,11 +268,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -339,11 +289,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -363,11 +308,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TemplatedItemsList`2.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TemplatedItemsList`2.xml
@@ -44,6 +44,11 @@
       <InterfaceName>Xamarin.Forms.ITemplatedItemsList&lt;TItem&gt;</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <typeparam name="TView">To be added.</typeparam>
     <typeparam name="TItem">To be added.</typeparam>
@@ -58,11 +63,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.Specialized.NotifyCollectionChangedEventHandler</ReturnType>
       </ReturnValue>
@@ -78,11 +78,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -99,11 +94,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>TItem</ReturnType>
       </ReturnValue>
@@ -144,11 +134,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -188,11 +173,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -213,11 +193,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -238,11 +213,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -263,11 +233,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -290,11 +255,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Tuple&lt;System.Int32,System.Int32&gt;</ReturnType>
       </ReturnValue>
@@ -315,11 +275,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Tuple&lt;System.Int32,System.Int32&gt;</ReturnType>
       </ReturnValue>
@@ -342,11 +297,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -369,11 +319,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindingBase</ReturnType>
       </ReturnValue>
@@ -390,11 +335,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.Specialized.NotifyCollectionChangedEventHandler</ReturnType>
       </ReturnValue>
@@ -410,11 +350,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.DataTemplate</ReturnType>
       </ReturnValue>
@@ -431,11 +366,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
       </ReturnValue>
@@ -452,11 +382,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindingBase</ReturnType>
       </ReturnValue>
@@ -473,11 +398,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>TItem</ReturnType>
       </ReturnValue>
@@ -494,11 +414,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -519,11 +434,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -540,11 +450,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
       </ReturnValue>
@@ -561,11 +466,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>TItem</ReturnType>
       </ReturnValue>
@@ -586,11 +486,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.IEnumerable</ReturnType>
       </ReturnValue>
@@ -607,11 +502,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
@@ -628,11 +518,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
       </ReturnValue>
@@ -648,11 +533,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Internals.TemplatedItemsList&lt;TView,TItem&gt;</ReturnType>
       </ReturnValue>
@@ -669,11 +549,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
       </ReturnValue>
@@ -690,11 +565,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
@@ -711,11 +581,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
       </ReturnValue>
@@ -731,11 +596,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.Generic.IReadOnlyList&lt;System.String&gt;</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Ticker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Ticker.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>
@@ -140,11 +145,6 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ToolbarTracker.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ToolbarTracker.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TypedBindingBase.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TypedBindingBase.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>Xamarin.Forms.BindingBase</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TypedBinding`2.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TypedBinding`2.xml
@@ -13,6 +13,11 @@
     <BaseTypeName>Xamarin.Forms.Internals.TypedBindingBase</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <typeparam name="TSource">To be added.</typeparam>
     <typeparam name="TProperty">To be added.</typeparam>


### PR DESCRIPTION
### Description of Change ###

Add `[EditorBrowsable(EditorBrowsableState.Never)]` to classes and interfaces in XF.Internals hides these classes and all their members from isense when XF.Core is referenced as an assembly. Our policy is that customers should not bind to these members. Hiding them in this fashion makes it more difficult for them to bind to them by mistake. 

When referenced as a csproj the members will still appear in isense. 

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
