### PR TITLE
Implicit impl of controller ifaces

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/CellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/CellTests.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			bool emitted = false;
 			cell.Appearing += (sender, args) => emitted = true;
 
-			((ICellController)cell).SendAppearing ();
+			cell.SendAppearing ();
 			Assert.True (emitted);
 			Assert.True (cell.OnAppearingSent);
 			Assert.False (cell.OnDisappearingSent);
@@ -58,7 +58,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			bool emitted = false;
 			cell.Disappearing += (sender, args) => emitted = true;
 
-			((ICellController)cell).SendDisappearing ();
+			cell.SendDisappearing ();
 			Assert.True (emitted);
 			Assert.False (cell.OnAppearingSent);
 			Assert.True (cell.OnDisappearingSent);
@@ -159,7 +159,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var cell = new ViewCell { Parent = lv };
 
 			int numberOfCalls = 0;
-			((ICellController)cell).ForceUpdateSizeRequested += (object sender, System.EventArgs e) => { numberOfCalls++; };
+			cell.ForceUpdateSizeRequested += (object sender, System.EventArgs e) => { numberOfCalls++; };
 
 			cell.ForceUpdateSize ();
 			cell.ForceUpdateSize ();
@@ -178,7 +178,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var cell = new ViewCell { Parent = lv };
 
 			int numberOfCalls = 0;
-			((ICellController)cell).ForceUpdateSizeRequested += (object sender, System.EventArgs e) => { numberOfCalls++; };
+			cell.ForceUpdateSizeRequested += (object sender, System.EventArgs e) => { numberOfCalls++; };
 
 			cell.ForceUpdateSize ();
 

--- a/Xamarin.Forms.Core.UnitTests/ImageTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ImageTests.cs
@@ -249,9 +249,9 @@ namespace Xamarin.Forms.Core.UnitTests
 			{
 				if (initialLoad && Element.Source != null) {
 					initialLoad = false;
-					((IImageController)Element).SetIsLoading(true);
+					Element.SetIsLoading(true);
 					await (Element.Source as UriImageSource).GetStreamAsync ();
-					((IImageController)Element).SetIsLoading(false);
+					Element.SetIsLoading(false);
 				}
 			}
 

--- a/Xamarin.Forms.Core.UnitTests/NavigationMenuUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationMenuUnitTests.cs
@@ -183,7 +183,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 			menu.Add (child);
 
-			((INavigationMenuController)menu).SendTargetSelected (child);
+			menu.SendTargetSelected (child);
 
 			Assert.True (pushed);
 			Assert.AreEqual (child, navForm.CurrentPage);

--- a/Xamarin.Forms.Core.UnitTests/OpenGLViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/OpenGLViewUnitTests.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var view = new OpenGLView ();
 			bool displayed = false;
 
-			((IOpenGlViewController)view).DisplayRequested += (s, o) => displayed = true;
+			view.DisplayRequested += (s, o) => displayed = true;
 
 			view.Display ();
 			Assert.True (displayed);

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -123,7 +123,8 @@ namespace Xamarin.Forms
 
 		ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 
-		void IApplicationController.SetAppIndexingProvider(IAppIndexingProvider provider)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SetAppIndexingProvider(IAppIndexingProvider provider)
 		{
 			_appIndexProvider = provider;
 		}

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
 using Xamarin.Forms.Internals;
@@ -109,18 +110,21 @@ namespace Xamarin.Forms
 			set { SetValueCore(IsEnabledProperty, value); }
 		}
 
-		void IButtonController.SendClicked()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendClicked()
 		{
 			Command?.Execute(CommandParameter);
 			Clicked?.Invoke(this, EventArgs.Empty);
 		}
 
-		void IButtonController.SendPressed()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendPressed()
 		{
 			Pressed?.Invoke(this, EventArgs.Empty);
 		}
 
-		void IButtonController.SendReleased()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendReleased()
 		{
 			Released?.Invoke(this, EventArgs.Empty);
 		}

--- a/Xamarin.Forms.Core/Cells/Cell.cs
+++ b/Xamarin.Forms.Core/Cells/Cell.cs
@@ -79,12 +79,8 @@ namespace Xamarin.Forms
 
 		public event EventHandler Disappearing;
 
-		event EventHandler ForceUpdateSizeRequested;
-		event EventHandler ICellController.ForceUpdateSizeRequested
-		{
-			add { ForceUpdateSizeRequested += value; }
-			remove { ForceUpdateSizeRequested -= value; }
-		}
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler ForceUpdateSizeRequested;
 
 		public void ForceUpdateSize()
 		{
@@ -156,20 +152,22 @@ namespace Xamarin.Forms
 			base.OnPropertyChanging(propertyName);
 		}
 
-		void ICellController.SendAppearing()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendAppearing()
 		{
 			OnAppearing();
 
-			var container = RealParent as IListViewController;
+			var container = RealParent as ListView;
 			if (container != null)
 				container.SendCellAppearing(this);
 		}
 
-		void ICellController.SendDisappearing()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendDisappearing()
 		{
 			OnDisappearing();
 
-			var container = RealParent as IListViewController;
+			var container = RealParent as ListView;
 			if (container != null)
 				container.SendCellDisappearing(this);
 		}

--- a/Xamarin.Forms.Core/Cells/EntryCell.cs
+++ b/Xamarin.Forms.Core/Cells/EntryCell.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Xamarin.Forms
 {
@@ -65,7 +66,8 @@ namespace Xamarin.Forms
 
 		public event EventHandler Completed;
 
-		void IEntryCellController.SendCompleted()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendCompleted()
 		{
 			EventHandler handler = Completed;
 			if (handler != null)

--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
@@ -88,7 +89,8 @@ namespace Xamarin.Forms
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		void IEditorController.SendCompleted()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendCompleted()
 		{
 			EventHandler handler = Completed;
 			if (handler != null)

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -109,7 +109,8 @@ namespace Xamarin.Forms
 
 		internal virtual ReadOnlyCollection<Element> LogicalChildrenInternal => EmptyChildren;
 
-		ReadOnlyCollection<Element> IElementController.LogicalChildren => LogicalChildrenInternal;
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public ReadOnlyCollection<Element> LogicalChildren => LogicalChildrenInternal;
 
 		internal bool Owned { get; set; }
 
@@ -222,7 +223,8 @@ namespace Xamarin.Forms
 			_changeHandlers.Remove(onchanged);
 		}
 
-		IEffectControlProvider IElementController.EffectControlProvider
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public IEffectControlProvider EffectControlProvider
 		{
 			get { return _effectControlProvider; }
 			set
@@ -246,17 +248,21 @@ namespace Xamarin.Forms
 			}
 		}
 
-		void IElementController.SetValueFromRenderer(BindableProperty property, object value)
+		void IElementController.SetValueFromRenderer(BindableProperty property, object value) => SetValueFromRenderer(property, value);
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SetValueFromRenderer(BindableProperty property, object value)
 		{
 			SetValueCore(property, value);
 		}
 
-		void IElementController.SetValueFromRenderer(BindablePropertyKey property, object value)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SetValueFromRenderer(BindablePropertyKey property, object value)
 		{
 			SetValueCore(property, value);
 		}
 
-		bool IElementController.EffectIsAttached(string name)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool EffectIsAttached(string name)
 		{
 			foreach (var effect in Effects)
 			{

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
@@ -110,7 +111,8 @@ namespace Xamarin.Forms
 
 		public event EventHandler<TextChangedEventArgs> TextChanged;
 
-		void IEntryController.SendCompleted()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendCompleted()
 		{
 			Completed?.Invoke(this, EventArgs.Empty);
 		}

--- a/Xamarin.Forms.Core/Image.cs
+++ b/Xamarin.Forms.Core/Image.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
@@ -160,7 +161,8 @@ namespace Xamarin.Forms
 			}
 		}
 
-		void IImageController.SetIsLoading(bool isLoading)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SetIsLoading(bool isLoading)
 		{
 			SetValue(IsLoadingPropertyKey, isLoading);
 		}

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using Xamarin.Forms.Internals;
 
@@ -17,7 +18,7 @@ namespace Xamarin.Forms
 			_children = new ElementCollection<T>(InternalChildren);
 		}
 
-		public IList<T> Children
+		public new IList<T> Children
 		{
 			get { return _children; }
 		}
@@ -98,7 +99,8 @@ namespace Xamarin.Forms
 
 		public event EventHandler LayoutChanged;
 
-		IReadOnlyList<Element> ILayoutController.Children
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public IReadOnlyList<Element> Children
 		{
 			get { return InternalChildren; }
 		}

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -214,15 +214,9 @@ namespace Xamarin.Forms
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public ListViewCachingStrategy CachingStrategy { get; private set; }
-		ListViewCachingStrategy IListViewController.CachingStrategy
-		{
-			get
-			{
-				return CachingStrategy;
-			}
-		}
 
-		bool RefreshAllowed
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool RefreshAllowed
 		{
 			set
 			{
@@ -235,36 +229,36 @@ namespace Xamarin.Forms
 			get { return _refreshAllowed; }
 		}
 
-		Element IListViewController.FooterElement
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public Element FooterElement
 		{
 			get { return _footerElement; }
 		}
 
-		Element IListViewController.HeaderElement
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public Element HeaderElement
 		{
 			get { return _headerElement; }
 		}
 
-		bool IListViewController.RefreshAllowed
-		{
-			get { return RefreshAllowed; }
-		}
-
-		void IListViewController.SendCellAppearing(Cell cell)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendCellAppearing(Cell cell)
 		{
 			EventHandler<ItemVisibilityEventArgs> handler = ItemAppearing;
 			if (handler != null)
 				handler(this, new ItemVisibilityEventArgs(cell.BindingContext));
 		}
 
-		void IListViewController.SendCellDisappearing(Cell cell)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendCellDisappearing(Cell cell)
 		{
 			EventHandler<ItemVisibilityEventArgs> handler = ItemDisappearing;
 			if (handler != null)
 				handler(this, new ItemVisibilityEventArgs(cell.BindingContext));
 		}
 
-		void IListViewController.SendRefreshing()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendRefreshing()
 		{
 			BeginRefresh();
 		}
@@ -371,12 +365,14 @@ namespace Xamarin.Forms
 			content.Parent = null;
 		}
 
-		Cell IListViewController.CreateDefaultCell(object item)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public Cell CreateDefaultCell(object item)
 		{
 			return CreateDefault(item);
 		}
 
-		string IListViewController.GetDisplayTextFromGroup(object cell)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public string GetDisplayTextFromGroup(object cell)
 		{
 			int groupIndex = TemplatedItems.GetGlobalIndexOfGroup(cell);
 			var group = TemplatedItems.GetGroup(groupIndex);
@@ -394,7 +390,8 @@ namespace Xamarin.Forms
 			return displayBinding;
 		}
 
-		internal void NotifyRowTapped(int groupIndex, int inGroupIndex, Cell cell = null)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void NotifyRowTapped(int groupIndex, int inGroupIndex, Cell cell = null)
 		{
 			var group = TemplatedItems.GetGroup(groupIndex);
 
@@ -415,7 +412,8 @@ namespace Xamarin.Forms
 			ItemTapped?.Invoke(this, new ItemTappedEventArgs(ItemsSource.Cast<object>().ElementAt(groupIndex), cell.BindingContext));
 		}
 
-		internal void NotifyRowTapped(int index, Cell cell = null)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void NotifyRowTapped(int index, Cell cell = null)
 		{
 			if (IsGroupingEnabled)
 			{
@@ -426,16 +424,6 @@ namespace Xamarin.Forms
 			}
 			else
 				NotifyRowTapped(0, index, cell);
-		}
-
-		void IListViewController.NotifyRowTapped(int index, Cell cell)
-		{
-			NotifyRowTapped(index, cell);
-		}
-
-		void IListViewController.NotifyRowTapped(int index, int inGroupIndex, Cell cell)
-		{
-			NotifyRowTapped(index, inGroupIndex, cell);
 		}
 
 		internal override void OnIsPlatformEnabledChanged()
@@ -449,8 +437,8 @@ namespace Xamarin.Forms
 			}
 		}
 
-		internal event EventHandler<ScrollToRequestedEventArgs> ScrollToRequested;
-		event EventHandler<ScrollToRequestedEventArgs> IListViewController.ScrollToRequested { add { ScrollToRequested += value; } remove { ScrollToRequested -= value; } }
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler<ScrollToRequestedEventArgs> ScrollToRequested;
 
 		void OnCommandCanExecuteChanged(object sender, EventArgs eventArgs)
 		{

--- a/Xamarin.Forms.Core/MasterDetailPage.cs
+++ b/Xamarin.Forms.Core/MasterDetailPage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
@@ -24,8 +25,6 @@ namespace Xamarin.Forms
 
 		Rectangle _masterBounds;
 
-		IPageController PageController => this as IPageController;
-
 		public Page Detail
 		{
 			get { return _detail; }
@@ -42,9 +41,9 @@ namespace Xamarin.Forms
 
 				OnPropertyChanging();
 				if (_detail != null)
-					PageController.InternalChildren.Remove(_detail);
+					InternalChildren.Remove(_detail);
 				_detail = value;
-				PageController.InternalChildren.Add(_detail);
+				InternalChildren.Add(_detail);
 				OnPropertyChanged();
 			}
 		}
@@ -80,9 +79,9 @@ namespace Xamarin.Forms
 
 				OnPropertyChanging();
 				if (_master != null)
-					PageController.InternalChildren.Remove(_master);
+					InternalChildren.Remove(_master);
 				_master = value;
-				PageController.InternalChildren.Add(_master);
+				InternalChildren.Add(_master);
 				OnPropertyChanged();
 			}
 		}
@@ -93,9 +92,11 @@ namespace Xamarin.Forms
 			set { SetValue(MasterBehaviorProperty, value); }
 		}
 
-		bool IMasterDetailPageController.CanChangeIsPresented { get; set; } = true;
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool CanChangeIsPresented { get; set; } = true;
 
-		Rectangle IMasterDetailPageController.DetailBounds
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public Rectangle DetailBounds
 		{
 			get { return _detailBounds; }
 			set
@@ -107,7 +108,8 @@ namespace Xamarin.Forms
 			}
 		}
 
-		Rectangle IMasterDetailPageController.MasterBounds
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public Rectangle MasterBounds
 		{
 			get { return _masterBounds; }
 			set
@@ -119,7 +121,8 @@ namespace Xamarin.Forms
 			}
 		}
 
-		bool IMasterDetailPageController.ShouldShowSplitMode
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool ShouldShowSplitMode
 		{
 			get
 			{
@@ -160,7 +163,7 @@ namespace Xamarin.Forms
 
 		protected override void OnAppearing()
 		{
-			((IMasterDetailPageController)this).CanChangeIsPresented = true;
+			CanChangeIsPresented = true;
 			UpdateMasterBehavior(this);
 			base.OnAppearing();
 		}
@@ -173,7 +176,7 @@ namespace Xamarin.Forms
 					return true;
 			}
 
-			EventHandler<BackButtonPressedEventArgs> handler = BackButtonPressedInternal;
+			EventHandler<BackButtonPressedEventArgs> handler = BackButtonPressed;
 			if (handler != null)
 			{
 				var args = new BackButtonPressedEventArgs();
@@ -197,25 +200,22 @@ namespace Xamarin.Forms
 			base.OnParentSet();
 		}
 
-		event EventHandler<BackButtonPressedEventArgs> BackButtonPressedInternal;
-		event EventHandler<BackButtonPressedEventArgs> IMasterDetailPageController.BackButtonPressed
-		{
-			add { BackButtonPressedInternal += value; }
-			remove { BackButtonPressedInternal -= value; }
-		}
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler<BackButtonPressedEventArgs> BackButtonPressed;
 
-		void IMasterDetailPageController.UpdateMasterBehavior()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void UpdateMasterBehavior()
 		{
 			UpdateMasterBehavior(this);
 		}
 
 		internal static void UpdateMasterBehavior(MasterDetailPage page)
 		{
-			if (((IMasterDetailPageController)page).ShouldShowSplitMode)
+			if (page.ShouldShowSplitMode)
 			{
 				page.SetValueCore(IsPresentedProperty, true);
 				if (page.MasterBehavior != MasterBehavior.Default)
-					((IMasterDetailPageController)page).CanChangeIsPresented = false;
+					page.CanChangeIsPresented = false;
 			}
 		}
 
@@ -230,7 +230,7 @@ namespace Xamarin.Forms
 		static void OnIsPresentedPropertyChanging(BindableObject sender, object oldValue, object newValue)
 		{
 			var page = (MasterDetailPage)sender;
-			if (!((IMasterDetailPageController)page).CanChangeIsPresented)
+			if (!page.CanChangeIsPresented)
 				throw new InvalidOperationException(string.Format("Can't change IsPresented when setting {0}", page.MasterBehavior));
 		}
 

--- a/Xamarin.Forms.Core/MenuItem.cs
+++ b/Xamarin.Forms.Core/MenuItem.cs
@@ -21,7 +21,8 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool), typeof(ToolbarItem), true);
 
-		string IMenuItemController.IsEnabledPropertyName
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public string IsEnabledPropertyName
 		{
 			get
 			{
@@ -80,7 +81,8 @@ namespace Xamarin.Forms
 				handler(this, EventArgs.Empty);
 		}
 
-		void IMenuItemController.Activate()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void Activate()
 		{
 			if (Command != null)
 			{

--- a/Xamarin.Forms.Core/MultiPage.cs
+++ b/Xamarin.Forms.Core/MultiPage.cs
@@ -26,8 +26,6 @@ namespace Xamarin.Forms
 
 		T _current;
 
-		ObservableCollection<Element> InternalChildren => ((IPageController)this).InternalChildren;
-
 		protected MultiPage()
 		{
 			_templatedItems = new TemplatedItemsList<MultiPage<T>, T>(this, ItemsSourceProperty, ItemTemplateProperty);

--- a/Xamarin.Forms.Core/NavigationMenu.cs
+++ b/Xamarin.Forms.Core/NavigationMenu.cs
@@ -66,7 +66,8 @@ namespace Xamarin.Forms.Internals
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		void INavigationMenuController.SendTargetSelected(Page target)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendTargetSelected(Page target)
 		{
 			Navigation.PushAsync(target);
 		}

--- a/Xamarin.Forms.Core/OpenGLView.cs
+++ b/Xamarin.Forms.Core/OpenGLView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
@@ -22,12 +23,6 @@ namespace Xamarin.Forms
 
 		public Action<Rectangle> OnDisplay { get; set; }
 
-		event EventHandler IOpenGlViewController.DisplayRequested
-		{
-			add { DisplayRequested += value; }
-			remove { DisplayRequested -= value; }
-		}
-
 		public void Display()
 		{
 			EventHandler handler = DisplayRequested;
@@ -35,7 +30,8 @@ namespace Xamarin.Forms
 				handler(this, EventArgs.Empty);
 		}
 
-		event EventHandler DisplayRequested;
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler DisplayRequested;
 
 		public OpenGLView()
 		{

--- a/Xamarin.Forms.Core/PanGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/PanGestureRecognizer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
@@ -13,22 +14,26 @@ namespace Xamarin.Forms
 			set { SetValue(TouchPointsProperty, value); }
 		}
 
-		void IPanGestureController.SendPan(Element sender, double totalX, double totalY, int gestureId)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendPan(Element sender, double totalX, double totalY, int gestureId)
 		{
 			PanUpdated?.Invoke(sender, new PanUpdatedEventArgs(GestureStatus.Running, gestureId, totalX, totalY));
 		}
 
-		void IPanGestureController.SendPanCanceled(Element sender, int gestureId)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendPanCanceled(Element sender, int gestureId)
 		{
 			PanUpdated?.Invoke(sender, new PanUpdatedEventArgs(GestureStatus.Canceled, gestureId));
 		}
 
-		void IPanGestureController.SendPanCompleted(Element sender, int gestureId)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendPanCompleted(Element sender, int gestureId)
 		{
 			PanUpdated?.Invoke(sender, new PanUpdatedEventArgs(GestureStatus.Completed, gestureId));
 		}
 
-		void IPanGestureController.SendPanStarted(Element sender, int gestureId)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendPanStarted(Element sender, int gestureId)
 		{
 			PanUpdated?.Invoke(sender, new PanUpdatedEventArgs(GestureStatus.Started, gestureId));
 		}

--- a/Xamarin.Forms.Core/PinchGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/PinchGestureRecognizer.cs
@@ -1,50 +1,56 @@
 ﻿using System;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
 	public sealed class PinchGestureRecognizer : GestureRecognizer, IPinchGestureController
 	{
-		bool IPinchGestureController.IsPinching { get; set; }
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool IsPinching { get; set; }
 
-		void IPinchGestureController.SendPinch(Element sender, double delta, Point currentScalePoint)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendPinch(Element sender, double delta, Point currentScalePoint)
 		{
 			EventHandler<PinchGestureUpdatedEventArgs> handler = PinchUpdated;
 			if (handler != null)
 			{
 				handler(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Running, delta, currentScalePoint));
 			}
-			((IPinchGestureController)this).IsPinching = true;
+			IsPinching = true;
 		}
 
-		void IPinchGestureController.SendPinchCanceled(Element sender)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendPinchCanceled(Element sender)
 		{
 			EventHandler<PinchGestureUpdatedEventArgs> handler = PinchUpdated;
 			if (handler != null)
 			{
 				handler(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Canceled));
 			}
-			((IPinchGestureController)this).IsPinching = false;
+			IsPinching = false;
 		}
 
-		void IPinchGestureController.SendPinchEnded(Element sender)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendPinchEnded(Element sender)
 		{
 			EventHandler<PinchGestureUpdatedEventArgs> handler = PinchUpdated;
 			if (handler != null)
 			{
 				handler(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Completed));
 			}
-			((IPinchGestureController)this).IsPinching = false;
+			IsPinching = false;
 		}
 
-		void IPinchGestureController.SendPinchStarted(Element sender, Point initialScalePoint)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendPinchStarted(Element sender, Point initialScalePoint)
 		{
 			EventHandler<PinchGestureUpdatedEventArgs> handler = PinchUpdated;
 			if (handler != null)
 			{
 				handler(sender, new PinchGestureUpdatedEventArgs(GestureStatus.Started, 1, initialScalePoint));
 			}
-			((IPinchGestureController)this).IsPinching = true;
+			IsPinching = true;
 		}
 
 		public event EventHandler<PinchGestureUpdatedEventArgs> PinchUpdated;

--- a/Xamarin.Forms.Core/ScrollView.cs
+++ b/Xamarin.Forms.Core/ScrollView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
@@ -76,7 +77,8 @@ namespace Xamarin.Forms
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<ScrollView>>(() => new PlatformConfigurationRegistry<ScrollView>(this));
 		}
 
-		Point IScrollViewController.GetScrollPositionForElement(VisualElement item, ScrollToPosition pos)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public Point GetScrollPositionForElement(VisualElement item, ScrollToPosition pos)
 		{
 			ScrollToPosition position = pos;
 			double y = GetCoordinate(item, "Y", 0);
@@ -114,19 +116,15 @@ namespace Xamarin.Forms
 			return new Point(x, y);
 		}
 
-		event EventHandler<ScrollToRequestedEventArgs> IScrollViewController.ScrollToRequested
-		{
-			add { ScrollToRequested += value; }
-			remove { ScrollToRequested -= value; }
-		}
-
-		void IScrollViewController.SendScrollFinished()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendScrollFinished()
 		{
 			if (_scrollCompletionSource != null)
 				_scrollCompletionSource.TrySetResult(true);
 		}
 
-		void IScrollViewController.SetScrolledPosition(double x, double y)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SetScrolledPosition(double x, double y)
 		{
 			if (ScrollX == x && ScrollY == y)
 				return;
@@ -295,6 +293,7 @@ namespace Xamarin.Forms
 				handler(this, e);
 		}
 
-		event EventHandler<ScrollToRequestedEventArgs> ScrollToRequested;
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler<ScrollToRequestedEventArgs> ScrollToRequested;
 	}
 }

--- a/Xamarin.Forms.Core/SearchBar.cs
+++ b/Xamarin.Forms.Core/SearchBar.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Windows.Input;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
@@ -139,7 +140,8 @@ namespace Xamarin.Forms
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<SearchBar>>(() => new PlatformConfigurationRegistry<SearchBar>(this));
 		}
 
-		void ISearchBarController.OnSearchButtonPressed()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void OnSearchButtonPressed()
 		{
 			ICommand cmd = SearchCommand;
 

--- a/Xamarin.Forms.Core/TableView.cs
+++ b/Xamarin.Forms.Core/TableView.cs
@@ -90,9 +90,10 @@ namespace Xamarin.Forms
 				OnModelChanged();
 			}
 		}
-		ITableModel ITableViewController.Model
+
+		ITableModel ITableViewController.Model 
 		{
-			get
+			get 
 			{
 				return Model;
 			}
@@ -124,12 +125,8 @@ namespace Xamarin.Forms
 			return new SizeRequest(request, minimumSize);
 		}
 
-		internal event EventHandler ModelChanged;
-		event EventHandler ITableViewController.ModelChanged
-		{
-			add { ModelChanged += value; }
-			remove { ModelChanged -= value; }
-		}
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler ModelChanged;
 
 		public IPlatformElementConfiguration<T, TableView> On<T>() where T : IConfigPlatform
 		{

--- a/Xamarin.Forms.Core/TemplatedPage.cs
+++ b/Xamarin.Forms.Core/TemplatedPage.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms
 			set { SetValue(ControlTemplateProperty, value); }
 		}
 
-		IList<Element> IControlTemplated.InternalChildren => ((IPageController)this).InternalChildren;
+		IList<Element> IControlTemplated.InternalChildren => InternalChildren;
 
 		internal override void ComputeConstraintForView(View view)
 		{

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -434,7 +434,8 @@ namespace Xamarin.Forms
 			}
 		}
 
-		void IVisualElementController.NativeSizeChanged()
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void NativeSizeChanged()
 		{
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
@@ -39,7 +40,9 @@ namespace Xamarin.Forms
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<WebView>>(() => new PlatformConfigurationRegistry<WebView>(this));
 		}
 
-		bool IWebViewController.CanGoBack {
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		bool IWebViewController.CanGoBack 
+		{
 			get { return CanGoBack; }
 			set { SetValue(CanGoBackPropertyKey, value); }
 		}
@@ -49,7 +52,9 @@ namespace Xamarin.Forms
 			get { return (bool)GetValue(CanGoBackProperty); }
 		}
 
-		bool IWebViewController.CanGoForward {
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		bool IWebViewController.CanGoForward 
+		{
 			get { return CanGoForward; }
 			set { SetValue(CanGoForwardPropertyKey, value); }
 		}
@@ -123,28 +128,23 @@ namespace Xamarin.Forms
 			remove { EvalRequested -= value; }
 		}
 
-		event EventHandler<EvalRequested> EvalRequested;
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler<EvalRequested> EvalRequested;
 
-		event EventHandler IWebViewController.GoBackRequested {
-			add { GoBackRequested += value; }
-			remove { GoBackRequested -= value; }
-		}
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler GoBackRequested;
 
-		event EventHandler GoBackRequested;
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler GoForwardRequested;
 
-		event EventHandler IWebViewController.GoForwardRequested {
-			add { GoForwardRequested += value; }
-			remove { GoForwardRequested -= value; }
-		}
-
-		event EventHandler GoForwardRequested;
-
-		void IWebViewController.SendNavigated(WebNavigatedEventArgs args)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendNavigated(WebNavigatedEventArgs args)
 		{
 			Navigated?.Invoke(this, args);
 		}
 
-		void IWebViewController.SendNavigating(WebNavigatingEventArgs args)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendNavigating(WebNavigatingEventArgs args)
 		{
 			Navigating?.Invoke(this, args);
 		}

--- a/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
@@ -41,16 +41,13 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (_cell == value)
 					return;
 
-				ICellController cellController = _cell;
-
-				if (cellController != null)
-					Device.BeginInvokeOnMainThread(cellController.SendDisappearing);
+				if (_cell != null)
+					Device.BeginInvokeOnMainThread(_cell.SendDisappearing);
 
 				_cell = value;
-				cellController = value;
 
-				if (cellController != null)
-					Device.BeginInvokeOnMainThread(cellController.SendAppearing);
+				if (_cell != null)
+					Device.BeginInvokeOnMainThread(_cell.SendAppearing);
 			}
 		}
 
@@ -217,7 +214,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (menuItem.Enabled)
 				menuItem.Activated += (sender, e) =>
 				{
-					((IMenuItemController)contextAction).Activate();
+					contextAction.Activate();
 				};
 			if (!string.IsNullOrEmpty(contextAction.Icon))
 				menuItem.Image = new NSImage(contextAction.Icon);

--- a/Xamarin.Forms.Platform.MacOS/Cells/ViewCellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/ViewCellNSView.cs
@@ -75,14 +75,12 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateCell(ViewCell cell)
 		{
-			ICellController cellController = _viewCell;
-			if (cellController != null)
-				Device.BeginInvokeOnMainThread(cellController.SendDisappearing);
+			if (_viewCell != null)
+				Device.BeginInvokeOnMainThread(_viewCell.SendDisappearing);
 
 			_viewCell = cell;
-			cellController = cell;
 
-			Device.BeginInvokeOnMainThread(cellController.SendAppearing);
+			Device.BeginInvokeOnMainThread(_viewCell.SendAppearing);
 
 			IVisualElementRenderer renderer;
 			if (_rendererRef == null || !_rendererRef.TryGetTarget(out renderer))

--- a/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
@@ -33,8 +33,6 @@ namespace Xamarin.Forms.Platform.MacOS
 	{
 		const string ToolBarId = "AwesomeBarToolbar";
 
-		INavigationPageController NavigationController => _navigation;
-
 		readonly string _defaultBackButtonTitle = "Back";
 		readonly ToolbarTracker _toolbarTracker;
 
@@ -153,7 +151,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (NSApplication.SharedApplication.MainWindow == null)
 				return;
 
-			if (NavigationController == null)
+			if (_navigation == null)
 			{
 				if (_toolbar != null)
 					_toolbar.Visible = false;
@@ -161,7 +159,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 			}
 
-			var currentPage = NavigationController.Peek();
+			var currentPage = _navigation.Peek(0);
 
 			if (NavigationPage.GetHasNavigationBar(currentPage))
 			{
@@ -220,7 +218,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		async Task NavigateBackFrombackButton()
 		{
-			var popAsyncInner = NavigationController?.PopAsyncInner(true, true);
+			var popAsyncInner = _navigation?.PopAsyncInner(true, true);
 			if (popAsyncInner != null)
 				await popAsyncInner;
 		}
@@ -235,9 +233,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		bool IsRootPage()
 		{
-			if (NavigationController == null)
+			if (_navigation == null)
 				return true;
-			return NavigationController.StackDepth <= 1;
+			return _navigation.StackDepth <= 1;
 		}
 
 		NSColor GetBackgroundColor()
@@ -259,17 +257,17 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		string GetCurrentPageTitle()
 		{
-			if (NavigationController == null)
+			if (_navigation == null)
 				return string.Empty;
-			return NavigationController.Peek().Title ?? "";
+			return _navigation.Peek(0).Title ?? "";
 		}
 
 		string GetPreviousPageTitle()
 		{
-			if (NavigationController == null || NavigationController.StackDepth <= 1)
+			if (_navigation == null || _navigation.StackDepth <= 1)
 				return string.Empty;
 
-			return NavigationController.Peek(1).Title ?? _defaultBackButtonTitle;
+			return _navigation.Peek(1).Title ?? _defaultBackButtonTitle;
 		}
 
 		List<ToolbarItem> GetToolbarItems()
@@ -316,7 +314,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (_toolbar == null || _navigation == null || _toolbarGroup == null)
 				return;
 
-			var currentPage = NavigationController.Peek();
+			var currentPage = _navigation.Peek(0);
 			UpdateGroup(_toolbarGroup, currentPage.ToolbarItems, ToolbarItemWidth, ToolbarItemSpacing);
 		}
 
@@ -387,7 +385,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					var element = toolbarItems[i];
 
 					var item = new NSToolbarItem(element.Text ?? "");
-					item.Activated += (sender, e) => (element as IMenuItemController).Activate();
+					item.Activated += (sender, e) => element.Activate();
 
 					var button = new NSButton();
 					button.Title = element.Text ?? "";
@@ -401,7 +399,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					button.Frame = new CGRect(currentX + i * itemSpacing, 0, buttonWidth, ToolbarItemHeight);
 					currentX += buttonWidth;
 					totalWidth += button.Frame.Width;
-					button.Activated += (sender, e) => (element as IMenuItemController).Activate();
+					button.Activated += (sender, e) => element.Activate();
 
 					button.BezelStyle = NSBezelStyle.TexturedRounded;
 					if (!string.IsNullOrEmpty(element.Icon))

--- a/Xamarin.Forms.Platform.MacOS/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/CarouselPageRenderer.cs
@@ -28,9 +28,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 		}
 
-		IElementController ElementController => Element;
-
-		IPageController PageController => (IPageController)Element;
+		Page Page => (Page)Element;
 
 		public override nint SelectedIndex
 		{
@@ -41,7 +39,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					return;
 				base.SelectedIndex = value;
 				if (Carousel != null)
-					Carousel.CurrentPage = (ContentPage)ElementController.LogicalChildren[(int)SelectedIndex];
+					Carousel.CurrentPage = (ContentPage)Element.LogicalChildren[(int)SelectedIndex];
 			}
 		}
 
@@ -80,7 +78,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 
 			_appeared = true;
-			PageController.SendAppearing();
+			Page.SendAppearing();
 		}
 
 		public override void ViewDidDisappear()
@@ -91,7 +89,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 
 			_appeared = false;
-			PageController.SendDisappearing();
+			Page.SendDisappearing();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -109,7 +107,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (_appeared)
 				{
 					_appeared = false;
-					PageController?.SendDisappearing();
+					Page?.SendDisappearing();
 				}
 
 				if (_events != null)
@@ -163,9 +161,9 @@ namespace Xamarin.Forms.Platform.MacOS
 		void UpdateSource()
 		{
 			var pages = new List<NSPageContainer>();
-			for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
+			for (var i = 0; i < Element.LogicalChildren.Count; i++)
 			{
-				Element element = ElementController.LogicalChildren[i];
+				Element element = Element.LogicalChildren[i];
 				var child = element as ContentPage;
 				if (child != null)
 					pages.Add(new NSPageContainer(child, i));

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			IImageSourceHandler handler;
 
-			((IImageController)Element).SetIsLoading(true);
+			Element.SetIsLoading(true);
 
 			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
 			{
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				Control.Image = null;
 
 			if (!_isDisposed)
-				((IImageController)Element).SetIsLoading(false);
+				Element.SetIsLoading(false);
 		}
 
 		void SetOpacity()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ListViewDataSource.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ListViewDataSource.cs
@@ -18,8 +18,6 @@ namespace Xamarin.Forms.Platform.MacOS
 		readonly NSTableView _nsTableView;
 		protected readonly ListView List;
 
-		IListViewController Controller => List;
-
 		ITemplatedItemsView<Cell> TemplatedItemsView => List;
 
 		bool _selectionFromNative;
@@ -63,7 +61,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 
 			_selectionFromNative = true;
-			Controller.NotifyRowTapped((int)indexPath.Section, (int)indexPath.Item, cell);
+			List.NotifyRowTapped((int)indexPath.Section, (int)indexPath.Item, cell);
 		}
 
 
@@ -158,7 +156,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			NSView nativeCell;
 
-			var cachingStrategy = Controller.CachingStrategy;
+			var cachingStrategy = List.CachingStrategy;
 			if (cachingStrategy == ListViewCachingStrategy.RetainElement)
 			{
 				cell = GetCellForPath(indexPath, isHeader);
@@ -176,10 +174,10 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					var templatedList = TemplatedItemsView.TemplatedItems.GetGroup(sectionIndex);
 					cell = (Cell)((INativeElementView)nativeCell).Element;
-					ICellController controller = cell;
-					controller.SendDisappearing();
+
+					cell.SendDisappearing();
 					templatedList.UpdateContent(cell, itemIndexInSection);
-					controller.SendAppearing();
+					cell.SendAppearing();
 				}
 			}
 			else

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
@@ -16,8 +16,6 @@ namespace Xamarin.Forms.Platform.MacOS
 		IVisualElementRenderer _headerRenderer;
 		IVisualElementRenderer _footerRenderer;
 
-		IListViewController Controller => Element;
-
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
 
 		public const int DefaultRowHeight = 44;
@@ -91,8 +89,8 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (e.OldElement != null)
 			{
-				var controller = (IListViewController)e.OldElement;
-				controller.ScrollToRequested -= OnScrollToRequested;
+				var listView = e.OldElement;
+				listView.ScrollToRequested -= OnScrollToRequested;
 
 				var templatedItems = ((ITemplatedItemsView<Cell>)e.OldElement).TemplatedItems;
 				templatedItems.CollectionChanged -= OnCollectionChanged;
@@ -112,8 +110,8 @@ namespace Xamarin.Forms.Platform.MacOS
 					SetNativeControl(scroller);
 				}
 
-				var controller = (IListViewController)e.NewElement;
-				controller.ScrollToRequested += OnScrollToRequested;
+				var listView = e.NewElement;
+				listView.ScrollToRequested += OnScrollToRequested;
 
 				var templatedItems = ((ITemplatedItemsView<Cell>)e.NewElement).TemplatedItems;
 				templatedItems.CollectionChanged += OnCollectionChanged;
@@ -175,7 +173,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateHeader()
 		{
-			var header = Controller.HeaderElement;
+			var header = Element.HeaderElement;
 			var headerView = (View)header;
 
 			if (headerView != null)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		VisualElementTracker _tracker;
 		MasterDetailPage _masterDetailPage;
 
-		IPageController PageController => Element as IPageController;
+		Page Page => Element as Page;
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)
 		{
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (!_disposed && disposing)
 			{
-				PageController?.SendDisappearing();
+				Page?.SendDisappearing();
 
 				if (Element != null)
 				{

--- a/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		VisualElementTracker _tracker;
 		Stack<NavigationChildPageWrapper> _currentStack = new Stack<NavigationChildPageWrapper>();
 
-		IPageController PageController => Element as IPageController;
-
-		IElementController ElementController => Element as IElementController;
-
-		INavigationPageController NavigationController => Element as INavigationPageController;
+		NavigationPage NavigationPage => Element as NavigationPage;
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)
 		{
@@ -91,8 +87,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				if (Element != null)
 				{
-					PageController?.SendDisappearing();
-					((Element as IPageContainer<Page>)?.CurrentPage as IPageController)?.SendDisappearing();
+					NavigationPage?.SendDisappearing();
+					((Element as IPageContainer<Page>)?.CurrentPage as Page)?.SendDisappearing();
 					Element.PropertyChanged -= HandlePropertyChanged;
 					Element = null;
 				}
@@ -115,7 +111,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 			Platform.NativeToolbarTracker.TryHide(Element as NavigationPage);
 			_appeared = false;
-			PageController?.SendDisappearing();
+			NavigationPage?.SendDisappearing();
 		}
 
 		public override void ViewDidAppear()
@@ -126,7 +122,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 
 			_appeared = true;
-			PageController?.SendAppearing();
+			NavigationPage?.SendAppearing();
 		}
 
 		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
@@ -181,11 +177,11 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			Platform.NativeToolbarTracker.Navigation = navPage;
 
-			NavigationController.PushRequested += OnPushRequested;
-			NavigationController.PopRequested += OnPopRequested;
-			NavigationController.PopToRootRequested += OnPopToRootRequested;
-			NavigationController.RemovePageRequested += OnRemovedPageRequested;
-			NavigationController.InsertPageBeforeRequested += OnInsertPageBeforeRequested;
+			NavigationPage.PushRequested += OnPushRequested;
+			NavigationPage.PopRequested += OnPopRequested;
+			NavigationPage.PopToRootRequested += OnPopToRootRequested;
+			NavigationPage.RemovePageRequested += OnRemovedPageRequested;
+			NavigationPage.InsertPageBeforeRequested += OnInsertPageBeforeRequested;
 
 			navPage.Popped += (sender, e) => Platform.NativeToolbarTracker.UpdateToolBar();
 			navPage.PoppedToRoot += (sender, e) => Platform.NativeToolbarTracker.UpdateToolBar();
@@ -197,7 +193,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			_events.LoadEvents(NativeView);
 			_tracker = new VisualElementTracker(this);
 
-			((INavigationPageController)navPage).Pages.ForEach(async p => await PushPageAsync(p, false));
+			navPage.Pages.ForEach(async p => await PushPageAsync(p, false));
 
 			UpdateBackgroundColor();
 		}
@@ -248,7 +244,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void RemovePage(Page page, bool removeFromStack)
 		{
-			(page as IPageController)?.SendDisappearing();
+			page?.SendDisappearing();
 			var target = Platform.GetRenderer(page);
 			target?.NativeView?.RemoveFromSuperview();
 			target?.ViewController?.RemoveFromParentViewController();
@@ -277,7 +273,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				throw new NotSupportedException("Popped page does not appear on top of current navigation stack, please file a bug.");
 
 			_currentStack.Pop();
-			(page as IPageController)?.SendDisappearing();
+			page.SendDisappearing();
 
 			var target = Platform.GetRenderer(page);
 			var previousPage = _currentStack.Peek().Page;
@@ -318,7 +314,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			var vco = Platform.GetRenderer(oldPage);
 			AddChildViewController(vc.ViewController);
 			return await this.HandleAsyncAnimation(vco.ViewController, vc.ViewController,
-				NSViewControllerTransitionOptions.SlideForward, () => (page as IPageController)?.SendAppearing(), true);
+				NSViewControllerTransitionOptions.SlideForward, () => page?.SendAppearing(), true);
 		}
 
 		void UpdateBackgroundColor()
@@ -344,9 +340,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (_tracker == null)
 				return;
 
-			if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName)
+			if (e.PropertyName == Xamarin.Forms.NavigationPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor();
-			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.NavigationPage.BarTextColorProperty.PropertyName)
 				UpdateBarTextColor();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/OpenGLViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/OpenGLViewRenderer.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				_displayLink = null;
 
 				if (Element != null)
-					((IOpenGlViewController)Element).DisplayRequested -= Display;
+					Element.DisplayRequested -= Display;
 			}
 
 			base.Dispose(disposing);
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		protected override void OnElementChanged(ElementChangedEventArgs<OpenGLView> e)
 		{
 			if (e.OldElement != null)
-				((IOpenGlViewController)e.OldElement).DisplayRequested -= Display;
+				e.OldElement.DisplayRequested -= Display;
 
 			if (e.NewElement != null)
 			{
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				var glkView = new MacOSOpenGLView();
 				SetNativeControl(glkView);
 
-				((IOpenGlViewController)e.NewElement).DisplayRequested += Display;
+				e.NewElement.DisplayRequested += Display;
 
 				SetupRenderLoop(false);
 			}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		VisualElementPackager _packager;
 		VisualElementTracker _tracker;
 
-		IPageController PageController => Element as IPageController;
+		Page Page => Element as Page;
 
 		public PageRenderer()
 		{
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 
 			_appeared = true;
-			PageController.SendAppearing();
+			Page.SendAppearing();
 		}
 
 		public override void ViewDidDisappear()
@@ -78,7 +78,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 
 			_appeared = false;
-			PageController.SendDisappearing();
+			Page.SendDisappearing();
 		}
 
 		public override void ViewWillAppear()
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				Element.PropertyChanged -= OnHandlePropertyChanged;
 				Platform.SetRenderer(Element, null);
 				if (_appeared)
-					PageController.SendDisappearing();
+					Page.SendDisappearing();
 
 				_appeared = false;
 

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			HasVerticalScroller = true;
 		}
 
-		IScrollViewController Controller => Element as IScrollViewController;
+		ScrollView ScrollView => Element as ScrollView;
 
 		public VisualElement Element { get; private set; }
 
@@ -48,13 +48,13 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (oldElement != null)
 			{
 				oldElement.PropertyChanged -= HandlePropertyChanged;
-				((IScrollViewController)oldElement).ScrollToRequested -= OnScrollToRequested;
+				((ScrollView)oldElement).ScrollToRequested -= OnScrollToRequested;
 			}
 
 			if (element != null)
 			{
 				element.PropertyChanged += HandlePropertyChanged;
-				((IScrollViewController)element).ScrollToRequested += OnScrollToRequested;
+				((ScrollView)element).ScrollToRequested += OnScrollToRequested;
 				if (_tracker == null)
 				{
 					PackContent();
@@ -120,10 +120,10 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			ClearContentRenderer();
 
-			if (Controller.Children.Count == 0 || !(Controller.Children[0] is VisualElement))
+			if (ScrollView.Children.Count == 0 || !(ScrollView.Children[0] is VisualElement))
 				return;
 
-			var content = (VisualElement)Controller.Children[0];
+			var content = (VisualElement)ScrollView.Children[0];
 			if (Platform.GetRenderer(content) == null)
 				Platform.SetRenderer(content, Platform.CreateRenderer(content));
 
@@ -152,7 +152,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void HandleScrollAnimationEnded(object sender, EventArgs e)
 		{
-			Controller.SendScrollFinished();
+			ScrollView.SendScrollFinished();
 		}
 
 		void HandleScrolled(object sender, EventArgs e)
@@ -175,11 +175,11 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			Point scrollPoint = (e.Mode == ScrollToMode.Position)
 				? new Point(e.ScrollX, Element.Height - e.ScrollY)
-				: Controller.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
+				: ScrollView.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
 
 			(DocumentView as NSView)?.ScrollPoint(scrollPoint.ToPointF());
 
-			Controller.SendScrollFinished();
+			ScrollView.SendScrollFinished();
 		}
 
 		void UpdateBackgroundColor()
@@ -202,7 +202,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			var convertedPoint = (DocumentView as NSView)?.ConvertPointFromView(ContentView.Bounds.Location, ContentView);
 			if (convertedPoint.HasValue)
-				Controller.SetScrolledPosition(Math.Max(0, convertedPoint.Value.X), Math.Max(0, convertedPoint.Value.Y));
+				ScrollView.SetScrolledPosition(Math.Max(0, convertedPoint.Value.X), Math.Max(0, convertedPoint.Value.Y));
 		}
 
 		void ClearContentRenderer()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SearchBarRenderer.cs
@@ -114,7 +114,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void OnSearchButtonClicked(object sender, EventArgs e)
 		{
-			((ISearchBarController)Element).OnSearchButtonPressed();
+			Element.OnSearchButtonPressed();
 			Control.ResignFirstResponder();
 		}
 

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
@@ -72,9 +72,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);
 		}
 
-		IPageController PageController => Element as IPageController;
-
-		IElementController ElementController => Element;
+		Page Page => Element as Page;
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)
 		{
@@ -104,7 +102,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				View.Frame = new System.Drawing.RectangleF((float)Element.X, (float)Element.Y, (float)Element.Width, (float)Element.Height);
 
 			var frame = View.Frame;
-			PageController.ContainerArea = new Rectangle(0, 0, frame.Width, frame.Height - TabHolderHeight);
+			Page.ContainerArea = new Rectangle(0, 0, frame.Width, frame.Height - TabHolderHeight);
 
 			if (!_queuedSize.IsZero)
 			{
@@ -129,14 +127,14 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public override void ViewDidAppear()
 		{
-			PageController.SendAppearing();
+			Page.SendAppearing();
 			base.ViewDidAppear();
 		}
 
 		public override void ViewDidDisappear()
 		{
 			base.ViewDidDisappear();
-			PageController.SendDisappearing();
+			Page.SendDisappearing();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -144,7 +142,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (disposing && !_disposed)
 			{
 				_disposed = true;
-				PageController.SendDisappearing();
+				Page.SendDisappearing();
 				Tabbed.PropertyChanged -= OnPropertyChanged;
 				Tabbed.PagesChanged -= OnPagesChanged;
 
@@ -286,9 +284,9 @@ namespace Xamarin.Forms.Platform.MacOS
 		void SetControllers()
 		{
 			_updatingControllers = true;
-			for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
+			for (var i = 0; i < Element.LogicalChildren.Count; i++)
 			{
-				var child = ElementController.LogicalChildren[i];
+				var child = Element.LogicalChildren[i];
 				var page = child as Page;
 				if (page == null)
 					continue;
@@ -342,7 +340,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				int originalIndex;
 				if (int.TryParse(TabViewItems[i].ViewController.Identifier, out originalIndex))
 				{
-					var page = PageController.InternalChildren[originalIndex];
+					var page = Page.InternalChildren[originalIndex];
 					TabbedPage.SetIndex(page as Page, i);
 				}
 			}
@@ -350,7 +348,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateCurrentPage()
 		{
-			var count = PageController.InternalChildren.Count;
+			var count = Page.InternalChildren.Count;
 			Tabbed.CurrentPage = SelectedTabViewItemIndex >= 0 && SelectedTabViewItemIndex < count
 				? Tabbed.GetPageByIndex((int)SelectedTabViewItemIndex)
 				: null;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TableViewDataSource.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TableViewDataSource.cs
@@ -11,8 +11,6 @@ namespace Xamarin.Forms.Platform.MacOS
 		const string HeaderIdentifier = nameof(TextCell);
 		const string ItemIdentifier = nameof(ViewCell);
 
-		protected ITableViewController Controller => _tableView;
-
 		readonly NSTableView _nsTableView;
 		readonly TableView _tableView;
 
@@ -20,7 +18,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			_tableView = tableViewRenderer.Element;
 			_nsTableView = tableViewRenderer.TableView;
-			Controller.ModelChanged += (s, e) => { _nsTableView?.ReloadData(); };
+			_tableView.ModelChanged += (s, e) => { _nsTableView?.ReloadData(); };
 			AutomaticallyDeselect = true;
 		}
 
@@ -38,8 +36,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			GetComputedIndexes(row, out sectionIndex, out itemIndexInSection, out isHeader);
 
-			var cell = Controller.Model.GetCell(sectionIndex, itemIndexInSection);
-			Controller.Model.RowSelected(cell);
+			var cell = _tableView.Model.GetCell(sectionIndex, itemIndexInSection);
+			_tableView.Model.RowSelected(cell);
 			if (AutomaticallyDeselect)
 				_nsTableView.DeselectRow(row);
 		}
@@ -47,10 +45,10 @@ namespace Xamarin.Forms.Platform.MacOS
 		public override nint GetRowCount(NSTableView tableView)
 		{
 			nint count = 0;
-			s_sectionCount = Controller.Model.GetSectionCount();
+			s_sectionCount = _tableView.Model.GetSectionCount();
 			for (int i = 0; i < s_sectionCount; i++)
 			{
-				count += Controller.Model.GetRowCount(i) + 1;
+				count += _tableView.Model.GetRowCount(i) + 1;
 			}
 
 			return count;
@@ -80,13 +78,13 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (isHeader)
 			{
 				id = HeaderIdentifier;
-				cell = Controller.Model.GetHeaderCell(sectionIndex) ??
-						new TextCell { Text = Controller.Model.GetSectionTitle(sectionIndex) };
+				cell = _tableView.Model.GetHeaderCell(sectionIndex) ??
+						new TextCell { Text = _tableView.Model.GetSectionTitle(sectionIndex) };
 			}
 			else
 			{
 				id = ItemIdentifier;
-				cell = Controller.Model.GetCell(sectionIndex, itemIndexInSection);
+				cell = _tableView.Model.GetCell(sectionIndex, itemIndexInSection);
 			}
 
 			var nativeCell = CellNSView.GetNativeCell(tableView, cell, id, isHeader);
@@ -102,7 +100,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			for (int i = 0; i < s_sectionCount; i++)
 			{
-				var groupCount = Controller.Model.GetRowCount(i);
+				var groupCount = _tableView.Model.GetRowCount(i);
 				var itemsInSection = groupCount + 1;
 
 				if (row < totalItems + itemsInSection)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
@@ -13,8 +13,6 @@ namespace Xamarin.Forms.Platform.MacOS
 		WebNavigationEvent _lastBackForwardEvent;
 		WebNavigationEvent _lastEvent;
 
-		IWebViewController ElementController => Element;
-
 		void IWebViewDelegate.LoadHtml(string html, string baseUrl)
 		{
 			if (html != null)
@@ -43,9 +41,9 @@ namespace Xamarin.Forms.Platform.MacOS
 					Control.OnFinishedLoading += OnNSWebViewFinishedLoad;
 					Control.OnFailedLoading += OnNSWebViewFailedLoadWithError;
 
-					ElementController.EvalRequested += OnEvalRequested;
-					ElementController.GoBackRequested += OnGoBackRequested;
-					ElementController.GoForwardRequested += OnGoForwardRequested;
+					Element.EvalRequested += OnEvalRequested;
+					Element.GoBackRequested += OnGoBackRequested;
+					Element.GoForwardRequested += OnGoForwardRequested;
 
 					Layer.BackgroundColor = NSColor.Clear.CGColor;
 				}
@@ -69,9 +67,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				_disposed = true;
 				Control.OnFinishedLoading -= OnNSWebViewFinishedLoad;
 				Control.OnFailedLoading -= OnNSWebViewFailedLoadWithError;
-				ElementController.EvalRequested -= OnEvalRequested;
-				ElementController.GoBackRequested -= OnGoBackRequested;
-				ElementController.GoForwardRequested -= OnGoForwardRequested;
+				Element.EvalRequested -= OnEvalRequested;
+				Element.GoBackRequested -= OnGoBackRequested;
+				Element.GoForwardRequested -= OnGoForwardRequested;
 			}
 			base.Dispose(disposing);
 		}
@@ -90,8 +88,8 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (Element == null)
 				return;
-			ElementController.CanGoBack = Control.CanGoBack();
-			ElementController.CanGoForward = Control.CanGoForward();
+			((IWebViewController)Element).CanGoBack = Control.CanGoBack();
+			((IWebViewController)Element).CanGoForward = Control.CanGoForward();
 		}
 
 		void OnEvalRequested(object sender, EvalRequested eventArg)
@@ -124,7 +122,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		void OnNSWebViewFailedLoadWithError(object sender, WebKit.WebResourceErrorEventArgs e)
 		{
 			_lastEvent = _lastBackForwardEvent;
-			ElementController?.SendNavigated(new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = Control.MainFrameUrl },
+			Element?.SendNavigated(new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = Control.MainFrameUrl },
 				Control.MainFrameUrl, WebNavigationResult.Failure));
 
 			UpdateCanGoBackForward();
@@ -136,11 +134,11 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 
 			_ignoreSourceChanges = true;
-			ElementController?.SetValueFromRenderer(WebView.SourceProperty, new UrlWebViewSource { Url = Control.MainFrameUrl });
+			Element?.SetValueFromRenderer(WebView.SourceProperty, new UrlWebViewSource { Url = Control.MainFrameUrl });
 			_ignoreSourceChanges = false;
 
 			_lastEvent = _lastBackForwardEvent;
-			ElementController?.SendNavigated(new WebNavigatedEventArgs(_lastEvent, Element?.Source, Control.MainFrameUrl,
+			Element?.SendNavigated(new WebNavigatedEventArgs(_lastEvent, Element?.Source, Control.MainFrameUrl,
 				WebNavigationResult.Success));
 
 			UpdateCanGoBackForward();

--- a/Xamarin.Forms.Platform.UAP/FormsPresenter.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsPresenter.cs
@@ -15,20 +15,20 @@ namespace Xamarin.Forms.Platform.UWP
 				if (ActualWidth > 0 && ActualHeight > 0)
 				{
 					var page = (Page)DataContext;
-					((IPageController)page.RealParent).ContainerArea = new Rectangle(0, 0, ActualWidth, ActualHeight);
+					((Page)page.RealParent).ContainerArea = new Rectangle(0, 0, ActualWidth, ActualHeight);
 				}
 			};
 		}
 
 		void FormsPresenter_Loaded(object sender, RoutedEventArgs e)
 		{
-			var page = (IPageController)DataContext;
+			var page = (Page)DataContext;
 			page.SendAppearing();
 		}
 
 		void FormsPresenter_Unloaded(object sender, RoutedEventArgs e)
 		{
-			var page = (IPageController)DataContext;
+			var page = (Page)DataContext;
 			page.SendDisappearing();
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -57,10 +57,6 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			set { Control.ToolbarForeground = value; }
 		}
-		
-		IPageController PageController => Element as IPageController;
-
-		IMasterDetailPageController MasterDetailPageController => Element as IMasterDetailPageController;
 
 		bool ITitleProvider.ShowTitle
 		{
@@ -210,13 +206,13 @@ namespace Xamarin.Forms.Platform.UWP
 			if (Element == null)
 				return;
 
-			PageController.SendAppearing();
+			Element.SendAppearing();
 			UpdateBounds();
 		}
 
 		void OnControlUnloaded(object sender, RoutedEventArgs routedEventArgs)
 		{
-			PageController?.SendDisappearing();
+			Element?.SendDisappearing();
 		}
 
 		void OnDetailPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -247,8 +243,8 @@ namespace Xamarin.Forms.Platform.UWP
 			Windows.Foundation.Size masterSize = Control.MasterSize;
 			Windows.Foundation.Size detailSize = Control.DetailSize;
 
-			MasterDetailPageController.MasterBounds = new Rectangle(0, 0, masterSize.Width, masterSize.Height);
-			MasterDetailPageController.DetailBounds = new Rectangle(0, 0, detailSize.Width, detailSize.Height);
+			Element.MasterBounds = new Rectangle(0, 0, masterSize.Width, masterSize.Height);
+			Element.DetailBounds = new Rectangle(0, 0, detailSize.Width, detailSize.Height);
 		}
 
 		void UpdateDetail()
@@ -316,7 +312,7 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdateDetailTitle();
 			Control.CollapseStyle = Element.OnThisPlatform().GetCollapseStyle();
 			Control.CollapsedPaneWidth = Element.OnThisPlatform().CollapsedPaneWidth();
-			Control.ShouldShowSplitMode = MasterDetailPageController.ShouldShowSplitMode;
+			Control.ShouldShowSplitMode = Element.ShouldShowSplitMode;
 		}
 
 		void UpdateToolbarPlacement()

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRendererUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRendererUWP.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateBackButton()
 		{
-			bool showBackButton = PageController.InternalChildren.Count > 1 && NavigationPage.GetHasBackButton(_currentPage);
+			bool showBackButton = Element.InternalChildren.Count > 1 && NavigationPage.GetHasBackButton(_currentPage);
 			_container.ShowBackButton = showBackButton;
 
 			if (_navManager != null)

--- a/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs e)
 		{
-			((ISearchBarController)Element).OnSearchButtonPressed();
+			Element.OnSearchButtonPressed();
 		}
 
 		void OnTextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs e)

--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -59,8 +59,6 @@ namespace Xamarin.Forms.Platform.UWP
             set { Control.ToolbarForeground = value; }
         }
 
-        IPageController PageController => Element as IPageController;
-
         bool ITitleProvider.ShowTitle
         {
             get { return _showTitle; }
@@ -186,7 +184,7 @@ namespace Xamarin.Forms.Platform.UWP
                 return;
 
             _disposed = true;
-            PageController?.SendDisappearing();
+            Element?.SendDisappearing();
             SetElement(null);
             Tracker = null;
         }
@@ -216,7 +214,7 @@ namespace Xamarin.Forms.Platform.UWP
 
         void OnLoaded(object sender, RoutedEventArgs args)
         {
-            PageController?.SendAppearing();
+            Element?.SendAppearing();
             UpdateBarTextColor();
             UpdateBarBackgroundColor();
         }
@@ -238,14 +236,14 @@ namespace Xamarin.Forms.Platform.UWP
             Page currentPage = Element.CurrentPage;
             if (currentPage == page)
                 return;
-            ((IPageController)currentPage)?.SendDisappearing();
+            currentPage?.SendDisappearing();
             Element.CurrentPage = page;
-            ((IPageController)page)?.SendAppearing();
+            page?.SendAppearing();
         }
 
         void OnUnloaded(object sender, RoutedEventArgs args)
         {
-            PageController?.SendDisappearing();
+            Element?.SendDisappearing();
         }
 
         Brush GetBarBackgroundBrush()

--- a/Xamarin.Forms.Platform.WP8/CellControl.cs
+++ b/Xamarin.Forms.Platform.WP8/CellControl.cs
@@ -57,12 +57,12 @@ namespace Xamarin.Forms.Platform.WinPhone
 			if (oldCell != null)
 			{
 				oldCell.PropertyChanged -= _propertyChangedHandler;
-				((ICellController)oldCell).SendDisappearing();
+				oldCell.SendDisappearing();
 			}
 
 			if (newCell != null)
 			{
-				((ICellController)newCell).SendAppearing();
+				newCell.SendAppearing();
 
 				if (oldCell == null || oldCell.GetType() != newCell.GetType())
 					ContentTemplate = GetTemplate(newCell);

--- a/Xamarin.Forms.Platform.WP8/CustomContextMenu.cs
+++ b/Xamarin.Forms.Platform.WP8/CustomContextMenu.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 				var menuItem = item.DataContext as MenuItem;
 				if (menuItem != null)
-					((IMenuItemController)menuItem).Activate();
+					menuItem.Activate();
 			};
 			return item;
 		}

--- a/Xamarin.Forms.Platform.WP8/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/ImageRenderer.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		async void SetSource(System.Windows.Controls.Image image)
 		{
-			((IImageController)Element).SetIsLoading(true);
+			Element.SetIsLoading(true);
 
 			ImageSource source = Element.Source;
 			IImageSourceHandler handler;
@@ -102,7 +102,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			else
 				image.Source = null;
 
-			((IImageController)Element).SetIsLoading(false);
+			Element.SetIsLoading(false);
 		}
 	}
 

--- a/Xamarin.Forms.Platform.WP8/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/ListViewRenderer.cs
@@ -194,8 +194,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 		System.Windows.Controls.ProgressBar _progressBar;
 
 		ViewportControl _viewport;
-		IListViewController Controller => Element;
-		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
+		ITemplatedItemsView<Cell> TemplatedItemsView => base.Element;
 
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
@@ -228,14 +227,13 @@ namespace Xamarin.Forms.Platform.WinPhone
 		{
 			base.OnElementChanged(e);
 
-			Controller.ScrollToRequested += OnScrollToRequested;
+			Element.ScrollToRequested += OnScrollToRequested;
 
-			if (Element.SelectedItem != null)
+			if (base.Element.SelectedItem != null)
 				_itemNeedsSelecting = true;
 
-			_listBox = new FixedLongListSelector
-			{
-				DataContext = Element,
+			_listBox = new FixedLongListSelector {
+				DataContext = base.Element,
 				ItemsSource = (IList)TemplatedItemsView.TemplatedItems,
 				ItemTemplate = (System.Windows.DataTemplate)System.Windows.Application.Current.Resources["CellTemplate"],
 				GroupHeaderTemplate = (System.Windows.DataTemplate)System.Windows.Application.Current.Resources["ListViewHeader"],
@@ -268,7 +266,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			base.OnElementPropertyChanged(sender, e);
 
 			if (e.PropertyName == ListView.SelectedItemProperty.PropertyName)
-				OnItemSelected(Element.SelectedItem);
+				OnItemSelected(base.Element.SelectedItem);
 			else if (e.PropertyName == "HeaderElement")
 				UpdateHeader();
 			else if (e.PropertyName == "FooterElement")
@@ -284,7 +282,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			base.UpdateNativeWidget();
 
 			if (_progressBar != null)
-				_progressBar.Width = Element.Width;
+				_progressBar.Width = base.Element.Width;
 		}
 
 		Cell FindCell(GestureEventArgs e, out FrameworkElement element)
@@ -415,11 +413,11 @@ namespace Xamarin.Forms.Platform.WinPhone
 				return;
 
 			var cell = e.Container.DataContext as Cell;
-			if (cell == null || !Equals(cell.BindingContext, Element.SelectedItem))
+			if (cell == null || !Equals(cell.BindingContext, base.Element.SelectedItem))
 				return;
 
 			_itemNeedsSelecting = false;
-			OnItemSelected(Element.SelectedItem);
+			OnItemSelected(base.Element.SelectedItem);
 		}
 
 		void OnItemSelected(object selectedItem)
@@ -463,19 +461,19 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 			Cell parentCell = null;
 
-			if (Element.IsGroupingEnabled)
+			if (base.Element.IsGroupingEnabled)
 			{
 				parentCell = cell.GetGroupHeaderContent<ItemsView<Cell>, Cell>();
 			}
 
 			_fromNative = cell.BindingContext;
 
-			if (Element.IsGroupingEnabled)
+			if (base.Element.IsGroupingEnabled)
 			{
-				Controller.NotifyRowTapped(parentCell.GetIndex<ItemsView<Cell>, Cell>(), cell.GetIndex<ItemsView<Cell>, Cell>(), null);
+				Element.NotifyRowTapped(parentCell.GetIndex<ItemsView<Cell>, Cell>(), cell.GetIndex<ItemsView<Cell>, Cell>(), null);
 			}
 			else
-				Controller.NotifyRowTapped(cell.GetIndex<ItemsView<Cell>, Cell>(), null);
+				Element.NotifyRowTapped(cell.GetIndex<ItemsView<Cell>, Cell>(), null);
 		}
 
 		void OnNativeSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -499,22 +497,22 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		void OnPullToRefreshCanceled(object sender, EventArgs args)
 		{
-			if (Element.IsPullToRefreshEnabled && Controller.RefreshAllowed)
+			if (base.Element.IsPullToRefreshEnabled && Element.RefreshAllowed)
 				_progressBar.Visibility = Visibility.Collapsed;
 		}
 
 		void OnPullToRefreshCompleted(object sender, EventArgs args)
 		{
-			if (Element.IsPullToRefreshEnabled && Controller.RefreshAllowed)
+			if (base.Element.IsPullToRefreshEnabled && Element.RefreshAllowed)
 			{
 				_progressBar.IsIndeterminate = true;
-				Controller.SendRefreshing();
+				Element.SendRefreshing();
 			}
 		}
 
 		void OnPullToRefreshStarted(object sender, EventArgs args)
 		{
-			if (Element.IsPullToRefreshEnabled && Controller.RefreshAllowed)
+			if (base.Element.IsPullToRefreshEnabled && Element.RefreshAllowed)
 			{
 				_progressBar.Visibility = Visibility.Visible;
 				_progressBar.IsIndeterminate = false;
@@ -524,7 +522,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		void OnPullToRefreshStatusUpdated(object sender, EventArgs eventArgs)
 		{
-			if (Element.IsPullToRefreshEnabled && Controller.RefreshAllowed)
+			if (base.Element.IsPullToRefreshEnabled && Element.RefreshAllowed)
 				_progressBar.Value = Math.Max(0, Math.Min(1, _listBox.PullToRefreshStatus));
 		}
 
@@ -575,7 +573,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 			var found = false;
 
-			if (Element.IsGroupingEnabled)
+			if (base.Element.IsGroupingEnabled)
 			{
 				for (var g = 0; g < templatedItems.Count; g++)
 				{
@@ -638,7 +636,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 					position = ScrollToPosition.Start;
 			}
 
-			if (position == ScrollToPosition.Start && Element.IsGroupingEnabled)
+			if (position == ScrollToPosition.Start && base.Element.IsGroupingEnabled)
 				y = y - targetHeaderHeight;
 			else if (position == ScrollToPosition.Center)
 				y = y - (_viewport.ActualHeight / 2 + targetHeight / 2);
@@ -688,17 +686,17 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		void UpdateFooter()
 		{
-			Control.ListFooter = Controller.FooterElement;
+			Control.ListFooter = Element.FooterElement;
 		}
 
 		void UpdateHeader()
 		{
-			Control.ListHeader = Controller.HeaderElement;
+			Control.ListHeader = Element.HeaderElement;
 		}
 
 		void UpdateIsRefreshing()
 		{
-			if (Element.IsRefreshing)
+			if (base.Element.IsRefreshing)
 			{
 				_progressBar.Visibility = Visibility.Visible;
 				_progressBar.IsIndeterminate = true;
@@ -706,13 +704,13 @@ namespace Xamarin.Forms.Platform.WinPhone
 			else
 			{
 				_progressBar.IsIndeterminate = false;
-				_progressBar.Visibility = _listBox.IsInPullToRefresh && Element.IsPullToRefreshEnabled && Controller.RefreshAllowed ? Visibility.Visible : Visibility.Collapsed;
+				_progressBar.Visibility = _listBox.IsInPullToRefresh && base.Element.IsPullToRefreshEnabled && Element.RefreshAllowed ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
 
 		void UpdateJumpList()
 		{
-			if (_listBox.IsGroupingEnabled && Element.GroupShortNameBinding == null)
+			if (_listBox.IsGroupingEnabled && base.Element.GroupShortNameBinding == null)
 				_listBox.JumpListStyle = null;
 			else
 				_listBox.JumpListStyle = (System.Windows.Style)System.Windows.Application.Current.Resources["HeaderJumpStyle"];

--- a/Xamarin.Forms.Platform.WP8/MasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/MasterDetailRenderer.cs
@@ -20,11 +20,9 @@ namespace Xamarin.Forms.Platform.WinPhone
 			AutoPackage = false;
 		}
 
-		IMasterDetailPageController MasterDetailPageController => Element as IMasterDetailPageController;
-
 		public bool Visible { get; private set; }
 
-		IPageController PageController => Element as IPageController;
+		IPageController PageController => (base.Element as IPageController);
 
 		protected override System.Windows.Size ArrangeOverride(System.Windows.Size finalSize)
 		{
@@ -37,10 +35,10 @@ namespace Xamarin.Forms.Platform.WinPhone
 			base.OnElementChanged(e);
 
 			if (e.OldElement != null)
-				((IMasterDetailPageController)e.OldElement).BackButtonPressed -= HandleBackButtonPressed;
+				e.OldElement.BackButtonPressed -= HandleBackButtonPressed;
 
 			if (e.NewElement != null)
-				((IMasterDetailPageController)e.NewElement).BackButtonPressed += HandleBackButtonPressed;
+				e.NewElement.BackButtonPressed += HandleBackButtonPressed;
 
 			LoadDetail();
 			LoadMaster();
@@ -49,7 +47,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 			Loaded += (sender, args) =>
 			{
-				if (Element.IsPresented)
+				if (base.Element.IsPresented)
 					Toggle();
 				PageController.SendAppearing();
 			};
@@ -58,7 +56,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 				PageController.SendDisappearing();
 				if (Visible)
 				{
-					var platform = (Platform)Element.Platform;
+					var platform = (Platform)base.Element.Platform;
 					Canvas container = platform.GetCanvas();
 
 					container.Children.Remove(_popup);
@@ -82,7 +80,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			}
 			else if (e.PropertyName == MasterDetailPage.IsPresentedProperty.PropertyName)
 			{
-				if (Visible == Element.IsPresented)
+				if (Visible == base.Element.IsPresented)
 					return;
 				Toggle();
 			}
@@ -90,7 +88,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		internal void Toggle()
 		{
-			var platform = Element.Platform as Platform;
+			var platform = base.Element.Platform as Platform;
 			Canvas container = platform.GetCanvas();
 
 			if (_toggleTransition != null)
@@ -124,7 +122,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 			Visible = !Visible;
 
-			((IElementController)Element).SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, Visible);
+			((IElementController)base.Element).SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, Visible);
 		}
 
 		void HandleBackButtonPressed(object sender, BackButtonPressedEventArgs e)
@@ -141,7 +139,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			if (_detailRenderer != null)
 				Children.Remove(_detailRenderer.ContainerElement);
 
-			Page detail = Element.Detail;
+			Page detail = base.Element.Detail;
 			if (Platform.GetRenderer(detail) == null)
 				Platform.SetRenderer(detail, Platform.CreateRenderer(detail));
 
@@ -157,7 +155,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			if (_masterRenderer != null && _popup != null)
 				_popup.Child = null;
 
-			Page master = Element.Master;
+			Page master = base.Element.Master;
 			if (Platform.GetRenderer(master) == null)
 				Platform.SetRenderer(master, Platform.CreateRenderer(master));
 
@@ -172,10 +170,10 @@ namespace Xamarin.Forms.Platform.WinPhone
 			if (width <= 0 || height <= 0)
 				return;
 
-			var platform = Element.Platform as Platform;
+			var platform = base.Element.Platform as Platform;
 			Size screenSize = platform.Size;
-			MasterDetailPageController.MasterBounds = new Rectangle(0, 0, screenSize.Width - 20, screenSize.Height - 20);
-			MasterDetailPageController.DetailBounds = new Rectangle(0, 0, width, height);
+			Element.MasterBounds = new Rectangle(0, 0, screenSize.Width - 20, screenSize.Height - 20);
+			Element.DetailBounds = new Rectangle(0, 0, width, height);
 
 			_popup.Width = width - 20;
 			_popup.Height = height - 20;

--- a/Xamarin.Forms.Platform.WP8/NavigationMenuRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/NavigationMenuRenderer.cs
@@ -10,8 +10,6 @@ namespace Xamarin.Forms.Platform.WinPhone
 	{
 		const int Spacing = 12;
 
-		INavigationMenuController ElementController => Element;
-
 		protected override void OnElementChanged(ElementChangedEventArgs<NavigationMenu> e)
 		{
 			base.OnElementChanged(e);
@@ -66,7 +64,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 					hubTile.Background = target.BackgroundColor.ToBrush();
 
 				Page tmp = target;
-				hubTile.Tap += (sender, args) => ElementController.SendTargetSelected(tmp);
+				hubTile.Tap += (sender, args) => Element.SendTargetSelected(tmp);
 
 				hubTile.SetValue(System.Windows.Controls.Grid.RowProperty, y);
 				hubTile.SetValue(System.Windows.Controls.Grid.ColumnProperty, x);

--- a/Xamarin.Forms.Platform.WP8/Platform.cs
+++ b/Xamarin.Forms.Platform.WP8/Platform.cs
@@ -537,7 +537,6 @@ namespace Xamarin.Forms.Platform.WinPhone
 			var buttonsToAdd = new List<TaggedAppBarButton>();
 			foreach (ToolbarItem item in items.Where(i => i.Order != ToolbarItemOrder.Secondary))
 			{
-				IMenuItemController controller = item;
 				if (_page.ApplicationBar.Buttons.OfType<TaggedAppBarButton>().Any(b => b.Tag == item))
 					continue;
 
@@ -545,10 +544,10 @@ namespace Xamarin.Forms.Platform.WinPhone
 				{
 					IconUri = new Uri(item.Icon ?? "ApplicationIcon.jpg", UriKind.Relative),
 					Text = !string.IsNullOrWhiteSpace(item.Text) ? item.Text : (string)item.Icon ?? "ApplicationIcon.jpg",
-					IsEnabled = controller.IsEnabled,
+					IsEnabled = item.IsEnabled,
 					Tag = item
 				};
-				button.Click += (sender, args) => controller.Activate();
+				button.Click += (sender, args) => item.Activate();
 				buttonsToAdd.Add(button);
 			}
 
@@ -559,7 +558,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 					continue;
 
 				var button = new TaggedAppBarMenuItem { Text = !string.IsNullOrWhiteSpace(item.Text) ? item.Text : (string)item.Icon ?? "MenuItem", IsEnabled = true, Tag = item };
-				button.Click += (sender, args) => ((IMenuItemController)item).Activate();
+				button.Click += (sender, args) => item.Activate();
 				menuItemsToAdd.Add(button);
 			}
 
@@ -625,10 +624,8 @@ namespace Xamarin.Forms.Platform.WinPhone
 				if (item == null)
 					return;
 
-				IMenuItemController controller = item;
-
-				if (e.PropertyName == controller.IsEnabledPropertyName)
-					IsEnabled = controller.IsEnabled;
+				if (e.PropertyName == item.IsEnabledPropertyName)
+					IsEnabled = item.IsEnabled;
 				else if (e.PropertyName == MenuItem.TextProperty.PropertyName)
 					Text = !string.IsNullOrWhiteSpace(item.Text) ? item.Text : (string)item.Icon ?? "ApplicationIcon.jpg";
 				else if (e.PropertyName == MenuItem.IconProperty.PropertyName)

--- a/Xamarin.Forms.Platform.WP8/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/ScrollViewRenderer.cs
@@ -14,11 +14,6 @@ namespace Xamarin.Forms.Platform.WinPhone
 			AutoPackage = false;
 		}
 
-		protected IScrollViewController Controller
-		{
-			get { return Element; }
-		}
-
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			SizeRequest result = base.GetDesiredSize(widthConstraint, heightConstraint);
@@ -59,7 +54,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			base.OnElementChanged(e);
 
 			if (e.OldElement != null)
-				((IScrollViewController)e.OldElement).ScrollToRequested -= OnScrollToRequested;
+				e.OldElement.ScrollToRequested -= OnScrollToRequested;
 
 			if (e.NewElement != null)
 			{
@@ -68,7 +63,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 					SetNativeControl(new ScrollViewer { ManipulationMode = ManipulationMode.Control });
 					Control.LayoutUpdated += (sender, args) => { UpdateScrollPosition(); };
 				}
-				((IScrollViewController)e.NewElement).ScrollToRequested += OnScrollToRequested;
+				e.NewElement.ScrollToRequested += OnScrollToRequested;
 			}
 
 			SizeChanged += (sender, args) =>
@@ -126,7 +121,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 			if (e.Mode == ScrollToMode.Element)
 			{
-				Point itemPosition = Controller.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
+				Point itemPosition = Element.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
 				x = itemPosition.X;
 				y = itemPosition.Y;
 			}
@@ -141,13 +136,13 @@ namespace Xamarin.Forms.Platform.WinPhone
 				animation.Commit(_animatable, "ScrollTo", length: 500, easing: Easing.CubicInOut, finished: (v, d) =>
 				{
 					UpdateScrollOffset(x, y);
-					Controller.SendScrollFinished();
+					Element.SendScrollFinished();
 				});
 			}
 			else
 			{
 				UpdateScrollOffset(x, y);
-				Controller.SendScrollFinished();
+				Element.SendScrollFinished();
 			}
 		}
 
@@ -188,7 +183,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 		void UpdateScrollPosition()
 		{
 			if (Element != null)
-				Controller.SetScrolledPosition(Control.HorizontalOffset, Control.VerticalOffset);
+				Element.SetScrolledPosition(Control.HorizontalOffset, Control.VerticalOffset);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WP8/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/SearchBarRenderer.cs
@@ -68,12 +68,12 @@ namespace Xamarin.Forms.Platform.WinPhone
 		void PhoneTextBoxOnKeyUp(object sender, KeyEventArgs keyEventArgs)
 		{
 			if (keyEventArgs.Key == Key.Enter)
-				((ISearchBarController)Element).OnSearchButtonPressed();
+				Element.OnSearchButtonPressed();
 		}
 
 		void PhoneTextBoxOnTextChanged(object sender, System.Windows.Controls.TextChangedEventArgs textChangedEventArgs)
 		{
-			((IElementController)Element).SetValueFromRenderer(SearchBar.TextProperty, Control.Text);
+			Element.SetValueFromRenderer(SearchBar.TextProperty, Control.Text);
 		}
 
 		void UpdateAlignment()

--- a/Xamarin.Forms.Platform.WinRT.Phone/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/SearchBarRenderer.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnQuerySubmitted (SearchBox sender, SearchBoxQuerySubmittedEventArgs e)
 		{
-			((ISearchBarController)Element).OnSearchButtonPressed ();
+			Element.OnSearchButtonPressed ();
 		}
 
 		void UpdatePlaceholder ()

--- a/Xamarin.Forms.Platform.WinRT.Phone/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/TabbedPageRenderer.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				if (ActualWidth > 0 && ActualHeight > 0)
 				{
 					var tab = ((Page)DataContext);
-					((IPageController)tab.RealParent).ContainerArea = new Rectangle(0, 0, ActualWidth, ActualHeight);
+					((Page)tab.RealParent).ContainerArea = new Rectangle(0, 0, ActualWidth, ActualHeight);
 				}
 			};
 		}
@@ -38,7 +38,6 @@ namespace Xamarin.Forms.Platform.WinRT
 		bool _showTitle;
 
 		ITitleProvider TitleProvider => this;
-		IPageController PageController => Element as IPageController;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
@@ -152,7 +151,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			_disposed = true;
 
-			PageController?.SendDisappearing();
+			Element?.SendDisappearing();
 			SetElement(null);
 			Tracker = null;
 		}
@@ -278,14 +277,14 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnLoaded(object sender, RoutedEventArgs args)
 		{
-			PageController?.SendAppearing();
+			Element?.SendAppearing();
 			UpdateBarTextColor();
 			UpdateBarBackgroundColor();
 		}
 
 		void OnUnloaded(object sender, RoutedEventArgs args)
 		{
-			PageController?.SendDisappearing();
+			Element?.SendDisappearing();
 		}
 
 		void OnTrackerUpdated(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.WinRT.Tablet/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/SearchBarRenderer.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnQuerySubmitted(SearchBox sender, SearchBoxQuerySubmittedEventArgs e)
 		{
-			((ISearchBarController)Element).OnSearchButtonPressed();
+			Element.OnSearchButtonPressed();
 		}
 
 		void UpdatePlaceholder()

--- a/Xamarin.Forms.Platform.WinRT.Tablet/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/TabbedPageRenderer.cs
@@ -27,8 +27,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			get { return (TabbedPage)Element; }
 		}
 
-		IPageController PageController => Element as IPageController;
-
 		protected VisualElementTracker<Page, Canvas> Tracker
 		{
 			get { return _tracker; }
@@ -161,7 +159,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			_disposed = true;
 
-			PageController?.SendDisappearing();
+			Page?.SendDisappearing();
 			SetElement(null);
 			Tracker = null;
 		}
@@ -259,7 +257,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				return;
 
 			ShowTabs();
-			PageController.SendAppearing();
+			Page.SendAppearing();
 		}
 
 		void tabs_OnLoaded(object sender, RoutedEventArgs e)
@@ -322,7 +320,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		void canvas_OnUnloaded(object sender, RoutedEventArgs args)
 		{
 			RemoveTabs();
-			PageController?.SendDisappearing();
+			Page?.SendDisappearing();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WinRT/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/CarouselPageRenderer.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			get { return Element; }
 		}
 
-		IPageController PageController => Element as IPageController;
+		Page Page => Element as Page;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			if (oldPage != null)
 			{
-				((IPageController)oldPage).SendDisappearing();
+				oldPage.SendDisappearing();
 				((INotifyCollectionChanged)oldPage.Children).CollectionChanged -= OnChildrenChanged;
 				oldPage.PropertyChanged -= OnElementPropertyChanged;
 			}
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				newPage.PropertyChanged += OnElementPropertyChanged;
 
 				UpdateCurrentPage();
-				((IPageController)newPage).SendAppearing();
+				newPage.SendAppearing();
 			}
 
 			OnElementChanged(new ElementChangedEventArgs<CarouselPage>(oldPage, newPage));
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 
 			_disposed = true;
-			PageController?.SendDisappearing();
+			Page?.SendDisappearing();
 			SetElement(null);
 		}
 
@@ -158,7 +158,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnLoaded(object sender, RoutedEventArgs e)
 		{
-			PageController?.SendAppearing();
+			Page?.SendAppearing();
 		}
 
 		void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -170,14 +170,14 @@ namespace Xamarin.Forms.Platform.WinRT
 			ContentPage currentPage = Element.CurrentPage;
 			if (currentPage == page)
 				return;
-			((IPageController)currentPage)?.SendDisappearing();
+			currentPage?.SendDisappearing();
 			Element.CurrentPage = page;
-			((IPageController)page)?.SendAppearing();
+			page?.SendAppearing();
 		}
 
 		void OnUnloaded(object sender, RoutedEventArgs e)
 		{
-			PageController?.SendDisappearing();
+			Page?.SendDisappearing();
 		}
 
 		void UpdateCurrentPage()

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -42,9 +42,8 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			Unloaded += (sender, args) =>
 			{
-				ICellController cell = Cell;
-				if (cell != null)
-					cell.SendDisappearing();
+				if (Cell != null)
+					Cell.SendDisappearing();
 			};
 
 			_propertyChangedHandler = OnCellPropertyChanged;
@@ -230,12 +229,10 @@ namespace Xamarin.Forms.Platform.WinRT
 				}
 				else
 				{
-					IListViewController listViewController = lv;
-
 					if (isGroupHeader)
-						bindingContext = listViewController.GetDisplayTextFromGroup(bindingContext);
+						bindingContext = lv.GetDisplayTextFromGroup(bindingContext);
 
-					cell = listViewController.CreateDefaultCell(bindingContext);
+					cell = lv.CreateDefaultCell(bindingContext);
 				}
 
 				// A TableView cell should already have its parent,
@@ -258,12 +255,12 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (oldCell != null)
 			{
 				oldCell.PropertyChanged -= _propertyChangedHandler;
-				((ICellController)oldCell).SendDisappearing();
+				oldCell.SendDisappearing();
 			}
 
 			if (newCell != null)
 			{
-				((ICellController)newCell).SendAppearing();
+				newCell.SendAppearing();
 
 				UpdateContent(newCell);
 				SetupContextMenu();

--- a/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
@@ -91,13 +91,13 @@ namespace Xamarin.Forms.Platform.WinRT
 				RefreshImage();
 			}
 
-			((IImageController)Element)?.SetIsLoading(false);
+			Element?.SetIsLoading(false);
 		}
 
 		void OnImageFailed(object sender, ExceptionRoutedEventArgs exceptionRoutedEventArgs)
 		{
 			Log.Warning("Image Loading", $"Image failed to load: {exceptionRoutedEventArgs.ErrorMessage}" );
-			((IImageController)Element)?.SetIsLoading(false);
+			Element?.SetIsLoading(false);
 		}
 
 		void RefreshImage()
@@ -122,7 +122,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		async Task UpdateSource()
 		{
-			((IImageController)Element).SetIsLoading(true);
+			Element.SetIsLoading(true);
 
 			ImageSource source = Element.Source;
 			IImageSourceHandler handler;
@@ -155,7 +155,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			else
 			{
 				Control.Source = null;
-				((IImageController)Element)?.SetIsLoading(false);
+				Element?.SetIsLoading(false);
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -25,7 +25,6 @@ namespace Xamarin.Forms.Platform.WinRT
 {
 	public class ListViewRenderer : ViewRenderer<ListView, FrameworkElement>
 	{
-		IListViewController Controller => Element;
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
 
 
@@ -53,13 +52,13 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (e.OldElement != null)
 			{
 				e.OldElement.ItemSelected -= OnElementItemSelected;
-				((IListViewController)e.OldElement).ScrollToRequested -= OnElementScrollToRequested;
+				e.OldElement.ScrollToRequested -= OnElementScrollToRequested;
 			}
 
 			if (e.NewElement != null)
 			{
 				e.NewElement.ItemSelected += OnElementItemSelected;
-				((IListViewController)e.NewElement).ScrollToRequested += OnElementScrollToRequested;
+				e.NewElement.ScrollToRequested += OnElementScrollToRequested;
 
 				if (List == null)
 				{
@@ -201,12 +200,12 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void UpdateFooter()
 		{
-			List.Footer = Controller.FooterElement;
+			List.Footer = Element.FooterElement;
 		}
 
 		void UpdateHeader()
 		{
-			List.Header = Controller.HeaderElement;
+			List.Header = Element.HeaderElement;
 		}
 
 		void UpdateGrouping()
@@ -479,7 +478,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 #endif
 
-			Controller.NotifyRowTapped(index, cell: null);
+			Element.NotifyRowTapped(index, cell: null);
 
 #if !WINDOWS_UWP
 

--- a/Xamarin.Forms.Platform.WinRT/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/MasterDetailPageRenderer.cs
@@ -57,8 +57,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			set { _container.ToolbarForeground = value; }
 		}
 
-		IMasterDetailPageController MasterDetailPageController => Element as IMasterDetailPageController;
-
 		bool ITitleProvider.ShowTitle
 		{
 			get { return _showTitle; }
@@ -179,7 +177,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		bool GetIsMasterAPopover()
 		{
 			// TODO: Support tablet being shrunk to a very small size
-			return !MasterDetailPageController.ShouldShowSplitMode;
+			return !Element.ShouldShowSplitMode;
 		}
 
 		void OnLoaded(object sender, RoutedEventArgs args)
@@ -273,8 +271,8 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (!isPopover)
 				detailWidth -= masterWidth;
 
-			MasterDetailPageController.MasterBounds = new Rectangle(0, 0, masterWidth, constraint.Height);
-			MasterDetailPageController.DetailBounds = new Rectangle(0, 0, detailWidth, constraint.Height);
+			Element.MasterBounds = new Rectangle(0, 0, masterWidth, constraint.Height);
+			Element.DetailBounds = new Rectangle(0, 0, detailWidth, constraint.Height);
 		}
 
 		void UpdateIsPresented()

--- a/Xamarin.Forms.Platform.WinRT/MenuItemCommand.cs
+++ b/Xamarin.Forms.Platform.WinRT/MenuItemCommand.cs
@@ -13,7 +13,6 @@ namespace Xamarin.Forms.Platform.WinRT
 	internal class MenuItemCommand : ICommand
 	{
 		readonly MenuItem _menuItem;
-		IMenuItemController Controller => _menuItem;
 
 		public MenuItemCommand(MenuItem item)
 		{
@@ -23,14 +22,14 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		public virtual bool CanExecute(object parameter)
 		{
-			return Controller.IsEnabled;
+			return _menuItem.IsEnabled;
 		}
 
 		public event EventHandler CanExecuteChanged;
 
 		public void Execute(object parameter)
 		{
-			Controller.Activate();
+			_menuItem.Activate();
 		}
 
 		void OnCanExecuteChanged()

--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -76,8 +76,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 		}
 
-		IPageController PageController => Element as IPageController;
-
 		bool ITitleProvider.ShowTitle
 		{
 			get { return _showTitle; }
@@ -152,10 +150,10 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			if (oldElement != null)
 			{
-				((INavigationPageController)oldElement).PushRequested -= OnPushRequested;
-				((INavigationPageController)oldElement).PopRequested -= OnPopRequested;
-				((INavigationPageController)oldElement).PopToRootRequested -= OnPopToRootRequested;
-				((IPageController)oldElement).InternalChildren.CollectionChanged -= OnChildrenChanged;
+				oldElement.PushRequested -= OnPushRequested;
+				oldElement.PopRequested -= OnPopRequested;
+				oldElement.PopToRootRequested -= OnPopToRootRequested;
+				oldElement.InternalChildren.CollectionChanged -= OnChildrenChanged;
 				oldElement.PropertyChanged -= OnElementPropertyChanged;
 			}
 
@@ -190,10 +188,10 @@ namespace Xamarin.Forms.Platform.WinRT
 #endif
 
 				Element.PropertyChanged += OnElementPropertyChanged;
-				((INavigationPageController)Element).PushRequested += OnPushRequested;
-				((INavigationPageController)Element).PopRequested += OnPopRequested;
-				((INavigationPageController)Element).PopToRootRequested += OnPopToRootRequested;
-				PageController.InternalChildren.CollectionChanged += OnChildrenChanged;
+				Element.PushRequested += OnPushRequested;
+				Element.PopRequested += OnPopRequested;
+				Element.PopToRootRequested += OnPopToRootRequested;
+				Element.InternalChildren.CollectionChanged += OnChildrenChanged;
 
 				if (!string.IsNullOrEmpty(Element.AutomationId))
 					_container.SetValue(AutomationProperties.AutomationIdProperty, Element.AutomationId);
@@ -211,7 +209,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				return;
 			}
 
-			PageController?.SendDisappearing();
+			Element?.SendDisappearing();
 			_disposed = true;
 
 			_container.PointerPressed -= OnPointerPressed;
@@ -340,7 +338,7 @@ namespace Xamarin.Forms.Platform.WinRT
 #if WINDOWS_UWP
 			_navManager = SystemNavigationManager.GetForCurrentView();
 #endif
-			PageController.SendAppearing();
+			Element.SendAppearing();
 			UpdateBackButton();
 			UpdateTitleOnParents();
 		}
@@ -371,7 +369,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnPopRequested(object sender, NavigationRequestedEventArgs e)
 		{
-			var newCurrent = ((INavigationPageController)Element).Peek(1);
+			var newCurrent = Element.Peek(1);
 			SetPage(newCurrent, e.Animated, true);
 		}
 
@@ -387,12 +385,12 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void OnUnloaded(object sender, RoutedEventArgs args)
 		{
-			PageController?.SendDisappearing();
+			Element?.SendDisappearing();
 		}
 
 		void PushExistingNavigationStack()
 		{
-			foreach (var page in ((INavigationPageController)Element).Pages)
+			foreach (var page in Element.Pages)
 			{
 				SetPage(page, false, false);
 			}
@@ -454,7 +452,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		void UpdateContainerArea()
 		{
-			PageController.ContainerArea = new Rectangle(0, 0, _container.ContentWidth, _container.ContentHeight);
+			Element.ContainerArea = new Rectangle(0, 0, _container.ContentWidth, _container.ContentHeight);
 		}
 
 		void UpdateNavigationBarBackground()

--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRendererWinRT.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRendererWinRT.cs
@@ -17,7 +17,7 @@
 
 		void UpdateBackButton()
 		{
-			bool showBackButton = PageController.InternalChildren.Count > 1 && NavigationPage.GetHasBackButton(_currentPage);
+			bool showBackButton = Element.InternalChildren.Count > 1 && NavigationPage.GetHasBackButton(_currentPage);
 			_container.ShowBackButton = showBackButton;
 		}
 

--- a/Xamarin.Forms.Platform.WinRT/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/PageRenderer.cs
@@ -15,8 +15,6 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		bool _loaded;
 
-		IPageController PageController => Element as IPageController;
-
 		protected override void Dispose(bool disposing)
 		{
 			if (!disposing || _disposed)
@@ -32,7 +30,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					var visualChild = children[i] as VisualElement;
 					visualChild?.Cleanup();
 				}
-				PageController?.SendDisappearing();
+				Element?.SendDisappearing();
 			}
 
 			base.Dispose();
@@ -42,7 +40,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			base.OnElementChanged(e);
 
-			((IPageController)e.OldElement)?.SendDisappearing();
+			e.OldElement?.SendDisappearing();
 
 			if (e.NewElement != null)
 			{
@@ -55,7 +53,7 @@ namespace Xamarin.Forms.Platform.WinRT
 				}
 
 				if (_loaded)
-					((IPageController)e.NewElement).SendAppearing();
+					e.NewElement.SendAppearing();
 			}
 		}
 
@@ -67,13 +65,13 @@ namespace Xamarin.Forms.Platform.WinRT
 				return;
 			}
 			_loaded = true;
-			PageController?.SendAppearing();
+			Element?.SendAppearing();
 		}
 
 		void OnUnloaded(object sender, RoutedEventArgs args)
 		{
 			_loaded = false;
-			PageController?.SendDisappearing();
+			Element?.SendDisappearing();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WinRT/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ScrollViewRenderer.cs
@@ -21,11 +21,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			AutoPackage = false;
 		}
 
-		protected IScrollViewController Controller
-		{
-			get { return Element; }
-		}
-
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			SizeRequest result = base.GetDesiredSize(widthConstraint, heightConstraint);
@@ -77,7 +72,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			if (e.OldElement != null)
 			{
-				((IScrollViewController)e.OldElement).ScrollToRequested -= OnScrollToRequested;
+				e.OldElement.ScrollToRequested -= OnScrollToRequested;
 			}
 
 			if (e.NewElement != null)
@@ -89,7 +84,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					Control.ViewChanged += OnViewChanged;
 				}
 
-				Controller.ScrollToRequested += OnScrollToRequested;
+				Element.ScrollToRequested += OnScrollToRequested;
 
 				UpdateOrientation();
 
@@ -136,7 +131,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			ScrollToMode mode = e.Mode;
 			if (mode == ScrollToMode.Element)
 			{
-				Point pos = Controller.GetScrollPositionForElement((VisualElement)e.Element, e.Position);
+				Point pos = Element.GetScrollPositionForElement((VisualElement)e.Element, e.Position);
 				x = pos.X;
 				y = pos.Y;
 				mode = ScrollToMode.Position;
@@ -146,15 +141,15 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				Control.ChangeView(x, y, null, !e.ShouldAnimate);
 			}
-			Controller.SendScrollFinished();
+			Element.SendScrollFinished();
 		}
 
 		void OnViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
 		{
-			Controller.SetScrolledPosition(Control.HorizontalOffset, Control.VerticalOffset);
+			Element.SetScrolledPosition(Control.HorizontalOffset, Control.VerticalOffset);
 
 			if (!e.IsIntermediate)
-				Controller.SendScrollFinished();
+				Element.SendScrollFinished();
 		}
 
 		void UpdateMargins()

--- a/Xamarin.Forms.Platform.WinRT/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/TableViewRenderer.cs
@@ -13,7 +13,6 @@ namespace Xamarin.Forms.Platform.WinRT
 	public class TableViewRenderer : ViewRenderer<TableView, Windows.UI.Xaml.Controls.ListView>
 	{
 		bool _ignoreSelectionEvent;
-		ITableViewController Controller => Element;
 
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
@@ -26,7 +25,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		{
 			if (e.OldElement != null)
 			{
-				((ITableViewController)e.OldElement).ModelChanged -= OnModelChanged;
+				e.OldElement.ModelChanged -= OnModelChanged;
 			}
 
 			if (e.NewElement != null)
@@ -47,7 +46,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					Control.SelectionChanged += OnSelectionChanged;
 				}
 
-				((ITableViewController)e.NewElement).ModelChanged += OnModelChanged;
+				e.NewElement.ModelChanged += OnModelChanged;
 				OnModelChanged(e.NewElement, EventArgs.Empty);
 			}
 
@@ -75,7 +74,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					if (cell != null)
 					{
 						if (cell.IsEnabled)
-							Controller.Model.RowSelected(cell);
+							Element.Model.RowSelected(cell);
 						break;
 					}
 				}

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -261,9 +261,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				if (!_wasPanGestureStartedSent)
 				{
-					((IPanGestureController)recognizer).SendPanStarted(view, Application.Current.PanGestureId);
+					recognizer.SendPanStarted(view, Application.Current.PanGestureId);
 				}
-				((IPanGestureController)recognizer).SendPan(view, e.Delta.Translation.X + e.Cumulative.Translation.X, e.Delta.Translation.Y + e.Cumulative.Translation.Y, Application.Current.PanGestureId);
+				recognizer.SendPan(view, e.Delta.Translation.X + e.Cumulative.Translation.X, e.Delta.Translation.Y + e.Cumulative.Translation.Y, Application.Current.PanGestureId);
 			}
 			_wasPanGestureStartedSent = true;
 		}
@@ -283,9 +283,9 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				if (!_wasPinchGestureStartedSent)
 				{
-					((IPinchGestureController)recognizer).SendPinchStarted(view, scaleOriginPoint);
+					recognizer.SendPinchStarted(view, scaleOriginPoint);
 				}
-				((IPinchGestureController)recognizer).SendPinch(view, e.Delta.Scale, scaleOriginPoint);
+				recognizer.SendPinch(view, e.Delta.Scale, scaleOriginPoint);
 			}
 			_wasPinchGestureStartedSent = true;
 		}
@@ -413,11 +413,11 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				if (success)
 				{
-					((IPanGestureController)recognizer).SendPanCompleted(view, Application.Current.PanGestureId);
+					recognizer.SendPanCompleted(view, Application.Current.PanGestureId);
 				}
 				else
 				{
-					((IPanGestureController)recognizer).SendPanCanceled(view, Application.Current.PanGestureId);
+					recognizer.SendPanCanceled(view, Application.Current.PanGestureId);
 				}
 			}
 
@@ -436,11 +436,11 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				if (success)
 				{
-					((IPinchGestureController)recognizer).SendPinchEnded(view);
+					recognizer.SendPinchEnded(view);
 				}
 				else
 				{
-					((IPinchGestureController)recognizer).SendPinchCanceled(view);
+					recognizer.SendPinchCanceled(view);
 				}
 			}
 

--- a/Xamarin.Forms.Platform.WinRT/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/WebViewRenderer.cs
@@ -31,8 +31,6 @@ var bases = head.getElementsByTagName('base');
 if(bases.length == 0){
     head.innerHTML = 'baseTag' + head.innerHTML;
 }";
-		IWebViewController ElementController => Element;
-
 		public void LoadHtml(string html, string baseUrl)
 		{
 			if (IsNullOrEmpty(baseUrl))
@@ -99,10 +97,10 @@ if(bases.length == 0){
 
 			if (e.OldElement != null)
 			{
-				var oldElementController = e.OldElement as IWebViewController;
-				oldElementController.EvalRequested -= OnEvalRequested;
-				oldElementController.GoBackRequested -= OnGoBackRequested;
-				oldElementController.GoForwardRequested -= OnGoForwardRequested;
+				var oldElement = e.OldElement;
+				oldElement.EvalRequested -= OnEvalRequested;
+				oldElement.GoBackRequested -= OnGoBackRequested;
+				oldElement.GoForwardRequested -= OnGoForwardRequested;
 			}
 
 			if (e.NewElement != null)
@@ -116,10 +114,10 @@ if(bases.length == 0){
 					SetNativeControl(webView);
 				}
 
-				var newElementController = e.NewElement as IWebViewController;
-				newElementController.EvalRequested += OnEvalRequested;
-				newElementController.GoForwardRequested += OnGoForwardRequested;
-				newElementController.GoBackRequested += OnGoBackRequested;
+				var newElement = e.NewElement;
+				newElement.EvalRequested += OnEvalRequested;
+				newElement.GoForwardRequested += OnGoForwardRequested;
+				newElement.GoBackRequested += OnGoBackRequested;
 
 				Load();
 			}
@@ -193,7 +191,7 @@ if(bases.length == 0){
 			{
 				var args = new WebNavigatingEventArgs(_eventState, new UrlWebViewSource { Url = uri.AbsoluteUri }, uri.AbsoluteUri);
 
-				ElementController.SendNavigating(args);
+				Element.SendNavigating(args);
 				e.Cancel = args.Cancel;
 
 				// reset in this case because this is the last event we will get
@@ -208,7 +206,7 @@ if(bases.length == 0){
 			((IElementController)Element).SetValueFromRenderer(WebView.SourceProperty, source);
 			_updating = false;
 
-			ElementController.SendNavigated(new WebNavigatedEventArgs(evnt, source, source.Url, result));
+			Element.SendNavigated(new WebNavigatedEventArgs(evnt, source, source.Url, result));
 
 			UpdateCanGoBackForward();
 			_eventState = WebNavigationEvent.NewPage;
@@ -216,8 +214,8 @@ if(bases.length == 0){
 
 		void UpdateCanGoBackForward()
 		{
-			ElementController.CanGoBack = Control.CanGoBack;
-			ElementController.CanGoForward = Control.CanGoForward;
+			((IWebViewController)Element).CanGoBack = Control.CanGoBack;
+			((IWebViewController)Element).CanGoForward = Control.CanGoForward;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -19,19 +19,17 @@ namespace Xamarin.Forms.Platform.iOS
 			get { return _cell; }
 			set
 			{
-				if (_cell == value)
+				if (this._cell == value)
 					return;
 
-				ICellController cellController = _cell;
+				if (_cell != null)
+					Device.BeginInvokeOnMainThread(_cell.SendDisappearing);
 
-				if (cellController != null)
-					Device.BeginInvokeOnMainThread(cellController.SendDisappearing);
-
+				this._cell = value;
 				_cell = value;
-				cellController = value;
 
-				if (cellController != null)
-					Device.BeginInvokeOnMainThread(cellController.SendAppearing);
+				if (_cell != null)
+					Device.BeginInvokeOnMainThread(_cell.SendAppearing);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -150,14 +150,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 			void UpdateCell(ViewCell cell)
 			{
-				ICellController cellController = _viewCell;
-				if (cellController != null)
-					Device.BeginInvokeOnMainThread(cellController.SendDisappearing);
+				if (_viewCell != null)
+					Device.BeginInvokeOnMainThread(_viewCell.SendDisappearing);
 
+				this._viewCell = cell;
 				_viewCell = cell;
-				cellController = cell;
 
-				Device.BeginInvokeOnMainThread(cellController.SendAppearing);
+				Device.BeginInvokeOnMainThread(_viewCell.SendAppearing);
 
 				IVisualElementRenderer renderer;
 				if (_rendererRef == null || !_rendererRef.TryGetTarget(out renderer))
@@ -167,9 +166,9 @@ namespace Xamarin.Forms.Platform.iOS
 					if (renderer.Element != null && renderer == Platform.GetRenderer(renderer.Element))
 						renderer.Element.ClearValue(Platform.RendererProperty);
 
-					var type = Internals.Registrar.Registered.GetHandlerType(_viewCell.View.GetType());
+					var type = Internals.Registrar.Registered.GetHandlerType(this._viewCell.View.GetType());
 					if (renderer.GetType() == type || (renderer is Platform.DefaultRenderer && type == null))
-						renderer.SetElement(_viewCell.View);
+						renderer.SetElement(this._viewCell.View);
 					else
 					{
 						//when cells are getting reused the element could be already set to another cell
@@ -180,7 +179,7 @@ namespace Xamarin.Forms.Platform.iOS
 					}
 				}
 
-				Platform.SetRenderer(_viewCell.View, renderer);
+				Platform.SetRenderer(this._viewCell.View, renderer);
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -117,7 +117,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public void Update(UITableView tableView, Cell cell, UITableViewCell nativeCell)
 		{
-			var parentListView = cell.RealParent as IListViewController;
+			var parentListView = cell.RealParent as ListView;
 			var recycling = parentListView != null && parentListView.CachingStrategy == ListViewCachingStrategy.RecycleElement;
 			if (_cell != cell && recycling)
 			{
@@ -322,7 +322,7 @@ namespace Xamarin.Forms.Platform.iOS
 						_scroller.SetContentOffset(new PointF(0, 0), true);
 						MenuItem mi;
 						if (weakItem.TryGetTarget(out mi))
-							((IMenuItemController)mi).Activate();
+							mi.Activate();
 					});
 					actionSheet.AddAction(action);
 				}
@@ -399,7 +399,7 @@ namespace Xamarin.Forms.Platform.iOS
 			button.SetTitle(item.Text, UIControlState.Normal);
 			button.TitleEdgeInsets = new UIEdgeInsets(0, 15, 0, 15);
 
-			button.Enabled = ((IMenuItemController)item).IsEnabled;
+			button.Enabled = item.IsEnabled;
 
 			return button;
 		}
@@ -440,7 +440,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				_scroller.SetContentOffset(new PointF(0, 0), true);
-				((IMenuItemController)_cell.ContextActions[(int)button.Tag]).Activate();
+				_cell.ContextActions[(int)button.Tag].Activate();
 			}
 		}
 
@@ -448,7 +448,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (e.PropertyName == "HasContextActions")
 			{
-				var parentListView = _cell.RealParent as IListViewController;
+				var parentListView = _cell.RealParent as ListView;
 				var recycling = parentListView != null && parentListView.CachingStrategy == ListViewCachingStrategy.RecycleElement;
 				if (!recycling)
 					ReloadRow();
@@ -457,7 +457,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnContextItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			var parentListView = _cell.RealParent as IListViewController;
+			var parentListView = _cell.RealParent as ListView;
 			var recycling = parentListView != null && parentListView.CachingStrategy == ListViewCachingStrategy.RecycleElement;
 			if (recycling)
 				Update(_tableView, _cell, ContentCell);
@@ -468,7 +468,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnMenuItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			var parentListView = _cell.RealParent as IListViewController;
+			var parentListView = _cell.RealParent as ListView;
 			var recycling = parentListView != null && parentListView.CachingStrategy == ListViewCachingStrategy.RecycleElement;
 			if (recycling)
 				Update(_tableView, _cell, ContentCell);
@@ -690,7 +690,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				// do not activate a -1 index when dismissing by clicking outside the popover
 				if (buttonIndex >= 0)
-					((IMenuItemController)Items[(int)buttonIndex]).Activate();
+					Items[(int)buttonIndex].Activate();
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				double startingScale = 1;
 				var uiRecognizer = CreatePinchRecognizer(r =>
 				{
-					var pinchGestureRecognizer = weakRecognizer.Target as IPinchGestureController;
+					var pinchGestureRecognizer = weakRecognizer.Target as PinchGestureRecognizer;
 					var eventTracker = weakEventTracker.Target as EventTracker;
 					var view = eventTracker?._renderer?.Element as View;
 
@@ -190,7 +190,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					var eventTracker = weakEventTracker.Target as EventTracker;
 					var view = eventTracker?._renderer?.Element as View;
 
-					var panGestureRecognizer = weakRecognizer.Target as IPanGestureController;
+					var panGestureRecognizer = weakRecognizer.Target as PanGestureRecognizer;
 					if (panGestureRecognizer != null && view != null)
 					{
 						switch (r.State)

--- a/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
@@ -19,8 +19,6 @@ namespace Xamarin.Forms.Platform.iOS
 			readonly bool _forceName;
 			readonly ToolbarItem _item;
 
-			IMenuItemController Controller => _item;
-
 			public PrimaryToolbarItem(ToolbarItem item, bool forceName)
 			{
 				_forceName = forceName;
@@ -32,7 +30,7 @@ namespace Xamarin.Forms.Platform.iOS
 					UpdateTextAndStyle();
 				UpdateIsEnabled();
 
-				Clicked += (sender, e) => Controller.Activate();
+				Clicked += (sender, e) => _item.Activate();
 				item.PropertyChanged += OnPropertyChanged;
 
 				if (item != null && !string.IsNullOrEmpty(item.AutomationId))
@@ -48,7 +46,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
 			{
-				if (e.PropertyName == Controller.IsEnabledPropertyName)
+				if (e.PropertyName == _item.IsEnabledPropertyName)
 					UpdateIsEnabled();
 				else if (e.PropertyName == MenuItem.TextProperty.PropertyName)
 				{
@@ -77,7 +75,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			void UpdateIsEnabled()
 			{
-				Enabled = Controller.IsEnabled;
+				Enabled = _item.IsEnabled;
 			}
 
 			void UpdateTextAndStyle()
@@ -91,7 +89,6 @@ namespace Xamarin.Forms.Platform.iOS
 		sealed class SecondaryToolbarItem : UIBarButtonItem
 		{
 			readonly ToolbarItem _item;
-			IMenuItemController Controller => _item;
 
 			public SecondaryToolbarItem(ToolbarItem item) : base(new SecondaryToolbarItemContent())
 			{
@@ -100,7 +97,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateIcon();
 				UpdateIsEnabled();
 
-				((SecondaryToolbarItemContent)CustomView).TouchUpInside += (sender, e) => Controller.Activate();
+				((SecondaryToolbarItemContent)CustomView).TouchUpInside += (sender, e) => _item.Activate();
 				item.PropertyChanged += OnPropertyChanged;
 
 				if (item != null && !string.IsNullOrEmpty(item.AutomationId))
@@ -120,7 +117,7 @@ namespace Xamarin.Forms.Platform.iOS
 					UpdateText();
 				else if (e.PropertyName == MenuItem.IconProperty.PropertyName)
 					UpdateIcon();
-				else if (e.PropertyName == Controller.IsEnabledPropertyName)
+				else if (e.PropertyName == _item.IsEnabledPropertyName)
 					UpdateIsEnabled();
 			}
 
@@ -137,7 +134,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			void UpdateIsEnabled()
 			{
-				((UIControl)CustomView).Enabled = Controller.IsEnabled;
+				((UIControl)CustomView).Enabled = _item.IsEnabled;
 			}
 
 			void UpdateText()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			IImageSourceHandler handler;
 
-			((IImageController)Element).SetIsLoading(true);
+			Element.SetIsLoading(true);
 
 			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
 			{
@@ -131,7 +131,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.Image = null;
 
 			if (!_isDisposed)
-				((IImageController)Element).SetIsLoading(false);
+				Element.SetIsLoading(false);
 		}
 
 		void SetOpacity()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _shouldEstimateRowHeight = true;
 
 		FormsUITableViewController _tableViewController;
-		IListViewController Controller => Element;
+		ListView ListView => Element;
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
 		public override UIViewController ViewController => _tableViewController;
 		bool _disposed;
@@ -156,12 +156,12 @@ namespace Xamarin.Forms.Platform.iOS
 					_footerRenderer = null;
 				}
 
-				var headerView = Controller?.HeaderElement as VisualElement;
+				var headerView = ListView?.HeaderElement as VisualElement;
 				if (headerView != null)
 					headerView.MeasureInvalidated -= OnHeaderMeasureInvalidated;
 				Control?.TableHeaderView?.Dispose();
 
-				var footerView = Controller?.FooterElement as VisualElement;
+				var footerView = ListView?.FooterElement as VisualElement;
 				if (footerView != null)
 					footerView.MeasureInvalidated -= OnFooterMeasureInvalidated;
 				Control?.TableFooterView?.Dispose();
@@ -178,16 +178,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (e.OldElement != null)
 			{
-				var controller = (IListViewController)e.OldElement;
-				var headerView = (VisualElement)controller.HeaderElement;
+				var listView = e.OldElement;
+				var headerView = (VisualElement)listView.HeaderElement;
 				if (headerView != null)
 					headerView.MeasureInvalidated -= OnHeaderMeasureInvalidated;
 
-				var footerView = (VisualElement)controller.FooterElement;
+				var footerView = (VisualElement)listView.FooterElement;
 				if (footerView != null)
 					footerView.MeasureInvalidated -= OnFooterMeasureInvalidated;
 
-				controller.ScrollToRequested -= OnScrollToRequested;
+				listView.ScrollToRequested -= OnScrollToRequested;
 				var templatedItems = ((ITemplatedItemsView<Cell>)e.OldElement).TemplatedItems;
 
 				templatedItems.CollectionChanged -= OnCollectionChanged;
@@ -212,9 +212,9 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 				_shouldEstimateRowHeight = true;
 
-				var controller = (IListViewController)e.NewElement;
+				var listView = e.NewElement;
 
-				controller.ScrollToRequested += OnScrollToRequested;
+				listView.ScrollToRequested += OnScrollToRequested;
 				var templatedItems = ((ITemplatedItemsView<Cell>)e.NewElement).TemplatedItems;
 
 				templatedItems.CollectionChanged += OnCollectionChanged;
@@ -243,22 +243,22 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-			if (e.PropertyName == ListView.RowHeightProperty.PropertyName)
+			if (e.PropertyName == Xamarin.Forms.ListView.RowHeightProperty.PropertyName)
 				UpdateRowHeight();
-			else if (e.PropertyName == ListView.IsGroupingEnabledProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.ListView.IsGroupingEnabledProperty.PropertyName)
 				_dataSource.UpdateGrouping();
-			else if (e.PropertyName == ListView.HasUnevenRowsProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.ListView.HasUnevenRowsProperty.PropertyName)
 			{
 				_estimatedRowHeight = false;
 				Control.Source = _dataSource = Element.HasUnevenRows ? new UnevenListViewDataSource(_dataSource) : new ListViewDataSource(_dataSource);
 			}
-			else if (e.PropertyName == ListView.IsPullToRefreshEnabledProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.ListView.IsPullToRefreshEnabledProperty.PropertyName)
 				UpdatePullToRefreshEnabled();
-			else if (e.PropertyName == ListView.IsRefreshingProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.ListView.IsRefreshingProperty.PropertyName)
 				UpdateIsRefreshing();
-			else if (e.PropertyName == ListView.SeparatorColorProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.ListView.SeparatorColorProperty.PropertyName)
 				UpdateSeparatorColor();
-			else if (e.PropertyName == ListView.SeparatorVisibilityProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.ListView.SeparatorVisibilityProperty.PropertyName)
 				UpdateSeparatorVisibility();
 			else if (e.PropertyName == "HeaderElement")
 				UpdateHeader();
@@ -395,7 +395,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateFooter()
 		{
-			var footer = Controller.FooterElement;
+			var footer = ListView.FooterElement;
 			var footerView = (View)footer;
 
 			if (footerView != null)
@@ -441,7 +441,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateHeader()
 		{
-			var header = Controller.HeaderElement;
+			var header = ListView.HeaderElement;
 			var headerView = (View)header;
 
 			if (headerView != null)
@@ -574,7 +574,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (_tableViewController != null)
 			{
-				var isPullToRequestEnabled = Element.IsPullToRefreshEnabled && Controller.RefreshAllowed;
+				var isPullToRequestEnabled = Element.IsPullToRefreshEnabled && ListView.RefreshAllowed;
 				_tableViewController.UpdatePullToRefreshEnabled(isPullToRequestEnabled);
 			}
 		}
@@ -730,7 +730,6 @@ namespace Xamarin.Forms.Platform.iOS
 			UITableView _uiTableView;
 			FormsUITableViewController _uiTableViewController;
 			protected ListView List;
-			IListViewController Controller => List;
 			protected ITemplatedItemsView<Cell> TemplatedItemsView => List;
 			bool _isDragging;
 			bool _selectionFromNative;
@@ -783,7 +782,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Cell cell;
 				UITableViewCell nativeCell;
 
-				var cachingStrategy = Controller.CachingStrategy;
+				var cachingStrategy = List.CachingStrategy;
 				if (cachingStrategy == ListViewCachingStrategy.RetainElement)
 				{
 					cell = GetCellForPath(indexPath);
@@ -801,11 +800,12 @@ namespace Xamarin.Forms.Platform.iOS
 					else
 					{
 						var templatedList = TemplatedItemsView.TemplatedItems.GetGroup(indexPath.Section);
-						cell = (Cell)((INativeElementView)nativeCell).Element;
-						ICellController controller = cell;
-						controller.SendDisappearing();
+
+						var cell = (Cell)((INativeElementView)nativeCell).Element;
+						cell.SendDisappearing();
+
 						templatedList.UpdateContent(cell, indexPath.Row);
-						controller.SendAppearing();
+						cell.SendAppearing();
 					}
 				}
 				else
@@ -911,7 +911,7 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 
 				Cell formsCell = null;
-				if (Controller.CachingStrategy == ListViewCachingStrategy.RecycleElement)
+				if (List.CachingStrategy == ListViewCachingStrategy.RecycleElement)
 					formsCell = (Cell)((INativeElementView)cell).Element;
 
 				SetCellBackgroundColor(cell, UIColor.Clear);
@@ -920,7 +920,7 @@ namespace Xamarin.Forms.Platform.iOS
 					_selectionFromNative = true;
 
 				tableView.EndEditing(true);
-				Controller.NotifyRowTapped(indexPath.Section, indexPath.Row, formsCell);
+				List.NotifyRowTapped(indexPath.Section, indexPath.Row, formsCell);
 			}
 
 			public override nint RowsInSection(UITableView tableview, nint section)
@@ -1114,7 +1114,6 @@ namespace Xamarin.Forms.Platform.iOS
 	internal class FormsUITableViewController : UITableViewController
 	{
 		ListView _list;
-		IListViewController Controller => _list;
 		UIRefreshControl _refresh;
 
 		bool _refreshAdded;
@@ -1233,7 +1232,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnRefreshingChanged(object sender, EventArgs eventArgs)
 		{
 			if (_refresh.Refreshing)
-				Controller.SendRefreshing();
+				_list.SendRefreshing();
 		}
 
 		void RemoveRefresh()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -801,7 +801,7 @@ namespace Xamarin.Forms.Platform.iOS
 					{
 						var templatedList = TemplatedItemsView.TemplatedItems.GetGroup(indexPath.Section);
 
-						var cell = (Cell)((INativeElementView)nativeCell).Element;
+						cell = (Cell)((INativeElementView)nativeCell).Element;
 						cell.SendDisappearing();
 
 						templatedList.UpdateContent(cell, indexPath.Row);

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationMenuRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationMenuRenderer.cs
@@ -110,8 +110,6 @@ namespace Xamarin.Forms.Platform.iOS
 				_menu = menu;
 			}
 
-			INavigationMenuController MenuController => _menu;
-
 			public override UICollectionViewCell GetCell(UICollectionView collectionView, NSIndexPath indexPath)
 			{
 				var cell = (NavigationCell)collectionView.DequeueReusableCell(new NSString("NavigationCell"), indexPath);
@@ -121,7 +119,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					cell.Name = target.Title;
 					cell.Icon = target.Icon?.File;
-					cell.Selected = () => MenuController.SendTargetSelected(target);
+					cell.Selected = () => _menu.SendTargetSelected(target);
 				}
 				else
 				{

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -196,20 +196,18 @@ namespace Xamarin.Forms.Platform.iOS
 					"NavigationPage must have a root Page before being used. Either call PushAsync with a valid Page, or pass a Page to the constructor before usage.");
 			}
 
-			var navController = ((INavigationPageController)navPage);
-
-			navController.PushRequested += OnPushRequested;
-			navController.PopRequested += OnPopRequested;
-			navController.PopToRootRequested += OnPopToRootRequested;
-			navController.RemovePageRequested += OnRemovedPageRequested;
-			navController.InsertPageBeforeRequested += OnInsertPageBeforeRequested;
+			navPage.PushRequested += OnPushRequested;
+			navPage.PopRequested += OnPopRequested;
+			navPage.PopToRootRequested += OnPopToRootRequested;
+			navPage.RemovePageRequested += OnRemovedPageRequested;
+			navPage.InsertPageBeforeRequested += OnInsertPageBeforeRequested;
 
 			UpdateTint();
 			UpdateBarBackgroundColor();
 			UpdateBarTextColor();
 
 			// If there is already stuff on the stack we need to push it
-			((INavigationPageController)navPage).Pages.ForEach(async p => await PushPageAsync(p, false));
+			navPage.Pages.ForEach(async p => await PushPageAsync(p, false));
 
 			_tracker = new VisualElementTracker(this);
 
@@ -242,12 +240,11 @@ namespace Xamarin.Forms.Platform.iOS
 				var navPage = (NavigationPage)Element;
 				navPage.PropertyChanged -= HandlePropertyChanged;
 
-				var navController = ((INavigationPageController)navPage);
-				navController.PushRequested -= OnPushRequested;
-				navController.PopRequested -= OnPopRequested;
-				navController.PopToRootRequested -= OnPopToRootRequested;
-				navController.RemovePageRequested -= OnRemovedPageRequested;
-				navController.InsertPageBeforeRequested -= OnInsertPageBeforeRequested;
+				navPage.PushRequested -= OnPushRequested;
+				navPage.PopRequested -= OnPopRequested;
+				navPage.PopToRootRequested -= OnPopToRootRequested;
+				navPage.RemovePageRequested -= OnRemovedPageRequested;
+				navPage.InsertPageBeforeRequested -= OnInsertPageBeforeRequested;
 			}
 
 			base.Dispose(disposing);
@@ -547,7 +544,7 @@ namespace Xamarin.Forms.Platform.iOS
 				for (var i = 0; i < removed; i++)
 				{
 					// lets just pop these suckers off, do not await, the true is there to make this fast
-					await ((INavigationPageController)Element).PopAsyncInner(animated, true);
+					await ((NavigationPage)Element).PopAsyncInner(animated, true);
 				}
 				// because we skip the normal pop process we need to dispose ourselves
 				controller.Dispose();
@@ -622,7 +619,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (containerController == null)
 				return;
 			var currentChild = containerController.Child;
-			var firstPage = ((INavigationPageController)Element).Pages.FirstOrDefault(); 
+			var firstPage = ((NavigationPage)Element).Pages.FirstOrDefault(); 
 			if ((firstPage != pageBeingRemoved && currentChild != firstPage && NavigationPage.GetHasBackButton(currentChild)) || _parentMasterDetailPage == null)
 				return;
 
@@ -849,7 +846,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (disposing)
 				{
-					((IPageController)Child).SendDisappearing();
+					Child.SendDisappearing();
 
 					if (Child != null)
 					{

--- a/Xamarin.Forms.Platform.iOS/Renderers/OpenGLViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/OpenGLViewRenderer.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Platform.iOS
 				_displayLink = null;
 
 				if (Element != null)
-					((IOpenGlViewController)Element).DisplayRequested -= Display;
+					Element.DisplayRequested -= Display;
 			}
 
 			base.Dispose(disposing);
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void OnElementChanged(ElementChangedEventArgs<OpenGLView> e)
 		{
 			if (e.OldElement != null)
-				((IOpenGlViewController)e.OldElement).DisplayRequested -= Display;
+				e.OldElement.DisplayRequested -= Display;
 
 			if (e.NewElement != null)
 			{
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var glkView = new GLKView(RectangleF.Empty) { Context = context, DrawableDepthFormat = GLKViewDrawableDepthFormat.Format24, Delegate = new Delegate(e.NewElement) };
 				SetNativeControl(glkView);
 
-				((IOpenGlViewController)e.NewElement).DisplayRequested += Display;
+				e.NewElement.DisplayRequested += Display;
 
 				SetupRenderLoop(false);
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.iOS
 		VisualElementPackager _packager;
 		VisualElementTracker _tracker;
 
-		IPageController PageController => Element as IPageController;
+		Page Page => Element as Page;
 
 		public PageRenderer()
 		{
@@ -73,7 +73,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			_appeared = true;
-			PageController.SendAppearing();
+			Page.SendAppearing();
 			UpdateStatusBarPrefersHidden();
 		}
 
@@ -85,7 +85,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			_appeared = false;
-			PageController.SendDisappearing();
+			Page.SendDisappearing();
 		}
 
 		public override void ViewDidLoad()
@@ -128,7 +128,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Element.PropertyChanged -= OnHandlePropertyChanged;
 				Platform.SetRenderer(Element, null);
 				if (_appeared)
-					PageController.SendDisappearing();
+					Page.SendDisappearing();
 
 				_appeared = false;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -24,13 +24,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		VisualElementTracker _tracker;
 
-		IPageController PageController => Element as IPageController;
+		Page Page => Element as Page;
 
 		public PhoneMasterDetailRenderer()
 		{
 		}
 
-		IMasterDetailPageController MasterDetailPageController => Element as IMasterDetailPageController;
+		MasterDetailPage MasterDetailPage => Element as MasterDetailPage;
 
 		bool Presented
 		{
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Platform.iOS
 				else
 					RemoveClickOffView();
 
-				((IElementController)Element).SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, value);
+				((IElementController)Element).SetValueFromRenderer(Xamarin.Forms.MasterDetailPage.IsPresentedProperty, value);
 			}
 		}
 
@@ -99,13 +99,13 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewDidAppear(bool animated)
 		{
 			base.ViewDidAppear(animated);
-			PageController.SendAppearing();
+			Page.SendAppearing();
 		}
 
 		public override void ViewDidDisappear(bool animated)
 		{
 			base.ViewDidDisappear(animated);
-			PageController?.SendDisappearing();
+			Page?.SendDisappearing();
 		}
 
 		public override void ViewDidLayoutSubviews()
@@ -142,7 +142,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void WillRotate(UIInterfaceOrientation toInterfaceOrientation, double duration)
 		{
-			if (!MasterDetailPageController.ShouldShowSplitMode && _presented)
+			if (!MasterDetailPage.ShouldShowSplitMode && _presented)
 				Presented = false;
 
 			base.WillRotate(toInterfaceOrientation, duration);
@@ -185,7 +185,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				EmptyContainers();
 
-				PageController.SendDisappearing();
+				Page.SendDisappearing();
 
 				_disposed = true;
 			}
@@ -225,9 +225,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (e.PropertyName == "Master" || e.PropertyName == "Detail")
 				UpdateMasterDetailContainers();
-			else if (e.PropertyName == MasterDetailPage.IsPresentedProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.MasterDetailPage.IsPresentedProperty.PropertyName)
 				Presented = ((MasterDetailPage)Element).IsPresented;
-			else if (e.PropertyName == MasterDetailPage.IsGestureEnabledProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.MasterDetailPage.IsGestureEnabledProperty.PropertyName)
 				UpdatePanGesture();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackground();
@@ -259,8 +259,8 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				_detailController.View.Frame = target;
 
-			MasterDetailPageController.MasterBounds = new Rectangle(0, 0, masterFrame.Width, masterFrame.Height);
-			MasterDetailPageController.DetailBounds = new Rectangle(0, 0, frame.Width, frame.Height);
+			MasterDetailPage.MasterBounds = new Rectangle(0, 0, masterFrame.Width, masterFrame.Height);
+			MasterDetailPage.DetailBounds = new Rectangle(0, 0, frame.Width, frame.Height);
 
 			if (Presented)
 				_clickOffView.Frame = _detailController.View.Frame;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -25,11 +25,6 @@ namespace Xamarin.Forms.Platform.iOS
 			Scrolled += HandleScrolled;
 		}
 
-		protected IScrollViewController Controller
-		{
-			get { return (IScrollViewController)Element; }
-		}
-
 		ScrollView ScrollView
 		{
 			get { return Element as ScrollView; }
@@ -58,13 +53,13 @@ namespace Xamarin.Forms.Platform.iOS
 			if (oldElement != null)
 			{
 				oldElement.PropertyChanged -= HandlePropertyChanged;
-				((IScrollViewController)oldElement).ScrollToRequested -= OnScrollToRequested;
+				((ScrollView)oldElement).ScrollToRequested -= OnScrollToRequested;
 			}
 
 			if (element != null)
 			{
 				element.PropertyChanged += HandlePropertyChanged;
-				((IScrollViewController)element).ScrollToRequested += OnScrollToRequested;
+				((ScrollView)element).ScrollToRequested += OnScrollToRequested;
 				if (_packager == null)
 				{
 					_packager = new VisualElementPackager(this);
@@ -175,7 +170,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void HandleScrollAnimationEnded(object sender, EventArgs e)
 		{
-			Controller.SendScrollFinished();
+			ScrollView.SendScrollFinished();
 		}
 
 		void HandleScrolled(object sender, EventArgs e)
@@ -200,7 +195,7 @@ namespace Xamarin.Forms.Platform.iOS
 				SetContentOffset(new PointF((nfloat)e.ScrollX, (nfloat)e.ScrollY), e.ShouldAnimate);
 			else
 			{
-				var positionOnScroll = Controller.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
+				var positionOnScroll = ScrollView.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
 
 				positionOnScroll.X = positionOnScroll.X.Clamp(0, ContentSize.Width - Bounds.Size.Width);
 				positionOnScroll.Y = positionOnScroll.Y.Clamp(0, ContentSize.Height - Bounds.Size.Height);
@@ -219,7 +214,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			}
 			if (!e.ShouldAnimate)
-				Controller.SendScrollFinished();
+				ScrollView.SendScrollFinished();
 		}
 
 		void UpdateDelaysContentTouches()
@@ -242,7 +237,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateScrollPosition()
 		{
 			if (ScrollView != null)
-				Controller.SetScrolledPosition(ContentOffset.X, ContentOffset.Y);
+				ScrollView.SetScrolledPosition(ContentOffset.X, ContentOffset.Y);
 		}
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -137,7 +137,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnSearchButtonClicked(object sender, EventArgs e)
 		{
-			((ISearchBarController)Element).OnSearchButtonPressed();
+			Element.OnSearchButtonPressed();
 			Control.ResignFirstResponder();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -21,8 +21,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _loaded;
 		Size _queuedSize;
 
-		IPageController PageController => Element as IPageController;
-		IElementController ElementController => Element as IElementController;
+		Page Page => Element as Page;
 
 		public override UIViewController SelectedViewController
 		{
@@ -100,14 +99,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewDidAppear(bool animated)
 		{
-			PageController.SendAppearing();
+			Page.SendAppearing();
 			base.ViewDidAppear(animated);
 		}
 
 		public override void ViewDidDisappear(bool animated)
 		{
 			base.ViewDidDisappear(animated);
-			PageController.SendDisappearing();
+			Page.SendDisappearing();
 		}
 
 		public override void ViewDidLayoutSubviews()
@@ -124,7 +123,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var frame = View.Frame;
 			var tabBarFrame = TabBar.Frame;
-			PageController.ContainerArea = new Rectangle(0, 0, frame.Width, frame.Height - tabBarFrame.Height);
+			Page.ContainerArea = new Rectangle(0, 0, frame.Width, frame.Height - tabBarFrame.Height);
 
 			if (!_queuedSize.IsZero)
 			{
@@ -139,7 +138,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (disposing)
 			{
-				PageController.SendDisappearing();
+				Page.SendDisappearing();
 				Tabbed.PropertyChanged -= OnPropertyChanged;
 				Tabbed.PagesChanged -= OnPagesChanged;
 				FinishedCustomizingViewControllers -= HandleFinishedCustomizingViewControllers;
@@ -267,9 +266,9 @@ namespace Xamarin.Forms.Platform.iOS
 		void SetControllers()
 		{
 			var list = new List<UIViewController>();
-			for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
+			for (var i = 0; i < Element.LogicalChildren.Count; i++)
 			{
-				var child = ElementController.LogicalChildren[i];
+				var child = Element.LogicalChildren[i];
 				var v = child as VisualElement;
 				if (v == null)
 					continue;
@@ -368,7 +367,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var originalIndex = -1;
 				if (int.TryParse(viewControllers[i].TabBarItem.Tag.ToString(), out originalIndex))
 				{
-					var page = (Page)((IPageController)Tabbed).InternalChildren[originalIndex];
+					var page = (Page)Tabbed.InternalChildren[originalIndex];
 					TabbedPage.SetIndex(page, i);
 				}
 			}
@@ -376,7 +375,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateCurrentPage()
 		{
-			var count = ((IPageController)Tabbed).InternalChildren.Count;
+			var count = Tabbed.InternalChildren.Count;
 			var index = (int)SelectedIndex;
 			((TabbedPage)Element).CurrentPage = index >= 0 && index < count ? Tabbed.GetPageByIndex(index) : null;
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
@@ -9,8 +9,6 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		readonly Dictionary<nint, Cell> _headerCells = new Dictionary<nint, Cell>();
 
-		protected ITableViewController Controller => View;
-
 		protected bool HasBoundGestures;
 		protected UITableView Table;
 
@@ -19,7 +17,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public TableViewModelRenderer(TableView model)
 		{
 			View = model;
-			Controller.ModelChanged += (s, e) =>
+			View.ModelChanged += (s, e) =>
 			{
 				if (Table != null)
 					Table.ReloadData();
@@ -31,7 +29,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override UITableViewCell GetCell(UITableView tableView, NSIndexPath indexPath)
 		{
-			var cell = Controller.Model.GetCell(indexPath.Section, indexPath.Row);
+			var cell = View.Model.GetCell(indexPath.Section, indexPath.Row);
 
 			var nativeCell = CellTableViewCell.GetNativeCell(tableView, cell);
 			return nativeCell;
@@ -40,7 +38,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override nfloat GetHeightForHeader(UITableView tableView, nint section)
 		{
 			if (!_headerCells.ContainsKey((int)section))
-				_headerCells[section] = Controller.Model.GetHeaderCell((int)section);
+				_headerCells[section] = View.Model.GetHeaderCell((int)section);
 
 			var result = _headerCells[section];
 
@@ -50,7 +48,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override UIView GetViewForHeader(UITableView tableView, nint section)
 		{
 			if (!_headerCells.ContainsKey((int)section))
-				_headerCells[section] = Controller.Model.GetHeaderCell((int)section);
+				_headerCells[section] = View.Model.GetHeaderCell((int)section);
 
 			var result = _headerCells[section];
 
@@ -71,35 +69,35 @@ namespace Xamarin.Forms.Platform.iOS
 			if (indexPath == null)
 				return;
 
-			Controller.Model.RowLongPressed(indexPath.Section, indexPath.Row);
+			View.Model.RowLongPressed(indexPath.Section, indexPath.Row);
 		}
 
 		public override nint NumberOfSections(UITableView tableView)
 		{
 			BindGestures(tableView);
-			return Controller.Model.GetSectionCount();
+			return View.Model.GetSectionCount();
 		}
 
 		public override void RowSelected(UITableView tableView, NSIndexPath indexPath)
 		{
-			Controller.Model.RowSelected(indexPath.Section, indexPath.Row);
+			View.Model.RowSelected(indexPath.Section, indexPath.Row);
 			if (AutomaticallyDeselect)
 				tableView.DeselectRow(indexPath, true);
 		}
 
 		public override nint RowsInSection(UITableView tableview, nint section)
 		{
-			return Controller.Model.GetRowCount((int)section);
+			return View.Model.GetRowCount((int)section);
 		}
 
 		public override string[] SectionIndexTitles(UITableView tableView)
 		{
-			return Controller.Model.GetSectionIndexTitles();
+			return View.Model.GetSectionIndexTitles();
 		}
 
 		public override string TitleForHeader(UITableView tableView, nint section)
 		{
-			return Controller.Model.GetSectionTitle((int)section);
+			return View.Model.GetSectionTitle((int)section);
 		}
 
 		void BindGestures(UITableView tableview)

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -55,12 +55,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		VisualElementTracker _tracker;
 
-		IPageController PageController => Element as IPageController;
-		IElementController ElementController => Element as IElementController;
+		Page PageController => Element as Page;
+		Element ElementController => Element as Element;
 
 		protected MasterDetailPage MasterDetailPage => _masterDetailPage ?? (_masterDetailPage = (MasterDetailPage)Element);
-
-		IMasterDetailPageController MasterDetailPageController => MasterDetailPage as IMasterDetailPageController;
 
 		UIBarButtonItem PresentButton
 		{
@@ -187,10 +185,10 @@ namespace Xamarin.Forms.Platform.iOS
 			var masterBounds = _masterController.View.Frame;
 
 			if (!masterBounds.IsEmpty)
-				MasterDetailPageController.MasterBounds = new Rectangle(0, 0, masterBounds.Width, masterBounds.Height);
+				MasterDetailPage.MasterBounds = new Rectangle(0, 0, masterBounds.Width, masterBounds.Height);
 
 			if (!detailsBounds.IsEmpty)
-				MasterDetailPageController.DetailBounds = new Rectangle(0, 0, detailsBounds.Width, detailsBounds.Height);
+				MasterDetailPage.DetailBounds = new Rectangle(0, 0, detailsBounds.Width, detailsBounds.Height);
 		}
 
 		public override void ViewDidLoad()
@@ -220,14 +218,14 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			// On IOS8 the MasterViewController ViewAppear/Disappear weren't being called correctly after rotation 
 			// We now close the Master by using the new SplitView API, basicly we set it to hidden and right back to the Normal/AutomaticMode
-			if (!MasterDetailPageController.ShouldShowSplitMode && _masterVisible)
+			if (!MasterDetailPage.ShouldShowSplitMode && _masterVisible)
 			{
-				MasterDetailPageController.CanChangeIsPresented = true;
+				MasterDetailPage.CanChangeIsPresented = true;
 				PreferredDisplayMode = UISplitViewControllerDisplayMode.PrimaryHidden;
 				PreferredDisplayMode = UISplitViewControllerDisplayMode.Automatic;
 			}
 
-			MasterDetailPageController.UpdateMasterBehavior();
+			MasterDetailPage.UpdateMasterBehavior();
 			MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
 			base.WillRotate(toInterfaceOrientation, duration);
 		}
@@ -281,24 +279,24 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (e.PropertyName == "Master" || e.PropertyName == "Detail")
 				UpdateControllers();
-			else if (e.PropertyName == MasterDetailPage.IsPresentedProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.MasterDetailPage.IsPresentedProperty.PropertyName)
 				ToggleMaster();
-			else if (e.PropertyName == MasterDetailPage.IsGestureEnabledProperty.PropertyName)
-				PresentsWithGesture = MasterDetailPage.IsGestureEnabled;
+			else if (e.PropertyName == Xamarin.Forms.MasterDetailPage.IsGestureEnabledProperty.PropertyName)
+				base.PresentsWithGesture = this.MasterDetailPage.IsGestureEnabled;
 			MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
 		}
 
 		void MasterControllerWillAppear(object sender, EventArgs e)
 		{
 			_masterVisible = true;
-			if (MasterDetailPageController.CanChangeIsPresented)
+			if (MasterDetailPage.CanChangeIsPresented)
 				ElementController.SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, true);
 		}
 
 		void MasterControllerWillDisappear(object sender, EventArgs e)
 		{
 			_masterVisible = false;
-			if (MasterDetailPageController.CanChangeIsPresented)
+			if (MasterDetailPage.CanChangeIsPresented)
 				ElementController.SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, false);
 		}
 
@@ -309,7 +307,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void ToggleMaster()
 		{
-			if (_masterVisible == MasterDetailPage.IsPresented || MasterDetailPageController.ShouldShowSplitMode)
+			if (_masterVisible == MasterDetailPage.IsPresented || MasterDetailPage.ShouldShowSplitMode)
 				return;
 
 			PerformButtonSelector();

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 		}
 
-		IWebViewController ElementController => Element as IWebViewController;
+		WebView WebView => Element as WebView;
 
 		public VisualElement Element { get; private set; }
 
@@ -36,9 +36,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var oldElement = Element;
 			Element = element;
 			Element.PropertyChanged += HandlePropertyChanged;
-			ElementController.EvalRequested += OnEvalRequested;
-			ElementController.GoBackRequested += OnGoBackRequested;
-			ElementController.GoForwardRequested += OnGoForwardRequested;
+			WebView.EvalRequested += OnEvalRequested;
+			WebView.GoBackRequested += OnGoBackRequested;
+			WebView.GoForwardRequested += OnGoForwardRequested;
 			Delegate = new CustomWebViewDelegate(this);
 
 			BackgroundColor = UIColor.Clear;
@@ -98,9 +98,9 @@ namespace Xamarin.Forms.Platform.iOS
 					StopLoading();
 
 				Element.PropertyChanged -= HandlePropertyChanged;
-				ElementController.EvalRequested -= OnEvalRequested;
-				ElementController.GoBackRequested -= OnGoBackRequested;
-				ElementController.GoForwardRequested -= OnGoForwardRequested;
+				WebView.EvalRequested -= OnEvalRequested;
+				WebView.GoBackRequested -= OnGoBackRequested;
+				WebView.GoForwardRequested -= OnGoForwardRequested;
 
 				_tracker?.Dispose();
 				_packager?.Dispose();
@@ -162,8 +162,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateCanGoBackForward()
 		{
-			ElementController.CanGoBack = CanGoBack;
-			ElementController.CanGoForward = CanGoForward;
+			((IWebViewController)WebView).CanGoBack = CanGoBack;
+			((IWebViewController)WebView).CanGoForward = CanGoForward;
 		}
 
 		class CustomWebViewDelegate : UIWebViewDelegate
@@ -178,8 +178,6 @@ namespace Xamarin.Forms.Platform.iOS
 				_renderer = renderer;
 			}
 
-			IWebViewController WebViewController => WebView;
-
 			WebView WebView
 			{
 				get { return (WebView)_renderer.Element; }
@@ -188,7 +186,7 @@ namespace Xamarin.Forms.Platform.iOS
 			public override void LoadFailed(UIWebView webView, NSError error)
 			{
 				var url = GetCurrentUrl();
-				WebViewController.SendNavigated(new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = url }, url, WebNavigationResult.Failure));
+				WebView.SendNavigated(new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = url }, url, WebNavigationResult.Failure));
 
 				_renderer.UpdateCanGoBackForward();
 			}
@@ -200,11 +198,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_renderer._ignoreSourceChanges = true;
 				var url = GetCurrentUrl();
-				((IElementController)WebView).SetValueFromRenderer(WebView.SourceProperty, new UrlWebViewSource { Url = url });
+				WebView.SetValueFromRenderer(WebView.SourceProperty, new UrlWebViewSource { Url = url });
 				_renderer._ignoreSourceChanges = false;
 
 				var args = new WebNavigatedEventArgs(_lastEvent, WebView.Source, url, WebNavigationResult.Success);
-				WebViewController.SendNavigated(args);
+				WebView.SendNavigated(args);
 
 				_renderer.UpdateCanGoBackForward();
 			}
@@ -242,7 +240,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var lastUrl = request.Url.ToString();
 				var args = new WebNavigatingEventArgs(navEvent, new UrlWebViewSource { Url = lastUrl }, lastUrl);
 
-				WebViewController.SendNavigating(args);
+				WebView.SendNavigating(args);
 				_renderer.UpdateCanGoBackForward();
 				return !args.Cancel;
 			}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationMenu.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/NavigationMenu.xml
@@ -105,6 +105,30 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendTargetSelected">
+      <MemberSignature Language="C#" Value="public void SendTargetSelected (Xamarin.Forms.Page target);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendTargetSelected(class Xamarin.Forms.Page target) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="target" Type="Xamarin.Forms.Page" />
+      </Parameters>
+      <Docs>
+        <param name="target">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Targets">
       <MemberSignature Language="C#" Value="public System.Collections.Generic.IEnumerable&lt;Xamarin.Forms.Page&gt; Targets { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.IEnumerable`1&lt;class Xamarin.Forms.Page&gt; Targets" />
@@ -118,25 +142,6 @@
       <Docs>
         <summary>To be added.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.INavigationMenuController.SendTargetSelected">
-      <MemberSignature Language="C#" Value="void INavigationMenuController.SendTargetSelected (Xamarin.Forms.Page target);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.INavigationMenuController.SendTargetSelected(class Xamarin.Forms.Page target) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="target" Type="Xamarin.Forms.Page" />
-      </Parameters>
-      <Docs>
-        <param name="target">To be added.</param>
-        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Application.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Application.xml
@@ -540,6 +540,30 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SetAppIndexingProvider">
+      <MemberSignature Language="C#" Value="public void SetAppIndexingProvider (Xamarin.Forms.IAppIndexingProvider provider);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SetAppIndexingProvider(class Xamarin.Forms.IAppIndexingProvider provider) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="provider" Type="Xamarin.Forms.IAppIndexingProvider" />
+      </Parameters>
+      <Docs>
+        <param name="provider">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="SetCurrentApplication">
       <MemberSignature Language="C#" Value="public static void SetCurrentApplication (Xamarin.Forms.Application value);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetCurrentApplication(class Xamarin.Forms.Application value) cil managed" />
@@ -561,25 +585,6 @@
       <Docs>
         <param name="value">To be added.</param>
         <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IApplicationController.SetAppIndexingProvider">
-      <MemberSignature Language="C#" Value="void IApplicationController.SetAppIndexingProvider (Xamarin.Forms.IAppIndexingProvider provider);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IApplicationController.SetAppIndexingProvider(class Xamarin.Forms.IAppIndexingProvider provider) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="provider" Type="Xamarin.Forms.IAppIndexingProvider" />
-      </Parameters>
-      <Docs>
-        <param name="provider">To be added.</param>
-        <summary>Internal. Do not use.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Button.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Button.xml
@@ -703,6 +703,69 @@ namespace FormsGallery
         <remarks>The released event always occur before the clicked event.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendClicked">
+      <MemberSignature Language="C#" Value="public void SendClicked ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendClicked() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendPressed">
+      <MemberSignature Language="C#" Value="public void SendPressed ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendPressed() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendReleased">
+      <MemberSignature Language="C#" Value="public void SendReleased ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendReleased() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Text">
       <MemberSignature Language="C#" Value="public string Text { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Text" />
@@ -800,7 +863,6 @@ namespace FormsGallery
         <AssemblyVersion>1.3.0.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
@@ -808,38 +870,6 @@ namespace FormsGallery
       <Parameters />
       <Docs>
         <summary>Sends a click event.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IButtonController.SendPressed">
-      <MemberSignature Language="C#" Value="void IButtonController.SendPressed ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IButtonController.SendPressed() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>Sends a press event.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IButtonController.SendReleased">
-      <MemberSignature Language="C#" Value="void IButtonController.SendReleased ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IButtonController.SendReleased() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>Sends a release event.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Cell.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Cell.xml
@@ -250,6 +250,26 @@ Content = new TableView
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="ForceUpdateSizeRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler ForceUpdateSizeRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler ForceUpdateSizeRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="HasContextActions">
       <MemberSignature Language="C#" Value="public bool HasContextActions { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance bool HasContextActions" />
@@ -504,6 +524,48 @@ Content = new TableView
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendAppearing">
+      <MemberSignature Language="C#" Value="public void SendAppearing ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendAppearing() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendDisappearing">
+      <MemberSignature Language="C#" Value="public void SendDisappearing ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendDisappearing() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Tapped">
       <MemberSignature Language="C#" Value="public event EventHandler Tapped;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler Tapped" />
@@ -524,38 +586,6 @@ Content = new TableView
         <summary>Occurs when the Cell is Tapped.</summary>
         <remarks>
         </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.ICellController.SendAppearing">
-      <MemberSignature Language="C#" Value="void ICellController.SendAppearing ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.ICellController.SendAppearing() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.ICellController.SendDisappearing">
-      <MemberSignature Language="C#" Value="void ICellController.SendDisappearing ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.ICellController.SendDisappearing() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Editor.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Editor.xml
@@ -232,6 +232,27 @@ var editor = new Editor {
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendCompleted">
+      <MemberSignature Language="C#" Value="public void SendCompleted ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendCompleted() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Text">
       <MemberSignature Language="C#" Value="public string Text { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Text" />
@@ -329,22 +350,6 @@ var editor = new Editor {
         <summary>Identifies the Text bindable property.</summary>
         <remarks>
         </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IEditorController.SendCompleted">
-      <MemberSignature Language="C#" Value="void IEditorController.SendCompleted ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IEditorController.SendCompleted() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Xamarin.Forms.Internals.IFontElement.FontSizeDefaultValueCreator">

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Element.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Element.xml
@@ -252,7 +252,7 @@
           <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Runtime.CompilerServices.IteratorStateMachine(typeof(Xamarin.Forms.Element/&lt;Descendants&gt;d__81))</AttributeName>
+          <AttributeName>System.Runtime.CompilerServices.IteratorStateMachine(typeof(Xamarin.Forms.Element/&lt;Descendants&gt;d__82))</AttributeName>
         </Attribute>
       </Attributes>
       <ReturnValue>
@@ -260,6 +260,52 @@
       </ReturnValue>
       <Parameters />
       <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="EffectControlProvider">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.IEffectControlProvider EffectControlProvider { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.IEffectControlProvider EffectControlProvider" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IEffectControlProvider</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="EffectIsAttached">
+      <MemberSignature Language="C#" Value="public bool EffectIsAttached (string name);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance bool EffectIsAttached(string name) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="name" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="name">To be added.</param>
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
@@ -302,6 +348,27 @@
         <summary>Gets a value that can be used to uniquely identify an element through the run of an application.</summary>
         <value>A Guid uniquely identifying the element.</value>
         <remarks>This value is generated at runtime and is not stable across runs of your app.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="LogicalChildren">
+      <MemberSignature Language="C#" Value="public System.Collections.ObjectModel.ReadOnlyCollection&lt;Xamarin.Forms.Element&gt; LogicalChildren { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.ObjectModel.ReadOnlyCollection`1&lt;class Xamarin.Forms.Element&gt; LogicalChildren" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Collections.ObjectModel.ReadOnlyCollection&lt;Xamarin.Forms.Element&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -590,6 +657,58 @@
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="SetValueFromRenderer">
+      <MemberSignature Language="C#" Value="public void SetValueFromRenderer (Xamarin.Forms.BindableProperty property, object value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SetValueFromRenderer(class Xamarin.Forms.BindableProperty property, object value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="property" Type="Xamarin.Forms.BindableProperty" />
+        <Parameter Name="value" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="property">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetValueFromRenderer">
+      <MemberSignature Language="C#" Value="public void SetValueFromRenderer (Xamarin.Forms.BindablePropertyKey property, object value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SetValueFromRenderer(class Xamarin.Forms.BindablePropertyKey property, object value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="property" Type="Xamarin.Forms.BindablePropertyKey" />
+        <Parameter Name="value" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="property">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="StyleId">
       <MemberSignature Language="C#" Value="public string StyleId { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string StyleId" />
@@ -694,58 +813,6 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Xamarin.Forms.IElementController.EffectControlProvider">
-      <MemberSignature Language="C#" Value="Xamarin.Forms.IEffectControlProvider Xamarin.Forms.IElementController.EffectControlProvider { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.IEffectControlProvider Xamarin.Forms.IElementController.EffectControlProvider" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.IEffectControlProvider</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>For internal use only.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IElementController.EffectIsAttached">
-      <MemberSignature Language="C#" Value="bool IElementController.EffectIsAttached (string name);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool Xamarin.Forms.IElementController.EffectIsAttached(string name) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="name" Type="System.String" />
-      </Parameters>
-      <Docs>
-        <param name="name">To be added.</param>
-        <summary>For internal use only.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IElementController.LogicalChildren">
-      <MemberSignature Language="C#" Value="System.Collections.ObjectModel.ReadOnlyCollection&lt;Xamarin.Forms.Element&gt; Xamarin.Forms.IElementController.LogicalChildren { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.ObjectModel.ReadOnlyCollection`1&lt;class Xamarin.Forms.Element&gt; Xamarin.Forms.IElementController.LogicalChildren" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Collections.ObjectModel.ReadOnlyCollection&lt;Xamarin.Forms.Element&gt;</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>For internal use only.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="Xamarin.Forms.IElementController.SetValueFromRenderer">
       <MemberSignature Language="C#" Value="void IElementController.SetValueFromRenderer (Xamarin.Forms.BindableProperty property, object value);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IElementController.SetValueFromRenderer(class Xamarin.Forms.BindableProperty property, object value) cil managed" />
@@ -780,7 +847,6 @@
         <AssemblyVersion>1.3.3.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Entry.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Entry.xml
@@ -417,6 +417,27 @@ View CreateLoginForm ()
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendCompleted">
+      <MemberSignature Language="C#" Value="public void SendCompleted ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendCompleted() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Text">
       <MemberSignature Language="C#" Value="public string Text { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Text" />
@@ -525,22 +546,6 @@ View CreateLoginForm ()
         <summary>Identifies the Text bindable property.</summary>
         <remarks>
         </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IEntryController.SendCompleted">
-      <MemberSignature Language="C#" Value="void IEntryController.SendCompleted ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IEntryController.SendCompleted() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>This interface is for internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Xamarin.Forms.Internals.IFontElement.FontSizeDefaultValueCreator">

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/EntryCell.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/EntryCell.xml
@@ -373,6 +373,27 @@ namespace FormsGallery
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendCompleted">
+      <MemberSignature Language="C#" Value="public void SendCompleted ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendCompleted() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Text">
       <MemberSignature Language="C#" Value="public string Text { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Text" />
@@ -472,22 +493,6 @@ namespace FormsGallery
         <summary>Identifies the XAlign bindable property.</summary>
         <remarks>
         </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IEntryCellController.SendCompleted">
-      <MemberSignature Language="C#" Value="void IEntryCellController.SendCompleted ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IEntryCellController.SendCompleted() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>This interface is for internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Image.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Image.xml
@@ -342,6 +342,30 @@ indicator.BindingContext = image;]]></code>
         <remarks>Overriden for Image.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SetIsLoading">
+      <MemberSignature Language="C#" Value="public void SetIsLoading (bool isLoading);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SetIsLoading(bool isLoading) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="isLoading" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="isLoading">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Source">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.ImageSource Source { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.ImageSource Source" />
@@ -390,25 +414,6 @@ indicator.BindingContext = image;]]></code>
         <summary>Identifies the Source bindable property.</summary>
         <remarks>
         </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IImageController.SetIsLoading">
-      <MemberSignature Language="C#" Value="void IImageController.SetIsLoading (bool isLoading);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IImageController.SetIsLoading(bool isLoading) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="isLoading" Type="System.Boolean" />
-      </Parameters>
-      <Docs>
-        <param name="isLoading">To be added.</param>
-        <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Layout.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Layout.xml
@@ -79,6 +79,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Children">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.IReadOnlyList&lt;Xamarin.Forms.Element&gt; Children { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.IReadOnlyList`1&lt;class Xamarin.Forms.Element&gt; Children" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IReadOnlyList&lt;Xamarin.Forms.Element&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="ForceLayout">
       <MemberSignature Language="C#" Value="public void ForceLayout ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void ForceLayout() cil managed" />
@@ -548,7 +569,6 @@
         <AssemblyVersion>1.3.5.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Collections.Generic.IReadOnlyList&lt;Xamarin.Forms.Element&gt;</ReturnType>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ListView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ListView.xml
@@ -319,6 +319,31 @@ class ListViewDemoPage : ContentPage
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="CreateDefaultCell">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Cell CreateDefaultCell (object item);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.Cell CreateDefaultCell(object item) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Cell</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="item">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="EndRefresh">
       <MemberSignature Language="C#" Value="public void EndRefresh ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void EndRefresh() cil managed" />
@@ -353,6 +378,27 @@ class ListViewDemoPage : ContentPage
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the string, binding, or view that will be displayed at the bottom of the list view.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FooterElement">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Element FooterElement { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.Element FooterElement" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Element</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
       </Docs>
@@ -409,6 +455,31 @@ class ListViewDemoPage : ContentPage
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Xamarin.Forms.ListView.FooterTemplate" /> property.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetDisplayTextFromGroup">
+      <MemberSignature Language="C#" Value="public string GetDisplayTextFromGroup (object cell);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance string GetDisplayTextFromGroup(object cell) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="cell" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="cell">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -766,6 +837,27 @@ ListView CreateListView()
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="HeaderElement">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Element HeaderElement { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.Element HeaderElement" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Element</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="HeaderProperty">
       <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty HeaderProperty;" />
       <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty HeaderProperty" />
@@ -1034,6 +1126,60 @@ ListView CreateListView()
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="NotifyRowTapped">
+      <MemberSignature Language="C#" Value="public void NotifyRowTapped (int index, Xamarin.Forms.Cell cell = null);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void NotifyRowTapped(int32 index, class Xamarin.Forms.Cell cell) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="index" Type="System.Int32" />
+        <Parameter Name="cell" Type="Xamarin.Forms.Cell" />
+      </Parameters>
+      <Docs>
+        <param name="index">To be added.</param>
+        <param name="cell">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NotifyRowTapped">
+      <MemberSignature Language="C#" Value="public void NotifyRowTapped (int groupIndex, int inGroupIndex, Xamarin.Forms.Cell cell = null);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void NotifyRowTapped(int32 groupIndex, int32 inGroupIndex, class Xamarin.Forms.Cell cell) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="groupIndex" Type="System.Int32" />
+        <Parameter Name="inGroupIndex" Type="System.Int32" />
+        <Parameter Name="cell" Type="Xamarin.Forms.Cell" />
+      </Parameters>
+      <Docs>
+        <param name="groupIndex">To be added.</param>
+        <param name="inGroupIndex">To be added.</param>
+        <param name="cell">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="On&lt;T&gt;">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.ListView&gt; On&lt;T&gt; () where T : Xamarin.Forms.IConfigPlatform;" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.IPlatformElementConfiguration`2&lt;!!T, class Xamarin.Forms.ListView&gt; On&lt;(class Xamarin.Forms.IConfigPlatform) T&gt;() cil managed" />
@@ -1103,6 +1249,27 @@ ListView CreateListView()
         <param name="heightConstraint">To be added.</param>
         <summary>Method that is called when a size request is made..</summary>
         <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RefreshAllowed">
+      <MemberSignature Language="C#" Value="public bool RefreshAllowed { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool RefreshAllowed" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1274,6 +1441,26 @@ ListView CreateListView()
           <see cref="P:Xamarin.Forms.ListView.IsGroupingEnabled" /> is <see langword="false" />.</exception>
       </Docs>
     </Member>
+    <Member MemberName="ScrollToRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.ScrollToRequestedEventArgs&gt; ScrollToRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.ScrollToRequestedEventArgs&gt; ScrollToRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.ScrollToRequestedEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="SelectedItem">
       <MemberSignature Language="C#" Value="public object SelectedItem { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance object SelectedItem" />
@@ -1319,6 +1506,75 @@ ListView CreateListView()
         <summary>Identifies the <see cref="P:Xamarin.Forms.ListView.SelectedItemProperty" /> property.</summary>
         <remarks>
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendCellAppearing">
+      <MemberSignature Language="C#" Value="public void SendCellAppearing (Xamarin.Forms.Cell cell);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendCellAppearing(class Xamarin.Forms.Cell cell) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="cell" Type="Xamarin.Forms.Cell" />
+      </Parameters>
+      <Docs>
+        <param name="cell">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendCellDisappearing">
+      <MemberSignature Language="C#" Value="public void SendCellDisappearing (Xamarin.Forms.Cell cell);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendCellDisappearing(class Xamarin.Forms.Cell cell) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="cell" Type="Xamarin.Forms.Cell" />
+      </Parameters>
+      <Docs>
+        <param name="cell">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendRefreshing">
+      <MemberSignature Language="C#" Value="public void SendRefreshing ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendRefreshing() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SeparatorColor">
@@ -1536,42 +1792,6 @@ ListView CreateListView()
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Xamarin.Forms.IListViewController.CachingStrategy">
-      <MemberSignature Language="C#" Value="Xamarin.Forms.ListViewCachingStrategy Xamarin.Forms.IListViewController.CachingStrategy { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.ListViewCachingStrategy Xamarin.Forms.IListViewController.CachingStrategy" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.ListViewCachingStrategy</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IListViewController.CreateDefaultCell">
-      <MemberSignature Language="C#" Value="Xamarin.Forms.Cell IListViewController.CreateDefaultCell (object item);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class Xamarin.Forms.Cell Xamarin.Forms.IListViewController.CreateDefaultCell(object item) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.Cell</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="item" Type="System.Object" />
-      </Parameters>
-      <Docs>
-        <param name="item">To be added.</param>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="Xamarin.Forms.IListViewController.FooterElement">
       <MemberSignature Language="C#" Value="Xamarin.Forms.Element Xamarin.Forms.IListViewController.FooterElement { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.Element Xamarin.Forms.IListViewController.FooterElement" />
@@ -1580,7 +1800,6 @@ ListView CreateListView()
         <AssemblyVersion>1.3.5.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Element</ReturnType>
@@ -1588,26 +1807,6 @@ ListView CreateListView()
       <Docs>
         <summary>Internal.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IListViewController.GetDisplayTextFromGroup">
-      <MemberSignature Language="C#" Value="string IListViewController.GetDisplayTextFromGroup (object cell);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance string Xamarin.Forms.IListViewController.GetDisplayTextFromGroup(object cell) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.String</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="cell" Type="System.Object" />
-      </Parameters>
-      <Docs>
-        <param name="cell">To be added.</param>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1619,7 +1818,6 @@ ListView CreateListView()
         <AssemblyVersion>1.3.5.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Element</ReturnType>
@@ -1627,104 +1825,6 @@ ListView CreateListView()
       <Docs>
         <summary>Internal.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IListViewController.NotifyRowTapped">
-      <MemberSignature Language="C#" Value="void IListViewController.NotifyRowTapped (int index, Xamarin.Forms.Cell cell);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IListViewController.NotifyRowTapped(int32 index, class Xamarin.Forms.Cell cell) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="index" Type="System.Int32" />
-        <Parameter Name="cell" Type="Xamarin.Forms.Cell" />
-      </Parameters>
-      <Docs>
-        <param name="index">To be added.</param>
-        <param name="cell">To be added.</param>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IListViewController.NotifyRowTapped">
-      <MemberSignature Language="C#" Value="void IListViewController.NotifyRowTapped (int index, int inGroupIndex, Xamarin.Forms.Cell cell);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IListViewController.NotifyRowTapped(int32 index, int32 inGroupIndex, class Xamarin.Forms.Cell cell) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="index" Type="System.Int32" />
-        <Parameter Name="inGroupIndex" Type="System.Int32" />
-        <Parameter Name="cell" Type="Xamarin.Forms.Cell" />
-      </Parameters>
-      <Docs>
-        <param name="index">To be added.</param>
-        <param name="inGroupIndex">To be added.</param>
-        <param name="cell">To be added.</param>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IListViewController.RefreshAllowed">
-      <MemberSignature Language="C#" Value="bool Xamarin.Forms.IListViewController.RefreshAllowed { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance bool Xamarin.Forms.IListViewController.RefreshAllowed" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IListViewController.SendCellAppearing">
-      <MemberSignature Language="C#" Value="void IListViewController.SendCellAppearing (Xamarin.Forms.Cell cell);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IListViewController.SendCellAppearing(class Xamarin.Forms.Cell cell) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="cell" Type="Xamarin.Forms.Cell" />
-      </Parameters>
-      <Docs>
-        <param name="cell">To be added.</param>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IListViewController.SendCellDisappearing">
-      <MemberSignature Language="C#" Value="void IListViewController.SendCellDisappearing (Xamarin.Forms.Cell cell);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IListViewController.SendCellDisappearing(class Xamarin.Forms.Cell cell) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="cell" Type="Xamarin.Forms.Cell" />
-      </Parameters>
-      <Docs>
-        <param name="cell">To be added.</param>
-        <summary>This method is for internal use by platform renderers.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1736,7 +1836,6 @@ ListView CreateListView()
         <AssemblyVersion>1.3.5.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/MasterDetailPage.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/MasterDetailPage.xml
@@ -150,6 +150,47 @@ namespace FormsGallery
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="BackButtonPressed">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.BackButtonPressedEventArgs&gt; BackButtonPressed;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.BackButtonPressedEventArgs&gt; BackButtonPressed" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.BackButtonPressedEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CanChangeIsPresented">
+      <MemberSignature Language="C#" Value="public bool CanChangeIsPresented { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool CanChangeIsPresented" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Detail">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.Page Detail { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.Page Detail" />
@@ -168,6 +209,27 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the detail page that is used to display details about items on the master page.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DetailBounds">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Rectangle DetailBounds { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Rectangle DetailBounds" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Rectangle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
       </Docs>
@@ -371,6 +433,27 @@ namespace FormsGallery
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="MasterBounds">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Rectangle MasterBounds { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Rectangle MasterBounds" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Rectangle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="On&lt;T&gt;">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.MasterDetailPage&gt; On&lt;T&gt; () where T : Xamarin.Forms.IConfigPlatform;" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.IPlatformElementConfiguration`2&lt;!!T, class Xamarin.Forms.MasterDetailPage&gt; On&lt;(class Xamarin.Forms.IConfigPlatform) T&gt;() cil managed" />
@@ -474,6 +557,27 @@ namespace FormsGallery
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="ShouldShowSplitMode">
+      <MemberSignature Language="C#" Value="public bool ShouldShowSplitMode { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool ShouldShowSplitMode" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="ShouldShowToolbarButton">
       <MemberSignature Language="C#" Value="public virtual bool ShouldShowToolbarButton ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance bool ShouldShowToolbarButton() cil managed" />
@@ -494,83 +598,24 @@ namespace FormsGallery
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Xamarin.Forms.IMasterDetailPageController.CanChangeIsPresented">
-      <MemberSignature Language="C#" Value="bool Xamarin.Forms.IMasterDetailPageController.CanChangeIsPresented { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance bool Xamarin.Forms.IMasterDetailPageController.CanChangeIsPresented" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IMasterDetailPageController.DetailBounds">
-      <MemberSignature Language="C#" Value="Xamarin.Forms.Rectangle Xamarin.Forms.IMasterDetailPageController.DetailBounds { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Rectangle Xamarin.Forms.IMasterDetailPageController.DetailBounds" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.Rectangle</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IMasterDetailPageController.MasterBounds">
-      <MemberSignature Language="C#" Value="Xamarin.Forms.Rectangle Xamarin.Forms.IMasterDetailPageController.MasterBounds { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Rectangle Xamarin.Forms.IMasterDetailPageController.MasterBounds" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.Rectangle</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IMasterDetailPageController.ShouldShowSplitMode">
-      <MemberSignature Language="C#" Value="bool Xamarin.Forms.IMasterDetailPageController.ShouldShowSplitMode { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance bool Xamarin.Forms.IMasterDetailPageController.ShouldShowSplitMode" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IMasterDetailPageController.UpdateMasterBehavior">
-      <MemberSignature Language="C#" Value="void IMasterDetailPageController.UpdateMasterBehavior ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IMasterDetailPageController.UpdateMasterBehavior() cil managed" />
+    <Member MemberName="UpdateMasterBehavior">
+      <MemberSignature Language="C#" Value="public void UpdateMasterBehavior ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void UpdateMasterBehavior() cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Internal.</summary>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/MenuItem.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/MenuItem.xml
@@ -75,6 +75,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Activate">
+      <MemberSignature Language="C#" Value="public void Activate ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Activate() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Clicked">
       <MemberSignature Language="C#" Value="public event EventHandler Clicked;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler Clicked" />
@@ -282,6 +303,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="IsEnabledPropertyName">
+      <MemberSignature Language="C#" Value="public string IsEnabledPropertyName { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string IsEnabledPropertyName" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="OnClicked">
       <MemberSignature Language="C#" Value="protected virtual void OnClicked ();" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig newslot virtual instance void OnClicked() cil managed" />
@@ -335,38 +377,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the text bound property.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IMenuItemController.Activate">
-      <MemberSignature Language="C#" Value="void IMenuItemController.Activate ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IMenuItemController.Activate() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IMenuItemController.IsEnabledPropertyName">
-      <MemberSignature Language="C#" Value="string Xamarin.Forms.IMenuItemController.IsEnabledPropertyName { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance string Xamarin.Forms.IMenuItemController.IsEnabledPropertyName" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.String</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/NavigationPage.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/NavigationPage.xml
@@ -367,6 +367,26 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="InsertPageBeforeRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; InsertPageBeforeRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; InsertPageBeforeRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="On&lt;T&gt;">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.NavigationPage&gt; On&lt;T&gt; () where T : Xamarin.Forms.IConfigPlatform;" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.IPlatformElementConfiguration`2&lt;!!T, class Xamarin.Forms.NavigationPage&gt; On&lt;(class Xamarin.Forms.IConfigPlatform) T&gt;() cil managed" />
@@ -412,6 +432,52 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Pages">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.IEnumerable&lt;Xamarin.Forms.Page&gt; Pages { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.IEnumerable`1&lt;class Xamarin.Forms.Page&gt; Pages" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerable&lt;Xamarin.Forms.Page&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Peek">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Page Peek (int depth);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.Page Peek(int32 depth) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Page</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="depth" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="depth">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="PopAsync">
       <MemberSignature Language="C#" Value="public System.Threading.Tasks.Task&lt;Xamarin.Forms.Page&gt; PopAsync ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Threading.Tasks.Task`1&lt;class Xamarin.Forms.Page&gt; PopAsync() cil managed" />
@@ -450,7 +516,7 @@
           <AttributeName>System.Diagnostics.DebuggerStepThrough</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.NavigationPage/&lt;PopAsync&gt;d__44))</AttributeName>
+          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.NavigationPage/&lt;PopAsync&gt;d__42))</AttributeName>
         </Attribute>
       </Attributes>
       <ReturnValue>
@@ -462,6 +528,39 @@
       <Docs>
         <param name="animated">To be added.</param>
         <summary>Asynchronously removes the top <see cref="T:Xamarin.Forms.Page" /> from the navigation stack, with optional animation.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PopAsyncInner">
+      <MemberSignature Language="C#" Value="public System.Threading.Tasks.Task&lt;Xamarin.Forms.Page&gt; PopAsyncInner (bool animated, bool fast);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class System.Threading.Tasks.Task`1&lt;class Xamarin.Forms.Page&gt; PopAsyncInner(bool animated, bool fast) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Diagnostics.DebuggerStepThrough</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.NavigationPage/&lt;PopAsyncInner&gt;d__64))</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task&lt;Xamarin.Forms.Page&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="animated" Type="System.Boolean" />
+        <Parameter Name="fast" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="animated">To be added.</param>
+        <param name="fast">To be added.</param>
+        <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
@@ -510,6 +609,26 @@
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="PopRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PopRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PopRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="PopToRootAsync">
       <MemberSignature Language="C#" Value="public System.Threading.Tasks.Task PopToRootAsync ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Threading.Tasks.Task PopToRootAsync() cil managed" />
@@ -548,7 +667,7 @@
           <AttributeName>System.Diagnostics.DebuggerStepThrough</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.NavigationPage/&lt;PopToRootAsync&gt;d__52))</AttributeName>
+          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.NavigationPage/&lt;PopToRootAsync&gt;d__50))</AttributeName>
         </Attribute>
       </Attributes>
       <ReturnValue>
@@ -561,6 +680,26 @@
         <param name="animated">To be added.</param>
         <summary>A task for asynchronously popping all pages off of the navigation stack.</summary>
         <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PopToRootRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PopToRootRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PopToRootRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -605,7 +744,7 @@
           <AttributeName>System.Diagnostics.DebuggerStepThrough</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.NavigationPage/&lt;PushAsync&gt;d__54))</AttributeName>
+          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.NavigationPage/&lt;PushAsync&gt;d__52))</AttributeName>
         </Attribute>
       </Attributes>
       <ReturnValue>
@@ -641,6 +780,46 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when a page is pushed onto this <see cref="T:Xamarin.Forms.NavigationPage" /> element.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PushRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PushRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; PushRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RemovePageRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; RemovePageRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt; RemovePageRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -804,6 +983,27 @@ public class MyPage : NavigationPage
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="StackDepth">
+      <MemberSignature Language="C#" Value="public int StackDepth { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 StackDepth" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Tint">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.Color Tint { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Color Tint" />
@@ -877,88 +1077,6 @@ public class MyPage : NavigationPage
       </ReturnValue>
       <Docs>
         <summary>Indicates the <see cref="M:Xamarin.Forms.NavigationPage.SetTitleIcon" />/<see cref="M:Xamarin.Forms.NavigationPage.GetTitleIcon" /> property.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.INavigationPageController.Pages">
-      <MemberSignature Language="C#" Value="System.Collections.Generic.IEnumerable&lt;Xamarin.Forms.Page&gt; Xamarin.Forms.INavigationPageController.Pages { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.IEnumerable`1&lt;class Xamarin.Forms.Page&gt; Xamarin.Forms.INavigationPageController.Pages" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Collections.Generic.IEnumerable&lt;Xamarin.Forms.Page&gt;</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>For internal use by platform renderers.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.INavigationPageController.Peek">
-      <MemberSignature Language="C#" Value="Xamarin.Forms.Page INavigationPageController.Peek (int depth);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class Xamarin.Forms.Page Xamarin.Forms.INavigationPageController.Peek(int32 depth) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.Page</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="depth" Type="System.Int32" />
-      </Parameters>
-      <Docs>
-        <param name="depth">To be added.</param>
-        <summary>For internal use by platform renderers.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.INavigationPageController.PopAsyncInner">
-      <MemberSignature Language="C#" Value="System.Threading.Tasks.Task&lt;Xamarin.Forms.Page&gt; INavigationPageController.PopAsyncInner (bool animated, bool fast);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class System.Threading.Tasks.Task`1&lt;class Xamarin.Forms.Page&gt; Xamarin.Forms.INavigationPageController.PopAsyncInner(bool animated, bool fast) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.Diagnostics.DebuggerStepThrough</AttributeName>
-        </Attribute>
-        <Attribute>
-          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.NavigationPage/&lt;Xamarin-Forms-INavigationPageController-PopAsyncInner&gt;d__69))</AttributeName>
-        </Attribute>
-      </Attributes>
-      <ReturnValue>
-        <ReturnType>System.Threading.Tasks.Task&lt;Xamarin.Forms.Page&gt;</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="animated" Type="System.Boolean" />
-        <Parameter Name="fast" Type="System.Boolean" />
-      </Parameters>
-      <Docs>
-        <param name="animated">To be added.</param>
-        <param name="fast">To be added.</param>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.INavigationPageController.StackDepth">
-      <MemberSignature Language="C#" Value="int Xamarin.Forms.INavigationPageController.StackDepth { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance int32 Xamarin.Forms.INavigationPageController.StackDepth" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Int32</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/OpenGLView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/OpenGLView.xml
@@ -133,6 +133,26 @@ namespace opengl
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="DisplayRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler DisplayRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler DisplayRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="HasRenderLoop">
       <MemberSignature Language="C#" Value="public bool HasRenderLoop { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance bool HasRenderLoop" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Page.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Page.xml
@@ -166,6 +166,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="ContainerArea">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Rectangle ContainerArea { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Rectangle ContainerArea" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Rectangle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Disappearing">
       <MemberSignature Language="C#" Value="public event EventHandler Disappearing;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler Disappearing" />
@@ -349,6 +370,48 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Xamarin.Forms.Page.Icon" /> property.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IgnoresContainerArea">
+      <MemberSignature Language="C#" Value="public bool IgnoresContainerArea { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool IgnoresContainerArea" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="InternalChildren">
+      <MemberSignature Language="C#" Value="public System.Collections.ObjectModel.ObservableCollection&lt;Xamarin.Forms.Element&gt; InternalChildren { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.ObjectModel.ObservableCollection`1&lt;class Xamarin.Forms.Element&gt; InternalChildren" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Collections.ObjectModel.ObservableCollection&lt;Xamarin.Forms.Element&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -681,6 +744,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendAppearing">
+      <MemberSignature Language="C#" Value="public void SendAppearing ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendAppearing() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="SendBackButtonPressed">
       <MemberSignature Language="C#" Value="public bool SendBackButtonPressed ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance bool SendBackButtonPressed() cil managed" />
@@ -698,6 +782,27 @@
       <Docs>
         <summary>Calls <see cref="M:Xamarin.Forms.Page.OnBackButtonPressed" />.</summary>
         <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendDisappearing">
+      <MemberSignature Language="C#" Value="public void SendDisappearing ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendDisappearing() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -785,86 +890,6 @@
       <Parameters />
       <Docs>
         <summary>Requests that the children <see cref="T:Xamarin.Forms.Element" />s of the <see cref="T:Xamarin.Forms.Page" /> update their layouts.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPageController.ContainerArea">
-      <MemberSignature Language="C#" Value="Xamarin.Forms.Rectangle Xamarin.Forms.IPageController.ContainerArea { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Rectangle Xamarin.Forms.IPageController.ContainerArea" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.Rectangle</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPageController.IgnoresContainerArea">
-      <MemberSignature Language="C#" Value="bool Xamarin.Forms.IPageController.IgnoresContainerArea { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance bool Xamarin.Forms.IPageController.IgnoresContainerArea" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPageController.InternalChildren">
-      <MemberSignature Language="C#" Value="System.Collections.ObjectModel.ObservableCollection&lt;Xamarin.Forms.Element&gt; Xamarin.Forms.IPageController.InternalChildren { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.ObjectModel.ObservableCollection`1&lt;class Xamarin.Forms.Element&gt; Xamarin.Forms.IPageController.InternalChildren" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Collections.ObjectModel.ObservableCollection&lt;Xamarin.Forms.Element&gt;</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPageController.SendAppearing">
-      <MemberSignature Language="C#" Value="void IPageController.SendAppearing ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPageController.SendAppearing() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>This method is for internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPageController.SendDisappearing">
-      <MemberSignature Language="C#" Value="void IPageController.SendDisappearing ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPageController.SendDisappearing() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>This method is for internal use by platform renderers.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/PanGestureRecognizer.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/PanGestureRecognizer.xml
@@ -49,6 +49,114 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendPan">
+      <MemberSignature Language="C#" Value="public void SendPan (Xamarin.Forms.Element sender, double totalX, double totalY, int gestureId);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendPan(class Xamarin.Forms.Element sender, float64 totalX, float64 totalY, int32 gestureId) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="sender" Type="Xamarin.Forms.Element" />
+        <Parameter Name="totalX" Type="System.Double" />
+        <Parameter Name="totalY" Type="System.Double" />
+        <Parameter Name="gestureId" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="sender">To be added.</param>
+        <param name="totalX">To be added.</param>
+        <param name="totalY">To be added.</param>
+        <param name="gestureId">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendPanCanceled">
+      <MemberSignature Language="C#" Value="public void SendPanCanceled (Xamarin.Forms.Element sender, int gestureId);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendPanCanceled(class Xamarin.Forms.Element sender, int32 gestureId) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="sender" Type="Xamarin.Forms.Element" />
+        <Parameter Name="gestureId" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="sender">To be added.</param>
+        <param name="gestureId">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendPanCompleted">
+      <MemberSignature Language="C#" Value="public void SendPanCompleted (Xamarin.Forms.Element sender, int gestureId);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendPanCompleted(class Xamarin.Forms.Element sender, int32 gestureId) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="sender" Type="Xamarin.Forms.Element" />
+        <Parameter Name="gestureId" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="sender">To be added.</param>
+        <param name="gestureId">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendPanStarted">
+      <MemberSignature Language="C#" Value="public void SendPanStarted (Xamarin.Forms.Element sender, int gestureId);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendPanStarted(class Xamarin.Forms.Element sender, int32 gestureId) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="sender" Type="Xamarin.Forms.Element" />
+        <Parameter Name="gestureId" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="sender">To be added.</param>
+        <param name="gestureId">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="TouchPoints">
       <MemberSignature Language="C#" Value="public int TouchPoints { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance int32 TouchPoints" />
@@ -79,94 +187,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Xamarin.Forms.PanGestureRecognizer.TouchPoints" /> property.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPanGestureController.SendPan">
-      <MemberSignature Language="C#" Value="void IPanGestureController.SendPan (Xamarin.Forms.Element sender, double totalX, double totalY, int gestureId);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPanGestureController.SendPan(class Xamarin.Forms.Element sender, float64 totalX, float64 totalY, int32 gestureId) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="sender" Type="Xamarin.Forms.Element" />
-        <Parameter Name="totalX" Type="System.Double" />
-        <Parameter Name="totalY" Type="System.Double" />
-        <Parameter Name="gestureId" Type="System.Int32" />
-      </Parameters>
-      <Docs>
-        <param name="sender">To be added.</param>
-        <param name="totalX">To be added.</param>
-        <param name="totalY">To be added.</param>
-        <param name="gestureId">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPanGestureController.SendPanCanceled">
-      <MemberSignature Language="C#" Value="void IPanGestureController.SendPanCanceled (Xamarin.Forms.Element sender, int gestureId);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPanGestureController.SendPanCanceled(class Xamarin.Forms.Element sender, int32 gestureId) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="sender" Type="Xamarin.Forms.Element" />
-        <Parameter Name="gestureId" Type="System.Int32" />
-      </Parameters>
-      <Docs>
-        <param name="sender">To be added.</param>
-        <param name="gestureId">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPanGestureController.SendPanCompleted">
-      <MemberSignature Language="C#" Value="void IPanGestureController.SendPanCompleted (Xamarin.Forms.Element sender, int gestureId);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPanGestureController.SendPanCompleted(class Xamarin.Forms.Element sender, int32 gestureId) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="sender" Type="Xamarin.Forms.Element" />
-        <Parameter Name="gestureId" Type="System.Int32" />
-      </Parameters>
-      <Docs>
-        <param name="sender">To be added.</param>
-        <param name="gestureId">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPanGestureController.SendPanStarted">
-      <MemberSignature Language="C#" Value="void IPanGestureController.SendPanStarted (Xamarin.Forms.Element sender, int gestureId);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPanGestureController.SendPanStarted(class Xamarin.Forms.Element sender, int32 gestureId) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="sender" Type="Xamarin.Forms.Element" />
-        <Parameter Name="gestureId" Type="System.Int32" />
-      </Parameters>
-      <Docs>
-        <param name="sender">To be added.</param>
-        <param name="gestureId">To be added.</param>
-        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/PinchGestureRecognizer.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/PinchGestureRecognizer.xml
@@ -33,6 +33,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="IsPinching">
+      <MemberSignature Language="C#" Value="public bool IsPinching { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool IsPinching" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="PinchUpdated">
       <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.PinchGestureUpdatedEventArgs&gt; PinchUpdated;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.PinchGestureUpdatedEventArgs&gt; PinchUpdated" />
@@ -49,29 +70,18 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Xamarin.Forms.IPinchGestureController.IsPinching">
-      <MemberSignature Language="C#" Value="bool Xamarin.Forms.IPinchGestureController.IsPinching { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance bool Xamarin.Forms.IPinchGestureController.IsPinching" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IPinchGestureController.SendPinch">
-      <MemberSignature Language="C#" Value="void IPinchGestureController.SendPinch (Xamarin.Forms.Element sender, double delta, Xamarin.Forms.Point currentScalePoint);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPinchGestureController.SendPinch(class Xamarin.Forms.Element sender, float64 delta, valuetype Xamarin.Forms.Point currentScalePoint) cil managed" />
+    <Member MemberName="SendPinch">
+      <MemberSignature Language="C#" Value="public void SendPinch (Xamarin.Forms.Element sender, double delta, Xamarin.Forms.Point currentScalePoint);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendPinch(class Xamarin.Forms.Element sender, float64 delta, valuetype Xamarin.Forms.Point currentScalePoint) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -88,13 +98,18 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Xamarin.Forms.IPinchGestureController.SendPinchCanceled">
-      <MemberSignature Language="C#" Value="void IPinchGestureController.SendPinchCanceled (Xamarin.Forms.Element sender);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPinchGestureController.SendPinchCanceled(class Xamarin.Forms.Element sender) cil managed" />
+    <Member MemberName="SendPinchCanceled">
+      <MemberSignature Language="C#" Value="public void SendPinchCanceled (Xamarin.Forms.Element sender);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendPinchCanceled(class Xamarin.Forms.Element sender) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -107,13 +122,18 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Xamarin.Forms.IPinchGestureController.SendPinchEnded">
-      <MemberSignature Language="C#" Value="void IPinchGestureController.SendPinchEnded (Xamarin.Forms.Element sender);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPinchGestureController.SendPinchEnded(class Xamarin.Forms.Element sender) cil managed" />
+    <Member MemberName="SendPinchEnded">
+      <MemberSignature Language="C#" Value="public void SendPinchEnded (Xamarin.Forms.Element sender);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendPinchEnded(class Xamarin.Forms.Element sender) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
@@ -126,13 +146,18 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Xamarin.Forms.IPinchGestureController.SendPinchStarted">
-      <MemberSignature Language="C#" Value="void IPinchGestureController.SendPinchStarted (Xamarin.Forms.Element sender, Xamarin.Forms.Point initialScalePoint);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IPinchGestureController.SendPinchStarted(class Xamarin.Forms.Element sender, valuetype Xamarin.Forms.Point initialScalePoint) cil managed" />
+    <Member MemberName="SendPinchStarted">
+      <MemberSignature Language="C#" Value="public void SendPinchStarted (Xamarin.Forms.Element sender, Xamarin.Forms.Point initialScalePoint);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendPinchStarted(class Xamarin.Forms.Element sender, valuetype Xamarin.Forms.Point initialScalePoint) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ScrollView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ScrollView.xml
@@ -167,6 +167,33 @@ MainPage = new ContentPage
         <remarks>This bindable property is read-only.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="GetScrollPositionForElement">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Point GetScrollPositionForElement (Xamarin.Forms.VisualElement item, Xamarin.Forms.ScrollToPosition pos);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance valuetype Xamarin.Forms.Point GetScrollPositionForElement(class Xamarin.Forms.VisualElement item, valuetype Xamarin.Forms.ScrollToPosition pos) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Point</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="Xamarin.Forms.VisualElement" />
+        <Parameter Name="pos" Type="Xamarin.Forms.ScrollToPosition" />
+      </Parameters>
+      <Docs>
+        <param name="item">To be added.</param>
+        <param name="pos">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="LayoutChildren">
       <MemberSignature Language="C#" Value="protected override void LayoutChildren (double x, double y, double width, double height);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void LayoutChildren(float64 x, float64 y, float64 width, float64 height) cil managed" />
@@ -375,6 +402,26 @@ MainPage = new ContentPage
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="ScrollToRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.ScrollToRequestedEventArgs&gt; ScrollToRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.ScrollToRequestedEventArgs&gt; ScrollToRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.ScrollToRequestedEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="ScrollX">
       <MemberSignature Language="C#" Value="public double ScrollX { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance float64 ScrollX" />
@@ -445,6 +492,53 @@ MainPage = new ContentPage
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendScrollFinished">
+      <MemberSignature Language="C#" Value="public void SendScrollFinished ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendScrollFinished() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetScrolledPosition">
+      <MemberSignature Language="C#" Value="public void SetScrolledPosition (double x, double y);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SetScrolledPosition(float64 x, float64 y) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="System.Double" />
+        <Parameter Name="y" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="x">To be added.</param>
+        <param name="y">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Xamarin.Forms.IScrollViewController.GetScrollPositionForElement">
       <MemberSignature Language="C#" Value="Xamarin.Forms.Point IScrollViewController.GetScrollPositionForElement (Xamarin.Forms.VisualElement item, Xamarin.Forms.ScrollToPosition pos);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance valuetype Xamarin.Forms.Point Xamarin.Forms.IScrollViewController.GetScrollPositionForElement(class Xamarin.Forms.VisualElement item, valuetype Xamarin.Forms.ScrollToPosition pos) cil managed" />
@@ -452,7 +546,6 @@ MainPage = new ContentPage
       <AssemblyInfo>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Point</ReturnType>
@@ -476,7 +569,6 @@ MainPage = new ContentPage
       <AssemblyInfo>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
@@ -494,7 +586,6 @@ MainPage = new ContentPage
       <AssemblyInfo>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/SearchBar.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/SearchBar.xml
@@ -339,6 +339,27 @@ public class App : Application
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="OnSearchButtonPressed">
+      <MemberSignature Language="C#" Value="public void OnSearchButtonPressed ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void OnSearchButtonPressed() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Placeholder">
       <MemberSignature Language="C#" Value="public string Placeholder { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Placeholder" />
@@ -717,22 +738,6 @@ public class App : Application
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
         <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.ISearchBarController.OnSearchButtonPressed">
-      <MemberSignature Language="C#" Value="void ISearchBarController.OnSearchButtonPressed ();" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.ISearchBarController.OnSearchButtonPressed() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>This method is for internal use.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/TableView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/TableView.xml
@@ -240,6 +240,26 @@ public class App : Application
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="ModelChanged">
+      <MemberSignature Language="C#" Value="public event EventHandler ModelChanged;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler ModelChanged" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="On&lt;T&gt;">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.TableView&gt; On&lt;T&gt; () where T : Xamarin.Forms.IConfigPlatform;" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.IPlatformElementConfiguration`2&lt;!!T, class Xamarin.Forms.TableView&gt; On&lt;(class Xamarin.Forms.IConfigPlatform) T&gt;() cil managed" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
@@ -1130,6 +1130,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="NativeSizeChanged">
+      <MemberSignature Language="C#" Value="public void NativeSizeChanged ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void NativeSizeChanged() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Navigation">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.INavigation Navigation { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.INavigation Navigation" />
@@ -2082,7 +2103,6 @@
         <AssemblyVersion>1.3.0.0</AssemblyVersion>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/WebView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/WebView.xml
@@ -194,6 +194,26 @@ namespace FormsGallery
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="EvalRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Internals.EvalRequested&gt; EvalRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Internals.EvalRequested&gt; EvalRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Internals.EvalRequested&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="GoBack">
       <MemberSignature Language="C#" Value="public void GoBack ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void GoBack() cil managed" />
@@ -213,6 +233,26 @@ namespace FormsGallery
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="GoBackRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler GoBackRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler GoBackRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="GoForward">
       <MemberSignature Language="C#" Value="public void GoForward ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void GoForward() cil managed" />
@@ -229,6 +269,26 @@ namespace FormsGallery
       <Parameters />
       <Docs>
         <summary>Navigates to the next page in the list of visited pages.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GoForwardRequested">
+      <MemberSignature Language="C#" Value="public event EventHandler GoForwardRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler GoForwardRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.EventHandler</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -361,6 +421,54 @@ namespace FormsGallery
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SendNavigated">
+      <MemberSignature Language="C#" Value="public void SendNavigated (Xamarin.Forms.WebNavigatedEventArgs args);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendNavigated(class Xamarin.Forms.WebNavigatedEventArgs args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="args" Type="Xamarin.Forms.WebNavigatedEventArgs" />
+      </Parameters>
+      <Docs>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendNavigating">
+      <MemberSignature Language="C#" Value="public void SendNavigating (Xamarin.Forms.WebNavigatingEventArgs args);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendNavigating(class Xamarin.Forms.WebNavigatingEventArgs args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="args" Type="Xamarin.Forms.WebNavigatingEventArgs" />
+      </Parameters>
+      <Docs>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Source">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.WebViewSource Source { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.WebViewSource Source" />
@@ -416,6 +524,11 @@ namespace FormsGallery
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -432,50 +545,17 @@ namespace FormsGallery
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>To be added.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IWebViewController.SendNavigated">
-      <MemberSignature Language="C#" Value="void IWebViewController.SendNavigated (Xamarin.Forms.WebNavigatedEventArgs args);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IWebViewController.SendNavigated(class Xamarin.Forms.WebNavigatedEventArgs args) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="args" Type="Xamarin.Forms.WebNavigatedEventArgs" />
-      </Parameters>
-      <Docs>
-        <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Xamarin.Forms.IWebViewController.SendNavigating">
-      <MemberSignature Language="C#" Value="void IWebViewController.SendNavigating (Xamarin.Forms.WebNavigatingEventArgs args);" />
-      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void Xamarin.Forms.IWebViewController.SendNavigating(class Xamarin.Forms.WebNavigatingEventArgs args) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="args" Type="Xamarin.Forms.WebNavigatingEventArgs" />
-      </Parameters>
-      <Docs>
-        <param name="args">To be added.</param>
-        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
### Description of Change ###

Convert from explicit to implicit implementation + `[EditorBrowsable(EditorBrowsableState.Never)]` of controller interfaces. Either way the members of the controller iface are hidden from customers however the latter has the advantage that it does not hide the members from the XF team (we use a ProjectReference to reference core and in that case the attribute is ignored by isense) which allows us to simplify all our call sites from `((ICtrlIface)Foo).Bar` to `Foo.Bar`. I've update the callsites for only one controller interface in this PR. If/when consensus has been reached on this change of convention then I'll merge this PR and create a second PR that updates the remaining callsites. 

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
