### PR TITLE
Fix 52962; Cont refresh even when pullToRefresh is disabled

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1148,14 +1148,15 @@ namespace Xamarin.Forms.Platform.iOS
 					RefreshControl = _refresh;
 				}
 			}
-			else if (_refreshAdded)
-			{
-				if (_refresh.Refreshing)
-					_refresh.EndRefreshing();
-
-				RefreshControl = null;
-				_refreshAdded = false;
-			}
+			// https://bugzilla.xamarin.com/show_bug.cgi?id=52962
+			// just because pullToRefresh is being disabled does not mean we should kill an in progress refresh. 
+			// Consider the case where:
+			//   1. User pulls to refresh
+			//   2. App RefreshCommand fires (at this point _refresh.Refreshing is true)
+			//   3. RefreshCommand disables itself via a call to ChangeCanExecute which returns false
+			//			(maybe the command it's attached to a button the app wants disabled)
+			//   4. OnCommandCanExecuteChanged handler sets RefreshAllowed to false because the RefreshCommand is disabled
+			//   5. We end up here; A refresh is in progress while being asked to disable pullToRefresh
 		}
 
 		public void UpdateShowHideRefresh(bool shouldHide)


### PR DESCRIPTION
### Description of Change ###

Expected that disabling pullToRefresh does not kill an in progress refresh. Actually observed disabling pullToRefresh killed in progress refresh. Consider the case of bug 52962:
1. User pulls to refresh
2. App RefreshCommand fires (at this point _refresh.Refreshing is true)
3. RefreshCommand disables itself via a call to ChangeCanExecute which returns false
     maybe the command it's attached to a button the app wants disabled)
4. OnCommandCanExecuteChanged handler sets RefreshAllowed to false because the RefreshCommand is disabled
5. We end up here; A refresh is in progress while being asked to disable pullToRefresh

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=52962

### API Changes ###

None

### Behavioral Changes ###

As described.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
