### PR TITLE
UWP MapRenderer NRE and Location fixes

### DIFF
--- a/Xamarin.Forms.Maps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.UWP/MapRenderer.cs
@@ -47,8 +47,8 @@ namespace Xamarin.Forms.Maps.WinRT
 				{
 					SetNativeControl(new MapControl());
 					Control.MapServiceToken = FormsMaps.AuthenticationToken;
-					Control.ZoomLevelChanged += (s, a) => UpdateVisibleRegion();
-					Control.CenterChanged += (s, a) => UpdateVisibleRegion();
+					Control.ZoomLevelChanged += async (s, a) => await UpdateVisibleRegion();
+					Control.CenterChanged += async (s, a) => await UpdateVisibleRegion();
 				}
 
 				MessagingCenter.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", async (s, a) => await MoveToRegion(a), mapModel);
@@ -62,8 +62,10 @@ namespace Xamarin.Forms.Maps.WinRT
 				if (mapModel.Pins.Any())
 					LoadPins();
 
-				await UpdateIsShowingUser();
-				await Control.Dispatcher.RunIdleAsync(async (i) => await MoveToRegion(mapModel.LastMoveToRegion, MapAnimationKind.None));
+                if (Control != null)
+                    await Control.Dispatcher.RunIdleAsync(async (i) => await MoveToRegion(mapModel.LastMoveToRegion, MapAnimationKind.None));
+
+                await UpdateIsShowingUser();
             }
 		}
 
@@ -160,38 +162,37 @@ namespace Xamarin.Forms.Maps.WinRT
 			Control.Children.Add(new PushPin(pin));
 		}
 
-		async Task UpdateIsShowingUser(bool moveToLocation = true)
-		{
-			
-			if (Element.IsShowingUser)
-			{
-				var myGeolocator = new Geolocator();
-				if (myGeolocator.LocationStatus != PositionStatus.NotAvailable &&
-				    myGeolocator.LocationStatus != PositionStatus.Disabled)
-				{
-					var userPosition = await myGeolocator.GetGeopositionAsync();
-					if (userPosition?.Coordinate != null)
-						LoadUserPosition(userPosition.Coordinate, moveToLocation);
-				}
+        async Task UpdateIsShowingUser(bool moveToLocation = true)
+        {
+            if (Element?.IsShowingUser == true)
+            {
+                var myGeolocator = new Geolocator();
+                if (myGeolocator.LocationStatus != PositionStatus.NotAvailable &&
+                     myGeolocator.LocationStatus != PositionStatus.Disabled)
+                {
+                    var userPosition = await myGeolocator.GetGeopositionAsync();
+                    if (userPosition?.Coordinate != null)
+                        LoadUserPosition(userPosition.Coordinate, moveToLocation);
+                }
 
-				if (_timer == null)
-				{
-					_timer = new DispatcherTimer();
-					_timer.Tick += async (s, o) => await UpdateIsShowingUser(moveToLocation: false);
-					_timer.Interval = TimeSpan.FromSeconds(15);
-				}
-				
-				if (!_timer.IsEnabled)
-					_timer.Start();
-			}
-			else if (_userPositionCircle != null && Control.Children.Contains(_userPositionCircle))
-			{
-				_timer?.Stop();
-				Control.Children.Remove(_userPositionCircle);
-			}
-		}
+                if (_timer == null)
+                {
+                    _timer = new DispatcherTimer();
+                    _timer.Tick += async (s, o) => await UpdateIsShowingUser(moveToLocation: false);
+                    _timer.Interval = TimeSpan.FromSeconds(15);
+                }
 
-		async Task MoveToRegion(MapSpan span, MapAnimationKind animation = MapAnimationKind.Bow)
+                if (_timer?.IsEnabled == false)
+                    _timer?.Start();
+            }
+            else if (_userPositionCircle != null && Control?.Children?.Contains(_userPositionCircle) == true)
+            {
+                _timer?.Stop();
+                Control?.Children?.Remove(_userPositionCircle);
+            }
+        }
+
+        async Task MoveToRegion(MapSpan span, MapAnimationKind animation = MapAnimationKind.Bow)
 		{
 			var nw = new BasicGeoposition
 			{
@@ -207,7 +208,7 @@ namespace Xamarin.Forms.Maps.WinRT
 			await Control.TrySetViewBoundsAsync(boundingBox, null, animation);
 		}
 
-		void UpdateVisibleRegion()
+		async Task UpdateVisibleRegion()
 		{
 			if (Control == null || Element == null)
 				return;
@@ -224,7 +225,10 @@ namespace Xamarin.Forms.Maps.WinRT
 					var center = new Position(boundingBox.Center.Latitude, boundingBox.Center.Longitude);
 					var latitudeDelta = Math.Abs(nw.Position.Latitude - se.Position.Latitude);
 					var longitudeDelta = Math.Abs(nw.Position.Longitude - se.Position.Longitude);
-					Element.VisibleRegion = new MapSpan(center, latitudeDelta, longitudeDelta);
+                    await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                    {
+                        Element.VisibleRegion = new MapSpan(center, latitudeDelta, longitudeDelta);
+                    });
 				}
             }
 			catch (Exception)
@@ -233,45 +237,45 @@ namespace Xamarin.Forms.Maps.WinRT
 			}
 		}
 
-		void LoadUserPosition(Geocoordinate userCoordinate, bool center)
-		{
-			var userPosition = new BasicGeoposition
-			{
-				Latitude = userCoordinate.Point.Position.Latitude,
-				Longitude = userCoordinate.Point.Position.Longitude
-			};
+        void LoadUserPosition(Geocoordinate userCoordinate, bool center)
+        {
+            var userPosition = new BasicGeoposition
+            {
+                Latitude = userCoordinate.Point.Position.Latitude,
+                Longitude = userCoordinate.Point.Position.Longitude
+            };
 
-			var point = new Geopoint(userPosition);
+            var point = new Geopoint(userPosition);
 
-			if (_userPositionCircle == null)
-			{
-				_userPositionCircle = new Ellipse
-				{
-					Stroke = new SolidColorBrush(Colors.White),
-					Fill = new SolidColorBrush(Colors.Blue),
-					StrokeThickness = 2,
-					Height = 20,
-					Width = 20,
-					Opacity = 50
-				};
-			}
+            if (_userPositionCircle == null)
+            {
+                _userPositionCircle = new Ellipse
+                {
+                    Stroke = new SolidColorBrush(Colors.White),
+                    Fill = new SolidColorBrush(Colors.Blue),
+                    StrokeThickness = 2,
+                    Height = 20,
+                    Width = 20,
+                    Opacity = 50
+                };
+            }
 
-			if (Control.Children.Contains(_userPositionCircle))
-				Control.Children.Remove(_userPositionCircle);
+            if (Control?.Children?.Contains(_userPositionCircle) == true)
+                Control.Children.Remove(_userPositionCircle);
 
-			MapControl.SetLocation(_userPositionCircle, point);
-			MapControl.SetNormalizedAnchorPoint(_userPositionCircle, new Windows.Foundation.Point(0.5, 0.5));
+            MapControl.SetLocation(_userPositionCircle, point);
+            MapControl.SetNormalizedAnchorPoint(_userPositionCircle, new Windows.Foundation.Point(0.5, 0.5));
 
-			Control.Children.Add(_userPositionCircle);
+            Control?.Children?.Add(_userPositionCircle);
 
-			if (center)
-			{
-				Control.Center = point;
-				Control.ZoomLevel = 13;
-			}
-		}
+            if (center && Control != null)
+            {
+                Control.Center = point;
+                Control.ZoomLevel = 13;
+            }
+        }
 
-		void UpdateMapType()
+        void UpdateMapType()
 		{
 			switch (Element.MapType)
 			{

--- a/Xamarin.Forms.Maps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.UWP/MapRenderer.cs
@@ -240,6 +240,8 @@ namespace Xamarin.Forms.Maps.WinRT
 
 		void LoadUserPosition(Geocoordinate userCoordinate, bool center)
 		{
+			if (Control == null || Element == null) return;
+
 			var userPosition = new BasicGeoposition
 			{
 				Latitude = userCoordinate.Point.Position.Latitude,
@@ -261,15 +263,15 @@ namespace Xamarin.Forms.Maps.WinRT
 				};
 			}
 
-			if (Control?.Children?.Contains(_userPositionCircle) == true)
+			if (Control.Children.Contains(_userPositionCircle))
 				Control.Children.Remove(_userPositionCircle);
 
 			MapControl.SetLocation(_userPositionCircle, point);
 			MapControl.SetNormalizedAnchorPoint(_userPositionCircle, new Windows.Foundation.Point(0.5, 0.5));
 
-			Control?.Children?.Add(_userPositionCircle);
+			Control.Children.Add(_userPositionCircle);
 
-			if (center && Control != null)
+			if (center)
 			{
 				Control.Center = point;
 				Control.ZoomLevel = 13;

--- a/Xamarin.Forms.Maps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.UWP/MapRenderer.cs
@@ -164,8 +164,9 @@ namespace Xamarin.Forms.Maps.WinRT
 
 		async Task UpdateIsShowingUser(bool moveToLocation = true)
 		{
-			
-			if (Element?.IsShowingUser == true)
+			if (Control == null || Element == null) return;
+
+			if (Element.IsShowingUser)
 			{
 				var myGeolocator = new Geolocator();
 				if (myGeolocator.LocationStatus != PositionStatus.NotAvailable &&
@@ -176,6 +177,8 @@ namespace Xamarin.Forms.Maps.WinRT
 						LoadUserPosition(userPosition.Coordinate, moveToLocation);
 				}
 
+				if (Control == null || Element == null) return;
+
 				if (_timer == null)
 				{
 					_timer = new DispatcherTimer();
@@ -183,13 +186,13 @@ namespace Xamarin.Forms.Maps.WinRT
 					_timer.Interval = TimeSpan.FromSeconds(15);
 				}
 				
-				if (_timer?.IsEnabled == false)
-					_timer?.Start();
+				if (!_timer.IsEnabled)
+					_timer.Start();
 			}
-			else if (_userPositionCircle != null && Control?.Children?.Contains(_userPositionCircle) == true)
+			else if (_userPositionCircle != null && Control.Children.Contains(_userPositionCircle))
 			{
-				_timer?.Stop();
-				Control?.Children?.Remove(_userPositionCircle);
+				_timer.Stop();
+				Control.Children.Remove(_userPositionCircle);
 			}
 		}
 

--- a/Xamarin.Forms.Maps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.UWP/MapRenderer.cs
@@ -62,11 +62,11 @@ namespace Xamarin.Forms.Maps.WinRT
 				if (mapModel.Pins.Any())
 					LoadPins();
 
-                if (Control == null) return;
+                		if (Control == null) return;
 
 				await Control.Dispatcher.RunIdleAsync(async (i) => await MoveToRegion(mapModel.LastMoveToRegion, MapAnimationKind.None));
 				await UpdateIsShowingUser();
-            }
+            		}
 		}
 
 		protected override async void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

1. If UWP MapRenderer is navigated away from, before the user location
is found, an uncaught NRE will be thrown.
2. UWP MapRenderer updates are not enforced to be on UI thread
3. Order of operations in MapRenderer would cause user location to never
be shown.

Fixes:
1. Added null checks in UpdateUserIsShowing and LoadUserPosition
methods.
2. Called map position updates on UI thread.
3. Changed order of operations in OnElementChanged to allow for user
geocoordinates to be shown.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=53113

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
