### PR TITLE
Bug 53224; Disable Cell if Command IsEnabled false

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/TableViewRenderer.cs
@@ -74,7 +74,8 @@ namespace Xamarin.Forms.Platform.WinRT
 					var cell = item as Cell;
 					if (cell != null)
 					{
-						Controller.Model.RowSelected(cell);
+						if (cell.IsEnabled)
+							Controller.Model.RowSelected(cell);
 						break;
 					}
 				}


### PR DESCRIPTION
TextCell expected to be disabled if Command.IsEnabled is false. Actually, on UAP, TextCell remained enabled. Fixed by checking if Cell.IsEnabled before dispatching command.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=53224

### API Changes ###

None

### Behavioral Changes ###

UAP TextCell no longer dispatches Command if the Command is disabled.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
