### PR TITLE
Bug 53275 - IProvideValueTarget TargetProperty always null

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using System.Xml;
+
+using Xamarin.Forms.Core.UnitTests;
+using System.Reflection;
+
+namespace Xamarin.Forms.Xaml.UnitTests.Issues
+{
+	class GetTargetPropertyName : IMarkupExtension
+	{
+		public object ProvideValue(IServiceProvider provider)
+		{
+
+			if (provider == null) return false;
+
+			//create a binding and assign it to the target
+			var service = provider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+			if (service == null) return false;
+
+			//we need dependency objects / properties
+			var propertyName = string.Empty;
+			var property = service.TargetProperty;
+			if (property is BindableProperty)
+			{
+				propertyName = ((BindableProperty)property).PropertyName;
+			}
+			else if(property is PropertyInfo)
+			{
+				propertyName = ((PropertyInfo)property).Name;
+			}
+			return propertyName;
+		}
+	}
+
+	[TestFixture]
+	class Bz53275:BaseTestFixture
+	{
+		IXamlTypeResolver typeResolver;
+
+		[SetUp]
+		public override void Setup()
+		{
+			base.Setup();
+			var nsManager = new XmlNamespaceManager(new NameTable());
+			nsManager.AddNamespace("local", "clr-namespace:Xamarin.Forms.Xaml.UnitTests.Issues;assembly=Xamarin.Forms.Xaml.UnitTests");
+			nsManager.AddNamespace("x", "http://schemas.microsoft.com/winfx/2006/xaml");
+
+			typeResolver = new Internals.XamlTypeResolver(nsManager, XamlParser.GetElementType, Assembly.GetCallingAssembly());
+		}
+
+		[Test]
+		public void TestGetTargetProperty()
+		{
+			var xaml = @"
+			<Label 
+				xmlns=""http://xamarin.com/schemas/2014/forms""
+				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+				xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests.Issues;assembly=Xamarin.Forms.Xaml.UnitTests""
+				Text=""{local:GetTargetPropertyName}""
+			/>";
+
+			var label = new Label();
+			label.LoadFromXaml(xaml);
+			Assert.AreEqual("Text", label.Text.ToString());
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests.Issues"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Issues.Bz53275"
+             >
+    <Label Text="{local:GetTargetPropertyName}"
+           x:Name="label"/>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml.cs
@@ -50,18 +50,21 @@ namespace Xamarin.Forms.Xaml.UnitTests.Issues
 		{
 
 		}
-	}
 
-	[TestFixture]
-	class Bz53275Test:BaseTestFixture
-	{
-		[Test]
-		[TestCase(true)]
-		[TestCase(false)]
-		public void TestGetTargetProperty(bool useCompiledXaml)
+		[TestFixture]
+		class Test : BaseTestFixture
 		{
-			var label = (new Bz53275(useCompiledXaml)).FindByName<Label>("label");
-			Assert.AreEqual("Text", label.Text.ToString());
+			[Test]
+			[TestCase(true)]
+			[TestCase(false)]
+			public void TestGetTargetProperty(bool useCompiledXaml)
+			{
+				var page = new Bz53275(useCompiledXaml);
+				var label = page.label;
+				Assert.AreEqual("Text", label.Text.ToString());
+			}
 		}
 	}
+
+
 }

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml.cs
@@ -4,10 +4,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using System.Xml;
 
 using Xamarin.Forms.Core.UnitTests;
 using System.Reflection;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Xaml.UnitTests.Issues
 {
@@ -37,35 +39,28 @@ namespace Xamarin.Forms.Xaml.UnitTests.Issues
 		}
 	}
 
-	[TestFixture]
-	class Bz53275:BaseTestFixture
+	public partial class Bz53275 : ContentPage
 	{
-		IXamlTypeResolver typeResolver;
-
-		[SetUp]
-		public override void Setup()
+		public Bz53275()
 		{
-			base.Setup();
-			var nsManager = new XmlNamespaceManager(new NameTable());
-			nsManager.AddNamespace("local", "clr-namespace:Xamarin.Forms.Xaml.UnitTests.Issues;assembly=Xamarin.Forms.Xaml.UnitTests");
-			nsManager.AddNamespace("x", "http://schemas.microsoft.com/winfx/2006/xaml");
-
-			typeResolver = new Internals.XamlTypeResolver(nsManager, XamlParser.GetElementType, Assembly.GetCallingAssembly());
+			InitializeComponent();
 		}
 
-		[Test]
-		public void TestGetTargetProperty()
+		public Bz53275(bool useCompiledXaml)
 		{
-			var xaml = @"
-			<Label 
-				xmlns=""http://xamarin.com/schemas/2014/forms""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests.Issues;assembly=Xamarin.Forms.Xaml.UnitTests""
-				Text=""{local:GetTargetPropertyName}""
-			/>";
 
-			var label = new Label();
-			label.LoadFromXaml(xaml);
+		}
+	}
+
+	[TestFixture]
+	class Bz53275Test:BaseTestFixture
+	{
+		[Test]
+		[TestCase(true)]
+		[TestCase(false)]
+		public void TestGetTargetProperty(bool useCompiledXaml)
+		{
+			var label = (new Bz53275(useCompiledXaml)).FindByName<Label>("label");
 			Assert.AreEqual("Text", label.Text.ToString());
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Issues\Bz41296.xaml.cs">
       <DependentUpon>Bz41296.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz53275.cs" />
     <Compile Include="LoaderTests.cs" />
     <Compile Include="PlatformSpecifics.xaml.cs">
       <DependentUpon>PlatformSpecifics.xaml</DependentUpon>

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -83,7 +83,9 @@
     <Compile Include="Issues\Bz41296.xaml.cs">
       <DependentUpon>Bz41296.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Issues\Bz53275.cs" />
+    <Compile Include="Issues\Bz53275.xaml.cs">
+      <DependentUpon>Bz53275.xaml</DependentUpon>
+    </Compile>
     <Compile Include="LoaderTests.cs" />
     <Compile Include="PlatformSpecifics.xaml.cs">
       <DependentUpon>PlatformSpecifics.xaml</DependentUpon>
@@ -846,6 +848,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Issues\Bz43450.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Issues\Bz53275.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Implements discovery of IProvideValueTarget.TargetProperty 

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=53275: When in custom MarkupExtension you using IProvideValueTarget to get TargetProperty is always null, Because in this [line](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Xaml/XamlServiceProvider.cs#L17 )  you always setted null the targetProperty parameter of XamlServiceProvider constructor.

### API Changes ###

Nothing.

### Behavioral Changes ###

The discovery of TargetProperty happens in lazy mode. When it called for the first time TargetProperty Check That the TargetObject exists in static field That is of type BindableProperty and That its name is equal to the name of the property plus the postfix "Property", if it is not found performs the search for a property with same name we are searching.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense