### PR TITLE
Add internal XF.Registrar.RegisterAll b/c previewer needs it

### DIFF
--- a/Xamarin.Forms.Core/DependencyService.cs
+++ b/Xamarin.Forms.Core/DependencyService.cs
@@ -70,9 +70,9 @@ namespace Xamarin.Forms
 			}
 
 			Assembly[] assemblies = Device.GetAssemblies();
-			if (Registrar.ExtraAssemblies != null)
+			if (Internals.Registrar.ExtraAssemblies != null)
 			{
-				assemblies = assemblies.Union(Registrar.ExtraAssemblies).ToArray();
+				assemblies = assemblies.Union(Internals.Registrar.ExtraAssemblies).ToArray();
 			}
 
 			Initialize(assemblies);

--- a/Xamarin.Forms.Core/Effect.cs
+++ b/Xamarin.Forms.Core/Effect.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms
 		{
 			Type effectType;
 			Effect result = null;
-			if (Registrar.Effects.TryGetValue(name, out effectType))
+			if (Internals.Registrar.Effects.TryGetValue(name, out effectType))
 			{
 				result = (Effect)Activator.CreateInstance(effectType);
 			}

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -4,7 +4,14 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 
-
+namespace Xamarin.Forms
+{
+	// Previewer uses reflection to bind to this method; Removal or modification of visibility will break previewer.
+	internal static class Registrar
+	{
+		internal static void RegisterAll(Type[] attrTypes) => Internals.Registrar.RegisterAll(attrTypes);
+	}
+}
 namespace Xamarin.Forms.Internals
 {
 	[EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
### Description of Change ###

Added internal Xamarin.Forms.Registrar.RegisterAll(). Without this previewer breaks. They bind to it using reflection.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
