### PR TITLE
Inherit Transitioning Delegate from Child (ModalWrapper)

### DIFF
--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			View.BackgroundColor = UIColor.White;
 			View.AddSubview(modal.ViewController.View);
+			TransitioningDelegate = modal.ViewController.TransitioningDelegate;
 			AddChildViewController(modal.ViewController);
 
 			modal.ViewController.DidMoveToParentViewController(this);


### PR DESCRIPTION
### Description of Change ###

The TransitioningDelegate of the ModalWrapper is now set to the TransitioningDelegate of the child ViewController.

This limits the need to create a custom renderer when wanting to provide custom transitions.

### Bugs Fixed ###

TransitioningDelegate was not being applied to a the ViewController when pushing Modally.

### API Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
