### PR TITLE
[Core] Fix internal children clear logic

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ContentFormUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ContentFormUnitTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
@@ -64,5 +65,21 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual (context, toolbarItem.BindingContext);
 		}
+
+        [Test]
+        public void ContentPage_should_have_the_InternalChildren_correctly_when_content_changed()
+        {
+            var sut = new ContentPage();
+            IList<Element> internalChildren = ((IControlTemplated)sut).InternalChildren;
+            internalChildren.Add(new VisualElement());
+            internalChildren.Add(new VisualElement());
+            internalChildren.Add(new VisualElement());
+
+            var expected = new View();
+            sut.Content = expected;
+
+            Assert.AreEqual(1, internalChildren.Count);
+            Assert.AreSame(expected, internalChildren[0]);
+        }
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ContentFormUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ContentFormUnitTests.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
         [Test]
-        public void ContentPage_should_have_the_InternalChildren_correctly_when_content_changed()
+        public void ContentPage_should_have_the_InternalChildren_correctly_when_Content_changed()
         {
             var sut = new ContentPage();
             IList<Element> internalChildren = ((IControlTemplated)sut).InternalChildren;

--- a/Xamarin.Forms.Core.UnitTests/ContentViewUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/ContentViewUnitTest.cs
@@ -390,7 +390,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
         [Test]
-        public void ContentView_should_have_the_InternalChildren_correctly_when_content_changed()
+        public void ContentView_should_have_the_InternalChildren_correctly_when_Content_changed()
         {
             var sut = new ContentView();
             IList<Element> internalChildren = ((IControlTemplated)sut).InternalChildren;

--- a/Xamarin.Forms.Core.UnitTests/ContentViewUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/ContentViewUnitTest.cs
@@ -388,6 +388,21 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual ("Foo", child.BindingContext);
 		}
-	}
 
+        [Test]
+        public void ContentView_should_have_the_InternalChildren_correctly_when_content_changed()
+        {
+            var sut = new ContentView();
+            IList<Element> internalChildren = ((IControlTemplated)sut).InternalChildren;
+            internalChildren.Add(new VisualElement());
+            internalChildren.Add(new VisualElement());
+            internalChildren.Add(new VisualElement());
+
+            var expected = new View();
+            sut.Content = expected;
+
+            Assert.AreEqual(1, internalChildren.Count);
+            Assert.AreSame(expected, internalChildren[0]);
+        }
+    }
 }

--- a/Xamarin.Forms.Core.UnitTests/TemplatedPageUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TemplatedPageUnitTests.cs
@@ -15,9 +15,17 @@ namespace Xamarin.Forms.Core.UnitTests
             internalChildren.Add(new VisualElement());
             internalChildren.Add(new VisualElement());
 
-            sut.ControlTemplate = new ControlTemplate(typeof(View));
+            sut.ControlTemplate = new ControlTemplate(typeof(ExpectedView));
 
             Assert.AreEqual(1, internalChildren.Count);
+            Assert.IsInstanceOf<ExpectedView>(internalChildren[0]);
+        }
+
+        private class ExpectedView : View
+        {
+            public ExpectedView()
+            {
+            }
         }
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/TemplatedPageUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TemplatedPageUnitTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+    [TestFixture]
+	public class TemplatedPageUnitTests : BaseTestFixture 
+	{
+        [Test]
+        public void TemplatedPage_should_have_the_InternalChildren_correctly_when_ControlTemplate_changed()
+        {
+            var sut = new TemplatedPage();
+            IList<Element> internalChildren = ((IControlTemplated)sut).InternalChildren;
+            internalChildren.Add(new VisualElement());
+            internalChildren.Add(new VisualElement());
+            internalChildren.Add(new VisualElement());
+
+            sut.ControlTemplate = new ControlTemplate();
+
+            Assert.AreEqual(1, internalChildren.Count);
+        }
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/TemplatedPageUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TemplatedPageUnitTests.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Core.UnitTests
             internalChildren.Add(new VisualElement());
             internalChildren.Add(new VisualElement());
 
-            sut.ControlTemplate = new ControlTemplate();
+            sut.ControlTemplate = new ControlTemplate(typeof(View));
 
             Assert.AreEqual(1, internalChildren.Count);
         }

--- a/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
@@ -15,9 +15,17 @@ namespace Xamarin.Forms.Core.UnitTests
             internalChildren.Add(new VisualElement());
             internalChildren.Add(new VisualElement());
 
-            sut.ControlTemplate = new ControlTemplate(typeof(View));
+            sut.ControlTemplate = new ControlTemplate(typeof(ExpectedView));
 
             Assert.AreEqual(1, internalChildren.Count);
+            Assert.IsInstanceOf<ExpectedView>(internalChildren[0]);
+        }
+
+        private class ExpectedView : View
+        {
+            public ExpectedView()
+            {
+            }
         }
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Core.UnitTests
             internalChildren.Add(new VisualElement());
             internalChildren.Add(new VisualElement());
 
-            sut.ControlTemplate = new ControlTemplate();
+            sut.ControlTemplate = new ControlTemplate(typeof(View));
 
             Assert.AreEqual(1, internalChildren.Count);
         }

--- a/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+    [TestFixture]
+	public class TemplatedViewUnitTests : BaseTestFixture 
+	{
+        [Test]
+        public void TemplatedView_should_have_the_InternalChildren_correctly_when_ControlTemplate_changed()
+        {
+            var sut = new TemplatedView();
+            IList<Element> internalChildren = ((IControlTemplated)sut).InternalChildren;
+            internalChildren.Add(new VisualElement());
+            internalChildren.Add(new VisualElement());
+            internalChildren.Add(new VisualElement());
+
+            sut.ControlTemplate = new ControlTemplate();
+
+            Assert.AreEqual(1, internalChildren.Count);
+        }
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -80,6 +80,8 @@
     <Compile Include="ColorUnitTests.cs" />
     <Compile Include="CommandSourceTests.cs" />
     <Compile Include="CommandTests.cs" />
+    <Compile Include="TemplatedViewUnitTests.cs" />
+    <Compile Include="TemplatedPageUnitTests.cs" />
     <Compile Include="ContentFormUnitTests.cs" />
     <Compile Include="ContraintTypeConverterTests.cs" />
     <Compile Include="ControlTemplateTests.cs" />

--- a/Xamarin.Forms.Core/TemplateUtilities.cs
+++ b/Xamarin.Forms.Core/TemplateUtilities.cs
@@ -58,9 +58,9 @@ namespace Xamarin.Forms
 			var newElement = (Element)newValue;
 			if (self.ControlTemplate == null)
 			{
-				for (var i = 0; i < self.InternalChildren.Count; i++)
+				while (self.InternalChildren.Count > 0)
 				{
-					self.InternalChildren.Remove(self.InternalChildren[i]);
+					self.InternalChildren.Remove(self.InternalChildren[0]);
 				}
 
 				if (newValue != null)
@@ -104,9 +104,9 @@ namespace Xamarin.Forms
 			}
 
 			// Now remove all remnants of any other children just to be sure
-			for (var i = 0; i < self.InternalChildren.Count; i++)
+			while (self.InternalChildren.Count > 0)
 			{
-				self.InternalChildren.Remove(self.InternalChildren[i]);
+				self.InternalChildren.Remove(self.InternalChildren[0]);
 			}
 
 			ControlTemplate template = self.ControlTemplate;

--- a/Xamarin.Forms.Core/TemplateUtilities.cs
+++ b/Xamarin.Forms.Core/TemplateUtilities.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Forms
 			{
 				while (self.InternalChildren.Count > 0)
 				{
-					self.InternalChildren.RemoveAt(0);
+					self.InternalChildren.RemoveAt(self.InternalChildren.Count - 1);
 				}
 
 				if (newValue != null)
@@ -106,7 +106,7 @@ namespace Xamarin.Forms
 			// Now remove all remnants of any other children just to be sure
 			while (self.InternalChildren.Count > 0)
 			{
-				self.InternalChildren.RemoveAt(0);
+				self.InternalChildren.RemoveAt(self.InternalChildren.Count - 1);
 			}
 
 			ControlTemplate template = self.ControlTemplate;

--- a/Xamarin.Forms.Core/TemplateUtilities.cs
+++ b/Xamarin.Forms.Core/TemplateUtilities.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Forms
 			{
 				while (self.InternalChildren.Count > 0)
 				{
-					self.InternalChildren.Remove(self.InternalChildren[0]);
+					self.InternalChildren.RemoveAt(0);
 				}
 
 				if (newValue != null)
@@ -106,7 +106,7 @@ namespace Xamarin.Forms
 			// Now remove all remnants of any other children just to be sure
 			while (self.InternalChildren.Count > 0)
 			{
-				self.InternalChildren.Remove(self.InternalChildren[0]);
+				self.InternalChildren.RemoveAt(0);
 			}
 
 			ControlTemplate template = self.ControlTemplate;


### PR DESCRIPTION
### Description of Change ###

I think the code before the change was intended to remove all the items in the InternalChildren. However, the code is removing only the odd-numbered items from InternalChildren. This PR modifies the code to fit the original intent.

### Bugs Fixed ###

This PR modifies the code to fit the original intent.

### API Changes ###

None

### PR Checklist ###

 - [x] Has tests (if omitted, state reason in description)
 - [x]  Rebased on top of master at time of PR
 - [x] Changes adhere to coding standard
 - [x] Consolidate commits as makes sense