### PR TITLE
null check effects before clearing

### DIFF
--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -525,7 +525,7 @@ namespace Xamarin.Forms
 		{
 			foreach (Effect effect in _effects)
 			{
-				effect.ClearEffect();
+				effect?.ClearEffect();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Element.Effects is a publicly exposed list and so users can insert null. Whenever we act on elements of the list we must first check for null. We failed to do that for EffectsOnClearing. This change adds the null check.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=53417

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
