### PR TITLE
Adopt iOS status bar visibility defaults

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -229,12 +229,7 @@ namespace Xamarin.Forms.Platform.iOS
 					return false;
 				case (StatusBarHiddenMode.Default):
 				default:
-					{
-						if (Device.info.CurrentOrientation.IsLandscape())
-							return true;
-						else
-							return false;
-					}
+					return base.PrefersStatusBarHidden();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

By default an iOS phones in landscape won't display the status bar. It's expected this is not the behavior for a tablet which will show the status bar either way. Actually we see the status bar is hidden for a tablet in landscape just like a phone. 

We tried to re-implement the iOS default behavior but omitted the idiom check. Instead, we simply call into iOS and allow it to handle it's own default behavior. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=52620

### API Changes ###

None

### Behavioral Changes ###

See description

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
