### PR TITLE
iOS renderers now properly look up the ImageSourceHandler for FileIma…

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 				_forceName = forceName;
 				_item = item;
 
-				if (!string.IsNullOrEmpty(item.Icon) && !forceName)
+				if (!string.IsNullOrEmpty(item.Icon?.File) && !forceName)
 					UpdateIconAndStyle();
 				else
 					UpdateTextAndStyle();
@@ -52,14 +52,14 @@ namespace Xamarin.Forms.Platform.iOS
 					UpdateIsEnabled();
 				else if (e.PropertyName == MenuItem.TextProperty.PropertyName)
 				{
-					if (string.IsNullOrEmpty(_item.Icon) || _forceName)
+					if (string.IsNullOrEmpty(_item.Icon?.File) || _forceName)
 						UpdateTextAndStyle();
 				}
 				else if (e.PropertyName == MenuItem.IconProperty.PropertyName)
 				{
 					if (!_forceName)
 					{
-						if (!string.IsNullOrEmpty(_item.Icon))
+						if (!string.IsNullOrEmpty(_item.Icon?.File))
 							UpdateIconAndStyle();
 						else
 							UpdateTextAndStyle();
@@ -67,9 +67,10 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			}
 
-			void UpdateIconAndStyle()
+			async void UpdateIconAndStyle()
 			{
-				var image = UIImage.FromBundle(_item.Icon);
+				var source = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(_item.Icon.GetType());
+				var image = await source.LoadImageAsync(_item.Icon);
 				Image = image;
 				Style = UIBarButtonItemStyle.Plain;
 			}
@@ -123,9 +124,15 @@ namespace Xamarin.Forms.Platform.iOS
 					UpdateIsEnabled();
 			}
 
-			void UpdateIcon()
+			async void UpdateIcon()
 			{
-				((SecondaryToolbarItemContent)CustomView).Image = string.IsNullOrEmpty(_item.Icon) ? null : new UIImage(_item.Icon);
+				UIImage image = null;
+				if (!string.IsNullOrEmpty(_item.Icon?.File))
+				{
+					var source = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(_item.Icon.GetType());
+					image = await source.LoadImageAsync(_item.Icon);
+				}
+				((SecondaryToolbarItemContent)CustomView).Image = image;
 			}
 
 			void UpdateIsEnabled()

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationMenuRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationMenuRenderer.cs
@@ -120,7 +120,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (target != null)
 				{
 					cell.Name = target.Title;
-					cell.Icon = target.Icon;
+					cell.Icon = target.Icon?.File;
 					cell.Selected = () => MenuController.SendTargetSelected(target);
 				}
 				else

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using UIKit;
 using Xamarin.Forms.Internals;
 using static Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page;
@@ -385,13 +386,13 @@ namespace Xamarin.Forms.Platform.iOS
 			VisualElementRenderer<VisualElement>.RegisterEffect(effect, View);
 		}
 
-		void SetTabBarItem(IVisualElementRenderer renderer)
+		async void SetTabBarItem(IVisualElementRenderer renderer)
 		{
 			var page = renderer.Element as Page;
 			if(page == null)
 				throw new InvalidCastException($"{nameof(renderer)} must be a {nameof(Page)} renderer.");
 
-			var icons = GetIcon(page);
+			var icons = await GetIcon(page);
 			renderer.ViewController.TabBarItem = new UITabBarItem(page.Title, icons?.Item1, icons?.Item2)
 			{
 				Tag = Tabbed.Children.IndexOf(page),
@@ -408,11 +409,12 @@ namespace Xamarin.Forms.Platform.iOS
 		/// A tuple containing as item1: the unselected version of the icon, item2: the selected version of the icon (item2 can be null),
 		/// or null if no icon should be set.
 		/// </returns>
-		protected virtual Tuple<UIImage, UIImage> GetIcon(Page page)
+		protected virtual async Task<Tuple<UIImage, UIImage>> GetIcon(Page page)
 		{
-		    if (!string.IsNullOrEmpty(page.Icon))
+		    if (!string.IsNullOrEmpty(page.Icon?.File))
 		    {
-		        var icon = new UIImage(page.Icon);
+				var source = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(page.Icon.GetType());
+				var icon = await source.LoadImageAsync(page.Icon);
 		        return Tuple.Create(icon, (UIImage)null);
 		    }
 		


### PR DESCRIPTION
iOS Renderers no longer use the implicit cast on FIleImageSource

### Description of Change ###

iOS Renderers no longer use the implicit cast on FIleImageSource.

Not really testable

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=52893

### API Changes ###

None


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
