### PR TITLE
[iOS/Win] Label will not unnecessarily expand

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53362.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53362.cs
@@ -1,0 +1,35 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 53362, "Layout regression in Grid on iOS: HorizontalOption = Center does not center", PlatformAffected.iOS)]
+	public class Bugzilla53362 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var label1 = new Label { Text = "auto sized row", TextColor = Color.Silver, HorizontalOptions = LayoutOptions.Center, BackgroundColor = Color.Purple };
+			var label2 = new Label { Text = "row size 20", TextColor = Color.Silver, HorizontalOptions = LayoutOptions.Center, BackgroundColor = Color.Purple };
+			var label3 = new Label { Text = "row size 25", TextColor = Color.Silver, HorizontalOptions = LayoutOptions.Center, BackgroundColor = Color.Purple };
+
+			var grid = new Grid
+			{
+				RowDefinitions =
+				{
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+					new RowDefinition { Height = new GridLength(20, GridUnitType.Absolute) },
+					new RowDefinition { Height = new GridLength(25, GridUnitType.Absolute) },
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+				}
+			};
+
+			grid.Children.Add(label1, 0, 0);
+			grid.Children.Add(label2, 0, 1);
+			grid.Children.Add(label3, 0, 2);
+			grid.Children.Add(new Label { Text = "If the three labels above are not all centered horizontally, this test has failed." }, 0, 3);
+
+			Content = grid;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -260,6 +260,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51503.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52533.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53362.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
@@ -72,15 +72,31 @@ namespace Xamarin.Forms.Platform.WinRT
 				_perfectSizeValid = true;
 			}
 
-			if (widthConstraint >= _perfectSize.Request.Width && heightConstraint >= _perfectSize.Request.Height)
+			var widthFits = widthConstraint >= _perfectSize.Request.Width;
+			var heightFits = heightConstraint >= _perfectSize.Request.Height;
+
+			if (widthFits && heightFits)
 				return _perfectSize;
 
 			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
-			result.Minimum = new Size(Math.Min(10, result.Request.Width), result.Request.Height);
-			if (Element.LineBreakMode != LineBreakMode.NoWrap)
+			var tinyWidth = Math.Min(10, result.Request.Width);
+			result.Minimum = new Size(tinyWidth, result.Request.Height);
+
+			if (widthFits || Element.LineBreakMode == LineBreakMode.NoWrap)
+				return result;
+
+			bool containerIsNotInfinitelyWide = !double.IsInfinity(widthConstraint);
+
+			if (containerIsNotInfinitelyWide)
 			{
-				if (result.Request.Width > widthConstraint || Element.LineBreakMode == LineBreakMode.WordWrap || Element.LineBreakMode == LineBreakMode.CharacterWrap)
-					result.Request = new Size(Math.Max(result.Minimum.Width, widthConstraint), result.Request.Height);
+				bool textCouldHaveWrapped = Element.LineBreakMode == LineBreakMode.WordWrap || Element.LineBreakMode == LineBreakMode.CharacterWrap;
+				bool textExceedsContainer = result.Request.Width > widthConstraint;
+
+				if (textExceedsContainer || textCouldHaveWrapped)
+				{
+					var expandedWidth = Math.Max(tinyWidth, widthConstraint);
+					result.Request = new Size(expandedWidth, result.Request.Height);
+				}
 			}
 
 			return result;


### PR DESCRIPTION
### Description of Change ###

Labels will no longer expand to the width constraint unless required to do so. Regression caused by #529. Jason tried to warn me. What could go wrong, I said. It's just a small fix, I said. 

### Bugs Fixed ###

- [Bug 53362 - Layout regression in Grid on iOS: HorizontalOption = Center does not center](https://bugzilla.xamarin.com/show_bug.cgi?id=53362)

### API Changes ###

None.

### Behavioral Changes ###

This shouldn't break anything, I said.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
