### PR TITLE
Add gesture disposed check to FrameRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
@@ -83,6 +83,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					ScaleGestureDetectorCompat.SetQuickScaleEnabled(_scaleDetector.Value, true);
 				handled = _scaleDetector.Value.OnTouchEvent(e);
 			}
+
+			if (_gestureDetector.IsValueCreated && _gestureDetector.Value.Handle == IntPtr.Zero)
+			{
+				// This gesture detector has already been disposed, probably because it's on a cell which is going away
+				return handled;
+			}
+
 			return _gestureDetector.Value.OnTouchEvent(e) || handled;
 		}
 


### PR DESCRIPTION
### Description of Change ###

This applies the same fix from [PR 706](https://github.com/xamarin/Xamarin.Forms/pull/706) to FrameRenderer.

### Bugs Fixed ###

- [45330 – System.ObjectDisposedException: Cannot access a disposed object. Object name: 'Android.Views.GestureDetector'.](https://bugzilla.xamarin.com/show_bug.cgi?id=45330)


