### PR TITLE
[C] Make sure all children are parented

### DIFF
--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -70,6 +70,10 @@ namespace Xamarin.Forms
 
 		protected Layout()
 		{
+			//if things were added in base ctor (through implicit styles), the items added aren't properly parented
+			if (InternalChildren.Count > 0)
+				InternalChildrenOnCollectionChanged(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, InternalChildren));
+
 			InternalChildren.CollectionChanged += InternalChildrenOnCollectionChanged;
 		}
 

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Xamarin.Forms.Xaml.UnitTests.Bz53381">
+	<Grid BackgroundColor="Green">
+		<Label Text="This is my custom control."/>
+	</Grid>
+</ContentView>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381.xaml.cs
@@ -40,6 +40,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			{
 				Application.Current = new Bz53381App();
 				var view = new Bz53381(useCompiledXaml);
+				Application.Current.MainPage = new ContentPage { Content = view };
 				var presenter = ((StackLayout)view.InternalChildren[0]).Children[1] as ContentPresenter;
 				Assume.That(presenter, Is.Not.Null);
 				var grid = presenter.Content as Grid;

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz53381 : ContentView
+	{
+		public Bz53381()
+		{
+			InitializeComponent();
+		}
+
+		public Bz53381(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Application.Current = null;
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void ControlTemplateAsImplicitAppLevelStyles(bool useCompiledXaml)
+			{
+				Application.Current = new Bz53381App();
+				var view = new Bz53381(useCompiledXaml);
+				var presenter = ((StackLayout)view.InternalChildren[0]).Children[1] as ContentPresenter;
+				Assume.That(presenter, Is.Not.Null);
+				var grid = presenter.Content as Grid;
+				Assert.That(grid, Is.Not.Null);
+				Assert.That(grid.BackgroundColor, Is.EqualTo(Color.Green));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381App.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381App.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Application xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+	x:Class="Xamarin.Forms.Xaml.UnitTests.Bz53381App">
+	<Application.Resources>
+		<ResourceDictionary>
+			<Style TargetType="local:Bz53381">
+				<Setter Property="ControlTemplate">
+				<Setter.Value>
+					<ControlTemplate>
+						<StackLayout>
+							<Label Text="This is the control template. A green Grid and Label should be below." />
+							<ContentPresenter  />
+						</StackLayout>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+			</Style>
+		</ResourceDictionary>
+	</Application.Resources>
+</Application>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381App.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53381App.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz53381App : Application
+	{
+		public Bz53381App()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -452,6 +452,12 @@
     <Compile Include="Issues\Bz53318.xaml.cs">
       <DependentUpon>Bz53318.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz53381.xaml.cs">
+      <DependentUpon>Bz53381.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Issues\Bz53381App.xaml.cs">
+      <DependentUpon>Bz53381App.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -822,6 +828,12 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz53318.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz53381.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz53381App.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

If Layout.InternalChildren are added in the base `ctor`, the event handler isn't connected yet, and the parenting code isn't executed.

So, all children added directly or indirectly through implicit styles (handled in base ctor) are orphans. This fix gives a foster parent to those children. They'll get as much love as natural borns, but they'll still be a bit different, and I have no code to fix that.

## NOTE: this is a regression introduced by a fix for the previewer, and it needs to be backported to 2.3.4

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=53381

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense