### PR TITLE
[XamlC] accept assignment of Object from unboxed value types in SetValue

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -903,6 +903,10 @@ namespace Xamarin.Forms.Build.Tasks
 			if (implicitOperator != null)
 				return true;
 
+			//as we're in the SetValue Scenario, we can accept value types, they'll be boxed
+			if (varValue.VariableType.IsValueType && bpTypeRef.FullName == "System.Object")
+				return true;
+
 			return varValue.VariableType.InheritsFromOrImplements(bpTypeRef);
 		}
 

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53203.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53203.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+	x:Class="Xamarin.Forms.Xaml.UnitTests.Bz53203">
+	<Label x:Name="label0"
+		Grid.Row="{x:Static local:Bz53203.IntValue}"
+		local:Bz53203.Parameter="{x:Static local:Bz53203Values.Better}"/>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53203.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53203.xaml.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Xamarin.Forms.Core.UnitTests;
+using Xamarin.Forms;
+
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public enum Bz53203Values
+	{
+		Unknown,
+		Good,
+		Better,
+		Best
+	}
+
+	public partial class Bz53203 : ContentPage
+	{
+		public static int IntValue = 42;
+		public static object ObjValue = new object();
+
+		public static readonly BindableProperty ParameterProperty = BindableProperty.CreateAttached("Parameter",
+			typeof(object), typeof(Bz53203), null);
+
+		public static object GetParameter(BindableObject obj) =>
+			obj.GetValue(ParameterProperty);
+
+		public static void SetParameter(BindableObject obj, object value) =>
+			obj.SetValue(ParameterProperty, value);
+
+		public Bz53203()
+		{
+			InitializeComponent();
+		}
+
+		public Bz53203(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			public void MarkupOnAttachedBPDoesNotThrowAtCompileTime(bool useCompiledXaml)
+			{
+				MockCompiler.Compile(typeof(Bz53203));
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void MarkupOnAttachedBP(bool useCompiledXaml)
+			{
+				var page = new Bz53203(useCompiledXaml);
+				var label = page.label0;
+				Assert.That(Grid.GetRow(label), Is.EqualTo(42));
+				Assert.That(GetParameter(label), Is.EqualTo(Bz53203Values.Better));
+			}
+
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -458,6 +458,9 @@
     <Compile Include="Issues\Bz53381App.xaml.cs">
       <DependentUpon>Bz53381App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz53203.xaml.cs">
+      <DependentUpon>Bz53203.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -834,6 +837,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz53381App.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz53203.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

[XamlC] accept assignment of Object from unboxed value types in SetValue

I sometimes wish our BP were generic...

## NOTE: this is a regression. It needs to be backported to 2.3.4

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=53203

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense