### PR TITLE
Bz53803 Android app crashes during initialization due to invalid cast…

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -851,8 +851,16 @@ namespace Xamarin.Forms.Platform.Android
 				int actionbarId = _context.Resources.GetIdentifier("action_bar", "id", "android");
 				if(actionbarId > 0)
 				{
-					var toolbar = (Toolbar)((Activity)_context).FindViewById(actionbarId);
-					actionBarTitleTextView = (TextView)toolbar.GetChildAt(0);
+					Toolbar toolbar = (Toolbar)((Activity)_context).FindViewById(actionbarId);
+					
+					for( int i = 0; i < toolbar.ChildCount; i++ )
+					{
+						if( toolbar.GetChildAt(i) is TextView )
+						{
+							actionBarTitleTextView = (TextView)toolbar.GetChildAt(i);
+							break;
+						}
+					}
 				}
 			}
 			else


### PR DESCRIPTION
… of toolbar TextView.

### Description of Change ###

Changed the lookup for the TextView in the Toolbar instead of assuming the first element.

### Bugs Fixed ###

- [Bug 53803 - Android crashes upon initialization when using FormsApplicationActivity.](https://bugzilla.xamarin.com/show_bug.cgi?id=53803)

### API Changes ###

None.

### Behavioral Changes ###

FormsApplicationActivity should load without an InvalidCastException.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
