### PR TITLE
[Android] ScrollView can now consume Effects

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -39,6 +39,10 @@ namespace Xamarin.Forms.ControlGallery.Android
 		protected override void OnAttached ()
 		{
 			Control.SetBackgroundColor (global::Android.Graphics.Color.Aqua);
+
+			var childLabel = (Element as ScrollView)?.Content as Label;
+			if (childLabel != null)
+				childLabel.Text = "Success";
 		}
 
 		protected override void OnDetached ()

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -25,6 +25,10 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		protected override void OnAttached()
 		{
 			Control.BackgroundColor = UIColor.Blue;
+
+			var childLabel = (Element as ScrollView)?.Content as Label;
+			if (childLabel != null)
+				childLabel.Text = "Success";
 		}
 
 		protected override void OnDetached()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45874.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45874.cs
@@ -1,0 +1,44 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 45874, "Effect not attaching to ScrollView", PlatformAffected.iOS | PlatformAffected.Android)]
+	public class Bugzilla45874 : TestContentPage
+	{
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var label = new Label { Text = "FAIL" };
+
+			var scrollView = new ScrollView { Content = label };
+
+			var effect = Effect.Resolve("XamControl.BorderEffect");
+
+			scrollView.Effects.Add(effect);
+
+			Content = scrollView;
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla45874Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(Success));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -262,6 +262,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52533.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53362.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45874.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -5,11 +5,12 @@ using Android.Animation;
 using Android.Graphics;
 using Android.Views;
 using Android.Widget;
+using Xamarin.Forms.Internals;
 using AScrollView = Android.Widget.ScrollView;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class ScrollViewRenderer : AScrollView, IVisualElementRenderer
+	public class ScrollViewRenderer : AScrollView, IVisualElementRenderer, IEffectControlProvider
 	{
 		ScrollViewContainer _container;
 		HorizontalScrollView _hScrollView;
@@ -77,6 +78,8 @@ namespace Xamarin.Forms.Platform.Android
 				if (!string.IsNullOrEmpty(element.AutomationId))
 					ContentDescription = element.AutomationId;
 			}
+
+			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);
 		}
 
 		public VisualElementTracker Tracker { get; private set; }
@@ -214,6 +217,19 @@ namespace Xamarin.Forms.Platform.Android
 
 				Controller.SetScrolledPosition(x, y);
 			}
+		}
+
+		void IEffectControlProvider.RegisterEffect(Effect effect)
+		{
+			var platformEffect = effect as PlatformEffect;
+			if (platformEffect != null)
+				OnRegisterEffect(platformEffect);
+		}
+
+		void OnRegisterEffect(PlatformEffect effect)
+		{
+			effect.SetContainer(this);
+			effect.SetControl(this);
 		}
 
 		static int GetDistance(double start, double position, double v)


### PR DESCRIPTION
### Description of Change ###

Made Android `ScrollView` an `IEffectControlProvider'`.

### Bugs Fixed ###

- [Bug 45874 - Effect not attaching to ScrollView (Android)](https://bugzilla.xamarin.com/show_bug.cgi?id=45874)
#### Needs to be backported to 2.3.4 ####

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
