### PR TITLE
Fix 53427; Change default UAP styling for a label

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -424,7 +424,7 @@
         <uwp:EntryCellTextBox IsEnabled="{Binding IsEnabled}" Header="{Binding}" Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextAlignment="{Binding HorizontalTextAlignment,Converter={StaticResource HorizontalTextAlignmentConverter}}" PlaceholderText="{Binding Placeholder}"  InputScope="{Binding Keyboard,Converter={StaticResource KeyboardConverter}}" HorizontalAlignment="Stretch">
 			<uwp:EntryCellTextBox.HeaderTemplate>
 				<DataTemplate>
-					<TextBlock Text="{Binding Label}" Style="{ThemeResource BaseTextBlockStyle}" Foreground="{Binding LabelColor, Converter={StaticResource ColorConverter}, ConverterParameter=SystemControlBackgroundChromeMediumLowBrush}" />
+					<TextBlock Text="{Binding Label}" Style="{ThemeResource BaseTextBlockStyle}" Foreground="{Binding LabelColor, Converter={StaticResource ColorConverter}, ConverterParameter=DefaultTextForegroundThemeBrush}" />
 				</DataTemplate>
 			</uwp:EntryCellTextBox.HeaderTemplate>
 		</uwp:EntryCellTextBox>


### PR DESCRIPTION
### Description of Change ###

Unexpected styling for UWP EntryCell label: https://bugzilla.xamarin.com/attachment.cgi?id=20400

The user expected the EntryCell label styling to match the SwitchCell label styling. EntryCell style is set here: https://github.com/xamarin/Xamarin.Forms/blob/c65a9a8c57d93b0eff38fd8b06223f6a04688c59/Xamarin.Forms.Platform.UAP/Resources.xaml#L427. 

As you can see it sets ` Foreground="{Binding LabelColor, Converter={StaticResource ColorConverter}, ConverterParameter=SystemControlBackgroundChromeMediumLowBrush}" `. 

This must have been added to allow coloring the label (prob to red to indicate validation error) however no other controls allow coloring the label -- just EntryCell. Which is fine but there is no precedent for the `ConverterParameter`. Currently its value is `SystemControlBackgroundChromeMediumLowBrush` but I think it should be `DefaultTextForegroundThemeBrush`. 

### Bugs Fixed ###

Bug https://bugzilla.xamarin.com/show_bug.cgi?id=53427

### API Changes ###

None

### Behavioral Changes ###

UAP EntryCell default label styling change. 

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
