### PR TITLE
[iOS] Don't skip row height estimation for grouped lists 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51536.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51536.cs
@@ -32,49 +32,49 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Content = listView;
 		}
-	}
 
-	[Preserve(AllMembers = true)]
-	public sealed class ItemViewModel
-	{
-		public string Name { get; set; }
-		public string Description { get; set; }
-	}
-
-	[Preserve(AllMembers = true)]
-	public sealed class ItemViewCell : ViewCell
-	{
-		public Label Label1 { get; set; }
-		public Label Label2 { get; set; }
-
-		public ItemViewCell()
+		[Preserve(AllMembers = true)]
+		public sealed class ItemViewModel
 		{
-			var stackLayout = new StackLayout
-			{
-				Orientation = StackOrientation.Vertical,
-				HorizontalOptions = LayoutOptions.StartAndExpand,
-				VerticalOptions = LayoutOptions.StartAndExpand
-			};
-
-			Label1 = new Label();
-			Label2 = new Label { LineBreakMode = LineBreakMode.WordWrap };
-
-			stackLayout.Children.Add(Label1);
-			stackLayout.Children.Add(Label2);
-
-			View = stackLayout;
+			public string Name { get; set; }
+			public string Description { get; set; }
 		}
 
-		protected override void OnBindingContextChanged()
+		[Preserve(AllMembers = true)]
+		public sealed class ItemViewCell : ViewCell
 		{
-			base.OnBindingContextChanged();
+			public Label Label1 { get; set; }
+			public Label Label2 { get; set; }
 
-			var item = BindingContext as ItemViewModel;
-
-			if (item != null)
+			public ItemViewCell()
 			{
-				Label1.Text = item.Name;
-				Label2.Text = item.Description;
+				var stackLayout = new StackLayout
+				{
+					Orientation = StackOrientation.Vertical,
+					HorizontalOptions = LayoutOptions.StartAndExpand,
+					VerticalOptions = LayoutOptions.StartAndExpand
+				};
+
+				Label1 = new Label();
+				Label2 = new Label { LineBreakMode = LineBreakMode.WordWrap };
+
+				stackLayout.Children.Add(Label1);
+				stackLayout.Children.Add(Label2);
+
+				View = stackLayout;
+			}
+
+			protected override void OnBindingContextChanged()
+			{
+				base.OnBindingContextChanged();
+
+				var item = BindingContext as ItemViewModel;
+
+				if (item != null)
+				{
+					Label1.Text = item.Name;
+					Label2.Text = item.Description;
+				}
 			}
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53834.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53834.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.ObjectModel;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 53834, "incorrect row heights on ios when using groupheadertemplate in Xamarin.Forms 2.3.4.214-pre5", PlatformAffected.iOS)]
+	public class Bugzilla53834 : TestContentPage
+	{
+		const string Instructions = "";
+		ObservableCollection<GroupedItem> grouped { get; set; }
+		ListView lstView;
+
+		class MyViewCell : ViewCell
+		{
+			public MyViewCell()
+			{
+				var label = new Label { HeightRequest = 66, VerticalOptions = LayoutOptions.Start };
+				label.SetBinding(Label.TextProperty, ".");
+				View = new StackLayout { Padding = 10, Children = { label } };
+			}
+		}
+
+		class MyHeaderViewCell : ViewCell
+		{
+			public MyHeaderViewCell()
+			{
+				Height = 25;
+				var label = new Label { VerticalOptions = LayoutOptions.Center };
+				label.SetBinding(Label.TextProperty, nameof(GroupedItem.LongName));
+				View = label;
+			}
+		}
+
+		class GroupedItem : ObservableCollection<string>
+		{
+			public string LongName { get; set; }
+			public string ShortName { get; set; }
+		}
+
+		protected override void Init()
+		{
+			var label = new Label { Text = Instructions };
+			grouped = new ObservableCollection<GroupedItem>();
+			lstView = new ListView()
+			{
+				IsGroupingEnabled = true,
+				HasUnevenRows = true,
+				ItemTemplate = new DataTemplate(typeof(MyViewCell)),
+				GroupHeaderTemplate = new DataTemplate(typeof(MyHeaderViewCell)),
+				ItemsSource = grouped,
+			};
+
+			var grp1 = new GroupedItem() { LongName = "Group 1", ShortName = "1" };
+			var grp2 = new GroupedItem() { LongName = "Group 2", ShortName = "2" };
+
+			for (int i = 1; i < 4; i++)
+			{
+				grp1.Add($"I am a short text #{i}");
+				grp1.Add($"I am a long text that should cause the line to wrap, and I should not be cut off or overlapping in any way. #{i}");
+				grp2.Add($"I am a short text #{i}");
+				grp2.Add($"I am a long text that should cause the line to wrap, and I should not be cut off or overlapping in any way. #{i}");
+			}
+
+			grouped.Add(grp1);
+			grouped.Add(grp2);
+
+			Content = new StackLayout
+			{
+				Children = {
+					label,
+					lstView
+				}
+			};
+		}
+
+#if (UITEST && __IOS__)
+		[Test]
+		[Category(UITestCategories.ManualReview)]
+		public void Bugzilla53834Test()
+		{
+			RunningApp.Screenshot("incorrect row heights test");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -156,6 +156,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43735.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43783.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53834.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51536.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44940.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44944.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -644,10 +644,11 @@ namespace Xamarin.Forms.Platform.iOS
 					return DefaultRowHeight;
 				}
 
-				// We're going to base our estimate off of the first cell 
+				// We're going to base our estimate off of the first cell
 				var firstCell = templatedItems.First();
 
-				if (firstCell.Height > 0)
+				// Let's skip this optimization for grouped lists. It will likely cause more trouble than it's worth.
+				if (firstCell.Height > 0 && !List.IsGroupingEnabled)
 				{
 					// Seems like we've got cells which already specify their height; since the heights are known,
 					// we don't need to use estimatedRowHeight at all; zero will disable it and use the known heights


### PR DESCRIPTION
### Description of Change ###

Reverting to calculating the estimated row height for grouped lists in the likely event that the group header has a known height. Related to #454.

### Bugs Fixed ###

- [Bug 53834 - incorrect row heights on ios when using groupheadertemplate in Xamarin.Forms 2.3.4.214-pre5](https://bugzilla.xamarin.com/show_bug.cgi?id=53834)

#### Needs to be backported to 2.3.4 ####

### API Changes ###

None

### Behavioral Changes ###

May reintroduce the scrolling issues for grouped lists that were fixed by #454.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
