### PR TITLE
Align iOS, Android, Windows handling of tap gesture event bubbling

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest.Queries;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	// This is similar to the test for 35477, but tests all of the basic controls to make sure that they all exhibit
+	// the same behavior across all the platforms. The question is whether tapping a control inside of a frame
+	// will trigger the frame's tap gesture; for most controls it will not (the control itself absorbs the tap),
+	// but for non-interactive controls (box, frame, image, label) the gesture bubbles up to the container.
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 00100100, "Verify that the tap gesture bubbling behavior is consistent across the platforms", PlatformAffected.All)]
+	public class GestureBubblingTests : TestNavigationPage
+	{
+		const string TargetAutomationId = "controlinsideofframe";
+		ContentPage _menu;
+
+#if UITEST
+		[Test, TestCaseSource(nameof(TestCases))]
+		public void VerifyTapBubbling(string menuItem, bool frameShouldRegisterTap)
+		{
+			var results = RunningApp.WaitForElement(q => q.Marked(menuItem));
+
+			if (results.Length > 1)
+			{
+				var rect = results.First(r => r.Class.Contains("Button")).Rect;
+
+				RunningApp.TapCoordinates(rect.CenterX, rect.CenterY);
+			}
+			else
+			{
+				RunningApp.Tap(q => q.Marked(menuItem));
+			}
+
+			// Find the start label
+			RunningApp.WaitForElement(q => q.Marked("Start"));
+
+			// Find the control we're testing
+			var result = RunningApp.WaitForElement(q => q.Marked(TargetAutomationId));
+			var target = result.First().Rect;
+
+			// Tap the control
+			var y = target.CenterY;
+
+			// In theory we want to tap the center of the control. But Stepper lays out differently than the other controls,
+			// (it doesn't center vertically within its layout), so we need to adjust for it until someone fixes it
+			if (menuItem == "Stepper")
+			{
+				y = target.Y;
+			}
+
+			RunningApp.TapCoordinates(target.CenterX, y);
+
+			if (menuItem == nameof(DatePicker) || menuItem == nameof(TimePicker))
+			{
+				// These controls show a pop-up which we have to cancel/done out of before we can continue
+#if __ANDROID__
+				var cancelButtonText = "Cancel";
+#elif __IOS__
+				var cancelButtonText = "Done";
+#else
+				var cancelButtonText = "X";
+#endif
+				RunningApp.WaitForElement(q => q.Marked(cancelButtonText));
+				RunningApp.Tap(q => q.Marked(cancelButtonText));
+			}
+
+			if (frameShouldRegisterTap)
+			{
+				RunningApp.WaitForElement(q => q.Marked("Frame was tapped"));
+			}
+			else
+			{
+				RunningApp.WaitForElement(q => q.Marked("Start"));
+			}
+		}
+#endif
+
+		ContentPage CreateTestPage(View view)
+		{
+			var instructions = new Label
+			{
+				Text = "Tap the frame below. The label with the text 'No taps yet' should change its text to 'Frame was tapped'."
+			};
+
+			var label = new Label { Text = "Start" };
+
+			var frame = new Frame();
+			frame.Content = new StackLayout { Children = { view } };
+
+			var rec = new TapGestureRecognizer { NumberOfTapsRequired = 1 };
+			rec.Tapped += (s, e) => { label.Text = "Frame was tapped"; };
+			frame.GestureRecognizers.Add(rec);
+			
+			var layout = new StackLayout();
+		
+			layout.Children.Add(instructions);
+			layout.Children.Add(label);
+			layout.Children.Add(frame);
+
+			return new ContentPage { Content = layout };
+		}
+
+		Button MenuButton(string label, Func<View> view)
+		{
+			var button = new Button { Text = label };
+
+			var testView = view();
+			testView.AutomationId = TargetAutomationId;
+
+			button.Clicked += (sender, args) => PushAsync(CreateTestPage(testView));
+
+			return button;
+		}
+
+		IEnumerable<object[]> TestCases
+		{
+			get
+			{
+				// These controls should allow the tap gesture to bubble up to their container; everything else should absorb the gesture
+				List<string> controlsWhichShouldAllowTheTapToBubbleUp = new List<string> { nameof(Image), nameof(Label), nameof(BoxView), nameof(Frame) };
+
+				return (BuildMenu().Content as Layout).InternalChildren.SelectMany(
+					element => (element as Layout).InternalChildren.Select(view => new object[]
+					{
+						(view as Button).Text,
+						controlsWhichShouldAllowTheTapToBubbleUp.Contains((view as Button).Text)
+					}));
+			}
+		}
+
+		ContentPage BuildMenu()
+		{
+			if (_menu != null)
+			{
+				return _menu;
+			}
+
+			var layout = new Grid
+			{
+				VerticalOptions = LayoutOptions.Fill,
+				HorizontalOptions = LayoutOptions.Fill,
+				ColumnDefinitions = new ColumnDefinitionCollection { new ColumnDefinition(), new ColumnDefinition() }
+			};
+
+			var col1 = new StackLayout();
+			layout.Children.Add(col1);
+			Grid.SetColumn(col1, 0);
+
+			var col2 = new StackLayout();
+			layout.Children.Add(col2);
+			Grid.SetColumn(col2, 1);
+
+			col1.Children.Add(MenuButton(nameof(Image), () => new Image { Source = ImageSource.FromFile("oasis.jpg") }));
+			col1.Children.Add(MenuButton(nameof(Frame), () => new Frame { BackgroundColor = Color.DarkGoldenrod }));
+			col1.Children.Add(MenuButton(nameof(Entry), () => new Entry()));
+			col1.Children.Add(MenuButton(nameof(Editor), () => new Editor()));
+			col1.Children.Add(MenuButton(nameof(Button), () => new Button { Text = "Test" }));
+			col1.Children.Add(MenuButton(nameof(Label), () => new Label
+			{
+				LineBreakMode = LineBreakMode.WordWrap,
+				Text = "Lorem ipsum dolor sit amet"
+			}));
+			col1.Children.Add(MenuButton(nameof(SearchBar), () => new SearchBar()));
+
+			col2.Children.Add(MenuButton(nameof(DatePicker), () => new DatePicker()));
+			col2.Children.Add(MenuButton(nameof(TimePicker), () => new TimePicker()));
+			col2.Children.Add(MenuButton(nameof(Slider), () => new Slider()));
+			col2.Children.Add(MenuButton(nameof(Switch), () => new Switch()));
+			col2.Children.Add(MenuButton(nameof(Stepper), () => new Stepper()));
+			col2.Children.Add(MenuButton(nameof(BoxView), () => new BoxView { BackgroundColor = Color.DarkMagenta, WidthRequest = 100, HeightRequest = 100 }));
+
+			return new ContentPage { Content = layout };
+		}
+
+		protected override void Init()
+		{
+			PushAsync(BuildMenu());
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
@@ -28,6 +28,10 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test, TestCaseSource(nameof(TestCases))]
 		public void VerifyTapBubbling(string menuItem, bool frameShouldRegisterTap)
 		{
+			// TODO hartez 2017/03/22 18:08:35 results are the same without basing in on the inputtransparent tests	
+			// The stepper failure is because of the broken renderer, just account for the position in the test and it will work
+			// Then fix Frame. Also, the instruction labels are wrong; adjust them based on the value of frameShouldRegisterTap
+
 			var results = RunningApp.WaitForElement(q => q.Marked(menuItem));
 
 			if (results.Length > 1)
@@ -50,15 +54,17 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// Tap the control
 			var y = target.CenterY;
+			var x = target.CenterX;
 
 			// In theory we want to tap the center of the control. But Stepper lays out differently than the other controls,
-			// (it doesn't center vertically within its layout), so we need to adjust for it until someone fixes it
+			// so we need to adjust for it until someone fixes it
 			if (menuItem == "Stepper")
 			{
-				y = target.Y;
+				y = target.Y + 5;
+				x = target.X + 5;
 			}
 
-			RunningApp.TapCoordinates(target.CenterX, y);
+			RunningApp.TapCoordinates(x, y);
 
 			if (menuItem == nameof(DatePicker) || menuItem == nameof(TimePicker))
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
@@ -132,18 +132,30 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		// These controls should allow the tap gesture to bubble up to their container; everything else should absorb the gesture
-		readonly List<string> _controlsWhichShouldAllowTheTapToBubbleUp = new List<string> { nameof(Image), nameof(Label), nameof(BoxView), nameof(Frame) };
+		readonly List<string> _controlsWhichShouldAllowTheTapToBubbleUp = new List<string>
+		{
+			nameof(Image),
+			nameof(Label),
+			nameof(BoxView),
+			nameof(Frame)
+		};
 
 		IEnumerable<object[]> TestCases
 		{
 			get
 			{
-				return (BuildMenu().Content as Layout).InternalChildren.SelectMany(
-					element => (element as Layout).InternalChildren.Select(view => new object[]
+				var layout = BuildMenu().Content as Layout;
+				var result =
+					from Layout element in layout.InternalChildren
+					from Button button in element.InternalChildren
+					let text = button.Text
+					select new object[]
 					{
-						(view as Button).Text,
-						_controlsWhichShouldAllowTheTapToBubbleUp.Contains((view as Button).Text)
-					}));
+						text,
+						_controlsWhichShouldAllowTheTapToBubbleUp.Contains(text)
+					};
+
+				return result;
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -200,6 +200,7 @@
       <DependentUpon>Bugzilla38416.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)FailImageSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GestureBubblingTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InputTransparentTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsInvokeRequiredRaceCondition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsPasswordToggleTest.cs" />

--- a/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ButtonRenderer.cs
@@ -99,6 +99,8 @@ namespace Xamarin.Forms.Platform.WinRT
 			return;
 		}
 
+		protected override bool PreventGestureBubbling { get; set; } = true;
+
 		void OnButtonClick(object sender, RoutedEventArgs e)
 		{
 			((IButtonController)Element)?.SendReleased();

--- a/Xamarin.Forms.Platform.WinRT/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/DatePickerRenderer.cs
@@ -70,6 +70,8 @@ namespace Xamarin.Forms.Platform.WinRT
 				UpdateTextColor();
 		}
 
+		protected override bool PreventGestureBubbling { get; set; } = true;
+
 		void OnControlDateChanged(object sender, DatePickerValueChangedEventArgs e)
 		{
 			Element.Date = e.NewDate.Date;

--- a/Xamarin.Forms.Platform.WinRT/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/SliderRenderer.cs
@@ -71,6 +71,8 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 		}
 
+		protected override bool PreventGestureBubbling { get; set; } = true;
+
 		void OnNativeValueChanged(object sender, RangeBaseValueChangedEventArgs e)
 		{
 			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, e.NewValue);

--- a/Xamarin.Forms.Platform.WinRT/StepperRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/StepperRenderer.cs
@@ -52,6 +52,8 @@ namespace Xamarin.Forms.Platform.WinRT
 				Control.ButtonBackgroundColor = Element.BackgroundColor;
 		}
 
+		protected override bool PreventGestureBubbling { get; set; } = true;
+
 		void OnControlValue(object sender, EventArgs e)
 		{
 			Element.SetValueCore(Stepper.ValueProperty, Control.Value);

--- a/Xamarin.Forms.Platform.WinRT/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/SwitchRenderer.cs
@@ -42,6 +42,8 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 		}
 
+		protected override bool PreventGestureBubbling { get; set; } = true;
+
 		void OnNativeToggled(object sender, RoutedEventArgs routedEventArgs)
 		{
 			((IElementController)Element).SetValueFromRenderer(Switch.IsToggledProperty, Control.IsOn);

--- a/Xamarin.Forms.Platform.WinRT/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/TimePickerRenderer.cs
@@ -65,6 +65,8 @@ namespace Xamarin.Forms.Platform.WinRT
 				UpdateTextColor();
 		}
 
+		protected override bool PreventGestureBubbling { get; set; } = true;
+
 		void OnControlTimeChanged(object sender, TimePickerValueChangedEventArgs e)
 		{
 			Element.Time = e.NewTime;

--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -38,6 +38,8 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		protected bool ArrangeNativeChildren { get; set; }
 
+		protected virtual bool PreventGestureBubbling { get; set; } = false;
+
 		IElementController ElementController => Element as IElementController;
 
 		protected VisualElementTracker<TElement, TNativeElement> Tracker
@@ -549,6 +551,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (_tracker == null)
 				return;
 
+			_tracker.PreventGestureBubbling = PreventGestureBubbling;
 			_tracker.Control = Control;
 			_tracker.Element = Element;
 			_tracker.Container = ContainerElement;

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -67,6 +67,8 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 		}
 
+		public bool PreventGestureBubbling { get; set; }
+
 		public TNativeElement Control
 		{
 			get { return _control; }
@@ -75,8 +77,19 @@ namespace Xamarin.Forms.Platform.WinRT
 				if (_control == value)
 					return;
 
+				if (_control != null)
+				{
+					_control.Tapped -= HandleTapped;
+					_control.DoubleTapped -= HandleDoubleTapped;
+				}
+
 				_control = value;
 				UpdateNativeControl();
+
+				if (PreventGestureBubbling)
+				{
+					UpdatingGestureRecognizers();
+				}
 			}
 		}
 
@@ -161,6 +174,12 @@ namespace Xamarin.Forms.Platform.WinRT
 					var oldRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
 					oldRecognizers.CollectionChanged -= _collectionChangedHandler;
 				}
+			}
+
+			if (_control != null)
+			{
+				_control.Tapped -= HandleTapped;
+				_control.DoubleTapped -= HandleDoubleTapped;
 			}
 
 			Control = null;
@@ -502,11 +521,29 @@ namespace Xamarin.Forms.Platform.WinRT
 			_container.PointerReleased -= OnPointerReleased;
 			_container.PointerCanceled -= OnPointerCanceled;
 
-			if (gestures.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).GetEnumerator().MoveNext())
+			if (gestures.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any())
+			{
 				_container.Tapped += OnTap;
+			}
+			else
+			{
+				if (_control != null && PreventGestureBubbling)
+				{
+					_control.Tapped += HandleTapped;
+				}
+			}
 
-			if (gestures.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2).GetEnumerator().MoveNext())
+			if (gestures.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2).Any())
+			{
 				_container.DoubleTapped += OnDoubleTap;
+			}
+			else
+			{
+				if (_control != null && PreventGestureBubbling)
+				{
+					_control.DoubleTapped += HandleDoubleTapped;
+				}
+			}
 
 			bool hasPinchGesture = gestures.GetGesturesFor<PinchGestureRecognizer>().GetEnumerator().MoveNext();
 			bool hasPanGesture = gestures.GetGesturesFor<PanGestureRecognizer>().GetEnumerator().MoveNext();
@@ -531,6 +568,16 @@ namespace Xamarin.Forms.Platform.WinRT
 			_container.PointerExited += OnPointerExited;
 			_container.PointerReleased += OnPointerReleased;
 			_container.PointerCanceled += OnPointerCanceled;
+		}
+
+		void HandleTapped(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)
+		{
+			tappedRoutedEventArgs.Handled = true;
+		}
+
+		void HandleDoubleTapped(object sender, DoubleTappedRoutedEventArgs doubleTappedRoutedEventArgs)
+		{
+			doubleTappedRoutedEventArgs.Handled = true;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This change brings iOS, Android, and WinRT/UWP all into alignment on how they treat taps/clicks on a control within a container. 

Previously, if a container (Grid, ContentView, Frame, etc.) had a tap gesture assigned to it and contained controls (Label, Box, Entry, etc.) which do not have gestures assigned, the platforms all behaved differently when those controls were tapped. On each platform, some of the controls would bubble the tap gesture up to the container and some would not, and those lists were different on each platform. 

With this change, controls which become interactive on tap/click (Entry, Editor, Button, etc.) will *not* bubble the tap gesture to the container. Controls which do not (Label, Image, Box, Frame) will allow the gesture to bubble up to their container. The two lists are now consistent across the platforms.

### Bugs Fixed ###

- This change partially addresses the problems described in [45453](https://bugzilla.xamarin.com/show_bug.cgi?id=45453) (in that the behavior of the controls on all of the platforms should now be consistent when the controls are enabled; the behavior inconsistencies Adrian points out in the Bugzilla discussion are still present for controls with `IsEnabled` set to false).

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
