### PR TITLE
Map renderer extensibility

### DIFF
--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -181,6 +181,33 @@ namespace Xamarin.Forms.Maps.Android
 				MoveToRegion(Element.LastMoveToRegion, false);
 			}
 		}
+		
+		protected virtual void OnMapReady(GoogleMap map)
+		{
+			if (map == null)
+			{
+				return;
+			}
+			
+			map.SetOnCameraChangeListener(this);
+			map.InfoWindowClick += MapOnMarkerClick;
+			
+			map.UiSettings.ZoomControlsEnabled = Map.HasZoomEnabled;
+			map.UiSettings.ZoomGesturesEnabled = Map.HasZoomEnabled;
+			map.UiSettings.ScrollGesturesEnabled = Map.HasScrollEnabled;
+			map.MyLocationEnabled = map.UiSettings.MyLocationButtonEnabled = Map.IsShowingUser;
+			SetMapType();
+		}
+		
+		protected virtual MarkerOptions CreateMarker(Pin pin)
+		{
+			var opts = new MarkerOptions();
+			opts.SetPosition(new LatLng(pin.Position.Latitude, pin.Position.Longitude));
+			opts.SetTitle(pin.Label);
+			opts.SetSnippet(pin.Address);
+			
+			return opts;
+		}
 
 		void AddPins(IList pins)
 		{
@@ -198,10 +225,7 @@ namespace Xamarin.Forms.Maps.Android
 			_markers.AddRange(pins.Cast<Pin>().Select(p =>
 			{
 				Pin pin = p;
-				var opts = new MarkerOptions();
-				opts.SetPosition(new LatLng(pin.Position.Latitude, pin.Position.Longitude));
-				opts.SetTitle(pin.Label);
-				opts.SetSnippet(pin.Address);
+				var opts = CreateMarker(pin);
 				var marker = map.AddMarker(opts);
 
 				// associate pin with marker for later lookup in event handlers
@@ -367,19 +391,7 @@ namespace Xamarin.Forms.Maps.Android
 		void IOnMapReadyCallback.OnMapReady(GoogleMap map)
 		{
 			NativeMap = map;
-			if (map == null)
-			{
-				return;
-			}
-
-			map.SetOnCameraChangeListener(this);
-			map.InfoWindowClick += MapOnMarkerClick;
-
-			map.UiSettings.ZoomControlsEnabled = Map.HasZoomEnabled;
-			map.UiSettings.ZoomGesturesEnabled = Map.HasZoomEnabled;
-			map.UiSettings.ScrollGesturesEnabled = Map.HasScrollEnabled;
-			map.MyLocationEnabled = map.UiSettings.MyLocationButtonEnabled = Map.IsShowingUser;
-			SetMapType();
+			OnMapReady(map);
 		}
 	}
 }

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -306,6 +306,16 @@ namespace Xamarin.Forms.Maps.MacOS
 		}
 #endif
 
+		protected virtual IMKAnnotation CreateAnnotation(Pin pin)
+		{
+			return new MKPointAnnotation
+			{
+				Title = pin.Label,
+				Subtitle = pin.Address ?? "",
+				Coordinate = new CLLocationCoordinate2D(pin.Position.Latitude, pin.Position.Longitude)
+			};
+		}
+
 		void UpdateRegion()
 		{
 			if (_shouldUpdateRegion)
@@ -319,10 +329,8 @@ namespace Xamarin.Forms.Maps.MacOS
 		{
 			foreach (Pin pin in pins)
 			{
-				var annotation = new MKPointAnnotation { Title = pin.Label, Subtitle = pin.Address ?? "" };
-
+				var annotation = CreateAnnotation(pin);
 				pin.Id = annotation;
-				annotation.SetCoordinate(new CLLocationCoordinate2D(pin.Position.Latitude, pin.Position.Longitude));
 				((MKMapView)Control).AddAnnotation(annotation);
 			}
 		}

--- a/Xamarin.Forms.Maps/Pin.cs
+++ b/Xamarin.Forms.Maps/Pin.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms.Maps
 {
-	public sealed class Pin : BindableObject
+	public class Pin : BindableObject
 	{
 		public static readonly BindableProperty TypeProperty = BindableProperty.Create("Type", typeof(PinType), typeof(Pin), default(PinType));
 
@@ -10,9 +10,7 @@ namespace Xamarin.Forms.Maps
 
 		public static readonly BindableProperty AddressProperty = BindableProperty.Create("Address", typeof(string), typeof(Pin), default(string));
 
-		// introduced to store the unique id for Android markers
-
-		string _label;
+		public static readonly BindableProperty LabelProperty = BindableProperty.Create("Label", typeof(string), typeof(Pin), default(string));
 
 		public string Address
 		{
@@ -22,14 +20,8 @@ namespace Xamarin.Forms.Maps
 
 		public string Label
 		{
-			get { return _label; }
-			set
-			{
-				if (_label == value)
-					return;
-				_label = value;
-				OnPropertyChanged();
-			}
+			get { return (string)GetValue(LabelProperty); }
+			set { SetValue(LabelProperty, value); }
 		}
 
 		public Position Position
@@ -44,6 +36,7 @@ namespace Xamarin.Forms.Maps
 			set { SetValue(TypeProperty, value); }
 		}
 
+		// introduced to store the unique id for Android markers
 		internal object Id { get; set; }
 
 		public event EventHandler Clicked;

--- a/docs/Xamarin.Forms.Maps/Xamarin.Forms.Maps/Pin.xml
+++ b/docs/Xamarin.Forms.Maps/Xamarin.Forms.Maps/Pin.xml
@@ -1,6 +1,6 @@
 <Type Name="Pin" FullName="Xamarin.Forms.Maps.Pin">
-  <TypeSignature Language="C#" Value="public sealed class Pin : Xamarin.Forms.BindableObject" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit Pin extends Xamarin.Forms.BindableObject" />
+  <TypeSignature Language="C#" Value="public class Pin : Xamarin.Forms.BindableObject" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Pin extends Xamarin.Forms.BindableObject" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Maps</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -188,6 +188,21 @@ public static Page GetMapPage ()
       <Docs>
         <summary>A user-readable <langword see="string" /> associated with the <see cref="T:Xamarin.Forms.Maps.Pin" />.</summary>
         <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="LabelProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty LabelProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty LabelProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
### Description of Change ###

Makes the Xamarin.Forms.Maps projects more extensible, by unsealing the Pin class and adding hooks in the MapRenderer classes for customization of map and pins.

### API Changes ###

Added:
- protected virtual void MapRenderer.OnMapReady(GoogleMap map) (Android)
- protected virtual MarkerOptions MapRenderer.CreateMarker(Pin pin) (Android)
- protected virtual IMKAnnotation MapRenderer.CreateAnnotation(Pin pin) (iOS)
- Pin.LabelProperty

Changed:

- IOnMapReadyCallback.OnMapReady(GoogleMap map) calls protected OnMapReady for map initialization 
- public sealed class Pin => public class Pin
- Pin.Label now uses backing BindableProperty LabelProperty

### Behavioral Changes ###

No behavioral changes to existing functionality, reduces need for workarounds when subclassing MapRenderer.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
