### PR TITLE
Don't auto reenable the cancel button

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -158,8 +158,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateCancelButton()
 		{
-			Control.ShowsCancelButton = !string.IsNullOrEmpty(Control.Text);
-
 			// We can't cache the cancel button reference because iOS drops it when it's not displayed
 			// and creates a brand new one when necessary, so we have to look for it each time
 			var cancelButton = Control.FindDescendantView<UIButton>();


### PR DESCRIPTION
### Description of Change ###

iOS SearchBar renderer will now no longer auto reenable the cancel button when text is being cleared.

### Bugs Fixed ###

When an user has a custom renderer with following code : Control.ShowsCancelButton = false;
Inside the OnElementPropertyChanged() method, the current implementation of the control on iOS would reverse this setting each time the search bar would be cleared from input text.

For reference blogpost about the problem and current work around [http://depblog.weblogs.us/2016/10/27/xamarin-forms-ios-disable-cancel-button-on-searchbar/](http://depblog.weblogs.us/2016/10/27/xamarin-forms-ios-disable-cancel-button-on-searchbar/), this commit will fix that problem.

### API Changes ###

List all API changes here (or just put None), example:

Removed:
 - Control.ShowsCancelButton = !string.IsNullOrEmpty(Control.Text);

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense