### PR TITLE
[Xaml] Set the TargetProperty on ServiceProvider

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.UnitTests/BaseTestFixture.cs
@@ -11,6 +11,8 @@ namespace Xamarin.Forms.Core.UnitTests
 		[SetUp]
 		public virtual void Setup ()
 		{
+			Device.PlatformServices = new MockPlatformServices();
+
 #if !WINDOWS_PHONE
 			var culture = Environment.GetEnvironmentVariable ("UNIT_TEST_CULTURE");
 			
@@ -24,7 +26,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[TearDown]
 		public virtual void TearDown ()
 		{
-			
+			Device.PlatformServices = null;
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+	x:Class="Xamarin.Forms.Xaml.UnitTests.Bz53275"
+	ANonBindableProperty="{local:TargetProperty}">
+	<Label x:Name="label" Text="{local:TargetProperty}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz53275.xaml.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Reflection;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class TargetPropertyExtension : IMarkupExtension
+	{
+		public object ProvideValue(IServiceProvider serviceProvider)
+		{
+			var targetProperty = (serviceProvider?.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget)?.TargetProperty;
+			return (targetProperty as BindableProperty)?.PropertyName ?? (targetProperty as PropertyInfo)?.Name;
+		}
+	}
+
+	public partial class Bz53275 : ContentPage
+	{
+		public Bz53275()
+		{
+			InitializeComponent();
+		}
+
+		public Bz53275(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		public string ANonBindableProperty { get; set; }
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void TargetPropertyIsSetOnMarkups(bool useCompiledXaml)
+			{
+				var page = new Bz53275(useCompiledXaml);
+				Assert.AreEqual("ANonBindableProperty", page.ANonBindableProperty);
+				var l0 = page.label;
+				Assert.AreEqual("Text", l0.Text);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Windows.Input;
 using Xamarin.Forms;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -46,6 +47,18 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		public class Tests
 		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
 			[TestCase(false)]
 			[TestCase(true)]
 			public void NestedMarkupExtensionInsideDataTemplate(bool useCompiledXaml)

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -470,6 +470,9 @@
     <Compile Include="Issues\Bz41048.xaml.cs">
       <DependentUpon>Bz41048.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz53275.xaml.cs">
+      <DependentUpon>Bz53275.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -858,6 +861,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz41048.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz53275.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/XamlServiceProvider.cs
+++ b/Xamarin.Forms.Xaml/XamlServiceProvider.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Forms.Xaml.Internals
 
 		HydratationContext Context { get; }
 		public object TargetObject { get; }
-		public object TargetProperty { get; } = null;
+		public object TargetProperty { get; internal set; } = null;
 
 		IEnumerable<object> IProvideParentValues.ParentObjects
 		{


### PR DESCRIPTION
### Description of Change ###

[Xaml] Set the TargetProperty on ServiceProvider

The TargetProperty was set in XamlC scenarios. Set it on uncompiled Xaml too.
This is an alternate version of #814.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=53275 which is not really a bug, as it's fine to get a `null` for the TargetProperty.

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense