### PR TITLE
[iOS] Hide alert window before setting result

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -357,8 +357,8 @@ namespace Xamarin.Forms.Platform.iOS
 			return UIAlertAction.Create(text, style,
 					a =>
 					{
-						setResult();
 						window.Hidden = true;
+						setResult();
 					});
 		}
 


### PR DESCRIPTION
### Description of Change ###

#481 and #543 made `UIAlertController` use a separate window which is hidden after the alert is dismissed. However this is causing [some](https://forums.xamarin.com/discussion/comment/263097/#Comment_263097) [issues](https://github.com/jamesmontemagno/MediaPlugin/issues/186) when trying to immediately present another view controller since the alert window is still in the view hierarchy. 

This can be worked around by adding a brief delay before presenting the new view controller, but we can also fix this on our end by hiding the new window _before_ setting the result and returning to the user's code.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=54153

### API Changes ###

None

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
