### PR TITLE
Make IAppLinks.RegisterLink etc awaitable to allow catching exceptions

### DIFF
--- a/Xamarin.Forms.Core/IAppLinks.cs
+++ b/Xamarin.Forms.Core/IAppLinks.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms
 {
 	public interface IAppLinks
 	{
-		void DeregisterLink(IAppLinkEntry appLink);
-		void DeregisterLink(Uri appLinkUri);
-		void RegisterLink(IAppLinkEntry appLink);
+		Task DeregisterLink(IAppLinkEntry appLink);
+		Task DeregisterLink(Uri appLinkUri);
+		Task RegisterLink(IAppLinkEntry appLink);
 	}
 }

--- a/Xamarin.Forms.Platform.Android.AppLinks/AndroidAppLinks.cs
+++ b/Xamarin.Forms.Platform.Android.AppLinks/AndroidAppLinks.cs
@@ -35,19 +35,21 @@ namespace Xamarin.Forms.Platform.Android.AppLinks
 			_client.Connect();
 		}
 
-		public void DeregisterLink(IAppLinkEntry appLink)
+		public Task DeregisterLink(IAppLinkEntry appLink)
 		{
 			RemoveFromIndexItemAsync(appLink.AppLinkUri.ToString());
+			return Task.FromResult<object>(null);
 		}
 
-		public void DeregisterLink(Uri appLinkUri)
+		public Task DeregisterLink(Uri appLinkUri)
 		{
 			RemoveFromIndexItemAsync(appLinkUri.ToString());
+			return Task.FromResult<object>(null);
 		}
 
-		public async void RegisterLink(IAppLinkEntry appLink)
+		public Task RegisterLink(IAppLinkEntry appLink)
 		{
-			await IndexItemAsync(appLink);
+			return IndexItemAsync(appLink);
 		}
 
 		public void Dispose()

--- a/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
+++ b/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
@@ -8,30 +8,30 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	internal class IOSAppLinks : IAppLinks
 	{
-		public async void DeregisterLink(IAppLinkEntry appLink)
+		public Task DeregisterLink(IAppLinkEntry appLink)
 		{
 			if (string.IsNullOrWhiteSpace(appLink.AppLinkUri?.ToString()))
 				throw new ArgumentNullException("AppLinkUri");
-			await RemoveLinkAsync(appLink.AppLinkUri?.ToString());
+			return RemoveLinkAsync(appLink.AppLinkUri?.ToString());
 		}
 
-		public async void DeregisterLink(Uri uri)
+		public Task DeregisterLink(Uri uri)
 		{
 			if (string.IsNullOrWhiteSpace(uri?.ToString()))
 				throw new ArgumentNullException(nameof(uri));
-			await RemoveLinkAsync(uri.ToString());
+			return RemoveLinkAsync(uri.ToString());
 		}
 
-		public async void RegisterLink(IAppLinkEntry appLink)
+		public Task RegisterLink(IAppLinkEntry appLink)
 		{
 			if (string.IsNullOrWhiteSpace(appLink.AppLinkUri?.ToString()))
 				throw new ArgumentNullException("AppLinkUri");
-			await AddLinkAsync(appLink);
+			return AddLinkAsync(appLink);
 		}
 
-		public async void DeregisterAll()
+		public Task DeregisterAll()
 		{
-			await ClearIndexedDataAsync();
+			return ClearIndexedDataAsync();
 		}
 
 		static async Task AddLinkAsync(IAppLinkEntry deepLinkUri)


### PR DESCRIPTION
### Description of Change ###

With the current implementation the app crashes when the thumbnail url can't be loaded on iOS. This change makes the RegisterLink etc. methods awaitable (return Task) so the dev can catch exceptions and avoid unhandled exception crashes.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=42061

### API Changes ###

Changed:
 - void IAppLinks.RegisterLink => Task IAppLinks.RegisterLink
 - void IAppLinks.DeregisterLink => Task IAppLinks.DeregisterLink

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
