### PR TITLE
Fix 54334

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -363,9 +363,10 @@ namespace Xamarin.Forms
 				value = property.CoerceValue(this, value);
 
 			BindablePropertyContext context = GetOrCreateContext(property);
-			if (manuallySet)
+			if (manuallySet) {
 				context.Attributes |= BindableContextAttributes.IsManuallySet;
-			else
+				context.Attributes &= ~BindableContextAttributes.IsSetFromStyle;
+			} else
 				context.Attributes &= ~BindableContextAttributes.IsManuallySet;
 
 			if (fromStyle)

--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Forms
 				return;
 
 			object actual = target.GetValue(Property);
-			if (!Equals(actual, Value))
+			if (!Equals(actual, Value) && !(Value is Binding) && !(Value is DynamicResource))
 			{
 				//Do not reset default value if the value has been changed
 				_originalValues.Remove(target);

--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -63,12 +63,12 @@ namespace Xamarin.Forms
 		internal void UnApply(BindableObject target, bool fromStyle = false)
 		{
 			if (target == null)
-				throw new ArgumentNullException("target");
+				throw new ArgumentNullException(nameof(target));
 			if (Property == null)
 				return;
 
 			object actual = target.GetValue(Property);
-			if (!fromStyle && !Equals(actual, Value))
+			if (!Equals(actual, Value))
 			{
 				//Do not reset default value if the value has been changed
 				_originalValues.Remove(target);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz28719.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz28719.xaml.cs
@@ -44,10 +44,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.NotNull (image0);
 
 				cell0.BindingContext = new {IsSelected = true};
-				Assert.AreEqual ("Remove.png", (image0.Source as FileImageSource).File);
+				Assert.AreEqual ("Remove.png", (image0.Source as FileImageSource)?.File);
 
 				cell0.BindingContext = new {IsSelected = false};
-				Assert.AreEqual ("Add.png", (image0.Source as FileImageSource).File);
+				Assert.AreEqual ("Add.png", (image0.Source as FileImageSource)?.File);
 
 				var cell1 = template.CreateContent () as ViewCell;
 				Assert.NotNull (cell1);
@@ -55,10 +55,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.NotNull (image1);
 
 				cell1.BindingContext = new {IsSelected = true};
-				Assert.AreEqual ("Remove.png", (image1.Source as FileImageSource).File);
+				Assert.AreEqual ("Remove.png", (image1.Source as FileImageSource)?.File);
 
 				cell1.BindingContext = new {IsSelected = false};
-				Assert.AreEqual ("Add.png", (image1.Source as FileImageSource).File);
+				Assert.AreEqual ("Add.png", (image1.Source as FileImageSource)?.File);
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz41048.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz41048.xaml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Xamarin.Forms.Xaml.UnitTests.Bz41048">
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<!-- Standard Style -->
+			<Style x:Key="StandardLabelStyle" TargetType="Label">
+				<Setter Property="TextColor" Value="Red"/>
+				<Setter Property="LineBreakMode" Value="TailTruncation"/>
+			</Style>
+
+			<!-- Derived style with bold font -->
+			<Style x:Key="StandarBoldLabelStyle" TargetType="Label" BasedOn="{StaticResource StandardLabelStyle}">
+				<Setter Property="FontAttributes" Value="Bold"/>
+			</Style>
+			
+			<!-- Use the StandardLabelStyle as implicit style for all labels -->
+			<Style TargetType="Label" BasedOn="{StaticResource StandardLabelStyle}"/>
+		</ResourceDictionary>
+	</ContentPage.Resources>
+	<Label x:Name="label0"
+		Style="{StaticResource StandarBoldLabelStyle}"
+		LineBreakMode="WordWrap" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz41048.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz41048.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz41048 : ContentPage
+	{
+		public Bz41048()
+		{
+			InitializeComponent();
+		}
+
+		public Bz41048(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Application.Current = null;
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void StyleDoesNotOverrideValues(bool useCompiledXaml)
+			{
+				var layout = new Bz41048(useCompiledXaml);
+				var label = layout.label0;
+				Assert.That (label.TextColor, Is.EqualTo(Color.Red));
+				Assert.That (label.FontAttributes, Is.EqualTo(FontAttributes.Bold));
+				Assert.That (label.LineBreakMode, Is.EqualTo(LineBreakMode.WordWrap));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz54334.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz54334.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Bz54334">
+<StackLayout Padding="10">
+        <Label x:Name="label" HorizontalTextAlignment="Center" Text="I have a set textcolor, but in since pre-3 styles will override it.."  TextColor="Black" />
+        <Label x:Name="themedLabel" HorizontalTextAlignment="Center" Text="I dont have a set textcolor, syles can override me as much as they want"   />
+        <Button x:Name="btn" Text="Change Theme"></Button>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz54334.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz54334.xaml.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Bz54334App : Application
+	{
+		bool daymode = true;
+		public Bz54334App(bool useCompiledXaml)
+		{
+			Resources = new ResourceDictionary{
+				new Style(typeof(Label)) {
+					Setters = {
+						new Setter {Property = Label.TextColorProperty, Value=Color.Blue}
+					}
+				}
+			};
+			MainPage = new Bz54334(useCompiledXaml);
+			MessagingCenter.Subscribe<ContentPage>(this, "ChangeTheme", (s) => {
+				ToggleTheme();
+			});
+		}
+
+		void ToggleTheme()
+		{
+			Resources = daymode ? new ResourceDictionary{
+				new Style(typeof(Label)) {
+					Setters = {
+						new Setter {Property = Label.TextColorProperty, Value=Color.Red}
+					}
+				}
+			} : new ResourceDictionary{
+				new Style(typeof(Label)) {
+					Setters = {
+						new Setter {Property = Label.TextColorProperty, Value=Color.Blue}
+					}
+				}
+			};
+			daymode = !daymode;
+		}
+	}
+
+	public partial class Bz54334 : ContentPage
+	{
+		public Bz54334()
+		{
+			InitializeComponent();
+		}
+		public Bz54334(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Application.Current = null;
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void Foo(bool useCompiledXaml)
+			{
+				var app = Application.Current = new Bz54334App(useCompiledXaml);
+				var page = app.MainPage as Bz54334;
+				var l0 = page.label;
+				var l1 = page.themedLabel;
+
+				Assert.That(l0.TextColor, Is.EqualTo(Color.Black));
+				Assert.That(l1.TextColor, Is.EqualTo(Color.Blue));
+
+				MessagingCenter.Send<ContentPage>(page, "ChangeTheme");
+				Assert.That(l0.TextColor, Is.EqualTo(Color.Black));
+				Assert.That(l1.TextColor, Is.EqualTo(Color.Red));
+
+				MessagingCenter.Send<ContentPage>(page, "ChangeTheme");
+				Assert.That(l0.TextColor, Is.EqualTo(Color.Black));
+				Assert.That(l1.TextColor, Is.EqualTo(Color.Blue));
+
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -461,6 +461,9 @@
     <Compile Include="Issues\Bz53203.xaml.cs">
       <DependentUpon>Bz53203.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz54334.xaml.cs">
+      <DependentUpon>Bz54334.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -840,6 +843,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz53203.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz54334.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -464,6 +464,9 @@
     <Compile Include="Issues\Bz54334.xaml.cs">
       <DependentUpon>Bz54334.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz41048.xaml.cs">
+      <DependentUpon>Bz41048.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -846,6 +849,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz54334.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz41048.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

When setting a value with SetValue, unset the IsFromStyle flag to avoid bypass determined on that flag only.

## NOTE: this might be a regression on 2.3.4 and might need to be backported and released

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=54334
- https://bugzilla.xamarin.com/show_bug.cgi?id=41048

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense