### PR TITLE
Fix NRE when RecycleElement is on and list is scrolled quickly on Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
@@ -179,12 +179,6 @@ namespace Xamarin.Forms.Platform.Android
 			LayoutParameters = new LayoutParams(ViewGroup.LayoutParams.MatchParent, (int)(height == -1 ? ViewGroup.LayoutParams.WrapContent : height));
 		}
 
-		protected override void OnDetachedFromWindow()
-		{
-			base.OnDetachedFromWindow();
-			_cell = null;
-		}
-
 		async void UpdateBitmap(ImageSource source, ImageSource previousSource = null)
 		{
 			if (Equals(source, previousSource))


### PR DESCRIPTION
### Description of Change ###

Removes an unnecessary optimization in BaseCellView which can, under certain circumstances, cause a `NullReferenceException` in the `ListViewAdapter` when the list is scrolled quickly enough.

The NRE occurs in `GetView` when the adapter attempts to get the Element from the cell; if the previous override of `OnDetachedFromWindow()` has already been called, the `Element` will return `null` and the application will crash.

No UI tests, it's a race condition and difficult to reliably reproduce.

### Bugs Fixed ###

- The aforementioned NRE

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
