### PR TITLE
OnResume assumed that _application had been set

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -236,7 +236,7 @@ namespace Xamarin.Forms.Platform.Android
 			// counterpart to OnPause
 			base.OnResume();
 
-			if (_application.OnThisPlatform().GetShouldPreserveKeyboardOnResume())
+			if (_application != null && _application.OnThisPlatform().GetShouldPreserveKeyboardOnResume())
 			{
 				if (CurrentFocus != null && (CurrentFocus is EditText || CurrentFocus is TextView || CurrentFocus is SearchView))
 				{


### PR DESCRIPTION
When OnResume is called it should not expect the _application to be set already.
I have an app where I use one activity for showing a splash screen and then it starts an intent to show the main activity containing the application.
This used to work before 2.3.4.224.

### Description of Change ###

I have added a null check for the `_application` object before it's used.

### Bugs Fixed ###

OnResume crashes if the `_application` has not been set.

### API Changes ###

None

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
