### PR TITLE
Do not emit implict_op if from/to are same type

### DIFF
--- a/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
@@ -73,6 +73,7 @@ namespace Xamarin.Forms.Build.Tasks
 						if (initCompRuntime == null) {
 							Logger.LogString(2, "   Creating empty {0}.__InitComponentRuntime ...", typeDef.Name);
 							initCompRuntime = new MethodDefinition("__InitComponentRuntime", initComp.Attributes, initComp.ReturnType);
+							initCompRuntime.Body.InitLocals = true;
 							Logger.LogLine(2, "done.");
 							Logger.LogString(2, "   Copying body of InitializeComponent to __InitComponentRuntime ...", typeDef.Name);
 							initCompRuntime.Body = new MethodBody(initCompRuntime);
@@ -116,6 +117,7 @@ namespace Xamarin.Forms.Build.Tasks
 						}
 
 						var body = new MethodBody(altCtor);
+						body.InitLocals = true;
 						var il = body.GetILProcessor();
 						var br2 = Instruction.Create(OpCodes.Ldarg_0);
 						var ret = Instruction.Create(OpCodes.Ret);

--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -480,6 +480,7 @@ namespace Xamarin.Forms.Build.Tasks
 					new CustomAttribute (context.Module.ImportReference(compilerGeneratedCtor))
 				}
 			};
+			getter.Body.InitLocals = true;
 			var il = getter.Body.GetILProcessor();
 
 			il.Emit(OpCodes.Ldarg_0);
@@ -550,6 +551,7 @@ namespace Xamarin.Forms.Build.Tasks
 					new CustomAttribute (module.ImportReference(compilerGeneratedCtor))
 				}
 			};
+			setter.Body.InitLocals = true;
 
 			var il = setter.Body.GetILProcessor();
 			var lastProperty = properties.LastOrDefault();
@@ -640,6 +642,7 @@ namespace Xamarin.Forms.Build.Tasks
 						new CustomAttribute (context.Module.ImportReference(compilerGeneratedCtor))
 					}
 				};
+				partGetter.Body.InitLocals = true;
 				var il = partGetter.Body.GetILProcessor();
 				il.Emit(OpCodes.Ldarg_0);
 				for (int j = 0; j < i; j++) {
@@ -1142,6 +1145,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var loadTemplate = new MethodDefinition("LoadDataTemplate",
 				MethodAttributes.Assembly | MethodAttributes.HideBySig,
 				module.TypeSystem.Object);
+			loadTemplate.Body.InitLocals = true;
 			anonType.Methods.Add(loadTemplate);
 
 			var parentValues = new FieldDefinition("parentValues", FieldAttributes.Assembly, module.ImportReference(typeof (object[])));

--- a/Xamarin.Forms.Build.Tasks/TypeDefinitionExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeDefinitionExtensions.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Forms.Build.Tasks
 				CallingConvention = MethodCallingConvention.Default,
 				ImplAttributes = (MethodImplAttributes.IL | MethodImplAttributes.Managed)
 			};
+			ctor.Body.InitLocals = true;
 
 			var IL = ctor.Body.GetILProcessor();
 

--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -246,6 +246,9 @@ namespace Xamarin.Forms.Build.Tasks
 
 		public static MethodReference GetImplicitOperatorTo(this TypeReference fromType, TypeReference toType, ModuleDefinition module)
 		{
+			if (TypeRefComparer.Default.Equals(fromType, toType))
+				return null;
+
 			var implicitOperatorsOnFromType = fromType.GetMethods(md => md.IsPublic && md.IsStatic && md.IsSpecialName && md.Name == "op_Implicit", module);
 			var implicitOperatorsOnToType = toType.GetMethods(md => md.IsPublic && md.IsStatic && md.IsSpecialName && md.Name == "op_Implicit", module);
 			var implicitOperators = implicitOperatorsOnFromType.Concat(implicitOperatorsOnToType).ToList();

--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -152,6 +152,7 @@ namespace Xamarin.Forms.Build.Tasks
 						else {
 							Logger.LogString(2, "   Creating empty {0}.__InitComponentRuntime ...", typeDef.Name);
 							initCompRuntime = new MethodDefinition("__InitComponentRuntime", initComp.Attributes, initComp.ReturnType);
+							initCompRuntime.Body.InitLocals = true;
 							Logger.LogLine(2, "done.");
 							Logger.LogString(2, "   Copying body of InitializeComponent to __InitComponentRuntime ...", typeDef.Name);
 							initCompRuntime.Body = new MethodBody(initCompRuntime);
@@ -160,6 +161,7 @@ namespace Xamarin.Forms.Build.Tasks
 								iCRIl.Append(instr);
 							initComp.Body.Instructions.Clear();
 							initComp.Body.GetILProcessor().Emit(OpCodes.Ret);
+							initComp.Body.InitLocals = true;
 							typeDef.Methods.Add(initCompRuntime);
 							Logger.LogLine(2, "done.");
 						}
@@ -245,6 +247,7 @@ namespace Xamarin.Forms.Build.Tasks
 			try {
 				var body = new MethodBody(initComp);
 				var module = body.Method.Module;
+				body.InitLocals = true;
 				var il = body.GetILProcessor();
 				il.Emit(OpCodes.Nop);
 


### PR DESCRIPTION
### Description of Change ###

After bisection I found that change `eacbc1acf4cc` in `GetImplicitOperatorTo` causes the reproduction of https://bugzilla.xamarin.com/show_bug.cgi?id=54012 to throw an AccessViolationException in https://github.com/xamarin/Xamarin.Forms/blob/c65a9a8c57d93b0eff38fd8b06223f6a04688c59/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs#L20. Note the bug reports a different issue; this is a regression  that blocks investigation of the reported issue.

Expected `MasterDetailNavigation.dll` for 54012 to successfully pass peverify but actually observed errors. Expected xaml compiler to emit initlocals for all method bodies but actually did not. Expected xaml compiler to not emit op_implicit if `fromType` equals `toType` but actually emits op_implicit when that is the case. Either actual behavior produces unverifiable code. 

Changed xaml compiler to emit initlocals for all MethodDefinitions. Changed xaml compiler to not emit op_implicit when from type equals to type. 

### Bugs Fixed ###

None. Discovered regression while investigating another bug. 

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
