### PR TITLE
Verify FragmentContainer created when queueing fragment transaction (Android)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30324.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30324.cs
@@ -9,6 +9,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[Category(Core.UITests.UITestCategories.MasterDetailPage)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 30324, "Detail view of MasterDetailPage does not get appearance events on Android when whole MasterDetailPage disappears/reappears")]
 	public class Bugzilla30324 : TestNavigationPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -387,6 +387,9 @@ namespace Xamarin.Forms.Controls
 		protected abstract void Init();
 	}
 
+#if UITEST
+	[Category(Core.UITests.UITestCategories.MasterDetailPage)]
+#endif
 	public abstract class TestMasterDetailPage : MasterDetailPage
 	{
 #if UITEST

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				// The renderers for NavigationPage and TabbedPage both host fragments, so they need to be wrapped in a 
 				// FragmentContainer in order to get isolated fragment management
 				Fragment fragment = FragmentContainer.CreateInstance(page);
-
+				
 				var fc = fragment as FragmentContainer;
 
 				fc?.SetOnCreateCallback(pc =>
@@ -115,8 +115,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				new Handler(Looper.MainLooper).PostAtFrontOfQueue(() =>
 				{
-					if (Handle == IntPtr.Zero)
+					if (_pageContainer == null)
 					{
+						// The view we're hosting in the fragment was never created (possibly we're already 
+						// navigating to another page?) so there's nothing to commit
 						return;
 					}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -1,3 +1,4 @@
+using System;
 using Android.App;
 using Android.Content;
 using Android.OS;
@@ -112,7 +113,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				_currentFragment = fragment;
 
-				new Handler(Looper.MainLooper).PostAtFrontOfQueue(() => FragmentManager.ExecutePendingTransactions());
+				new Handler(Looper.MainLooper).PostAtFrontOfQueue(() =>
+				{
+					if (Handle == IntPtr.Zero)
+					{
+						return;
+					}
+
+					FragmentManager.ExecutePendingTransactions();
+				});
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Android.Content;
+using Android.OS;
 using Android.Views;
 using Android.Views.Animations;
 using ARelativeLayout = Android.Widget.RelativeLayout;
 using Xamarin.Forms.Internals;
+using Debug = System.Diagnostics.Debug;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -219,12 +221,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		internal void SetPage(Page newRoot)
 		{
 			var layout = false;
+			List<IVisualElementRenderer> toDispose = null;
+
 			if (Page != null)
 			{
 				_renderer.RemoveAllViews();
 
-				foreach (IVisualElementRenderer rootRenderer in _navModel.Roots.Select(Android.Platform.GetRenderer))
-					rootRenderer.Dispose();
+				toDispose = _navModel.Roots.Select(Android.Platform.GetRenderer).ToList();
+
 				_navModel = new NavigationModel();
 
 				layout = true;
@@ -240,6 +244,18 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AddChild(Page, layout);
 
 			Application.Current.NavigationProxy.Inner = this;
+
+			if (toDispose?.Count > 0)
+			{
+				// Queue up disposal of the previous renderers after the current layout updates have finished
+				new Handler(Looper.MainLooper).Post(() =>
+				{	
+					foreach (IVisualElementRenderer rootRenderer in toDispose)
+					{
+						rootRenderer.Dispose();
+					}
+				});
+			}
 		}
 
 		void AddChild(Page page, bool layout = false)

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -132,8 +132,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 			if (disposing)
 			{
-				_disposed = true;
-
 				if (_visualElementTracker != null)
 				{
 					_visualElementTracker.Dispose();

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -9,6 +9,7 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
 using Android.Graphics.Drawables;
+using Android.OS;
 using Android.Support.V4.App;
 using Android.Util;
 using Android.Views;
@@ -394,12 +395,14 @@ namespace Xamarin.Forms.Platform.Android
 		internal void SetPage(Page newRoot)
 		{
 			var layout = false;
+			List<IVisualElementRenderer> toDispose = null;
+
 			if (Page != null)
 			{
 				_renderer.RemoveAllViews();
 
-				foreach (IVisualElementRenderer rootRenderer in _navModel.Roots.Select(GetRenderer))
-					rootRenderer.Dispose();
+				toDispose = _navModel.Roots.Select(Android.Platform.GetRenderer).ToList();
+
 				_navModel = new NavigationModel();
 
 				layout = true;
@@ -419,6 +422,18 @@ namespace Xamarin.Forms.Platform.Android
 			_toolbarTracker.Target = newRoot;
 
 			UpdateActionBar();
+
+			if (toDispose?.Count > 0)
+			{
+				// Queue up disposal of the previous renderers after the current layout updates have finished
+				new Handler(Looper.MainLooper).Post(() =>
+				{
+					foreach (IVisualElementRenderer rootRenderer in toDispose)
+					{
+						rootRenderer.Dispose();
+					}
+				});
+			}
 		}
 
 		internal static void SetPageContext(BindableObject bindable, Context context)


### PR DESCRIPTION
### Description of Change ###

Switching the application's main page when a fragment transaction has already been queued up by `MasterDetailContainer.AddChildView` can cause a race condition where the FragmentContainer is never created and attempting to commit the transaction causes a crash. This change adds a check to verify that the FragmentContainer has been created.

This change also defers the disposal of the previous page set until after all currently queued events for that page set have been processed; this prevents a race conditions which can result in an `ObjectDisposedException`.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
