### PR TITLE
Update ListProxyTest.WeakToWeak so it works in Release mode

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ListProxyTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ListProxyTests.cs
@@ -425,7 +425,9 @@ namespace Xamarin.Forms.Core.UnitTests
 
 		// Need a member to keep this reference around, otherwise it gets optimized
 		// out early in Release mode during the WeakToWeak test
-		ListProxy _proxyForWeakToWeakTest; 
+#pragma warning disable 0414 // Never accessed, it's just here to prevent GC
+		ListProxy _proxyForWeakToWeakTest;
+#pragma warning restore 0414
 
 		[Test]
 		public void WeakToWeak()


### PR DESCRIPTION
### Description of Change ###

Original version of the test didn't work in Release mode because the local ListProxy object was optimized out before the end of the test. Added a member reference to keep it around throughout the test.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
