### PR TITLE
[XamlC] allow namespaces in {x:Type} markups

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XmlTypeExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/XmlTypeExtensions.cs
@@ -107,16 +107,23 @@ namespace Xamarin.Forms.Build.Tasks
 					if (type != null)
 						break;
 
+					var clrNamespace = asm.ClrNamespace;
+					var typeName = name;
+					var idx = typeName.LastIndexOf('.');
+					if (idx >= 0) {
+						clrNamespace += '.' + typeName.Substring(0, typeName.LastIndexOf('.'));
+						typeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
+					}
 					var assemblydefinition = module.Assembly.Name.Name == asm.AssemblyName ?
 												module.Assembly :
 												module.AssemblyResolver.Resolve(AssemblyNameReference.Parse(asm.AssemblyName));
 
-					type = assemblydefinition.MainModule.GetType(asm.ClrNamespace, name);
+					type = assemblydefinition.MainModule.GetType(clrNamespace, typeName);
 					if (type == null)
 					{
 						var exportedtype =
 							assemblydefinition.MainModule.ExportedTypes.FirstOrDefault(
-								(ExportedType arg) => arg.IsForwarder && arg.Namespace == asm.ClrNamespace && arg.Name == name);
+								(ExportedType arg) => arg.IsForwarder && arg.Namespace == clrNamespace && arg.Name == typeName);
 						if (exportedtype != null)
 							type = exportedtype.Resolve();
 					}

--- a/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml
@@ -1,13 +1,19 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<ListView xmlns="http://xamarin.com/schemas/2014/forms"
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+		xmlns:localshort="clr-namespace:Xamarin.Forms.Xaml"
 		x:Class="Xamarin.Forms.Xaml.UnitTests.TypeExtension">
-	<ListView.ItemTemplate>
-		<DataTemplate>
-			<ViewCell>
-				<Button Command="{local:Navigate Operation=Forward, Type={x:Type Grid}}" />
-			</ViewCell>
-		</DataTemplate>
-	</ListView.ItemTemplate>
-</ListView>
+	<StackLayout>
+		<ListView x:Name="listview">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<ViewCell>
+						<Button Command="{local:Navigate Operation=Forward, Type={x:Type Grid}}" />
+					</ViewCell>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+		<Button x:Name="button0" CommandParameter="{x:Type localshort:UnitTests.TypeExtension}" />
+	</StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml.cs
@@ -75,6 +75,16 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				button = (Button)cell.View;
 				Assert.IsNotNull(button.Command);
 			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			//https://bugzilla.xamarin.com/show_bug.cgi?id=55027
+			public void TypeExtensionSupportsNamespace(bool useCompiledXaml)
+			{
+				var page=new TypeExtension(useCompiledXaml);
+				var button = page.button0;
+				Assert.That(button.CommandParameter, Is.EqualTo(typeof(TypeExtension)));
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/TypeExtension.xaml.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 		public ICommand ProvideValue(IServiceProvider serviceProvider)
 		{
-			return new Command(() => { });
+			return new Command(() => {});
 		}
 
 		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 	}
 
-	public partial class TypeExtension : ListView
+	public partial class TypeExtension : ContentPage
 	{
 		public TypeExtension()
 		{
@@ -63,7 +63,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TestCase(true)]
 			public void NestedMarkupExtensionInsideDataTemplate(bool useCompiledXaml)
 			{
-				var listView = new TypeExtension(useCompiledXaml);
+				var page = new TypeExtension(useCompiledXaml);
+				var listView = page.listview;
 				listView.ItemsSource = new string [2];
 
 				var cell = (ViewCell)listView.TemplatedItems [0];


### PR DESCRIPTION
### Description of Change ###

[XamlC] allow namespaces in {x:Type} markups, like in 
```
<Button CommandParameter="{x:Type ns:Foo.Bar}" />
```

as it's supported with XamlC off

## this fixes a regression in 2.3.4

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=55027

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense