### PR TITLE
[Evolution] Merged Dictionaries

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -10,70 +10,74 @@ namespace Xamarin.Forms.Core.UnitTests
 	public class ResourceDictionaryTests : BaseTestFixture
 	{
 		[Test]
-		public void Add ()
+		public void Add()
 		{
-			var rd = new ResourceDictionary ();
-			rd.Add ("foo", "bar");
-			Assert.AreEqual ("bar", rd ["foo"]);
+			var rd = new ResourceDictionary();
+			rd.Add("foo", "bar");
+			Assert.AreEqual("bar", rd["foo"]);
 		}
 
 		[Test]
-		public void AddKVP ()
+		public void AddKVP()
 		{
-			var rd = new ResourceDictionary ();
-			((ICollection<KeyValuePair<string,object>>)rd).Add (new KeyValuePair<string,object> ("foo", "bar"));
-			Assert.AreEqual ("bar", rd ["foo"]);
+			var rd = new ResourceDictionary();
+			((ICollection<KeyValuePair<string, object>>)rd).Add(new KeyValuePair<string, object>("foo", "bar"));
+			Assert.AreEqual("bar", rd["foo"]);
 		}
 
 		[Test]
-		public void ResourceDictionaryTriggersValueChangedOnAdd ()
+		public void ResourceDictionaryTriggersValueChangedOnAdd()
 		{
-			var rd = new ResourceDictionary ();
-			((IResourceDictionary)rd).ValuesChanged += (sender, e) => {
-				Assert.AreEqual (1, e.Values.Count());
+			var rd = new ResourceDictionary();
+			((IResourceDictionary)rd).ValuesChanged += (sender, e) =>
+			{
+				Assert.AreEqual(1, e.Values.Count());
 				var kvp = e.Values.First();
-				Assert.AreEqual ("foo", kvp.Key);
-				Assert.AreEqual ("FOO", kvp.Value);
-				Assert.Pass ();
+				Assert.AreEqual("foo", kvp.Key);
+				Assert.AreEqual("FOO", kvp.Value);
+				Assert.Pass();
 			};
-			rd.Add ("foo", "FOO");
-			Assert.Fail ();
+			rd.Add("foo", "FOO");
+			Assert.Fail();
 		}
 
 		[Test]
-		public void ResourceDictionaryTriggersValueChangedOnChange ()
+		public void ResourceDictionaryTriggersValueChangedOnChange()
 		{
-			var rd = new ResourceDictionary ();
-			rd.Add ("foo", "FOO");
-			((IResourceDictionary)rd).ValuesChanged += (sender, e) => {
-				Assert.AreEqual (1, e.Values.Count());
+			var rd = new ResourceDictionary();
+			rd.Add("foo", "FOO");
+			((IResourceDictionary)rd).ValuesChanged += (sender, e) =>
+			{
+				Assert.AreEqual(1, e.Values.Count());
 				var kvp = e.Values.First();
-				Assert.AreEqual ("foo", kvp.Key);
-				Assert.AreEqual ("BAR", kvp.Value);
-				Assert.Pass ();
+				Assert.AreEqual("foo", kvp.Key);
+				Assert.AreEqual("BAR", kvp.Value);
+				Assert.Pass();
 			};
-			rd ["foo"] = "BAR";
-			Assert.Fail ();
+			rd["foo"] = "BAR";
+			Assert.Fail();
 		}
 
 		[Test]
-		public void ResourceDictionaryCtor ()
+		public void ResourceDictionaryCtor()
 		{
-			var rd = new ResourceDictionary ();
-			Assert.AreEqual (0, rd.Count());
+			var rd = new ResourceDictionary();
+			Assert.AreEqual(0, rd.Count());
 		}
 
 		[Test]
-		public void ElementMergesParentRDWithCurrent ()
+		public void ElementMergesParentRDWithCurrent()
 		{
-			var elt = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var elt = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "bar","BAR" },
 				}
 			};
 
-			var parent = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var parent = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "foo", "FOO" },
 				}
 			};
@@ -81,23 +85,25 @@ namespace Xamarin.Forms.Core.UnitTests
 			elt.Parent = parent;
 
 			object value;
-			Assert.True (elt.TryGetResource ("foo", out value));
-			Assert.AreEqual ("FOO", value);
-			Assert.True (elt.TryGetResource ("bar", out value));
-			Assert.AreEqual ("BAR", value);
+			Assert.True(elt.TryGetResource("foo", out value));
+			Assert.AreEqual("FOO", value);
+			Assert.True(elt.TryGetResource("bar", out value));
+			Assert.AreEqual("BAR", value);
 		}
 
 		[Test]
-		public void CurrentOverridesParentValues ()
+		public void CurrentOverridesParentValues()
 		{
-			var elt = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var elt = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "bar","BAZ" },
 				}
 			};
 
-			var parent = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var parent = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "foo", "FOO" },
 					{ "bar","BAR" },
 				}
@@ -106,108 +112,118 @@ namespace Xamarin.Forms.Core.UnitTests
 			elt.Parent = parent;
 
 			object value;
-			Assert.True (elt.TryGetResource ("foo", out value));
-			Assert.AreEqual ("FOO", value);
-			Assert.True (elt.TryGetResource ("bar", out value));
-			Assert.AreEqual ("BAZ", value);
+			Assert.True(elt.TryGetResource("foo", out value));
+			Assert.AreEqual("FOO", value);
+			Assert.True(elt.TryGetResource("bar", out value));
+			Assert.AreEqual("BAZ", value);
 		}
 
 		[Test]
-		public void AddingToParentTriggersValuesChanged ()
+		public void AddingToParentTriggersValuesChanged()
 		{
-			var elt = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var elt = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "bar","BAR" },
 				}
 			};
 
-			var parent = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var parent = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "foo", "FOO" },
 				}
 			};
 
 			elt.Parent = parent;
 
-			((IElement)elt).AddResourcesChangedListener ((sender, e) => {
-				Assert.AreEqual (1, e.Values.Count ());
-				var kvp = e.Values.First ();
-				Assert.AreEqual ("baz", kvp.Key);
-				Assert.AreEqual ("BAZ", kvp.Value);
-				Assert.Pass ();
+			((IElement)elt).AddResourcesChangedListener((sender, e) =>
+			{
+				Assert.AreEqual(1, e.Values.Count());
+				var kvp = e.Values.First();
+				Assert.AreEqual("baz", kvp.Key);
+				Assert.AreEqual("BAZ", kvp.Value);
+				Assert.Pass();
 			});
 
-			parent.Resources ["baz"] = "BAZ";
-			Assert.Fail ();
+			parent.Resources["baz"] = "BAZ";
+			Assert.Fail();
 		}
 
 		[Test]
-		public void ResourcesChangedNotRaisedIfKeyExistsInCurrent ()
+		public void ResourcesChangedNotRaisedIfKeyExistsInCurrent()
 		{
-			var elt = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var elt = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "bar","BAR" },
 				}
 			};
 
-			var parent = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var parent = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "foo", "FOO" },
 				}
 			};
 
 			elt.Parent = parent;
 
-			((IElement)elt).AddResourcesChangedListener ((sender, e) => Assert.Fail ());
-			parent.Resources ["bar"] = "BAZ";
-			Assert.Pass ();
+			((IElement)elt).AddResourcesChangedListener((sender, e) => Assert.Fail());
+			parent.Resources["bar"] = "BAZ";
+			Assert.Pass();
 		}
 
 		[Test]
-		public void SettingParentTriggersValuesChanged ()
+		public void SettingParentTriggersValuesChanged()
 		{
-			var elt = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var elt = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "bar","BAR" },
 				}
 			};
 
-			var parent = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var parent = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{"foo", "FOO"},
 					{"baz", "BAZ"},
 					{"bar", "NEWBAR"}
 				}
 			};
 
-			((IElement)elt).AddResourcesChangedListener ((sender, e) => {
-				Assert.AreEqual (2, e.Values.Count ());
-				Assert.AreEqual ("FOO", e.Values.First (kvp => kvp.Key == "foo").Value);
-				Assert.AreEqual ("BAZ", e.Values.First (kvp => kvp.Key == "baz").Value);
-				Assert.Pass ();
+			((IElement)elt).AddResourcesChangedListener((sender, e) =>
+			{
+				Assert.AreEqual(2, e.Values.Count());
+				Assert.AreEqual("FOO", e.Values.First(kvp => kvp.Key == "foo").Value);
+				Assert.AreEqual("BAZ", e.Values.First(kvp => kvp.Key == "baz").Value);
+				Assert.Pass();
 			});
 			elt.Parent = parent;
-			Assert.Fail ();
+			Assert.Fail();
 		}
 
 		[Test]
-		public void SettingResourcesTriggersResourcesChanged ()
+		public void SettingResourcesTriggersResourcesChanged()
 		{
-			var elt = new VisualElement ();
+			var elt = new VisualElement();
 
-			var parent = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var parent = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{"bar", "BAR"}
 				}
 			};
 
 			elt.Parent = parent;
 
-			((IElement)elt).AddResourcesChangedListener ((sender, e) => {
-				Assert.AreEqual (3, e.Values.Count ());
-				Assert.Pass ();
+			((IElement)elt).AddResourcesChangedListener((sender, e) =>
+			{
+				Assert.AreEqual(3, e.Values.Count());
+				Assert.Pass();
 			});
-			elt.Resources = new ResourceDictionary { 
+			elt.Resources = new ResourceDictionary {
 				{"foo", "FOO"},
 				{"baz", "BAZ"},
 				{"bar", "NEWBAR"}
@@ -216,42 +232,46 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void DontThrowOnReparenting ()
+		public void DontThrowOnReparenting()
 		{
-			var elt = new View { Resources = new ResourceDictionary () };
-			var parent = new StackLayout ();
+			var elt = new View { Resources = new ResourceDictionary() };
+			var parent = new StackLayout();
 
-			parent.Children.Add (elt);
-			Assert.DoesNotThrow (() => parent.Children.Remove (elt));
+			parent.Children.Add(elt);
+			Assert.DoesNotThrow(() => parent.Children.Remove(elt));
 		}
 
 		[Test]
-		public void MultiLevelMerge ()
+		public void MultiLevelMerge()
 		{
-			var elt = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var elt = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "bar","BAR" },
 				}
 			};
 
-			var parent = new VisualElement {
-				Resources = new ResourceDictionary { 
+			var parent = new VisualElement
+			{
+				Resources = new ResourceDictionary {
 					{ "foo", "FOO" },
 				},
-				Parent = new VisualElement {
-					Resources = new ResourceDictionary { 
+				Parent = new VisualElement
+				{
+					Resources = new ResourceDictionary {
 						{"baz", "BAZ"}
 					}
 				}
 			};
 
-			((IElement)elt).AddResourcesChangedListener ((sender, e) => {
-				Assert.AreEqual (2, e.Values.Count ());
-				Assert.Pass ();
+			((IElement)elt).AddResourcesChangedListener((sender, e) =>
+			{
+				Assert.AreEqual(2, e.Values.Count());
+				Assert.Pass();
 			});
 
 			elt.Parent = parent;
-			Assert.Fail ();
+			Assert.Fail();
 		}
 
 		[Test]
@@ -259,7 +279,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var rd = new ResourceDictionary();
 			rd.Add("foo", "bar");
-			var ex = Assert.Throws<KeyNotFoundException>(() => { var foo = rd ["test_invalid_key"]; });
+			var ex = Assert.Throws<KeyNotFoundException>(() => { var foo = rd["test_invalid_key"]; });
 			Assert.That(ex.Message, Is.StringContaining("test_invalid_key"));
 		}
 
@@ -299,9 +319,12 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var rd0 = new ResourceDictionary();
 			rd0.Add("foo", "Foo");
-			try {
+			try
+			{
 				rd0.Add("foo", "Bar");
-			} catch (ArgumentException ae) {
+			}
+			catch (ArgumentException ae)
+			{
 				Assert.AreEqual("A resource with the key 'foo' is already present in the ResourceDictionary.", ae.Message);
 				Assert.Pass();
 			}
@@ -316,7 +339,6 @@ namespace Xamarin.Forms.Core.UnitTests
 				{"qux", "QUX"},
 			};
 			rd.MergedWith = typeof(MyRD);
-
 			Assert.That(rd.Contains(new KeyValuePair<string, object>("foo", "Foo")), Is.True);
 		}
 
@@ -328,7 +350,6 @@ namespace Xamarin.Forms.Core.UnitTests
 				{"qux", "Qux"},
 			};
 			rd.MergedWith = typeof(MyRD);
-
 			Assert.That(rd.Count, Is.EqualTo(2));
 		}
 
@@ -340,7 +361,6 @@ namespace Xamarin.Forms.Core.UnitTests
 				{"qux", "QUX"},
 			};
 			rd.MergedWith = typeof(MyRD);
-
 			Assert.That(() => rd["foo"], Throws.Nothing);
 			Assert.That(rd["foo"], Is.EqualTo("Foo"));
 		}
@@ -348,15 +368,66 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TryGetValueLookupInMerged()
 		{
-			var rd = new ResourceDictionary { 
+			var rd = new ResourceDictionary {
 				{"baz", "BAZ"},
 				{"qux", "QUX"},
 			};
 			rd.MergedWith = typeof(MyRD);
-
 			object _;
 			Assert.That(rd.TryGetValue("foo", out _), Is.True);
 			Assert.That(rd.TryGetValue("baz", out _), Is.True);
-}
+		}
+
+		[Test]
+		public void MergedDictionaryResourcesAreFound()
+		{
+			var rd0 = new ResourceDictionary();
+			rd0.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar" } });
+
+			object _;
+			Assert.True(rd0.TryGetValue("foo", out _));
+			Assert.AreEqual("bar", _);
+		}
+
+		[Test]
+		public void MergedDictionaryResourcesAreFoundLastDictionaryTakesPriority()
+		{
+			var rd0 = new ResourceDictionary();
+			rd0.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar" } });
+			rd0.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar1" } });
+			rd0.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar2" } });
+
+			object _;
+			Assert.True(rd0.TryGetValue("foo", out _));
+			Assert.AreEqual("bar2", _);
+		}
+
+		[Test]
+		public void CountDoesNotIncludeMergedDictionaries()
+		{
+			var rd = new ResourceDictionary {
+				{"baz", "Baz"},
+				{"qux", "Qux"},
+			};
+			rd.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar" } });
+
+			Assert.That(rd.Count, Is.EqualTo(2));
+		}
+
+		[Test]
+		public void ClearMergedDictionaries()
+		{
+			var rd = new ResourceDictionary {
+				{"baz", "Baz"},
+				{"qux", "Qux"},
+			};
+			rd.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar" } });
+
+			Assert.That(rd.Count, Is.EqualTo(2));
+
+			rd.MergedDictionaries.Clear();
+
+			Assert.That(rd.MergedDictionaries.Count, Is.EqualTo(0));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -5,6 +5,8 @@ using System.Runtime.CompilerServices;
 using System.Linq;
 using System.Reflection;
 using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 
 namespace Xamarin.Forms
 {
@@ -14,10 +16,12 @@ namespace Xamarin.Forms
 		readonly Dictionary<string, object> _innerDictionary = new Dictionary<string, object>();
 
 		Type _mergedWith;
-		[TypeConverter (typeof(TypeTypeConverter))]
-		public Type MergedWith {
+		[TypeConverter(typeof(TypeTypeConverter))]
+		public Type MergedWith
+		{
 			get { return _mergedWith; }
-			set { 
+			set
+			{
 				if (_mergedWith == value)
 					return;
 
@@ -28,12 +32,66 @@ namespace Xamarin.Forms
 				if (_mergedWith == null)
 					return;
 
-				_mergedInstance = s_instances.GetValue(_mergedWith,(key) => (ResourceDictionary)Activator.CreateInstance(key));
-				OnValuesChanged (_mergedInstance.ToArray());
+				_mergedInstance = s_instances.GetValue(_mergedWith, (key) => (ResourceDictionary)Activator.CreateInstance(key));
+				OnValuesChanged(_mergedInstance.ToArray());
 			}
 		}
 
 		ResourceDictionary _mergedInstance;
+		public ICollection<ResourceDictionary> MergedDictionaries { get; private set; }
+
+		public ResourceDictionary()
+		{
+			var collection = new ObservableCollection<ResourceDictionary>();
+			collection.CollectionChanged += MergedDictionaries_CollectionChanged;
+			MergedDictionaries = collection;
+		}
+
+		void MergedDictionaries_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			// Movement of items doesn't affect monitoring of events
+			if (e.Action == NotifyCollectionChangedAction.Move)
+				return;
+
+			// New Items
+			var newItems = e.NewItems?.Cast<ResourceDictionary>();
+			if (newItems != null)
+			{
+				foreach (var item in newItems)
+				{
+					_collectionTrack.Add(item);
+					item.ValuesChanged += Item_ValuesChanged;
+				}
+
+				if (newItems.Count() > 0)
+					OnValuesChanged(newItems.SelectMany(x => x).ToArray());
+			}
+
+			// Old Items
+			var oldItems = e.OldItems?.Cast<ResourceDictionary>();
+			if (oldItems != null)
+				foreach (var item in oldItems)
+				{
+					item.ValuesChanged -= Item_ValuesChanged;
+					_collectionTrack.Remove(item);
+				}
+
+			// Collection has been cleared
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				foreach (var dictionary in _collectionTrack)
+					dictionary.ValuesChanged -= Item_ValuesChanged;
+
+				_collectionTrack.Clear();
+			}
+		}
+
+		IList<ResourceDictionary> _collectionTrack = new List<ResourceDictionary>();
+
+		void Item_ValuesChanged(object sender, ResourcesChangedEventArgs e)
+		{
+			OnValuesChanged(e.Values.ToArray());
+		}
 
 		void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
 		{
@@ -94,6 +152,10 @@ namespace Xamarin.Forms
 					return _innerDictionary[index];
 				if (_mergedInstance != null && _mergedInstance.ContainsKey(index))
 					return _mergedInstance[index];
+				if (MergedDictionaries != null)
+					foreach (var dict in MergedDictionaries.Reverse())
+						if (dict.ContainsKey(index))
+							return dict[index];
 				throw new KeyNotFoundException($"The resource '{index}' is not present in the dictionary.");
 			}
 			set
@@ -128,8 +190,13 @@ namespace Xamarin.Forms
 			return _innerDictionary.GetEnumerator();
 		}
 
-		internal IEnumerable<KeyValuePair<string, object>> MergedResources {
-			get {
+		internal IEnumerable<KeyValuePair<string, object>> MergedResources
+		{
+			get
+			{
+				if (MergedDictionaries != null)
+					foreach (var r in MergedDictionaries.Reverse().SelectMany(x => x.MergedResources))
+						yield return r;
 				if (_mergedInstance != null)
 					foreach (var r in _mergedInstance.MergedResources)
 						yield return r;
@@ -140,7 +207,19 @@ namespace Xamarin.Forms
 
 		public bool TryGetValue(string key, out object value)
 		{
-			return _innerDictionary.TryGetValue(key, out value) || (_mergedInstance != null && _mergedInstance.TryGetValue(key, out value));
+			return _innerDictionary.TryGetValue(key, out value)
+				|| (_mergedInstance != null && _mergedInstance.TryGetValue(key, out value))
+				|| (MergedDictionaries != null && TryGetMergedDictionaryValue(key, out value));
+		}
+
+		bool TryGetMergedDictionaryValue(string key, out object value)
+		{
+			foreach (var dictionary in MergedDictionaries.Reverse())
+				if (dictionary.TryGetValue(key, out value))
+					return true;
+
+			value = null;
+			return false;
 		}
 
 		event EventHandler<ResourcesChangedEventArgs> IResourceDictionary.ValuesChanged

--- a/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
+++ b/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml.Internals;
 
@@ -106,10 +105,23 @@ namespace Xamarin.Forms.Xaml
 			if (ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out propertyName))
 			{
 				if ((propertyName.LocalName == "Resources" ||
-				     propertyName.LocalName.EndsWith(".Resources", StringComparison.Ordinal)) && value is ResourceDictionary)
+					 propertyName.LocalName == "MergedDictionaries" ||
+					 propertyName.LocalName.EndsWith(".Resources", StringComparison.Ordinal)) && value is ResourceDictionary)
 				{
 					var source = Values[parentNode];
 					ApplyPropertiesVisitor.SetPropertyValue(source, propertyName, value, Context.RootElement, node, Context, node);
+				}
+			}
+
+			//Add ResourceDictionary into MergedDictionaries
+			XmlName parentPropertyName;
+			if (parentNode is IListNode && ApplyPropertiesVisitor.TryGetPropertyName(parentNode, parentNode.Parent, out parentPropertyName))
+			{
+				if (parentPropertyName.LocalName == "MergedDictionaries")
+				{
+					var source = Values[parentNode.Parent];
+					node.Parent = node.Parent.Parent;
+					ApplyPropertiesVisitor.SetPropertyValue(source, parentPropertyName, value, Context.RootElement, node, Context, node);
 				}
 			}
 		}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
@@ -246,6 +246,22 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="MergedDictionaries">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.ICollection&lt;Xamarin.Forms.ResourceDictionary&gt; MergedDictionaries { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.ICollection`1&lt;class Xamarin.Forms.ResourceDictionary&gt; MergedDictionaries" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.ICollection&lt;Xamarin.Forms.ResourceDictionary&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="MergedWith">
       <MemberSignature Language="C#" Value="public Type MergedWith { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class System.Type MergedWith" />


### PR DESCRIPTION
### Description of Change ###

The addition of Multiple MergedDictionaries into ResourceDictionary, as discussed in the Evolution forum: https://forums.xamarin.com/discussion/86308/multiple-merged-dictionaries. Allows multiple ResourceDictionaries to be added to the VisualElement root Resources property.

### Bugs Fixed ###

- N/A

### API Changes ###

Added:
 - ICollection<ResourceDictionary> MergedDictionaries // In ResourceDictionary.cs

### Behavioral Changes ###

The addition, of adding multiple ResourceDictionaries into a ResourceDictionary. No behavioral changes to existing functionality were made.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
