### PR TITLE
fix 54730

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.WinRT
 	{
 		public static Run ToRun(this Span span)
 		{
-			var run = new Run { Text = span.Text };
+			var run = new Run { Text = span.Text ?? string.Empty };
 
 			if (span.ForegroundColor != Color.Default)
 				run.Foreground = span.ForegroundColor.ToBrush();


### PR DESCRIPTION
### Description of Change ###

Allow Span to have null value by replacing null with empty string before rendering the span.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=54730

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
