### PR TITLE
[XamlC] Check param type in op_Implicit

### DIFF
--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -249,9 +249,16 @@ namespace Xamarin.Forms.Build.Tasks
 			if (TypeRefComparer.Default.Equals(fromType, toType))
 				return null;
 
-			var implicitOperatorsOnFromType = fromType.GetMethods(md => md.IsPublic && md.IsStatic && md.IsSpecialName && md.Name == "op_Implicit", module);
-			var implicitOperatorsOnToType = toType.GetMethods(md => md.IsPublic && md.IsStatic && md.IsSpecialName && md.Name == "op_Implicit", module);
+			var implicitOperatorsOnFromType = fromType.GetMethods(md =>    md.IsPublic
+																		&& md.IsStatic
+																		&& md.IsSpecialName
+																		&& md.Name == "op_Implicit", module);
+			var implicitOperatorsOnToType = toType.GetMethods(md =>    md.IsPublic
+																	&& md.IsStatic
+																	&& md.IsSpecialName
+																	&& md.Name == "op_Implicit", module);
 			var implicitOperators = implicitOperatorsOnFromType.Concat(implicitOperatorsOnToType).ToList();
+
 			if (implicitOperators.Any()) {
 				foreach (var op in implicitOperators) {
 					var cast = op.Item1;
@@ -260,8 +267,12 @@ namespace Xamarin.Forms.Build.Tasks
 					var returnType = castDef.ReturnType;
 					if (returnType.IsGenericParameter)
 						returnType = ((GenericInstanceType)opDeclTypeRef).GenericArguments [((GenericParameter)returnType).Position];
-					if (returnType.InheritsFromOrImplements(toType))
-						return castDef;
+					if (!returnType.InheritsFromOrImplements(toType))
+						continue;
+					var paramType = cast.Parameters[0].ParameterType;
+					if (!fromType.InheritsFromOrImplements(paramType))
+						continue;
+					return castDef;
 				}
 			}
 			return null;

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz55347.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz55347.xaml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Xamarin.Forms.Xaml.UnitTests.Bz55347"
+	Padding="{StaticResource Padding}"/>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz55347.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz55347.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz55347 : ContentPage
+	{
+		public Bz55347()
+		{
+		}
+
+		public Bz55347(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+				Application.Current = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void PaddingThicknessResource(bool useCompiledXaml)
+			{
+				Application.Current = new MockApplication {
+					Resources = new ResourceDictionary {
+						{"Padding", new Thickness(8)}
+					}
+				};
+				var layout = new Bz55347(useCompiledXaml);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -476,6 +476,9 @@
     <Compile Include="Issues\Bz55343.xaml.cs">
       <DependentUpon>Bz55343.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz55347.xaml.cs">
+      <DependentUpon>Bz55347.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -870,6 +873,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz55343.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz55347.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Who could have guessed that picking the first implicit operator with the right return type without checking the input parameter would not work all the time ?

What were the chances that it would fail ?

1 out of a trillion. No more. No less.

But still that particular unlikely case happened. That's really bad luck.

## this is a regression on 2.3.5, and the fix needs to be backported

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=55347

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense