### PR TITLE
[XamlG] supports x:FieldModifier

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/FieldModifier.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/FieldModifier.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.FieldModifier">
+	<StackLayout>
+        <Label x:Name="privateLabel" />
+        <Label x:Name="internalLabel" x:FieldModifier="NotPublic" />
+        <Label x:Name="publicLabel" x:FieldModifier="Public" />
+	</StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/FieldModifier.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/FieldModifier.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class FieldModifier : ContentPage
+	{
+		public FieldModifier()
+		{
+			InitializeComponent();
+		}
+
+		public FieldModifier (bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class FindByNameTests
+		{
+			[TestCase (false)]
+			[TestCase (true)]
+			public void TestFieldModifier (bool useCompiledXaml)
+			{
+				var layout = new FieldModifier();
+				Assert.That(layout.privateLabel, Is.Not.Null);
+				Assert.That(layout.internalLabel, Is.Not.Null);
+				Assert.That(layout.publicLabel, Is.Not.Null);
+
+				var fields = typeof(FieldModifier).GetTypeInfo().DeclaredFields;
+
+				Assert.That(fields.First(fi => fi.Name == "privateLabel").IsPrivate, Is.True);
+
+				Assert.That(fields.First(fi => fi.Name == "internalLabel").IsPrivate, Is.False);
+				Assert.That(fields.First(fi => fi.Name == "internalLabel").IsPublic, Is.False);
+
+				Assert.That(fields.First(fi => fi.Name == "publicLabel").IsPublic, Is.True);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Issue2450.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Issue2450.xaml
@@ -1,10 +1,16 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage
 		xmlns="http://xamarin.com/schemas/2014/forms"
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		x:Class="Xamarin.Forms.Xaml.UnitTests.Issue2450">
-	<StackLayout>
-		<Label x:Name="label0"/>
-		<Label x:Name="label0"/>
-	</StackLayout>
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<DataTemplate x:Key="foo">
+				<ViewCell>
+					<Label x:Name="label0"/>
+					<Label x:Name="label0"/>
+				</ViewCell>
+			</DataTemplate>
+		</ResourceDictionary>
+	</ContentPage.Resources>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Issue2450.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Issue2450.xaml.cs
@@ -29,15 +29,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			}
 
 			[TestCase (false)]
-			[TestCase (true)]
 			public void ThrowMeaningfulExceptionOnDuplicateXName (bool useCompiledXaml)
 			{
-				if (useCompiledXaml)
-					Assert.Throws(new XamlParseExceptionConstraint(8, 10, m => m == "An element with the name \"label0\" already exists in this NameScope"),
-								  () => MockCompiler.Compile(typeof(Issue2450)));
-				else
-					Assert.Throws(new XamlParseExceptionConstraint(8, 10, m => m == "An element with the name \"label0\" already exists in this NameScope"),
-								  () => new Issue2450(useCompiledXaml));
+				var layout = new Issue2450(useCompiledXaml);
+				Assert.Throws(new XamlParseExceptionConstraint(11, 13, m => m == "An element with the name \"label0\" already exists in this NameScope"),
+							  () => (layout.Resources ["foo"] as Forms.DataTemplate).CreateContent());
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -482,6 +482,9 @@
     <Compile Include="Issues\Bz55347.xaml.cs">
       <DependentUpon>Bz55347.xaml</DependentUpon>
     </Compile> 
+    <Compile Include="FieldModifier.xaml.cs">
+      <DependentUpon>FieldModifier.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -882,6 +885,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz55347.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FieldModifier.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/XamlgTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlgTests.cs
@@ -26,20 +26,20 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
 			Assert.NotNull (rootType);
 			Assert.NotNull (rootNs);
 			Assert.NotNull (baseType);
-			Assert.NotNull (namesAndTypes);
+			Assert.NotNull (codeMemberFields);
 
 			Assert.AreEqual ("CustomView", rootType);
 			Assert.AreEqual ("Xamarin.Forms.Xaml.UnitTests", rootNs);
 			Assert.AreEqual ("Xamarin.Forms.View", baseType.BaseType);
-			Assert.AreEqual (1, namesAndTypes.Count);
-			Assert.AreEqual ("label0", namesAndTypes.First().Key);
-			Assert.AreEqual ("Xamarin.Forms.Label", namesAndTypes.First().Value.BaseType);
+			Assert.AreEqual (1, codeMemberFields.Count());
+			Assert.AreEqual ("label0", codeMemberFields.First().Name);
+			Assert.AreEqual ("Xamarin.Forms.Label", codeMemberFields.First().Type.BaseType);
 		}
 
 		[Test]
@@ -55,20 +55,20 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
 			Assert.NotNull (rootType);
 			Assert.NotNull (rootNs);
 			Assert.NotNull (baseType);
-			Assert.NotNull (namesAndTypes);
+			Assert.NotNull (codeMemberFields);
 
 			Assert.AreEqual ("CustomView", rootType);
 			Assert.AreEqual ("Xamarin.Forms.Xaml.UnitTests", rootNs);
 			Assert.AreEqual ("Xamarin.Forms.View", baseType.BaseType);
-			Assert.AreEqual (1, namesAndTypes.Count);
-			Assert.AreEqual ("label0", namesAndTypes.First().Key);
-			Assert.AreEqual ("Xamarin.Forms.Label", namesAndTypes.First().Value.BaseType);
+			Assert.AreEqual (1, codeMemberFields.Count());
+			Assert.AreEqual ("label0", codeMemberFields.First().Name);
+			Assert.AreEqual ("Xamarin.Forms.Label", codeMemberFields.First().Type.BaseType);
 		}
 
 		[Test]
@@ -92,13 +92,12 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
-			Assert.AreEqual (1, namesAndTypes.Count);
-			Assert.AreEqual ("listView", namesAndTypes.First ().Key);
-			Assert.AreEqual ("CustomListViewSample.CustomListView", namesAndTypes.First ().Value.BaseType);
-
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
+			Assert.AreEqual (1, codeMemberFields.Count());
+			Assert.AreEqual ("listView", codeMemberFields.First ().Name);
+			Assert.AreEqual ("CustomListViewSample.CustomListView", codeMemberFields.First ().Type.BaseType);
 		}
 
 		[Test]
@@ -122,12 +121,12 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
-			Assert.Contains ("included", namesAndTypes.Keys.ToList());
-			Assert.False (namesAndTypes.Keys.Contains ("notincluded"));
-			Assert.AreEqual (1, namesAndTypes.Count);
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
+			Assert.Contains ("included", codeMemberFields.Select(cmf => cmf.Name).ToList());
+			Assert.False (codeMemberFields.Select(cmf => cmf.Name).Contains ("notincluded"));
+			Assert.AreEqual (1, codeMemberFields.Count());
 		}
 
 		[Test]
@@ -152,11 +151,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
-			Assert.False (namesAndTypes.Keys.Contains ("notincluded"));
-			Assert.AreEqual (0, namesAndTypes.Count);
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
+			Assert.False (codeMemberFields.Select(cmf => cmf.Name).Contains ("notincluded"));
+			Assert.AreEqual (0, codeMemberFields.Count());
 		}
 
 		[Test]
@@ -171,9 +170,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
 			Assert.AreEqual ("FooBar", rootType);
 			Assert.AreEqual ("Xamarin.Forms.Foo`1", baseType.BaseType);
 			Assert.AreEqual (1, baseType.TypeArguments.Count);
@@ -192,9 +191,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
 			Assert.AreEqual ("FooBar", rootType);
 			Assert.AreEqual ("Xamarin.Forms.Foo`2", baseType.BaseType);
 			Assert.AreEqual (2, baseType.TypeArguments.Count);
@@ -214,9 +213,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
 			Assert.AreEqual ("FooBar", rootType);
 			Assert.AreEqual ("Xamarin.Forms.Foo`2", baseType.BaseType);
 			Assert.AreEqual (2, baseType.TypeArguments.Count);
@@ -239,9 +238,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
 			Assert.AreEqual ("FooBar", rootType);
 			Assert.AreEqual ("Xamarin.Forms.Foo`2", baseType.BaseType);
 			Assert.AreEqual (2, baseType.TypeArguments.Count);
@@ -264,9 +263,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var reader = new StringReader (xaml);
 			string rootType, rootNs;
 			CodeTypeReference baseType;
-			IDictionary<string,CodeTypeReference> namesAndTypes;
+			IEnumerable<CodeMemberField> codeMemberFields;
 
-			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
+			XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
 			Assert.AreEqual ("FooBar", rootType);
 			Assert.AreEqual ("Xamarin.Forms.Foo`2", baseType.BaseType);
 			Assert.AreEqual (2, baseType.TypeArguments.Count);
@@ -288,13 +287,40 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			using (var reader = new StringReader (xaml)) {
 				string rootType, rootNs;
 				CodeTypeReference baseType;
-				IDictionary<string,CodeTypeReference> namesAndTypes;
+				IEnumerable<CodeMemberField> codeMemberFields;
 
-				XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out namesAndTypes);
+				XamlGTask.ParseXaml (reader, out rootType, out rootNs, out baseType, out codeMemberFields);
 				Assert.IsTrue (baseType.Options.HasFlag (CodeTypeReferenceOptions.GlobalReference));
-				Assert.IsTrue (namesAndTypes.Values.First ().Options.HasFlag (CodeTypeReferenceOptions.GlobalReference));
+				Assert.IsTrue (codeMemberFields.Select(cmf => cmf.Type).First ().Options.HasFlag (CodeTypeReferenceOptions.GlobalReference));
+			}
+		}
+
+		[Test]
+		public void FieldModifier()
+		{
+			var xaml = @"
+			<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+			             xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+			             xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests""
+			             x:Class=""Xamarin.Forms.Xaml.UnitTests.FieldModifier"">
+				<StackLayout>
+			        <Label x:Name=""privateLabel"" />
+			        <Label x:Name=""internalLabel"" x:FieldModifier=""NotPublic"" />
+			        <Label x:Name=""publicLabel"" x:FieldModifier=""Public"" />
+				</StackLayout>
+			</ContentPage>";
+
+			using (var reader = new StringReader(xaml))
+			{
+				string rootType, rootNs;
+				CodeTypeReference baseType;
+				IEnumerable<CodeMemberField> codeMemberFields;
+
+				XamlGTask.ParseXaml(reader, out rootType, out rootNs, out baseType, out codeMemberFields);
+				Assert.That(codeMemberFields.First(cmf => cmf.Name == "privateLabel").Attributes, Is.EqualTo(MemberAttributes.Private));
+				Assert.That(codeMemberFields.First(cmf => cmf.Name == "internalLabel").Attributes, Is.EqualTo(MemberAttributes.Assembly));
+				Assert.That(codeMemberFields.First(cmf => cmf.Name == "publicLabel").Attributes, Is.EqualTo(MemberAttributes.Public));
 			}
 		}
 	}
 }
-

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -213,12 +213,13 @@ namespace Xamarin.Forms.Xaml
 						propertyName = XmlName.xName;
 						break;
 					case "x:Class":
+					case "x:FieldModifier":
 						continue;
 					default:
 						Debug.WriteLine("Unhandled attribute {0}", reader.Name);
 						continue;
 					}
-				}
+                }
 
 				if (reader.NamespaceURI == "http://schemas.microsoft.com/winfx/2009/xaml")
 				{
@@ -237,6 +238,7 @@ namespace Xamarin.Forms.Xaml
 						propertyName = XmlName.xDataType;
 						break;
 					case "x:Class":
+					case "x:FieldModifier":
 						continue;
 					case "x:FactoryMethod":
 						propertyName = XmlName.xFactoryMethod;


### PR DESCRIPTION
### Description of Change ###

Supports `x:FieldModifier` in Xaml files.

This attribute is only looked for if:
 - the top-level node as an `x:Class`,
 - the current node as an `x:Name`,
 - and some other conditions, but those are the same ones used for generating fields from `x:Name` 

If the value of the attribute isn't set, the generated field will be `private`. If the attribute is set to `NonPublic`, the field will be `internal`, and the field will be bright pink if you set the attribute to `Public`.

This feature isn't supposed to be used by any sane developers, but has been implemented as requested by you-know-who. Using this feature encourages bad design, when any Mvvm framework can do the exact same work while adding 2 full seconds at your app startup (did I already told you that you do not require a Mvvm framework to do proper Mvvm? No? Well, that's not a story for kids anyway).

If you ever use this in a production app, I'll find out, find where you live, send the ninja, and he'll drop very small LEGO(™) pieces next to your bed so you'll walk on them in the morning.

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense