### PR TITLE
Unsubscribe OnModelChanged event when TableViewModelRenderer is disposed

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewModelRenderer.cs
@@ -51,11 +51,7 @@ namespace Xamarin.Forms.Platform.Android
 			_view = view;
 			Context = context;
 
-			Controller.ModelChanged += (sender, args) =>
-			{
-				InvalidateCellCache();
-				NotifyDataSetChanged();
-			};
+			Controller.ModelChanged += OnModelChanged;
 
 			listView.OnItemClickListener = this;
 			listView.OnItemLongClickListener = this;
@@ -255,10 +251,19 @@ namespace Xamarin.Forms.Platform.Android
 			_nextIsHeaderCache = null;
 		}
 
+		void OnModelChanged(object sender, EventArgs e)
+		{
+			InvalidateCellCache();
+			NotifyDataSetChanged();
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
+			{
 				InvalidateCellCache();
+				Controller.ModelChanged -= OnModelChanged;
+			}
 
 			base.Dispose(disposing);
 		}


### PR DESCRIPTION
### Description of Change ###

Unsubscribe the ModelChanged Event when the Android TableViewModelRenderer is disposed. 

### Bugs Fixed ###

### API Changes ###

### Behavioral Changes ###

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
