### PR TITLE
UWP; Bugzilla 55397; Set v-align to bottom for TextBoxStyle

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -186,7 +186,7 @@
 						                Content="{TemplateBinding PlaceholderText}"
 						                Foreground="{TemplateBinding PlaceholderForegroundBrush}" IsHitTestVisible="False"
 						                IsTabStop="False" Margin="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}"
-						                Grid.Row="1"
+						                Grid.Row="1" VerticalAlignment="Bottom"
 						                HorizontalAlignment="{Binding TextAlignment, 
                                             RelativeSource={RelativeSource Mode=TemplatedParent}, 
                                             Converter={StaticResource AlignmentConverter}}" />


### PR DESCRIPTION
### Description of Change ###

Bug 52419 notes vertical mis-alignment of text in entry control (see https://bugzilla.xamarin.com/attachment.cgi?id=21636). Modify v-align property to taste. Chose `bottom` instead of `centered` because the padding pushes the text up so `bottom` alignment "looked" better. Padding numbers were/are inherited/copied from the default TextBoxStyle (see https://msdn.microsoft.com/en-us/library/windows/apps/mt299154.aspx) so I didn't want to mess with them.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=55397

### API Changes ###

None

### Behavioral Changes ###

Centers text in Entry control. 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
