### PR TITLE
[iOS] Prevent NRE in ListView OnItemSelected

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ListViewNRE.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ListViewNRE.cs
@@ -1,0 +1,51 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "ListView crashes when disposed on ItemSelected", PlatformAffected.iOS)]
+	public class ListViewNRE : TestContentPage
+	{
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var listView = new ListView
+			{
+				ItemsSource = Enumerable.Range(0, 10)
+			};
+
+			listView.ItemSelected += ListView_ItemSelected;
+
+			Content = listView;
+		}
+
+		void ListView_ItemSelected(object sender, SelectedItemChangedEventArgs e)
+		{
+			Content = new Label { Text = Success };
+		}
+
+#if UITEST
+		[Test]
+		public void ListViewNRETest()
+		{
+			RunningApp.WaitForElement(q => q.Marked("1"));
+			RunningApp.Tap(q => q.Marked("1"));
+			RunningApp.WaitForElement(q => q.Marked(Success));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -275,6 +275,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45874.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Unreported1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53909.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ListViewNRE.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -514,6 +514,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void SelectItem(object item)
 		{
+			if (_listView == null)
+				return;
+
 			int position = TemplatedItemsView.TemplatedItems.GetGlobalIndexOfItem(item);
 			AView view = null;
 			if (position != -1)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -868,6 +868,9 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 				}
 
+				if (List == null)
+					return;
+
 				var location = TemplatedItemsView.TemplatedItems.GetGroupAndIndexOfItem(eventArg.SelectedItem);
 				if (location.Item1 == -1 || location.Item2 == -1)
 				{


### PR DESCRIPTION
### Description of Change ###

Changes made in #520 will allow the code in `OnItemSelected` to execute in more situations, including when the `ListView` has already been disposed. In this situation, we will get a `NullReferenceException`. Adding a null check to prevent this. Exception was not observed on Android, but I added a check there nonetheless to be safe.

### Bugs Fixed ###

- Not reported

###  ----Please backport to 2.3.5---- ###

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
