### PR TITLE
Bugzilla55607 - [iOS] Opening a ListView Cell's context action will disable context actions for all other ListViews

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
@@ -203,7 +203,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return false;
 
 			UIScrollView scrollViewBeingScrolled;
-			if (!s_scrollViewBeingScrolled.TryGetTarget(out scrollViewBeingScrolled) || ReferenceEquals(scrollViewBeingScrolled, scrollView))
+			if (!s_scrollViewBeingScrolled.TryGetTarget(out scrollViewBeingScrolled) || ReferenceEquals(scrollViewBeingScrolled, scrollView) || !ReferenceEquals(((ContextScrollViewDelegate)scrollViewBeingScrolled.Delegate)._table, ((ContextScrollViewDelegate)scrollView.Delegate)._table))
 				return false;
 
 			scrollView.SetContentOffset(new PointF(0, 0), false);


### PR DESCRIPTION
### Description of Change ###

Added check for instance of UITableView, so that only one ContextAction can be open **per ListView**.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=55588
https://bugzilla.xamarin.com/show_bug.cgi?id=55607 (duplicate)

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
