### PR TITLE
[Android] Add disposed check on FastRenderers.LabelRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -62,6 +62,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
+		 	if (_disposed)
+ +			{
+ +				return new SizeRequest();
+ +			}
+		
 			if (_lastSizeRequest.HasValue)
 			{
 				// if we are measuring the same thing, no need to waste the time

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -63,9 +63,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
 		 	if (_disposed)
- +			{
- +				return new SizeRequest();
- +			}
+ 			{
+ 				return new SizeRequest();
+ 			}
 		
 			if (_lastSizeRequest.HasValue)
 			{


### PR DESCRIPTION
### Description of Change ###

Check if the Label is disposed on GetDesiredSize() on FastRenderer.LabelRenderer

### Bugs Fixed ###

Doesnt crash if GetDesiredSize is called when Label is disposed

### API Changes ###

none

### Behavioral Changes ###

none

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ X] Rebased on top of master at time of PR
- [ X] Changes adhere to coding standard
- [ X] Consolidate commits as makes sense
