### PR TITLE
[Xaml] move ValueConverterProvider to Core

### DIFF
--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -460,6 +460,8 @@
     <Compile Include="ITextElement.cs" />
     <Compile Include="TextElement.cs" />
     <Compile Include="Internals\ResourceLoader.cs" />
+    <Compile Include="Xaml\TypeConversionExtensions.cs" />
+    <Compile Include="Xaml\ValueConverterProvider.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>
@@ -475,4 +477,7 @@
   </PropertyGroup>
   <ItemGroup />
   <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Xaml\" />
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
+++ b/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
@@ -35,7 +35,7 @@ using Xamarin.Forms.Xaml.Internals;
 
 namespace Xamarin.Forms.Xaml
 {
-	internal static class TypeConversionExtensions
+	static class TypeConversionExtensions
 	{
 		internal static object ConvertTo(this object value, Type toType, Func<ParameterInfo> pinfoRetriever,
 			IServiceProvider serviceProvider)

--- a/Xamarin.Forms.Core/Xaml/ValueConverterProvider.cs
+++ b/Xamarin.Forms.Core/Xaml/ValueConverterProvider.cs
@@ -5,7 +5,6 @@ using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 [assembly:Dependency(typeof(ValueConverterProvider))]
-
 namespace Xamarin.Forms.Xaml
 {
 	class ValueConverterProvider : IValueConverterProvider

--- a/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
+++ b/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
@@ -58,7 +58,6 @@
     <Compile Include="XmlnsHelper.cs" />
     <Compile Include="IExpressionParser.cs" />
     <Compile Include="MarkupExtensionParser.cs" />
-    <Compile Include="TypeConversionExtensions.cs" />
     <Compile Include="IDictionaryExtensions.cs" />
     <Compile Include="MarkupExtensions\NullExtension.cs" />
     <Compile Include="MarkupExtensions\ReferenceExtension.cs" />
@@ -76,7 +75,6 @@
     <Compile Include="MarkupExtensions\BindingExtension.cs" />
     <Compile Include="MarkupExtensions\StaticResourceExtension.cs" />
     <Compile Include="MarkupExtensions\DynamicResourceExtension.cs" />
-    <Compile Include="ValueConverterProvider.cs" />
     <Compile Include="FillResourceDictionariesVisitor.cs" />
     <Compile Include="ExpandMarkupsVisitor.cs" />
     <Compile Include="XamlCompilationAttribute.cs" />

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -120,6 +120,9 @@
           <AttributeName>System.Runtime.Versioning.TargetFramework(".NETPortable,Version=v4.5,Profile=Profile259", FrameworkDisplayName=".NET Portable Subset")</AttributeName>
         </Attribute>
         <Attribute>
+          <AttributeName>Xamarin.Forms.Dependency(typeof(Xamarin.Forms.Xaml.ValueConverterProvider))</AttributeName>
+        </Attribute>
+        <Attribute>
           <AttributeName>Xamarin.Forms.Internals.Preserve</AttributeName>
         </Attribute>
       </Attributes>

--- a/docs/Xamarin.Forms.Xaml/index.xml
+++ b/docs/Xamarin.Forms.Xaml/index.xml
@@ -48,9 +48,6 @@
           <AttributeName>System.Runtime.Versioning.TargetFramework(".NETPortable,Version=v4.5,Profile=Profile259", FrameworkDisplayName=".NET Portable Subset")</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>Xamarin.Forms.Dependency(typeof(Xamarin.Forms.Xaml.ValueConverterProvider))</AttributeName>
-        </Attribute>
-        <Attribute>
           <AttributeName>Xamarin.Forms.Internals.Preserve</AttributeName>
         </Attribute>
         <Attribute>


### PR DESCRIPTION
### Description of Change ###

introducing the ValueConverterProvider created a dependency from Core to Xaml. Moving the files to Core to avoid implicit dependency.

## This is probably a regression in 2.3.4 and 2.3.5. Please backport accordingly

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=55636

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense