### PR TITLE
Remove status bar underlay view in Android AppCompat

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -15,6 +15,7 @@ using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms.Platform.Android.AppLinks;
 using Android.Content;
+using Android.Views;
 using AColor = Android.Graphics.Color;
 
 [assembly: Dependency (typeof (CacheService))]
@@ -286,6 +287,9 @@ namespace Xamarin.Forms.ControlGallery.Android
 		{
 			ToolbarResource = Resource.Layout.Toolbar;
 			TabLayoutResource = Resource.Layout.Tabbar;
+
+			// Uncomment the next line to run this as a full screen app (no status bar)
+			//Window.AddFlags(WindowManagerFlags.Fullscreen | WindowManagerFlags.TurnScreenOn);
 
 			base.OnCreate (bundle);
 

--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -15,6 +15,7 @@ using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms.Platform.Android.AppLinks;
 using Android.Content;
+using AColor = Android.Graphics.Color;
 
 [assembly: Dependency (typeof (CacheService))]
 [assembly: Dependency (typeof (TestCloudService))]
@@ -310,6 +311,9 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
 			MessagingCenter.Subscribe<NativeBindingGalleryPage >(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
+
+			// Listen for the message from the status bar color toggle test
+			MessagingCenter.Subscribe<AndroidStatusBarColor>(this, AndroidStatusBarColor.Message, color => SetStatusBarColor(AColor.Red));
 
 			LoadApplication(app);
 		}

--- a/Xamarin.Forms.ControlGallery.Android/Resources/values/Colors.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/values/Colors.xml
@@ -2,4 +2,5 @@
 <resources>
   <color name="cellback">#FFFFFFE0</color>
   <color name="cellback2">#FFDAFF7F</color>
+  <color name="primary_dark">#1976D2</color>
 </resources>

--- a/Xamarin.Forms.ControlGallery.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/values/styles.xml
@@ -18,7 +18,7 @@
     <!-- colorPrimary is used for the default action bar background -->
     <item name="colorPrimary">#2196F3</item>
     <!-- colorPrimaryDark is used for the status bar -->
-    <item name="colorPrimaryDark">#1976D2</item>
+    <item name="android:colorPrimaryDark">@color/primary_dark</item>
     <!-- colorAccent is used as the default value for colorControlActivated
          which is used to tint widgets -->
     <item name="colorAccent">#FF4081</item>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -46,7 +46,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidLinkMode>Full</AndroidLinkMode>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <CustomCommands>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -46,7 +46,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <AndroidLinkMode>Full</AndroidLinkMode>
+    <AndroidLinkMode>None</AndroidLinkMode>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <CustomCommands>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AndroidStatusBarColor.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AndroidStatusBarColor.cs
@@ -1,0 +1,37 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 5553226, "Set status bar color on Android", PlatformAffected.Android)]
+	public class AndroidStatusBarColor : TestContentPage
+	{
+		public const string Message = "ChangeStatusBarToRed";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+				Margin = new Thickness(100)
+			};
+
+			var instructions = new Label
+			{
+				Text =
+					"Tapping the button below should change the status bar color to red. If the status bar does not change to red, the test has failed. (Ignore this test for pre-Lollipop devices.)"
+			};
+
+			var button = new Button { Text = "Change Status Bar Color" };
+
+			button.Clicked += (sender, args) => { MessagingCenter.Send(this, Message); };
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(button);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47548.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47548.cs
@@ -1,0 +1,59 @@
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 47548, "Setting soft input mode to resize creates gap", PlatformAffected.Android)]
+	public class Bugzilla47548 : TestContentPage 
+	{
+		static string GetMode()
+		{
+			return Application.Current.On<Android>().GetWindowSoftInputModeAdjust() == WindowSoftInputModeAdjust.Pan
+				? "Pan"
+				: "Resize";
+		}
+
+		protected override void Init()
+		{
+			var button = new Button() { Text = $"Toggle Soft Input Mode (Currently {GetMode()})"};
+
+			button.Clicked += (sender, args) =>
+			{
+				Application.Current.On<Android>()
+					.UseWindowSoftInputModeAdjust(Application.Current.On<Android>().GetWindowSoftInputModeAdjust() ==
+					                              WindowSoftInputModeAdjust.Pan
+						? WindowSoftInputModeAdjust.Resize
+						: WindowSoftInputModeAdjust.Pan);
+				
+				button.Text = $"Toggle Soft Input Mode (Currently {GetMode()})";
+			};
+
+			Content = new StackLayout
+			{
+				BackgroundColor = Color.CadetBlue,
+				Spacing = 10,
+				VerticalOptions = LayoutOptions.Fill,
+				Children =
+				{
+					new Label
+					{
+						Text = @"With Soft Input Mode set to Pan, tapping the Entry at the bottom of the screen should cause the whole page to scroll up above the keyboard.
+With Soft Input Mode set to Resize, tapping the Entry at the bottom of the screen should resize the content to display everything above the keyboard (the Crimson Label in the middle should be squashed to fit)."
+					},
+					button,
+					new Label
+					{
+						FontSize = 12f,
+						HeightRequest = 500,
+						Text = @"Meh",
+						BackgroundColor = Color.Crimson
+					},
+					new Entry()
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AddingMultipleItemsListView.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AndroidStatusBarColor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AppBarIconColors.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla21368.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla21501.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -161,6 +161,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44096.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44176.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47548.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53834.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51536.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44940.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -45,7 +45,6 @@ namespace Xamarin.Forms.Platform.Android
 		AndroidApplicationLifecycleState _previousState;
 
 		bool _renderersAdded, _isFullScreen;
-		int _statusBarHeight = -1;
 
 		// Override this if you want to handle the default Android behavior of restoring fragments on an application restart
 		protected virtual bool AllowFragmentRestore => false;
@@ -286,18 +285,6 @@ namespace Xamarin.Forms.Platform.Android
 			OnStateChanged();
 		}
 
-		internal int GetStatusBarHeight()
-		{
-			if (_statusBarHeight >= 0)
-				return _statusBarHeight;
-
-			var result = 0;
-			int resourceId = Resources.GetIdentifier("status_bar_height", "dimen", "android");
-			if (resourceId > 0)
-				result = Resources.GetDimensionPixelSize(resourceId);
-			return _statusBarHeight = result;
-		}
-
 		void AppOnPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
 			if (args.PropertyName == "MainPage")
@@ -430,7 +417,6 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			Window.SetSoftInputMode(adjust);
-			SetStatusBarVisibility(adjust);
 		}
 
 		public override void OnWindowAttributesChanged(WindowManagerLayoutParams @params)
@@ -463,21 +449,6 @@ namespace Xamarin.Forms.Platform.Android
 			var width = displayMetrics.WidthPixels;
 			var height = displayMetrics.HeightPixels;
 			AppCompat.Platform.LayoutRootPage(this, Xamarin.Forms.Application.Current.MainPage, width, height);
-		}
-
-		void SetStatusBarVisibility(SoftInput mode)
-		{
-			if (!Forms.IsLollipopOrNewer)
-				return;
-
-			if (mode == SoftInput.AdjustResize)
-			{
-				Window.DecorView.SystemUiVisibility = (StatusBarVisibility)(SystemUiFlags.Immersive);
-			}
-			else
-				Window.DecorView.SystemUiVisibility = (StatusBarVisibility)(SystemUiFlags.LayoutFullscreen | SystemUiFlags.LayoutStable);
-
-			_layout?.Invalidate();
 		}
 
 		void UpdateProgressBarVisibility(bool isBusy)

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -113,23 +113,17 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				oldElement.Disappearing -= MasterDetailPageDisappearing;
 			}
 
-			var statusBarHeight = 0;
-			if (Forms.IsLollipopOrNewer)
-				statusBarHeight = ((FormsAppCompatActivity)Context).GetStatusBarHeight();
-
 			if (newElement != null)
 			{
 				if (_detailLayout == null)
 				{
 					_detailLayout = new MasterDetailContainer(newElement, false, Context)
 					{
-						TopPadding = HasAncestorNavigationPage(Element) ? 0 : statusBarHeight,
 						LayoutParameters = new LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent)
 					};
 
 					_masterLayout = new MasterDetailContainer(newElement, true, Context)
 					{
-						TopPadding = ((IMasterDetailPageController)newElement).ShouldShowSplitMode ? statusBarHeight : 0,
 						LayoutParameters = new LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent) { Gravity = (int)GravityFlags.Start }
 					};
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -8,7 +8,6 @@ using Android.Views;
 using Android.Views.Animations;
 using ARelativeLayout = Android.Widget.RelativeLayout;
 using Xamarin.Forms.Internals;
-using Debug = System.Diagnostics.Debug;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -196,7 +195,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void IPlatformLayout.OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			if (changed)
+			{
 				LayoutRootPage((FormsAppCompatActivity)_context, Page, r - l, b - t);
+			}
 
 			Android.Platform.GetRenderer(Page).UpdateLayout();
 
@@ -286,15 +287,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		internal static void LayoutRootPage(FormsAppCompatActivity activity, Page page, int width, int height)
 		{
-			int statusBarHeight = Forms.IsLollipopOrNewer ? activity.GetStatusBarHeight() : 0;
-			statusBarHeight = activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen) || Forms.TitleBarVisibility == AndroidTitleBarVisibility.Never ? 0 : statusBarHeight;
-
-			if (page is MasterDetailPage)
-				page.Layout(new Rectangle(0, 0, activity.FromPixels(width), activity.FromPixels(height)));
-			else
-			{
-				page.Layout(new Rectangle(0, activity.FromPixels(statusBarHeight), activity.FromPixels(width), activity.FromPixels(height - statusBarHeight)));
-			}
+			page.Layout(new Rectangle(0, 0, activity.FromPixels(width), activity.FromPixels(height)));
 		}
 
 		Task PresentModal(Page modal, bool animated)
@@ -381,18 +374,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			protected override void OnLayout(bool changed, int l, int t, int r, int b)
 			{
-				var activity = (FormsAppCompatActivity)Context;
-				int statusBarHeight = Forms.IsLollipopOrNewer ? activity.GetStatusBarHeight() : 0;
 				if (changed)
 				{
-					if (_modal is MasterDetailPage)
-						_modal.Layout(new Rectangle(0, 0, activity.FromPixels(r - l), activity.FromPixels(b - t)));
-					else
-					{
-						_modal.Layout(new Rectangle(0, activity.FromPixels(statusBarHeight), activity.FromPixels(r - l), activity.FromPixels(b - t - statusBarHeight)));
-					}
+					var activity = (FormsAppCompatActivity)Context;
 
-					_backgroundView.Layout(0, statusBarHeight, r - l, b - t);
+					_modal.Layout(new Rectangle(0, 0, activity.FromPixels(r - l), activity.FromPixels(b - t)));
+					_backgroundView.Layout(0, 0, r - l, b - t);
 				}
 
 				_renderer.UpdateLayout();


### PR DESCRIPTION
### Description of Change ###

Previously, Android status bar background color was set by creating a view to be laid out behind the status bar and setting its background color. This required an extra view, a query for the height of the status bar, several adjustments to layouts to account for the size of the view, and a search through application resources to find the "colorPrimaryDark" value, all of which affect application startup (on older devices, this took as much as 100 ms). Additionally, this caused an issue when setting the soft input adjustment mode to "resize"; a gap would appear between the status bar and the application.

This change removes the status bar underlay. Status bar background color is still determined by the "colorPrimaryDark" value (the default for AppCompat). Changing the status bar color at runtime is handled by the `Window.SetStatusBarColor()` method. 

By removing the status bar underlay and removing the status bar height adjustments, the gap from [issue 47548](https://bugzilla.xamarin.com/show_bug.cgi?id=47548) (see the screenshots in [PR 552](https://github.com/xamarin/Xamarin.Forms/pull/552) ) goes away.

With this change, making an application full screen no longer [requires reflection to remove the status bar](https://forums.xamarin.com/discussion/comment/237310/#Comment_237310).

### Bugs Fixed ###

- [47548 – There is no way to skip adding status bar underlay on AppCompat](https://bugzilla.xamarin.com/show_bug.cgi?id=47548)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
