### PR TITLE
[iOS Maps] Pin customization in iOS MapRenderer

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.cs
@@ -144,7 +144,10 @@ namespace Xamarin.Forms.Controls
 
 		static void PinClicked (object sender, EventArgs e)
 		{
-			// yea!
+			Pin pin = (Pin)sender;
+			Application.Current.MainPage.DisplayAlert("Pin Click",
+				$"You clicked the {pin.Label} pin, located at {pin.Address}, or coordinates ({pin.Position.Latitude}, {pin.Position.Longitude})", 
+				"OK");
 		}
 	}
 }

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -23,10 +23,7 @@ namespace Xamarin.Forms.Maps.MacOS
 	public class MapDelegate : MKMapViewDelegate
 	{
 		protected Map _map;
-
-		// keep references alive, removing this will cause a segfault
-		readonly List<object> List = new List<object>();
-
+		
 		object _lastTouchedView;
 		bool _disposed;
 
@@ -77,13 +74,14 @@ namespace Xamarin.Forms.Maps.MacOS
 			}
 
 			Action<UITapGestureRecognizer> action = g => OnClick(annotation, g);
-			var recognizer = new UITapGestureRecognizer(action) { ShouldReceiveTouch = (gestureRecognizer, touch) =>
-			{
-				_lastTouchedView = touch.View;
-				return true;
-			} };
-			List.Add(action);
-			List.Add(recognizer);
+			var recognizer = new UITapGestureRecognizer(action) 
+			{ 
+				ShouldReceiveTouch = (gestureRecognizer, touch) =>
+				{
+					_lastTouchedView = touch.View;
+					return true;
+				} 
+			};
 			mapPin.AddGestureRecognizer(recognizer);
 		}
 #else
@@ -98,11 +96,8 @@ namespace Xamarin.Forms.Maps.MacOS
 					mapPin.RemoveGestureRecognizer(r);
 				}
 			}
-
-			Action<NSClickGestureRecognizer> action = g => OnClick(annotation, g);
-			var recognizer = new NSClickGestureRecognizer(action);
-			List.Add(action);
-			List.Add(recognizer);
+			
+			var recognizer = new NSClickGestureRecognizer(g => OnClick(annotation, g));
 			mapPin.AddGestureRecognizer(recognizer);
 		}
 #endif


### PR DESCRIPTION
### Description of Change ###

- Continuation of #844 to create customization feature parity between Android and iOS.

[Evolution Forum Post](https://forums.xamarin.com/discussion/91907/map-renderer-extensibility/)

### API Changes ###

Changed:
- public class MapDelegate : ViewRenderer => MapDelegate : ViewRenderer<Map, MKMapView>
- private void AttachGestureToPin(MKPinAnnotationView mapPin, IMKAnnotation annotation) => protected void AttachGestureToPin(MKAnnotationView mapPin, IMKAnnotation annotation) // So the Pin.Clicked event can be used when GetViewForAnnotation is overridden and/or native pin is rendered as a different subclass MKAnnotationView

Removed:
 - MapDelegate class // Methods moved into MapRenderer class

### Behavioral Changes ###

Should not change any existing functionality in the base library, makes it easier to customize pins when extending the iOS MapRenderer.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense