### PR TITLE
Fix bugzilla55542

### DIFF
--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Controls
 			return new MasterDetailPage
 			{
 				AutomationId = DefaultMainPageId,
-				Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
+				Master = new ContentPage { Title = "Master", Content = new View { BackgroundColor = Color.Red } },
 				Detail = CoreGallery.GetMainPage()
 			};
 		}

--- a/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
@@ -145,5 +145,22 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual (typeof (MockRenderer), registrar.GetHandlerType (typeof (View)));
 		}
+
+		[Test]
+		public void TestGetRendererNullViewRenderer()
+		{
+			var registrar = new Internals.Registrar<MockRenderer>();
+
+			//let's say that we are now registering the view of a viewcell
+			registrar.Register(typeof(View), typeof(MockRenderer));
+			//later we had a view that was registered with null because there's
+			//no default renderer for View
+			registrar.Register(typeof(View), null);
+
+			var renderer = registrar.GetHandler(typeof(View));
+
+			Assert.That(renderer, Is.InstanceOf<MockRenderer>());
+		}
+
 	}
 }

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -21,6 +21,9 @@ namespace Xamarin.Forms.Internals
 
 		public void Register(Type tview, Type trender)
 		{
+			//avoid caching null renderers
+			if (trender == null)
+				return;
 			_handlers[tview] = trender;
 		}
 
@@ -156,7 +159,7 @@ namespace Xamarin.Forms.Internals
 					foreach (Attribute attribute in effectAttributes)
 					{
 						var effect = (ExportEffectAttribute)attribute;
-						Effects [resolutionName + "." + effect.Id] = effect.Type;
+						Effects[resolutionName + "." + effect.Id] = effect.Type;
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Change ###

This issue comes from January related with #674 , what happens is View was being cached with a null renderer.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=55542

### Behavioral Changes ###

We don't cache null renderers 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense