### PR TITLE
[Android] Add null check before creating and drawing canvas bugzilla 55559 & 45602

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -188,14 +188,17 @@ namespace Xamarin.Forms.Platform.Android
 					e.PropertyName == Frame.OutlineColorProperty.PropertyName ||
 					e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
 				{
-					using (var canvas = new ACanvas(_normalBitmap))
+					if (_normalBitmap != null)
 					{
-						int width = Bounds.Width();
-						int height = Bounds.Height();
-						canvas.DrawColor(global::Android.Graphics.Color.Black, PorterDuff.Mode.Clear);
-						DrawCanvas(canvas, width, height, false);
+						using (var canvas = new ACanvas(_normalBitmap))
+						{
+							int width = Bounds.Width();
+							int height = Bounds.Height();
+							canvas.DrawColor(global::Android.Graphics.Color.Black, PorterDuff.Mode.Clear);
+							DrawCanvas(canvas, width, height, false);
+						}
+						InvalidateSelf();
 					}
-					InvalidateSelf();
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -188,17 +188,17 @@ namespace Xamarin.Forms.Platform.Android
 					e.PropertyName == Frame.OutlineColorProperty.PropertyName ||
 					e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
 				{
-					if (_normalBitmap != null)
+					if(_normalBitmap == null)
+						return;
+						
+					using (var canvas = new ACanvas(_normalBitmap))
 					{
-						using (var canvas = new ACanvas(_normalBitmap))
-						{
-							int width = Bounds.Width();
-							int height = Bounds.Height();
-							canvas.DrawColor(global::Android.Graphics.Color.Black, PorterDuff.Mode.Clear);
-							DrawCanvas(canvas, width, height, false);
-						}
-						InvalidateSelf();
+						int width = Bounds.Width();
+						int height = Bounds.Height();
+						canvas.DrawColor(global::Android.Graphics.Color.Black, PorterDuff.Mode.Clear);
+						DrawCanvas(canvas, width, height, false);
 					}
+					InvalidateSelf();
 				}
 			}
 


### PR DESCRIPTION
[Android] Add null check before creating and drawing canvas bugzilla 55559 & 45602

### Description of Change ###

Bugs 

### Bugs Fixed ###
[Android] Exception when setting the backgroundcolor of a frame
https://bugzilla.xamarin.com/show_bug.cgi?id=55559

NullPointerException when applying style
https://bugzilla.xamarin.com/show_bug.cgi?id=45602


### API Changes ###
None.

Added:
a null check on the _bitmap object before creating a canvas with it.

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description): No, not necessary.
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense