### PR TITLE
[UWP] Call UpdateTitleVisible on NavigationPage's appearing when inside a TabbedPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla54649.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla54649.cs
@@ -1,0 +1,46 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 54649, "[UWP] Navigation page title bar disappears upon navigating through tabs", PlatformAffected.UWP)]
+	public class Bugzilla54649 : TestTabbedPage
+	{
+		protected override void Init()
+		{
+			Children.Add(CreateChildPage(1));
+			Children.Add(CreateChildPage(2));
+			Children.Add(CreateChildPage(3));
+			Children.Add(CreateChildPage(4));
+		}
+
+		Page CreateChildPage(int number)
+		{
+			var content = new StackLayout
+			{
+				Children =
+				{
+					new Label { Text = $"This is page {number}" },
+					new BoxView { Color = Color.Red }
+				}
+			};
+			
+			var page = new ContentPage
+			{
+				Content = content,
+				Title = $"Page {number}"
+			};
+			
+			return new NavigationPage(page)
+			{
+				Title = $"Tab {number}"
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -196,6 +196,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52266.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53445.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -185,6 +185,8 @@ namespace Xamarin.Forms.Platform.WinRT
 #if WINDOWS_UWP
 				// Enforce consistency rules on toolbar (show toolbar if top-level page is Navigation Page)
 				_container.ShouldShowToolbar = _parentMasterDetailPage == null && _parentTabbedPage == null;
+				if (_parentTabbedPage != null)
+					Element.Appearing += OnElementAppearing;
 #endif
 
 				Element.PropertyChanged += OnElementPropertyChanged;
@@ -227,6 +229,9 @@ namespace Xamarin.Forms.Platform.WinRT
 				_parentMasterDetailPage.PropertyChanged -= MultiPagePropertyChanged;
 
 #if WINDOWS_UWP
+			if (_parentTabbedPage != null)
+				Element.Appearing -= OnElementAppearing;
+
 			if (_navManager != null)
 			{
 				_navManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
@@ -314,6 +319,11 @@ namespace Xamarin.Forms.Platform.WinRT
 				UpdateTitleVisible();
 			else if (e.PropertyName == Page.TitleProperty.PropertyName)
 				UpdateTitleOnParents();
+		}
+
+		void OnElementAppearing(object sender, EventArgs e)
+		{
+			UpdateTitleVisible();
 		}
 
 		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

When a `NavigationPage` is inside of a `TabbedPage` on UWP, navigating between the tabs would not update the title when navigating back to a given tab. Calling `UpdateTitleVisible` upon the page's appearing resolves this, and the hook is only assigned when it is inside a parent `TabbedPage` (`_parentTabbedPage`).

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=54649

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
