### PR TITLE
[Android] Remove the ". " on empty labels (Accessibility) on Fastrenderers

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
@@ -8,8 +8,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 	{
 		const string GetFromElement = "GetValueFromElement";
 		string _defaultContentDescription;
-		bool? _defaultFocusable;
-		string _defaultHint;
+		bool? _defaultFocusable;		
 		bool _disposed;
 
 		IVisualElementRenderer _renderer;
@@ -117,9 +116,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			Control.Focusable =
 				(bool)(value ?? (bool?)Element.GetValue(Accessibility.IsInAccessibleTreeProperty) ?? _defaultFocusable);
 		}
-
-		bool SetHint(string hint = GetFromElement)
-		{
+				
+		 bool SetHint()
+		 {
 			if (Element == null || Control == null)
 			{
 				return false;
@@ -137,18 +136,15 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				return true;
 			}
 
-			if (_defaultHint == null)
+			string accessibilityName = (string)Element.GetValue(Accessibility.NameProperty);
+			string accessibilityHint = (string)Element.GetValue(Accessibility.HintProperty);
+
+			if (string.IsNullOrWhiteSpace(accessibilityName) && string.IsNullOrWhiteSpace(accessibilityHint))
 			{
-				_defaultHint = textView.Hint;
+				return true;
 			}
 
-			string value = hint;
-			if (value == GetFromElement)
-			{
-				value = string.Join((String.IsNullOrWhiteSpace((string)(Element.GetValue(Accessibility.NameProperty))) || String.IsNullOrWhiteSpace((string)(Element.GetValue(Accessibility.HintProperty)))) ? "" : ". ", (string)Element.GetValue(Accessibility.NameProperty), (string)Element.GetValue(Accessibility.HintProperty));
-			}
-
-			textView.Hint = !string.IsNullOrWhiteSpace(value) ? value : _defaultHint;
+			textView.Hint = string.Join(". ", accessibilityName, accessibilityHint);
 
 			return true;
 		}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
@@ -144,12 +144,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				return true;
 			}
 
-		        string divider = ". ";
-
-			if (string.IsNullOrWhiteSpace(accessibilityName) || string.IsNullOrWhiteSpace(accessibilityHint))
-			{
-				divider = "";
-			}
+		        string divider = string.IsNullOrWhiteSpace(accessibilityName) || string.IsNullOrWhiteSpace(accessibilityHint) ? "" : ". ";	
 
 			textView.Hint =  accessibilityName + divider + accessibilityHint;
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
@@ -145,8 +145,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			string value = hint;
 			if (value == GetFromElement)
 			{
-				value = string.Join(". ", (string)Element.GetValue(Accessibility.NameProperty),
-					(string)Element.GetValue(Accessibility.HintProperty));
+				value = string.Join((String.IsNullOrWhiteSpace((string)(Element.GetValue(Accessibility.NameProperty))) || String.IsNullOrWhiteSpace((string)(Element.GetValue(Accessibility.HintProperty)))) ? "" : ". ", (string)Element.GetValue(Accessibility.NameProperty), (string)Element.GetValue(Accessibility.HintProperty));
 			}
 
 			textView.Hint = !string.IsNullOrWhiteSpace(value) ? value : _defaultHint;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
@@ -144,7 +144,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				return true;
 			}
 
-			textView.Hint = string.Join(". ", accessibilityName, accessibilityHint);
+		        textView.Hint =  accessibilityName + ". " + accessibilityHint;
 
 			return true;
 		}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AccessibilityProvider.cs
@@ -144,7 +144,14 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				return true;
 			}
 
-		        textView.Hint =  accessibilityName + ". " + accessibilityHint;
+		        string divider = ". ";
+
+			if (string.IsNullOrWhiteSpace(accessibilityName) || string.IsNullOrWhiteSpace(accessibilityHint))
+			{
+				divider = "";
+			}
+
+			textView.Hint =  accessibilityName + divider + accessibilityHint;
 
 			return true;
 		}


### PR DESCRIPTION
### Description of Change ###

Removes the ". " if a label has no text. Labels are today given a hint from the SetHint() method. The hint will allways include ". "  wich leads to empty labels being rendered with a dot instead of being empty. Also hints set by a custom renderer are ignored because of this.

This image shows what empty labels are rendered as  http://imgur.com/Min569d


### Bugs Fixed ###

The dot comes from a string.join with the accessibility values, but if those values are null we now return from that method before setting a hint.
result   http://imgur.com/PxoKvwi


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
