### PR TITLE
[Xaml] decorate TypeConverter for additional check

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Core.XamlC
 {
 	class BoundsTypeConverter : ICompiledTypeConverter
 	{
-		IEnumerable<Instruction> ICompiledTypeConverter.ConvertFromString(string value, ILContext context, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
 			var module = context.Body.Method.Module;
 

--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -931,7 +931,8 @@ namespace Xamarin.Forms.Build.Tasks
 			if (bpRef == null)
 				return false;
 
-			if (node is ValueNode)
+			var valueNode = node as ValueNode;
+			if (valueNode != null && valueNode.CanConvertValue(context, bpRef))
 				return true;
 
 			var elementNode = node as IElementNode;
@@ -1026,11 +1027,13 @@ namespace Xamarin.Forms.Build.Tasks
 			var property = parent.VariableType.GetProperty(pd => pd.Name == localName, out declaringTypeReference);
 			if (property == null)
 				return false;
+			var propertyType = property.ResolveGenericPropertyType(declaringTypeReference, module);
 			var propertySetter = property.SetMethod;
 			if (propertySetter == null || !propertySetter.IsPublic || propertySetter.IsStatic)
 				return false;
 
-			if (node is ValueNode)
+			var valueNode = node as ValueNode;
+			if (valueNode != null && valueNode.CanConvertValue(context, propertyType, new ICustomAttributeProvider[] { property, propertyType.Resolve()}))
 				return true;
 
 			var elementNode = node as IElementNode;
@@ -1038,7 +1041,6 @@ namespace Xamarin.Forms.Build.Tasks
 				return false;
 
 			var vardef = context.Variables [elementNode];
-			var propertyType = property.ResolveGenericPropertyType(declaringTypeReference, module);
 			var implicitOperator = vardef.VariableType.GetImplicitOperatorTo(propertyType, module);
 
 			if (implicitOperator != null)

--- a/Xamarin.Forms.Core/BindablePropertyConverter.cs
+++ b/Xamarin.Forms.Core/BindablePropertyConverter.cs
@@ -9,6 +9,7 @@ using Xamarin.Forms.Xaml;
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.BindablePropertyConverter")]
+	[Xaml.TypeConversion(typeof(BindableProperty))]
 	public sealed class BindablePropertyConverter : TypeConverter, IExtendedTypeConverter
 	{
 		object IExtendedTypeConverter.ConvertFrom(CultureInfo culture, object value, IServiceProvider serviceProvider)

--- a/Xamarin.Forms.Core/BindingTypeConverter.cs
+++ b/Xamarin.Forms.Core/BindingTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.BindingTypeConverter")]
+	[Xaml.TypeConversion(typeof(Binding))]
 	public sealed class BindingTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/BoundsTypeConverter.cs
+++ b/Xamarin.Forms.Core/BoundsTypeConverter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled ("Xamarin.Forms.Core.XamlC.BoundsTypeConverter")]
+	[Xaml.TypeConversion(typeof(Rectangle))]
 	public sealed class BoundsTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -273,6 +273,7 @@ namespace Xamarin.Forms
 			}
 		}
 
+		[Xaml.TypeConversion(typeof(ButtonContentLayout))]
 		public sealed class ButtonContentTypeConverter : TypeConverter
 		{
 			public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/ColorTypeConverter.cs
+++ b/Xamarin.Forms.Core/ColorTypeConverter.cs
@@ -6,6 +6,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.ColorTypeConverter")]
+	[Xaml.TypeConversion(typeof(Color))]
 	public class ColorTypeConverter : TypeConverter
 	{
 		// Supported inputs

--- a/Xamarin.Forms.Core/ConstraintTypeConverter.cs
+++ b/Xamarin.Forms.Core/ConstraintTypeConverter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.ConstraintTypeConverter")]
+	[Xaml.TypeConversion(typeof(Constraint))]
 	public class ConstraintTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/FileImageSourceConverter.cs
+++ b/Xamarin.Forms.Core/FileImageSourceConverter.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace Xamarin.Forms
 {
+	[Xaml.TypeConversion(typeof(FileImageSource))]
 	public sealed class FileImageSourceConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/FontSizeConverter.cs
+++ b/Xamarin.Forms.Core/FontSizeConverter.cs
@@ -4,6 +4,7 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms
 {
+	[Xaml.TypeConversion(typeof(double))]
 	public class FontSizeConverter : TypeConverter, IExtendedTypeConverter
 	{
 		[Obsolete("IExtendedTypeConverter.ConvertFrom is obsolete as of version 2.2.0. Please use ConvertFromInvariantString (string, IServiceProvider) instead.")]

--- a/Xamarin.Forms.Core/FontTypeConverter.cs
+++ b/Xamarin.Forms.Core/FontTypeConverter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 namespace Xamarin.Forms
 {
+	[Xaml.TypeConversion(typeof(Font))]
 	public sealed class FontTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/GridLengthTypeConverter.cs
+++ b/Xamarin.Forms.Core/GridLengthTypeConverter.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 
 namespace Xamarin.Forms
 {
+	[Xaml.TypeConversion(typeof(GridLength))]
 	public class GridLengthTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/ImageSourceConverter.cs
+++ b/Xamarin.Forms.Core/ImageSourceConverter.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace Xamarin.Forms
 {
+	[Xaml.TypeConversion(typeof(ImageSource))]
 	public sealed class ImageSourceConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/KeyboardTypeConverter.cs
+++ b/Xamarin.Forms.Core/KeyboardTypeConverter.cs
@@ -5,6 +5,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
+	[Xaml.TypeConversion(typeof(Keyboard))]
 	public class KeyboardTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/LayoutOptionsConverter.cs
+++ b/Xamarin.Forms.Core/LayoutOptionsConverter.cs
@@ -6,6 +6,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.LayoutOptionsConverter")]
+	[Xaml.TypeConversion(typeof(LayoutOptions))]
 	public sealed class LayoutOptionsConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/ListStringTypeConverter.cs
+++ b/Xamarin.Forms.Core/ListStringTypeConverter.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.ListStringTypeConverter")]
+	[Xaml.TypeConversion(typeof(List<string>))]
 	public class ListStringTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/PointTypeConverter.cs
+++ b/Xamarin.Forms.Core/PointTypeConverter.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 
 namespace Xamarin.Forms
 {
+	[Xaml.TypeConversion(typeof(Point))]
 	public class PointTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/RectangleTypeConverter.cs
+++ b/Xamarin.Forms.Core/RectangleTypeConverter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.RectangleTypeConverter")]
+	[Xaml.TypeConversion(typeof(Rectangle))]
 	public class RectangleTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/ThicknessTypeConverter.cs
+++ b/Xamarin.Forms.Core/ThicknessTypeConverter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.ThicknessTypeConverter")]
+	[Xaml.TypeConversion(typeof(Thickness))]
 	public class ThicknessTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/TypeConversionAttribute.cs
+++ b/Xamarin.Forms.Core/TypeConversionAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Xamarin.Forms.Xaml
+{
+	[System.AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+	public sealed class TypeConversionAttribute : Attribute
+	{
+		public Type TargetType { get; private set; }
+
+		public TypeConversionAttribute(Type targetType)
+		{
+			TargetType = targetType;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/TypeTypeConverter.cs
+++ b/Xamarin.Forms.Core/TypeTypeConverter.cs
@@ -5,6 +5,7 @@ using Xamarin.Forms.Xaml;
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.TypeTypeConverter")]
+	[Xaml.TypeConversion(typeof(Type))]
 	public sealed class TypeTypeConverter : TypeConverter, IExtendedTypeConverter
 	{
 		[Obsolete("IExtendedTypeConverter.ConvertFrom is obsolete as of version 2.2.0. Please use ConvertFromInvariantString (string, IServiceProvider) instead.")]

--- a/Xamarin.Forms.Core/UriTypeConverter.cs
+++ b/Xamarin.Forms.Core/UriTypeConverter.cs
@@ -3,6 +3,7 @@
 namespace Xamarin.Forms
 {
 	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.UriTypeConverter")]
+	[Xaml.TypeConversion(typeof(Uri))]
 	public class UriTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/WebViewSourceTypeConverter.cs
+++ b/Xamarin.Forms.Core/WebViewSourceTypeConverter.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace Xamarin.Forms
 {
+	[Xaml.TypeConversion(typeof(UrlWebViewSource))]
 	public class WebViewSourceTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)
@@ -9,7 +10,7 @@ namespace Xamarin.Forms
 			if (value != null)
 				return new UrlWebViewSource { Url = value };
 
-			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(Color)));
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(UrlWebViewSource)));
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -478,6 +478,7 @@
     <Compile Include="TextAlignmentElement.cs" />
     <Compile Include="PaddingElement.cs" />
     <Compile Include="IPaddingElement.cs" />
+    <Compile Include="TypeConversionAttribute.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Xamarin.Forms.Pages/JsonSourceConverter.cs
+++ b/Xamarin.Forms.Pages/JsonSourceConverter.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace Xamarin.Forms.Pages
 {
+	[Xaml.TypeConversion(typeof(JsonSource))]
 	public class JsonSourceConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)
@@ -12,7 +13,7 @@ namespace Xamarin.Forms.Pages
 				Uri uri;
 				if (Uri.TryCreate(value, UriKind.Absolute, out uri) && uri.Scheme != "file")
 					return new UriJsonSource { Uri = uri };
-				if (value.StartsWith("[") || value.StartsWith("{"))
+				if (value.StartsWith("[", StringComparison.OrdinalIgnoreCase) || value.StartsWith("{", StringComparison.OrdinalIgnoreCase))
 					return new StringJsonSource { Json = value };
 			}
 

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz55862.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz55862.xaml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Xaml.UnitTests.Bz55862"
+    Foo="2"/>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz55862.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz55862.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[TypeConverter(typeof(ThicknessTypeConverter))]
+	public struct Bz55862Bar
+	{
+	}
+
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Bz55862 : ContentPage
+	{
+		public Bz55862Bar Foo { get; set; }
+		public Bz55862()
+		{
+			InitializeComponent();
+		}
+
+		public Bz55862(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void BindingContextWithConverter(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.That(() => MockCompiler.Compile(typeof(Bz55862)), Throws.Exception.TypeOf<XamlParseException>());
+				else
+					Assert.That(() => new Bz55862(useCompiledXaml), Throws.Exception.TypeOf<XamlParseException>());	
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -510,6 +510,9 @@
     <Compile Include="Issues\Bz60203.xaml.cs">
       <DependentUpon>Bz60203.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz55862.xaml.cs">
+      <DependentUpon>Bz55862.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -948,6 +951,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz60203.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz55862.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Xaml/TypeConversionAttribute.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Xaml/TypeConversionAttribute.xml
@@ -1,0 +1,55 @@
+<Type Name="TypeConversionAttribute" FullName="Xamarin.Forms.Xaml.TypeConversionAttribute">
+  <TypeSignature Language="C#" Value="public sealed class TypeConversionAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit TypeConversionAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public TypeConversionAttribute (Type targetType);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(class System.Type targetType) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="targetType" Type="System.Type" />
+      </Parameters>
+      <Docs>
+        <param name="targetType">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TargetType">
+      <MemberSignature Language="C#" Value="public Type TargetType { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Type TargetType" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Type</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/BindablePropertyConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/BindablePropertyConverter.xml
@@ -14,6 +14,11 @@
       <InterfaceName>Xamarin.Forms.IExtendedTypeConverter</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.BindableProperty))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> for bindable properties.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/BindingTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/BindingTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Binding))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Type converter that converts from strings to <see cref="T:Xamarin.Forms.Binding" /> objects.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/BoundsTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/BoundsTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Rectangle))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts strings into <see cref="T:Xamarin.Forms.Rectangle" />s for use with <see cref="T:Xamarin.Forms.AbsoluteLayout" />s.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Button+ButtonContentTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Button+ButtonContentTypeConverter.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Button/ButtonContentLayout))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Class that the XAML parser uses to convert strings to <see cref="T:Xamarin.Forms.Button+ButtonContentLayout" /> objects.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ColorTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ColorTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Color))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts from strings to a <see cref="T:Xamarin.Forms.Color" />.</summary>
     <remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ConstraintTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ConstraintTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Constraint))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts from strings to a <see cref="T:Xamarin.Forms.Constraint" />.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FileImageSourceConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FileImageSourceConverter.xml
@@ -10,6 +10,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.FileImageSource))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts to <see cref="P:Xamarin.Forms.FileImageSource" />.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FontSizeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FontSizeConverter.xml
@@ -16,6 +16,11 @@
       <InterfaceName>Xamarin.Forms.IExtendedTypeConverter</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(System.Double))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Converts a string into a font size.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FontTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FontTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Font))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts from strings to <see cref="T:Xamarin.Forms.Core.Font" />.</summary>
     <remarks>String should be formatted as "[name],[attributes],[size]" there may be multiple attributes, e.g. "Georgia, Bold, Italic, 42"</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/GridLengthTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/GridLengthTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.GridLength))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts from strings to <see cref="T:Xamarin.Forms.GridLength" />s.</summary>
     <remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ImageSourceConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ImageSourceConverter.xml
@@ -10,6 +10,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.ImageSource))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Class that takes a string representation of an image file location and returns a <see cref="T:Xamarin.Forms.ImageSource" /> from the specified resource.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/KeyboardTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/KeyboardTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Keyboard))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts a string into a <see cref="T:Xamarin.Forms.Keyboard" />.</summary>
     <remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/LayoutOptionsConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/LayoutOptionsConverter.xml
@@ -10,6 +10,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.LayoutOptions))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Class that takes a string representation of a <see cref="T:Xamarin.Forms.LayoutOptions" /> and returns a corresponding <see cref="T:Xamarin.Forms.LayoutOptions" />.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ListStringTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ListStringTypeConverter.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(System.Collections.Generic.List`1&lt;System.String&gt;))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Type converter for converting properly formatted string lists to lists.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/PointTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/PointTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Point))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts from a string to a <see cref="T:Xamarin.Forms.Point" />.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/RectangleTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/RectangleTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Rectangle))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts a string to a <see cref="T:Xamarin.Forms.Rectangle" />.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ThicknessTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ThicknessTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Thickness))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts from a string to a <see cref="T:Xamarin.Forms.Thickness" />.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/TypeTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/TypeTypeConverter.xml
@@ -14,6 +14,11 @@
       <InterfaceName>Xamarin.Forms.IExtendedTypeConverter</InterfaceName>
     </Interface>
   </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(System.Type))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Class that takes a string representation of a <see cref="T:System.Type" /> and returns a corresponding <see cref="T:System.Type" />.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/UriTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/UriTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(System.Uri))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts from a string or <see cref="T:System.Uri" /> to a <see cref="T:System.Uri" />.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/WebViewSourceTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/WebViewSourceTypeConverter.xml
@@ -15,6 +15,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.UrlWebViewSource))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.TypeConverter" /> that converts a string to a <see cref="T:Xamarin.Forms.UrlWebViewSource" />.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -564,6 +564,7 @@
       <Type Name="IValueProvider" Kind="Interface" />
       <Type Name="IXamlTypeResolver" Kind="Interface" />
       <Type Name="IXmlLineInfoProvider" Kind="Interface" />
+      <Type Name="TypeConversionAttribute" Kind="Class" />
       <Type Name="XamlParseException" Kind="Class" />
       <Type Name="XamlResourceIdAttribute" Kind="Class" />
       <Type Name="XmlLineInfo" Kind="Class" />

--- a/docs/Xamarin.Forms.Pages/Xamarin.Forms.Pages/JsonSourceConverter.xml
+++ b/docs/Xamarin.Forms.Pages/Xamarin.Forms.Pages/JsonSourceConverter.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.Pages.JsonSource))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Converter that returns a <see cref="T:Xamarin.Forms.Pages.JsonSource" /> for a JSON string or a URI string.</summary>
     <remarks>To be added.</remarks>


### PR DESCRIPTION
### Description of Change ###

Catch error at XamlC step if a property or type has a non-compatible [TypeConverter]

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=55862

### API Changes ###

Added:
 - public class Xamarin.Forms.Xaml.TypeConversionAttribute

Changed:
 - added [TypeConversion] to our converters


### Behavioral Changes ###

a wrongly attributed property will now fail at compile time vs runtime

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense