### PR TITLE
[Core] Accessibility works with XamlC

### DIFF
--- a/Xamarin.Forms.Core/Accessibility.cs
+++ b/Xamarin.Forms.Core/Accessibility.cs
@@ -1,4 +1,4 @@
-﻿
+﻿﻿
 namespace Xamarin.Forms
 {
 	public class Accessibility
@@ -10,5 +10,46 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty LabeledByProperty = BindableProperty.Create("LabeledBy", typeof(VisualElement), typeof(Element), default(VisualElement));
 
 		public static readonly BindableProperty NameProperty = BindableProperty.Create("Name", typeof(string), typeof(Element), default(string));
+
+
+		public static string GetHint(BindableObject bindable)
+		{
+			return (string)bindable.GetValue(HintProperty);
+		}
+
+		public static bool? GetIsInAccessibleTree(BindableObject bindable)
+		{
+			return (bool?)bindable.GetValue(IsInAccessibleTreeProperty);
+		}
+
+		public static VisualElement GetLabeledBy(BindableObject bindable)
+		{
+			return (VisualElement)bindable.GetValue(LabeledByProperty);
+		}
+
+		public static string GetName(BindableObject bindable)
+		{
+			return (string)bindable.GetValue(NameProperty);
+		}
+
+		public static void SetHint(BindableObject bindable, string value)
+		{
+			bindable.SetValue(HintProperty, value);
+		}
+
+		public static void SetIsInAccessibleTree(BindableObject bindable, bool? value)
+		{
+			bindable.SetValue(IsInAccessibleTreeProperty, value);
+		}
+
+		public static void SetLabeledBy(BindableObject bindable, VisualElement value)
+		{
+			bindable.SetValue(LabeledByProperty, value);
+		}
+
+		public static void SetName(BindableObject bindable, string value)
+		{
+			bindable.SetValue(NameProperty, value);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Accessibility.cs
+++ b/Xamarin.Forms.Core/Accessibility.cs
@@ -11,7 +11,6 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty NameProperty = BindableProperty.Create("Name", typeof(string), typeof(Element), default(string));
 
-
 		public static string GetHint(BindableObject bindable)
 		{
 			return (string)bindable.GetValue(HintProperty);

--- a/Xamarin.Forms.Xaml.UnitTests/Accessibility.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Accessibility.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Accessibility">
+
+	<StackLayout>
+		<Label x:Name="label" Text="Your Name" />
+		<Entry x:Name="entry"
+			Accessibility.Name="Name"
+			Accessibility.Hint="Sets your name"
+			Accessibility.IsInAccessibleTree="true"
+			Accessibility.LabeledBy="{x:Reference label}"
+		 />
+	</StackLayout>
+
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Accessibility.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Accessibility.xaml.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Accessibility : ContentPage
+	{
+		public Accessibility()
+		{
+			InitializeComponent();
+		}
+
+		public Accessibility(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+				Application.Current = new MockApplication();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+				Application.Current = null;
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void AccessibilityName(bool useCompiledXaml)
+			{
+				var layout = new Accessibility(useCompiledXaml);
+
+				Assert.AreEqual("Name", (string)layout.entry.GetValue(Xamarin.Forms.Accessibility.NameProperty));
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void AccessibilityHint(bool useCompiledXaml)
+			{
+				var layout = new Accessibility(useCompiledXaml);
+
+				Assert.AreEqual("Sets your name", (string)layout.entry.GetValue(Xamarin.Forms.Accessibility.HintProperty));
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void AccessibilityIsInAccessibleTree(bool useCompiledXaml)
+			{
+				var layout = new Accessibility(useCompiledXaml);
+				Application.Current.MainPage = layout;
+
+				Assert.AreEqual(true, (bool)layout.entry.GetValue(Xamarin.Forms.Accessibility.IsInAccessibleTreeProperty));
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void AccessibilityLabeledBy(bool useCompiledXaml)
+			{
+				var layout = new Accessibility(useCompiledXaml);
+				Application.Current.MainPage = layout;
+
+				Assert.AreEqual(layout.label, (Element)layout.entry.GetValue(Xamarin.Forms.Accessibility.LabeledByProperty));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -76,6 +76,9 @@
     <Compile Include="..\Xamarin.Forms.Core.UnitTests\MockPlatformServices.cs">
       <Link>MockPlatformServices.cs</Link>
     </Compile>
+    <Compile Include="Accessibility.xaml.cs">
+      <DependentUpon>Accessibility.xaml</DependentUpon>
+    </Compile>
     <Compile Include="FontConverterTests.cs" />
     <Compile Include="Issues\Bz43450.xaml.cs">
       <DependentUpon>Bz43450.xaml</DependentUpon>
@@ -387,19 +390,19 @@
     <Compile Include="Issues\Bz47703.xaml.cs">
       <DependentUpon>Bz47703.xaml</DependentUpon>
     </Compile>
-     <Compile Include="FactoryMethodMissingCtor.xaml.cs">
-       <DependentUpon>FactoryMethodMissingCtor.xaml</DependentUpon>
-     </Compile>
-     <Compile Include="FactoryMethodMissingMethod.xaml.cs">
-       <DependentUpon>FactoryMethodMissingMethod.xaml</DependentUpon>
-     </Compile>
+    <Compile Include="FactoryMethodMissingCtor.xaml.cs">
+      <DependentUpon>FactoryMethodMissingCtor.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="FactoryMethodMissingMethod.xaml.cs">
+      <DependentUpon>FactoryMethodMissingMethod.xaml</DependentUpon>
+    </Compile>
     <Compile Include="XamlC\TypeReferenceExtensionsTests.cs" />
     <Compile Include="Issues\Bz46921.xaml.cs">
       <DependentUpon>Bz46921.xaml</DependentUpon>
     </Compile>
-     <Compile Include="I8.xaml.cs">
-       <DependentUpon>I8.xaml</DependentUpon>
-     </Compile>
+    <Compile Include="I8.xaml.cs">
+      <DependentUpon>I8.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Issues\Bz49307.xaml.cs">
       <DependentUpon>Bz49307.xaml</DependentUpon>
     </Compile>
@@ -481,7 +484,7 @@
     </Compile>
     <Compile Include="Issues\Bz55347.xaml.cs">
       <DependentUpon>Bz55347.xaml</DependentUpon>
-    </Compile> 
+    </Compile>
     <Compile Include="FieldModifier.xaml.cs">
       <DependentUpon>FieldModifier.xaml</DependentUpon>
     </Compile>
@@ -917,6 +920,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Issues\Bz43450.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Accessibility.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Accessibility.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Accessibility.xml
@@ -27,6 +27,86 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="GetHint">
+      <MemberSignature Language="C#" Value="public static string GetHint (Xamarin.Forms.BindableObject bindable);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig string GetHint(class Xamarin.Forms.BindableObject bindable) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetIsInAccessibleTree">
+      <MemberSignature Language="C#" Value="public static Nullable&lt;bool&gt; GetIsInAccessibleTree (Xamarin.Forms.BindableObject bindable);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype System.Nullable`1&lt;bool&gt; GetIsInAccessibleTree(class Xamarin.Forms.BindableObject bindable) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Nullable&lt;System.Boolean&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetLabeledBy">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.VisualElement GetLabeledBy (Xamarin.Forms.BindableObject bindable);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.VisualElement GetLabeledBy(class Xamarin.Forms.BindableObject bindable) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.VisualElement</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetName">
+      <MemberSignature Language="C#" Value="public static string GetName (Xamarin.Forms.BindableObject bindable);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig string GetName(class Xamarin.Forms.BindableObject bindable) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="HintProperty">
       <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty HintProperty;" />
       <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty HintProperty" />
@@ -84,6 +164,90 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that contains the brief description of the UI element</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetHint">
+      <MemberSignature Language="C#" Value="public static void SetHint (Xamarin.Forms.BindableObject bindable, string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetHint(class Xamarin.Forms.BindableObject bindable, string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetIsInAccessibleTree">
+      <MemberSignature Language="C#" Value="public static void SetIsInAccessibleTree (Xamarin.Forms.BindableObject bindable, Nullable&lt;bool&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetIsInAccessibleTree(class Xamarin.Forms.BindableObject bindable, valuetype System.Nullable`1&lt;bool&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Nullable&lt;System.Boolean&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetLabeledBy">
+      <MemberSignature Language="C#" Value="public static void SetLabeledBy (Xamarin.Forms.BindableObject bindable, Xamarin.Forms.VisualElement value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetLabeledBy(class Xamarin.Forms.BindableObject bindable, class Xamarin.Forms.VisualElement value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="Xamarin.Forms.VisualElement" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetName">
+      <MemberSignature Language="C#" Value="public static void SetName (Xamarin.Forms.BindableObject bindable, string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetName(class Xamarin.Forms.BindableObject bindable, string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
### Description of Change ###

Add the required get/set methods for XamlC to properly parse the Accessibility attached properties.

### Bugs Fixed ###

- [Bug 56079 - Accessibility Support doesn't work in XAML](https://bugzilla.xamarin.com/show_bug.cgi?id=56079)

### API Changes ###

Added: 
- `Accessibility.GetHint`
- `Accessibility.GetIsInAccessibleTree`
- `Accessibility.GetLabeledBy`
- `Accessibility.GetName`
- `Accessibility.SetHint`
- `Accessibility.SetIsInAccessibleTree`
- `Accessibility.SetLabeledBy`
- `Accessibility.SetName`

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
