### PR TITLE
Allow specifying AutomationProperties.LabeledBy by name

### DIFF
--- a/Xamarin.Forms.Core/AutomationProperties.cs
+++ b/Xamarin.Forms.Core/AutomationProperties.cs
@@ -20,6 +20,7 @@
 			return (bool?)bindable.GetValue(IsInAccessibleTreeProperty);
 		}
 
+		[TypeConverter(typeof(ReferenceTypeConverter))]
 		public static VisualElement GetLabeledBy(BindableObject bindable)
 		{
 			return (VisualElement)bindable.GetValue(LabeledByProperty);

--- a/Xamarin.Forms.Core/Internals/INamescopeProvider.cs
+++ b/Xamarin.Forms.Core/Internals/INamescopeProvider.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Xaml.Internals
+{
+	interface INameScopeProvider
+	{
+		INameScope NameScope { get; }
+	}
+}

--- a/Xamarin.Forms.Core/ReferenceTypeConverter.cs
+++ b/Xamarin.Forms.Core/ReferenceTypeConverter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Globalization;
+
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Xaml.Internals;
+
+namespace Xamarin.Forms
+{
+	public sealed class ReferenceTypeConverter : TypeConverter, IExtendedTypeConverter
+	{
+		object IExtendedTypeConverter.ConvertFrom(CultureInfo culture, object value, IServiceProvider serviceProvider)
+		{
+			return ((IExtendedTypeConverter)this).ConvertFromInvariantString(value as string, serviceProvider);
+		}
+
+		object IExtendedTypeConverter.ConvertFromInvariantString(string value, IServiceProvider serviceProvider)
+		{
+			if (serviceProvider == null)
+				throw new ArgumentNullException(nameof(serviceProvider));
+			var valueProvider = serviceProvider.GetService(typeof(IProvideValueTarget)) as IProvideParentValues;
+			if (valueProvider == null)
+				throw new ArgumentException("serviceProvider does not provide an IProvideValueTarget");
+			var namescopeprovider = serviceProvider.GetService(typeof(INameScopeProvider)) as INameScopeProvider;
+			if (namescopeprovider != null && namescopeprovider.NameScope != null) {
+				var element = namescopeprovider.NameScope.FindByName(value);
+				if (element != null)
+					return element;
+			}
+
+			foreach (var target in valueProvider.ParentObjects) {
+				var ns = target as INameScope;
+				if (ns == null)
+					continue;
+				var element = ns.FindByName(value);
+				if (element != null)
+					return element;
+			}
+			throw new Exception("Can't resolve name on Element");
+		}
+
+		public override object ConvertFromInvariantString(string value)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -472,6 +472,8 @@
     <Compile Include="Xaml\IResourcesLoader.cs" />
     <Compile Include="Xaml\XamlResourceIdAttribute.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\LargeTitleDisplayMode.cs" />
+    <Compile Include="Internals\INamescopeProvider.cs" />
+    <Compile Include="ReferenceTypeConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/AutomationProperties.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/AutomationProperties.xaml
@@ -9,7 +9,7 @@
 			AutomationProperties.Name="Name"
 			AutomationProperties.HelpText="Sets your name"
 			AutomationProperties.IsInAccessibleTree="true"
-			AutomationProperties.LabeledBy="{x:Reference label}"
+			AutomationProperties.LabeledBy="label"
 		 />
 	</StackLayout>
 

--- a/Xamarin.Forms.Xaml/MarkupExtensions/ReferenceExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/ReferenceExtension.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Xaml
 		public object ProvideValue(IServiceProvider serviceProvider)
 		{
 			if (serviceProvider == null)
-				throw new ArgumentNullException("serviceProvider");
+				throw new ArgumentNullException(nameof(serviceProvider));
 			var valueProvider = serviceProvider.GetService(typeof (IProvideValueTarget)) as IProvideParentValues;
 			if (valueProvider == null)
 				throw new ArgumentException("serviceProvider does not provide an IProvideValueTarget");

--- a/Xamarin.Forms.Xaml/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Xaml/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using Xamarin.Forms.Internals;
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "Xamarin.Forms.Xaml")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+
+[assembly: TypeForwardedTo(typeof(Xamarin.Forms.Xaml.Internals.INameScopeProvider))]

--- a/Xamarin.Forms.Xaml/XamlServiceProvider.cs
+++ b/Xamarin.Forms.Xaml/XamlServiceProvider.cs
@@ -270,11 +270,6 @@ namespace Xamarin.Forms.Xaml.Internals
 		public IXmlLineInfo XmlLineInfo { get; }
 	}
 
-	interface INameScopeProvider
-	{
-		INameScope NameScope { get; }
-	}
-
 	public class NameScopeProvider : INameScopeProvider
 	{
 		public INameScope NameScope { get; set; }

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/AutomationProperties.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/AutomationProperties.xml
@@ -74,6 +74,11 @@
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.ReferenceTypeConverter))</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.VisualElement</ReturnType>
       </ReturnValue>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ReferenceTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ReferenceTypeConverter.xml
@@ -1,0 +1,101 @@
+<Type Name="ReferenceTypeConverter" FullName="Xamarin.Forms.ReferenceTypeConverter">
+  <TypeSignature Language="C#" Value="public sealed class ReferenceTypeConverter : Xamarin.Forms.TypeConverter, Xamarin.Forms.IExtendedTypeConverter" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit ReferenceTypeConverter extends Xamarin.Forms.TypeConverter implements class Xamarin.Forms.IExtendedTypeConverter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IExtendedTypeConverter</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public ReferenceTypeConverter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="public override object ConvertFromInvariantString (string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance object ConvertFromInvariantString(string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IExtendedTypeConverter.ConvertFrom">
+      <MemberSignature Language="C#" Value="object IExtendedTypeConverter.ConvertFrom (System.Globalization.CultureInfo culture, object value, IServiceProvider serviceProvider);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance object Xamarin.Forms.IExtendedTypeConverter.ConvertFrom(class System.Globalization.CultureInfo culture, object value, class System.IServiceProvider serviceProvider) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="culture" Type="System.Globalization.CultureInfo" />
+        <Parameter Name="value" Type="System.Object" />
+        <Parameter Name="serviceProvider" Type="System.IServiceProvider" />
+      </Parameters>
+      <Docs>
+        <param name="culture">To be added.</param>
+        <param name="value">To be added.</param>
+        <param name="serviceProvider">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IExtendedTypeConverter.ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="object IExtendedTypeConverter.ConvertFromInvariantString (string value, IServiceProvider serviceProvider);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance object Xamarin.Forms.IExtendedTypeConverter.ConvertFromInvariantString(string value, class System.IServiceProvider serviceProvider) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+        <Parameter Name="serviceProvider" Type="System.IServiceProvider" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <param name="serviceProvider">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -359,6 +359,7 @@
       <Type Name="PropertyCondition" Kind="Class" />
       <Type Name="Rectangle" Kind="Structure" />
       <Type Name="RectangleTypeConverter" Kind="Class" />
+      <Type Name="ReferenceTypeConverter" Kind="Class" />
       <Type Name="RelativeLayout" Kind="Class" />
       <Type Name="RelativeLayout+IRelativeList`1" DisplayName="RelativeLayout+IRelativeList&lt;T&gt;" Kind="Interface" />
       <Type Name="RenderWithAttribute" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###

this
```
AutomationProperties.LabeledBy="label"
```
is now a shortcut for
```
AutomationProperties.LabeledBy="{x:Reference label}"
```

### Bugs Fixed ###

/

### API Changes ###

Moved:
- Xamarin.Forms.Xaml.Internals.INameScopeProvider from Xaml to Core, with additional type forwarding for backward compat

Added:
- class ReferenceTypeConverter

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense