### PR TITLE
[Android] Remove the ". " on empty labels (Accessibility) on Fastrenderers

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -30,6 +30,7 @@ using Xamarin.Forms.Controls.Issues;
 
 [assembly: ExportRenderer(typeof(Bugzilla42000._42000NumericEntryNoDecimal), typeof(EntryRendererNoDecimal))]
 [assembly: ExportRenderer(typeof(Bugzilla42000._42000NumericEntryNoNegative), typeof(EntryRendererNoNegative))]
+[assembly: ExportRenderer(typeof(AndroidHelpText.HintLabel), typeof(HintLabel))]
 
 #if PRE_APPLICATION_CLASS
 #elif FORMS_APPLICATION_ACTIVITY
@@ -234,9 +235,10 @@ namespace Xamarin.Forms.ControlGallery.Android
 			{// no view to re-use, create new
 				view = (context as Activity).LayoutInflater.Inflate(Resource.Layout.NativeAndroidCell, null);
 			}
-			else { // re-use, clear image
-				   // doesn't seem to help
-				   //view.FindViewById<ImageView> (Resource.Id.Image).Drawable.Dispose ();
+			else
+			{ // re-use, clear image
+			  // doesn't seem to help
+			  //view.FindViewById<ImageView> (Resource.Id.Image).Drawable.Dispose ();
 			}
 
 			view.FindViewById<TextView>(Resource.Id.Text1).Text = x.Name;
@@ -273,7 +275,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 				}, TaskScheduler.FromCurrentSynchronizationContext());
 
 			}
-			else {
+			else
+			{
 				// clear the image
 				view.FindViewById<ImageView>(Resource.Id.Image).SetImageBitmap(null);
 			}
@@ -388,9 +391,10 @@ namespace Xamarin.Forms.ControlGallery.Android
 			{// no view to re-use, create new
 				view = _context.LayoutInflater.Inflate(Resource.Layout.NativeAndroidListViewCell, null);
 			}
-			else { // re-use, clear image
-				   // doesn't seem to help
-				   //view.FindViewById<ImageView> (Resource.Id.Image).Drawable.Dispose ();
+			else
+			{ // re-use, clear image
+			  // doesn't seem to help
+			  //view.FindViewById<ImageView> (Resource.Id.Image).Drawable.Dispose ();
 			}
 			view.FindViewById<TextView>(Resource.Id.Text1).Text = item.Name;
 			view.FindViewById<TextView>(Resource.Id.Text2).Text = item.Category;
@@ -425,7 +429,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 					}
 				}, TaskScheduler.FromCurrentSynchronizationContext());
 			}
-			else {
+			else
+			{
 				// clear the image
 				view.FindViewById<ImageView>(Resource.Id.Image).SetImageBitmap(null);
 			}
@@ -514,6 +519,14 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			return base.GetDigitsKeyListener(inputTypes);
 		}
+	}
+
+	public class HintLabel : Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer
+	{
+		public HintLabel()
+		{
+			Hint = AndroidHelpText.HintLabel.Success;
+		}	
 	}
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AndroidHelpText.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AndroidHelpText.cs
@@ -1,0 +1,50 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST && __ANDROID__
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST && __ANDROID__
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Android shows . in empty labels because of a11y Name/HelpText", PlatformAffected.Android)]
+	public class AndroidHelpText : TestContentPage
+	{
+		[Preserve(AllMembers = true)]
+		public class HintLabel : Label
+		{
+			public const string Success = "SUCCESS";
+		}
+
+		protected override void Init()
+		{
+			var label = new Label
+			{
+				Text = $"There should be an empty label below this one. If the label shows a period (.), this test has failed. There should also be a label that says \"{HintLabel.Success}\"."
+			};
+
+			var emptyLabel = new Label { HorizontalTextAlignment = TextAlignment.Center };
+
+			var customLabel = new HintLabel { HorizontalTextAlignment = TextAlignment.Center }; ;
+
+			Content = new StackLayout { Children = { label, emptyLabel, customLabel } };
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void AndroidHelpTextTest()
+		{
+			RunningApp.WaitForNoElement(q => q.Marked("."));
+			RunningApp.WaitForElement(q => q.Marked(HintLabel.Success));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -285,6 +285,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ListViewNRE.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55745.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AndroidHelpText.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55365.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54036.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -139,18 +139,17 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			return true;
 		}
 
-		static string ConcatenateNameAndHelpText(Element Element)
+		internal static string ConcatenateNameAndHelpText(Element Element)
 		{
-			string separator;
 			var name = (string)Element.GetValue(AutomationProperties.NameProperty);
 			var helpText = (string)Element.GetValue(AutomationProperties.HelpTextProperty);
 
-			if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(helpText))
-				separator = "";
-			else
-				separator = ". ";
+			if (string.IsNullOrWhiteSpace(name))
+				return helpText;
+			if (string.IsNullOrWhiteSpace(helpText))
+				return name;
 
-			return $"{name}{separator}{helpText}";
+			return $"{name}. {helpText}";
 		}
 
 		void SetLabeledBy()

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -6,7 +6,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
 	internal class AutomationPropertiesProvider : IDisposable 
 	{
-		const string GetFromElement = "GetValueFromElement";
 		string _defaultContentDescription;
 		bool? _defaultFocusable;
 		string _defaultHint;
@@ -49,18 +48,14 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 		}
 
-		void SetAutomationId(string id = GetFromElement)
+		void SetAutomationId()
 		{
 			if (Element == null || Control == null)
 			{
 				return;
 			}
 
-			string value = id;
-			if (value == GetFromElement)
-			{
-				value = Element.AutomationId;
-			}
+			string value = Element.AutomationId;
 
 			if (!string.IsNullOrEmpty(value))
 			{
@@ -68,7 +63,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 		}
 
-		void SetContentDescription(string contentDescription = GetFromElement)
+		void SetContentDescription()
 		{
 			if (Element == null || Control == null)
 			{
@@ -85,12 +80,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				_defaultContentDescription = Control.ContentDescription;
 			}
 
-			string value = contentDescription;
-			if (value == GetFromElement)
-			{
-				value = string.Join(" ", (string)Element.GetValue(AutomationProperties.NameProperty),
-					(string)Element.GetValue(AutomationProperties.HelpTextProperty));
-			}
+			string value = ConcatenateNameAndHelpText(Element);
 
 			if (!string.IsNullOrWhiteSpace(value))
 			{
@@ -102,7 +92,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 		}
 
-		void SetFocusable(bool? value = null)
+		void SetFocusable()
 		{
 			if (Element == null || Control == null)
 			{
@@ -115,10 +105,10 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 
 			Control.Focusable =
-				(bool)(value ?? (bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? _defaultFocusable);
+				(bool)((bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? _defaultFocusable);
 		}
 
-		bool SetHint(string hint = GetFromElement)
+		bool SetHint()
 		{
 			if (Element == null || Control == null)
 			{
@@ -142,16 +132,25 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				_defaultHint = textView.Hint;
 			}
 
-			string value = hint;
-			if (value == GetFromElement)
-			{
-				value = string.Join(". ", (string)Element.GetValue(AutomationProperties.NameProperty),
-					(string)Element.GetValue(AutomationProperties.HelpTextProperty));
-			}
+			string value = ConcatenateNameAndHelpText(Element);
 
 			textView.Hint = !string.IsNullOrWhiteSpace(value) ? value : _defaultHint;
 
 			return true;
+		}
+
+		static string ConcatenateNameAndHelpText(Element Element)
+		{
+			string separator;
+			var name = (string)Element.GetValue(AutomationProperties.NameProperty);
+			var helpText = (string)Element.GetValue(AutomationProperties.HelpTextProperty);
+
+			if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(helpText))
+				separator = "";
+			else
+				separator = ". ";
+
+			return $"{name}{separator}{helpText}";
 		}
 
 		void SetLabeledBy()

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -366,7 +366,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_defaultContentDescription == null)
 				_defaultContentDescription = ContentDescription;
 
-			var elemValue = ConcatenateNameAndHelpText(Element);
+			var elemValue = FastRenderers.AutomationPropertiesProvider.ConcatenateNameAndHelpText(Element);
 
 			if (!string.IsNullOrWhiteSpace(elemValue))
 				ContentDescription = elemValue;

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -366,7 +366,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_defaultContentDescription == null)
 				_defaultContentDescription = ContentDescription;
 
-			var elemValue = string.Join(" ", (string)Element.GetValue(AutomationProperties.NameProperty), (string)Element.GetValue(AutomationProperties.HelpTextProperty));
+			var elemValue = ConcatenateNameAndHelpText(Element);
 
 			if (!string.IsNullOrWhiteSpace(elemValue))
 				ContentDescription = elemValue;
@@ -401,7 +401,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_defaultHint == null)
 				_defaultHint = textView.Hint;
 
-			var elemValue = string.Join((String.IsNullOrWhiteSpace((string)(Element.GetValue(AutomationProperties.NameProperty))) || String.IsNullOrWhiteSpace((string)(Element.GetValue(AutomationProperties.HelpTextProperty)))) ? "" : ". ", (string)Element.GetValue(AutomationProperties.NameProperty), (string)Element.GetValue(AutomationProperties.HelpTextProperty));
+			var elemValue = ConcatenateNameAndHelpText(Element);
 
 			if (!string.IsNullOrWhiteSpace(elemValue))
 				textView.Hint = elemValue;
@@ -409,6 +409,20 @@ namespace Xamarin.Forms.Platform.Android
 				textView.Hint = _defaultHint;
 
 			return true;
+		}
+
+		static string ConcatenateNameAndHelpText(Element Element)
+		{
+			string separator;
+			var name = (string)Element.GetValue(AutomationProperties.NameProperty);
+			var helpText = (string)Element.GetValue(AutomationProperties.HelpTextProperty);
+
+			if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(helpText))
+				separator = "";
+			else
+				separator = ". ";
+
+			return $"{name}{separator}{helpText}";
 		}
 
 		void UpdateInputTransparent()

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -401,7 +401,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_defaultHint == null)
 				_defaultHint = textView.Hint;
 
-			var elemValue = ConcatenateNameAndHelpText(Element);
+			var elemValue = FastRenderers.AutomationPropertiesProvider.ConcatenateNameAndHelpText(Element);
 
 			if (!string.IsNullOrWhiteSpace(elemValue))
 				textView.Hint = elemValue;
@@ -409,20 +409,6 @@ namespace Xamarin.Forms.Platform.Android
 				textView.Hint = _defaultHint;
 
 			return true;
-		}
-
-		static string ConcatenateNameAndHelpText(Element Element)
-		{
-			string separator;
-			var name = (string)Element.GetValue(AutomationProperties.NameProperty);
-			var helpText = (string)Element.GetValue(AutomationProperties.HelpTextProperty);
-
-			if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(helpText))
-				separator = "";
-			else
-				separator = ". ";
-
-			return $"{name}{separator}{helpText}";
 		}
 
 		void UpdateInputTransparent()


### PR DESCRIPTION
### Description of Change ###

This is an alternative to #904 (and revision to #801). This will clarify and simplify the code a bit more. 

Note that this code will be moved to extension methods if #889 is accepted.

Also adds a UI test to prevent recurrence.

Also removed the nullable parameters in the `AutomationPropertiesProvider` that are no longer necessary.

### Bugs Fixed ###

- Reported in #904 and #801
- [Bug 56444 - A small "dot" shows up as value in Android labels when the value is null/empty.](https://bugzilla.xamarin.com/show_bug.cgi?id=56444)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
