### PR TITLE
Do not layout page in OnWindowAttributesChanged on fullscreen flag change

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		AndroidApplicationLifecycleState _previousState;
 
-		bool _renderersAdded, _isFullScreen;
+		bool _renderersAdded;
 
 		// Override this if you want to handle the default Android behavior of restoring fragments on an application restart
 		protected virtual bool AllowFragmentRestore => false;
@@ -417,38 +417,6 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			Window.SetSoftInputMode(adjust);
-		}
-
-		public override void OnWindowAttributesChanged(WindowManagerLayoutParams @params)
-		{
-			base.OnWindowAttributesChanged(@params);
-
-			if (Xamarin.Forms.Application.Current == null || Xamarin.Forms.Application.Current.MainPage == null)
-				return;
-
-			if (@params.Flags.HasFlag(WindowManagerFlags.Fullscreen))
-			{
-				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Never)
-					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Never;
-
-				if (_isFullScreen)
-					return;
-			}
-			else
-			{
-				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Default)
-					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Default;
-
-				if (!_isFullScreen)
-					return;
-			}
-
-			_isFullScreen = !_isFullScreen;
-
-			var displayMetrics = Resources.DisplayMetrics;
-			var width = displayMetrics.WidthPixels;
-			var height = displayMetrics.HeightPixels;
-			AppCompat.Platform.LayoutRootPage(this, Xamarin.Forms.Application.Current.MainPage, width, height);
 		}
 
 		void UpdateProgressBarVisibility(bool isBusy)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		AndroidApplicationLifecycleState _previousState;
 
-		bool _renderersAdded;
+		bool _renderersAdded, _isFullScreen;
 
 		// Override this if you want to handle the default Android behavior of restoring fragments on an application restart
 		protected virtual bool AllowFragmentRestore => false;
@@ -417,6 +417,33 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			Window.SetSoftInputMode(adjust);
+		}
+
+		public override void OnWindowAttributesChanged(WindowManagerLayoutParams @params)
+		{
+			base.OnWindowAttributesChanged(@params);
+
+			if (Xamarin.Forms.Application.Current == null || Xamarin.Forms.Application.Current.MainPage == null)
+				return;
+
+			if (@params.Flags.HasFlag(WindowManagerFlags.Fullscreen))
+			{
+				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Never)
+					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Never;
+
+				if (_isFullScreen)
+					return;
+			}
+			else
+			{
+				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Default)
+					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Default;
+
+				if (!_isFullScreen)
+					return;
+			}
+
+			_isFullScreen = !_isFullScreen;
 		}
 
 		void UpdateProgressBarVisibility(bool isBusy)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		AndroidApplicationLifecycleState _previousState;
 
-		bool _renderersAdded, _isFullScreen;
+		bool _renderersAdded;
 
 		// Override this if you want to handle the default Android behavior of restoring fragments on an application restart
 		protected virtual bool AllowFragmentRestore => false;
@@ -426,24 +426,17 @@ namespace Xamarin.Forms.Platform.Android
 			if (Xamarin.Forms.Application.Current == null || Xamarin.Forms.Application.Current.MainPage == null)
 				return;
 
+			// sync between Window flag and Forms property
 			if (@params.Flags.HasFlag(WindowManagerFlags.Fullscreen))
 			{
 				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Never)
 					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Never;
-
-				if (_isFullScreen)
-					return;
 			}
 			else
 			{
 				if (Forms.TitleBarVisibility != AndroidTitleBarVisibility.Default)
 					Forms.TitleBarVisibility = AndroidTitleBarVisibility.Default;
-
-				if (!_isFullScreen)
-					return;
 			}
-
-			_isFullScreen = !_isFullScreen;
 		}
 
 		void UpdateProgressBarVisibility(bool isBusy)

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -196,7 +196,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			if (changed)
 			{
-				LayoutRootPage((FormsAppCompatActivity)_context, Page, r - l, b - t);
+				LayoutRootPage(Page, r - l, b - t);
 			}
 
 			Android.Platform.GetRenderer(Page).UpdateLayout();
@@ -269,7 +269,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Android.Platform.SetRenderer(page, renderView);
 
 			if (layout)
-				LayoutRootPage((FormsAppCompatActivity)_context, page, _renderer.Width, _renderer.Height);
+				LayoutRootPage(page, _renderer.Width, _renderer.Height);
 
 			_renderer.AddView(renderView.View);
 		}
@@ -285,8 +285,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			return handled;
 		}
 
-		internal static void LayoutRootPage(FormsAppCompatActivity activity, Page page, int width, int height)
+		void LayoutRootPage(Page page, int width, int height)
 		{
+			var activity = (FormsAppCompatActivity)_context;
 			page.Layout(new Rectangle(0, 0, activity.FromPixels(width), activity.FromPixels(height)));
 		}
 


### PR DESCRIPTION
### Description of Change ###

I wrote #350 a while ago so we could programmatically toggle the status bar on and off both at application start and during runtime. However, this was needed only because of the dummy underlay added to the overall view tree (which was recently removed by #892). We don't need to layout the root page anymore. This cuts down startup time by as much as 40 ms (at least in my case) if you were hiding the status bar behind the splash screen.

The following still works:

`<item name="android:windowFullscreen">true</item>` in `styles.xml` will not show the status bar at app start.

`global::Xamarin.Forms.Forms.SetTitleBarVisibility(Xamarin.Forms.AndroidTitleBarVisibility.Never);` in `MainActivity` will add `WindowManagerFlags.Fullscreen` flag to window attributes and hide the status bar.

Alternatively, one could add this flag manually in a dependency service call which should sync Form's `TitleBarVisibility`.

Please note that this PR assumes #892 will make it to production.

### Bugs Fixed ###

- N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
