### PR TITLE
Remove VisualElement finalizer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla55365.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla55365.cs
@@ -1,75 +1,75 @@
-﻿using Xamarin.Forms.CustomAttributes;
-using Xamarin.Forms.Internals;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Specialized;
+﻿using System;
 using System.Collections.ObjectModel;
-using System;
-
+using System.Collections.Specialized;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
 #if UITEST
-using Xamarin.UITest;
 using NUnit.Framework;
-#endif
 
-// Apply the default category of "Issues" to all of the tests in this assembly
-// We use this as a catch-all for tests which haven't been individually categorized
-#if UITEST
-[assembly: NUnit.Framework.Category("Issues")]
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 55365, "~VisualElement crashes with System.Runtime.InteropServices.COMException", PlatformAffected.UWP)]
-	public class Bugzilla55365 : TestContentPage // or TestMasterDetailPage, etc ...
+	public class Bugzilla55365 : TestContentPage
 	{
+		readonly StackLayout _itemsPanel = new StackLayout();
+		readonly DataTemplate _itemTemplate = new DataTemplate(CreateBoxView);
+		readonly StackLayout _layout = new StackLayout();
+
+#if UITEST
+		[Test]
+		public void ForcingGCDoesNotCrash()
+		{
+			RunningApp.WaitForElement("Clear");
+			RunningApp.Tap("Clear");
+			RunningApp.Tap("Garbage");
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+
 		protected override void Init()
 		{
-			var viewModel = new ObservableCollection<Item>()
+			var viewModel = new ObservableCollection<_55365Item>
 			{
-				//new Item() { Subject = 65 },
-				//new Item() { Subject = 66 },
-				new Item() { Subject = 65 },
+				new _55365Item { Subject = 65 }
 			};
 
 			viewModel.CollectionChanged += OnCollectionChanged;
 
 			_itemsPanel.BindingContext = viewModel;
 
-			foreach (var item in viewModel)
+			foreach (_55365Item item in viewModel)
 			{
 				_itemTemplate.SetValue(BindingContextProperty, item);
 				var view = (View)_itemTemplate.CreateContent();
 				_itemsPanel.Children.Add(view);
 			}
 
-
-			var clearButton = new Button() { Text = "Clear", Command = new Command((o) => viewModel.Clear()) };
-			var addButton = new Button()
-			{
-				Text = "Add",
-				Command = new Command((o) =>
-				{
-					for (int i = 0; i < 10; i++)
-					{
-						viewModel.Add(new Item { Subject = 66 + i });
-					}
-					
-					foreach (var item in viewModel)
-					{
-						_itemTemplate.SetValue(BindingContextProperty, item);
-						var view = (View)_itemTemplate.CreateContent();
-						_itemsPanel.Children.Add(view);
-					}
-				})
-			};
+			var clearButton = new Button { Text = "Clear", Command = new Command(o => viewModel.Clear()) };
 			_layout.Children.Add(clearButton);
-			_layout.Children.Add(addButton);
 
-			var collectButton = new Button() { Text = "Garbage", Command = new Command((o) => GC.Collect()) };
+			var collectButton = new Button { Text = "Garbage", Command = new Command(o =>
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				_layout.Children.Add(new Label {Text = "Success"});
+			}) };
 			_layout.Children.Add(collectButton);
 			_layout.Children.Add(_itemsPanel);
+
 			Content = _layout;
+		}
+
+		static object CreateBoxView()
+		{
+			var boxView1 = new BoxView { HeightRequest = 100, Color = new Color(0.55, 0.23, 0.147) };
+			var setter1 = new Setter { Property = BoxView.ColorProperty, Value = "#FF2879DD" };
+			var trigger1 = new DataTrigger(typeof(BoxView)) { Binding = new Binding("Subject"), Value = 65 };
+			trigger1.Setters.Add(setter1);
+			boxView1.Triggers.Add(trigger1);
+			return boxView1;
 		}
 
 		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -81,254 +81,10 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-		private static object CreateBoxView()
-		{
-			var boxView1 = new BoxView() { HeightRequest = 100, Color = new Color(0.55, 0.23, 0.147) };
-			var setter1 = new Setter() { Property = BoxView.ColorProperty, Value = "#FF2879DD" };
-			var trigger1 = new DataTrigger(typeof(BoxView)) { Binding = new Binding("Subject"), Value = 65 };
-			trigger1.Setters.Add(setter1);
-			boxView1.Triggers.Add(trigger1);
-			return boxView1;
-		}
-
-		public class Item
+		[Preserve(AllMembers = true)]
+		public class _55365Item
 		{
 			public int Subject { get; set; }
 		}
-
-		StackLayout _layout = new StackLayout();
-		StackLayout _itemsPanel = new StackLayout();
-		DataTemplate _itemTemplate = new DataTemplate(CreateBoxView);
-
-		[ContentProperty("ItemsSource")]
-		public class ItemsControl : ContentView
-		{
-			//#region ItemsPanel
-
-			///// <Summary>
-			///// ItemsPanel BindableProperty
-			///// </Summary>
-			//public static readonly BindableProperty ItemsPanelProperty = BindableProperty.Create(
-			//  propertyName: nameof(ItemsPanel),
-			//  returnType: typeof(Layout<View>),
-			//  declaringType: typeof(ItemsControl),
-			//  defaultBindingMode: BindingMode.OneWay,
-			//  defaultValueCreator: (b) => new StackLayout(),
-			//  propertyChanged: ItemsPanelChanged);
-
-			///// <Summary>
-			///// ItemsPanel CLR property
-			///// </Summary>
-			//public Layout<View> ItemsPanel
-			//{
-			//    get { return (Layout<View>)GetValue(ItemsPanelProperty); }
-			//    set { SetValue(ItemsPanelProperty, value); }
-			//}
-
-			///// <Summary>
-			///// ItemsPanel change event handler
-			///// </Summary>
-			///// <Param name="bindable">BindableObject</param>
-			///// <Param name="oldValue">old value</param>
-			///// <Param name="newValue">new value</param>
-			//private static void ItemsPanelChanged(BindableObject bindable, object oldValue, object newValue)
-			//{
-			//    var control = (ItemsControl)bindable;
-			//    control.LoadChildren();
-			//    control.Content = control.ItemsPanel;
-			//}
-
-			//#endregion ItemsPanel
-
-			private Layout<View> ItemsPanel = new StackLayout();
-
-			#region ItemsSource
-
-			/// <Summary>
-			/// ItemsSource BindableProperty
-			/// </Summary>
-			public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
-			  propertyName: nameof(ItemsSource),
-			  returnType: typeof(IEnumerable),
-			  declaringType: typeof(ItemsControl),
-			  defaultValueCreator: (b) => new List<object>(),
-			  defaultBindingMode: BindingMode.OneWay,
-			  propertyChanged: ItemsSourceChanged);
-
-			/// <Summary>
-			/// ItemsSource CLR property
-			/// </Summary>
-			public IEnumerable ItemsSource
-			{
-				get { return (IEnumerable)GetValue(ItemsSourceProperty); }
-				set { SetValue(ItemsSourceProperty, value); }
-			}
-
-			/// <Summary>
-			/// ItemsSource change event handler
-			/// </Summary>
-			/// <Param name="bindable">BindableObject</param>
-			/// <Param name="oldValue">old value</param>
-			/// <Param name="newValue">new value</param>
-			private static void ItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
-			{
-				var control = (ItemsControl)bindable;
-				var oldCollection = oldValue as INotifyCollectionChanged;
-
-				if (oldCollection != null)
-				{
-					oldCollection.CollectionChanged -= control.OnCollectionChanged;
-				}
-
-				var newCollection = newValue as INotifyCollectionChanged;
-
-				if (newCollection != null)
-				{
-					newCollection.CollectionChanged += control.OnCollectionChanged;
-				}
-
-				control.LoadChildren();
-			}
-
-			#endregion // ItemsSource
-
-			#region ItemTemplate
-
-			/// <Summary>
-			/// ItemTemplate BindableProperty
-			/// </Summary>
-			public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(
-			  propertyName: nameof(ItemTemplate),
-			  returnType: typeof(DataTemplate),
-			  declaringType: typeof(ItemsControl),
-			  defaultValue: default(DataTemplate),
-			  propertyChanged: ItemTemplateChanged);
-
-			/// <Summary>
-			/// ItemTemplate CLR property
-			/// </Summary>
-			public DataTemplate ItemTemplate
-			{
-				get { return (DataTemplate)GetValue(ItemTemplateProperty); }
-				set { SetValue(ItemTemplateProperty, value); }
-			}
-
-			/// <Summary>
-			/// ItemTemplate change event handler
-			/// </Summary>
-			/// <Param name="bindable">BindableObject</param>
-			/// <Param name="oldValue">old value</param>
-			/// <Param name="newValue">new value</param>
-			private static void ItemTemplateChanged(BindableObject bindable, object oldValue, object newValue)
-			{
-				var control = (ItemsControl)bindable;
-				control.LoadChildren();
-			}
-
-			#endregion // ItemTemplate
-
-			/// <summary>
-			/// Create an items control with a <see cref="ItemsPanel"/> container
-			/// </summary>
-			public ItemsControl()
-			{
-				Content = ItemsPanel;
-			}
-
-			/// <Summary>
-			/// Items of change event handler
-			/// </Summary>
-			/// <Param name="sender">The observable collection</param>
-			/// <Param name="e">The notify collection changed arguments</param>
-			private void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-			{
-				if (e.Action == NotifyCollectionChangedAction.Reset)
-				{
-					// reset the list
-					ItemsPanel.Children.Clear();
-					//System.GC.Collect();
-				}
-				else
-				{
-					// add, remove and replace 
-					if (e.OldItems != null)
-					{
-						var index = e.OldStartingIndex;
-						var count = 0;
-						while (index < ItemsPanel.Children.Count && count < e.OldItems.Count)
-						{
-							ItemsPanel.Children.RemoveAt(index);
-							++count;
-						}
-					}
-
-					if (e.NewItems != null && ItemTemplate != null)
-					{
-						for (var i = 0; i < e.NewItems.Count; ++i)
-						{
-							var item = e.NewItems[i];
-							var view = CreateChildViewFor(item);
-							ItemsPanel.Children.Insert(i + e.NewStartingIndex, view);
-						}
-					}
-				}
-			}
-
-			/// <summary>
-			/// Load the ItemsPanel with the children from the ItemsSource
-			/// </summary>
-			private void LoadChildren()
-			{
-				ItemsPanel.Children.Clear();
-
-				if (ItemTemplate != null && ItemsSource != null)
-				{
-					foreach (var item in ItemsSource)
-					{
-						var view = CreateChildViewFor(item);
-						ItemsPanel.Children.Add(view);
-					}
-				}
-			}
-
-			/// <summary>
-			/// Create a child view for the specified view model.
-			/// This uses the ItemTemplate to create the view.
-			/// Two scenarios exist:
-			/// 1) ItemTemplate is a <see cref="DataTemplateSelector"/> and this is used to select the appropriate view for the view model.
-			/// 2) ItemTemplate is a <see cref="DataTemplate"/> and this is used to create the view.
-			/// </summary>
-			/// <param name="viewModel">The view model</param>
-			/// <returns>The view created</returns>
-			private View CreateChildViewFor(object viewModel)
-			{
-				//            ItemTemplate.SetValue(BindingContextProperty, viewModel);
-				//return (View)ItemTemplate.CreateContent();
-				var view = (View)ItemTemplate.CreateContent();
-				view.BindingContext = viewModel;
-				return view;
-			}
-
-			//protected override void OnBindingContextChanged()
-			//{
-			//    var bindableObject = ItemsSource as BindableObject;
-			//    if (bindableObject != null)
-			//    {
-			//        bindableObject.BindingContext = BindingContext;
-			//    }
-
-			//    base.OnBindingContextChanged();
-			//}
-		}
-
-#if UITEST
-		[Test]
-		public void Issue1Test()
-		{
-			RunningApp.Screenshot("I am at Issue 1");
-			RunningApp.WaitForElement(q => q.Marked("IssuePageLabel"));
-			RunningApp.Screenshot("I see the Label");
-		}
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla55365.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla55365.cs
@@ -1,0 +1,334 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Collections.ObjectModel;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 55365, "~VisualElement crashes with System.Runtime.InteropServices.COMException", PlatformAffected.UWP)]
+	public class Bugzilla55365 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var viewModel = new ObservableCollection<Item>()
+			{
+				//new Item() { Subject = 65 },
+				//new Item() { Subject = 66 },
+				new Item() { Subject = 65 },
+			};
+
+			viewModel.CollectionChanged += OnCollectionChanged;
+
+			_itemsPanel.BindingContext = viewModel;
+
+			foreach (var item in viewModel)
+			{
+				_itemTemplate.SetValue(BindingContextProperty, item);
+				var view = (View)_itemTemplate.CreateContent();
+				_itemsPanel.Children.Add(view);
+			}
+
+
+			var clearButton = new Button() { Text = "Clear", Command = new Command((o) => viewModel.Clear()) };
+			var addButton = new Button()
+			{
+				Text = "Add",
+				Command = new Command((o) =>
+				{
+					for (int i = 0; i < 10; i++)
+					{
+						viewModel.Add(new Item { Subject = 66 + i });
+					}
+					
+					foreach (var item in viewModel)
+					{
+						_itemTemplate.SetValue(BindingContextProperty, item);
+						var view = (View)_itemTemplate.CreateContent();
+						_itemsPanel.Children.Add(view);
+					}
+				})
+			};
+			_layout.Children.Add(clearButton);
+			_layout.Children.Add(addButton);
+
+			var collectButton = new Button() { Text = "Garbage", Command = new Command((o) => GC.Collect()) };
+			_layout.Children.Add(collectButton);
+			_layout.Children.Add(_itemsPanel);
+			Content = _layout;
+		}
+
+		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				// reset the list
+				_itemsPanel.Children.Clear();
+			}
+		}
+
+		private static object CreateBoxView()
+		{
+			var boxView1 = new BoxView() { HeightRequest = 100, Color = new Color(0.55, 0.23, 0.147) };
+			var setter1 = new Setter() { Property = BoxView.ColorProperty, Value = "#FF2879DD" };
+			var trigger1 = new DataTrigger(typeof(BoxView)) { Binding = new Binding("Subject"), Value = 65 };
+			trigger1.Setters.Add(setter1);
+			boxView1.Triggers.Add(trigger1);
+			return boxView1;
+		}
+
+		public class Item
+		{
+			public int Subject { get; set; }
+		}
+
+		StackLayout _layout = new StackLayout();
+		StackLayout _itemsPanel = new StackLayout();
+		DataTemplate _itemTemplate = new DataTemplate(CreateBoxView);
+
+		[ContentProperty("ItemsSource")]
+		public class ItemsControl : ContentView
+		{
+			//#region ItemsPanel
+
+			///// <Summary>
+			///// ItemsPanel BindableProperty
+			///// </Summary>
+			//public static readonly BindableProperty ItemsPanelProperty = BindableProperty.Create(
+			//  propertyName: nameof(ItemsPanel),
+			//  returnType: typeof(Layout<View>),
+			//  declaringType: typeof(ItemsControl),
+			//  defaultBindingMode: BindingMode.OneWay,
+			//  defaultValueCreator: (b) => new StackLayout(),
+			//  propertyChanged: ItemsPanelChanged);
+
+			///// <Summary>
+			///// ItemsPanel CLR property
+			///// </Summary>
+			//public Layout<View> ItemsPanel
+			//{
+			//    get { return (Layout<View>)GetValue(ItemsPanelProperty); }
+			//    set { SetValue(ItemsPanelProperty, value); }
+			//}
+
+			///// <Summary>
+			///// ItemsPanel change event handler
+			///// </Summary>
+			///// <Param name="bindable">BindableObject</param>
+			///// <Param name="oldValue">old value</param>
+			///// <Param name="newValue">new value</param>
+			//private static void ItemsPanelChanged(BindableObject bindable, object oldValue, object newValue)
+			//{
+			//    var control = (ItemsControl)bindable;
+			//    control.LoadChildren();
+			//    control.Content = control.ItemsPanel;
+			//}
+
+			//#endregion ItemsPanel
+
+			private Layout<View> ItemsPanel = new StackLayout();
+
+			#region ItemsSource
+
+			/// <Summary>
+			/// ItemsSource BindableProperty
+			/// </Summary>
+			public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
+			  propertyName: nameof(ItemsSource),
+			  returnType: typeof(IEnumerable),
+			  declaringType: typeof(ItemsControl),
+			  defaultValueCreator: (b) => new List<object>(),
+			  defaultBindingMode: BindingMode.OneWay,
+			  propertyChanged: ItemsSourceChanged);
+
+			/// <Summary>
+			/// ItemsSource CLR property
+			/// </Summary>
+			public IEnumerable ItemsSource
+			{
+				get { return (IEnumerable)GetValue(ItemsSourceProperty); }
+				set { SetValue(ItemsSourceProperty, value); }
+			}
+
+			/// <Summary>
+			/// ItemsSource change event handler
+			/// </Summary>
+			/// <Param name="bindable">BindableObject</param>
+			/// <Param name="oldValue">old value</param>
+			/// <Param name="newValue">new value</param>
+			private static void ItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
+			{
+				var control = (ItemsControl)bindable;
+				var oldCollection = oldValue as INotifyCollectionChanged;
+
+				if (oldCollection != null)
+				{
+					oldCollection.CollectionChanged -= control.OnCollectionChanged;
+				}
+
+				var newCollection = newValue as INotifyCollectionChanged;
+
+				if (newCollection != null)
+				{
+					newCollection.CollectionChanged += control.OnCollectionChanged;
+				}
+
+				control.LoadChildren();
+			}
+
+			#endregion // ItemsSource
+
+			#region ItemTemplate
+
+			/// <Summary>
+			/// ItemTemplate BindableProperty
+			/// </Summary>
+			public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(
+			  propertyName: nameof(ItemTemplate),
+			  returnType: typeof(DataTemplate),
+			  declaringType: typeof(ItemsControl),
+			  defaultValue: default(DataTemplate),
+			  propertyChanged: ItemTemplateChanged);
+
+			/// <Summary>
+			/// ItemTemplate CLR property
+			/// </Summary>
+			public DataTemplate ItemTemplate
+			{
+				get { return (DataTemplate)GetValue(ItemTemplateProperty); }
+				set { SetValue(ItemTemplateProperty, value); }
+			}
+
+			/// <Summary>
+			/// ItemTemplate change event handler
+			/// </Summary>
+			/// <Param name="bindable">BindableObject</param>
+			/// <Param name="oldValue">old value</param>
+			/// <Param name="newValue">new value</param>
+			private static void ItemTemplateChanged(BindableObject bindable, object oldValue, object newValue)
+			{
+				var control = (ItemsControl)bindable;
+				control.LoadChildren();
+			}
+
+			#endregion // ItemTemplate
+
+			/// <summary>
+			/// Create an items control with a <see cref="ItemsPanel"/> container
+			/// </summary>
+			public ItemsControl()
+			{
+				Content = ItemsPanel;
+			}
+
+			/// <Summary>
+			/// Items of change event handler
+			/// </Summary>
+			/// <Param name="sender">The observable collection</param>
+			/// <Param name="e">The notify collection changed arguments</param>
+			private void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+			{
+				if (e.Action == NotifyCollectionChangedAction.Reset)
+				{
+					// reset the list
+					ItemsPanel.Children.Clear();
+					//System.GC.Collect();
+				}
+				else
+				{
+					// add, remove and replace 
+					if (e.OldItems != null)
+					{
+						var index = e.OldStartingIndex;
+						var count = 0;
+						while (index < ItemsPanel.Children.Count && count < e.OldItems.Count)
+						{
+							ItemsPanel.Children.RemoveAt(index);
+							++count;
+						}
+					}
+
+					if (e.NewItems != null && ItemTemplate != null)
+					{
+						for (var i = 0; i < e.NewItems.Count; ++i)
+						{
+							var item = e.NewItems[i];
+							var view = CreateChildViewFor(item);
+							ItemsPanel.Children.Insert(i + e.NewStartingIndex, view);
+						}
+					}
+				}
+			}
+
+			/// <summary>
+			/// Load the ItemsPanel with the children from the ItemsSource
+			/// </summary>
+			private void LoadChildren()
+			{
+				ItemsPanel.Children.Clear();
+
+				if (ItemTemplate != null && ItemsSource != null)
+				{
+					foreach (var item in ItemsSource)
+					{
+						var view = CreateChildViewFor(item);
+						ItemsPanel.Children.Add(view);
+					}
+				}
+			}
+
+			/// <summary>
+			/// Create a child view for the specified view model.
+			/// This uses the ItemTemplate to create the view.
+			/// Two scenarios exist:
+			/// 1) ItemTemplate is a <see cref="DataTemplateSelector"/> and this is used to select the appropriate view for the view model.
+			/// 2) ItemTemplate is a <see cref="DataTemplate"/> and this is used to create the view.
+			/// </summary>
+			/// <param name="viewModel">The view model</param>
+			/// <returns>The view created</returns>
+			private View CreateChildViewFor(object viewModel)
+			{
+				//            ItemTemplate.SetValue(BindingContextProperty, viewModel);
+				//return (View)ItemTemplate.CreateContent();
+				var view = (View)ItemTemplate.CreateContent();
+				view.BindingContext = viewModel;
+				return view;
+			}
+
+			//protected override void OnBindingContextChanged()
+			//{
+			//    var bindableObject = ItemsSource as BindableObject;
+			//    if (bindableObject != null)
+			//    {
+			//        bindableObject.BindingContext = BindingContext;
+			//    }
+
+			//    base.OnBindingContextChanged();
+			//}
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1Test()
+		{
+			RunningApp.Screenshot("I am at Issue 1");
+			RunningApp.WaitForElement(q => q.Marked("IssuePageLabel"));
+			RunningApp.Screenshot("I see the Label");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -282,6 +282,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ListViewNRE.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55745.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55365.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Core.UnitTests/BehaviorTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/BehaviorTest.cs
@@ -109,42 +109,5 @@ namespace Xamarin.Forms.Core.UnitTests
 			collection.Remove (behavior);
 			Assert.Null (behavior.AssociatedObject);
 		}
-
-		[Test]
-		//https://bugzilla.xamarin.com/show_bug.cgi?id=44074
-		public void TestBehaviorsAreDetachedBeforeGarbageCollection()
-		{
-			WeakReference weakBindable = null;
-
-			var attachCount = MockBehavior<VisualElement>.AttachCount;
-
-			int i = 0;
-			Action create = null;
-			create = () =>
-			{
-				if (i++ < 1024)
-				{
-					create();
-					return;
-				}
-
-				var bindable = new MockBindable
-				{
-					Behaviors = {
-						new MockBehavior<VisualElement> ()
-					}
-				};
-				weakBindable = new WeakReference(bindable);
-			};
-
-			create();
-
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
-
-			Assert.False(weakBindable.IsAlive);
-			Assert.AreEqual(attachCount, MockBehavior<VisualElement>.AttachCount);
-		}
 	}
 }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
@@ -795,19 +796,6 @@ namespace Xamarin.Forms
 			public bool Focus { get; set; }
 
 			public bool Result { get; set; }
-		}
-
-		~VisualElement()
-		{
-			if (!GetIsDefault(BehaviorsProperty)) {
-				var behaviors = GetValue(BehaviorsProperty) as AttachedCollection<Behavior>;
-				behaviors.DetachFrom(this);
-			}
-
-			if (!GetIsDefault(TriggersProperty)) {
-				var triggers = GetValue(TriggersProperty) as AttachedCollection<TriggerBase>;
-				triggers.DetachFrom(this);
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
@@ -352,22 +352,6 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Finalize">
-      <MemberSignature Language="C#" Value="~VisualElement ();" />
-      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void Finalize() cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>Finalizer for visual elements.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="Focus">
       <MemberSignature Language="C#" Value="public bool Focus ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance bool Focus() cil managed" />


### PR DESCRIPTION
### Description of Change ###

The finalizer added to fix [44074](https://bugzilla.xamarin.com/show_bug.cgi?id=44074) causes an InvalidOperationException during the .NET finalization process because it attempts to operate on other objects which are not guaranteed to be alive and which contain ConditionalWeakTables which may or may not have already had their finalizers run. This ends up causing the ConditionalWeakTable to fail its integrity check. Detaching behaviors and triggers during finalization cannot safely be done, because there are no guarantees of the order that the objects are collected/finalized.

This change removes the finalizer so the exception does not occur.

This change also removes the test `TestBehaviorsAreDetachedBeforeGarbageCollection`, which actually tested whether behaviors were detached during finalization, which cannot safely be done.

The finalizer was added to fix [44074 – OnDetachingFrom for Behavior is never called, therefore memory can leak due to event handlers not being unbound](https://bugzilla.xamarin.com/show_bug.cgi?id=44074). 44074 is not a bug; there is no way to magically remove behaviors from controls as they are garbage collected, and there is no deterministic disposal mechanism for VisualElement. This is [documented behavior](https://developer.xamarin.com/guides/xamarin-forms/application-fundamentals/behaviors/creating/#Removing_a_Behavior_from_a_Control) - Behaviors have to be explicitly removed from controls. 

The potential for leaks only exists in the situation where an attached Behavior holds a reference to the VisualElement and something holds a reference to the Behavior; for many situations (e.g., the [XAML example in the documentation](https://developer.xamarin.com/guides/xamarin-forms/application-fundamentals/behaviors/creating/#Consuming_a_Xamarin.Forms_Behavior) ), this is not an issue. It could potentially be an issue if a Behavior reference is held Application-wide (e.g., in a Style), in which case the Behavior would need to be explicitly removed when its target is no longer relevant (e.g., in Page.Disappearing).

### Bugs Fixed ###

- [55365 – ~VisualElement crashes with System.Runtime.InteropServices.COMException](https://bugzilla.xamarin.com/show_bug.cgi?id=55365)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
