### PR TITLE
[Android] Do not call DisallowAddToBackStack()

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -69,7 +69,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					// But first, if the previous occupant of this container was a fragment, we need to remove it properly
 					FragmentTransaction transaction = FragmentManager.BeginTransaction();
-					transaction.DisallowAddToBackStack();
 					transaction.Remove(_currentFragment);
 					transaction.SetTransition((int)FragmentTransit.None);
 
@@ -97,7 +96,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				});
 
 				FragmentTransaction transaction = FragmentManager.BeginTransaction();
-				transaction.DisallowAddToBackStack();
 
 				if (_currentFragment != null)
 				{
@@ -141,7 +139,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (_currentFragment != null)
 				{
 					FragmentTransaction transaction = FragmentManager.BeginTransaction();
-					transaction.DisallowAddToBackStack();
 					transaction.Remove(_currentFragment);
 					transaction.SetTransition((int)FragmentTransit.None);
 					transaction.CommitAllowingStateLoss();

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -643,8 +643,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (animated)
 				SetupPageTransition(transaction, !removed);
 
-			transaction.DisallowAddToBackStack();
-
 			if (_fragmentStack.Count == 0)
 			{
 				transaction.Add(Id, fragment);


### PR DESCRIPTION
### Description of Change ###

Calling `DisallowAddToBackStack()` is costing me more than 100 ms. I'm not sure why we need this. As per the [documentation](https://developer.android.com/reference/android/app/FragmentTransaction.html#disallowAddToBackStack()), this method throws an exception if we have already called `AddToBackStack()`. Since it doesn't throw an exception in our case, it means we haven't. I also searched the codebase for any references and did not find any. Another purpose of this method is to make sure any subsequent calls to `AddToBackStack()` will throw an exception so it acts as a safety check.

I think we could let go of this safety check because, if we call `AddToBackStack()`, I'd assume that it was on purpose.

I have tested `NavigationPage`. Please test MDP to make sure all is okay.

Also referencing #451 so if it gets added, we should remove `DisallowAddToBackStack()` from there as well.

Maybe I'm not fully understanding the use case of this method, so feel free to leave feedback.

### Bugs Fixed ###

- N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
