### PR TITLE
[Android] Avoid using GetGesturesFor when checking pinch gesture presence

### DIFF
--- a/Xamarin.Forms.Platform.Android/PinchGestureHandler.cs
+++ b/Xamarin.Forms.Platform.Android/PinchGestureHandler.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.Android
 			get
 			{
 				View view = GetView();
-				return view != null && view.GestureRecognizers.GetGesturesFor<PinchGestureRecognizer>().Any();
+				return view != null && view.GestureRecognizers.OfType<PinchGestureRecognizer>().Any();
 			}
 		}
 
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Android
 				return true;
 
 			var scalePointTransformed = new Point(scalePoint.X / view.Width, scalePoint.Y / view.Height);
-			((IPinchGestureController)pinchGesture).SendPinch(view, 1 + (scale - 1) * _pinchStartingScale, scalePointTransformed);
+			pinchGesture.SendPinch(view, 1 + (scale - 1) * _pinchStartingScale, scalePointTransformed);
 
 			return true;
 		}
@@ -52,7 +52,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			PinchGestureRecognizer pinchGesture = PinchGesture;
-			((IPinchGestureController)pinchGesture)?.SendPinchEnded(view);
+			pinchGesture?.SendPinchEnded(view);
 		}
 
 		public bool OnPinchStarted(Point scalePoint)
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			var scalePointTransformed = new Point(scalePoint.X / view.Width, scalePoint.Y / view.Height);
 
-			((IPinchGestureController)pinchGesture).SendPinchStarted(view, scalePointTransformed);
+			pinchGesture.SendPinchStarted(view, scalePointTransformed);
 			return true;
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

When processing touch events, `VisualElementRenderer` is checking if the current view has a pinch gesture. Instead of using `GetGesturesFor`, we can use LINQ's built-in `OfType` method. This seems to reduce processing time by as much as 8 ms (in my case).

Note that `GetGesturesFor` seems to be used in many different places. If there is room for improvement in those, one should take a look at. 

Also removed a redundant cast.

### Bugs Fixed ###

- N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
