### PR TITLE
[Android] Defer setting accent color during initialization

### DIFF
--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -31,8 +31,19 @@ namespace Xamarin.Forms
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static void SetAccent(Color value) => Accent = value;
-		public static Color Accent { get; internal set; }
+		public static void SetAccent(Color value) => s_accent = value;
+
+		static Color s_accent;
+		public static Color Accent
+		{
+			get
+			{
+				if (Device.RuntimePlatform == Device.Android && s_accent.IsDefault)
+					MessagingCenter.Send(Application.Current.MainPage, Page.AccentColorSignalName);
+
+				return s_accent;
+			}
+		}
 
 		readonly float _a;
 

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -20,6 +20,8 @@ namespace Xamarin.Forms
 
 		public const string ActionSheetSignalName = "Xamarin.ShowActionSheet";
 
+		public const string AccentColorSignalName = "Xamarin.AccentColor";
+
 		internal static readonly BindableProperty IgnoresContainerAreaProperty = BindableProperty.Create("IgnoresContainerArea", typeof(bool), typeof(Page), false);
 
 		public static readonly BindableProperty BackgroundImageProperty = BindableProperty.Create("BackgroundImage", typeof(string), typeof(Page), default(string));

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -9,9 +9,7 @@ using Android.Content;
 using Android.Content.Res;
 using Android.OS;
 using Android.Runtime;
-using Android.Support.V4.Content;
 using Android.Support.V7.App;
-using Android.Util;
 using Android.Views;
 using Android.Widget;
 using Xamarin.Forms.Platform.Android.AppCompat;
@@ -197,6 +195,7 @@ namespace Xamarin.Forms.Platform.Android
 			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
 			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
 			MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName);
+			MessagingCenter.Unsubscribe<Page>(this, Page.AccentColorSignalName);
 
 			_platform?.Dispose();
 
@@ -319,6 +318,7 @@ namespace Xamarin.Forms.Platform.Android
 			MessagingCenter.Subscribe<Page, bool>(this, Page.BusySetSignalName, OnPageBusy);
 			MessagingCenter.Subscribe<Page, AlertArguments>(this, Page.AlertSignalName, OnAlertRequested);
 			MessagingCenter.Subscribe<Page, ActionSheetArguments>(this, Page.ActionSheetSignalName, OnActionSheetRequested);
+			MessagingCenter.Subscribe<Page>(this, Page.AccentColorSignalName, OnAccentColorRequested);
 
 			_platform = new AppCompat.Platform(this);
 			if (_application != null)
@@ -326,6 +326,11 @@ namespace Xamarin.Forms.Platform.Android
 			_platform.SetPage(page);
 			_layout.AddView(_platform);
 			_layout.BringToFront();
+		}
+
+		void OnAccentColorRequested(Page sender)
+		{
+			Color.SetAccent(Forms.GetAccentColor());
 		}
 
 		void OnActionSheetRequested(Page sender, ActionSheetArguments arguments)

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -115,8 +115,6 @@ namespace Xamarin.Forms
 
 			ResourceManager.Init(resourceAssembly);
 
-			Color.SetAccent(GetAccentColor());
-
 			if (!IsInitialized)
 				Internals.Log.Listeners.Add(new DelegateLogListener((c, m) => Trace.WriteLine(m, c)));
 
@@ -151,7 +149,7 @@ namespace Xamarin.Forms
 			IsInitialized = true;
 		}
 
-		static Color GetAccentColor()
+		public static Color GetAccentColor()
 		{
 			Color rc;
 			using (var value = new TypedValue())

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -151,16 +151,16 @@ namespace Xamarin.Forms
 
 		public static Color GetAccentColor()
 		{
-			Color rc;
+			Color accentColor;
 			using (var value = new TypedValue())
 			{
 				if (Context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorAccent, value, true))	// Android 5.0+
 				{
-					rc = Color.FromUint((uint)value.Data);
+					accentColor = Color.FromUint((uint)value.Data);
 				}
 				else if(Context.Theme.ResolveAttribute(Context.Resources.GetIdentifier("colorAccent", "attr", Context.PackageName), value, true))	// < Android 5.0
 				{
-					rc = Color.FromUint((uint)value.Data);
+					accentColor = Color.FromUint((uint)value.Data);
 				}
 				else                    // fallback to old code if nothing works (don't know if that ever happens)
 				{
@@ -170,16 +170,16 @@ namespace Xamarin.Forms
 					if (sdkVersion <= 10)
 					{
 						// legacy theme button pressed color
-						rc = Color.FromHex("#fffeaa0c");
+						accentColor = Color.FromHex("#fffeaa0c");
 					}
 					else
 					{
 						// Holo dark light blue
-						rc = Color.FromHex("#ff33b5e5");
+						accentColor = Color.FromHex("#ff33b5e5");
 					}
 				}
 			}
-			return rc;
+			return accentColor;
 		}
 
 		class AndroidDeviceInfo : DeviceInfo


### PR DESCRIPTION
### Description of Change ###

We don't need to set accent color during initialization and can defer it until first use. This seems to reduce startup time by about 20 ms (theme attribute resolution + call to Color.FromUint()). Subscribing a new Message seems to add 1 ms which is negligible compared to the gain. Surprisingly, setting accent color after main page is loaded seems to be instantaneous.

### Bugs Fixed ###

- N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
