### PR TITLE
Adjust unhook location from PR #901

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -218,6 +218,11 @@ namespace Xamarin.Forms.Platform.WinRT
 			_container.SizeChanged -= OnNativeSizeChanged;
 			_container.BackClicked -= OnBackClicked;
 
+#if WINDOWS_UWP
+			if (_parentTabbedPage != null)
+				Element.Appearing -= OnElementAppearing;
+#endif
+
 			SetElement(null);
 			SetPage(null, false, true);
 			_previousPage = null;
@@ -229,9 +234,6 @@ namespace Xamarin.Forms.Platform.WinRT
 				_parentMasterDetailPage.PropertyChanged -= MultiPagePropertyChanged;
 
 #if WINDOWS_UWP
-			if (_parentTabbedPage != null)
-				Element.Appearing -= OnElementAppearing;
-
 			if (_navManager != null)
 			{
 				_navManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;


### PR DESCRIPTION
### Description of Change ###

Adjust the unhook from #901 which was called after `SetElement(null)` leading to a NRE.

### Bugs Fixed ###

N/A

### API Changes ###

N/A

### Behavioral Changes ###

N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
