### PR TITLE
Fix bz56030; DynamicResource overriding

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/DynamicResourceTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DynamicResourceTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -17,6 +18,39 @@ namespace Xamarin.Forms.Core.UnitTests
 		public override void TearDown()
 		{
 			Application.Current = null;
+		}
+
+		[Test]
+		public void TestDynamicResourceOverride()
+		{
+			Application.Current.Resources = new ResourceDictionary();
+			Application.Current.Resources.Add("GreenColor", Color.Green);
+			Application.Current.Resources.Add("RedColor", Color.Red);
+
+			var setter = new Setter()
+			{
+				Property = Label.TextColorProperty,
+				Value = new DynamicResource("RedColor")
+			};
+			var style = new Style(typeof(Label));
+			style.Setters.Add(setter);
+			Application.Current.Resources.Add(style);
+
+			var label = new Label()
+			{
+				Text = "Green = :)"
+			};
+			label.SetDynamicResource(Label.TextColorProperty, "GreenColor");
+
+			Application.Current.MainPage = new ContentPage
+			{
+				Content = new StackLayout
+				{
+					Children = { label }
+				}
+			};
+
+			Assert.AreEqual(Color.Green, label.TextColor);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms
 
 		List<Action<object, ResourcesChangedEventArgs>> _changeHandlers;
 
-		List<KeyValuePair<string, BindableProperty>> _dynamicResources;
+		Dictionary<BindableProperty, string> _dynamicResources;
 
 		IEffectControlProvider _effectControlProvider;
 
@@ -163,9 +163,9 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Element RealParent { get; private set; }
 
-		List<KeyValuePair<string, BindableProperty>> DynamicResources
+		Dictionary<BindableProperty, string> DynamicResources
 		{
-			get { return _dynamicResources ?? (_dynamicResources = new List<KeyValuePair<string, BindableProperty>>(4)); }
+			get { return _dynamicResources ?? (_dynamicResources = new Dictionary<BindableProperty, string>()); }
 		}
 
 		void IElement.AddResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
@@ -427,7 +427,8 @@ namespace Xamarin.Forms
 
 		internal override void OnRemoveDynamicResource(BindableProperty property)
 		{
-			DynamicResources.RemoveAll(kvp => kvp.Value == property);
+			DynamicResources.Remove(property);
+
 			if (DynamicResources.Count == 0)
 				_dynamicResources = null;
 			base.OnRemoveDynamicResource(property);
@@ -452,12 +453,12 @@ namespace Xamarin.Forms
 			foreach (KeyValuePair<string, object> value in values)
 			{
 				List<BindableProperty> changedResources = null;
-				foreach (KeyValuePair<string, BindableProperty> dynR in DynamicResources)
+				foreach (KeyValuePair<BindableProperty, string> dynR in DynamicResources)
 				{
-					if (dynR.Key != value.Key)
+					if (dynR.Value != value.Key)
 						continue;
 					changedResources = changedResources ?? new List<BindableProperty>();
-					changedResources.Add(dynR.Value);
+					changedResources.Add(dynR.Key);
 				}
 				if (changedResources == null)
 					continue;
@@ -477,7 +478,7 @@ namespace Xamarin.Forms
 		internal override void OnSetDynamicResource(BindableProperty property, string key)
 		{
 			base.OnSetDynamicResource(property, key);
-			DynamicResources.Add(new KeyValuePair<string, BindableProperty>(key, property));
+			DynamicResources[property] = key;
 			object value;
 			if (this.TryGetResource(key, out value))
 				OnResourceChanged(property, value);

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -455,6 +455,10 @@ namespace Xamarin.Forms
 				List<BindableProperty> changedResources = null;
 				foreach (KeyValuePair<BindableProperty, string> dynR in DynamicResources)
 				{
+					// when the DynamicResource bound to a BindableProperty is
+					// changing then the BindableProperty needs to be refreshed;
+					// The .Value is the name of DynamicResouce to which the BindableProperty is bound.
+					// The .Key is the name of the DynamicResource whose value is changing.
 					if (dynR.Value != value.Key)
 						continue;
 					changedResources = changedResources ?? new List<BindableProperty>();


### PR DESCRIPTION
### Description of Change ###

Prior to this change Element tracked which DynamicResources would trigger a change in one of its properties by storing a List of BindableProperty/Key pairs where Key was the name of a DynamicResource. When a change to the DynamicResources was reported to the Element via Element.OnResourcesChanged the Element would compare the names of the changed DynamicResources to it's list of DynamicResource key names and when there was a match re-initialize the associated BindableProperty. This worked so long as the the Element had a unique set of Keys. However this bug demonstrates that's not always the case.

This bug constructed an example whereby a Label had two different DynamicResources bound to its  Label.TextColor BindableProperty. The first was bound via a Style declared at the application level and a second bound directly to the Label. Which should have precedence and control the TextColor? Clearly the one applied directly to the label should override the style. However this didn't always happen. Why? Because the Element stored both associations in it's list and would apply them in a "random" order (depending on the order the resources were declared) when the DynamicResources were refreshed.

The fix is to have Element store an Element's DynamicResources in a Dictionary keyed by its BindableProperties. This way an Element is guaranteed to associate a BindableProperty with a single DynamicResource and so long as the Element's DynamicResources are added in increasing order of precedence (as appears to be the case) then the last assignment will overwrite previous assignments leaving the highest precedent binding controlling the BindableProperty value. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=56030

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
