### PR TITLE
[XamlC] process symbols if DebugType is set

### DIFF
--- a/.nuspec/Xamarin.Forms.Debug.targets
+++ b/.nuspec/Xamarin.Forms.Debug.targets
@@ -74,6 +74,7 @@
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
 			DebugSymbols = "$(DebugSymbols)"
+			DebugType = "$(DebugType)"
 			Verbosity = "4"
 			KeepXamlResources = "true"
 			OptimizeIL = "true" />

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -64,6 +64,7 @@
 			ReferencePath = "@(ReferencePath)"
 			Verbosity = "2"
 			OptimizeIL = "true"
-			DebugSymbols = "$(DebugSymbols)" />
+			DebugSymbols = "$(DebugSymbols)"
+			DebugType = "$(DebugType)"/>
 	</Target>
 </Project>

--- a/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
@@ -43,9 +43,12 @@ namespace Xamarin.Forms.Build.Tasks
 					//					resolver.AddAssembly (p);
 				}
 			}
+
+			var debug = DebugSymbols || (!string.IsNullOrEmpty(DebugType) && DebugType.ToLowerInvariant() != "none");
+
 			using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(Assembly, new ReaderParameters {
 				ReadWrite = true,
-				ReadSymbols = DebugSymbols,
+				ReadSymbols = debug,
 				AssemblyResolver = resolver
 			})) {
 				foreach (var module in assemblyDefinition.Modules) {
@@ -147,7 +150,7 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 				Logger.LogString(1, "Writing the assembly... ");
 				assemblyDefinition.Write(new WriterParameters {
-					WriteSymbols = DebugSymbols
+					WriteSymbols = debug
 				});
 			}
 			Logger.LogLine(1, "done.");

--- a/Xamarin.Forms.Build.Tasks/XamlTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlTask.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Forms.Build.Tasks
 		public string ReferencePath { get; set; }
 		public int Verbosity { get; set; }
 		public bool DebugSymbols { get; set; }
+		public string DebugType { get; set; }
 
 		internal XamlTask()
 		{


### PR DESCRIPTION
### Description of Change ###

It can happen that DebugType is set and DebugSymbols is not. In that case, a .pdb is generated, and we should process it to avoid a linker failure.

## This needs to be back ported to 2.3.5, and eventually even to 2.3.4

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=53805
- https://bugzilla.xamarin.com/show_bug.cgi?id=56296

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense