### PR TITLE
Switch to EntranceThemeTransition Animation

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NavigationPageRenderer.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Platform.WinRT
 		TabbedPage _parentTabbedPage;
 		bool _showTitle = true;
 		VisualElementTracker<Page, PageControl> _tracker;
-		ContentThemeTransition _transition;
+		EntranceThemeTransition _transition;
 
 		public NavigationPage Element { get; private set; }
 
@@ -440,7 +440,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			if (isAnimated && _transition == null)
 			{
-				_transition = new ContentThemeTransition();
+				_transition = new EntranceThemeTransition();
 				_container.ContentTransitions = new TransitionCollection();
 			}
 


### PR DESCRIPTION
### Description of Change ###
A [ContentThemeTransition](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.Animation.ContentThemeTransition) animation is triggered whenever the content is changed which results in flickering when the app window is resized:

![uwp_animation_bad](https://cloud.githubusercontent.com/assets/4087358/26167109/b5b99628-3aea-11e7-9338-a63c1b3311c9.gif)

By using an [EntranceThemeTransition](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.Animation.EntranceThemeTransition) instead, the animation only runs when the content first appears so resizing is fluid:

![uwp_animation_good](https://cloud.githubusercontent.com/assets/4087358/26167122/bf23be28-3aea-11e7-9d32-ef69fe7cfa05.gif)


### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=56169

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
