### PR TITLE
[UWP] Respect TextBox BackgroundFocusBrush Effect

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/FocusEffect.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/FocusEffect.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml.Media;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Platform.UWP;
+
+[assembly: ResolutionGroupName("Xamarin")]
+[assembly: ExportEffect(typeof(FocusEffect), "FocusEffect")]
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	public class FocusEffect : PlatformEffect
+	{
+		protected override void OnAttached()
+		{
+			try
+			{
+				(Control as Windows.UI.Xaml.Controls.Control).Background = new SolidColorBrush(Colors.Cyan);
+				(Control as FormsTextBox).BackgroundFocusBrush = new SolidColorBrush(Colors.White);
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine("Cannot set property on attached control. Error: ", ex.Message);
+			}
+		}
+
+		protected override void OnDetached()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -169,6 +169,7 @@
     </Compile>
     <Compile Include="BrokenNativeControl.cs" />
     <Compile Include="CustomRenderers.cs" />
+    <Compile Include="FocusEffect.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56609.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56609.cs
@@ -1,0 +1,45 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 56609, "[UWP] Attached effect does not update focused background color", PlatformAffected.UWP)]
+	public class Bugzilla56609 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var entry = new Entry
+			{
+				Text = "Effect attached to an Entry - the background should turn white when focused",
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+				HorizontalOptions = LayoutOptions.CenterAndExpand
+			};
+			entry.Effects.Add(Effect.Resolve("Xamarin.FocusEffect"));
+
+			Content = new StackLayout
+			{
+				Padding = new Thickness(0, 20, 0, 0),
+				Children = {
+					new Label {
+						Text = "Effects Demo - Focus Effect",
+						FontAttributes = FontAttributes.Bold,
+						HorizontalOptions = LayoutOptions.Center
+					},
+					entry
+				}
+			};
+		}
+	}
+	public class Bugzilla56609FocusEffect : RoutingEffect
+	{
+		public Bugzilla56609FocusEffect() : base("Xamarin.FocusEffect")
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -199,6 +199,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52266.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53445.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54649.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56609.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55912.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />

--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -132,6 +132,11 @@
 											<DiscreteObjectKeyFrame KeyTime="0"
 											                        Value="{Binding BackgroundFocusBrush, RelativeSource={RelativeSource TemplatedParent}}" />
 										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
+										                               Storyboard.TargetName="BorderElement">
+											<DiscreteObjectKeyFrame KeyTime="0"
+											                        Value="{Binding BackgroundFocusBrush, RelativeSource={RelativeSource TemplatedParent}}" />
+										</ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity" Storyboard.TargetName="BackgroundElement">
 											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundFocusedOpacity}" />
 										</ObjectAnimationUsingKeyFrames>


### PR DESCRIPTION
### Description of Change ###

Changes in #749 were made to respect behaviors adjusting the `BackgroundFocusBrush` but an adjustment needed to be made so that setting it via Effect works as well, which can be fixed via the template. The issue 44955 in the reproductions still functions as expected.

(If the Effect in the UWP control gallery project can be placed elsewhere, feel free to suggest it.)

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=56609

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
