### PR TITLE
[Android] Support up to 20 templates, as documented.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42956.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42956.cs
@@ -16,132 +16,132 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-    [Preserve(AllMembers = true)]
-    [Issue(IssueTracker.Bugzilla, 9942956, "ListView with DataTemplateSelector can have only 17 Templates, even with CachingStrategy=RetainElement", PlatformAffected.Android)]
-    public class Bugzilla42956 : TestContentPage
-    {
-        const string Success = "Success";
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 9942956, "ListView with DataTemplateSelector can have only 17 Templates, even with CachingStrategy=RetainElement", PlatformAffected.Android)]
+	public class Bugzilla42956 : TestContentPage
+	{
+		const string Success = "Success";
 
-        class MyDataTemplateSelector : DataTemplateSelector
-        {
-            readonly DataTemplate one;
-            readonly DataTemplate two;
-            readonly DataTemplate three;
-            readonly DataTemplate four;
-            readonly DataTemplate five;
-            readonly DataTemplate six;
-            readonly DataTemplate seven;
-            readonly DataTemplate eight;
-            readonly DataTemplate nine;
-            readonly DataTemplate ten;
-            readonly DataTemplate eleven;
-            readonly DataTemplate twelve;
-            readonly DataTemplate thirteen;
-            readonly DataTemplate fourteen;
-            readonly DataTemplate fifteen;
-            readonly DataTemplate sixteen;
-            readonly DataTemplate seventeen;
-            readonly DataTemplate eighteen;
-            readonly DataTemplate nineteen;
-            readonly DataTemplate twenty;
+		class MyDataTemplateSelector : DataTemplateSelector
+		{
+			readonly DataTemplate one;
+			readonly DataTemplate two;
+			readonly DataTemplate three;
+			readonly DataTemplate four;
+			readonly DataTemplate five;
+			readonly DataTemplate six;
+			readonly DataTemplate seven;
+			readonly DataTemplate eight;
+			readonly DataTemplate nine;
+			readonly DataTemplate ten;
+			readonly DataTemplate eleven;
+			readonly DataTemplate twelve;
+			readonly DataTemplate thirteen;
+			readonly DataTemplate fourteen;
+			readonly DataTemplate fifteen;
+			readonly DataTemplate sixteen;
+			readonly DataTemplate seventeen;
+			readonly DataTemplate eighteen;
+			readonly DataTemplate nineteen;
+			readonly DataTemplate twenty;
 
-            public MyDataTemplateSelector()
-            {
-                one = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the one!" } });
-                two = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the two!" } });
-                three = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the three!" } });
-                four = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the four!" } });
-                five = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the five!" } });
-                six = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the six!" } });
-                seven = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the seven!" } });
-                eight = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the eight!" } });
-                nine = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the nine!" } });
-                ten = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the ten!" } });
-                eleven = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the eleven!" } });
-                twelve = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the twelve!" } });
-                thirteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the thirteen!" } });
-                fourteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the fourteen!" } });
-                fifteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the fifteen!" } });
-                sixteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the sixteen!" } });
-                seventeen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the seventeen!" } });
-                eighteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the eighteen!" } });
-                nineteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the nineteen! Is this how I should be databinding? Whatev." } });
-                twenty = new DataTemplate(() => new ViewCell { View = new Label { Text = Success } });
-            }
+			public MyDataTemplateSelector()
+			{
+				one = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the one!" } });
+				two = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the two!" } });
+				three = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the three!" } });
+				four = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the four!" } });
+				five = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the five!" } });
+				six = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the six!" } });
+				seven = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the seven!" } });
+				eight = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the eight!" } });
+				nine = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the nine!" } });
+				ten = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the ten!" } });
+				eleven = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the eleven!" } });
+				twelve = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the twelve!" } });
+				thirteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the thirteen!" } });
+				fourteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the fourteen!" } });
+				fifteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the fifteen!" } });
+				sixteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the sixteen!" } });
+				seventeen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the seventeen!" } });
+				eighteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the eighteen!" } });
+				nineteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the nineteen! Is this how I should be databinding? Whatev." } });
+				twenty = new DataTemplate(() => new ViewCell { View = new Label { Text = Success } });
+			}
 
-            protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
-            {
-                var val = (int)item;
+			protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+			{
+				var val = (int)item;
 
-                switch (val)
-                {
-                    case 1:
-                        return one;
-                    case 2:
-                        return two;
-                    case 3:
-                        return three;
-                    case 4:
-                        return four;
-                    case 5:
-                        return five;
-                    case 6:
-                        return six;
-                    case 7:
-                        return seven; //not six
-                    case 8:
-                        return eight;
-                    case 9:
-                        return nine;
-                    case 10:
-                        return ten;
-                    case 11:
-                        return eleven;
-                    case 12:
-                        return twelve;
-                    case 13:
-                        return thirteen;
-                    case 14:
-                        return fourteen;
-                    case 15:
-                        return fifteen;
-                    case 16:
-                        return sixteen;
-                    case 17:
-                        return seventeen;
-                    case 18:
-                        return eighteen;
-                    case 19:
-                    default:
-                        return nineteen;
-                    case 75:
-                        return twenty;
-                }
-            }
-        }
+				switch (val)
+				{
+					case 1:
+						return one;
+					case 2:
+						return two;
+					case 3:
+						return three;
+					case 4:
+						return four;
+					case 5:
+						return five;
+					case 6:
+						return six;
+					case 7:
+						return seven; //not six
+					case 8:
+						return eight;
+					case 9:
+						return nine;
+					case 10:
+						return ten;
+					case 11:
+						return eleven;
+					case 12:
+						return twelve;
+					case 13:
+						return thirteen;
+					case 14:
+						return fourteen;
+					case 15:
+						return fifteen;
+					case 16:
+						return sixteen;
+					case 17:
+						return seventeen;
+					case 18:
+						return eighteen;
+					case 19:
+					default:
+						return nineteen;
+					case 75:
+						return twenty;
+				}
+			}
+		}
 
-        protected override void Init()
-        {
-            var dts = new MyDataTemplateSelector();
-            var listView = new ListView
-            {
-                ItemsSource = Enumerable.Range(0, 100),
-                ItemTemplate = dts
-            };
+		protected override void Init()
+		{
+			var dts = new MyDataTemplateSelector();
+			var listView = new ListView
+			{
+				ItemsSource = Enumerable.Range(0, 100),
+				ItemTemplate = dts
+			};
 
-            var layout = new StackLayout { Children = { listView } };
+			var layout = new StackLayout { Children = { listView } };
 
-            Content = layout;
+			Content = layout;
 
-            listView.ScrollTo(75, ScrollToPosition.MakeVisible, true);
-        }
+			listView.ScrollTo(75, ScrollToPosition.MakeVisible, true);
+		}
 
 #if UITEST
 		[Test]
-		public void Bugzilla42956Test ()
+		public void Bugzilla42956Test()
 		{
-			RunningApp.WaitForElement (q => q.Marked (Success));
+			RunningApp.WaitForElement(q => q.Marked(Success));
 		}
 #endif
-    }
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42956.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42956.cs
@@ -17,7 +17,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 9942956, "ListView with DataTemplateSelector can have only 17 Templates, even with CachingStrategy=RetainElement", PlatformAffected.Android)]
+	[Issue(IssueTracker.Bugzilla, 42956, "ListView with DataTemplateSelector can have only 17 Templates, even with CachingStrategy=RetainElement", PlatformAffected.Android)]
 	public class Bugzilla42956 : TestContentPage
 	{
 		const string Success = "Success";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42956.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42956.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 9942956, "ListView with DataTemplateSelector can have only 17 Templates, even with CachingStrategy=RetainElement", PlatformAffected.Android)]
+    public class Bugzilla42956 : TestContentPage
+    {
+        const string Success = "Success";
+
+        class MyDataTemplateSelector : DataTemplateSelector
+        {
+            readonly DataTemplate one;
+            readonly DataTemplate two;
+            readonly DataTemplate three;
+            readonly DataTemplate four;
+            readonly DataTemplate five;
+            readonly DataTemplate six;
+            readonly DataTemplate seven;
+            readonly DataTemplate eight;
+            readonly DataTemplate nine;
+            readonly DataTemplate ten;
+            readonly DataTemplate eleven;
+            readonly DataTemplate twelve;
+            readonly DataTemplate thirteen;
+            readonly DataTemplate fourteen;
+            readonly DataTemplate fifteen;
+            readonly DataTemplate sixteen;
+            readonly DataTemplate seventeen;
+            readonly DataTemplate eighteen;
+            readonly DataTemplate nineteen;
+            readonly DataTemplate twenty;
+
+            public MyDataTemplateSelector()
+            {
+                one = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the one!" } });
+                two = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the two!" } });
+                three = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the three!" } });
+                four = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the four!" } });
+                five = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the five!" } });
+                six = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the six!" } });
+                seven = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the seven!" } });
+                eight = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the eight!" } });
+                nine = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the nine!" } });
+                ten = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the ten!" } });
+                eleven = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the eleven!" } });
+                twelve = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the twelve!" } });
+                thirteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the thirteen!" } });
+                fourteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the fourteen!" } });
+                fifteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the fifteen!" } });
+                sixteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the sixteen!" } });
+                seventeen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the seventeen!" } });
+                eighteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the eighteen!" } });
+                nineteen = new DataTemplate(() => new ViewCell { View = new Label { Text = "I am the nineteen! Is this how I should be databinding? Whatev." } });
+                twenty = new DataTemplate(() => new ViewCell { View = new Label { Text = Success } });
+            }
+
+            protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+            {
+                var val = (int)item;
+
+                switch (val)
+                {
+                    case 1:
+                        return one;
+                    case 2:
+                        return two;
+                    case 3:
+                        return three;
+                    case 4:
+                        return four;
+                    case 5:
+                        return five;
+                    case 6:
+                        return six;
+                    case 7:
+                        return seven; //not six
+                    case 8:
+                        return eight;
+                    case 9:
+                        return nine;
+                    case 10:
+                        return ten;
+                    case 11:
+                        return eleven;
+                    case 12:
+                        return twelve;
+                    case 13:
+                        return thirteen;
+                    case 14:
+                        return fourteen;
+                    case 15:
+                        return fifteen;
+                    case 16:
+                        return sixteen;
+                    case 17:
+                        return seventeen;
+                    case 18:
+                        return eighteen;
+                    case 19:
+                    default:
+                        return nineteen;
+                    case 75:
+                        return twenty;
+                }
+            }
+        }
+
+        protected override void Init()
+        {
+            var dts = new MyDataTemplateSelector();
+            var listView = new ListView
+            {
+                ItemsSource = Enumerable.Range(0, 100),
+                ItemTemplate = dts
+            };
+
+            var layout = new StackLayout { Children = { listView } };
+
+            Content = layout;
+
+            listView.ScrollTo(75, ScrollToPosition.MakeVisible, true);
+        }
+
+#if UITEST
+		[Test]
+		public void Bugzilla42956Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked (Success));
+		}
+#endif
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -549,6 +549,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54977.xaml.cs">
       <DependentUpon>Bugzilla54977.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42956.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -25,7 +25,12 @@ namespace Xamarin.Forms.Platform.Android
 		protected readonly ListView _listView;
 		readonly AListView _realListView;
 		readonly Dictionary<DataTemplate, int> _templateToId = new Dictionary<DataTemplate, int>();
-		int _dataTemplateIncrementer = 2; // lets start at not 0 because
+		int _dataTemplateIncrementer = 2; // lets start at not 0 because ... 
+
+		// We will use _dataTemplateIncrementer to get the proper ViewType key for the item's DataTemplate and store these keys in  _templateToId.
+		// If an item does _not_ use a DataTemplate, then the ViewType key will be DefaultItemTemplateId (1) or DefaultGroupHeaderTemplateId (0).
+		// To prevent a conflict in the event that a ListView supports both templates and non-templates, we will start the DataTemplate key at 2.
+
 		int _listCount = -1; // -1 we need to get count from the list
 		Cell _enabledCheckCell;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -109,7 +109,13 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override int ViewTypeCount
 		{
-			get { return 20; }
+			get
+			{
+				// We have a documented limit of 20 templates on Android.
+				// ViewTypes are selected on a zero-based index, so this count must be at least 20 + 1.
+				// Plus, we arbitrarily increased the index of the DataTemplate index by 2 (see _dataTemplateIncrementer).
+				return 23;
+			}
 		}
 
 		public override bool AreAllItemsEnabled()


### PR DESCRIPTION
### Description of Change ###

As documented [here](https://developer.xamarin.com/api/type/Xamarin.Forms.DataTemplateSelector/#Remarks), the `DataTemplateSelector` can have up to 20 `DataTemplates` on Android. 

Due to some indexing issues, the actual limit was 17. Increasing the limit to the documented limit of 20. 

Surpassing this limit will cause the following known (and expected) exception:

```
08-01 15:50:32.987 E/mono    (22808): 
08-01 15:50:32.987 E/mono    (22808): Unhandled Exception:
08-01 15:50:32.987 E/mono    (22808): Java.Lang.RuntimeException: length=23; index=26
08-01 15:50:32.987 E/mono    (22808):   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <filename unknown>:0 
08-01 15:50:32.987 E/mono    (22808):   at Java.Interop.JniEnvironment+InstanceMethods.CallNonvirtualBooleanMethod (JniObjectReference instance, JniObjectReference type, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x000a8] in /Users/builder/data/lanes/3415/7db2aac3/source/Java.Interop/src/Java.Interop/Java.Interop/JniEnvironment.g.cs:11732 
08-01 15:50:32.987 E/mono    (22808):   at Java.Interop.JniPeerMembers+JniInstanceMethods.InvokeVirtualBooleanMethod (System.String encodedMember, IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x0006b] in /Users/builder/data/lanes/3415/7db2aac3/source/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods_Invoke.cs:67 
08-01 15:50:32.987 E/mono    (22808):   at Android.Views.View.DispatchTouchEvent (Android.Views.MotionEvent e) [0x00036] in <filename unknown>:0
```

Please also note that if you improperly configure your `DataTemplateSelector` to return a new `DataTemplate` instead of a reference to a `DataTemplate`, you may also encounter this same error on Android. Be sure to implement the `DataTemplateSelector` as documented.

### Bugs Fixed ###

- [Bug 42956 - ListView with DataTemplateSelector can have only 17 Templates, even with CachingStrategy=RetainElement](https://bugzilla.xamarin.com/show_bug.cgi?id=42956)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
