### PR TITLE
Fix animations with GLViews

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/OpenGLViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/OpenGLViewRenderer.cs
@@ -76,8 +76,8 @@ namespace Xamarin.Forms.Platform.iOS
 					control.Display();
 				if (control == null || model == null || !model.HasRenderLoop)
 				{
-					_displayLink.Invalidate();
-					_displayLink.Dispose();
+					_displayLink?.Invalidate();
+					_displayLink?.Dispose();
 					_displayLink = null;
 				}
 			});

--- a/Xamarin.Forms.Platform.iOS/Renderers/OpenGLViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/OpenGLViewRenderer.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Forms.Platform.iOS
 					_displayLink = null;
 				}
 			});
-			_displayLink.AddToRunLoop(NSRunLoop.Current, NSRunLoop.NSDefaultRunLoopMode);
+			_displayLink.AddToRunLoop(NSRunLoop.Current, NSRunLoop.NSRunLoopCommonModes);
 		}
 
 		class Delegate : GLKViewDelegate


### PR DESCRIPTION
### Description of Change ###

use a different RunLoop and add a null-check

#### Tests results

I ran the UITest provided by Jon in https://bugzilla.xamarin.com/show_bug.cgi?id=41413#c7 on XTC on iOS 8.4.1 and 10.3.2
- Using XF 2.2.0.45 (the bug reproduction)
  - Fails on 8.4.1
  - works on 10.3.2
- Using XF 2.3.6.103-nightly (current master)
  - Fails on 8.4.1
  - works on 10.3.2
- Using the `Xamarin.Forms.Platform.iOS` produced by this PR:
  - **WORKS** on 8.4.1
  - works on 10.3.2

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=41413
- https://bugzilla.xamarin.com/show_bug.cgi?id=42755

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense