### PR TITLE
[Android] Set SingleLine to true when we only have 1 line on a TextView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla49069.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla49069.cs
@@ -1,0 +1,66 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 49069, "Java.Lang.ArrayIndexOutOfBoundsException when rendering long Label on Android", PlatformAffected.Default)]
+	public class Bugzilla49069 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			Label longLabelWithHorizontalTextAlignmentOfEndAndHeadTruncation = new Label
+			{
+                AutomationId = "lblLong",
+				TextColor = Color.Black,
+				BackgroundColor = Color.Pink,
+				Text = "This is a long string that should hopefully truncate. It has HeadTruncation enabled and HorizontalTextAlignment = End",
+				LineBreakMode = LineBreakMode.HeadTruncation,
+				HorizontalTextAlignment = TextAlignment.End
+			};
+
+			StackLayout vslOuterPage = new StackLayout
+			{
+				BackgroundColor = Color.White, // viewModel.PageBackgroundColor,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				Margin = new Thickness(0, 0, 0, 0), // gets rid of the white
+				Padding = new Thickness(0, 10, 0, 10),
+				Spacing = 0,
+				Children =
+					{
+						longLabelWithHorizontalTextAlignmentOfEndAndHeadTruncation,
+					}
+			};
+
+			ScrollView sv = new ScrollView
+			{
+				Content = vslOuterPage,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.Fill,
+				Orientation = ScrollOrientation.Vertical
+			};
+
+            Content = sv;
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla49069Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked ("lblLong"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -548,7 +548,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54977.xaml.cs">
       <DependentUpon>Bugzilla54977.xaml</DependentUpon>
-    </Compile>\
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla49069.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42956.cs" />
   </ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -549,6 +549,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54977.xaml.cs">
       <DependentUpon>Bugzilla54977.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla49069.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -1,0 +1,45 @@
+﻿using Android.Text;
+using Android.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+    internal static class TextViewExtensions
+    {
+		public static void SetLineBreakMode(this TextView textView, LineBreakMode lineBreakMode)
+		{
+			switch (lineBreakMode)
+			{
+				case LineBreakMode.NoWrap:
+					textView.SetMaxLines(1);
+					textView.SetSingleLine(true);
+					textView.Ellipsize = null;
+					break;
+				case LineBreakMode.WordWrap:
+					textView.Ellipsize = null;
+					textView.SetMaxLines(100);
+					textView.SetSingleLine(false);
+					break;
+				case LineBreakMode.CharacterWrap:
+					textView.Ellipsize = null;
+					textView.SetMaxLines(100);
+					textView.SetSingleLine(false);
+					break;
+				case LineBreakMode.HeadTruncation:
+					textView.SetMaxLines(1);
+					textView.SetSingleLine(true);
+					textView.Ellipsize = TextUtils.TruncateAt.Start;
+					break;
+				case LineBreakMode.TailTruncation:
+					textView.SetMaxLines(1);
+					textView.SetSingleLine(true);
+					textView.Ellipsize = TextUtils.TruncateAt.End;
+					break;
+				case LineBreakMode.MiddleTruncation:
+					textView.SetMaxLines(1);
+					textView.SetSingleLine(true);
+					textView.Ellipsize = TextUtils.TruncateAt.Middle;
+					break;
+			}
+		}
+    }
+}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -255,34 +255,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		void UpdateLineBreakMode()
 		{
-			SetSingleLine(false);
-			switch (Element.LineBreakMode)
-			{
-				case LineBreakMode.NoWrap:
-					SetMaxLines(1);
-					Ellipsize = null;
-					break;
-				case LineBreakMode.WordWrap:
-					Ellipsize = null;
-					SetMaxLines(100);
-					break;
-				case LineBreakMode.CharacterWrap:
-					Ellipsize = null;
-					SetMaxLines(100);
-					break;
-				case LineBreakMode.HeadTruncation:
-					SetMaxLines(1);
-					Ellipsize = TextUtils.TruncateAt.Start;
-					break;
-				case LineBreakMode.TailTruncation:
-					SetMaxLines(1);
-					Ellipsize = TextUtils.TruncateAt.End;
-					break;
-				case LineBreakMode.MiddleTruncation:
-					SetMaxLines(1);
-					Ellipsize = TextUtils.TruncateAt.Middle;
-					break;
-			}
+			this.SetLineBreakMode(Element.LineBreakMode);
 			_lastSizeRequest = null;
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -164,34 +164,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateLineBreakMode()
 		{
-            _view.SetSingleLine(false);
-			switch (Element.LineBreakMode)
-			{
-				case LineBreakMode.NoWrap:
-					_view.SetMaxLines(1);
-					_view.Ellipsize = null;
-					break;
-				case LineBreakMode.WordWrap:
-					_view.Ellipsize = null;
-					_view.SetMaxLines(100);
-					break;
-				case LineBreakMode.CharacterWrap:
-					_view.Ellipsize = null;
-					_view.SetMaxLines(100);
-					break;
-				case LineBreakMode.HeadTruncation:
-					_view.SetMaxLines(1);
-					_view.Ellipsize = TextUtils.TruncateAt.Start;
-					break;
-				case LineBreakMode.TailTruncation:
-					_view.SetMaxLines(1);
-					_view.Ellipsize = TextUtils.TruncateAt.End;
-					break;
-				case LineBreakMode.MiddleTruncation:
-					_view.SetMaxLines(1);
-					_view.Ellipsize = TextUtils.TruncateAt.Middle;
-					break;
-			}
+			_view.SetLineBreakMode(Element.LineBreakMode);
 			_lastSizeRequest = null;
 		}
 

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -258,6 +258,7 @@
     <Compile Include="Renderers\GroupedListViewAdapter.cs" />
     <Compile Include="FastRenderers\ImageRenderer.cs" />
     <Compile Include="Extensions\ImageViewExtensions.cs" />
+    <Compile Include="Extensions\TextViewExtensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
### Description of Change ###

The issue here is a [old Android bug ](https://issuetracker.google.com/issues/36950033) that when calculating the Ellipsis for wrapping the text it takes in account we provide the correct value for SingleLine.
Also refactored to share the fix between the 2 LabelRenderers 

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=49069

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense