### PR TITLE
[iOS] Handle user popping pages out of order

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRendererBugzila38731.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRendererBugzila38731.cs
@@ -1,0 +1,29 @@
+﻿using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Controls.Issues;
+
+[assembly: ExportRenderer(typeof(Bugzilla38731), typeof(CustomRendererBugzila38731))]
+[assembly: ExportRenderer(typeof(Bugzilla38731.PageTwo), typeof(CustomRendererBugzila38731))]
+[assembly: ExportRenderer(typeof(Bugzilla38731.PageThree), typeof(CustomRendererBugzila38731))]
+[assembly: ExportRenderer(typeof(Bugzilla38731.PageFour), typeof(CustomRendererBugzila38731))]
+
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class CustomRendererBugzila38731 : Platform.iOS.PageRenderer
+	{
+		public override void ViewWillAppear(bool animated)
+		{
+			base.ViewWillAppear(animated);
+
+			if (NavigationController.ViewControllers.Length > 1)
+			{
+				NavigationController.TopViewController.NavigationItem.SetLeftBarButtonItem(new UIBarButtonItem(
+					UIImage.FromFile("bank.png"), UIBarButtonItemStyle.Plain, (sender, args) =>
+					{
+						NavigationController.PopViewController(true);
+					}), true);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <None Include="packages.config" />
     <Compile Include="CustomRenderers.cs" />
+    <Compile Include="CustomRendererBugzila38731.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38731.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38731.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 938731, "Xamarin.Forms.Platform.iOS.NavigationRenderer.GetAppearedOrDisappearedTask NullReferenceExceptionObject", PlatformAffected.Default)]
+	public class Bugzilla38731 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var label = new Label();
+			label.Text = "Page one...";
+			label.HorizontalTextAlignment = TextAlignment.Center;
+
+			var button = new Button();
+			button.AutomationId = "btn1";
+			button.Text = "Navigate to page two";
+			button.Clicked += Button_Clicked;
+
+			var content = new StackLayout();
+			content.Children.Add(label);
+			content.Children.Add(button);
+
+			Title = "Page one";
+			Content = content;
+		}
+
+		void Button_Clicked(object sender, EventArgs e)
+		{
+			Navigation.PushAsync(new PageTwo());
+		}
+
+		public class PageTwo : ContentPage
+		{
+			public PageTwo()
+			{
+				var label = new Label();
+				label.Text = "Page two...";
+				label.HorizontalTextAlignment = TextAlignment.Center;
+
+				var button = new Button();
+				button.AutomationId = "btn2";
+				button.Text = "Navigate to page three";
+				button.Clicked += Button_Clicked;
+
+				var content = new StackLayout();
+				content.Children.Add(label);
+				content.Children.Add(button);
+
+				Title = "Page two";
+				Content = content;
+			}
+
+			void Button_Clicked(object sender, EventArgs e)
+			{
+				Navigation.PushAsync(new PageThree());
+			}
+		}
+
+		public class PageThree : ContentPage
+		{
+			public PageThree()
+			{
+				var label = new Label();
+				label.Text = "Page three...";
+				label.HorizontalTextAlignment = TextAlignment.Center;
+
+				var button = new Button();
+				button.AutomationId = "btn3";
+				button.Text = "Navigate to page four";
+				button.Clicked += Button_Clicked;
+
+				var content = new StackLayout();
+				content.Children.Add(label);
+				content.Children.Add(button);
+
+				Title = "Page three";
+				Content = content;
+			}
+
+			void Button_Clicked(object sender, EventArgs e)
+			{
+				Navigation.PushAsync(new PageFour());
+			}
+		}
+
+		public class PageFour : ContentPage
+		{
+			public PageFour()
+			{
+				var label = new Label();
+				label.Text = "Last page... Tap back very quick";
+				label.HorizontalTextAlignment = TextAlignment.Center;
+
+				var content = new StackLayout();
+				content.Children.Add(label);
+
+				Title = "Page four";
+				Content = content;
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla38731Test ()
+		{
+			RunningApp.Tap(q => q.Marked("btn1"));
+			RunningApp.Tap(q => q.Marked("btn2"));
+			RunningApp.Tap(q => q.Marked("btn3"));
+			RunningApp.Back();
+			RunningApp.Back();
+			RunningApp.Back();
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38731.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38731.cs
@@ -16,7 +16,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 938731, "Xamarin.Forms.Platform.iOS.NavigationRenderer.GetAppearedOrDisappearedTask NullReferenceExceptionObject", PlatformAffected.Default)]
+	[Issue(IssueTracker.Bugzilla, 38731, "Xamarin.Forms.Platform.iOS.NavigationRenderer.GetAppearedOrDisappearedTask NullReferenceExceptionObject", PlatformAffected.Default)]
 	public class Bugzilla38731 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -550,6 +550,7 @@
       <DependentUpon>Bugzilla54977.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42956.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38731.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -525,7 +525,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void RemoveViewControllers(bool animated)
 		{
 			var controller = TopViewController as ParentingViewController;
-			if (controller == null || controller.Child == null)
+			if (controller == null || controller.Child == null || Platform.GetRenderer(controller.Child) == null)
 				return;
 
 			// Gesture in progress, lets not be proactive and just wait for it to finish


### PR DESCRIPTION
### Description of Change ###

If the user has some custom code to pop a page using a custom renderer that could bring situations were disposing the page and tapping multiple times calling pop makes it happen concurrently, so we should just check if we still have the renderer for that page, if we don't we don't need to handle it.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=38731

### API Changes ###
None 

### Behavioral Changes ###
None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense