### PR TITLE
Align Layout transparency behavior between Android, iOS, Windows

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25943.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25943.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 25943, "[Android] TapGestureRecognizer does not work with a nested StackLayout", PlatformAffected.Android)]
+	public class Bugzilla25943 : TestContentPage 
+	{
+		protected override void Init()
+		{
+			StackLayout layout = GetNestedStackLayout();
+
+			var tapGestureRecognizer = new TapGestureRecognizer();
+			tapGestureRecognizer.Tapped += (sender, e) => Debug.WriteLine(">>>>>>>> foo");
+			layout.GestureRecognizers.Add(tapGestureRecognizer);
+
+			Content = layout;
+		}
+
+		public StackLayout GetNestedStackLayout()
+		{
+			var innerLayout = new StackLayout
+			{
+				AutomationId = "innerlayout",
+				HeightRequest = 100,
+				Orientation = StackOrientation.Horizontal,
+				BackgroundColor = Color.Transparent,
+				Children =
+						{
+							new Label
+							{
+								Text = "inner label",
+								FontSize = 20,
+								HorizontalOptions = LayoutOptions.Center,
+								VerticalOptions = LayoutOptions.CenterAndExpand
+							}
+						}
+			};
+
+			var outerLayout = new StackLayout
+			{
+				AutomationId = "outerlayout",
+				Orientation = StackOrientation.Vertical,
+				BackgroundColor = Color.Blue,
+				Children =
+						{
+							innerLayout,
+							new Label
+							{
+								Text = "outer label",
+								FontSize = 20,
+								HorizontalOptions = LayoutOptions.Center,
+							}
+						}
+			};
+
+			return outerLayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25943.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla25943.cs
@@ -2,6 +2,7 @@ using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
 #if UITEST
+using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
 using NUnit.Framework;
 #endif
@@ -86,7 +87,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
         [Test]
-        public void VerifyNestedStacklayoutTapsBubble(TestPoint test)
+        public void VerifyNestedStacklayoutTapsBubble(TransparentOverlayTests.TestPoint test)
         {
             RunningApp.WaitForElement(q => q.Marked(InnerLayout));
             RunningApp.Tap(InnerLayout);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39331.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39331.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.BoxView)]
+	[Category(UITestCategories.InputTransparent)]
 #endif
 
 	[Preserve (AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40173.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40173.cs
@@ -10,109 +10,118 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.BoxView)]
+	[Category(UITestCategories.InputTransparent)]
 #endif
 
-    [Preserve(AllMembers = true)]
-    [Issue(IssueTracker.Bugzilla, 40173, "Android BoxView/Frame not clickthrough in ListView")]
-	public class Bugzilla40173 : TestContentPage // or TestMasterDetailPage, etc ...
-    {
-        const string CantTouchButtonId = "CantTouchButtonId";
-        const string CanTouchButtonId = "CanTouchButtonId";
-        const string ListTapTarget = "ListTapTarget";
-        const string CantTouchFailText = "Failed";
-        const string CanTouchSuccessText = "ButtonTapped";
-        const string ListTapSuccessText = "ItemTapped";
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40173, "Android BoxView/Frame not clickthrough in ListView")]
+	public class Bugzilla40173 : TestContentPage
+	{
+		const string CantTouchButtonId = "CantTouchButtonId";
+		const string CanTouchButtonId = "CanTouchButtonId";
+		const string ListTapTarget = "ListTapTarget";
+		const string CantTouchFailText = "Failed";
+		const string CanTouchSuccessText = "ButtonTapped";
+		const string ListTapSuccessText = "ItemTapped";
 
 #if UITEST
-        [Test]
-        public void ButtonBlocked()
-        {
-            RunningApp.Tap(q => q.All().Marked(CantTouchButtonId));
-            RunningApp.WaitForNoElement(q => q.All().Text(CantTouchFailText));
+		[Test]
+		public void ButtonBlocked()
+		{
+			RunningApp.Tap(q => q.All().Marked(CantTouchButtonId));
+			RunningApp.WaitForNoElement(q => q.All().Text(CantTouchFailText));
 
-            RunningApp.Tap(q => q.All().Marked(CanTouchButtonId));
-            RunningApp.WaitForElement(q => q.All().Text(CanTouchSuccessText));
+			RunningApp.Tap(q => q.All().Marked(CanTouchButtonId));
+			RunningApp.WaitForElement(q => q.All().Text(CanTouchSuccessText));
 #if !__MACOS__
-            RunningApp.Tap(q => q.All().Marked(ListTapTarget));
-            RunningApp.WaitForElement(q => q.All().Text(ListTapSuccessText));
+			RunningApp.Tap(q => q.All().Marked(ListTapTarget));
+			RunningApp.WaitForElement(q => q.All().Text(ListTapSuccessText));
 #endif
-        }
+		}
 #endif
 
-        protected override void Init()
-        {
-            var outputLabel = new Label();
-            var testButton = new Button
-            {
-                Text = "Can't Touch This",
-                AutomationId = CantTouchButtonId
-            };
+		protected override void Init()
+		{
+			var outputLabel = new Label();
+			var testButton = new Button
+			{
+				Text = "Can't Touch This",
+				AutomationId = CantTouchButtonId
+			};
 
-            testButton.Clicked += (sender, args) => outputLabel.Text = CantTouchFailText;
+			testButton.Clicked += (sender, args) => outputLabel.Text = CantTouchFailText;
 
-            var testGrid = new Grid
-            {
-                Children =
-                {
-                    testButton,
-                    new BoxView
-                    {
-                        Color = Color.Pink.MultiplyAlpha(0.5)
-                    }
-                }
-            };
+			var testGrid = new Grid
+			{
+				AutomationId = "testgrid",
+				Children =
+				{
+					testButton,
+					new BoxView
+					{
+						AutomationId = "nontransparentBoxView",
+						Color = Color.Pink.MultiplyAlpha(0.5)
+					}
+				}
+			};
 
-            // BoxView over Button prevents Button click
-            var testButtonOk = new Button
-            {
-                Text = "Can Touch This",
-                AutomationId = CanTouchButtonId
-            };
+			// BoxView over Button prevents Button click
+			var testButtonOk = new Button
+			{
+				Text = "Can Touch This",
+				AutomationId = CanTouchButtonId
+			};
 
-            testButtonOk.Clicked += (sender, args) => outputLabel.Text = CanTouchSuccessText;
+			testButtonOk.Clicked += (sender, args) =>
+			{
+				outputLabel.Text = CanTouchSuccessText;
+			};
 
-            var testGridOk = new Grid
-            {
-                Children =
-                {
-                    testButtonOk,
-                    new BoxView
-                    {
-                        Color = Color.Pink.MultiplyAlpha(0.5),
-                        InputTransparent = true
-                    }
-                }
-            };
+			var testGridOk = new Grid
+			{
+				AutomationId = "testgridOK",
+				Children =
+				{
+					testButtonOk,
+					new BoxView
+					{
+						AutomationId = "transparentBoxView",
+						Color = Color.Pink.MultiplyAlpha(0.5),
+						InputTransparent = true
+					}
+				}
+			};
 
-            var testListView = new ListView();
-            var items = new[] { "Foo" };
-            testListView.ItemsSource = items;
-            testListView.ItemTemplate = new DataTemplate(() =>
-            {
-                var result = new ViewCell
-                {
-                    View = new Grid
-                    {
-                        Children =
-                        {
-                            new BoxView
-                            {
-                                AutomationId = ListTapTarget,
-                                Color = Color.Pink.MultiplyAlpha(0.5)
-                            }
-                        }
-                    }
-                };
+			var testListView = new ListView();
+			var items = new[] { "Foo" };
+			testListView.ItemsSource = items;
+			testListView.ItemTemplate = new DataTemplate(() =>
+			{
+				var result = new ViewCell
+				{
+					View = new Grid
+					{
+						Children =
+						{
+							new BoxView
+							{
+								AutomationId = ListTapTarget,
+								Color = Color.Pink.MultiplyAlpha(0.5)
+							}
+						}
+					}
+				};
 
-                return result;
-            });
+				return result;
+			});
 
-            testListView.ItemSelected += (sender, args) => outputLabel.Text = ListTapSuccessText;
+			testListView.ItemSelected += (sender, args) => outputLabel.Text = ListTapSuccessText;
 
-            Content = new StackLayout
-            {
-                Children = { outputLabel, testGrid, testGridOk, testListView }
-            };
-        }
-    }
+			Content = new StackLayout
+			{
+				AutomationId = "Container Stack Layout",
+				Children = { outputLabel, testGrid, testGridOk, testListView }
+			};
+		}
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla55912.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla55912.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 955912, "Tap event not always propagated to containing Grid/StackLayout",
+	[Issue(IssueTracker.Bugzilla, 55912, "Tap event not always propagated to containing Grid/StackLayout",
 		PlatformAffected.Android)]
 	public class Bugzilla55912 : TestContentPage
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla55912.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla55912.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
 			layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
 			layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
 
-			var testGrid = new Grid { BackgroundColor = Color.Red };
+			var testGrid = new Grid { BackgroundColor = Color.Red, AutomationId = "testgrid"};
 			var gridLabel = new Label
 			{
 				AutomationId = GridLabelId,
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Grid.SetRow(testGrid, 1);
 			testGrid.Children.Add(gridLabel);
 
-			var testStack = new StackLayout { BackgroundColor = Color.Default };
+			var testStack = new StackLayout { BackgroundColor = Color.Default, AutomationId = "teststack"};
 			var stackLabel = new Label
 			{
 				AutomationId = StackLabelId,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2775.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2775.cs
@@ -5,15 +5,19 @@ using System.Collections.Generic;
 using Xamarin.Forms.Internals;
 
 #if UITEST
+using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[Category(UITestCategories.InputTransparent)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2775, "ViewCell background conflicts with ListView Semi-Transparent and Transparent backgrounds")]
-	public class Issue2775 : TestContentPage // or TestMasterDetailPage, etc ...
+	public class Issue2775 : TestContentPage 
 	{
 		protected override void Init ()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 618, "Transparent Overlays", PlatformAffected.All)]
+	public class TransparentOverlayTests : TestContentPage
+	{
+		// Need a grid with two rows, controls in each, and an overlaying stacklayout
+		protected override void Init()
+		{
+			var grid = new Grid
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill
+			};
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+
+			var button1 = new Button
+			{
+				Text = "Button 1",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+			button1.Clicked += (sender, args) => { Debug.WriteLine($">>>>> TransparentOverlayTests Init 81: Button1"); };
+			grid.Children.Add(button1);
+			Grid.SetRow(button1, 0);
+
+
+			var button2 = new Button
+			{
+				Text = "Button 2",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+			button2.Clicked += (sender, args) => { Debug.WriteLine($">>>>> TransparentOverlayTests Init 81: Button2"); };
+			grid.Children.Add(button2);
+			Grid.SetRow(button2, 1);
+
+			var layout1 = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+				BackgroundColor = Color.Transparent
+			};
+
+			grid.Children.Add(layout1);
+			Grid.SetRow(layout1, 0);
+
+			var layout2 = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+				BackgroundColor = Color.Blue,
+				Opacity = 0.2
+			};
+
+			grid.Children.Add(layout2);
+			Grid.SetRow(layout2, 1);
+
+			Content = grid;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
@@ -65,12 +65,12 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				AutomationId = $"transparenttest{i}";
 
-				// TODO hartez 2017/05/22 15:45:12 Update this with real values	
-				ShouldBeTransparent = true;
-
 				Opacity = (i & (1 << 0)) == 0;
 				InputTransparent = (i & (1 << 1)) == 0;
 				BackgroundColor = (i & (1 << 2)) == 0;
+
+				// Layouts should be input transparent _only_ if they were explicitly told to be
+				ShouldBeTransparent = InputTransparent;
 			}
 
 			internal string AutomationId { get; set; }
@@ -157,14 +157,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(DefaultButtonText);
 			RunningApp.Tap(DefaultButtonText);
 
-			if (test.ShouldBeTransparent)
-			{
-				RunningApp.WaitForElement(Success);
-			}
-			else
-			{
-				RunningApp.WaitForElement(DefaultButtonText);
-			}
+			RunningApp.WaitForElement(test.ShouldBeTransparent ? Success : DefaultButtonText);
 		}
 #endif
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
@@ -158,8 +158,6 @@ namespace Xamarin.Forms.Controls.Issues
             RunningApp.WaitForElement(q => q.Marked(test.AutomationId));
             RunningApp.Tap(test.AutomationId);
 
-
-
 #if __IOS__
 			// For the tests where the overlay is not input transparent, the UI tests on 
 			// iOS can't find the button. So we'll just tap the coordinates of the layout's center blindly instead

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
@@ -97,7 +97,9 @@ namespace Xamarin.Forms.Controls.Issues
 			double opacity = test.Opacity ? _transparentOpacity : _nonTransparentOpacity;
 			bool inputTransparent = test.InputTransparent;
 
-			var grid = new Grid() {
+            var grid = new Grid
+            {
+                AutomationId = "testgrid",
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill
 			};
@@ -131,6 +133,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var layout = new StackLayout
 			{
+                AutomationId = "overlay",
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill,
 				BackgroundColor = backgroundColor,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
@@ -151,18 +151,25 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 #if UITEST
-		[Test, TestCaseSource(nameof(GenerateTests))]
-		public void VerifyInputTransparent(TestPoint test)
-		{
-			RunningApp.WaitForElement(q => q.Marked(test.AutomationId));
-			RunningApp.Tap(test.AutomationId);
+        [Test, TestCaseSource(nameof(GenerateTests))]
+        public void VerifyInputTransparent(TestPoint test)
+        {
+            RunningApp.WaitForElement(q => q.Marked(test.AutomationId));
+            RunningApp.Tap(test.AutomationId);
 
-			RunningApp.WaitForElement(DefaultButtonText);
-			RunningApp.Tap(DefaultButtonText);
+            var button = RunningApp.WaitForElement(DefaultButtonText);
 
-			RunningApp.WaitForElement(test.ShouldBeTransparent ? Success : DefaultButtonText);
+#if __IOS__
+            // For the tests where the overlay is not input transparent, the UI tests on 
+            // iOS can 'see' the button with WaitForElement but not with Tap. So we'll
+            // just tap the coordinates of the button's center blindly instead
+            RunningApp.TapCoordinates(button[0].Rect.CenterX, button[0].Rect.CenterY);
+#else
+            RunningApp.Tap(DefaultButtonText);
+#endif
+            RunningApp.WaitForElement(test.ShouldBeTransparent ? Success : DefaultButtonText);
 		}
 #endif
 
-	}
+        }
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
@@ -1,67 +1,172 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System.Linq;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[Category(UITestCategories.InputTransparent)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 618, "Transparent Overlays", PlatformAffected.All)]
-	public class TransparentOverlayTests : TestContentPage
+	public class TransparentOverlayTests : TestNavigationPage
 	{
-		// Need a grid with two rows, controls in each, and an overlaying stacklayout
+		readonly Color _transparentColor = Color.Transparent;
+		readonly Color _nontransparentColor = Color.Blue;
+
+		double _transparentOpacity = 0;
+		double _nonTransparentOpacity = 0.2;
+
+		const string Success = "Success";
+		const string Failure = "Failure";
+		const string DefaultButtonText = "Button";
+
 		protected override void Init()
 		{
-			var grid = new Grid
+			PushAsync(Menu());
+		}
+
+		ContentPage Menu()
+		{
+			var layout = new StackLayout();
+
+			layout.Children.Add(new Label {Text = "Select a test below"});
+
+			foreach (var test in GenerateTests)
 			{
+				layout.Children.Add(MenuButton(test));
+			}
+
+			return new ContentPage { Content = layout };
+		}
+
+		Button MenuButton(TestPoint test)
+		{
+			var button = new Button { Text = test.ToString(), AutomationId = test.AutomationId };
+
+			button.Clicked += (sender, args) => PushAsync(CreateTestPage(test));
+
+			return button;
+		}
+
+		[Preserve(AllMembers = true)]
+		public struct TestPoint
+		{
+			public TestPoint(int i) : this()
+			{
+				AutomationId = $"transparenttest{i}";
+
+				// TODO hartez 2017/05/22 15:45:12 Update this with real values	
+				ShouldBeTransparent = true;
+
+				Opacity = (i & (1 << 0)) == 0;
+				InputTransparent = (i & (1 << 1)) == 0;
+				BackgroundColor = (i & (1 << 2)) == 0;
+			}
+
+			internal string AutomationId { get; set; }
+			internal bool ShouldBeTransparent { get; set; }
+
+			internal bool Opacity { get; set; }
+			internal bool InputTransparent { get; set; }
+			internal bool BackgroundColor { get; set; }
+			
+			public override string ToString()
+			{
+				return $"O{(Opacity ? "1" : "0")}, B{(BackgroundColor ? "1" : "0")}, I{(InputTransparent ? "1" : "0")}";
+			}
+		}
+
+		static IEnumerable<TestPoint> GenerateTests
+		{
+			get { return Enumerable.Range(0, 8).Select(i => new TestPoint(i)); }
+		}
+
+		ContentPage CreateTestPage(TestPoint test)
+		{
+			Color backgroundColor = test.BackgroundColor? _transparentColor : _nontransparentColor;
+			double opacity = test.Opacity ? _transparentOpacity : _nonTransparentOpacity;
+			bool inputTransparent = test.InputTransparent;
+
+			var grid = new Grid() {
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill
 			};
-			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
 			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
 
-			var button1 = new Button
+			var instructions = new Label
 			{
-				Text = "Button 1",
+				HorizontalOptions = LayoutOptions.Fill,
+				HorizontalTextAlignment = TextAlignment.Center,
+				Text = $"Tap the button below."
+				       + (test.ShouldBeTransparent
+					       ? $" If the button's text changes to {Success} the test has passed."
+					       : " If the button's text remains unchanged, the test has passed.")
+			};
+
+			grid.Children.Add(instructions);
+
+			var button = new Button
+			{
+				Text = DefaultButtonText,
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.Center
 			};
-			button1.Clicked += (sender, args) => { Debug.WriteLine($">>>>> TransparentOverlayTests Init 81: Button1"); };
-			grid.Children.Add(button1);
-			Grid.SetRow(button1, 0);
 
-
-			var button2 = new Button
+			button.Clicked += (sender, args) =>
 			{
-				Text = "Button 2",
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center
+				button.Text = test.ShouldBeTransparent ? Success : Failure;
 			};
-			button2.Clicked += (sender, args) => { Debug.WriteLine($">>>>> TransparentOverlayTests Init 81: Button2"); };
-			grid.Children.Add(button2);
-			Grid.SetRow(button2, 1);
 
-			var layout1 = new StackLayout
+			var layout = new StackLayout
 			{
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill,
-				BackgroundColor = Color.Transparent
+				BackgroundColor = backgroundColor,
+				InputTransparent = inputTransparent,
+				Opacity = opacity
 			};
 
-			grid.Children.Add(layout1);
-			Grid.SetRow(layout1, 0);
+			grid.Children.Add(button);
+			Grid.SetRow(button, 1);
+			
+			grid.Children.Add(layout);
+			Grid.SetRow(layout, 1);
 
-			var layout2 = new StackLayout
-			{
-				HorizontalOptions = LayoutOptions.Fill,
-				VerticalOptions = LayoutOptions.Fill,
-				BackgroundColor = Color.Blue,
-				Opacity = 0.2
-			};
-
-			grid.Children.Add(layout2);
-			Grid.SetRow(layout2, 1);
-
-			Content = grid;
+			return new ContentPage { Content = grid, Title = test.ToString()};
 		}
+
+#if UITEST
+		[Test, TestCaseSource(nameof(GenerateTests))]
+		public void VerifyInputTransparent(TestPoint test)
+		{
+			RunningApp.WaitForElement(q => q.Marked(test.AutomationId));
+			RunningApp.Tap(test.AutomationId);
+
+			RunningApp.WaitForElement(DefaultButtonText);
+			RunningApp.Tap(DefaultButtonText);
+
+			if (test.ShouldBeTransparent)
+			{
+				RunningApp.WaitForElement(Success);
+			}
+			else
+			{
+				RunningApp.WaitForElement(DefaultButtonText);
+			}
+		}
+#endif
+
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 		const string Success = "Success";
 		const string Failure = "Failure";
 		const string DefaultButtonText = "Button";
+		const string Overlay = "overlay";
 
 		protected override void Init()
 		{
@@ -133,7 +134,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var layout = new StackLayout
 			{
-                AutomationId = "overlay",
+                AutomationId = Overlay,
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill,
 				BackgroundColor = backgroundColor,
@@ -157,15 +158,16 @@ namespace Xamarin.Forms.Controls.Issues
             RunningApp.WaitForElement(q => q.Marked(test.AutomationId));
             RunningApp.Tap(test.AutomationId);
 
-            var button = RunningApp.WaitForElement(DefaultButtonText);
+
 
 #if __IOS__
-            // For the tests where the overlay is not input transparent, the UI tests on 
-            // iOS can 'see' the button with WaitForElement but not with Tap. So we'll
-            // just tap the coordinates of the button's center blindly instead
-            RunningApp.TapCoordinates(button[0].Rect.CenterX, button[0].Rect.CenterY);
+			// For the tests where the overlay is not input transparent, the UI tests on 
+			// iOS can't find the button. So we'll just tap the coordinates of the layout's center blindly instead
+			var overlay = RunningApp.WaitForElement(Overlay);
+			RunningApp.TapCoordinates(overlay[0].Rect.CenterX, overlay[0].Rect.CenterY);
 #else
-            RunningApp.Tap(DefaultButtonText);
+			var button = RunningApp.WaitForElement(DefaultButtonText);
+			RunningApp.Tap(DefaultButtonText);
 #endif
             RunningApp.WaitForElement(test.ShouldBeTransparent ? Success : DefaultButtonText);
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla24769.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla25234.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla25662.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla25943.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla26501.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla26868.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla27378.cs" />
@@ -280,6 +281,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52533.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53362.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45874.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TransparentOverlayTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Unreported1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ListViewNRE.cs" />

--- a/Xamarin.Forms.Platform.Android/FastRenderers/GestureManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/GestureManager.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			if (View.GestureRecognizers.Count == 0)
 			{
 				handled = true;
-				return _motionEventHelper.HandleMotionEvent(parent);
+				return _motionEventHelper.HandleMotionEvent(parent, e);
 			}
 
 			handled = false;

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1046,7 +1046,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (base.OnTouchEvent(e))
 					return true;
 
-				return _motionEventHelper.HandleMotionEvent(Parent);
+				return _motionEventHelper.HandleMotionEvent(Parent, e);
 			}
 
 			protected override void OnElementChanged(ElementChangedEventArgs<View> e)
@@ -1058,7 +1058,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			public override bool DispatchTouchEvent(MotionEvent e)
 			{
-				#region
+				#region Excessive explanation
 				// Normally dispatchTouchEvent feeds the touch events to its children one at a time, top child first,
 				// (and only to the children in the hit-test area of the event) stopping as soon as one of them has handled
 				// the event. 

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1094,7 +1094,7 @@ namespace Xamarin.Forms.Platform.Android
 					return OnTouchEvent(e);
 				}
 
-                return result;
+				return result;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1034,9 +1034,26 @@ namespace Xamarin.Forms.Platform.Android
 		internal class DefaultRenderer : VisualElementRenderer<View>
 		{
 			bool _notReallyHandled;
+			readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
+
 			internal void NotifyFakeHandling()
 			{
 				_notReallyHandled = true;
+			}
+
+			public override bool OnTouchEvent(MotionEvent e)
+			{
+				if (base.OnTouchEvent(e))
+					return true;
+
+				return _motionEventHelper.HandleMotionEvent(Parent);
+			}
+
+			protected override void OnElementChanged(ElementChangedEventArgs<View> e)
+			{
+				base.OnElementChanged(e);
+
+				_motionEventHelper.UpdateElement(e.NewElement);
 			}
 
 			public override bool DispatchTouchEvent(MotionEvent e)
@@ -1074,11 +1091,10 @@ namespace Xamarin.Forms.Platform.Android
 					// don't consider the event truly "handled" yet. 
 					// Since a child control short-circuited the normal dispatchTouchEvent stuff, this layout never got the chance for
 					// IOnTouchListener.OnTouch and the OnTouchEvent override to try handling the touches; we'll do that now
-
 					return OnTouchEvent(e);
 				}
 
-				return result;
+                return result;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (base.OnTouchEvent(e))
 				return true;
 
-			return _motionEventHelper.HandleMotionEvent(Parent);
+			return _motionEventHelper.HandleMotionEvent(Parent, e);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)

--- a/Xamarin.Forms.Platform.Android/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ImageRenderer.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Platform.Android
             if (base.OnTouchEvent(e))
                 return true;
 
-            return _motionEventHelper.HandleMotionEvent(Parent);
+            return _motionEventHelper.HandleMotionEvent(Parent, e);
         }
     }
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -200,7 +200,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (base.OnTouchEvent(e))
 				return true;
 
-			return _motionEventHelper.HandleMotionEvent(Parent);
+			return _motionEventHelper.HandleMotionEvent(Parent, e);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/MotionEventHelper.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MotionEventHelper.cs
@@ -7,9 +7,9 @@ namespace Xamarin.Forms.Platform.Android
 		VisualElement _element;
 		bool _isInViewCell;
 
-		public bool HandleMotionEvent(IViewParent parent)
+		public bool HandleMotionEvent(IViewParent parent, MotionEvent motionEvent)
 		{
-			if (_isInViewCell || _element.InputTransparent)
+			if (_isInViewCell || _element.InputTransparent || motionEvent.Action == MotionEventActions.Cancel)
 			{
 				return false;
 			}

--- a/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
@@ -27,28 +27,27 @@ namespace Xamarin.Forms.Platform.Android
 				}
 			}
 
-			// do some evil
-			// This is required so that a layout only absorbs click events if it is not fully transparent
-			// However this is not desirable behavior in a ViewCell because it prevents the ViewCell from activating
-			if (view is Layout && view.BackgroundColor != Color.Transparent && view.BackgroundColor != Color.Default)
+			// Most layouts should be clickable, but not if they're in a ViewCell because that
+			// interferes with the ViewCell's handlers
+			if (!(view is Layout))
 			{
-				Element parent = view.RealParent;
-				var skip = false;
-				while (parent != null)
-				{
-					if (parent is ViewCell)
-					{
-						skip = true;
-						break;
-					}
-					parent = parent.RealParent;
-				}
-
-				if (!skip)
-					shouldBeClickable = true;
+				return shouldBeClickable;
 			}
 
-			return shouldBeClickable;
+			// Walk up the view tree to ensure we aren't in a ViewCell
+			Element parent = view.RealParent;
+			while (parent != null)
+			{
+				if (parent is ViewCell)
+				{
+					// We're in a ViewCell, so clickable should be false
+					return false;
+				}
+				parent = parent.RealParent;
+			}
+
+			// If we're not, we can be clickable
+			return true;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -16,38 +17,31 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static bool ShouldBeMadeClickable(this View view)
 		{
-			var shouldBeClickable = false;
-			for (var i = 0; i < view.GestureRecognizers.Count; i++)
-			{
-				IGestureRecognizer gesture = view.GestureRecognizers[i];
-				if (gesture is TapGestureRecognizer || gesture is PinchGestureRecognizer || gesture is PanGestureRecognizer)
-				{
-					shouldBeClickable = true;
-					break;
-				}
-			}
+            for (var i = 0; i < view.GestureRecognizers.Count; i++)
+            {
+                IGestureRecognizer gesture = view.GestureRecognizers[i];
+                if (gesture is TapGestureRecognizer || gesture is PinchGestureRecognizer || gesture is PanGestureRecognizer)
+                {
+                    return true;
+                }
+            }
 
-			// Most layouts should be clickable, but not if they're in a ViewCell because that
-			// interferes with the ViewCell's handlers
-			if (!(view is Layout))
-			{
-				return shouldBeClickable;
-			}
+            return false;
+		}
 
-			// Walk up the view tree to ensure we aren't in a ViewCell
+		static bool IsInViewCell(this View view)
+		{
 			Element parent = view.RealParent;
 			while (parent != null)
 			{
 				if (parent is ViewCell)
 				{
-					// We're in a ViewCell, so clickable should be false
-					return false;
+					return true;
 				}
 				parent = parent.RealParent;
 			}
 
-			// If we're not, we can be clickable
-			return true;
+			return false;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -27,21 +26,6 @@ namespace Xamarin.Forms.Platform.Android
             }
 
             return false;
-		}
-
-		static bool IsInViewCell(this View view)
-		{
-			Element parent = view.RealParent;
-			while (parent != null)
-			{
-				if (parent is ViewCell)
-				{
-					return true;
-				}
-				parent = parent.RealParent;
-			}
-
-			return false;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
@@ -16,16 +16,16 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static bool ShouldBeMadeClickable(this View view)
 		{
-            for (var i = 0; i < view.GestureRecognizers.Count; i++)
-            {
-                IGestureRecognizer gesture = view.GestureRecognizers[i];
-                if (gesture is TapGestureRecognizer || gesture is PinchGestureRecognizer || gesture is PanGestureRecognizer)
-                {
-                    return true;
-                }
-            }
+			for (var i = 0; i < view.GestureRecognizers.Count; i++)
+			{
+				IGestureRecognizer gesture = view.GestureRecognizers[i];
+				if (gesture is TapGestureRecognizer || gesture is PinchGestureRecognizer || gesture is PanGestureRecognizer)
+				{
+					return true;
+				}
+			}
 
-            return false;
+			return false;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -92,8 +92,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)
 		{
-			if (!Element.IsEnabled || (Element.InputTransparent && Element.IsEnabled))
+            if (!Element.IsEnabled || (Element.InputTransparent && Element.IsEnabled))
+            {
 				return true;
+            }
 
 			return base.OnInterceptTouchEvent(ev);
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -92,10 +92,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)
 		{
-            if (!Element.IsEnabled || (Element.InputTransparent && Element.IsEnabled))
-            {
+			if (!Element.IsEnabled || (Element.InputTransparent && Element.IsEnabled))
+			{
 				return true;
-            }
+			}
 
 			return base.OnInterceptTouchEvent(ev);
 		}

--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -543,7 +543,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (control != null)
 				control.IsEnabled = Element.IsEnabled;
 			else
-				IsHitTestVisible = Element.IsEnabled;
+				IsHitTestVisible = Element.IsEnabled && !Element.InputTransparent;
 		}
 
 		void UpdateTracker()

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -449,7 +449,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		static void UpdateInputTransparent(VisualElement view, FrameworkElement frameworkElement)
 		{
-			frameworkElement.IsHitTestVisible = !view.InputTransparent;
+			frameworkElement.IsHitTestVisible = view.IsEnabled && !view.InputTransparent;
 		}
 
 		static void UpdateOpacity(VisualElement view, FrameworkElement frameworkElement)

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 using RectangleF = CoreGraphics.CGRect;
@@ -478,6 +479,30 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal class DefaultRenderer : VisualElementRenderer<VisualElement>
 		{
+			public override UIView HitTest(CGPoint point, UIEvent uievent)
+			{
+				// UIview hit testing ignores objects which have an alpha of less than 0.01 
+				// (see https://developer.apple.com/reference/uikit/uiview/1622469-hittest)
+				// To prevent layouts with low opacity from being implicitly input transparent, 
+				// we need to temporarily bump their alpha value during the actual hit testing,
+				// then restore it. If the opacity is high enough or user interaction is disabled, 
+				// we don't have to worry about it.
+
+				nfloat old = Alpha;
+				if (UserInteractionEnabled && old <= 0.01)
+				{
+					Alpha = (nfloat)0.011;
+				}
+
+				var result = base.HitTest(point, uievent);
+
+				if (UserInteractionEnabled && old <= 0.01)
+				{
+					Alpha = old;
+				}
+
+				return result;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This change brings iOS, Windows, and Android into alignment with regard to Layout transparency. 

Previously, Layouts with sufficiently low `Opacity` were input transparent on iOS but not on Windows or Android; Layouts with a `BackgroundColor` of `Transparent` or `Default` were input transparent on Android but not on Windows or iOS; and Layouts with `InputTransparent` were input transparent on iOS, mostly input transparent on Android, and not input transparent at all on Windows. 

With this change, input transparency is entirely a function of the `InputTransparent` flag; if a layout is marked `InputTransparent`, then clicks/taps/gestures will pass through it to controls below. Visual transparency (i.e., `Opacity` and the transparency of the background color) no longer has any bearing on whether a layout is is input transparent. 

### Bugs Fixed ###

- Layouts marked InputTransparent on Windows were not actually input transparent
- [25943 – [Android] TapGestureRecognizer does not work with a nested StackLayout](https://bugzilla.xamarin.com/show_bug.cgi?id=25943)

### API Changes ###

None

### Behavioral Changes ###

- On Android, layouts with a BackgroundColor of Clear or Default are no longer effectively InputTransparent
- On iOS, layouts with an Opacity <= 0.01 are no longer effectively InputTransparent

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
