### PR TITLE
Moving to version 2.0.9 of Xamarin.UITest

### DIFF
--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -57,8 +57,8 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.UITest, Version=2.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.UITest.2.0.5\lib\Xamarin.UITest.dll</HintPath>
+    <Reference Include="Xamarin.UITest, Version=2.0.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.UITest.2.0.9\lib\Xamarin.UITest.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Xamarin.Forms.Core.Android.UITests/packages.config
+++ b/Xamarin.Forms.Core.Android.UITests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="2.0.5" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="2.0.9" targetFramework="net45" />
 </packages>

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -46,8 +46,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Xamarin.UITest, Version=2.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.UITest.2.0.5\lib\Xamarin.UITest.dll</HintPath>
+    <Reference Include="Xamarin.UITest, Version=2.0.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.UITest.2.0.9\lib\Xamarin.UITest.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Xamarin.Forms.Core.Windows.UITests/packages.config
+++ b/Xamarin.Forms.Core.Windows.UITests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="2.0.5" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="2.0.9" targetFramework="net45" />
 </packages>

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -58,8 +58,8 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.UITest, Version=2.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.UITest.2.0.5\lib\Xamarin.UITest.dll</HintPath>
+    <Reference Include="Xamarin.UITest, Version=2.0.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.UITest.2.0.9\lib\Xamarin.UITest.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Xamarin.Forms.Core.iOS.UITests/packages.config
+++ b/Xamarin.Forms.Core.iOS.UITests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="2.0.5" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="2.0.9" targetFramework="net45" />
 </packages>

--- a/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
+++ b/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
@@ -41,6 +41,10 @@
     <Reference Include="ServiceStack.Client">
       <HintPath>..\packages\ServiceStack.Client.4.5.4\lib\net45\ServiceStack.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.UITest, Version=2.0.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.UITest.2.0.9\lib\Xamarin.UITest.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Xamarin.UITest.Desktop">
       <HintPath>..\packages\Xamarin.UITest.Desktop.0.0.7\lib\net45\Xamarin.UITest.Desktop.dll</HintPath>
     </Reference>
@@ -62,9 +66,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.UITest">
-      <HintPath>..\packages\Xamarin.UITest.2.0.5\lib\Xamarin.UITest.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.macOS.UITests/packages.config
+++ b/Xamarin.Forms.Core.macOS.UITests/packages.config
@@ -5,6 +5,6 @@
   <package id="ServiceStack.Client" version="4.5.4" targetFramework="net45" />
   <package id="ServiceStack.Interfaces" version="4.5.4" targetFramework="net45" />
   <package id="ServiceStack.Text" version="4.5.4" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="2.0.5" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="2.0.9" targetFramework="net45" />
   <package id="Xamarin.UITest.Desktop" version="0.0.7" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
### Description of Change ###

Bumps the UI test library version to 2.0.9 so we can run UI tests on machines with XCode 8.3.

