### PR TITLE
[UWP] ListView memory leak fix

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -44,6 +44,11 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				if (Cell != null)
 					Cell.SendDisappearing();
+//disconnect Forms versions
+				Xamarin.Forms.ViewCell XCell = Cell as Xamarin.Forms.ViewCell;
+				if (XCell != null)
+					XCell.Parent = null; //disconnect from parent view
+				
 			};
 
 			_propertyChangedHandler = OnCellPropertyChanged;
@@ -247,6 +252,10 @@ namespace Xamarin.Forms.Platform.WinRT
 				cell.SetIsGroupHeader<ItemsView<Cell>, Cell>(isGroupHeader);
 			}
 
+		//disconnect Forms versions during scrolling operations
+				Xamarin.Forms.ViewCell VCell = Cell as Xamarin.Forms.ViewCell;
+				if (VCell != null)
+					VCell.Parent = null; //disconnect from parent view
 			Cell = cell;
 		}
 


### PR DESCRIPTION
### Description of Change ###

ListView on UWP have memory leak. Xamarin Forms objects created inside of list view keeps attached to listview even when ItemSource is nulled. 

Also it slightly improve situation after modification of attached collections but doesn't fixing it completelly.

### Bugs Fixed ###

-Not 

### API Changes ###

No changes

### Behavioral Changes ###

In case of lot of items in ItemSource can assigment null take time/makes application slower in that time because of freeing lot of created items.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
