### PR TITLE
[macOS] bz56855 Implementation of macOS.MasterDetailsPage.IsPresented.

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
@@ -126,27 +126,54 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (e.PropertyName == "Master" || e.PropertyName == "Detail")
 				UpdateControllers();
+			else if( e.PropertyName == Xamarin.Forms.MasterDetailPage.IsPresentedProperty.PropertyName )
+				UpdateIsPresented( );
+		}
+
+		void UpdateIsPresented( )
+		{
+			if( MasterDetailPage == null || SplitView == null )
+				return;
+
+			NSView view = SplitView.Subviews.FirstOrDefault( );
+			if( view == null )
+				return;
+
+			if( MasterDetailPage.IsPresented && view.Hidden )
+				view.Hidden = false;
+			else if( !MasterDetailPage.IsPresented && !view.Hidden )
+				view.Hidden = true;
 		}
 
 		void UpdateControllers()
 		{
 			ClearControllers();
 
-			if (Platform.GetRenderer(MasterDetailPage.Master) == null)
+			ClearControllers( );
+
+			if( Platform.GetRenderer(MasterDetailPage.Master) == null )
 				Platform.SetRenderer(MasterDetailPage.Master, Platform.CreateRenderer(MasterDetailPage.Master));
-			if (Platform.GetRenderer(MasterDetailPage.Detail) == null)
+			if( Platform.GetRenderer(MasterDetailPage.Detail) == null )
 				Platform.SetRenderer(MasterDetailPage.Detail, Platform.CreateRenderer(MasterDetailPage.Detail));
 
+			ViewControllerWrapper masterController = new ViewControllerWrapper(Platform.GetRenderer(MasterDetailPage.Master));
+			masterController.WillAppear -= MasterController_WillAppear;
+			masterController.WillAppear += MasterController_WillAppear;
+			masterController.WillDisappear -= MasterController_WillDisappear;
+			masterController.WillDisappear += MasterController_WillDisappear;
+			ViewControllerWrapper detailController = new ViewControllerWrapper(Platform.GetRenderer(MasterDetailPage.Detail));
+
 			AddSplitViewItem(new NSSplitViewItem
 			{
-				ViewController = new ViewControllerWrapper(Platform.GetRenderer(MasterDetailPage.Master))
+				ViewController = masterController
 			});
 			AddSplitViewItem(new NSSplitViewItem
 			{
-				ViewController = new ViewControllerWrapper(Platform.GetRenderer(MasterDetailPage.Detail))
+				ViewController = detailController
 			});
 
-			UpdateChildrenLayout();
+			UpdateChildrenLayout( );
+			UpdateIsPresented( );
 		}
 
 		void ClearControllers()
@@ -155,6 +182,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				var splitItem = SplitViewItems.Last();
 				var childVisualRenderer = splitItem.ViewController as ViewControllerWrapper;
+				childVisualRenderer.WillAppear -= MasterController_WillAppear;
+				childVisualRenderer.WillDisappear -= MasterController_WillDisappear;
 				RemoveSplitViewItem(splitItem);
 				IVisualElementRenderer render = null;
 				if (childVisualRenderer.RendererWeakRef.TryGetTarget(out render))
@@ -171,9 +200,29 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 		}
 
+		private void MasterController_WillDisappear( object sender, EventArgs e )
+		{
+			if (Element == null || MasterDetailPage == null)
+				return;
+
+			if( MasterDetailPage.CanChangeIsPresented && MasterDetailPage.IsPresented )
+				Element.SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, false);
+		}
+
+		private void MasterController_WillAppear( object sender, EventArgs e )
+		{
+			if (Element == null || MasterDetailPage == null)
+				return;
+
+			if( MasterDetailPage.CanChangeIsPresented && !MasterDetailPage.IsPresented )
+				Element.SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, true);
+		}
+
 		sealed class ViewControllerWrapper : NSViewController
 		{
 			internal WeakReference<IVisualElementRenderer> RendererWeakRef;
+			public event EventHandler WillAppear;
+			public event EventHandler WillDisappear;
 
 			public ViewControllerWrapper(IVisualElementRenderer renderer)
 			{
@@ -189,6 +238,20 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (RendererWeakRef.TryGetTarget(out renderer))
 					renderer?.Element?.Layout(new Rectangle(0, 0, View.Bounds.Width, View.Bounds.Height));
 				base.ViewWillLayout();
+			}
+
+			public override void ViewWillAppear( )
+			{
+				base.ViewWillAppear( );
+				if( WillAppear != null )
+					WillAppear(this, EventArgs.Empty);
+			}
+
+			public override void ViewWillDisappear( )
+			{
+				base.ViewWillDisappear( );
+				if( WillDisappear != null )
+					WillDisappear(this, EventArgs.Empty);
 			}
 
 			protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
@@ -126,22 +126,22 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (e.PropertyName == "Master" || e.PropertyName == "Detail")
 				UpdateControllers();
-			else if( e.PropertyName == Xamarin.Forms.MasterDetailPage.IsPresentedProperty.PropertyName )
-				UpdateIsPresented( );
+			else if (e.PropertyName == Xamarin.Forms.MasterDetailPage.IsPresentedProperty.PropertyName)
+				UpdateIsPresented();
 		}
 
-		void UpdateIsPresented( )
+		void UpdateIsPresented()
 		{
-			if( MasterDetailPage == null || SplitView == null )
+			if (MasterDetailPage == null || SplitView == null)
 				return;
 
-			NSView view = SplitView.Subviews.FirstOrDefault( );
-			if( view == null )
+			NSView view = SplitView.Subviews.FirstOrDefault();
+			if (view == null)
 				return;
 
-			if( MasterDetailPage.IsPresented && view.Hidden )
+			if (MasterDetailPage.IsPresented && view.Hidden)
 				view.Hidden = false;
-			else if( !MasterDetailPage.IsPresented && !view.Hidden )
+			else if (!MasterDetailPage.IsPresented && !view.Hidden)
 				view.Hidden = true;
 		}
 
@@ -149,11 +149,11 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			ClearControllers();
 
-			ClearControllers( );
+			ClearControllers();
 
-			if( Platform.GetRenderer(MasterDetailPage.Master) == null )
+			if (Platform.GetRenderer(MasterDetailPage.Master) == null)
 				Platform.SetRenderer(MasterDetailPage.Master, Platform.CreateRenderer(MasterDetailPage.Master));
-			if( Platform.GetRenderer(MasterDetailPage.Detail) == null )
+			if (Platform.GetRenderer(MasterDetailPage.Detail) == null)
 				Platform.SetRenderer(MasterDetailPage.Detail, Platform.CreateRenderer(MasterDetailPage.Detail));
 
 			ViewControllerWrapper masterController = new ViewControllerWrapper(Platform.GetRenderer(MasterDetailPage.Master));
@@ -172,8 +172,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				ViewController = detailController
 			});
 
-			UpdateChildrenLayout( );
-			UpdateIsPresented( );
+			UpdateChildrenLayout();
+			UpdateIsPresented();
 		}
 
 		void ClearControllers()
@@ -200,21 +200,21 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 		}
 
-		private void MasterController_WillDisappear( object sender, EventArgs e )
+		private void MasterController_WillDisappear(object sender, EventArgs e)
 		{
 			if (Element == null || MasterDetailPage == null)
 				return;
 
-			if( MasterDetailPage.CanChangeIsPresented && MasterDetailPage.IsPresented )
+			if (MasterDetailPage.CanChangeIsPresented && MasterDetailPage.IsPresented)
 				Element.SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, false);
 		}
 
-		private void MasterController_WillAppear( object sender, EventArgs e )
+		private void MasterController_WillAppear(object sender, EventArgs e)
 		{
 			if (Element == null || MasterDetailPage == null)
 				return;
 
-			if( MasterDetailPage.CanChangeIsPresented && !MasterDetailPage.IsPresented )
+			if (MasterDetailPage.CanChangeIsPresented && !MasterDetailPage.IsPresented)
 				Element.SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, true);
 		}
 
@@ -240,17 +240,17 @@ namespace Xamarin.Forms.Platform.MacOS
 				base.ViewWillLayout();
 			}
 
-			public override void ViewWillAppear( )
+			public override void ViewWillAppear()
 			{
-				base.ViewWillAppear( );
-				if( WillAppear != null )
+				base.ViewWillAppear();
+				if (WillAppear != null)
 					WillAppear(this, EventArgs.Empty);
 			}
 
-			public override void ViewWillDisappear( )
+			public override void ViewWillDisappear()
 			{
-				base.ViewWillDisappear( );
-				if( WillDisappear != null )
+				base.ViewWillDisappear();
+				if (WillDisappear != null)
 					WillDisappear(this, EventArgs.Empty);
 			}
 


### PR DESCRIPTION
### Description of Change ###

Added handling of IsPresented on macOS's MasterDetailsPage.

Omitted tests as this is new functionality.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=56855

### API Changes ###

none

### Behavioral Changes ###

MasterDetailsPage can now handle IsPresented correctly for hiding and showing.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
