### PR TITLE
[XamlG] use random (short) file names for XamlG outputs

### DIFF
--- a/.nuspec/Xamarin.Forms.Debug.targets
+++ b/.nuspec/Xamarin.Forms.Debug.targets
@@ -43,7 +43,7 @@
 			<Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="XamlFiles" />
 		</FixedCreateCSharpManifestResourceName>
 		<ItemGroup>
-			<XamlGFiles Include="@(XamlFiles->'$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)')"/>
+			<XamlGFiles Include="@(XamlFiles->'$(IntermediateOutputPath)%(RandomFileName).g$(DefaultLanguageSourceExtension)')"/>
 			<Compile Include="@(XamlGFiles)"/>
 			<FileWrites Include="@(XamlGFiles)"/>
 		</ItemGroup>
@@ -51,12 +51,12 @@
 
 	<Target Name="_CoreXamlG"
 		Inputs = "@(XamlFiles)"
-		Outputs = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
+		Outputs = "$(IntermediateOutputPath)%(RandomFileName).g$(DefaultLanguageSourceExtension)">
 		<XamlGTask
 			Source="@(XamlFiles)"
 			Language = "$(Language)"
 			AssemblyName = "$(AssemblyName)"
-			OutputFile = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
+			OutputFile = "$(IntermediateOutputPath)%(RandomFileName).g$(DefaultLanguageSourceExtension)">
 		</XamlGTask>
 	</Target>
 

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -41,7 +41,7 @@
 			<Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="XamlFiles" />
 		</FixedCreateCSharpManifestResourceName>
 		<ItemGroup>
-			<XamlGFiles Include="@(XamlFiles->'$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)')"/>
+			<XamlGFiles Include="@(XamlFiles->'$(IntermediateOutputPath)%(RandomFileName).g$(DefaultLanguageSourceExtension)')"/>
 			<Compile Include="@(XamlGFiles)"/>
 			<FileWrites Include="@(XamlGFiles)"/>
 		</ItemGroup>
@@ -49,12 +49,12 @@
   
 	<Target Name="_CoreXamlG"
 		Inputs = "@(XamlFiles)"
-		Outputs = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
+		Outputs = "$(IntermediateOutputPath)%(RandomFileName).g$(DefaultLanguageSourceExtension)">
 		<XamlGTask
 			Source="@(XamlFiles)"
 			Language = "$(Language)"
 			AssemblyName = "$(AssemblyName)"
-			OutputFile = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
+			OutputFile = "$(IntermediateOutputPath)%(RandomFileName).g$(DefaultLanguageSourceExtension)">
 		</XamlGTask>
 	</Target>
   

--- a/Xamarin.Forms.Build.Tasks/FixedCreateCSharpManifestResourceName.cs
+++ b/Xamarin.Forms.Build.Tasks/FixedCreateCSharpManifestResourceName.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Build.Tasks
 			{
 				var copy = new TaskItem(ResourceFiles[i]);
 				copy.SetMetadata("ManifestResourceName", ManifestResourceNames[i].ItemSpec);
+				copy.SetMetadata("RandomFileName", System.IO.Path.GetRandomFileName());
 				ResourceFilesWithManifestResourceNames[i] = copy;
 			}
 			return ret;


### PR DESCRIPTION
### Description of Change ###

Use random short filenames for XamlG outputs.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=40077

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense