### PR TITLE
bz56945, macOS: Issue where colored text on buttons were not centering correctly…

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 			else
 			{
-				var textWithColor = new NSAttributedString(Element.Text ?? "", foregroundColor: color.ToNSColor());
+				var textWithColor = new NSAttributedString(Element.Text ?? "", foregroundColor: color.ToNSColor( ), paragraphStyle: new NSMutableParagraphStyle( ) { Alignment = NSTextAlignment.Center });
 				Control.AttributedTitle = textWithColor;
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Added AttributedText to center horizontally in macOS on Buttons.

Tests omitted.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=56945

### API Changes ###

None.

### Behavioral Changes ###

macOS's buttons will now layout their colored text to the center rather than defaulting to start.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
