### PR TITLE
[C] use picker creation date as default Date

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
@@ -162,7 +162,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var datePicker = new DatePicker ();
 			Assert.DoesNotThrow (() => datePicker.SetValue (DatePicker.DateProperty, null));
-			Assert.AreEqual (DatePicker.DateProperty.DefaultValue, datePicker.Date);
+			Assert.AreEqual (DateTime.Today, datePicker.Date);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -8,8 +8,10 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(DatePicker), "d");
 
-		public static readonly BindableProperty DateProperty = BindableProperty.Create(nameof(Date), typeof(DateTime), typeof(DatePicker), DateTime.Today, BindingMode.TwoWay, coerceValue: CoerceDate,
-			propertyChanged: DatePropertyChanged);
+		public static readonly BindableProperty DateProperty = BindableProperty.Create(nameof(Date), typeof(DateTime), typeof(DatePicker), default(DateTime), BindingMode.TwoWay,
+			coerceValue: CoerceDate,
+			propertyChanged: DatePropertyChanged,
+			defaultValueCreator: (bindable) => DateTime.Today);
 
 		public static readonly BindableProperty MinimumDateProperty = BindableProperty.Create(nameof(MinimumDate), typeof(DateTime), typeof(DatePicker), new DateTime(1900, 1, 1),
 			validateValue: ValidateMinimumDate, coerceValue: CoerceMinimumDate);


### PR DESCRIPTION
### Description of Change ###

Use picker creation date as default Date.

Not easy to write a unit test for this, so there's none.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44011

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense