### PR TITLE
[previewer] make sure we do not crash even if the previewer doesn't s…

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/XamlLoaderGetXamlForTypeTests.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlLoaderGetXamlForTypeTests.xaml.cs
@@ -28,7 +28,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 #pragma warning disable 0618
 				Xamarin.Forms.Xaml.Internals.XamlLoader.XamlFileProvider = null;
 #pragma warning restore 0618
-
 			}
 
 			[TestCase(false)]

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Xaml.Internals
 			internal set {
 				xamlFileProvider = value;
 				//¯\_(ツ)_/¯ the previewer forgot to set that bool
-				DoNotThrowOnExceptions = true;
+				DoNotThrowOnExceptions = value != null;
 			}
 		}
 

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -39,7 +39,17 @@ namespace Xamarin.Forms.Xaml.Internals
 	[Obsolete ("Replaced by ResourceLoader")]
 	public static class XamlLoader
 	{
-		public static Func<Type, string> XamlFileProvider { get; internal set; }
+		static Func<Type, string> xamlFileProvider;
+
+		public static Func<Type, string> XamlFileProvider {
+			get { return xamlFileProvider; }
+			internal set {
+				xamlFileProvider = value;
+				//¯\_(ツ)_/¯ the previewer forgot to set that bool
+				DoNotThrowOnExceptions = true;
+			}
+		}
+
 		internal static bool DoNotThrowOnExceptions { get; set; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Make sure we do not crash even if the previewer doesn't sets the flag. This used to work, but somehow regressed when the previewer started to use the XamlLoader API...

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=56895

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense