### PR TITLE
[UWP] Use CompositeTransform for ScrollView/ListView/TableView to allow scrolling

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla49304.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla49304.cs
@@ -30,17 +30,22 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Children =
 				{
-					new Label { Text = "The ScrollView, ListView, and TableView below should be rotated 180 degrees, but still scrollable" },
+					new Label {
+						Text = "The ScrollView, ListView, and TableView below should be rotated 180 degrees, but only the latter two " +
+							   "should still be scrollable, as the ScrollView has non-zero (.000001/-.000001 RotationX/RotationY values."
+					},
 					new ScrollView
 					{
 						Content = stack,
 						Rotation = 180,
-						TranslationX = -20
+						RotationX = .000001,
+						RotationY = -.000001
 					},
 					new ListView
 					{
 						ItemsSource = items,
-						Rotation = 180
+						Rotation = 180,
+						TranslationX = -20
 					},
 					new TableView {
 						Rotation = 180,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla49304.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla49304.cs
@@ -1,0 +1,76 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 49304, "[UWP] ScrollView and ListView are not scrolling after rotation", PlatformAffected.UWP)]
+	public class Bugzilla49304 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var stack = new StackLayout();
+			for (int i = 0; i < 50; i++)
+			{
+				stack.Children.Add(new Label { Text = i.ToString() });
+			}
+
+			var items = new List<string>();
+			for (int i = 0; i < 50; i++)
+			{
+				items.Add(i.ToString());
+			}
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label { Text = "The ScrollView, ListView, and TableView below should be rotated 180 degrees, but still scrollable" },
+					new ScrollView
+					{
+						Content = stack,
+						Rotation = 180,
+						TranslationX = -20
+					},
+					new ListView
+					{
+						ItemsSource = items,
+						Rotation = 180
+					},
+					new TableView {
+						Rotation = 180,
+						Intent = TableIntent.Form,
+						Root = new TableRoot ("Table Title") {
+							new TableSection ("Section 1 Title") {
+								new TextCell {
+									Text = "TextCell Text",
+									Detail = "TextCell Detail"
+								},
+								new EntryCell {
+									Label = "EntryCell:",
+									Placeholder = "default keyboard",
+									Keyboard = Keyboard.Default
+								}
+							},
+							new TableSection ("Section 2 Title") {
+								new EntryCell {
+									Label = "Another EntryCell:",
+									Placeholder = "phone keyboard",
+									Keyboard = Keyboard.Telephone
+								},
+								new SwitchCell {
+									Text = "SwitchCell:"
+								}
+							}
+						}
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -172,6 +172,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46363.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47548.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52419.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla49304.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53834.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51536.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44940.cs" />

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -478,16 +478,30 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 			else
 			{
-				frameworkElement.Projection = new PlaneProjection
+				if (frameworkElement is ListViewRenderer || frameworkElement is ScrollViewRenderer || frameworkElement is TableViewRenderer)
 				{
-					CenterOfRotationX = anchorX,
-					CenterOfRotationY = anchorY,
-					GlobalOffsetX = scale == 0 ? 0 : translationX / scale,
-					GlobalOffsetY = scale == 0 ? 0 : translationY / scale,
-					RotationX = -rotationX,
-					RotationY = -rotationY,
-					RotationZ = -rotation
-				};
+					frameworkElement.RenderTransform = new CompositeTransform
+					{
+						CenterX = anchorX,
+						CenterY = anchorY,
+						Rotation = rotation,
+						TranslateX = scale == 0 ? 0 : translationX / scale,
+						TranslateY = scale == 0 ? 0 : translationY / scale
+					};
+				}
+				else
+				{
+					frameworkElement.Projection = new PlaneProjection
+					{
+						CenterOfRotationX = anchorX,
+						CenterOfRotationY = anchorY,
+						GlobalOffsetX = scale == 0 ? 0 : translationX / scale,
+						GlobalOffsetY = scale == 0 ? 0 : translationY / scale,
+						RotationX = -rotationX,
+						RotationY = -rotationY,
+						RotationZ = -rotation
+					};
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -478,7 +478,12 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 			else
 			{
-				if (frameworkElement is ListViewRenderer || frameworkElement is ScrollViewRenderer || frameworkElement is TableViewRenderer)
+				// PlaneProjection removes touch and scrollwheel functionality on scrollable views such
+				// as ScrollView, ListView, and TableView. If neither RotationX or RotationY are set
+				// (i.e. their absolute value is 0), a CompositeTransform is instead used to allow for
+				// rotation of the control on a 2D plane, and the other values are set. Otherwise, the
+				// rotation values are set, but the aforementioned functionality will be lost.
+				if (Math.Abs(view.RotationX) == 0 && Math.Abs(view.RotationY) == 0)
 				{
 					frameworkElement.RenderTransform = new CompositeTransform
 					{

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -485,17 +485,6 @@ namespace Xamarin.Forms.Platform.WinRT
 				// rotation values are set, but the aforementioned functionality will be lost.
 				if (Math.Abs(view.RotationX) == 0 && Math.Abs(view.RotationY) == 0)
 				{
-					frameworkElement.RenderTransform = new CompositeTransform
-					{
-						CenterX = anchorX,
-						CenterY = anchorY,
-						Rotation = rotation,
-						TranslateX = scale == 0 ? 0 : translationX / scale,
-						TranslateY = scale == 0 ? 0 : translationY / scale
-					};
-				}
-				else
-				{
 					frameworkElement.Projection = new PlaneProjection
 					{
 						CenterOfRotationX = anchorX,
@@ -505,6 +494,17 @@ namespace Xamarin.Forms.Platform.WinRT
 						RotationX = -rotationX,
 						RotationY = -rotationY,
 						RotationZ = -rotation
+					};
+				}
+				else
+				{
+					frameworkElement.RenderTransform = new CompositeTransform
+					{
+						CenterX = anchorX,
+						CenterY = anchorY,
+						Rotation = rotation,
+						TranslateX = scale == 0 ? 0 : translationX / scale,
+						TranslateY = scale == 0 ? 0 : translationY / scale
 					};
 				}
 			}


### PR DESCRIPTION
### Description of Change ###

Using [`PlaneProjection`](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.PlaneProjection) when rotating a `FrameworkElement` prevents scroll functionality from working on `ScrollView`/`ListView`/`TableView`. Using [`CompositeTransform`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.compositetransform) instead allows this functionality to work as expected.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=49304

### API Changes ###

None

### Behavioral Changes ###

Only a Z rotation isn't being applied, but it shouldn't matter in this case.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
