### PR TITLE
Provide better exception for bad INotifyCollectionChanged index bounds

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -500,6 +500,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var groupReset = resetWhenGrouped && Element.IsGroupingEnabled;
 
+			var lastIndex = Control.NumberOfRowsInSection(section);
+			if (e.NewStartingIndex > lastIndex || e.OldStartingIndex > lastIndex)
+				throw new ArgumentException(
+					$"Index '{Math.Max(e.NewStartingIndex, e.OldStartingIndex)}' is greater than the number of rows '{lastIndex}'.");
+
 			switch (e.Action)
 			{
 				case NotifyCollectionChangedAction.Add:


### PR DESCRIPTION
### Description of Change ###

User tried to add multiple rows to a ListView but passed bad arguments to NotifyCollectionChangedEventArgs. Basically, the user asked to insert 2 elements at index 6 however the list had only 2 elements to start. The bad index was passed to iOS which generated an error which, due to the translation, was hard to understand. This PR simply adds a check before the translation and throws a more comprehensible error message.

I've updated the customer reproduction with correct arguments. Basically, when inserting 2 elements at the end of a 4 element list the start index should be 4 instead of 6. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=56771

### API Changes ###

None

### Behavioral Changes ###

None; Better error message. The existing tests are sufficient as they throw the exception on bad input. We're just throwing a more comprehensible message. 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
