### PR TITLE
[iOS] decoupling UpdateText() on LabelRenderer

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -172,7 +172,8 @@ namespace Xamarin.Forms
 			return GetContext(targetProperty) == null;
 		}
 
-		internal object[] GetValues(BindableProperty property0, BindableProperty property1)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public object[] GetValues(BindableProperty property0, BindableProperty property1)
 		{
 			var values = new object[2];
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -6,12 +6,14 @@ using SizeF = CoreGraphics.CGSize;
 #if __MOBILE__
 using UIKit;
 using NativeLabel = UIKit.UILabel;
-
-namespace Xamarin.Forms.Platform.iOS
 #else
 using AppKit;
 using NativeLabel = AppKit.NSTextField;
+#endif
 
+#if __MOBILE__
+namespace Xamarin.Forms.Platform.iOS
+#else
 namespace Xamarin.Forms.Platform.MacOS
 #endif
 {
@@ -110,6 +112,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				}
 
 				UpdateText();
+				UpdateTextColor();
+				UpdateFont();
+
 				UpdateLineBreakMode();
 				UpdateAlignment();
 			}
@@ -126,9 +131,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			else if (e.PropertyName == Label.VerticalTextAlignmentProperty.PropertyName)
 				UpdateLayout();
 			else if (e.PropertyName == Label.TextColorProperty.PropertyName)
-				UpdateText();
+				UpdateTextColor();
 			else if (e.PropertyName == Label.FontProperty.PropertyName)
-				UpdateText();
+				UpdateFont();
 			else if (e.PropertyName == Label.TextProperty.PropertyName)
 				UpdateText();
 			else if (e.PropertyName == Label.FormattedTextProperty.PropertyName)
@@ -248,29 +253,44 @@ namespace Xamarin.Forms.Platform.MacOS
 			var values = Element.GetValues(Label.FormattedTextProperty, Label.TextProperty, Label.TextColorProperty);
 			var formatted = values[0] as FormattedString;
 			if (formatted != null)
-			{
 #if __MOBILE__
 				Control.AttributedText = formatted.ToAttributed(Element, (Color)values[2]);
-			}
-			else
-			{
-				Control.Text = (string)values[1];
-				// default value of color documented to be black in iOS docs
-				Control.Font = Element.ToUIFont();
-				Control.TextColor = ((Color)values[2]).ToUIColor(ColorExtensions.Black);
-			}
 #else
 				Control.AttributedStringValue = formatted.ToAttributed(Element, (Color)values[2]);
-			}
-			else
-			{
-				Control.StringValue = (string)values[1] ?? "";
-				// default value of color documented to be black in iOS docs
-				Control.Font = Element.ToNSFont();
-				Control.TextColor = ((Color)values[2]).ToNSColor(ColorExtensions.Black);
-			}
 #endif
+			else
+#if __MOBILE__
+				Control.Text = (string)values[1];
+#else
+				Control.StringValue = (string)values[1] ?? "";
+#endif
+			UpdateLayout();
+		}
 
+		void UpdateFont()
+		{
+			_perfectSizeValid = false;
+
+#if __MOBILE__
+			Control.Font = Element.ToUIFont();
+#else
+			Control.Font = Element.ToNSFont();
+#endif
+			UpdateLayout();
+		}
+
+		void UpdateTextColor()
+		{
+			_perfectSizeValid = false;
+
+			var textColor = (Color)Element.GetValue(Label.TextColorProperty);
+
+			// default value of color documented to be black in iOS docs
+#if __MOBILE__
+			Control.TextColor = textColor.ToUIColor(ColorExtensions.Black);
+#else
+			Control.TextColor = textColor.ToNSColor(ColorExtensions.Black);
+#endif
 			UpdateLayout();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -246,6 +246,7 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 		}
 
+		bool isTextFormatted;
 		void UpdateText()
 		{
 			_perfectSizeValid = false;
@@ -253,22 +254,35 @@ namespace Xamarin.Forms.Platform.MacOS
 			var values = Element.GetValues(Label.FormattedTextProperty, Label.TextProperty, Label.TextColorProperty);
 			var formatted = values[0] as FormattedString;
 			if (formatted != null)
+			{
 #if __MOBILE__
 				Control.AttributedText = formatted.ToAttributed(Element, (Color)values[2]);
 #else
 				Control.AttributedStringValue = formatted.ToAttributed(Element, (Color)values[2]);
 #endif
+				isTextFormatted = true;
+			}
 			else
+			{
+				if (isTextFormatted)
+				{
+					UpdateFont();
+					UpdateTextColor();
+				}
 #if __MOBILE__
 				Control.Text = (string)values[1];
 #else
 				Control.StringValue = (string)values[1] ?? "";
 #endif
+				isTextFormatted = false;
+			}
 			UpdateLayout();
 		}
 
 		void UpdateFont()
 		{
+			if(isTextFormatted)
+				return;
 			_perfectSizeValid = false;
 
 #if __MOBILE__
@@ -281,6 +295,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateTextColor()
 		{
+			if (isTextFormatted)
+				return;
+			
 			_perfectSizeValid = false;
 
 			var textColor = (Color)Element.GetValue(Label.TextColorProperty);

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/BindableObject.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/BindableObject.xml
@@ -381,6 +381,33 @@ class MyBindable : BindableObject
       </Docs>
     </Member>
     <Member MemberName="GetValues">
+      <MemberSignature Language="C#" Value="public object[] GetValues (Xamarin.Forms.BindableProperty property0, Xamarin.Forms.BindableProperty property1);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance object[] GetValues(class Xamarin.Forms.BindableProperty property0, class Xamarin.Forms.BindableProperty property1) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Object[]</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="property0" Type="Xamarin.Forms.BindableProperty" />
+        <Parameter Name="property1" Type="Xamarin.Forms.BindableProperty" />
+      </Parameters>
+      <Docs>
+        <param name="property0">To be added.</param>
+        <param name="property1">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetValues">
       <MemberSignature Language="C#" Value="public object[] GetValues (Xamarin.Forms.BindableProperty property0, Xamarin.Forms.BindableProperty property1, Xamarin.Forms.BindableProperty property2);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance object[] GetValues(class Xamarin.Forms.BindableProperty property0, class Xamarin.Forms.BindableProperty property1, class Xamarin.Forms.BindableProperty property2) cil managed" />
       <MemberType>Method</MemberType>


### PR DESCRIPTION
### Description of Change ###

As fonts or colors can be changed via an inherited renderer, or an effect, do not force reset them on every text changes.

Those are still resets when switching from formatted text to texts.

As before, no-op on font or color change if the text is formatted, as that would change the Label in a way the user do not expect.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=51631

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
