### PR TITLE
Prevent double dismiss of modal view controller when webview opens image picker on iOS

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Info.plist
+++ b/Xamarin.Forms.ControlGallery.iOS/Info.plist
@@ -104,5 +104,7 @@
 	</dict>
 	<key>CFBundleName</key>
 	<string>XamControl</string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>This app needs access to photos.</string>
 </dict>
 </plist>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44500.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44500.cs
@@ -1,0 +1,62 @@
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 44500,
+		"A WebView that has a file picker control fails to show photo picker when page is pushed modally.",
+		PlatformAffected.iOS)]
+	public class Bugzilla44500 : TestNavigationPage
+	{
+		const string Html = @"
+<html>
+	<head>
+		<title></title>
+	</head>
+	<body>
+		<form>
+			<p>Please select a file:<br>
+				<input type=""file"" name=""datafile"" size=""40"">
+			</p>
+		</form>
+	</body>
+</html>";
+
+		protected override async void Init()
+		{
+			// If you run this test and see a ton of errors like this in your console:
+			// 2017-05-31 17:09:17.662 XamarinFormsControlGalleryiOS[933:703025] AX Exchange error: Error Domain=Accessibility Code=0 "Remote service does not respond to _accessibilityMachPort" UserInfo={NSLocalizedDescription=Remote service does not respond to _accessibilityMachPort}
+			// That's just a Calabash bug, you can safely ignore it. 
+			// If you want to avoid having your console spammed, remove 'Xamarin.Calabash.Start();' from your application. 
+
+			var instructions = new Label
+			{
+				Text = "Click the 'Choose file' button in the WebView. Select 'Photo Library'. If the Photos screen displays, this test has passed. (You may have to give the app permission to open Photos first.)"
+			};
+
+			var showModal = new Button { Text = "Tap Here" };
+			var root = new ContentPage { Content = showModal };
+
+			var htmlSource = new HtmlWebViewSource { Html = Html };
+
+			var modalContent = new ContentPage
+			{
+				Content = new StackLayout
+				{
+					Margin = new Thickness(40),
+					VerticalOptions = LayoutOptions.Fill,
+					Children =
+					{
+						instructions,
+						new WebView { HeightRequest = 200, Source = htmlSource }
+					}
+				}
+			};
+
+			showModal.Clicked += (sender, args) => { Navigation.PushModalAsync(modalContent); };
+
+			await PushAsync(root);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -162,6 +162,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44176.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45215.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44500.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47548.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53834.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51536.cs" />

--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Diagnostics;
 using UIKit;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
@@ -19,13 +21,29 @@ namespace Xamarin.Forms.Platform.iOS
 			modal.ViewController.DidMoveToParentViewController(this);
 		}
 
+		public override void DismissViewController(bool animated, Action completionHandler)
+		{
+			if (PresentedViewController == null)
+			{
+				// After dismissing a UIDocumentMenuViewController, (for instance, if a WebView with an Upload button
+				// is asking the user for a source (camera roll, etc.)), the view controller accidentally calls dismiss
+				// again on itself before presenting the UIImagePickerController; this leaves the UIImagePickerController
+				// without an anchor to the view hierarchy and it doesn't show up. This appears to be an iOS bug.
+
+				// We can work around it by ignoring the dismiss call when PresentedViewController is null. 
+				return;
+			}
+
+			base.DismissViewController(animated, completionHandler);
+		}
+
 		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
 		{
 			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
 			{
 				return ChildViewControllers[0].GetSupportedInterfaceOrientations();
 			}
-
+			
 			return base.GetSupportedInterfaceOrientations();
 		}
 


### PR DESCRIPTION
### Description of Change ###

Work around an iOS bug where a UIWebView presented modally calls dismiss twice after presenting a UIDocumentMenuViewController, which leaves the UIImagePickerController (or whatever else it's displaying) without a connection to the view hierarchy.

No UI tests - can't reliably handle the permissions issues on the test devices.

### Bugs Fixed ###

- [44500 – A WebView that has a file picker control fails to show photo picker when page is pushed modally.](https://bugzilla.xamarin.com/show_bug.cgi?id=44500)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
