### PR TITLE
[macOS] Scroll view background not working.

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public ScrollViewRenderer() : base(RectangleF.Empty)
 		{
+			DrawsBackground = false;
 			ContentView.PostsBoundsChangedNotifications = true;
 			NSNotificationCenter.DefaultCenter.AddObserver(this, new Selector(nameof(UpdateScrollPosition)),
 				BoundsChangedNotification, ContentView);
@@ -183,7 +184,18 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateBackgroundColor()
 		{
-			BackgroundColor = Element.BackgroundColor.ToNSColor(Color.Transparent);
+			if (Element.BackgroundColor == Color.Default)
+			{
+				if (DrawsBackground)
+					DrawsBackground = false;
+				if (BackgroundColor != NSColor.Clear)
+					BackgroundColor = NSColor.Clear;
+			}
+			else
+			{
+				DrawsBackground = true;
+				BackgroundColor = Element.BackgroundColor.ToNSColor();
+			}
 		}
 
 		void UpdateContentSize()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -19,7 +19,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public ScrollViewRenderer() : base(RectangleF.Empty)
 		{
-			DrawsBackground = false;
 			ContentView.PostsBoundsChangedNotifications = true;
 			NSNotificationCenter.DefaultCenter.AddObserver(this, new Selector(nameof(UpdateScrollPosition)),
 				BoundsChangedNotification, ContentView);


### PR DESCRIPTION
### Description of Change ###
macOS.ScrollViewer: Tested against a background color existing or not.  This fixes the issue where ScrollViewer's background color wasnt showing correctly.

Tests Omitted.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=57022

### API Changes ###

None.

### Behavioral Changes ###

ScrollViewer's BackgroundColor should show properly now.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
