### PR TITLE
[UWP] Correctly calculates height of Master Page content

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla54036.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla54036.cs
@@ -1,0 +1,52 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 54036, "[UWP] MasterPage - Bad Rendering", PlatformAffected.UWP)]
+	public class Bugzilla54036 : TestMasterDetailPage
+	{
+		class MasterPage : ContentPage
+		{
+			public MasterPage()
+			{
+				Title = "Master";
+				var grid = new Grid
+				{
+					RowDefinitions =
+					{
+						new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+						new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+						new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+						new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+					}
+				};
+
+				var label1 = new Label { Text = "On UWP, the very last Label will be visible until the Master is hidden and presented again." };
+				var label2 = new Label { Text = "If you do not see a Label that says Success at the bottom of the Master" };
+				var label3 = new Label { Text = "then this test has failed." };
+				var label4 = new Label { Text = "Success" };
+
+				grid.AddChild(label1, 0, 0);
+				grid.AddChild(label2, 0, 1);
+				grid.AddChild(label3, 0, 2);
+				grid.AddChild(label4, 0, 3);
+
+				Content = grid;
+			}
+		}
+
+		protected override void Init()
+		{
+			Master = new MasterPage();
+			Detail = new ContentPage();
+
+			IsPresented = true;
+
+			Device.StartTimer(TimeSpan.FromMilliseconds(500), () => { IsPresented = false; return false; });
+			Device.StartTimer(TimeSpan.FromMilliseconds(1000), () => { IsPresented = true; return false; });
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -283,6 +283,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ListViewNRE.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55745.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55365.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54036.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -128,10 +128,18 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			get
 			{
-				double height = ActualHeight;
+				// Use the ActualHeight of the _masterPresenter to automatically adjust for the Master Title
+				double height = _masterPresenter?.ActualHeight ?? 0;
+
+				// If there's no content, use the height of the control to make sure the background color expands.
+				if (height == 0)
+					height = ActualHeight;
+
 				double width = 0;
 
-				if (_commandBar != null)
+				// On first load, the _commandBar will still occupy space by the time this is called.
+				// Check ShouldShowToolbar to make sure the _commandBar will still be there on render.
+				if (_commandBar != null && ShouldShowToolbar)
 					height -= _commandBar.ActualHeight;
 
 				if (_split != null)


### PR DESCRIPTION
### Description of Change ###

Only account for the height of the `CommandBar` when it is actually going to be rendered and use the height of the `Master`'s `ContentPresenter` instead of the `MasterDetailControl` to account for the height of the `Master` title area.

### Bugs Fixed ###

- [Bug 54036 - [UWP] MasterPage - Bad Rendering](https://bugzilla.xamarin.com/show_bug.cgi?id=54036)

### API Changes ###

None

### Behavioral Changes ###

There's a possibility that a `Page` will no longer extend to the bottom of the screen if the content does not also extend to the bottom of the screen. Was not seen during dev testing, but looks like it could be possible.

### PR Checklist ###

- [x] Has tests (manual)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
