### PR TITLE
Fix possible crash on API 21+ at launch when using Holo theme and FormsApplicationActivity

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -852,7 +852,7 @@ namespace Xamarin.Forms.Platform.Android
 				int actionbarId = _context.Resources.GetIdentifier("action_bar", "id", "android");
 				if (actionbarId > 0)
 				{
-					var toolbar = (ViewGroup)((Activity)_context).FindViewById(actionbarId);
+					var toolbar = ((Activity)_context).FindViewById(actionbarId) as ViewGroup;
 					if (toolbar != null)
 					{
 						for (int i = 0; i < toolbar.ChildCount; i++)

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -857,7 +857,8 @@ namespace Xamarin.Forms.Platform.Android
 					{
 						for (int i = 0; i < toolbar.ChildCount; i++)
 						{
-							if (toolbar.GetChildAt(i) is TextView textView)
+							var textView = toolbar.GetChildAt(i) as TextView;
+							if (textView != null)
 							{
 								actionBarTitleTextView = textView;
 								break;

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -847,24 +847,27 @@ namespace Xamarin.Forms.Platform.Android
 			Color navigationBarTextColor = CurrentNavigationPage == null ? Color.Default : CurrentNavigationPage.BarTextColor;
 			TextView actionBarTitleTextView = null;
 
-			if(Forms.IsLollipopOrNewer)
+			if (Forms.IsLollipopOrNewer)
 			{
 				int actionbarId = _context.Resources.GetIdentifier("action_bar", "id", "android");
-				if(actionbarId > 0)
+				if (actionbarId > 0)
 				{
-					Toolbar toolbar = (Toolbar)((Activity)_context).FindViewById(actionbarId);
-					
-					for( int i = 0; i < toolbar.ChildCount; i++ )
+					var toolbar = (ViewGroup)((Activity)_context).FindViewById(actionbarId);
+					if (toolbar != null)
 					{
-						if( toolbar.GetChildAt(i) is TextView )
+						for (int i = 0; i < toolbar.ChildCount; i++)
 						{
-							actionBarTitleTextView = (TextView)toolbar.GetChildAt(i);
-							break;
+							if (toolbar.GetChildAt(i) is TextView textView)
+							{
+								actionBarTitleTextView = textView;
+								break;
+							}
 						}
 					}
 				}
-			}
-			else
+			}			
+
+			if (actionBarTitleTextView == null)
 			{
 				int actionBarTitleId = _context.Resources.GetIdentifier("action_bar_title", "id", "android");
 				if (actionBarTitleId > 0)


### PR DESCRIPTION
### Description of Change ###

The changes made in #631 and #835 were causing an InvalidCastException when using the Holo theme on Lollipop or higher since that theme does not use a Toolbar.

This fixes it by first checking if there is the older ActionBarTextView on all Android versions and if not, _then_ checking for a Toolbar. This also includes a null check for the Toolbar for situations were it is not present, e.g. using a NoActionBar theme.


### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=57108

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
