### PR TITLE
[iOS/Android] Fixes "jumping" when navigation to a page with a NavigationBar from a page without one

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -31,6 +31,8 @@ using Xamarin.Forms.Controls.Issues;
 [assembly: ExportRenderer(typeof(Bugzilla42000._42000NumericEntryNoDecimal), typeof(EntryRendererNoDecimal))]
 [assembly: ExportRenderer(typeof(Bugzilla42000._42000NumericEntryNoNegative), typeof(EntryRendererNoNegative))]
 
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.NoFlashTestNavigationPage), typeof(Xamarin.Forms.ControlGallery.Android.NoFlashTestNavigationPage))]
+
 #if PRE_APPLICATION_CLASS
 #elif FORMS_APPLICATION_ACTIVITY
 #else
@@ -513,6 +515,14 @@ namespace Xamarin.Forms.ControlGallery.Android
 			inputTypes &= ~InputTypes.NumberFlagDecimal;
 
 			return base.GetDigitsKeyListener(inputTypes);
+		}
+	}
+
+	public class NoFlashTestNavigationPage : Xamarin.Forms.Platform.Android.AppCompat.NavigationPageRenderer
+	{
+		protected override void SetupPageTransition(global::Android.Support.V4.App.FragmentTransaction transaction, bool isPush)
+		{
+			transaction.SetTransition((int)FragmentTransit.None);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Controls.Issues
 	}
 
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 932830, "Hiding navigation bar causes layouts to shift during navigation", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Bugzilla, 32830, "Hiding navigation bar causes layouts to shift during navigation", PlatformAffected.iOS)]
 	public class Bugzilla32830 : NoFlashTestNavigationPage
 	{
 		const string Button1 = "button1";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
@@ -7,12 +7,6 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-// Apply the default category of "Issues" to all of the tests in this assembly
-// We use this as a catch-all for tests which haven't been individually categorized
-#if UITEST
-[assembly: NUnit.Framework.Category("Issues")]
-#endif
-
 namespace Xamarin.Forms.Controls.Issues
 {
 	// Uses a custom renderer on Android to override SetupPageTransition.

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
@@ -1,0 +1,130 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 932830, "Hiding navigation bar causes layouts to shift during navigation", PlatformAffected.iOS)]
+	public class Bugzilla32830 : TestNavigationPage
+	{
+		const string Button1 = "button1";
+		const string Button2 = "button2";
+		const string BottomLabel = "I am visible at the bottom of the page";
+
+		[Preserve(AllMembers = true)]
+		class Page1 : ContentPage
+		{
+			public Page1()
+			{
+				Title = "Page 1";
+				BackgroundColor = Color.Gray;
+
+				var relativeLayout = new RelativeLayout { };
+
+				relativeLayout.Children.Add(new StackLayout
+				{
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+						new Label {
+							HorizontalTextAlignment = TextAlignment.Center,
+							Text = "Page 1",
+							TextColor = Color.White
+						},
+						new Button {
+							Text = "Go to page 2",
+							Command = new Command(async () => await Navigation.PushAsync(new Page2())),
+							AutomationId = Button1,
+							TextColor = Color.White
+						},
+						new Button {
+							Text = "Toggle Nav Bar",
+							Command = new Command(() => NavigationPage.SetHasNavigationBar(this, !NavigationPage.GetHasNavigationBar(this))),
+							AutomationId = Button2,
+							TextColor = Color.White
+						}
+					}
+				}, yConstraint: Xamarin.Forms.Constraint.RelativeToParent(parent => { return parent.Y; }));
+
+				relativeLayout.Children.Add(new Label
+				{
+					Text = BottomLabel,
+					TextColor = Color.White
+				}, yConstraint: Xamarin.Forms.Constraint.RelativeToParent(parent => { return parent.Height - 30; }));
+
+				Content = relativeLayout;
+
+				NavigationPage.SetHasNavigationBar(this, false);
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class Page2 : ContentPage
+		{
+			public Page2()
+			{
+				Title = "Page 2";
+				BackgroundColor = Color.Gray;
+				var relativeLayout = new RelativeLayout { };
+				relativeLayout.Children.Add(new StackLayout
+				{
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+							new Label {
+								HorizontalTextAlignment = TextAlignment.Center,
+								Text = "Page 2",
+									TextColor = Color.White
+							},
+							new Button {
+								Text = "Go to page 1",
+								Command = new Command(async () => await Navigation.PushAsync(new Page1())),
+								TextColor = Color.White
+							},
+							new Button {
+								Text = "Toggle Nav Bar",
+								Command = new Command(() => NavigationPage.SetHasNavigationBar(this, !NavigationPage.GetHasNavigationBar(this))),
+								TextColor = Color.White
+							}
+						}
+				}, yConstraint: Xamarin.Forms.Constraint.RelativeToParent(parent => { return parent.Y; }));
+
+				relativeLayout.Children.Add(new Label
+				{
+					Text = BottomLabel,
+					TextColor = Color.White
+				}, yConstraint: Xamarin.Forms.Constraint.RelativeToParent(parent => { return parent.Height - 30; }));
+
+				Content = relativeLayout;
+			}
+		}
+
+		protected override void Init()
+		{
+			Navigation.PushAsync(new Page1());
+
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla32830Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(BottomLabel));
+			RunningApp.WaitForElement(q => q.Marked(Button1));
+			RunningApp.Tap(q => q.Marked(Button1));
+			RunningApp.WaitForElement(q => q.Marked(Button2));
+			RunningApp.Tap(q => q.Marked(Button2));
+			RunningApp.WaitForElement(q => q.Marked(BottomLabel));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
@@ -56,7 +56,6 @@ namespace Xamarin.Forms.Controls.Issues
 						new Button {
 							Text = "Toggle Nav Bar",
 							Command = new Command(() => NavigationPage.SetHasNavigationBar(this, !NavigationPage.GetHasNavigationBar(this))),
-							AutomationId = Button2,
 							TextColor = Color.White
 						}
 					}
@@ -92,8 +91,9 @@ namespace Xamarin.Forms.Controls.Issues
 									TextColor = Color.White
 							},
 							new Button {
-								Text = "Go to page 1",
-								Command = new Command(async () => await Navigation.PushAsync(new Page1())),
+								Text = "Go to tabs",
+								AutomationId = Button2,
+								Command = new Command(async () => await Navigation.PushAsync(new MyTabs())),
 								TextColor = Color.White
 							},
 							new Button {
@@ -111,6 +111,15 @@ namespace Xamarin.Forms.Controls.Issues
 				}, yConstraint: Xamarin.Forms.Constraint.RelativeToParent(parent => { return parent.Height - 30; }));
 
 				Content = relativeLayout;
+			}
+		}
+
+		class MyTabs : TabbedPage
+		{
+			public MyTabs()
+			{
+				Children.Add(new NavigationPage(new Page1()));
+				Children.Add(new Page2());
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32830.cs
@@ -1,5 +1,6 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System;
 
 #if UITEST
 using Xamarin.UITest;
@@ -14,9 +15,20 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+	// Uses a custom renderer on Android to override SetupPageTransition.
+	// While these transitions are often desired, they can appear to cause the "flash"
+	// at the top and bottom of the screen that could be confused with the bug we're fixing.
+	public class NoFlashTestNavigationPage : TestNavigationPage
+	{
+		protected override void Init()
+		{
+
+		}
+	}
+
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 932830, "Hiding navigation bar causes layouts to shift during navigation", PlatformAffected.iOS)]
-	public class Bugzilla32830 : TestNavigationPage
+	public class Bugzilla32830 : NoFlashTestNavigationPage
 	{
 		const string Button1 = "button1";
 		const string Button2 = "button2";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -285,6 +285,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ListViewNRE.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55745.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32830.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55365.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54036.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -304,33 +304,54 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			bar.Measure(MeasureSpecFactory.MakeMeasureSpec(r - l, MeasureSpecMode.Exactly), MeasureSpecFactory.MakeMeasureSpec(barHeight, MeasureSpecMode.Exactly));
 
-			int internalHeight = b - t - barHeight;
-			int containerHeight = ToolbarVisible ? internalHeight : b - t;
-			containerHeight -= ContainerPadding;
+			var barOffset = ToolbarVisible ? barHeight : 0;
+			int containerHeight = b - t - ContainerPadding - barOffset;
 
 			PageController.ContainerArea = new Rectangle(0, 0, Context.FromPixels(r - l), Context.FromPixels(containerHeight));
+
 			// Potential for optimization here, the exact conditions by which you don't need to do this are complex
 			// and the cost of doing when it's not needed is moderate to low since the layout will short circuit pretty fast
 			Element.ForceLayout();
 
+			bool toolbarLayoutCompleted = false;
 			for (var i = 0; i < ChildCount; i++)
 			{
 				AView child = GetChildAt(i);
-				bool isBar = JNIEnv.IsSameObject(child.Handle, bar.Handle);
 
-				if (ToolbarVisible)
+				Page childPage = (child as PageContainer)?.Child?.Element as Page;
+
+				if (childPage == null)
+					return;
+
+				// We need to base the layout of both the child and the bar on the presence of the NavBar on the child Page itself.
+				// If we layout the bar based on ToolbarVisible, we get a white bar flashing at the top of the screen.
+				// If we layout the child based on ToolbarVisible, we get a white bar flashing at the bottom of the screen.
+				bool childHasNavBar = NavigationPage.GetHasNavigationBar(childPage);
+
+				if (childHasNavBar)
 				{
-					if (isBar)
-						bar.Layout(0, 0, r - l, barHeight);
-					else
-						child.Layout(0, barHeight + ContainerPadding, r, b);
+					bar.Layout(0, 0, r - l, barHeight);
+					child.Layout(0, barHeight + ContainerPadding, r, b);
 				}
 				else
 				{
-					if (isBar)
-						bar.Layout(0, -1000, r, barHeight - 1000);
-					else
-						child.Layout(0, ContainerPadding, r, b);
+					bar.Layout(0, -1000, r, barHeight - 1000);
+					child.Layout(0, ContainerPadding, r, b);
+				}
+				toolbarLayoutCompleted = true;
+			}
+
+			// Making the layout of the toolbar dependant on having a child Page could potentially mean that the toolbar is not laid out.
+			// We'll do one more check to make sure it isn't missed.
+			if (!toolbarLayoutCompleted)
+			{
+				if (ToolbarVisible)
+				{
+					bar.Layout(0, 0, r - l, barHeight);
+				}
+				else
+				{
+					bar.Layout(0, -1000, r, barHeight - 1000);
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -914,7 +914,11 @@ namespace Xamarin.Forms.Platform.iOS
 				var hasNavBar = NavigationPage.GetHasNavigationBar(current);
 
 				if (NavigationController.NavigationBarHidden == hasNavBar)
+				{
+					// prevent bottom content "jumping"
+					current.IgnoresContainerArea = !hasNavBar;
 					NavigationController.SetNavigationBarHidden(!hasNavBar, animated);
+				}
 			}
 
 			void UpdateToolbarItems()


### PR DESCRIPTION
### Description of Change ###

On iOS, set `IgnoresContainerArea` to true when the `Page` does not have a `NavigationBar`. This will tell the XF layout system to use the total area of the screen to layout the `Page`.

On Android, use the presence of a `NavigationBar` on the `Page` hosted by the `NavigationPage` rather than the `NavigationPage`'s `ToolbarVisible` property to hide/show the `CommandBar`. The `CommandBar` and `PageContainer` will be set simultaneously to avoid the two being out of sync, which was causing a white bar to appear briefly.

### Bugs Fixed ###

- [Bug 32830 - Hiding navigation bar causes layouts to shift during navigation
briefly](https://bugzilla.xamarin.com/show_bug.cgi?id=32830) (also reported in #431)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (manual)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
