### PR TITLE
[A] Check Visibility for tab's page appearing

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52419.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52419.cs
@@ -1,0 +1,112 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 52419, "[A] OnAppearing called for previous pages in a tab's navigation when switching active tabs", PlatformAffected.Android)]
+	public class Bugzilla52419 : TestTabbedPage
+	{
+		protected override void Init()
+		{
+			var nav1 = new NavigationPage { Title = "Tab Page 1" };
+			nav1.PushAsync(new Bugzilla52419Page1());
+			var nav2 = new NavigationPage { Title = "Tab Page 2" };
+			nav2.PushAsync(new Bugzilla52419Page2());
+			Children.Add(nav1);
+			Children.Add(nav2);
+		}
+
+#if UITEST
+
+#if __ANDROID__
+		[Test]
+		public void Bugzilla52419Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Push new page"));
+			RunningApp.Tap(q => q.Marked("Push new page"));
+			RunningApp.WaitForElement(q => q.Marked("Push new page"));
+			RunningApp.Tap(q => q.Marked("Push new page"));
+			RunningApp.WaitForElement(q => q.Marked("Push new page"));
+			RunningApp.Tap(q => q.Marked("Push new page"));
+			RunningApp.Tap(q => q.Marked("Tab Page 2"));
+			RunningApp.Tap(q => q.Marked("Tab Page 1"));
+			RunningApp.Tap(q => q.Marked("Tab Page 2"));
+			RunningApp.Tap(q => q.Marked("Tab Page 1"));
+			RunningApp.Back();
+			RunningApp.WaitForElement(q => q.Marked("AppearanceLabel"));
+			var label = RunningApp.Query(q => q.Marked("AppearanceLabel"))[0];
+			Assert.AreEqual("Times Appeared: 2", label.Text);
+		}
+#endif
+
+#endif
+	}
+
+	class Bugzilla52419Page1 : ContentPage
+	{
+		public Label _timesAppeared { get; set; }
+		int _count;
+
+		string _guid = Guid.NewGuid().ToString();
+		public Bugzilla52419Page1()
+		{
+			_timesAppeared = new Label
+			{
+				Text = "Times Appeared: " + _count.ToString(),
+				AutomationId = "AppearanceLabel"
+			};
+			Content = new StackLayout
+			{
+				Children =
+					{
+						new Label
+						{
+							Text = "Page Guid: " + _guid
+						},
+						_timesAppeared,
+						new Label
+						{
+							Text = "Click the button a couple times, switch to the second tab, and then back to the first. The Appearing event (which increase the counter) should only occur for the visible first tab."
+						},
+						new Button
+						{
+							Text = "Push new page",
+							Command = new Command(() => Navigation.PushAsync(new Bugzilla52419Page1()))
+						}
+					}
+			};
+			Appearing += OnAppearing;
+		}
+
+		void OnAppearing(object sender, EventArgs e)
+		{
+			_count++;
+			_timesAppeared.Text = "Times Appeared: " + _count.ToString();
+		}
+	}
+
+	class Bugzilla52419Page2 : ContentPage
+	{
+		public Bugzilla52419Page2()
+		{
+			Title = "Tab Page 2";
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = "Other content"
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -163,6 +163,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45215.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47548.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52419.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53834.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51536.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44940.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnAttachedToWindow();
 			var pageContainer = Parent as PageContainer;
-			if (pageContainer != null && pageContainer.IsInFragment)
+			if (pageContainer != null && (pageContainer.IsInFragment || pageContainer.Visibility == ViewStates.Gone))
 				return;
 			PageController.SendAppearing();
 		}


### PR DESCRIPTION
### Description of Change ###

In a pre-AppCompat `TabbedPage`, navigating to new pages on one of the tabs, switching to another tab, and then switching back to the prior tab will fire the Appearing event for each page in its navigation stack. Checking for `Visibility` state of `ViewStates.Gone` (along with the already existing check for `pageContainer`) prevents this from occurring.

The gallery reproduction currently outputs the event firing to debug with the Guid of the visible page in the first tab.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=52419

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
