### PR TITLE
Allow multiple tap gestures to fire simultaneously on iOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36780.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36780.cs
@@ -1,0 +1,85 @@
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Gestures)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 36780, "[iOS] Multiple TapGestureRecognizers on an Object Are Not Fired", PlatformAffected.iOS)]
+	public class Bugzilla36780 : TestContentPage 
+	{
+		const string Gesture1Success = "Gesture1Success";
+		const string Gesture2Success = "Gesture2Success";
+		const string Gesture3Success = "Gesture3Success";
+		const string Waiting = "Waiting";
+		const string TestImage = "TestImage";
+
+		protected override void Init()
+		{
+			var gesture1Label = new Label { FontSize = 18, Text = Waiting };
+			var gesture2Label = new Label { FontSize = 18, Text = Waiting };
+			var gesture3Label = new Label { FontSize = 18, Text = Waiting };
+
+			var testImage = new Image { Source = "coffee.png", AutomationId = TestImage, HeightRequest = 75 };
+
+			testImage.GestureRecognizers.Add(new TapGestureRecognizer
+			{
+				Command = new Command(() =>
+				{
+					gesture1Label.Text = Gesture1Success;
+				})
+			});
+
+			testImage.GestureRecognizers.Add(new TapGestureRecognizer
+			{
+				Command = new Command(() =>
+				{
+					gesture2Label.Text = Gesture2Success;
+				})
+			});
+
+			testImage.GestureRecognizers.Add(new TapGestureRecognizer
+			{
+				Command = new Command(() =>
+				{
+					gesture3Label.Text = Gesture3Success;
+				})
+			});
+
+			Content = new StackLayout
+			{
+				Padding = new Thickness(0, 20, 0, 0),
+				Children =
+				{
+					gesture1Label,
+					gesture2Label,
+					gesture3Label,
+					testImage
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void MultipleTapGestures()
+		{
+			RunningApp.WaitForElement(TestImage);
+			RunningApp.Tap(TestImage);
+
+			RunningApp.WaitForElement(Gesture1Success);
+			RunningApp.WaitForElement(Gesture2Success);
+			RunningApp.WaitForElement(Gesture3Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -82,6 +82,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36559.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36171.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36780.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36846.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37462.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -32,6 +32,7 @@
 		public const string Maps = "Maps";
 		public const string InputTransparent = "InputTransparent";
 		public const string IsEnabled = "IsEnabled";
+		public const string Gestures = "Gestures";
 
 		public const string ManualReview = "ManualReview";
 	}

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -256,10 +256,45 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		UITapGestureRecognizer CreateTapRecognizer(int numTaps, Action action, int numFingers = 1)
 		{
-			var result = new UITapGestureRecognizer(action);
-			result.NumberOfTouchesRequired = (uint)numFingers;
-			result.NumberOfTapsRequired = (uint)numTaps;
+			var result = new UITapGestureRecognizer(action)
+			{
+				NumberOfTouchesRequired = (uint)numFingers,
+				NumberOfTapsRequired = (uint)numTaps,
+				ShouldRecognizeSimultaneously = ShouldRecognizeTapsTogether
+			};
+
 			return result;
+		}
+
+		static bool ShouldRecognizeTapsTogether(NativeGestureRecognizer gesture, NativeGestureRecognizer other)
+		{
+			// If multiple tap gestures are potentially firing (because multiple tap gesture recognizers have been
+			// added to the XF Element), we want to allow them to fire simultaneously if they have the same number
+			// of taps and touches
+
+			var tap = gesture as UITapGestureRecognizer;
+			if (tap == null)
+			{
+				return false;
+			}
+
+			var otherTap = other as UITapGestureRecognizer;
+			if (otherTap == null)
+			{
+				return false;
+			}
+
+			if (tap.NumberOfTapsRequired != otherTap.NumberOfTapsRequired)
+			{
+				return false;
+			}
+			
+			if (tap.NumberOfTouchesRequired != otherTap.NumberOfTouchesRequired)
+			{
+				return false;
+			}
+
+			return true;
 		}
 #else
 		NSPanGestureRecognizer CreatePanRecognizer(int numTouches, Action<NSPanGestureRecognizer> action)

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -284,6 +284,11 @@ namespace Xamarin.Forms.Platform.MacOS
 				return false;
 			}
 
+			if (!Equals(tap.View, otherTap.View))
+			{
+				return false;
+			}
+
 			if (tap.NumberOfTapsRequired != otherTap.NumberOfTapsRequired)
 			{
 				return false;


### PR DESCRIPTION
### Description of Change ###

Because of the way XF sets up tap gestures on iOS, the last one in always wins. This change adds a [`ShouldRecognizeSimultaneously`](https://developer.apple.com/reference/uikit/uigesturerecognizerdelegate/1624208-gesturerecognizer) delegate to the native tap gestures to allow for more than one to be recognized at the same time.

### Bugs Fixed ###

- [36780 – [iOS] Multiple TapGestureRecognizers on an Object Are Not Fired](https://bugzilla.xamarin.com/show_bug.cgi?id=36780)
- [45014 – Only top level TapGestureRecognizer works on iOS when multiples are on same view](https://bugzilla.xamarin.com/show_bug.cgi?id=45014)
- [45251 – GestureRecognizer added from a renderer](https://bugzilla.xamarin.com/show_bug.cgi?id=45251)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
