### PR TITLE
bug 40161; force layout of centered image in abs layout

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40161.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40161.cs
@@ -1,0 +1,140 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 40161, "Issue Description", PlatformAffected.Default)]
+	public class Bugzilla40161 : TestContentPage
+	{
+		// If an image is swapped out for another image must the size of an image be recomputed? 
+		// That would work but is slow. As an optimization, if an image's size is controlled by 
+		// it's parents and the parents dictate that any image will be a specific size then there
+		// is no need to layout the image. Consider the following scenarios:
+
+		// (a) An aboslute layout dictates the size of a child image when the child specifies that it
+		// should fill the space allocated by the aboslute layout. In this case the optimization 
+		// should be enabled; the layout pass for the replaced image can be skipped. The replaced image
+		// should occupy the same space as the orig image.
+
+		// (b) The image size is *not* dicatated by the absolute layout if it chooses not to fill the 
+		// space the absolute layout  allocates it and instead chooses to simply be centered with in 
+		// that space. In this case the layout pass for the replaced image must be run to compute the 
+		// size of the replaced image. This was the case reported by the bug that led to this UITest.
+		protected override void Init()
+		{
+			var absolute = new AbsoluteLayout()
+			{
+				// The size of an AbsoluteLayout whose H/V options equal Fill will match its
+				// parent container. Given that, the layout engine will optimize any re-layout of 
+				// such an AbsoluteLayout by not recomputing its size if its parent container 
+				// does not change size. Such an AbsoluteLayout is marked as special by setting
+				// its AbsoluteLayout.LayoutConstraint to fixed. All it's children will inherit
+				// the special setting.
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+			};
+
+			var imageA = "seth.png";
+			var imageB = "test.jpg";
+
+			var image = new Image()
+			{
+				Source = imageA,
+				Aspect = Aspect.AspectFill,
+
+				// Children of an AbsoluteLayout can potentially inherit its LayoutConstraint.
+				// This should happen if the child H/V options are also set to Fill AND its size
+				// is all proportional. In that case the child fills the size allocated to it by 
+				// the layout and so it's size should be re-computed iff the layout's size has
+				// changed. This behavior is achived by inheriting the layout's LayoutConstraint.
+
+				// *IF* however the H/V options are Center then the Image should be rendered to 
+				// to *AT MOST* the image size regardless of whether the region allocated by
+				// the absolute layout is larger than the image. 
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+			};
+
+			AbsoluteLayout.SetLayoutFlags(image, AbsoluteLayoutFlags.All);
+			AbsoluteLayout.SetLayoutBounds(image, new Rectangle(0, 0, 1, 1));
+			absolute.Children.Add(image);
+
+			var stack = new StackLayout();
+			stack.Children.Add(absolute);
+
+			bool flipSwap = false;
+			var swap = new Button() { Text = "SWAP" };
+			swap.Clicked += (object sender, EventArgs e) => 
+			{
+				if (flipSwap)
+					image.Source = imageA;
+				else
+					image.Source = imageB;
+
+				flipSwap = !flipSwap;
+			};
+			stack.Children.Add(swap);
+
+			bool flipLayout = false;
+			var layout = new Button() { Text = "LAYOUT" };
+			layout.Clicked += (object sender, EventArgs e) => 
+			{
+				if (flipLayout)
+				{
+					image.HorizontalOptions = LayoutOptions.Center;
+					image.VerticalOptions = LayoutOptions.Center;
+				}
+				else
+				{
+					image.HorizontalOptions = LayoutOptions.Fill;
+					image.VerticalOptions = LayoutOptions.Fill;
+				}
+
+				flipLayout = !flipLayout;
+			};
+			stack.Children.Add(layout);
+
+			var counter = new Label() { Text = "counter", AutomationId="counter" };
+			var height = new Label() { Text = "height", AutomationId="height" };
+			var width = new Label() { Text = "width", AutomationId= "width" };
+			stack.Children.Add(counter);
+			stack.Children.Add(height);
+			stack.Children.Add(width);
+
+			var count = 0;
+			var refresh = new Button() { Text = "REFRESH" };
+			refresh.Clicked += (object sender, EventArgs e) =>
+			{
+				height.Text = $"h={image.Height}";
+				width.Text = $"w={image.Width}";
+				counter.Text = $"step={count++}";
+			};
+			stack.Children.Add(refresh);
+
+			Content = stack;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1Test ()
+		{
+			RunningApp.Screenshot ("I am at Issue 40161");
+			RunningApp.WaitForElement (q => q.Marked ("REFRESH"));
+			RunningApp.Screenshot ("I see the first image");
+
+			RunningApp.Tap ("SWAP");
+			RunningApp.Tap ("REFRESH");
+			RunningApp.WaitForElement(q => q.Marked("step=0"));
+			RunningApp.Screenshot ("I swap the image");
+			RunningApp.WaitForElement(q => q.Marked("w=50"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -287,6 +287,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55745.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55365.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54036.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40161.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Core/AbsoluteLayout.cs
+++ b/Xamarin.Forms.Core/AbsoluteLayout.cs
@@ -98,7 +98,10 @@ namespace Xamarin.Forms
 
 			if ((layoutFlags & AbsoluteLayoutFlags.SizeProportional) == AbsoluteLayoutFlags.SizeProportional)
 			{
-				view.ComputedConstraint = Constraint;
+				if (view.VerticalOptions.Alignment == LayoutAlignment.Fill &&
+					view.HorizontalOptions.Alignment == LayoutAlignment.Fill)
+					view.ComputedConstraint = Constraint;
+
 				return;
 			}
 


### PR DESCRIPTION
### Description of Change ###

Expected swapping an image source of an image in an absolute layout with h/v options of center to render the swapped in image to it's native size. Actually observed swapped in image within an absolute layout rendering to the size of the original image. This happened because of an optimization in the layout engine which assumed re-computation of the size was unnecessary. The optimization was trying to take advantage of the fact that an absolute layout can sometimes dictate the size of it's children. The optimization was treating a child with h/v options _centered_ as one of those cases but it's not. With h/v options centered the child determines its own size in the case where more space was allocated to the image than the native image size. When more space is allocated the image does not fill that space and is the native size of the image. This change disables the optimization for h/v centered children causing their size to be recomputed. 

At the same time, the change enables the optimization for h/v _filled_ children. Filled children occupy the entire area allocated by the absolute layout; the absolute layout controls the the child size. In that case, the child can inherit the optimization status of the parent layout; if the parent size has not changed then the child size need not be recomputed during the next layout pass because the child size is the parent size.  

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40161

### API Changes ###

List all API changes here (or just put None), example:

### Behavioral Changes ###

None that are breaking.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
