### PR TITLE
Update View Enabled property when IsEnabled changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36703.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36703.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 936703, "TapGestureRecognizer inside initially disable Image will never fire Tapped event", PlatformAffected.All)]
+	[Issue(IssueTracker.Bugzilla, 36703, "TapGestureRecognizer inside initially disable Image will never fire Tapped event", PlatformAffected.All)]
 	public class Bugzilla36703 : TestContentPage
 	{
 		const string TestImage = "testimage";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36703.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36703.cs
@@ -1,0 +1,65 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 936703, "TapGestureRecognizer inside initially disable Image will never fire Tapped event", PlatformAffected.All)]
+	public class Bugzilla36703 : TestContentPage
+	{
+		const string TestImage = "testimage";
+		const string Success = "Success";
+		const string Toggle = "toggle";
+		const string Testing = "Testing...";
+
+		protected override void Init()
+		{
+			var image = new Image { Source = "coffee.png", IsEnabled = false, AutomationId = TestImage };
+			var button = new Button { Text = $"Toggle IsEnabled (now {image.IsEnabled})", AutomationId = Toggle };
+			var resultLabel = new Label { Text = "Testing..."};
+			var instructions = new Label { Text = $"Tap the image. The '{Testing}' label should remain unchanged. Tap the 'Toggle IsEnabled' button. Now tap the image again. The {Testing} Label should change its text to {Success}." };
+			
+			button.Clicked += (sender, args) =>
+			{
+				image.IsEnabled = !image.IsEnabled;
+				button.Text = $"Toggle IsEnabled (now {image.IsEnabled})";
+			};
+
+			Content = new StackLayout
+			{
+				Padding = new Thickness(0, 20, 0, 0),
+				Children =
+				{
+					instructions, resultLabel,
+					image, button
+				}
+			};
+
+			var tapGestureRecognizer = new TapGestureRecognizer();
+			tapGestureRecognizer.Tapped += delegate
+			{
+				resultLabel.Text = Success;
+			};
+
+			image.GestureRecognizers.Add(tapGestureRecognizer);
+		}
+
+#if UITEST
+		[Test]
+		public void _36703Test()
+		{
+			RunningApp.WaitForElement(TestImage);
+			RunningApp.Tap(TestImage);
+			RunningApp.WaitForElement(Testing);
+			RunningApp.Tap(Toggle);
+			RunningApp.Tap(TestImage);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -82,6 +82,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36559.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36171.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36703.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36846.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36955.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37462.cs" />

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -160,6 +160,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateTranslationX();
 			else if (e.PropertyName == VisualElement.TranslationYProperty.PropertyName)
 				UpdateTranslationY();
+			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+				UpdateIsEnabled();
 		}
 
 		void HandleRedrawNeeded(object sender, EventArg<VisualElement> e)
@@ -380,6 +382,11 @@ namespace Xamarin.Forms.Platform.Android
 			AView aview = _renderer.View;
 
 			aview.TranslationY = _context.ToPixels(view.TranslationY);
+		}
+
+		void UpdateIsEnabled()
+		{
+			_renderer.View.Enabled = _renderer.Element.IsEnabled;
 		}
 
 		class AttachTracker : Object, AView.IOnAttachStateChangeListener


### PR DESCRIPTION
### Description of Change ###

Now updates the `Enabled` property on Android Views when the Element's `IsEnabled` property changes.

### Bugs Fixed ###

- [36703 – TapGestureRecognizer inside initially disable Image will never fire Tapped event](https://bugzilla.xamarin.com/show_bug.cgi?id=36703)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
