### PR TITLE
Trap for OnElementChanged implementation error

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -415,6 +415,11 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			Children.Add(control);
 
+			if (Element == null)
+				throw new InvalidOperationException(
+					"Cannot assign a native control without an Element; Renderer unbound and/or disposed. " +
+					"Please consult Xamarin.Forms renderers for reference implementation of OnElementChanged.");
+
 			Element.IsNativeStateConsistent = false;
 			control.Loaded += OnControlLoaded;
 


### PR DESCRIPTION
### Description of Change ###

Developers of custom renderers expect descriptive error messages but they actually are getting NullReferenceExceptions. Custom renderer developers are essentially extending the system and so if they fail to follow unwritten conventions of the system they'll encounter states for which we do not have heavy test coverage. 

OnElementChanged is one such method whose implementation must follow an unwritten conventional form and so often trips up custom renderer developers as is the case here. This change provides a more descriptive exception which should hopefully point our developers in the right direction.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=57021

### API Changes ###

None

### Behavioral Changes ###

None that are breaking. 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
