### PR TITLE
[macOS] Button's Font attributes arent setting when using color.

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 			else
 			{
-				var textWithColor = new NSAttributedString(Element.Text ?? "", foregroundColor: color.ToNSColor( ), paragraphStyle: new NSMutableParagraphStyle( ) { Alignment = NSTextAlignment.Center });
+				var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.Font.ToNSFont(), foregroundColor: color.ToNSColor( ), paragraphStyle: new NSMutableParagraphStyle( ) { Alignment = NSTextAlignment.Center });
 				Control.AttributedTitle = textWithColor;
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

macOS's NSButton was using AttributedTitle for TextColor.  This sets the Font's attributes to that property.

Tests omitted.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=57190

### API Changes ###

None.

### Behavioral Changes ###

Buttons should now have font attributes associated with the Forms Button control.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
