### PR TITLE
[Android] Respect use of TextFormatted on Button

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -649,8 +649,13 @@ namespace Xamarin.Forms.ControlGallery.Android
 	}
 #pragma warning restore CS0618 // Type or member is obsolete
 
-	public class Bugzilla47430ButtonRenderer : Xamarin.Forms.Platform.Android.AppCompat.ButtonRenderer
+	public class Bugzilla47430ButtonRenderer : Platform.Android.AppCompat.ButtonRenderer
 	{
+
+		public Bugzilla47430ButtonRenderer(Context context) : base(context)
+		{
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
 		{
 			base.OnElementChanged(e);

--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -16,6 +16,7 @@ using Android.Content;
 using Android.Runtime;
 using Android.Util;
 using AButton = Android.Widget.Button;
+using ATextView = Android.Widget.TextView;
 using AView = Android.Views.View;
 using Android.OS;
 using System.Reflection;
@@ -35,6 +36,8 @@ using Xamarin.Forms.Controls.Issues;
 
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.NoFlashTestNavigationPage), typeof(Xamarin.Forms.ControlGallery.Android.NoFlashTestNavigationPage))]
+
+[assembly: ExportRenderer(typeof(Bugzilla47430.Bugzilla47430Button), typeof(Bugzilla47430ButtonRenderer))]
 
 #if PRE_APPLICATION_CLASS
 #elif FORMS_APPLICATION_ACTIVITY
@@ -645,5 +648,30 @@ namespace Xamarin.Forms.ControlGallery.Android
 		}
 	}
 #pragma warning restore CS0618 // Type or member is obsolete
+
+	public class Bugzilla47430ButtonRenderer : Xamarin.Forms.Platform.Android.AppCompat.ButtonRenderer
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
+		{
+			base.OnElementChanged(e);
+
+			if (Control == null || Element == null)
+			{
+				return;
+			}
+
+			var formsControl = Element as Bugzilla47430.Bugzilla47430Button;
+
+			if (formsControl.FormattedText != null)
+			{
+				var textView = new ATextView(Control.Context);
+				var spannableString = formsControl.FormattedText.ToAttributed(Font.Default, Color.White, textView);
+				Control.TextFormatted = spannableString;
+
+				// There is a bug in AppCompat where the default all caps text ignores spans
+				Control.SetAllCaps(false);
+			}
+		}
+	}
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47430.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47430.cs
@@ -1,0 +1,96 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 47430, "[A] ButtonRenderer does not set TextFormatted property on override to OnElementChanged", PlatformAffected.Android)]
+    public class Bugzilla47430 : TestContentPage
+    {
+        protected override void Init()
+        {
+            var button = new Bugzilla47430Button
+            {
+                BackgroundColor = Color.Red,
+                AutomationId = "Bugzilla47430Button"
+            };
+
+            var formattedString = new FormattedString();
+            formattedString.Spans.Add(new Span
+            {
+                Text = "Testing",
+                FontAttributes = FontAttributes.Italic,
+                ForegroundColor = Color.Aqua,
+                BackgroundColor = Color.Black
+            });
+            formattedString.Spans.Add(new Span
+            {
+                Text = "FormattedText",
+                FontAttributes = FontAttributes.Bold,
+                ForegroundColor = Color.Green,
+                BackgroundColor = Color.Aqua
+            });
+            button.FormattedText = formattedString;
+
+            Content = new StackLayout
+            {
+                Children =
+                {
+                    button,
+                    new Label
+                    {
+                        Text = "The above button should show spans on its text due to the use of a custom renderer."
+                    },
+                    new Button
+                    {
+                        AutomationId = "Bugzilla47430ChangeTextButton",
+                        Text = "Click to change text",
+                        Command = new Command(() => button.Text = "Updated text!")
+                    },
+                    new Button
+                    {
+                        AutomationId = "Bugzilla47430ChangeTextToEmptyStringButton",
+                        Text = "Click to change text",
+                        Command = new Command(() => button.Text = "")
+                    }
+                }
+            };
+        }
+
+        public class Bugzilla47430Button : Button
+        {
+            public static readonly BindableProperty FormattedTextProperty =
+                BindableProperty.Create(propertyName: nameof(FormattedText), returnType: typeof(FormattedString), declaringType: typeof(Bugzilla47430Button), defaultValue: null);
+
+            public FormattedString FormattedText
+            {
+                get { return (FormattedString)GetValue(FormattedTextProperty); }
+                set { SetValue(FormattedTextProperty, value); }
+            }
+        }
+
+#if UITEST
+
+#if __ANDROID__
+		[Test]
+		public void Bugzilla47430Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Bugzilla47430Button"));
+			var button = RunningApp.Query(q => q.Marked("Bugzilla47430Button"))[0];
+			Assert.AreEqual("TestingFormattedText", button.Text);
+			RunningApp.Tap("Bugzilla47430ChangeTextButton");
+			RunningApp.WaitForElement(q => q.Marked("Updated Text!"));
+			Assert.AreEqual("Updated text!", button.Text);
+			RunningApp.Tap("Bugzilla47430ChangeTextToEmptyStringButton");
+			Assert.AreEqual("", button.Text);
+		}
+#endif
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -172,6 +172,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44500.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46363.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46363_2.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47430.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47548.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52299.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52419.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -282,7 +282,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdateText()
 		{
 			var oldText = NativeButton.Text;
-			NativeButton.Text = Element.Text;
+			if ((IsNullOrEmpty(NativeButton.TextFormatted.ToString()) || Element.Text != null))
+				NativeButton.Text = Element.Text;
 
 			// If we went from or to having no text, we need to update the image position
 			if (IsNullOrEmpty(oldText) != IsNullOrEmpty(NativeButton.Text))

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -282,7 +282,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdateText()
 		{
 			var oldText = NativeButton.Text;
-			if ((IsNullOrEmpty(NativeButton.TextFormatted.ToString()) || Element.Text != null))
+			if ((IsNullOrEmpty(NativeButton.TextFormatted?.ToString()) || Element.Text != null))
 				NativeButton.Text = Element.Text;
 
 			// If we went from or to having no text, we need to update the image position

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -492,7 +492,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 
 			string oldText = Text;
-			Text = Button.Text;
+			if ((IsNullOrEmpty(TextFormatted.ToString()) || Button.Text != null))
+				Text = Button.Text;
 
 			// If we went from or to having no text, we need to update the image position
 			if (IsNullOrEmpty(oldText) != IsNullOrEmpty(Text))

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -492,7 +492,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 
 			string oldText = Text;
-			if ((IsNullOrEmpty(TextFormatted.ToString()) || Button.Text != null))
+			if ((IsNullOrEmpty(TextFormatted?.ToString()) || Button.Text != null))
 				Text = Button.Text;
 
 			// If we went from or to having no text, we need to update the image position


### PR DESCRIPTION
### Description of Change ###

In a situation where a user wishes to create a custom renderer for Android's `Button` to set `TextFormatted` (in this issue's case, with spans), the `Text` property prevents it from working correctly, particularly when using `OnElementChanged`. If `TextFormatted` is null or empty, it will use the `Element.Text` value as normally expected; otherwise, the `Button` inherently defaults to using that `TextFormatted` value. Due to a small bug in Android, `SetAllCaps(false)` must be used in the custom renderer for this to display the spans correctly. 

This change has only been applied to AppCompat.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=47430

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
