### PR TITLE
Fix possible crash on iOS when using ContextActions

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56710.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56710.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 56710, "ContextActionsCell.OnMenuItemPropertyChanged throws NullReferenceException", PlatformAffected.iOS)]
+    public class Bugzilla56710 : TestNavigationPage
+    {
+        protected override void Init()
+        {
+            var root = new ContentPage
+            {
+                Content = new Button
+                {
+                    Text = "Go to Test Page",
+                    Command = new Command(() => PushAsync(new TestPage()))
+                }
+            };
+
+            PushAsync(root);
+        }
+
+#if UITEST
+        [Test]
+        public void Bugzilla56710Test ()
+        {
+            RunningApp.WaitForElement (q => q.Marked ("Go to Test Page"));
+            RunningApp.Tap (q => q.Marked ("Go to Test Page"));
+
+            RunningApp.WaitForElement(q => q.Marked("Item 3"));
+            RunningApp.Back();
+        }
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class TestPage : ContentPage
+	{
+		ObservableCollection<TestItem> Items;
+
+		public TestPage()
+		{
+			Items = new ObservableCollection<TestItem>();
+			Items.Add(new TestItem { Text = "Item 1", ItemText = "Action 1" });
+			Items.Add(new TestItem { Text = "Item 2", ItemText = "Action 2" });
+			Items.Add(new TestItem { Text = "Item 3", ItemText = "Action 3" });
+
+			var testListView = new ListView
+			{
+				ItemsSource = Items,
+				ItemTemplate = new DataTemplate(typeof(TestCell))
+			};
+
+			Content = testListView;
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			Items.Clear();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class TestItem
+	{
+		public string Text { get; set; }
+		public string ItemText { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class TestCell : ViewCell
+	{
+		public TestCell()
+		{
+			var menuItem = new MenuItem();
+			menuItem.SetBinding(MenuItem.TextProperty, "ItemText");
+			ContextActions.Add(menuItem);
+
+
+			var textLabel = new Label();
+			textLabel.SetBinding(Label.TextProperty, "Text");
+			View = textLabel;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -556,6 +556,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla49069.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42956.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38731.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56710.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -274,6 +274,11 @@ namespace Xamarin.Forms.Platform.iOS
 				for (var i = 0; i < _buttons.Count; i++)
 					_buttons[i].Dispose();
 
+				var handler = new PropertyChangedEventHandler(OnMenuItemPropertyChanged);
+
+				foreach (var item in _menuItems)
+					item.PropertyChanged -= handler;
+
 				_buttons.Clear();
 				_menuItems.Clear();
 


### PR DESCRIPTION
### Description of Change ###

On iOS, if a Cell had one or more ContextActions that used bindings and the ItemsSource was modified after the Cell was disposed (e.g. when the ListView page was popped), then an NRE was thrown because the`OnMenuItemPropertyChanged` handler would still respond to the property change.

This may only have begun in 2.3.5 because of the fixes in #524. Previously it looks like the Cell was not calling `Dispose()` so this wasn't an issue.

This fix ensures that the MenuItem.PropertyChanged handler is removed when the Cell is disposing.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=56710

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
