### PR TITLE
[C] reset children animation on repeat

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/AnimationTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AnimationTests.cs
@@ -1,0 +1,33 @@
+﻿using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class AnimationTests : BaseTestFixture
+	{
+		[Test]
+		//https://bugzilla.xamarin.com/show_bug.cgi?id=51424
+		public async void AnimationRepeats()
+		{
+			var box = new BoxView();
+			Assume.That(box.Rotation, Is.EqualTo(0d));
+			var sb = new Animation();
+			var animcount = 0;
+			var rot45 = new Animation(d =>
+			{
+				box.Rotation = d;
+				if (d > 44)
+					animcount++;
+			}, box.Rotation, box.Rotation + 45);
+			sb.Add(0, .5, rot45);
+			Assume.That(box.Rotation, Is.EqualTo(0d));
+
+			var i = 0;
+			sb.Commit(box, "foo", length: 100, repeat: () => ++i < 2);
+
+			await Task.Delay(250);
+			Assert.That(animcount, Is.EqualTo(2));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -183,6 +183,7 @@
     <Compile Include="AppLinkEntryTests.cs" />
     <Compile Include="NativeBindingTests.cs" />
     <Compile Include="TypedBindingUnitTests.cs" />
+    <Compile Include="AnimationTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/Xamarin.Forms.Core/Animation.cs
+++ b/Xamarin.Forms.Core/Animation.cs
@@ -112,6 +112,12 @@ namespace Xamarin.Forms
 			return result;
 		}
 
+		internal void ResetChildren()
+		{
+			foreach (var anim in _children)
+				anim._finishedTriggered = false;
+		}
+
 		public Animation Insert(double beginAt, double finishAt, Animation animation)
 		{
 			Add(beginAt, finishAt, animation);


### PR DESCRIPTION
### Description of Change ###

On repeat, we restart animating from 0 to 1, so the _finishedTriggered flag that is used to avoid invoking the callback when a children animation is finished can be reset, and the sub animation will run again.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=51424

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense