### PR TITLE
[Android]Dispose check on FastButtonRenderer to prevent crash

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -214,7 +214,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			{
 				_backgroundTracker?.Reset();
 			}
-			if (e.NewElement != null)
+			if (e.NewElement != null && !_isDisposed)
 			{
 				UpdateFont();
 				UpdateText();


### PR DESCRIPTION
Check if buttonrenderer is disposed when making changes

### Description of Change ###

Check if disposed on elementChanged

### Bugs Fixed ###

Prevent crashes when making changes to a disposed renderer
"System.ObjectDisposedException: Cannot access a disposed object."

### API Changes ###

None

### Behavioral Changes ###

None


