### PR TITLE
[UWP] Bug 56843; LayoutUpdated > SizeChanged; Layout Cycle

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/NativeViewWrapperRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/NativeViewWrapperRenderer.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (e.OldElement == null)
 			{
 				SetNativeControl(Element.NativeElement);
-				Control.LayoutUpdated += (sender, args) => { ((IVisualElementController)Element)?.InvalidateMeasure(InvalidationTrigger.MeasureChanged); };
+				Control.SizeChanged += (sender, args) => { ((IVisualElementController)Element)?.InvalidateMeasure(InvalidationTrigger.MeasureChanged); };
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Customer expected to be able to embed native TextBlock into AbsolutLayout but that actually generated a layout cycle. Looks like OnElementChanged hooked up Contol.LayoutUpdated so the native control could lay itself out when something changed. Turns out that event gets call just after the layout cycle is complete and doesn't appear to be documented as a place where actual layout should be preformed. Instead, we can use Control.SizeChanged which is only fired if the size of the control changes which should trigger a new layout of the view. See: 

https://blogs.msdn.microsoft.com/devdave/2008/05/27/layout-events-sizechanged-and-layoutupdated/

FYI, @hartez I just kinda made some of this stuff as my best guess as to what is going on. I added a test next to your other tests but that doesn't trigger the issue. So there is something about the wrapping of the test harness that is preventing it from reproducing and which is also prob why the bug slipped through. I attached a non XAML reproduction to the bug. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=56843

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
