### PR TITLE
[WinRT/UWP] Update ZIndex on LowerChild/RaiseChild

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38770.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38770.cs
@@ -1,0 +1,115 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 38770, "RaiseChild and LowerChild do not work on Windows", PlatformAffected.WinRT)]
+	public class Bugzilla38770 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var red = new BoxView
+			{
+				BackgroundColor = Color.Red,
+				WidthRequest = 50,
+				HeightRequest = 50,
+				TranslationX = 25
+			};
+			var green = new BoxView
+			{
+				BackgroundColor = Color.Green,
+				WidthRequest = 50,
+				HeightRequest = 50
+			};
+			var blue = new BoxView
+			{
+				BackgroundColor = Color.Blue,
+				WidthRequest = 50,
+				HeightRequest = 50,
+				TranslationX = -25
+			};
+			var boxStack = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal,
+				Spacing = 0,
+				Margin = new Thickness(0,50,0,0),
+				HorizontalOptions = LayoutOptions.Center,
+				Children =
+				{
+					red,
+					green,
+					blue
+				}
+			};
+
+			var raiseButtons = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal,
+				HorizontalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Button
+					{
+						Text = "Raise Red",
+						WidthRequest = 110,
+						Command = new Command(() => boxStack.RaiseChild(red))
+					},
+					new Button
+					{
+						Text = "Raise Green",
+						WidthRequest = 110,
+						Command = new Command(() => boxStack.RaiseChild(green))
+					},
+					new Button
+					{
+						Text = "Raise Blue",
+						WidthRequest = 110,
+						Command = new Command(() => boxStack.RaiseChild(blue))
+					}
+				}
+			};
+			var lowerButtons = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal,
+				HorizontalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Button
+					{
+						Text = "Lower Red",
+						WidthRequest = 110,
+						Command = new Command(() => boxStack.LowerChild(red))
+					},
+					new Button
+					{
+						Text = "Lower Green",
+						WidthRequest = 110,
+						Command = new Command(() => boxStack.LowerChild(green))
+					},
+					new Button
+					{
+						Text = "Lower Blue",
+						WidthRequest = 110,
+						Command = new Command(() => boxStack.LowerChild(blue))
+					}
+				}
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					raiseButtons,
+					lowerButtons,
+					boxStack
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -90,6 +90,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37601.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38105.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38723.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38770.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38827.xaml.cs">
       <DependentUpon>Bugzilla38827.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.WinRT/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementPackager.cs
@@ -62,6 +62,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				element.ChildAdded -= OnChildAdded;
 				element.ChildRemoved -= OnChildRemoved;
+				element.ChildrenReordered -= OnChildrenReordered;
 			}
 		}
 
@@ -73,6 +74,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			_isLoaded = true;
 			_renderer.Element.ChildAdded += OnChildAdded;
 			_renderer.Element.ChildRemoved += OnChildRemoved;
+			_renderer.Element.ChildrenReordered += OnChildrenReordered;
 
 			ReadOnlyCollection<Element> children = ElementController.LogicalChildren;
 			for (var i = 0; i < children.Count; i++)
@@ -150,6 +152,11 @@ namespace Xamarin.Forms.Platform.WinRT
 
 				view.Cleanup();
 			}
+		}
+
+		void OnChildrenReordered(object sender, EventArgs e)
+		{
+			EnsureZIndex();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

`EnsureZIndex` was not being called upon use of `LowerChild` or `RaiseChild` in the `VisualElementPackager`. `OnChildrenReordered` calls `EnsureZIndex` which corrects this and enables expected behavior.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=38770

### API Changes ###

None.

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
