### PR TITLE
Fix crash when modifying ContextActions on Android

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57317.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57317.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest.iOS;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers = true)]
+	[Issue (IssueTracker.Bugzilla, 57317, "Modifying Cell.ContextActions can crash on Android", PlatformAffected.Android)]
+	public class Bugzilla57317 : TestContentPage
+	{
+		protected override void Init ()
+		{
+			var tableView = new TableView();
+			var tableSection = new TableSection();
+			var switchCell = new TextCell
+			{
+				Text = "Cell"
+			};
+
+			var menuItem = new MenuItem
+			{
+				Text = "Self-Deleting item",
+				Command = new Command(() => switchCell.ContextActions.RemoveAt(0)),
+				IsDestructive = true
+			};
+			switchCell.ContextActions.Add(menuItem);
+			tableSection.Add(switchCell);
+			tableView.Root.Add(tableSection);
+			Content = tableView;
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla57317Test ()
+		{
+			RunningApp.WaitForElement (c => c.Marked ("Cell"));
+			var cell = RunningApp.Query (c => c.Marked ("Cell")) [0];
+			RunningApp.TouchAndHoldCoordinates (cell.Rect.CenterX, cell.Rect.CenterY);
+			RunningApp.WaitForElement (c => c.Marked ("Self-Deleting item"));
+			RunningApp.Tap (c => c.Marked ("Self-Deleting item"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -204,6 +204,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56609.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55912.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57317.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -295,7 +295,8 @@ namespace Xamarin.Forms.Platform.Android
 		void OnContextItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			_actionModeNeedsUpdates = true;
-			_actionMode.Invalidate();
+			_actionMode?.Invalidate();
+			_supportActionMode?.Invalidate();
 		}
 
 		void OnDestroyActionModeImpl()


### PR DESCRIPTION
### Description of Change ###

When modifying ContextActions while the ActionMode is open, a call is made to _actionMode.Invalidate() without checking for null (which _actionMode will be if you're using FormsAppCompatActivity).

This occurs if you modify the ContextAction while the ActionMode is open (typically reacting to the command/click event from a ContextAction but something running asynchronously in the background could do it too).

The rest of CellAdapter.cs has calls to _actionMode?.XX() to prevent null references, so I've followed that standard (and added a call to _supportActionMode too).

There's a UI test added for Android.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=57317

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense