### PR TITLE
[C] do not reapply a Binding with a Source when the Context changes

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2114,5 +2114,34 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual ("Baz", label.Text);
 		}
+
+		class VM57081
+		{
+			string _foo;
+			public string Foo
+			{
+				get {
+					Count++;
+					return _foo;
+				}
+				set { _foo = value; }
+			}
+
+			public int Count { get; set; }
+		}
+
+		[Test]
+		// https://bugzilla.xamarin.com/show_bug.cgi?id=57081
+		public void BindingWithSourceNotReappliedWhenBindingContextIsChanged()
+		{
+			var bindable = new MockBindable();
+			var model = new VM57081();
+			var bp = BindableProperty.Create("foo", typeof(string), typeof(MockBindable), null);
+			Assume.That(model.Count, Is.EqualTo(0));
+			bindable.SetBinding(bp, new Binding { Path = "Foo", Source = model });
+			Assume.That(model.Count, Is.EqualTo(1));
+			bindable.BindingContext = new object();
+			Assert.That(model.Count, Is.EqualTo(1));
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2143,5 +2143,19 @@ namespace Xamarin.Forms.Core.UnitTests
 			bindable.BindingContext = new object();
 			Assert.That(model.Count, Is.EqualTo(1));
 		}
+
+		[Test]
+		// https://bugzilla.xamarin.com/show_bug.cgi?id=57081
+		public void BindingWithSourceNotReappliedWhenParented()
+		{
+			var view = new ContentView();
+			var model = new VM57081();
+			Assume.That(model.Count, Is.EqualTo(0));
+			view.SetBinding(BindableObject.BindingContextProperty, new Binding { Path = "Foo", Source = model });
+			Assume.That(model.Count, Is.EqualTo(1));
+			var parent = new ContentView { BindingContext = new object() };
+			parent.Content = view;
+			Assert.That(model.Count, Is.EqualTo(1));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -404,7 +404,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		void ApplyBindings(bool skipBindingContext)
+		void ApplyBindings(bool fromBindingContextChanged)
 		{
 			var prop = _properties.ToArray();
 			for (int i = 0, propLength = prop.Length; i < propLength; i++) {
@@ -413,11 +413,11 @@ namespace Xamarin.Forms
 				if (binding == null)
 					continue;
 
-				if (skipBindingContext && ReferenceEquals(context.Property, BindingContextProperty))
+				if (fromBindingContextChanged && ReferenceEquals(context.Property, BindingContextProperty))
 					continue;
 
-				binding.Unapply();
-				binding.Apply(BindingContext, this, context.Property);
+				binding.Unapply(fromBindingContextChanged: fromBindingContextChanged);
+				binding.Apply(BindingContext, this, context.Property, fromBindingContextChanged: fromBindingContextChanged);
 			}
 		}
 

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -116,13 +116,13 @@ namespace Xamarin.Forms
 				bindable._inheritedContext = value;
 			}
 
-			bindable.ApplyBindings();
+			bindable.ApplyBindings(skipBindingContext:false, fromBindingContextChanged:true);
 			bindable.OnBindingContextChanged();
 		}
 
 		protected void ApplyBindings()
 		{
-			ApplyBindings(false);
+			ApplyBindings(skipBindingContext: false, fromBindingContextChanged: false);
 		}
 
 		protected virtual void OnBindingContextChanged()
@@ -404,7 +404,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		void ApplyBindings(bool fromBindingContextChanged)
+		internal void ApplyBindings(bool skipBindingContext, bool fromBindingContextChanged)
 		{
 			var prop = _properties.ToArray();
 			for (int i = 0, propLength = prop.Length; i < propLength; i++) {
@@ -413,7 +413,7 @@ namespace Xamarin.Forms
 				if (binding == null)
 					continue;
 
-				if (fromBindingContextChanged && ReferenceEquals(context.Property, BindingContextProperty))
+				if (skipBindingContext && ReferenceEquals(context.Property, BindingContextProperty))
 					continue;
 
 				binding.Unapply(fromBindingContextChanged: fromBindingContextChanged);
@@ -436,7 +436,7 @@ namespace Xamarin.Forms
 		static void BindingContextPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
 		{
 			bindable._inheritedContext = null;
-			bindable.ApplyBindings(true);
+			bindable.ApplyBindings(skipBindingContext: true, fromBindingContextChanged:true);
 			bindable.OnBindingContextChanged();
 		}
 

--- a/Xamarin.Forms.Core/Binding.cs
+++ b/Xamarin.Forms.Core/Binding.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms
 		string _path;
 		object _source;
 		string _updateSourceEventName;
+		bool _hasSourceApplied;
 
 		public Binding()
 		{
@@ -81,6 +82,7 @@ namespace Xamarin.Forms
 			{
 				ThrowIfApplied();
 				_source = value;
+				_hasSourceApplied = false;
 			}
 		}
 
@@ -119,11 +121,17 @@ namespace Xamarin.Forms
 			object src = _source;
 			base.Apply(src ?? newContext, bindObj, targetProperty);
 
+			if (src != null && _hasSourceApplied)
+				return;
+			
 			object bindingContext = src ?? Context ?? newContext;
 			if (_expression == null && bindingContext != null)
 				_expression = new BindingExpression(this, SelfPath);
 
 			_expression.Apply(bindingContext, bindObj, targetProperty);
+
+			if (src != null)
+				_hasSourceApplied = true;
 		}
 
 		internal override BindingBase Clone()

--- a/Xamarin.Forms.Core/Binding.cs
+++ b/Xamarin.Forms.Core/Binding.cs
@@ -20,7 +20,6 @@ namespace Xamarin.Forms
 		string _path;
 		object _source;
 		string _updateSourceEventName;
-		bool _hasSourceApplied;
 
 		public Binding()
 		{
@@ -82,7 +81,6 @@ namespace Xamarin.Forms
 			{
 				ThrowIfApplied();
 				_source = value;
-				_hasSourceApplied = false;
 			}
 		}
 
@@ -116,22 +114,21 @@ namespace Xamarin.Forms
 			_expression.Apply(fromTarget);
 		}
 
-		internal override void Apply(object newContext, BindableObject bindObj, BindableProperty targetProperty)
+		internal override void Apply(object newContext, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged = false)
 		{
 			object src = _source;
-			base.Apply(src ?? newContext, bindObj, targetProperty);
+			var isApplied = IsApplied;
 
-			if (src != null && _hasSourceApplied)
+			base.Apply(src ?? newContext, bindObj, targetProperty, fromBindingContextChanged: fromBindingContextChanged);
+
+			if (src != null && isApplied && fromBindingContextChanged)
 				return;
-			
+
 			object bindingContext = src ?? Context ?? newContext;
 			if (_expression == null && bindingContext != null)
 				_expression = new BindingExpression(this, SelfPath);
 
 			_expression.Apply(bindingContext, bindObj, targetProperty);
-
-			if (src != null)
-				_hasSourceApplied = true;
 		}
 
 		internal override BindingBase Clone()
@@ -155,9 +152,12 @@ namespace Xamarin.Forms
 			return base.GetTargetValue(value, sourcePropertyType);
 		}
 
-		internal override void Unapply()
+		internal override void Unapply(bool fromBindingContextChanged = false)
 		{
-			base.Unapply();
+			if (Source != null && fromBindingContextChanged && IsApplied)
+				return;
+			
+			base.Unapply(fromBindingContextChanged: fromBindingContextChanged);
 
 			if (_expression != null)
 				_expression.Unapply();

--- a/Xamarin.Forms.Core/BindingBase.cs
+++ b/Xamarin.Forms.Core/BindingBase.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Forms
 			IsApplied = true;
 		}
 
-		internal virtual void Apply(object context, BindableObject bindObj, BindableProperty targetProperty)
+		internal virtual void Apply(object context, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged = false)
 		{
 			IsApplied = true;
 		}
@@ -103,7 +103,7 @@ namespace Xamarin.Forms
 			return SynchronizedCollections.TryGetValue(collection, out synchronizationContext);
 		}
 
-		internal virtual void Unapply()
+		internal virtual void Unapply(bool fromBindingContextChanged = false)
 		{
 			IsApplied = false;
 		}

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -356,7 +356,7 @@ namespace Xamarin.Forms
 			if (Platform != null)
 				child.Platform = Platform;
 
-			child.ApplyBindings();
+			child.ApplyBindings(skipBindingContext: false, fromBindingContextChanged:true);
 
 			if (ChildAdded != null)
 				ChildAdded(this, new ElementEventArgs(child));

--- a/Xamarin.Forms.Core/TemplateBinding.cs
+++ b/Xamarin.Forms.Core/TemplateBinding.cs
@@ -75,13 +75,13 @@ namespace Xamarin.Forms
 			_expression.Apply(fromTarget);
 		}
 
-		internal override async void Apply(object newContext, BindableObject bindObj, BindableProperty targetProperty)
+		internal override async void Apply(object newContext, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged = false)
 		{
 			var view = bindObj as Element;
 			if (view == null)
 				throw new InvalidOperationException();
 
-			base.Apply(newContext, bindObj, targetProperty);
+			base.Apply(newContext, bindObj, targetProperty, fromBindingContextChanged);
 
 			Element templatedParent = await TemplateUtilities.FindTemplatedParentAsync(view);
 			ApplyInner(templatedParent, bindObj, targetProperty);
@@ -108,9 +108,9 @@ namespace Xamarin.Forms
 			return base.GetTargetValue(value, sourcePropertyType);
 		}
 
-		internal override void Unapply()
+		internal override void Unapply(bool fromBindingContextChanged = false)
 		{
-			base.Unapply();
+			base.Unapply(fromBindingContextChanged: fromBindingContextChanged);
 
 			if (_expression != null)
 				_expression.Unapply();

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Internals
 		object _converterParameter;
 		object _source;
 		string _updateSourceEventName;
+		internal bool _hasSourceApplied;
 
 		public IValueConverter Converter {
 			get { return _converter; }
@@ -38,6 +39,7 @@ namespace Xamarin.Forms.Internals
 			set {
 				ThrowIfApplied();
 				_source = value;
+				_hasSourceApplied = false;
 			}
 		}
 
@@ -107,6 +109,9 @@ namespace Xamarin.Forms.Internals
 			_targetProperty = targetProperty;
 			var source = Source ?? Context ?? context;
 
+			if (Source != null && _hasSourceApplied)
+				return;
+			
 #if (!DO_NOT_CHECK_FOR_BINDING_REUSE)
 			base.Apply(source, bindObj, targetProperty);
 
@@ -122,6 +127,9 @@ namespace Xamarin.Forms.Internals
 			_weakTarget.SetTarget(bindObj);
 
 			ApplyCore(source, bindObj, targetProperty);
+
+			if (Source != null)
+				_hasSourceApplied = true;
 		}
 
 		internal override BindingBase Clone()

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -16,7 +16,6 @@ namespace Xamarin.Forms.Internals
 		object _converterParameter;
 		object _source;
 		string _updateSourceEventName;
-		internal bool _hasSourceApplied;
 
 		public IValueConverter Converter {
 			get { return _converter; }
@@ -39,7 +38,6 @@ namespace Xamarin.Forms.Internals
 			set {
 				ThrowIfApplied();
 				_source = value;
-				_hasSourceApplied = false;
 			}
 		}
 
@@ -104,17 +102,18 @@ namespace Xamarin.Forms.Internals
 		}
 
 		// Applies the binding to a new source or target.
-		internal override void Apply(object context, BindableObject bindObj, BindableProperty targetProperty)
+		internal override void Apply(object context, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged = false)
 		{
 			_targetProperty = targetProperty;
 			var source = Source ?? Context ?? context;
+			var isApplied = IsApplied;
 
-			if (Source != null && _hasSourceApplied)
+			if (Source != null && isApplied && fromBindingContextChanged)
 				return;
+
+			base.Apply(source, bindObj, targetProperty, fromBindingContextChanged);
 			
 #if (!DO_NOT_CHECK_FOR_BINDING_REUSE)
-			base.Apply(source, bindObj, targetProperty);
-
 			BindableObject prevTarget;
 			if (_weakTarget.TryGetTarget(out prevTarget) && !ReferenceEquals(prevTarget, bindObj))
 				throw new InvalidOperationException("Binding instances can not be reused");
@@ -127,9 +126,6 @@ namespace Xamarin.Forms.Internals
 			_weakTarget.SetTarget(bindObj);
 
 			ApplyCore(source, bindObj, targetProperty);
-
-			if (Source != null)
-				_hasSourceApplied = true;
 		}
 
 		internal override BindingBase Clone()
@@ -170,10 +166,13 @@ namespace Xamarin.Forms.Internals
 			return value;
 		}
 
-		internal override void Unapply()
+		internal override void Unapply(bool fromBindingContextChanged = false)
 		{
+			if (Source != null && fromBindingContextChanged && IsApplied)
+				return;
+
 #if (!DO_NOT_CHECK_FOR_BINDING_REUSE)
-			base.Unapply();
+			base.Unapply(fromBindingContextChanged:fromBindingContextChanged);
 #endif
 			if (_handlers != null)
 				Unsubscribe();

--- a/Xamarin.Forms.Pages/DataSourceBinding.cs
+++ b/Xamarin.Forms.Pages/DataSourceBinding.cs
@@ -77,13 +77,13 @@ namespace Xamarin.Forms.Pages
 			_expression.Apply(fromTarget);
 		}
 
-		internal override async void Apply(object newContext, BindableObject bindObj, BindableProperty targetProperty)
+		internal override async void Apply(object newContext, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged)
 		{
 			var view = bindObj as VisualElement;
 			if (view == null)
 				throw new InvalidOperationException();
 
-			base.Apply(newContext, bindObj, targetProperty);
+			base.Apply(newContext, bindObj, targetProperty, fromBindingContextChanged: fromBindingContextChanged);
 
 			Element dataSourceParent = await FindDataSourceParentAsync(view);
 
@@ -116,9 +116,9 @@ namespace Xamarin.Forms.Pages
 			return base.GetTargetValue(value, sourcePropertyType);
 		}
 
-		internal override void Unapply()
+		internal override void Unapply(bool fromBindingContextChanged = false)
 		{
-			base.Unapply();
+			base.Unapply(fromBindingContextChanged: fromBindingContextChanged);
 
 			var dataSourceProviderer = (IDataSourceProvider)_dataSourceRef?.Target;
 			dataSourceProviderer?.UnmaskKey(_path);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz34037.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz34037.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using Xamarin.Forms;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -72,19 +73,30 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[SetUp]
 			public void Setup ()
 			{
+				Device.PlatformServices = new MockPlatformServices();
 				Bz34037Converter0.Invoked = 0;
 				Bz34037Converter1.Invoked = 0;
 			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+				Application.Current = null;
+			}
+
 
 			[TestCase(true)]
 			[TestCase(false)]
 			public void ConverterParameterOrderDoesNotMatters (bool useCompiledXaml)
 			{
 				var layout = new Bz34037 (useCompiledXaml);
-				Assert.AreEqual (2, Bz34037Converter0.Invoked);
-//				Assert.AreEqual (2, Bz34037Converter1.Invoked);
+				Assert.AreEqual (1, Bz34037Converter0.Invoked);
+				Assert.AreEqual (1, Bz34037Converter1.Invoked);
 				Assert.AreEqual (typeof(string), Bz34037Converter0.Parameter);
-//				Assert.AreEqual (typeof(string), Bz34037Converter1.Parameter);
+				Assert.AreEqual (typeof(string), Bz34037Converter1.Parameter);
+				Assert.That(layout.s0.IsToggled, Is.True);
+				Assert.That(layout.s1.IsToggled, Is.True);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

[C] do not reapply a Binding with a Source:
- when the Context changes,
- the view is parented
- the inherited context changes.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=57081

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense