### PR TITLE
Make Grid.AddHz/Vt span ortho dim

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/GridTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/GridTests.cs
@@ -39,6 +39,164 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.Throws<ArgumentNullException> (() => layout.Children.Remove (null));
 		}
 
+		[TestFixture]
+		public class AddDimension : GridTests
+		{
+			[Datapoints]
+			public static IEnumerable<string> Operations = new[]
+			{
+				"HHH",
+				"HHV",
+				"HVH",
+				"HVV",
+				"VHH",
+				"VHV",
+				"VVH",
+				"VVV",
+
+				"RCRHVHVHVHVHV",
+
+				"HHHV",
+				"VVVH",
+
+				"RV",
+				"RH",
+				"CV",
+				"CH",
+
+				"RVRRV",
+				"CHCCH",
+			};
+
+			Grid _grid;
+
+			int _id = 0;
+			int _rowDef = 0;
+			int _colDef = 0;
+			int _totalWidth = 0;
+			int _totalHeight = 0;
+
+			public void AddHoizontal()
+			{
+				// new block gets new id
+				var id = _id++;
+
+				// adding column only increases height if no rows exist
+				if (_totalHeight == 0)
+					_totalHeight = 1;
+
+				// adding column always increased width by 1
+				_totalWidth++;
+
+				// column spans rows 0 to the last row
+				var row = 0;
+				var height = _totalHeight;
+
+				// column is always added at the end with a width of 1
+				var column = _totalWidth - 1;
+				var width = 1;
+
+				_grid.Children.AddHorizontal(
+					new Label()
+					{
+						Text = $"{id}: {column}x{row} {width}x{height}"
+					}
+				);
+			}
+			public void AddVertical()
+			{
+				// new block gets new id
+				var id = _id++;
+
+				// adding row only increases width if no columns exist
+				if (_totalWidth == 0)
+					_totalWidth = 1;
+
+				// adding row always increased height by 1
+				_totalHeight++;
+
+				// row spans columns 0 to the last column
+				var column = 0;
+				var width = _totalWidth;
+
+				// row is always added at the end with a height of 1
+				var row = _totalHeight - 1;
+				var height = 1;
+
+				_grid.Children.AddVertical(
+					new Label()
+					{
+						Text = $"{id}: {column}x{row} {width}x{height}"
+					}
+				);
+			}
+			public void AddRowDef()
+			{
+				_rowDef++;
+				_totalHeight = Math.Max(_rowDef, _totalHeight);
+
+				_grid.RowDefinitions.Add(new RowDefinition());
+			}
+			public void AddColumnDef()
+			{
+				_colDef++;
+				_totalWidth = Math.Max(_colDef, _totalWidth);
+
+				_grid.ColumnDefinitions.Add(new ColumnDefinition());
+			}
+
+			[TearDown]
+			public override void TearDown()
+			{
+				_grid = null;
+
+				_id = 0;
+				_rowDef = 0;
+				_colDef = 0;
+				_totalWidth = 0;
+				_totalHeight = 0;
+			}
+
+			[Theory]
+			public void AddDimensionTheory(string operations)
+			{
+				_grid = new Grid();
+				_grid.Platform = new UnitPlatform();
+
+				foreach (var op in operations)
+				{
+					if (op == 'H')
+						AddHoizontal();
+
+					if (op == 'V')
+						AddVertical();
+
+					if (op == 'R')
+						AddRowDef();
+
+					if (op == 'C')
+						AddColumnDef();
+
+					_grid.Layout(new Rectangle(0, 0, 912, 912));
+				}
+
+				Console.WriteLine($"Operations: {string.Join(string.Empty, operations)}");
+
+				var id = 0;
+				foreach (var view in _grid.Children.Cast<Label>().OrderBy(o => o.Text))
+				{
+					var expected = $"{id++}: " +
+						$"{Grid.GetColumn(view)}x{Grid.GetRow(view)} " +
+						$"{Grid.GetColumnSpan(view)}x{Grid.GetRowSpan(view)}";
+
+					var actual = view.Text;
+
+					Console.WriteLine($"  {expected} == {actual}");
+					Assert.That(expected == actual);
+				}
+			}
+		}
+
 		[Test]
 		public void TestBasicVerticalLayout ()
 		{

--- a/Xamarin.Forms.Core/Grid.cs
+++ b/Xamarin.Forms.Core/Grid.cs
@@ -332,12 +332,14 @@ namespace Xamarin.Forms
 				if (view == null)
 					throw new ArgumentNullException("view");
 
-				int lastRow = this.Any() ? this.Max(w => GetRow(w) + GetRowSpan(w) - 1) : -1;
-				lastRow = Math.Max(lastRow, Parent.RowDefinitions.Count - 1);
-				int lastCol = this.Any() ? this.Max(w => GetColumn(w) + GetColumnSpan(w) - 1) : -1;
-				lastCol = Math.Max(lastCol, Parent.ColumnDefinitions.Count - 1);
+				var rows = RowCount();
+				var columns = ColumnCount();
 
-				Add(view, lastCol + 1, lastCol + 2, 0, Math.Max(1, lastRow));
+				// if no rows, create a row
+				if (rows == 0)
+					rows++;
+
+				Add(view, columns, columns + 1, 0, rows);
 			}
 
 			public void AddVertical(IEnumerable<View> views)
@@ -353,13 +355,25 @@ namespace Xamarin.Forms
 				if (view == null)
 					throw new ArgumentNullException("view");
 
-				int lastRow = this.Any() ? this.Max(w => GetRow(w) + GetRowSpan(w) - 1) : -1;
-				lastRow = Math.Max(lastRow, Parent.RowDefinitions.Count - 1);
-				int lastCol = this.Any() ? this.Max(w => GetColumn(w) + GetColumnSpan(w) - 1) : -1;
-				lastCol = Math.Max(lastCol, Parent.ColumnDefinitions.Count - 1);
+				var rows = RowCount();
+				var columns = ColumnCount();
 
-				Add(view, 0, Math.Max(1, lastCol), lastRow + 1, lastRow + 2);
+				// if no columns, create a column
+				if (columns == 0)
+					columns++;
+
+				Add(view, 0, columns, rows, rows + 1);
 			}
+
+			private int RowCount() => Math.Max(
+				this.Max<View, int?>(w => GetRow(w) + GetRowSpan(w)) ?? 0,
+				Parent.RowDefinitions.Count
+			);
+
+			private int ColumnCount() => Math.Max(
+				this.Max<View, int?>(w => GetColumn(w) + GetColumnSpan(w)) ?? 0,
+				Parent.ColumnDefinitions.Count
+			);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

User expected Grid.AddHorizontal to add a column which spans all rows. What actually happens is that the column spans all the rows except the last one _unless_ there are no rows in which case it creates a new row and spans that single row. 

The fix requires tweaking Grid.AddHorizontal. Grid.AddHorizontal calls Add to create the column. Add takes a view, left/right, and top/bottom. For simplicity consider just the arguments to create the columns: left/right. Starting with a grid with no columns calling add with 0,1 will create one column. First, note that the first index doesn't exist. When the first index doesn't exist that means create a new dimension. Second, note that the second index is one past the index to be created. Now consider the top/bottom values specifying the rows to span. To span all rows we'd need to pass 0, RowCount. However if no rows exist then 0 will create the row and we need to bump RowCount to 1. The same logic applies for Grid.AddVertical just transformed for that dimension. 

Now, consider our existing Grid.AddHorizontal code:

`Add(view, lastCol + 1, lastCol + 2, 0, Math.Max(1, lastRow));`

Notice that the last parameter, bottom, will be `lastRow` when there is more than a single row. This would be correct if `lastRow` were the number of rows however it's not -- it's the last valid row index. As such it actually excludes the last valid index when there is more than a single row; The existing logic works when there are no rows or when there is one row. 

I tested that the above logic works for the simple case in UWP. I haven't considered the merged row/column cases or tested the other platforms because the first case is breaking; we have to decide if we're take the break in the simple case before considering other cases. 

Grid.AddHorizontal calls no private or internal members so is essentially a helper method. So, as a work around, the user could copy/paste the fix here into their own extension method to build a method with the expected behavior.

Deprecation is also an option.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=42620

### API Changes ###

None added.

### Behavioral Changes ###

*Breaking Change*; Changes Grid.AddHorizontal and Grid.AddVertical.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
