### PR TITLE
Allow Context Actions on ViewCells with TapGestures

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46363.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46363.cs
@@ -3,6 +3,7 @@ using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
 #if UITEST
+using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
 using NUnit.Framework;
 #endif
@@ -10,7 +11,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 946363, "TapGestureRecognizer blocks List View Context Actions", PlatformAffected.Android)]
+	[Issue(IssueTracker.Bugzilla, 46363, "TapGestureRecognizer blocks List View Context Actions", PlatformAffected.Android)]
 	public class Bugzilla46363 : TestContentPage
 	{
 		const string Target = "Two";
@@ -93,7 +94,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public void _46363_ContextAction_Succeeds()
 		{
 			RunningApp.WaitForElement(Testing);
-			RunningApp.TouchAndHold(Target);
+			RunningApp.ActivateContextMenu(Target);
 			RunningApp.WaitForElement(ContextAction);
 			RunningApp.Tap(ContextAction);
 			RunningApp.WaitForElement(ContextSuccess);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46363.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46363.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 946363, "TapGestureRecognizer blocks List View Context Actions", PlatformAffected.Android)]
+	public class Bugzilla46363 : TestContentPage 
+	{
+		protected override void Init()
+		{
+			var list = new List<string> { "one", "two", "three" };
+
+			var lv = new ListView
+			{
+				ItemsSource = list,
+				ItemTemplate = new DataTemplate(typeof(_46363Template))
+			};
+
+			Content = lv;
+		}
+
+		[Preserve(AllMembers = true)]
+		class _46363Template : ViewCell
+		{
+			public _46363Template()
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				View = new StackLayout { Children = { label } };
+
+				ContextActions.Add(new MenuItem
+				{
+					Text = "Context Action",
+					Command = new Command(() => { Debug.WriteLine($">>>>> _46363Template _46363Template 39: Context Action"); })
+				});
+
+				//View.GestureRecognizers.Add(new TapGestureRecognizer
+				//{ Command = new Command(() => { Debug.WriteLine($">>>>> _46363Template _46363Template 47: Tap Gesture"); }) });
+			}
+		}
+
+#if UITEST
+		//[Test]
+		//public void _46363Test()
+		//{
+		//	//RunningApp.WaitForElement(q => q.Marked(""));
+		//}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -164,6 +164,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44453.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45215.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44500.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46363.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47548.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53834.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51536.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/Gestures.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/Gestures.cs
@@ -111,8 +111,9 @@ namespace Xamarin.Forms.Core.UITests
 #if __IOS__
 			var element = app.WaitForElement(target);
 			var rect = element[0].Rect;
+			var appRect = app.RootViewRect();
 
-			app.DragCoordinates(rect.X + (0.85f * rect.Width), 
+			app.DragCoordinates(rect.X + (0.85f * appRect.Width), 
 				rect.CenterY, 
 				rect.X + (0.25f * rect.Width),
 				rect.CenterY);

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/Gestures.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/Gestures.cs
@@ -105,5 +105,21 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			app.DragCoordinates (drag.XStart, drag.YStart, drag.XEnd, drag.YEnd);
 		}
+
+		public static void ActivateContextMenu(this IApp app, string target)
+		{
+#if __IOS__
+			var element = app.WaitForElement(target);
+			var rect = element[0].Rect;
+
+			app.DragCoordinates(rect.X + (0.85f * rect.Width), 
+				rect.CenterY, 
+				rect.X + (0.25f * rect.Width),
+				rect.CenterY);
+#else
+			app.TouchAndHold(target);
+#endif
+
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -63,6 +63,7 @@ namespace Xamarin.Forms.Platform.Android
 				_viewCell = viewCell;
 				AddView(view.View);
 				UpdateIsEnabled();
+				UpdateLongClickable();
 			}
 
 			protected bool ParentHasUnevenRows
@@ -84,6 +85,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (!Enabled)
 					return true;
+
 				return base.OnInterceptTouchEvent(ev);
 			}
 
@@ -135,6 +137,7 @@ namespace Xamarin.Forms.Platform.Android
 				AddView(_view.View);
 
 				UpdateIsEnabled();
+				UpdateLongClickable();
 
 				Performance.Stop();
 			}
@@ -177,6 +180,14 @@ namespace Xamarin.Forms.Platform.Android
 				SetMeasuredDimension(width, height);
 
 				Performance.Stop();
+			}
+
+			void UpdateLongClickable()
+			{
+				// In order for context menu long presses/clicks to work on ViewCells which have 
+				// and Clickable content, we have to make the container view LongClickable
+				// If we don't have a context menu, we don't have to worry about it
+				_view.View.LongClickable = _viewCell.ContextActions.Count > 0;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/GestureManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/GestureManager.cs
@@ -170,7 +170,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 			// It's very important that the gesture detection happen first here
 			// if we check handled first, we might short-circuit and never check for tap/pan
-			return _gestureDetector.Value.OnTouchEvent(e) || handled;
+			handled = _gestureDetector.Value.OnTouchEvent(e) || handled;
+
+			v.EnsureLongClickCancellation(e, handled, Element);
+
+			return handled;
 		}
 
 		void HandleGestureRecognizerCollectionChanged(object sender,

--- a/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
+++ b/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool _isScrolling;		
 		float _lastX;
 		float _lastY;
+		bool _disposed;
 
 		Func<bool> _scrollCompleteDelegate;
 		Func<float, float, int, bool> _scrollDelegate;
@@ -23,15 +24,15 @@ namespace Xamarin.Forms.Platform.Android
 									Func<int, bool> scrollStartedDelegate, Func<bool> scrollCompleteDelegate)
 		{
 			if (tapDelegate == null)
-				throw new ArgumentNullException("tapDelegate");
+				throw new ArgumentNullException(nameof(tapDelegate));
 			if (tapGestureRecognizers == null)
-				throw new ArgumentNullException("tapGestureRecognizers");
+				throw new ArgumentNullException(nameof(tapGestureRecognizers));
 			if (scrollDelegate == null)
-				throw new ArgumentNullException("scrollDelegate");
+				throw new ArgumentNullException(nameof(scrollDelegate));
 			if (scrollStartedDelegate == null)
-				throw new ArgumentNullException("scrollStartedDelegate");
+				throw new ArgumentNullException(nameof(scrollStartedDelegate));
 			if (scrollCompleteDelegate == null)
-				throw new ArgumentNullException("scrollCompleteDelegate");
+				throw new ArgumentNullException(nameof(scrollCompleteDelegate));
 
 			_tapDelegate = tapDelegate;
 			_tapGestureRecognizers = tapGestureRecognizers;
@@ -59,8 +60,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool GestureDetector.IOnDoubleTapListener.OnDoubleTap(MotionEvent e)
 		{
-			if (_tapDelegate == null || _tapGestureRecognizers == null)
+			if (_disposed)
 				return false;
+
 			return _tapDelegate(2);
 		}
 
@@ -71,7 +73,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool GestureDetector.IOnDoubleTapListener.OnSingleTapConfirmed(MotionEvent e)
 		{
-			if (_tapDelegate == null || _tapGestureRecognizers == null)
+			if (_disposed)
 				return false;
 
 			// optimization: only wait for a second tap if there is a double tap handler
@@ -90,7 +92,6 @@ namespace Xamarin.Forms.Platform.Android
 		bool GestureDetector.IOnGestureListener.OnFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY)
 		{
 			EndScrolling();
-
 			return false;
 		}
 
@@ -115,7 +116,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool GestureDetector.IOnGestureListener.OnSingleTapUp(MotionEvent e)
 		{
-			if (_tapDelegate == null || _tapGestureRecognizers == null)
+			if (_disposed)
 				return false;
 
 			// optimization: do not wait for a second tap if there is no double tap handler
@@ -127,6 +128,13 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
 			if (disposing)
 			{
 				_tapDelegate = null;

--- a/Xamarin.Forms.Platform.Android/Renderers/MotionEventHelper.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MotionEventHelper.cs
@@ -38,16 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			// Determine whether this control is inside a ViewCell;
 			// we don't fake handle the events because ListView needs them for row selection
-			var parent = _element.Parent;
-			while (parent != null)
-			{
-				if (parent is ViewCell)
-				{
-					_isInViewCell = true;
-					break;
-				}
-				parent = parent.Parent;
-			}
+			_isInViewCell = element.IsInViewCell();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ViewCellExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ViewCellExtensions.cs
@@ -1,0 +1,37 @@
+using Android.Views;
+using AView = Android.Views.View;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal static class ViewCellExtensions
+	{
+		public static bool IsInViewCell(this VisualElement element)
+		{
+			var parent = element.Parent;
+			while (parent != null)
+			{
+				if (parent is ViewCell)
+				{
+					return true;
+				}
+				parent = parent.Parent;
+			}
+
+			return false;
+		}
+
+		public static void EnsureLongClickCancellation(this AView view, MotionEvent motionEvent, bool handled, VisualElement element)
+		{
+			if (motionEvent.Action == MotionEventActions.Up && handled && view.LongClickable && element.IsInViewCell())
+			{
+				// In order for long presses/clicks (for opening context menus) to work in a ViewCell 
+				// which contains any Clickable Views (e.g., any with TapGestures associated, or Buttons) 
+				// the top-level container in the ViewCell has to be LongClickable; unfortunately, Android 
+				// cancels a pending long press/click during MotionEventActions.Up, which the View won't
+				// get if the gesture listener has already processed it. So when all these conditions are 
+				// true, we need to go ahead and send the Up event to the View; if we don't, the context menu will open
+				view.OnTouchEvent(motionEvent);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -126,6 +126,8 @@ namespace Xamarin.Forms.Platform.Android
 			// if we check handled first, we might short-circuit and never check for tap/pan
 			handled = _gestureDetector.Value.OnTouchEvent(e) || handled;
 
+			v.EnsureLongClickCancellation(e, handled, Element);
+
 			return handled;
 		}
 

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Renderers\StreamImagesourceHandler.cs" />
     <Compile Include="Renderers\ToolbarButton.cs" />
     <Compile Include="Renderers\ToolbarImageButton.cs" />
+    <Compile Include="Renderers\ViewCellExtensions.cs" />
     <Compile Include="Renderers\ViewGroupExtensions.cs" />
     <Compile Include="TapGestureHandler.cs" />
     <Compile Include="TextColorSwitcher.cs" />


### PR DESCRIPTION
### Description of Change ###

Android stops paying attention to long presses/clicks in ListViews when a list item has any Clickable View inside of it unless the list item's container is marked as LongClickable. This change marks the View inside the ViewCell as LongClickable if the ViewCell has any ContextActions. It also handles pushing the UP MotionEvent to the ViewCell's child layout (if necessary) to cancel any pending long presses/clicks after handling a TapGesture.

### Bugs Fixed ###

- [46363 – TapGestureRecognizer blocks List View Context Actions](https://bugzilla.xamarin.com/show_bug.cgi?id=46363)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
