### PR TITLE
[iOS] workaround a weird iOS behavior.

### DIFF
--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -88,25 +88,21 @@ namespace Xamarin.Forms
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
-		{
-		}
-
-		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
-		{
-		}
-
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			Device.GetNamedSize(NamedSize.Default, (Entry)this);
 
-		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
-		{
-		}
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-		void IFontElement.OnFontChanged(Font oldValue, Font newValue)
-		{
-		}
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+
+		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
+			 InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		
 		public event EventHandler Completed;
 
 		public event EventHandler<TextChangedEventArgs> TextChanged;

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -17,6 +17,18 @@ namespace Xamarin.Forms.Platform.iOS
 			Frame = new RectangleF(0, 20, 320, 40);
 		}
 
+		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			//with borderStyle set to RoundedRect, iOS always returns a height of 30
+			//https://stackoverflow.com/a/36569247/1063783
+			//we get the current value, and restor it, to allow custom renderers to change the border style
+			var borderStyle = Control.BorderStyle;
+			Control.BorderStyle = UITextBorderStyle.None;
+			var size = Control.GetSizeRequest(widthConstraint, double.PositiveInfinity);
+			Control.BorderStyle = borderStyle;
+			return size;
+		}
+
 		IElementController ElementController => Element as IElementController;
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change ###

Work around the fact the UITextField always returns 30 as fitting size for RoundedRect BorderStyle.
Also make sure the layout is invalidated when the font is changed.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44774

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense