### PR TITLE
[WinRT/UWP] Add delay for layout in OnScrollToRequested

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36651.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36651.cs
@@ -1,0 +1,78 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 36651, "ScrollToAsync fails to scroll on Windows Phone 8.1 RT", PlatformAffected.WinRT)]
+	public class Bugzilla36651 : TestNavigationPage
+	{
+		public class LandingPage : ContentPage
+		{
+			private static int numberOfButtons = 3;
+			StackLayout layout;
+			Button addItem, removeItem;
+			ScrollView scrollView;
+
+			public LandingPage()
+			{
+				layout = new StackLayout();
+				for (var i = 0; i < 10; i++)
+				{
+					layout.Children.Add(new Button { Text = "This is a button" });
+				}
+
+				addItem = new Button { Text = "Add Item" };
+				removeItem = new Button { Text = "Remove Item" };
+				scrollView = new ScrollView { Content = layout };
+
+				Content = new StackLayout
+				{
+					Children =
+					{
+						new Label
+						{
+							Text = "Clicking 'Add Item' should scroll to the end when added items go out of the view"
+						},
+						scrollView,
+						addItem,
+						removeItem
+					}
+				};
+
+				addItem.Clicked += (object sender, EventArgs e) =>
+				{
+					Button lastButton = null;
+					for (int i = 0; i < numberOfButtons; ++i)
+					{
+						lastButton = new Button
+						{
+							Text = String.Format("This is button #{0}", i)
+						};
+						layout.Children.Add(lastButton);
+					}
+					++numberOfButtons;
+
+					scrollView.ScrollToAsync(lastButton, ScrollToPosition.End, false);
+				};
+				removeItem.Clicked += (object sender, EventArgs e) =>
+				{
+					if (layout.Children.Count != 0)
+						layout.Children.RemoveAt(layout.Children.Count - 1);
+				};
+			}
+		}
+
+		protected override void Init()
+		{
+			var page = new LandingPage();
+			Navigation.PushAsync(page);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -84,6 +84,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36559.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36171.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36780.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36651.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36703.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36846.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36955.cs" />

--- a/Xamarin.Forms.Platform.WinRT/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ScrollViewRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -124,8 +125,22 @@ namespace Xamarin.Forms.Platform.WinRT
 			UpdateMargins();
 		}
 
-		void OnScrollToRequested(object sender, ScrollToRequestedEventArgs e)
+		async void OnScrollToRequested(object sender, ScrollToRequestedEventArgs e)
 		{
+			// Adding items into the view while scrolling to the end can cause it to fail, as
+			// the items have not actually been laid out and return incorrect scroll position
+			// values. The ScrollViewRenderer for Android does something similar by waiting up
+			// to 10ms for layout to occur.
+			int cycle = 0;
+			while (!Element.IsInNativeLayout)
+			{
+				await Task.Delay(TimeSpan.FromMilliseconds(1));
+				cycle++;
+
+				if (cycle >= 10)
+					break;
+			}
+
 			double x = e.ScrollX, y = e.ScrollY;
 
 			ScrollToMode mode = e.Mode;


### PR DESCRIPTION
### Description of Change ###

When items are being added into a ScrollView on WinRT/UWP, it can cause ScrollToAsync to fail, particularly when scrolling to the end, as the items are added but have not yet been laid out, leading to incorrect scroll values in OnScrollToRequested. It appears as if the Android implementation of the ScrollViewRenderer does something [similar](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs#L284-L292) by running a small delay of up to 10ms; a similar usage here appears to alleviate the problem while not affecting the previous behavior (based on the use of the control gallery's ScrollView page).

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=36651

### API Changes ###

Adjust OnScrollToRequested to use async

### Behavioral Changes ###

A very small 10ms addition which should otherwise not be noticeable by the user.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
