### PR TITLE
[iOS] Allow Forms gestures on custom renderers for controls which already have gestures

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -182,6 +182,7 @@
     <Compile Include="ColorPicker.cs" />
     <Compile Include="_38989CustomRenderer.cs" />
     <Compile Include="BrokenImageSourceHandler.cs" />
+    <Compile Include="_57114CustomRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\default.css" />

--- a/Xamarin.Forms.ControlGallery.Android/_57114CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_57114CustomRenderer.cs
@@ -1,0 +1,42 @@
+using System;
+using Android.Content;
+using Android.OS;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.Android;
+using AView = Android.Views.View;
+
+[assembly: ExportRenderer(typeof(Bugzilla57114._57114View), typeof(_57114CustomRenderer))]
+
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class _57114CustomRenderer : Platform.Android.AppCompat.ViewRenderer<Bugzilla57114._57114View, _57114NativeView>
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Bugzilla57114._57114View> e)
+		{
+			if (e.NewElement != null && Control == null)
+			{
+				var view = new _57114NativeView(Context);
+				SetNativeControl(view);
+			}
+
+			base.OnElementChanged(e);
+		}
+	}
+
+	public class _57114NativeView : global::Android.Views.View
+	{
+		public _57114NativeView(Context context)
+			: base(context)
+		{
+			Touch += OnTouch;
+		}
+
+		void OnTouch(object sender, AView.TouchEventArgs e)
+		{
+			MessagingCenter.Send(this as object, Bugzilla57114._57114NativeGestureFiredMessage);
+			e.Handled = false;
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -120,6 +120,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="_57114Renderer.cs" />
     <Content Include="coffee.png" />
     <Content Include="default.css" />
     <Content Include="invalidimage.jpg" />

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/_57114Renderer.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/_57114Renderer.cs
@@ -1,0 +1,48 @@
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.UWP;
+
+[assembly: ExportRenderer(typeof(Bugzilla57114._57114View), typeof(_57114Renderer))]
+
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	public class _57114Renderer : VisualElementRenderer<Bugzilla57114._57114View, _57114NativeView>
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Bugzilla57114._57114View> e)
+		{
+			if (e.NewElement != null && Control == null)
+			{
+				var view = new _57114NativeView();
+				SetNativeControl(view);
+				
+			}
+
+			base.OnElementChanged(e);
+
+			if (Control != null)
+			{
+				Control.Background = ColorToBrush(Element.BackgroundColor);
+			}
+		}
+
+		Brush ColorToBrush(Color color)
+		{
+			return new SolidColorBrush(Windows.UI.Color.FromArgb((byte)(color.A * 255), (byte)(color.R * 255), (byte)(color.G * 255), (byte)(color.B * 255)));
+		}
+	}
+
+	public class _57114NativeView : Windows.UI.Xaml.Controls.Grid
+	{
+		public _57114NativeView()
+		{
+			Tapped += OnTapped;
+		}
+
+		void OnTapped(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)
+		{
+			MessagingCenter.Send(this as object, Bugzilla57114._57114NativeGestureFiredMessage);
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -164,6 +164,7 @@
     <Compile Include="CustomRenderer40251.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
+    <Compile Include="_57114Renderer.cs" />
     <None Include="app.config" />
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Xamarin.Forms.ControlGallery.iOS/_57114Renderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/_57114Renderer.cs
@@ -1,0 +1,44 @@
+using System;
+using Foundation;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(Bugzilla57114._57114View), typeof(_57114Renderer))]
+
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class _57114Renderer : ViewRenderer<Bugzilla57114._57114View, _57114NativeView>
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Bugzilla57114._57114View> e)
+		{
+			if (e.NewElement != null && Control == null)
+			{
+				var view = new _57114NativeView();
+				SetNativeControl(view);
+			}
+
+			base.OnElementChanged(e);
+		}
+	}
+
+	public class _57114NativeView : UIView, IUIGestureRecognizerDelegate
+	{
+		public _57114NativeView()
+		{
+			var rec = new CustomGestureRecognizer();
+			AddGestureRecognizer(rec);
+		}
+	}
+
+	public class CustomGestureRecognizer : UIGestureRecognizer
+	{
+		public override void TouchesBegan(NSSet touches, UIEvent evt)
+		{
+			base.TouchesBegan(touches, evt);
+			MessagingCenter.Instance.Send(this as object, Bugzilla57114._57114NativeGestureFiredMessage);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57114.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57114.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Diagnostics;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Gestures)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 57114, "Forms gestures are not supported on UIViews that have native gestures", PlatformAffected.iOS)]
+	public class Bugzilla57114 : TestContentPage
+	{
+		public static string _57114NativeGestureFiredMessage = "_57114NativeGestureFiredMessage";
+
+		Label _results;
+		bool _nativeGestureFired;
+		bool _formsGestureFired;
+
+		const string Testing = "Testing...";
+		const string Success = "Success";
+		const string AutomationId = "_57114View";
+
+		protected override void Init()
+		{
+			var instructions = new Label
+			{
+				Text = $"Tap the Aqua View below. If the label below changes from '{Testing}' to '{Success}', the test has passed."
+			};
+
+			_results = new Label { Text = Testing };
+
+			var view = new _57114View
+			{
+				AutomationId = AutomationId,
+				HeightRequest = 200, WidthRequest = 200,
+				BackgroundColor = Color.Aqua,
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill
+			};
+
+			var tap = new TapGestureRecognizer
+			{
+				Command = new Command(() =>
+				{
+					_formsGestureFired = true;
+					UpdateResults();
+				})
+			};
+
+			MessagingCenter.Subscribe<object>(this, _57114NativeGestureFiredMessage, NativeGestureFired);
+
+			view.GestureRecognizers.Add(tap);
+
+			var layout = new StackLayout()
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+				Children =
+				{
+					instructions, _results, view
+				}
+			};
+
+			Content = layout;
+		}
+
+		void NativeGestureFired(object obj)
+		{
+			_nativeGestureFired = true;
+			UpdateResults();
+		}
+
+		void UpdateResults()
+		{
+			if (_nativeGestureFired && _formsGestureFired)
+			{
+				_results.Text = Success;
+			}
+			else
+			{
+				_results.Text = Testing;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class _57114View : View
+		{
+		}
+		
+		// TODO hartez 2017/06/13 10:41:47 Add a custom renderer for UWP and test it	
+
+#if UITEST
+		[Test]
+		public void _57114BothTypesOfGesturesFire()
+		{
+			RunningApp.WaitForElement(Testing);
+			RunningApp.Tap(AutomationId);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57114.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57114.cs
@@ -96,8 +96,6 @@ namespace Xamarin.Forms.Controls.Issues
 		public class _57114View : View
 		{
 		}
-		
-		// TODO hartez 2017/06/13 10:41:47 Add a custom renderer for UWP and test it	
 
 #if UITEST
 		[Test]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -208,6 +208,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56609.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55912.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57317.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57114.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -32,6 +32,7 @@
 		public const string Maps = "Maps";
 		public const string InputTransparent = "InputTransparent";
 		public const string IsEnabled = "IsEnabled";
+		public const string Gestures = "Gestures";
 
 		public const string ManualReview = "ManualReview";
 	}

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -32,7 +32,9 @@ namespace Xamarin.Forms.Platform.MacOS
 		NativeView _handler;
 
 		double _previousScale = 1.0;
+#if __MOBILE__
 		UITouchEventArgs _shouldReceiveTouch;
+#endif
 
 		public EventTracker(IVisualElementRenderer renderer)
 		{
@@ -278,19 +280,18 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 #endif
 
-#if __MOBILE__
-		
-#endif
 		void LoadRecognizers()
 		{
 			if (ElementGestureRecognizers == null)
 				return;
 
+#if __MOBILE__
 			if (_shouldReceiveTouch == null)
 			{
 				// Cache this so we don't create a new UITouchEventArgs instance for every recognizer
 				_shouldReceiveTouch = ShouldReceiveTouch;
 			}
+#endif
 
 			foreach (var recognizer in ElementGestureRecognizers)
 			{
@@ -320,6 +321,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 		}
 
+#if __MOBILE__
 		bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
 		{
 			if (touch.View is IVisualElementRenderer)
@@ -342,6 +344,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			return false;
 		}
+#endif
 
 		void ModelGestureRecognizersOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 		{

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -337,7 +337,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return false;
 			}
 			
-			if (touch.View.IsDescendantOfView(_renderer.NativeView))
+			if (touch.View.IsDescendantOfView(_renderer.NativeView) && touch.View.GestureRecognizers?.Length > 0)
 			{
 				return true;
 			}

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -288,6 +288,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (_shouldReceiveTouch == null)
 			{
+				// Cache this so we don't create a new UITouchEventArgs instance for every recognizer
 				_shouldReceiveTouch = ShouldReceiveTouch;
 			}
 


### PR DESCRIPTION
### Description of Change ###

If you create a custom renderer for a control which already has a gesture recognizer, gestures from that control will not be recognized by the Forms gesture recognizer. This change allows the gestures from the control to be processed by the Forms recognizer.

### Bugs Fixed ###

- [57114 – Forms gestures are not supported on UIViews that have native gestures](https://bugzilla.xamarin.com/show_bug.cgi?id=57114)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
