### PR TITLE
NavigationEventArgs.Page should provide the popped page, not root

### DIFF
--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -339,7 +339,7 @@ namespace Xamarin.Forms
 					await args.Task;
 			}
 
-			PoppedToRoot?.Invoke(this, new PoppedToRootEventArgs(RootPage, childrenToRemove.OfType<Page>().ToList()));
+			PoppedToRoot?.Invoke(this, new PoppedToRootEventArgs(childrenToRemove.OfType<Page>().ToList()));
 		}
 
 		async Task PushAsyncInner(Page page, bool animated)

--- a/Xamarin.Forms.Core/PoppedToRootEventArgs.cs
+++ b/Xamarin.Forms.Core/PoppedToRootEventArgs.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Xamarin.Forms
 {
 	public class PoppedToRootEventArgs : NavigationEventArgs
 	{
-		public PoppedToRootEventArgs(Page page, IEnumerable<Page> poppedPages) : base(page)
+		public PoppedToRootEventArgs(IEnumerable<Page> poppedPages) : base(poppedPages.Last())
 		{
 			if (poppedPages == null)
 				throw new ArgumentNullException(nameof(poppedPages));


### PR DESCRIPTION
### Description of Change ###

NavigationEventArgs.Page provides the popped page, not root. It was inconsistent between PopAsync and PopToRootAsync.

### Bugs Fixed ###

None.

### API Changes ###

None.

### Behavioral Changes ###

Instead of writing

`NavigationPage.PoppedToRoot += (sender, e) => ((e as PoppedToRootEventArgs).PoppedPages.Last() ...`

we can now write 

`NavigationPage.PoppedToRoot += (sender, e) => ((e as NavigationEventArgs).Page ...`

which behaves the same as `NavigationPage.Popped`

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
