### PR TITLE
[macOS] ScrollView's content are showing at End.

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/FlippedClipView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/FlippedClipView.cs
@@ -1,0 +1,31 @@
+﻿using AppKit;
+using RectangleF = CoreGraphics.CGRect;
+
+namespace Xamarin.Forms.Platform.MacOS
+{
+	internal class FlippedClipView : NSClipView
+	{
+		public override bool IsFlipped
+		{
+			get
+			{
+				return true;
+			}
+		}
+
+		public IVisualElementRenderer ContentRenderer { get; set; }
+
+		public override RectangleF ConstrainBoundsRect(RectangleF proposedBounds)
+		{
+			RectangleF ret = base.ConstrainBoundsRect(proposedBounds);
+
+			if (ContentRenderer == null || ContentRenderer.Element == null)
+				return ret;
+
+			if (Frame.Height > ContentRenderer.Element.Height)
+				ret.Y = (float)(Frame.Height - ContentRenderer.Element.Height - ContentRenderer.Element.Y - ContentRenderer.Element.Y);
+
+			return ret;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.ComponentModel;
 using AppKit;
 using RectangleF = CoreGraphics.CGRect;
@@ -19,10 +19,10 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public ScrollViewRenderer() : base(RectangleF.Empty)
 		{
+            ContentView = new FlippedClipView();
 			DrawsBackground = false;
-			ContentView.PostsBoundsChangedNotifications = true;
-			NSNotificationCenter.DefaultCenter.AddObserver(this, new Selector(nameof(UpdateScrollPosition)),
-				BoundsChangedNotification, ContentView);
+            ContentView.PostsBoundsChangedNotifications = false;
+			NSNotificationCenter.DefaultCenter.AddObserver(this, new Selector(nameof(UpdateScrollPosition)), BoundsChangedNotification, ContentView);
 			HasVerticalScroller = true;
 		}
 
@@ -128,8 +128,10 @@ namespace Xamarin.Forms.Platform.MacOS
 				Platform.SetRenderer(content, Platform.CreateRenderer(content));
 
 			_contentRenderer = Platform.GetRenderer(content);
-
+            (ContentView as FlippedClipView).ContentRenderer = _contentRenderer;
 			DocumentView = _contentRenderer.NativeView;
+
+            ContentView.PostsBoundsChangedNotifications = true;
 		}
 
 		void LayoutSubviews()
@@ -150,16 +152,6 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateBackgroundColor();
 		}
 
-		void HandleScrollAnimationEnded(object sender, EventArgs e)
-		{
-			ScrollView.SendScrollFinished();
-		}
-
-		void HandleScrolled(object sender, EventArgs e)
-		{
-			UpdateScrollPosition();
-		}
-
 		void OnNativeControlUpdated(object sender, EventArgs eventArgs)
 		{
 			UpdateContentSize();
@@ -177,8 +169,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				? new Point(e.ScrollX, Element.Height - e.ScrollY)
 				: ScrollView.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
 
-			(DocumentView as NSView)?.ScrollPoint(scrollPoint.ToPointF());
-
+            ContentView.ScrollToPoint(scrollPoint.ToPointF());
 			ScrollView.SendScrollFinished();
 		}
 
@@ -200,27 +191,77 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateContentSize()
 		{
-			if (_contentRenderer == null)
+			if (ContentView == null || ScrollView == null)
 				return;
-			var contentSize = ((ScrollView)Element).ContentSize.ToSizeF();
-			if (!contentSize.IsEmpty)
-				_contentRenderer.NativeView.Frame = new RectangleF(0, Element.Height - contentSize.Height, contentSize.Width,
-					contentSize.Height);
+
+            ContentView.Frame = new RectangleF(ContentView.Frame.X, ContentView.Frame.Y, Frame.Width, Frame.Height);
+            ResetNativeNonScroll();
 		}
+
+        private bool ResetNativeNonScroll( )
+        {
+            if (ScrollView == null || ContentView == null)
+                return false;
+
+            if (ScrollView.ScrollY <= 0.0f && ContentView.DocumentVisibleRect().Location.Y > 0.0f)
+            {
+                ContentView.ScrollToPoint(new CoreGraphics.CGPoint(0, 0));
+                return true;
+            }
+
+            return false;
+        }
 
 		[Export(nameof(UpdateScrollPosition))]
 		void UpdateScrollPosition()
 		{
-			var convertedPoint = (DocumentView as NSView)?.ConvertPointFromView(ContentView.Bounds.Location, ContentView);
-			if (convertedPoint.HasValue)
-				ScrollView.SetScrolledPosition(Math.Max(0, convertedPoint.Value.X), Math.Max(0, convertedPoint.Value.Y));
+            if (ScrollView == null)
+                return;
+            
+            if (ScrollView.ContentSize.Height >= ScrollView.Height)
+            {
+                RectangleF visibleRect = ContentView.DocumentVisibleRect();
+                if (visibleRect.Location.Y > -1)
+                    ScrollView.SetScrolledPosition(Math.Max(0, visibleRect.Location.X), Math.Max(0, ContentView.Frame.Height - visibleRect.Location.Y));
+            }
+            else
+                ResetNativeNonScroll();            
 		}
 
 		void ClearContentRenderer()
 		{
+            if ((ContentView as FlippedClipView) != null)
+                (ContentView as FlippedClipView).ContentRenderer = null;
+            
 			_contentRenderer?.NativeView?.RemoveFromSuperview();
 			_contentRenderer?.Dispose();
 			_contentRenderer = null;
+		}
+
+		private sealed class FlippedClipView : NSClipView
+		{
+			public override bool IsFlipped
+			{
+				get
+				{
+                    return true;
+				}
+			}
+
+			public IVisualElementRenderer ContentRenderer { get; set; }
+
+			public override RectangleF ConstrainBoundsRect(RectangleF proposedBounds)
+			{
+				RectangleF ret = base.ConstrainBoundsRect(proposedBounds);
+
+                if (ContentRenderer == null || ContentRenderer.Element == null)
+                    return ret;
+
+				if (Frame.Height > ContentRenderer.Element.Height)
+					ret.Y = (float)(Frame.Height - ContentRenderer.Element.Height - ContentRenderer.Element.Y - ContentRenderer.Element.Y);
+
+                return ret;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -19,9 +19,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public ScrollViewRenderer() : base(RectangleF.Empty)
 		{
-            ContentView = new FlippedClipView();
+			ContentView = new FlippedClipView();
 			DrawsBackground = false;
-            ContentView.PostsBoundsChangedNotifications = false;
+			ContentView.PostsBoundsChangedNotifications = false;
 			NSNotificationCenter.DefaultCenter.AddObserver(this, new Selector(nameof(UpdateScrollPosition)), BoundsChangedNotification, ContentView);
 			HasVerticalScroller = true;
 		}
@@ -128,10 +128,10 @@ namespace Xamarin.Forms.Platform.MacOS
 				Platform.SetRenderer(content, Platform.CreateRenderer(content));
 
 			_contentRenderer = Platform.GetRenderer(content);
-            (ContentView as FlippedClipView).ContentRenderer = _contentRenderer;
+			(ContentView as FlippedClipView).ContentRenderer = _contentRenderer;
 			DocumentView = _contentRenderer.NativeView;
 
-            ContentView.PostsBoundsChangedNotifications = true;
+			ContentView.PostsBoundsChangedNotifications = true;
 		}
 
 		void LayoutSubviews()
@@ -169,7 +169,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				? new Point(e.ScrollX, Element.Height - e.ScrollY)
 				: ScrollView.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
 
-            ContentView.ScrollToPoint(scrollPoint.ToPointF());
+			ContentView.ScrollToPoint(scrollPoint.ToPointF());
 			ScrollView.SendScrollFinished();
 		}
 
@@ -194,30 +194,30 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (ContentView == null || ScrollView == null)
 				return;
 
-            ContentView.Frame = new RectangleF(ContentView.Frame.X, ContentView.Frame.Y, Frame.Width, Frame.Height);
-            ResetNativeNonScroll();
+			ContentView.Frame = new RectangleF(ContentView.Frame.X, ContentView.Frame.Y, Frame.Width, Frame.Height);
+			ResetNativeNonScroll();
 		}
 
-        private bool ResetNativeNonScroll( )
-        {
-            if (ScrollView == null || ContentView == null)
-                return false;
+		private bool ResetNativeNonScroll( )
+		{
+			if (ScrollView == null || ContentView == null)
+				return false;
 
-            if (ScrollView.ScrollY <= 0.0f && ContentView.DocumentVisibleRect().Location.Y > 0.0f)
-            {
-                ContentView.ScrollToPoint(new CoreGraphics.CGPoint(0, 0));
-                return true;
-            }
+			if (ScrollView.ScrollY <= 0.0f && ContentView.DocumentVisibleRect().Location.Y > 0.0f)
+			{
+				ContentView.ScrollToPoint(new CoreGraphics.CGPoint(0, 0));
+				return true;
+			}
 
-            return false;
-        }
+			return false;
+		}
 
 		[Export(nameof(UpdateScrollPosition))]
 		void UpdateScrollPosition()
 		{
 			if (ScrollView == null)
 				return;
-            
+
 			if (ScrollView.ContentSize.Height >= ScrollView.Height)
 			{
 				CoreGraphics.CGPoint location = ContentView.DocumentVisibleRect().Location;
@@ -233,7 +233,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if ((ContentView as FlippedClipView) != null)
 				(ContentView as FlippedClipView).ContentRenderer = null;
-            
+
 			_contentRenderer?.NativeView?.RemoveFromSuperview();
 			_contentRenderer?.Dispose();
 			_contentRenderer = null;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -215,53 +215,28 @@ namespace Xamarin.Forms.Platform.MacOS
 		[Export(nameof(UpdateScrollPosition))]
 		void UpdateScrollPosition()
 		{
-            if (ScrollView == null)
-                return;
+			if (ScrollView == null)
+				return;
             
-            if (ScrollView.ContentSize.Height >= ScrollView.Height)
-            {
-                RectangleF visibleRect = ContentView.DocumentVisibleRect();
-                if (visibleRect.Location.Y > -1)
-                    ScrollView.SetScrolledPosition(Math.Max(0, visibleRect.Location.X), Math.Max(0, ContentView.Frame.Height - visibleRect.Location.Y));
-            }
-            else
-                ResetNativeNonScroll();            
+			if (ScrollView.ContentSize.Height >= ScrollView.Height)
+			{
+				CoreGraphics.CGPoint location = ContentView.DocumentVisibleRect().Location;
+
+				if (location.Y > -1)
+					ScrollView.SetScrolledPosition(Math.Max(0, location.X), Math.Max(0, ContentView.Frame.Height - location.Y));
+			}
+			else
+				ResetNativeNonScroll();
 		}
 
 		void ClearContentRenderer()
 		{
-            if ((ContentView as FlippedClipView) != null)
-                (ContentView as FlippedClipView).ContentRenderer = null;
+			if ((ContentView as FlippedClipView) != null)
+				(ContentView as FlippedClipView).ContentRenderer = null;
             
 			_contentRenderer?.NativeView?.RemoveFromSuperview();
 			_contentRenderer?.Dispose();
 			_contentRenderer = null;
-		}
-
-		private sealed class FlippedClipView : NSClipView
-		{
-			public override bool IsFlipped
-			{
-				get
-				{
-                    return true;
-				}
-			}
-
-			public IVisualElementRenderer ContentRenderer { get; set; }
-
-			public override RectangleF ConstrainBoundsRect(RectangleF proposedBounds)
-			{
-				RectangleF ret = base.ConstrainBoundsRect(proposedBounds);
-
-                if (ContentRenderer == null || ContentRenderer.Element == null)
-                    return ret;
-
-				if (Frame.Height > ContentRenderer.Element.Height)
-					ret.Y = (float)(Frame.Height - ContentRenderer.Element.Height - ContentRenderer.Element.Y - ContentRenderer.Element.Y);
-
-                return ret;
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -88,6 +88,7 @@
     <Compile Include="..\Xamarin.Forms.Platform.iOS\EffectUtilities.cs">
       <Link>EffectUtilities.cs</Link>
     </Compile>
+    <Compile Include="Renderers\FlippedClipView.cs" />
     <Compile Include="Renderers\PageRenderer.cs" />
     <Compile Include="Renderers\DefaultRenderer.cs" />
     <Compile Include="Extensions\AlignmentExtensions.cs" />


### PR DESCRIPTION
### Description of Change ###

Changed ScrollViewRenderer on macOS to align for Start,Center,End on contents that are smaller than the ScrollView panel.  It also fixes an issue where the coordinates being sent into the Forms control from the macOS control on ScrollY were inverted.

Tests omitted.
### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=56947

### API Changes ###
None

### Behavioral Changes ###

ScrollView's should now render at top left rather than bottom left, they should behave vertically for Start, Center, and End.  The correct Y coord should be correct for the Xamarin control.  The only remaining issue is when a window is resized vertically, the control doesnt resize correctly, when the window is resize horizontally it resets to the correct position.  I think this is outside of that control and maybe related to some other events not getting correctly passed down.  For instance some Page controls dont resize to the window at all when sized.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
