### PR TITLE
[iOS] ListView with UnevenRows and Cell Heights will no longer be slow to load

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56896.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56896.cs
@@ -1,0 +1,224 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System;
+using System.Diagnostics;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 56896, "ListViews for lists with many elements regressed in performance on iOS", PlatformAffected.iOS)]
+	public class Bugzilla56896 : TestContentPage
+	{
+		const string Instructions = "The number in blue is the number of constructor calls. The number in red is the initial load time in milliseconds.";
+		const string ConstructorCountId = "constructorCount";
+		const string TimeId = "time";
+
+		[Preserve(AllMembers = true)]
+		class MyViewModel : INotifyPropertyChanged
+		{
+			int _constructorCallCount;
+
+			public int ConstructorCallCount
+			{
+				get { return _constructorCallCount; }
+				set
+				{
+					_constructorCallCount = value;
+					OnPropertyChanged();
+				}
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class Fizz : ViewCell
+		{
+			readonly MyViewModel _vm;
+
+			Label myLabel;
+			public Fizz(MyViewModel vm)
+			{
+				_vm = vm;
+
+				vm.ConstructorCallCount++;
+
+				Height = 30;
+
+				myLabel = new Label { Text = "fizz" };
+				View = myLabel;
+			}
+			~Fizz()
+			{
+				_vm.ConstructorCallCount--;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class Buzz : ViewCell
+		{
+			readonly MyViewModel _vm;
+
+			Label myLabel;
+			public Buzz(MyViewModel vm)
+			{
+				_vm = vm;
+
+				vm.ConstructorCallCount++;
+
+				Height = 50;
+
+				myLabel = new Label { Text = "buzz" };
+				View = myLabel;
+			}
+			~Buzz()
+			{
+				_vm.ConstructorCallCount--;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class Fizzbuzz : ViewCell
+		{
+			readonly MyViewModel _vm;
+
+			Label myLabel;
+			public Fizzbuzz(MyViewModel vm)
+			{
+				_vm = vm;
+
+				vm.ConstructorCallCount++;
+
+				Height = 150;
+
+				myLabel = new Label { Text = "fizzbuzz" };
+				View = myLabel;
+			}
+			~Fizzbuzz()
+			{
+				_vm.ConstructorCallCount--;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class Number : ViewCell
+		{
+			readonly MyViewModel _vm;
+
+			Label myLabel;
+			public Number(MyViewModel vm)
+			{
+				_vm = vm;
+
+				vm.ConstructorCallCount++;
+
+				Height = 44;
+
+				myLabel = new Label();
+				myLabel.SetBinding(Label.TextProperty, ".");
+				View = myLabel;
+			}
+			~Number()
+			{
+				_vm.ConstructorCallCount--;
+			}
+		}
+
+		class MyDataTemplateSelector : DataTemplateSelector
+		{
+			DataTemplate _fizzbuzz;
+			DataTemplate _fizz;
+			DataTemplate _buzz;
+			DataTemplate _number;
+
+			public MyDataTemplateSelector(MyViewModel vm)
+			{
+				_fizzbuzz = new DataTemplate(() => new Fizzbuzz(vm));
+				_fizz = new DataTemplate(() => new Fizz(vm));
+				_buzz = new DataTemplate(() => new Buzz(vm));
+				_number = new DataTemplate(() => new Number(vm));
+			}
+
+			protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+			{
+				int number = (int)item;
+
+				if (number % 15 == 0)
+					return _fizzbuzz;
+				else if (number % 5 == 0)
+					return _buzz;
+				else if (number % 3 == 0)
+					return _fizz;
+				else
+					return _number;
+			}
+		}
+
+
+		Label _timeLabel = new Label { TextColor = Color.Purple, AutomationId = TimeId };
+		Stopwatch _timer = new Stopwatch();
+		ListView _listView;
+		protected override void Init()
+		{
+			_timer.Start();
+			var vm = new MyViewModel();
+
+			BindingContext = vm;
+
+			var label = new Label { TextColor = Color.Blue, AutomationId = ConstructorCountId };
+			label.SetBinding(Label.TextProperty, nameof(vm.ConstructorCallCount));
+
+			_listView = new ListView(ListViewCachingStrategy.RecycleElement)
+			{
+				HasUnevenRows = true,
+				// Set the RowHeight to enable optimal performance and minimal constructor calls.
+				// It will still use the specified Cell heights on final measure.
+				// Note, however, that doing this negates the fix for Bugzilla 43313, so if user expects
+				// to add items to the bottom of this list and scroll smoothly, user should omit the RowHeight
+				// and rely solely on the Cell heights. This will cause each row to be constructed at least once,
+				// but it will allow the ListView to estimate the height properly for smooth scrolling.
+				// Also note that performance will degrade if the first cell does not have a specified height or
+				// if most of the cells do not have a specified height. It is recommended to specify a height on all
+				// or none of the cells when possible.
+				RowHeight = 50, 
+				ItemsSource = Enumerable.Range(1, 5001),
+				ItemTemplate = new MyDataTemplateSelector(vm)
+			};
+			Content = new StackLayout { Children = { new Label { Text = Instructions }, label, _timeLabel, _listView } };
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			_timer.Stop();
+			_timeLabel.Text = _timer.ElapsedMilliseconds.ToString();
+			_timer.Reset();
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla56896Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(Instructions));
+			var count = int.Parse(RunningApp.Query(q => q.Marked(ConstructorCountId))[0].Text);
+			Assert.IsTrue(count < 100); // Failing test makes ~15000 constructor calls
+			var time = int.Parse(RunningApp.Query(q => q.Marked(TimeId))[0].Text);
+			Assert.IsTrue(count < 2000); // Failing test takes ~4000ms
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -294,6 +294,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39802.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53179.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54036.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56896.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40161.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -373,7 +373,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				// We want to make sure we reset the cached defined row heights whenever this is called.
 				// Failing to do this will regress Bugzilla 43313 (strange animation when adding rows with uneven heights)
-				source.CacheDefinedRowHeights();
+				source?.CacheDefinedRowHeights();
 
 				if (_shouldEstimateRowHeight && !_estimatedRowHeight)
 				{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Internals;
@@ -364,14 +366,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateEstimatedRowHeight()
 		{
-			if (_estimatedRowHeight)
-				return;
-
 			var rowHeight = Element.RowHeight;
 			if (Element.HasUnevenRows && rowHeight == -1)
 			{
 				var source = _dataSource as UnevenListViewDataSource;
-				if (_shouldEstimateRowHeight)
+
+				// We want to make sure we reset the cached defined row heights whenever this is called.
+				// Failing to do this will regress Bugzilla 43313 (strange animation when adding rows with uneven heights)
+				source.CacheDefinedRowHeights();
+
+				if (_shouldEstimateRowHeight && !_estimatedRowHeight)
 				{
 					if (source != null)
 					{
@@ -386,7 +390,7 @@ namespace Xamarin.Forms.Platform.iOS
 					}
 				}
 			}
-			else
+			else if (!_estimatedRowHeight)
 			{
 				Control.EstimatedRowHeight = 0;
 				_estimatedRowHeight = true;
@@ -623,6 +627,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			IVisualElementRenderer _prototype;
 			bool _disposed;
+			bool _useEstimatedRowHeight;
+
+			ConcurrentDictionary<NSIndexPath, nfloat> _rowHeights = new ConcurrentDictionary<NSIndexPath, nfloat>();
 
 			public UnevenListViewDataSource(ListView list, FormsUITableViewController uiTableViewController) : base(list, uiTableViewController)
 			{
@@ -630,6 +637,24 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public UnevenListViewDataSource(ListViewDataSource source) : base(source)
 			{
+			}
+
+			internal void CacheDefinedRowHeights()
+			{
+				Task.Run(() =>
+				{
+					var templatedItems = TemplatedItemsView.TemplatedItems;
+
+					foreach (var cell in templatedItems)
+					{
+						if (_disposed)
+							return;
+
+						double? cellRenderHeight = cell?.RenderHeight;
+						if (cellRenderHeight > 0)
+							_rowHeights[cell.GetIndexPath()] = (nfloat)cellRenderHeight;
+					}
+				});
 			}
 
 			internal nfloat GetEstimatedRowHeight(UITableView table)
@@ -656,11 +681,28 @@ namespace Xamarin.Forms.Platform.iOS
 				if (firstCell.Height > 0 && !List.IsGroupingEnabled)
 				{
 					// Seems like we've got cells which already specify their height; since the heights are known,
-					// we don't need to use estimatedRowHeight at all; zero will disable it and use the known heights
+					// we don't need to use estimatedRowHeight at all; zero will disable it and use the known heights.
+					// However, not setting the EstimatedRowHeight will drastically degrade performance with large lists.
+					// In this case, we will cache the specified cell heights asynchronously, which will be returned one time on
+					// table load by EstimatedHeight. 
+
 					return 0;
 				}
 
 				return CalculateHeightForCell(table, firstCell);
+			}
+
+			public override nfloat EstimatedHeight(UITableView tableView, NSIndexPath indexPath)
+			{
+				if (_useEstimatedRowHeight)
+					return tableView.EstimatedRowHeight;
+
+				// Note: It is *not* an optimization to first check if the array has any values.
+				nfloat specifiedRowHeight;
+				if (_rowHeights.TryGetValue(indexPath, out specifiedRowHeight) && specifiedRowHeight > 0)
+					return specifiedRowHeight;
+
+				return UITableView.AutomaticDimension;
 			}
 
 			public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
@@ -668,9 +710,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var cell = GetCellForPath(indexPath);
 
 				if (List.RowHeight == -1 && cell.Height == -1 && cell is ViewCell)
-				{
 					return UITableView.AutomaticDimension;
-				}
 
 				var renderHeight = cell.RenderHeight;
 				return renderHeight > 0 ? (nfloat)renderHeight : DefaultRowHeight;
@@ -709,6 +749,9 @@ namespace Xamarin.Forms.Platform.iOS
 						}
 					}
 
+					// Let the EstimatedHeight method know to use this value.
+					// Much more efficient than checking the value each time.
+					_useEstimatedRowHeight = true;
 					return (nfloat)req.Request.Height;
 				}
 


### PR DESCRIPTION
### Description of Change ###

#454 turned off row height estimation for `ListView`s enabling `HasUnevenRows` when the first `ViewCell` had a non-zero `Height`. This requires every row to be measured on initial load to prepare the scroll area, so large item sources developed a significant load time.

Re-enabling estimation is ideal for performance; however, it will regress the issue resolved by #454. As a compromise, this change will cache known `ViewCell` heights to be used by `EstimateHeight`, which will be called once when the `ListView` loads and allow the scroll area to be accurately estimated (preserving the resolved status of Bugzilla 43313) while still providing a value for estimation quick enough to restore performance. 

Users may still see that the `ViewCell` constructors will be called more times than they were before #454, since we still need to query each `ViewCell` for its `Height`. However, this should be a value closer to 1x instead of 3-4x. 

If users are **not** concerned about adding rows and scrolling to them with smooth animation, users may now also specify a `RowHeight` on the `ListView`. This value will be used for initial estimation, and the actual measured heights of the rows will be used when they are displayed. This, in effect, returns the behavior back to pre-#454, reducing the constructor calls to just those necessary for initial display. 

### Bugs Fixed ###

- [Bug 56896 - ListViews for lists with many elements regressed in performance on iOS](https://bugzilla.xamarin.com/show_bug.cgi?id=56896)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
