### PR TITLE
[iOS] Picker no longer allows arbitrary text to be typed with keyboard

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37285.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37285.cs
@@ -5,14 +5,16 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 9937285, "Possible to enter text into Picker control", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Bugzilla, 37285, "Possible to enter text into Picker control", PlatformAffected.iOS)]
 	public class Bugzilla37285 : TestContentPage
 	{
+		const string Instructions = "On iOS, focus the Picker below and type with a hardware keyboard. If text appears in the Picker text view, this test has failed. Note that Windows will allow you to select items with the keyboard, but the text you type will not appear in the text view. Also note that Android will allow you to select an item using the arrow and enter keys, but again, no text will appear in the text view.";
+
 		protected override void Init()
 		{
-			var picker = new Picker { ItemsSource = Enumerable.Range(0, 100).Select(c=> c.ToString()).ToList() };
+			var picker = new Picker { ItemsSource = Enumerable.Range(0, 100).Select(c => c.ToString()).ToList() };
 
-			var stack = new StackLayout { Children = { picker } };
+			var stack = new StackLayout { Children = { new Label { Text = Instructions }, picker } };
 
 			Content = stack;
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37285.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla37285.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 9937285, "Possible to enter text into Picker control", PlatformAffected.iOS)]
+	public class Bugzilla37285 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var picker = new Picker { ItemsSource = Enumerable.Range(0, 100).Select(c=> c.ToString()).ToList() };
+
+			var stack = new StackLayout { Children = { picker } };
+
+			Content = stack;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -85,6 +85,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36703.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36846.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36955.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37285.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37462.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37841.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37863.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					entry.EditingDidBegin += OnStarted;
 					entry.EditingDidEnd += OnEnded;
+					entry.EditingChanged += OnEditing;
 
 					_picker = new UIPickerView();
 
@@ -73,6 +74,14 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdatePicker();
 			if (e.PropertyName == Picker.TextColorProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateTextColor();
+		}
+
+		void OnEditing(object sender, EventArgs eventArgs)
+		{
+			// Reset the TextField's Text so it appears as if typing with a keyboard does not work.
+			var selectedIndex = Element.SelectedIndex;
+			var items = Element.Items;
+			Control.Text = selectedIndex == -1 || items == null ? "" : items[selectedIndex];
 		}
 
 		void OnEnded(object sender, EventArgs eventArgs)


### PR DESCRIPTION
### Description of Change ###

Now clearing any text that is entered with a hardware keyboard on a Picker.

### Bugs Fixed ###

- [Bug 37285 - Possible to enter text into Picker control](https://bugzilla.xamarin.com/show_bug.cgi?id=37285)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (manual)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
