### PR TITLE
[C] reset the BindingContext on template change

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
@@ -27,5 +27,31 @@ namespace Xamarin.Forms.Core.UnitTests
             {
             }
         }
+
+		public class MyTemplate : StackLayout
+		{
+			public MyTemplate()
+			{
+				Children.Add(new ContentPresenter());
+			}
+		}
+
+		[Test]
+		public void BindingsShouldBeAppliedOnTemplateChange()
+		{
+			var template0 = new ControlTemplate(typeof(MyTemplate));
+			var template1 = new ControlTemplate(typeof(MyTemplate));
+			var label = new Label();
+			label.SetBinding(Label.TextProperty, ".");
+			var cv = new ContentView {
+				ControlTemplate = template0,
+				Content = label
+			};
+			cv.BindingContext = "Foo";
+
+			Assume.That(label.Text, Is.EqualTo("Foo"));
+			cv.ControlTemplate = template1;
+			Assert.That(label.Text, Is.EqualTo("Foo"));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/ContentPage.cs
+++ b/Xamarin.Forms.Core/ContentPage.cs
@@ -22,5 +22,19 @@ namespace Xamarin.Forms
 				SetInheritedBindingContext(content, BindingContext);
 			}
 		}
+
+		internal override void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
+		{
+			if (oldValue == null)
+				return;
+
+			base.OnControlTemplateChanged(oldValue, newValue);
+			View content = Content;
+			ControlTemplate controlTemplate = ControlTemplate;
+			if (content != null && controlTemplate != null)
+			{
+				SetInheritedBindingContext(content, BindingContext);
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Core/ContentView.cs
+++ b/Xamarin.Forms.Core/ContentView.cs
@@ -22,5 +22,19 @@ namespace Xamarin.Forms
 				SetInheritedBindingContext(content, BindingContext);
 			}
 		}
+
+		internal override void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
+		{
+			if (oldValue == null)
+				return;
+
+			base.OnControlTemplateChanged(oldValue, newValue);
+			View content = Content;
+			ControlTemplate controlTemplate = ControlTemplate;
+			if (content != null && controlTemplate != null)
+			{
+				SetInheritedBindingContext(content, BindingContext);
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Core/IControlTemplated.cs
+++ b/Xamarin.Forms.Core/IControlTemplated.cs
@@ -7,5 +7,7 @@ namespace Xamarin.Forms
 		ControlTemplate ControlTemplate { get; set; }
 
 		IList<Element> InternalChildren { get; }
+
+		void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue);
 	}
 }

--- a/Xamarin.Forms.Core/TemplateUtilities.cs
+++ b/Xamarin.Forms.Core/TemplateUtilities.cs
@@ -123,6 +123,7 @@ namespace Xamarin.Forms
 				}
 
 				self.InternalChildren.Add(content);
+				((TemplatedView)bindable).OnControlTemplateChanged((ControlTemplate)oldValue, (ControlTemplate)newValue);
 			}
 		}
 	}

--- a/Xamarin.Forms.Core/TemplateUtilities.cs
+++ b/Xamarin.Forms.Core/TemplateUtilities.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms
 				}
 
 				self.InternalChildren.Add(content);
-				((TemplatedView)bindable).OnControlTemplateChanged((ControlTemplate)oldValue, (ControlTemplate)newValue);
+				((IControlTemplated)bindable).OnControlTemplateChanged((ControlTemplate)oldValue, (ControlTemplate)newValue);
 			}
 		}
 	}

--- a/Xamarin.Forms.Core/TemplatedPage.cs
+++ b/Xamarin.Forms.Core/TemplatedPage.cs
@@ -34,5 +34,14 @@ namespace Xamarin.Forms
 			if (ControlTemplate == null)
 				base.SetChildInheritedBindingContext(child, context);
 		}
+
+		void IControlTemplated.OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
+		{
+			OnControlTemplateChanged(oldValue, newValue);
+		}
+
+		internal virtual void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
+		{
+		}
 	}
 }

--- a/Xamarin.Forms.Core/TemplatedView.cs
+++ b/Xamarin.Forms.Core/TemplatedView.cs
@@ -64,5 +64,9 @@ namespace Xamarin.Forms
 			if (ControlTemplate == null)
 				base.SetChildInheritedBindingContext(child, context);
 		}
+
+		internal virtual void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
+		{
+		}
 	}
 }

--- a/Xamarin.Forms.Core/TemplatedView.cs
+++ b/Xamarin.Forms.Core/TemplatedView.cs
@@ -65,6 +65,11 @@ namespace Xamarin.Forms
 				base.SetChildInheritedBindingContext(child, context);
 		}
 
+		void IControlTemplated.OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
+		{
+			OnControlTemplateChanged(oldValue, newValue);
+		}
+
 		internal virtual void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
 		{
 		}


### PR DESCRIPTION
### Description of Change ###

When we remove an old template before setting a new one, all Bindings are unapplied (as part of unparenting).
This fix force a setting back the binding context when the an existing ControlTemplate is swapped for another one.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=43685

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense