### PR TITLE
[Android] Redraw NavigationPage upon TabbedPage's tab visibility change

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -241,8 +241,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					var child = PageController.InternalChildren[i] as VisualElement;
 					if (child == null)
 						continue;
-					IVisualElementRenderer renderer = Android.Platform.GetRenderer(child);
-					if (renderer is NavigationPageRenderer navigationRenderer)
+
+					var navigationRenderer = Android.Platform.GetRenderer(child) as NavigationPageRenderer;
+					if (navigationRenderer != null)
 					{
 						navigationRenderer.ContainerPadding = tabsHeight;
 						navigationRenderer.Invalidate();

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -242,9 +242,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					if (child == null)
 						continue;
 					IVisualElementRenderer renderer = Android.Platform.GetRenderer(child);
-					var navigationRenderer = renderer as NavigationPageRenderer;
-					if (navigationRenderer != null)
+					if (renderer is NavigationPageRenderer navigationRenderer)
+					{
 						navigationRenderer.ContainerPadding = tabsHeight;
+						navigationRenderer.Invalidate();
+						navigationRenderer.RequestLayout();
+					}
 				}
 
 				pager.Layout(0, 0, width, b);


### PR DESCRIPTION
### Description of Change ###

#365 accounted for the visibility state of `TabLayout` in a `TabbedPage` during initialization, but setting `tabsHeight` to 0 during runtime does not seem to trigger re-draw of a `NavigationPage`.

`OnLayout` seems to be measuring and laying out `TabLayout` and `ViewPager` fields. For `NavigationPage`, it was setting `ContainerPadding` to the appropriate number. By invalidating and requesting layout, `NavigationPage` can be redrawn based on the new container padding.

Please see user sample in the bug description.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=56305

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
