### PR TITLE
[iOS] Issue warning to console when MasterDetailPage is pushed onto NavigationPage

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -320,7 +320,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected virtual async Task<bool> OnPushAsync(Page page, bool animated)
 		{
 			if(page is MasterDetailPage)
-				System.Diagnostics.Debug.WriteLine($"Pushing a {nameof(MasterDetailPage)} onto a {nameof(NavigationPage)} is not a supported UI pattern on iOS. " +
+				System.Diagnostics.Trace.WriteLine($"Pushing a {nameof(MasterDetailPage)} onto a {nameof(NavigationPage)} is not a supported UI pattern on iOS. " +
 					"Please see https://developer.apple.com/documentation/uikit/uisplitviewcontroller for more details.");
 
 			var pack = CreateViewControllerForPage(page);

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -319,6 +319,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual async Task<bool> OnPushAsync(Page page, bool animated)
 		{
+			if(page is MasterDetailPage)
+				System.Diagnostics.Debug.WriteLine($"Pushing a {nameof(MasterDetailPage)} onto a {nameof(NavigationPage)} is not a supported UI pattern on iOS. " +
+					"Please see https://developer.apple.com/documentation/uikit/uisplitviewcontroller for more details.");
+
 			var pack = CreateViewControllerForPage(page);
 			var task = GetAppearedOrDisappearedTask(page);
 


### PR DESCRIPTION
### Description of Change ###

Can we issue a warning to people who're pushing a `MasterDetailPage` onto a `NavigationPage` on iOS? I'm not sure how existing apps are using this pattern with or without problems, but new apps should not be encouraged to use it.

https://developer.apple.com/documentation/uikit/uisplitviewcontroller

> Note
> You cannot push a split view controller onto a navigation stack. Although it is possible to install a split view controller as a child in some other container view controllers, doing is not recommended in most cases. Split view controllers are normally installed at the root of your app’s window. For tips and guidance about ways to implement your interface, see iOS Human Interface Guidelines.

Looks like only the Tablet idiom seems to be using `UISplitViewController` in the case of XF. Should this warning be shown only for that idiom or across iOS?

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=56952 (not fixed, but there is more communication there)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
