### PR TITLE
[Android] Change modifiers on NavigationPageRenderer's navigation methods

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -454,12 +454,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			e.Task = PopToRootAsync(e.Page, e.Animated);
 		}
 
-		Task<bool> OnPopToRootAsync(Page page, bool animated)
+		protected virtual Task<bool> OnPopToRootAsync(Page page, bool animated)
 		{
 			return SwitchContentAsync(page, animated, true, true);
 		}
 
-		Task<bool> OnPopViewAsync(Page page, bool animated)
+		protected virtual Task<bool> OnPopViewAsync(Page page, bool animated)
 		{
 			Page pageToShow = ((INavigationPageController)Element).Peek(1);
 			if (pageToShow == null)
@@ -468,7 +468,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			return SwitchContentAsync(pageToShow, animated, true);
 		}
 
-		Task<bool> OnPushAsync(Page view, bool animated)
+		protected virtual Task<bool> OnPushAsync(Page view, bool animated)
 		{
 			return SwitchContentAsync(view, animated);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Android.Views;
 using Xamarin.Forms.Internals;

--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
@@ -3,8 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Android.Views;
 using Xamarin.Forms.Internals;
-using AButton = Android.Widget.Button;
-using AView = Android.Views.View;
 using AndroidAnimation = Android.Animation;
 
 namespace Xamarin.Forms.Platform.Android


### PR DESCRIPTION
### Description of Change ###

Unlike its predecessor, `AppCompat`'s `NavigationPageRenderer` does not allow certain methods to be overridable and accessible.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=57578

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
