### PR TITLE
[iOS] Proxy UITableViewCell SelectionStyle when wrapped

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -591,8 +591,8 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		{
 			var cell = base.GetCell(item, reusableCell, tv);
 
-            // remove highlight on selected cell
-            cell.SelectionStyle = UITableViewCellSelectionStyle.None;
+			// remove highlight on selected cell
+			cell.SelectionStyle = UITableViewCellSelectionStyle.None;
 
 			return cell;
 		}

--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -20,6 +20,7 @@ using RectangleF = CoreGraphics.CGRect;
 [assembly: ExportRenderer(typeof(TabbedPage), typeof(TabbedPageWithCustomBarColorRenderer))]
 [assembly: ExportRenderer(typeof(Bugzilla43161.AccessoryViewCell), typeof(AccessoryViewCellRenderer))]
 [assembly: ExportRenderer(typeof(Bugzilla36802.AccessoryViewCell), typeof(AccessoryViewCellRenderer))]
+[assembly: ExportRenderer(typeof(Bugzilla52700.NoSelectionViewCell), typeof(NoSelectionViewCellRenderer))]
 namespace Xamarin.Forms.ControlGallery.iOS
 {
 	public class CustomIOSMapRenderer : ViewRenderer<CustomMapView, MKMapView>
@@ -579,6 +580,19 @@ namespace Xamarin.Forms.ControlGallery.iOS
 
 			// iOS right arrow
 			cell.Accessory = UITableViewCellAccessory.DisclosureIndicator;
+
+			return cell;
+		}
+	}
+
+	public class NoSelectionViewCellRenderer : ViewCellRenderer
+	{
+		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+		{
+			var cell = base.GetCell(item, reusableCell, tv);
+
+            // remove highlight on selected cell
+            cell.SelectionStyle = UITableViewCellSelectionStyle.None;
 
 			return cell;
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52700.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52700.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
-    [Issue (IssueTracker.Bugzilla, 52700, "[iOS] Recycled cell should respect selection style set to none", PlatformAffected.iOS)]
+	[Issue (IssueTracker.Bugzilla, 52700, "[iOS] Recycled cell should respect selection style set to none", PlatformAffected.iOS)]
 	public class Bugzilla52700 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
 		const string Instructions = "On iOS, all three of the following ListViews should not change background color upon selection. If the background of the row changes color, this test fails.";
@@ -21,59 +21,50 @@ namespace Xamarin.Forms.Controls.Issues
 
 		public class NoSelectionViewCell : ViewCell
 		{
-            public Label label { get; set; }
+			public Label label { get; set; }
 
-			public NoSelectionViewCell()
+			public NoSelectionViewCell ()
 			{
-				label = new Label();
-				label.SetBinding(Label.TextProperty, ".");
+				label = new Label ();
+				label.SetBinding (Label.TextProperty, ".");
 				View = label;
 			}
 		}
 
 		public class NoSelectionViewCellWithContextActions : NoSelectionViewCell
 		{
-			public NoSelectionViewCellWithContextActions()
+			public NoSelectionViewCellWithContextActions ()
 			{
-				label = new Label();
-				label.SetBinding(Label.TextProperty, ".");
+				label = new Label ();
+				label.SetBinding (Label.TextProperty, ".");
 				View = label;
 
 				var delete = new MenuItem { Text = "Delete" };
-				ContextActions.Add(delete);
+				ContextActions.Add (delete);
 			}
 		}
 
 		protected override void Init ()
 		{
 			var label = new Label { Text = Instructions };
-            var selectionLabel = new Label { Text = "<< THIS changes when row selected >>" };
-			var listView = new ListView { ItemTemplate = new DataTemplate(typeof(NoSelectionViewCellWithContextActions)), ItemsSource = Enumerable.Range(0, 9), Header = ListView1 };
-			var listView2 = new ListView(ListViewCachingStrategy.RecycleElement) { ItemTemplate = new DataTemplate(typeof(NoSelectionViewCell)), ItemsSource = Enumerable.Range(10, 19), Header = ListView2 };
-			var listView3 = new ListView { ItemTemplate = new DataTemplate(typeof(NoSelectionViewCell)), ItemsSource = Enumerable.Range(20, 29), Header = ListView3 };
+			var selectionLabel = new Label { Text = "<< THIS changes when row selected >>" };
+			var listView = new ListView { ItemTemplate = new DataTemplate (typeof (NoSelectionViewCellWithContextActions)), ItemsSource = Enumerable.Range (0, 9), Header = ListView1 };
+			var listView2 = new ListView (ListViewCachingStrategy.RecycleElement) { ItemTemplate = new DataTemplate (typeof (NoSelectionViewCell)), ItemsSource = Enumerable.Range (10, 19), Header = ListView2 };
+			var listView3 = new ListView { ItemTemplate = new DataTemplate (typeof (NoSelectionViewCell)), ItemsSource = Enumerable.Range (20, 29), Header = ListView3 };
 
-            listView.ItemSelected += (sender, e) => {
-                selectionLabel.Text = DateTime.Now.ToLocalTime().ToString();
-            };
+			listView.ItemSelected += (sender, e) => {
+				selectionLabel.Text = DateTime.Now.ToLocalTime ().ToString ();
+			};
 
 			listView2.ItemSelected += (sender, e) => {
-				selectionLabel.Text = DateTime.Now.ToLocalTime().ToString();
+				selectionLabel.Text = DateTime.Now.ToLocalTime ().ToString ();
 			};
 
 			listView3.ItemSelected += (sender, e) => {
-				selectionLabel.Text = DateTime.Now.ToLocalTime().ToString();
+				selectionLabel.Text = DateTime.Now.ToLocalTime ().ToString ();
 			};
 
 			Content = new StackLayout { Children = { label, selectionLabel, listView, listView2, listView3 } };
 		}
-
-#if UITEST
-		[Test]
-		public void Issue1Test ()
-		{
-            // no test
-		}
-#endif
-    }
-
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52700.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52700.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers = true)]
+    [Issue (IssueTracker.Bugzilla, 52700, "[iOS] Recycled cell should respect selection style set to none", PlatformAffected.iOS)]
+	public class Bugzilla52700 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		const string Instructions = "On iOS, all three of the following ListViews should not change background color upon selection. If the background of the row changes color, this test fails.";
+		const string ListView1 = "Custom Cell with Context Actions";
+		const string ListView2 = "Custom Cell + RecycleElement";
+		const string ListView3 = "Custom Cell + RetainElement";
+
+		public class NoSelectionViewCell : ViewCell
+		{
+            public Label label { get; set; }
+
+			public NoSelectionViewCell()
+			{
+				label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				View = label;
+			}
+		}
+
+		public class NoSelectionViewCellWithContextActions : NoSelectionViewCell
+		{
+			public NoSelectionViewCellWithContextActions()
+			{
+				label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				View = label;
+
+				var delete = new MenuItem { Text = "Delete" };
+				ContextActions.Add(delete);
+			}
+		}
+
+		protected override void Init ()
+		{
+			var label = new Label { Text = Instructions };
+            var selectionLabel = new Label { Text = "<< THIS changes when row selected >>" };
+			var listView = new ListView { ItemTemplate = new DataTemplate(typeof(NoSelectionViewCellWithContextActions)), ItemsSource = Enumerable.Range(0, 9), Header = ListView1 };
+			var listView2 = new ListView(ListViewCachingStrategy.RecycleElement) { ItemTemplate = new DataTemplate(typeof(NoSelectionViewCell)), ItemsSource = Enumerable.Range(10, 19), Header = ListView2 };
+			var listView3 = new ListView { ItemTemplate = new DataTemplate(typeof(NoSelectionViewCell)), ItemsSource = Enumerable.Range(20, 29), Header = ListView3 };
+
+            listView.ItemSelected += (sender, e) => {
+                selectionLabel.Text = DateTime.Now.ToLocalTime().ToString();
+            };
+
+			listView2.ItemSelected += (sender, e) => {
+				selectionLabel.Text = DateTime.Now.ToLocalTime().ToString();
+			};
+
+			listView3.ItemSelected += (sender, e) => {
+				selectionLabel.Text = DateTime.Now.ToLocalTime().ToString();
+			};
+
+			Content = new StackLayout { Children = { label, selectionLabel, listView, listView2, listView3 } };
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1Test ()
+		{
+            // no test
+		}
+#endif
+    }
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -565,6 +565,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42956.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38731.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56710.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52700.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -252,10 +252,10 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				_scroller.SetContentOffset(new PointF(0, 0), false);
 
-            if (ContentCell != null)
-            {
-                SelectionStyle = ContentCell.SelectionStyle;
-            }
+			if (ContentCell != null)
+			{
+				SelectionStyle = ContentCell.SelectionStyle;
+			}
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -251,6 +251,11 @@ namespace Xamarin.Forms.Platform.iOS
 				_scroller.SetContentOffset(new PointF(ScrollDelegate.ButtonsWidth, 0), false);
 			else
 				_scroller.SetContentOffset(new PointF(0, 0), false);
+
+            if (ContentCell != null)
+            {
+                SelectionStyle = ContentCell.SelectionStyle;
+            }
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change ###

Now passing SelectionStyle property when wrapping the ViewCell.

https://www.screencast.com/t/ruwrHQxI

### Bugs Fixed ###

- [Bug 52700 - Can't disable cell SelectionStyle using ViewCellRenderer for cells when using recycling](https://bugzilla.xamarin.com/show_bug.cgi?id=52700)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (manual) 
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
