### PR TITLE
[XamlC] Allow overriding the assembly resolver and whether to compile

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Build.Tasks
 		public bool OutputGeneratedILAsCode { get; set; }
 
 		public bool CompileByDefault { get; set; }
+		public bool ForceCompile { get; set; }
 
 		public IAssemblyResolver DefaultAssemblyResolver { get; set; }
 
@@ -72,6 +73,9 @@ namespace Xamarin.Forms.Build.Tasks
 						xamlCResolver.AddSearchDirectory(searchpath);
 					}
 				}
+			}
+			else {
+				Logger.LogLine(3, "Ignoring dependency and reference paths due to an unsupported resolver");
 			}
 
 			var debug = DebugSymbols || (!string.IsNullOrEmpty(DebugType) && DebugType.ToLowerInvariant() != "none");
@@ -137,7 +141,7 @@ namespace Xamarin.Forms.Build.Tasks
 						if (Type != null)
 							skiptype = !(Type == classname);
 
-						if (skiptype) {
+						if (skiptype && !ForceCompile) {
 							Logger.LogLine(2, "Has XamlCompilationAttribute set to Skip and not Compile... skipped");
 							continue;
 						}


### PR DESCRIPTION
### Description of Change ###

This adds two public properties to XamlC task to allow some of its hard coded defaults to be overridden.

1. You can now override its assembly resolver to use/reuse your own
2. You can change the default of whether to compile

### API Changes ###

Added:
 - `bool XamlCTask.ForceCompile { get; set; }`
 - `bool XamlCTask.CompileByDefault { get; set; }`
 - `IAssemblyResolver XamlCTask.DefaultAssemblyResolver { get; set; }`

### Behavioral Changes ###

This will cause the task to use the given assembly resolver instead of always creating its own.

This will also allow tools to force compilation.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
    - XamlCTask doesn't have any tests
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense