### PR TITLE
Set the Id field for Android Views created by Forms

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MapsModalCrash.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MapsModalCrash.cs
@@ -66,6 +66,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			return new ContentPage
 			{
+				BackgroundColor = Color.LightBlue,
 				Content = new Label { Text = "If you're seeing this, then the test was a success.", AutomationId = Success }
 			};
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MapsModalCrash.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MapsModalCrash.cs
@@ -1,0 +1,69 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Maps;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 1701, "Modal Page over Map crashes application", PlatformAffected.Android)]
+	public class MapsModalCrash : TestContentPage 
+	{
+		protected override void Init()
+		{
+			var button = new Button { Text = "Start Test" };
+			button.Clicked += (sender, args) =>
+			{
+				Application.Current.MainPage = MapPage();
+			};
+
+			Content = new StackLayout
+			{
+				Padding = new Thickness(0, 20, 0, 0),
+				Children =
+				{
+					button
+				}
+			};
+		}
+
+		static ContentPage MapPage()
+		{
+			var map = new Map();
+
+			var button = new Button { Text = "Click Me" };
+			button.Clicked += (sender, args) => button.Navigation.PushModalAsync(new NavigationPage(SuccessPage()));
+
+			return new ContentPage
+			{
+				Content = new StackLayout
+				{
+					Children =
+					{
+						map,
+						button
+					}
+				}
+			};
+		}
+
+		static ContentPage SuccessPage()
+		{
+			return new ContentPage
+			{
+				Content = new Label { Text = "If you're seeing this, then the test was a success.", AutomationId = "SuccessLabel" }
+			};
+		}
+
+#if UITEST
+		//[Test]
+		//public void _$BZ$Test()
+		//{
+		//	//RunningApp.WaitForElement(q => q.Marked(""));
+		//}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MapsModalCrash.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MapsModalCrash.cs
@@ -1,20 +1,32 @@
-﻿using Xamarin.Forms.CustomAttributes;
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Maps;
 #if UITEST
+using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+
+#if UITEST
+	[Category(UITestCategories.Maps)]
+	[Category(UITestCategories.ManualReview)]
+#endif
+
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 1701, "Modal Page over Map crashes application", PlatformAffected.Android)]
-	public class MapsModalCrash : TestContentPage 
+	public class MapsModalCrash : TestContentPage
 	{
+		const string StartTest = "Start Test";
+		const string DisplayModal = "Click Me";
+		const string Success = "SuccessLabel";
+
 		protected override void Init()
 		{
-			var button = new Button { Text = "Start Test" };
+			var button = new Button { Text = StartTest };
 			button.Clicked += (sender, args) =>
 			{
 				Application.Current.MainPage = MapPage();
@@ -34,7 +46,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var map = new Map();
 
-			var button = new Button { Text = "Click Me" };
+			var button = new Button { Text = DisplayModal };
 			button.Clicked += (sender, args) => button.Navigation.PushModalAsync(new NavigationPage(SuccessPage()));
 
 			return new ContentPage
@@ -54,16 +66,20 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			return new ContentPage
 			{
-				Content = new Label { Text = "If you're seeing this, then the test was a success.", AutomationId = "SuccessLabel" }
+				Content = new Label { Text = "If you're seeing this, then the test was a success.", AutomationId = Success }
 			};
 		}
 
 #if UITEST
-		//[Test]
-		//public void _$BZ$Test()
-		//{
-		//	//RunningApp.WaitForElement(q => q.Marked(""));
-		//}
+		[Test]
+		public void CanDisplayModalOverMap()
+		{
+			RunningApp.WaitForElement(StartTest);
+			RunningApp.Tap(StartTest);
+			RunningApp.WaitForElement(DisplayModal);
+			RunningApp.Tap(DisplayModal);
+			RunningApp.WaitForElement(Success);
+		}
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -250,6 +250,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32462.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36681.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36479.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37625.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38658.cs" />

--- a/Xamarin.Forms.Controls/TestCases.cs
+++ b/Xamarin.Forms.Controls/TestCases.cs
@@ -141,9 +141,10 @@ namespace Xamarin.Forms.Controls
 				var untrackedIssueCells = 
 					from issueModel in issueModels
 					where issueModel.IssueTracker == IssueTracker.None
-					orderby issueModel.Description 
+					orderby issueModel.IssueNumber descending, issueModel.Description 
 					select MakeIssueCell (issueModel.Name, issueModel.Description, issueModel.Action);
 
+				// TODO hartez 2017/06/21 09:12:51 Restore the original order	
 				var issueCells = bugzillaIssueCells.Concat (githubIssueCells).Concat (untrackedIssueCells);
 
 				foreach (var issueCell in issueCells) {

--- a/Xamarin.Forms.Controls/TestCases.cs
+++ b/Xamarin.Forms.Controls/TestCases.cs
@@ -144,7 +144,6 @@ namespace Xamarin.Forms.Controls
 					orderby issueModel.IssueNumber descending, issueModel.Description 
 					select MakeIssueCell (issueModel.Name, issueModel.Description, issueModel.Action);
 
-				// TODO hartez 2017/06/21 09:12:51 Restore the original order	
 				var issueCells = bugzillaIssueCells.Concat (githubIssueCells).Concat (untrackedIssueCells);
 
 				foreach (var issueCell in issueCells) {

--- a/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 						LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent),
 						Adapter = new FormsFragmentPagerAdapter<ContentPage>(e.NewElement, activity.SupportFragmentManager) { CountOverride = e.NewElement.Children.Count }
 					};
-				pager.Id = FormsAppCompatActivity.GetUniqueId();
+				pager.Id = Platform.GenerateViewId();
 				pager.AddOnPageChangeListener(this);
 
 				ViewGroup.AddView(pager);

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -461,23 +461,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static int ToolbarResource { get; set; }
 
-		internal static int GetUniqueId()
-		{
-			// getting unique Id's is an art, and I consider myself the Jackson Pollock of the field
-			if ((int)Build.VERSION.SdkInt >= 17)
-				return global::Android.Views.View.GenerateViewId();
-
-			// Numbers higher than this range reserved for xml
-			// If we roll over, it can be exceptionally problematic for the user if they are still retaining things, android's internal implementation is
-			// basically identical to this except they do a lot of locking we don't have to because we know we only do this
-			// from the UI thread
-			if (s_id >= 0x00ffffff)
-				s_id = 0x00000400;
-			return s_id++;
-		}
-
-		static int s_id = 0x00000400;
-
 		#endregion
 	}
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		public MasterDetailContainer(MasterDetailPage parent, bool isMaster, Context context) : base(parent, isMaster, context)
 		{
-			Id = FormsAppCompatActivity.GetUniqueId();
+			Id = Platform.GenerateViewId();
 			_parent = parent;
 			_isMaster = isMaster;
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		public NavigationPageRenderer()
 		{
 			AutoPackage = false;
-			Id = FormsAppCompatActivity.GetUniqueId();
+			Id = Platform.GenerateViewId();
 			Device.Info.PropertyChanged += DeviceInfoPropertyChanged;
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -347,6 +347,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				Android.Platform.SetRenderer(modal, _renderer);
 
 				AddView(_renderer.View);
+
+				Id = Platform.GenerateViewId();
 			}
 
 			protected override void Dispose(bool disposing)
@@ -385,6 +387,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				_renderer.UpdateLayout();
 			}
+		}
+
+		internal static int GenerateViewId()
+		{
+			return Android.Platform.GenerateViewId();
 		}
 
 		#region Statics

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -166,7 +166,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 							LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent),
 							Adapter = new FormsFragmentPagerAdapter<Page>(e.NewElement, FragmentManager) { CountOverride = e.NewElement.Children.Count }
 						};
-					pager.Id = FormsAppCompatActivity.GetUniqueId();
+					pager.Id = Platform.GenerateViewId();
 					pager.AddOnPageChangeListener(this);
 
 					AddView(pager);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -164,8 +164,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			if (elemValue != null)
 			{
 				var id = Control.Id;
-				if (id == -1)
-					id = Control.Id = FormsAppCompatActivity.GetUniqueId();
+				if (id == global::Android.Views.View.NoId)
+					id = Control.Id = Platform.GenerateViewId();
 
 				var renderer = elemValue?.GetRenderer();
 				renderer?.SetLabelFor(id);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			_effectControlProvider = new EffectControlProvider(this);
             _textColorSwitcher = new Lazy<TextColorSwitcher>(() => new TextColorSwitcher(TextColors));
 
-            Initialize();
+			Initialize();
 		}
 
 		public VisualElement Element => Button;
@@ -216,6 +216,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 			if (e.NewElement != null && !_isDisposed)
 			{
+				if (Id == NoId)
+				{
+					Id = Platform.GenerateViewId();
+				}
+
 				UpdateFont();
 				UpdateText();
 				UpdateBitmap();

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -216,10 +216,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 			if (e.NewElement != null && !_isDisposed)
 			{
-				if (Id == NoId)
-				{
-					Id = Platform.GenerateViewId();
-				}
+				this.EnsureId();
 
 				UpdateFont();
 				UpdateText();

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -145,6 +145,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 			if (e.NewElement != null)
 			{
+				if (Id == NoId)
+				{
+					Id = Platform.GenerateViewId();
+				}
+
 				if (_visualElementTracker == null)
 				{
 					_visualElementTracker = new VisualElementTracker(this);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -145,10 +145,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 			if (e.NewElement != null)
 			{
-				if (Id == NoId)
-				{
-					Id = Platform.GenerateViewId();
-				}
+				this.EnsureId();
 
 				if (_visualElementTracker == null)
 				{

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -62,16 +62,12 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			await TryUpdateBitmap(e.OldElement);
 			UpdateAspect();
-
-			if (Id == NoId)
-			{
-				Id = Platform.GenerateViewId();
-			}
+			this.EnsureId();
 
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
 		}
 
-        public override bool OnTouchEvent(MotionEvent e)
+		public override bool OnTouchEvent(MotionEvent e)
         {
             bool handled;
             var result = _visualElementRenderer.OnTouchEvent(e, Parent, out handled);
@@ -79,7 +75,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
             return handled ? result : base.OnTouchEvent(e);
         }
 
-        protected virtual Size MinimumSize()
+		protected virtual Size MinimumSize()
 		{
 			return new Size();
 		}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -63,6 +63,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			await TryUpdateBitmap(e.OldElement);
 			UpdateAspect();
 
+			if (Id == NoId)
+			{
+				Id = Platform.GenerateViewId();
+			}
+
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
 		}
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -177,6 +177,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 			if (e.NewElement != null)
 			{
+				if (Id == NoId)
+				{
+					Id = Platform.GenerateViewId();
+				}
+
 				if (_visualElementTracker == null)
 				{
 					_visualElementTracker = new VisualElementTracker(this);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -177,10 +177,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 			if (e.NewElement != null)
 			{
-				if (Id == NoId)
-				{
-					Id = Platform.GenerateViewId();
-				}
+				this.EnsureId();
 
 				if (_visualElementTracker == null)
 				{

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1031,6 +1031,23 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+		internal static int GenerateViewId()
+		{
+			// getting unique Id's is an art, and I consider myself the Jackson Pollock of the field
+			if ((int)Build.VERSION.SdkInt >= 17)
+				return global::Android.Views.View.GenerateViewId();
+
+			// Numbers higher than this range reserved for xml
+			// If we roll over, it can be exceptionally problematic for the user if they are still retaining things, android's internal implementation is
+			// basically identical to this except they do a lot of locking we don't have to because we know we only do this
+			// from the UI thread
+			if (s_id >= 0x00ffffff)
+				s_id = 0x00000400;
+			return s_id++;
+		}
+
+		static int s_id = 0x00000400;
+
 		internal class DefaultRenderer : VisualElementRenderer<View>
 		{
 			bool _notReallyHandled;

--- a/Xamarin.Forms.Platform.Android/Renderers/PageContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageContainer.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Forms.Platform.Android
 			AddView(child.View);
 			Child = child;
 			IsInFragment = inFragment;
+			Id = Platform.GenerateViewId();
 		}
 
 		public IVisualElementRenderer Child { get; set; }

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -45,6 +45,11 @@ namespace Xamarin.Forms.Platform.Android
 			Page view = e.NewElement;
 			base.OnElementChanged(e);
 
+			if (Id == NoId)
+			{
+				Id = Platform.GenerateViewId();
+			}
+
 			UpdateBackgroundColor(view);
 			UpdateBackgroundImage(view);
 

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -64,5 +64,18 @@ namespace Xamarin.Forms.Platform.Android
 				}
 			}
 		}
+
+		public static void EnsureId(this AView view)
+		{
+			if (view.IsDisposed())
+			{
+				return;
+			}
+
+			if (view.Id == AView.NoId)
+			{
+				view.Id = Platform.GenerateViewId();
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -290,6 +290,10 @@ namespace Xamarin.Forms.Platform.Android
 			_container = container;
 
 			Control = control;
+			if (Control.Id == NoId)
+			{
+				Control.Id = Platform.GenerateViewId();
+			}
 
 			AView toAdd = container == this ? control : (AView)container;
 			AddView(toAdd, LayoutParams.MatchParent);
@@ -310,8 +314,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (elemValue != null)
 			{
 				var id = Control.Id;
-				if (id == -1)
-					id = Control.Id = FormsAppCompatActivity.GetUniqueId();
+				if (id == NoId)
+					id = Control.Id = Platform.GenerateViewId();
 
 				var renderer = elemValue?.GetRenderer();
 				renderer?.SetLabelFor(id);


### PR DESCRIPTION
### Description of Change ###

Because Forms doesn't set the `Id` value for Android Views it creates, some methods (most notably `BackStackRecord.configureTransitions`) which search for Views by `Id` and cast them were failing because all of the Views had the default of `NO_ID` (-1). 

This change sets the `Id` field for the various renderers and for the `ModalContainer` to prevent this issue.

### Bugs Fixed ###

- https://forums.xamarin.com/discussion/comment/280624/#Comment_280624
- https://forums.xamarin.com/discussion/81768/launching-a-modal-over-a-page-containing-a-map-maps-ad-m-cannot-be-cast-to-android-view-viewgroup

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
