### PR TITLE
[UWP] ListView ItemSelected event will fire only once on selection changed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
@@ -1,0 +1,89 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.ComponentModel;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 9944886, "UWP Listview ItemSelected event triggered twice for each selection", PlatformAffected.UWP)]
+	public class Bugzilla44886 : TestContentPage
+	{
+		[Preserve(AllMembers = true)]
+		class MyViewModel : INotifyPropertyChanged
+		{
+			int _count;
+			public int Count
+			{
+				get { return _count; }
+				set
+				{
+					if (value != _count)
+					{
+						_count = value;
+						RaisePropertyChanged();
+					}
+				}
+			}
+
+			void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+			{
+				PropertyChangedEventHandler handler = PropertyChanged;
+
+				handler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
+
+			#region INotifyPropertyChanged implementation
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			#endregion
+		}
+
+		const string Instructions = "Select one of the items in the list. The text in blue should show 1, indicating that the ItemSelected event fired once. If it shows 2, this test has failed. Be sure to also test Keyboard selection and Narrator selection.";
+		const string CountId = "countId";
+		Label _CountLabel = new Label { AutomationId = CountId, TextColor = Color.Blue };
+		MyViewModel _vm = new MyViewModel();
+
+		protected override void Init()
+		{
+			BindingContext = _vm;
+
+			_CountLabel.SetBinding(Label.TextProperty, nameof(MyViewModel.Count));
+
+				var listView = new ListView
+			{
+				ItemsSource = new List<string> { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" }
+			};
+			listView.ItemSelected += ListView_ItemSelected;
+
+			var stack = new StackLayout { Children = { new Label { Text = Instructions }, _CountLabel, listView } };
+			Content = stack;
+		}
+
+		void ListView_ItemSelected(object sender, SelectedItemChangedEventArgs e)
+		{
+			_vm.Count++;
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla44886Test()
+		{
+			RunningApp.Screenshot("I am at Issue 1");
+			RunningApp.WaitForElement(q => q.Marked("Item 1"));
+
+			int count = int.Parse(RunningApp.Query(q => q.Marked(CountId))[0].Text);
+
+			Assert.IsTrue(count == 1);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
@@ -1,7 +1,6 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.ComponentModel;
 
@@ -13,9 +12,16 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 9944886, "UWP Listview ItemSelected event triggered twice for each selection", PlatformAffected.UWP)]
+	[Issue(IssueTracker.Bugzilla, 44886, "UWP Listview ItemSelected event triggered twice for each selection", PlatformAffected.UWP)]
 	public class Bugzilla44886 : TestContentPage
 	{
+		const string Item1 = "Item 1";
+		const string Instructions = "Select one of the items in the list. The text in blue should show 1, indicating that the ItemSelected event fired once. If it shows 2, this test has failed. Be sure to also test Keyboard selection and Narrator selection. On UWP, the ItemSelected event should fire when an item is highlighted and _not_ when it is un-highlighted (by pressing spacebar).";
+		const string CountId = "countId";
+
+		Label _CountLabel = new Label { AutomationId = CountId, TextColor = Color.Blue };
+		MyViewModel _vm = new MyViewModel();
+
 		[Preserve(AllMembers = true)]
 		class MyViewModel : INotifyPropertyChanged
 		{
@@ -47,11 +53,6 @@ namespace Xamarin.Forms.Controls.Issues
 			#endregion
 		}
 
-		const string Instructions = "Select one of the items in the list. The text in blue should show 1, indicating that the ItemSelected event fired once. If it shows 2, this test has failed. Be sure to also test Keyboard selection and Narrator selection.";
-		const string CountId = "countId";
-		Label _CountLabel = new Label { AutomationId = CountId, TextColor = Color.Blue };
-		MyViewModel _vm = new MyViewModel();
-
 		protected override void Init()
 		{
 			BindingContext = _vm;
@@ -60,7 +61,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 				var listView = new ListView
 			{
-				ItemsSource = new List<string> { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" }
+				ItemsSource = new List<string> { Item1, "Item 2", "Item 3", "Item 4", "Item 5" }
 			};
 			listView.ItemSelected += ListView_ItemSelected;
 
@@ -77,8 +78,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla44886Test()
 		{
-			RunningApp.Screenshot("I am at Issue 1");
-			RunningApp.WaitForElement(q => q.Marked("Item 1"));
+			RunningApp.WaitForElement(q => q.Marked(Item1));
 
 			int count = int.Parse(RunningApp.Query(q => q.Marked(CountId))[0].Text);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
@@ -79,6 +79,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Bugzilla44886Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Item1));
+			RunningApp.Tap(q => q.Marked(Item1));
 
 			int count = int.Parse(RunningApp.Query(q => q.Marked(CountId))[0].Text);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 	public class Bugzilla44886 : TestContentPage
 	{
 		const string Item1 = "Item 1";
-		const string Instructions = "Select one of the items in the list. The text in blue should show 1, indicating that the ItemSelected event fired once. If it shows 2, this test has failed. Be sure to also test Keyboard selection and Narrator selection. On UWP, the ItemSelected event should fire when an item is highlighted and _not_ when it is un-highlighted (by pressing spacebar).";
+		const string Instructions = "Select one of the items in the list. The text in blue should show 1, indicating that the ItemSelected event fired once. If it shows 2, this test has failed. Be sure to also test Keyboard selection and Narrator selection. On UWP, the ItemSelected event should fire when an item is highlighted and again when it is un-highlighted (by pressing spacebar).";
 		const string CountId = "countId";
 
 		Label _CountLabel = new Label { AutomationId = CountId, TextColor = Color.Blue };

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -310,6 +310,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54036.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56896.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40161.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44886.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzila57749.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollViewObjectDisposed.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -399,17 +399,19 @@ namespace Xamarin.Forms
 
 			_previousRowSelected = inGroupIndex;
 			_previousGroupSelected = groupIndex;
-			if (cell == null)
+
+			// A11y: Keyboards and screen readers can deselect items, allowing -1 to be possible
+			if (cell == null && inGroupIndex != -1)
 			{
 				cell = group[inGroupIndex];
 			}
 
 			// Set SelectedItem before any events so we don't override any changes they may have made.
-			SetValueCore(SelectedItemProperty, cell.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0));
+			SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0));
 
-			cell.OnTapped();
+			cell?.OnTapped();
 
-			ItemTapped?.Invoke(this, new ItemTappedEventArgs(ItemsSource.Cast<object>().ElementAt(groupIndex), cell.BindingContext));
+			ItemTapped?.Invoke(this, new ItemTappedEventArgs(ItemsSource.Cast<object>().ElementAt(groupIndex), cell?.BindingContext));
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -62,7 +62,8 @@ namespace Xamarin.Forms.Platform.WinRT
 
 				if (List == null)
 				{
-					List = new WListView {
+					List = new WListView
+					{
 						IsSynchronizedWithCurrentItem = false,
 						ItemTemplate = (Windows.UI.Xaml.DataTemplate)WApp.Current.Resources["CellTemplate"],
 						HeaderTemplate = (Windows.UI.Xaml.DataTemplate)WApp.Current.Resources["View"],
@@ -465,10 +466,10 @@ namespace Xamarin.Forms.Platform.WinRT
 		void OnListItemClicked(int index)
 		{
 #if !WINDOWS_UWP
-	// If we're on the phone , we need to cache the selected item in case the handler 
-	// we're about to call changes any item indexes;
-	// in some cases, those index changes will throw an exception we can't catch if 
-	// the listview has an item selected
+			// If we're on the phone , we need to cache the selected item in case the handler 
+			// we're about to call changes any item indexes;
+			// in some cases, those index changes will throw an exception we can't catch if 
+			// the listview has an item selected
 			object selectedItem = null;
 			if (Device.Idiom == TargetIdiom.Phone)
 			{
@@ -508,7 +509,15 @@ namespace Xamarin.Forms.Platform.WinRT
 			RestorePreviousSelectedVisual();
 
 			if (e.AddedItems.Count == 0)
+			{
+				// Deselecting an item is a valid SelectedItem change.
+				if (Element.SelectedItem != List.SelectedItem)
+				{
+					OnListItemClicked(List.SelectedIndex);
+				}
+
 				return;
+			}
 
 			object cell = e.AddedItems[0];
 			if (cell == null)
@@ -525,11 +534,11 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 #endif
 
-			// A11y: Tapped event will not be routed when Narrator is active
+			// A11y: Tapped event will not be routed when Narrator is active, so we need to handle it here.
 			// Also handles keyboard selection. 
 			// Default UWP behavior is that items are selected when you navigate to them via the arrow keys
-			// and unselected with the space bar, so this will remain the same.
-			if (List.SelectedItem != null && Element.SelectedItem != List.SelectedItem)
+			// and deselected with the space bar, so this will remain the same.
+			if (Element.SelectedItem != List.SelectedItem)
 				OnListItemClicked(List.SelectedIndex);
 		}
 

--- a/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ListViewRenderer.cs
@@ -526,8 +526,11 @@ namespace Xamarin.Forms.Platform.WinRT
 #endif
 
 			// A11y: Tapped event will not be routed when Narrator is active
-			// Also handles keyboard selection
-			SelectElementItem();
+			// Also handles keyboard selection. 
+			// Default UWP behavior is that items are selected when you navigate to them via the arrow keys
+			// and unselected with the space bar, so this will remain the same.
+			if (List.SelectedItem != null && Element.SelectedItem != List.SelectedItem)
+				OnListItemClicked(List.SelectedIndex);
 		}
 
 		FrameworkElement FindElement(object cell)
@@ -539,15 +542,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 
 			return null;
-		}
-
-		void SelectElementItem()
-		{
-			if (List.SelectedItem != null && Element.SelectedItem != List.SelectedItem)
-			{
-				((IElementController)Element).SetValueFromRenderer(ListView.SelectedItemProperty, List?.SelectedItem);
-				OnElementItemSelected(null, new SelectedItemChangedEventArgs(Element?.SelectedItem));
-			}
 		}
 
 #if WINDOWS_UWP


### PR DESCRIPTION
### Description of Change ###

Resolves regressions caused by #713.

Now calling `OnListItemClicked` when the native `ListView`s selection is changed and _not_ attempting to set the `SelectedItem` property of the `ListView` renderer at the same time. This was causing the second `ItemSelected` event to fire.

Calling `OnListItemClicked` when the selection changes ensures a consistent experience when using touch, mouse, keyboard, and Narrator navigation. UWP by default will select an item when it is focused by the keyboard, and using the spacebar/enter key will deselect the item. This PR preserves that default behavior. Deselecting an item will now fire an event, too, since that is a valid `SelectedItem` change. Note that this now allows the item returned by `Tapped` events to be null in these cases.

### Bugs Fixed ###

- [Bug 44886 - UWP Listview ItemSelected event triggered twice for each selection](https://bugzilla.xamarin.com/show_bug.cgi?id=44886)
- [Bug 42188 - ViewCell with focus does not recognise being tapped using keyboard on UWP](https://bugzilla.xamarin.com/show_bug.cgi?id=42188)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
