### PR TITLE
[All] Use IReflectableType when accessing the Registrar

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
@@ -147,6 +147,27 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void GetHandlerTypeForObject()
+		{
+			var registrar = new Internals.Registrar<MockRenderer>();
+			registrar.Register (typeof (View), typeof (MockRenderer));
+			registrar.Register (typeof (Button), typeof (ButtonMockRenderer));
+
+			Assert.AreEqual (typeof (ButtonMockRenderer), registrar.GetHandlerTypeForObject (new Button ()));
+		}
+
+		[Test]
+		public void GetHandlerForObject()
+		{
+			var registrar = new Internals.Registrar<MockRenderer>();
+			registrar.Register (typeof (View), typeof (MockRenderer));
+			registrar.Register (typeof (Button), typeof (ButtonMockRenderer));
+
+            var buttonRenderer = registrar.GetHandlerForObject<MockRenderer> (new Button ());
+            Assert.That (buttonRenderer, Is.InstanceOf<ButtonMockRenderer> ());
+		}
+
+		[Test]
 		public void TestGetRendererNullViewRenderer()
 		{
 			var registrar = new Internals.Registrar<MockRenderer>();

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -42,6 +42,17 @@ namespace Xamarin.Forms.Internals
 			return (TOut)GetHandler(type);
 		}
 
+		public TOut GetHandlerForObject<TOut>(object obj) where TOut : TRegistrable
+		{
+			if (obj == null)
+				throw new ArgumentNullException(nameof(obj));
+
+			var reflectableType = obj as IReflectableType;
+			var type = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : obj.GetType();
+
+			return (TOut)GetHandler(type);
+		}
+
 		public Type GetHandlerType(Type viewType)
 		{
 			Type type;
@@ -75,6 +86,17 @@ namespace Xamarin.Forms.Internals
 			Register(viewType, type); // Register this so we don't have to look for the RenderWith Attibute again in the future
 
 			return type;
+		}
+
+		public Type GetHandlerTypeForObject(object obj)
+		{
+			if (obj == null)
+				throw new ArgumentNullException(nameof(obj));
+
+			var reflectableType = obj as IReflectableType;
+			var type = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : obj.GetType();
+
+			return GetHandlerType(type);
 		}
 
 		bool LookupHandlerType(Type viewType, out Type handlerType)

--- a/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Forms.Platform.Android
 			Bitmap bitmap = null;
 			IImageSourceHandler handler;
 
-			if (source != null && (handler = Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				try
 				{

--- a/Xamarin.Forms.Platform.Android/Cells/CellFactory.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/CellFactory.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Platform.Android
 			CellRenderer renderer = CellRenderer.GetRenderer(item);
 			if (renderer == null)
 			{
-				renderer = Registrar.Registered.GetHandler<CellRenderer>(item.GetType());
+				renderer = Registrar.Registered.GetHandlerForObject<CellRenderer>(item);
 				renderer.ParentView = view;
 			}
 

--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -143,7 +143,7 @@ namespace Xamarin.Forms.Platform.Android
 				var renderer = GetChildAt(0) as IVisualElementRenderer;
 				var viewHandlerType = Registrar.Registered.GetHandlerTypeForObject(cell.View) ?? typeof(Platform.DefaultRenderer);
 				var reflectableType = renderer as System.Reflection.IReflectableType;
-				var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : (renderer != null ? renderer.GetType() : typeof(obj));
+				var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : (renderer != null ? renderer.GetType() : typeof(System.Object));
 				if (renderer != null && rendererType == viewHandlerType)
 				{
 					Performance.Start("Reuse");

--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -142,7 +142,9 @@ namespace Xamarin.Forms.Platform.Android
 
 				var renderer = GetChildAt(0) as IVisualElementRenderer;
 				var viewHandlerType = Registrar.Registered.GetHandlerTypeForObject(cell.View) ?? typeof(Platform.DefaultRenderer);
-				if (renderer != null && renderer.GetType() == viewHandlerType)
+				var reflectableType = renderer as System.Reflection.IReflectableType;
+				var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : (renderer != null ? renderer.GetType() : typeof(obj));
+				if (renderer != null && rendererType == viewHandlerType)
 				{
 					Performance.Start("Reuse");
 					_viewCell = cell;

--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -141,7 +141,7 @@ namespace Xamarin.Forms.Platform.Android
 				Performance.Start();
 
 				var renderer = GetChildAt(0) as IVisualElementRenderer;
-				var viewHandlerType = Registrar.Registered.GetHandlerType(cell.View.GetType()) ?? typeof(Platform.DefaultRenderer);
+				var viewHandlerType = Registrar.Registered.GetHandlerTypeForObject(cell.View) ?? typeof(Platform.DefaultRenderer);
 				if (renderer != null && renderer.GetType() == viewHandlerType)
 				{
 					Performance.Start("Reuse");

--- a/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android
 			Bitmap bitmap = null;
 			IImageSourceHandler handler;
 
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				try
 				{

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -281,7 +281,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			UpdateGlobalContext(element);
 
-			IVisualElementRenderer renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType()) ?? new DefaultRenderer();
+			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultRenderer();
 			renderer.SetElement(element);
 
 			return renderer;
@@ -314,7 +314,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			UpdateGlobalContext(element);
 
-			IVisualElementRenderer renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType()) ?? new DefaultRenderer();
+			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultRenderer();
 
 			var managesFragments = renderer as IManageFragments;
 			managesFragments?.SetFragmentManager(fragmentManager);

--- a/Xamarin.Forms.Platform.Android/RendererPool.cs
+++ b/Xamarin.Forms.Platform.Android/RendererPool.cs
@@ -79,7 +79,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void PushRenderer(IVisualElementRenderer renderer)
 		{
-			Type rendererType = renderer.GetType();
+			var reflectableType = renderer as System.Reflection.IReflectableType;
+			var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : renderer.GetType();
 
 			Stack<IVisualElementRenderer> renderers;
 			if (!_freeRenderers.TryGetValue(rendererType, out renderers))

--- a/Xamarin.Forms.Platform.Android/RendererPool.cs
+++ b/Xamarin.Forms.Platform.Android/RendererPool.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (view == null)
 				throw new ArgumentNullException("view");
 
-			Type rendererType = Internals.Registrar.Registered.GetHandlerType(view.GetType()) ?? typeof(ViewRenderer);
+			Type rendererType = Internals.Registrar.Registered.GetHandlerTypeForObject(view) ?? typeof(ViewRenderer);
 
 			Stack<IVisualElementRenderer> renderers;
 			if (!_freeRenderers.TryGetValue(rendererType, out renderers) || renderers.Count == 0)

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -275,12 +275,17 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateFooter()
 		{
 			var footer = (VisualElement)Controller.FooterElement;
-			if (_footerRenderer != null && (footer == null || Registrar.Registered.GetHandlerType(footer.GetType()) != _footerRenderer.GetType()))
+			if (_footerRenderer != null)
 			{
-				if (_footerView != null)
-					_footerView.Child = null;
-				_footerRenderer.Dispose();
-				_footerRenderer = null;
+				var reflectableType = _footerRenderer as System.Reflection.IReflectableType;
+				var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : _footerRenderer.GetType();
+				if (footer == null || Registrar.Registered.GetHandlerTypeForObject(footer) != rendererType)
+				{
+					if (_footerView != null)
+						_footerView.Child = null;
+					_footerRenderer.Dispose();
+					_footerRenderer = null;
+				}
 			}
 
 			if (footer == null)
@@ -301,12 +306,17 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateHeader()
 		{
 			var header = (VisualElement)Controller.HeaderElement;
-			if (_headerRenderer != null && (header == null || Registrar.Registered.GetHandlerType(header.GetType()) != _headerRenderer.GetType()))
+			if (_headerRenderer != null)
 			{
-				if (_headerView != null)
-					_headerView.Child = null;
-				_headerRenderer.Dispose();
-				_headerRenderer = null;
+				var reflectableType = _headerRenderer as System.Reflection.IReflectableType;
+				var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : _headerRenderer.GetType();
+				if (header == null || Registrar.Registered.GetHandlerTypeForObject(header) != rendererType)
+				{
+					if (_headerView != null)
+						_headerView.Child = null;
+					_headerRenderer.Dispose();
+					_headerRenderer = null;
+				}
 			}
 
 			if (header == null)

--- a/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			NSView nativeCell;
 			if (reusable == null || !isRecycle)
 			{
-				var renderer = (CellRenderer)Internals.Registrar.Registered.GetHandler<IRegisterable>(cell.GetType());
+				var renderer = (CellRenderer)Internals.Registrar.Registered.GetHandlerForObject<IRegisterable>(cell);
 				nativeCell = renderer.GetCell(cell, null, tableView);
 			}
 			else

--- a/Xamarin.Forms.Platform.MacOS/Cells/ImageCellRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/ImageCellRenderer.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			IImageSourceHandler handler;
 
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				NSImage uiimage;
 				try

--- a/Xamarin.Forms.Platform.MacOS/Cells/ViewCellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/ViewCellNSView.cs
@@ -91,7 +91,9 @@ namespace Xamarin.Forms.Platform.MacOS
 					renderer.Element.ClearValue(Platform.RendererProperty);
 
 				var type = Internals.Registrar.Registered.GetHandlerTypeForObject(_viewCell.View);
-				if (renderer.GetType() == type || (renderer is DefaultRenderer && type == null))
+				var reflectableType = renderer as System.Reflection.IReflectableType;
+				var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : renderer.GetType();
+				if (rendererType == type || (renderer is DefaultRenderer && type == null))
 					renderer.SetElement(_viewCell.View);
 				else
 				{

--- a/Xamarin.Forms.Platform.MacOS/Cells/ViewCellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/ViewCellNSView.cs
@@ -90,7 +90,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (renderer.Element != null && renderer == Platform.GetRenderer(renderer.Element))
 					renderer.Element.ClearValue(Platform.RendererProperty);
 
-				var type = Internals.Registrar.Registered.GetHandlerType(_viewCell.View.GetType());
+				var type = Internals.Registrar.Registered.GetHandlerTypeForObject(_viewCell.View);
 				if (renderer.GetType() == type || (renderer is DefaultRenderer && type == null))
 					renderer.SetElement(_viewCell.View);
 				else

--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -108,8 +108,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public static IVisualElementRenderer CreateRenderer(VisualElement element)
 		{
-			var t = element.GetType();
-			var renderer = Internals.Registrar.Registered.GetHandler<IVisualElementRenderer>(t) ?? new DefaultRenderer();
+			var renderer = Internals.Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultRenderer();
 			renderer.SetElement(element);
 			return renderer;
 		}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -92,7 +92,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			IImageSourceHandler handler;
 			FileImageSource source = Element.Image;
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				NSImage uiimage;
 				try

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
@@ -96,7 +96,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			Element.SetIsLoading(true);
 
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				NSImage nsImage;
 				try

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
@@ -181,7 +181,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				//Header reuse is not working for now , problem with size of something that is not inside a layout
 				//if (_headerRenderer != null)
 				//{
-				//	if (header != null && _headerRenderer.GetType() == Registrar.Registered.GetHandlerType(header.GetType()))
+				//	var reflectableType = _headerRenderer as System.Reflection.IReflectableType;
+				//	var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : _headerRenderer.GetType();
+				//	if (header != null && rendererType == Registrar.Registered.GetHandlerTypeForObject(header))
 				//	{
 				//		_headerRenderer.SetElement(headerView);
 				//		_table.HeaderView = new CustomNSTableHeaderView(Bounds.Width, _headerRenderer);

--- a/Xamarin.Forms.Platform.WP8/CellControl.cs
+++ b/Xamarin.Forms.Platform.WP8/CellControl.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		System.Windows.DataTemplate GetTemplate(Cell cell)
 		{
-			var renderer = Registrar.Registered.GetHandler<ICellRenderer>(cell.GetType());
+			var renderer = Registrar.Registered.GetHandlerForObject<ICellRenderer>(cell);
 			return renderer.GetTemplate(cell);
 		}
 

--- a/Xamarin.Forms.Platform.WP8/CellTemplateSelector.cs
+++ b/Xamarin.Forms.Platform.WP8/CellTemplateSelector.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			if (cell == null)
 				return null;
 
-			var renderer = Registrar.Registered.GetHandler<ICellRenderer>(cell.GetType());
+			var renderer = Registrar.Registered.GetHandlerForObject<ICellRenderer>(cell);
 			return renderer.GetTemplate(cell);
 		}
 

--- a/Xamarin.Forms.Platform.WP8/Converters/ImageConverter.cs
+++ b/Xamarin.Forms.Platform.WP8/Converters/ImageConverter.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 			var source = (ImageSource)value;
 			IImageSourceHandler handler;
 
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				Task<System.Windows.Media.ImageSource> task = handler.LoadImageAsync(source);
 				return new AsyncValue<System.Windows.Media.ImageSource>(task, null);

--- a/Xamarin.Forms.Platform.WP8/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WP8/ImageRenderer.cs
@@ -82,7 +82,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 			ImageSource source = Element.Source;
 			IImageSourceHandler handler;
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				System.Windows.Media.ImageSource imagesource;
 				try

--- a/Xamarin.Forms.Platform.WP8/Platform.cs
+++ b/Xamarin.Forms.Platform.WP8/Platform.cs
@@ -211,7 +211,7 @@ namespace Xamarin.Forms.Platform.WinPhone
 
 		public static IVisualElementRenderer CreateRenderer(VisualElement element)
 		{
-			IVisualElementRenderer result = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType()) ?? new ViewRenderer();
+			IVisualElementRenderer result = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new ViewRenderer();
 			result.SetElement(element);
 			return result;
 		}

--- a/Xamarin.Forms.Platform.WinRT/CellControl.cs
+++ b/Xamarin.Forms.Platform.WinRT/CellControl.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		Windows.UI.Xaml.DataTemplate GetTemplate(Cell cell)
 		{
-			var renderer = Registrar.Registered.GetHandler<ICellRenderer>(cell.GetType());
+			var renderer = Registrar.Registered.GetHandlerForObject<ICellRenderer>(cell);
 			return renderer.GetTemplate(cell);
 		}
 

--- a/Xamarin.Forms.Platform.WinRT/ImageConverter.cs
+++ b/Xamarin.Forms.Platform.WinRT/ImageConverter.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			var source = (ImageSource)value;
 			IImageSourceHandler handler;
 
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				Task<Windows.UI.Xaml.Media.ImageSource> task = handler.LoadImageAsync(source);
 				return new AsyncValue<Windows.UI.Xaml.Media.ImageSource>(task, null);

--- a/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
@@ -167,7 +167,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			ImageSource source = Element.Source;
 			IImageSourceHandler handler;
-			if (source != null && (handler = Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				Windows.UI.Xaml.Media.ImageSource imagesource;
 

--- a/Xamarin.Forms.Platform.WinRT/Platform.cs
+++ b/Xamarin.Forms.Platform.WinRT/Platform.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			if (element == null)
 				throw new ArgumentNullException(nameof(element));
 
-			IVisualElementRenderer renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType()) ??
+			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ??
 			                                  new DefaultRenderer();
 			renderer.SetElement(element);
 			return renderer;

--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var id = cell.GetType().FullName;
 
-			var renderer = (CellRenderer)Internals.Registrar.Registered.GetHandler<IRegisterable>(cell.GetType());
+			var renderer = (CellRenderer)Internals.Registrar.Registered.GetHandlerForObject<IRegisterable>(cell);
 
 			ContextActionsCell contextCell = null;
 			UITableViewCell reusableCell = null;

--- a/Xamarin.Forms.Platform.iOS/Cells/ImageCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ImageCellRenderer.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			IImageSourceHandler handler;
 
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				UIImage uiimage;
 				try

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -166,7 +166,7 @@ namespace Xamarin.Forms.Platform.iOS
 					if (renderer.Element != null && renderer == Platform.GetRenderer(renderer.Element))
 						renderer.Element.ClearValue(Platform.RendererProperty);
 
-					var type = Internals.Registrar.Registered.GetHandlerType(this._viewCell.View.GetType());
+					var type = Internals.Registrar.Registered.GetHandlerTypeForObject(this._viewCell.View);
 					if (renderer.GetType() == type || (renderer is Platform.DefaultRenderer && type == null))
 						renderer.SetElement(this._viewCell.View);
 					else

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -167,7 +167,9 @@ namespace Xamarin.Forms.Platform.iOS
 						renderer.Element.ClearValue(Platform.RendererProperty);
 
 					var type = Internals.Registrar.Registered.GetHandlerTypeForObject(this._viewCell.View);
-					if (renderer.GetType() == type || (renderer is Platform.DefaultRenderer && type == null))
+					var reflectableType = renderer as System.Reflection.IReflectableType;
+					var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : renderer.GetType();
+					if (rendererType == type || (renderer is Platform.DefaultRenderer && type == null))
 						renderer.SetElement(this._viewCell.View);
 					else
 					{

--- a/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			async void UpdateIconAndStyle()
 			{
-				var source = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(_item.Icon.GetType());
+				var source = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(_item.Icon);
 				var image = await source.LoadImageAsync(_item.Icon);
 				Image = image;
 				Style = UIBarButtonItemStyle.Plain;
@@ -126,7 +126,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UIImage image = null;
 				if (!string.IsNullOrEmpty(_item.Icon?.File))
 				{
-					var source = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(_item.Icon.GetType());
+					var source = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(_item.Icon);
 					image = await source.LoadImageAsync(_item.Icon);
 				}
 				((SecondaryToolbarItemContent)CustomView).Image = image;

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -189,8 +189,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public static IVisualElementRenderer CreateRenderer(VisualElement element)
 		{
-			var t = element.GetType();
-			var renderer = Internals.Registrar.Registered.GetHandler<IVisualElementRenderer>(t) ?? new DefaultRenderer();
+			var renderer = Internals.Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultRenderer();
 			renderer.SetElement(element);
 			return renderer;
 		}

--- a/Xamarin.Forms.Platform.iOS/RendererPool.cs
+++ b/Xamarin.Forms.Platform.iOS/RendererPool.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (view == null)
 				throw new ArgumentNullException("view");
 
-			var rendererType = Internals.Registrar.Registered.GetHandlerType(view.GetType()) ?? typeof(ViewRenderer);
+			var rendererType = Internals.Registrar.Registered.GetHandlerTypeForObject(view) ?? typeof(ViewRenderer);
 
 			Stack<IVisualElementRenderer> renderers;
 			if (!_freeRenderers.TryGetValue(rendererType, out renderers) || renderers.Count == 0)

--- a/Xamarin.Forms.Platform.iOS/RendererPool.cs
+++ b/Xamarin.Forms.Platform.iOS/RendererPool.cs
@@ -122,7 +122,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void PushRenderer(IVisualElementRenderer renderer)
 		{
-			var rendererType = renderer.GetType();
+			var reflectableType = renderer as System.Reflection.IReflectableType;
+			var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : renderer.GetType();
 
 			Stack<IVisualElementRenderer> renderers;
 			if (!_freeRenderers.TryGetValue(rendererType, out renderers))

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
@@ -151,7 +151,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			IImageSourceHandler handler;
 			FileImageSource source = Element.Image;
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				UIImage uiimage;
 				try

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -137,7 +137,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Element.SetIsLoading(true);
 
 			if (source != null &&
-			    (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			    (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				UIImage uiimage;
 				try

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -406,7 +406,9 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_footerRenderer != null)
 				{
 					_footerRenderer.Element.MeasureInvalidated -= OnFooterMeasureInvalidated;
-					if (footer != null && _footerRenderer.GetType() == Internals.Registrar.Registered.GetHandlerType(footer.GetType()))
+					var reflectableType = _footerRenderer as System.Reflection.IReflectableType;
+					var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : _footerRenderer.GetType();
+					if (footer != null && rendererType == Internals.Registrar.Registered.GetHandlerTypeForObject(footer))
 					{
 						_footerRenderer.SetElement(footerView);
 						return;
@@ -452,7 +454,9 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_headerRenderer != null)
 				{
 					_headerRenderer.Element.MeasureInvalidated -= OnHeaderMeasureInvalidated;
-					if (header != null && _headerRenderer.GetType() == Internals.Registrar.Registered.GetHandlerType(header.GetType()))
+					var reflectableType = _headerRenderer as System.Reflection.IReflectableType;
+					var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : _headerRenderer.GetType();
+					if (header != null && rendererType == Internals.Registrar.Registered.GetHandlerTypeForObject(header))
 					{
 						_headerRenderer.SetElement(headerView);
 						return;
@@ -897,7 +901,7 @@ namespace Xamarin.Forms.Platform.iOS
 					if (cell.HasContextActions)
 						throw new NotSupportedException("Header cells do not support context actions");
 
-					var renderer = (CellRenderer)Internals.Registrar.Registered.GetHandler<IRegisterable>(cell.GetType());
+					var renderer = (CellRenderer)Internals.Registrar.Registered.GetHandlerForObject<IRegisterable>(cell);
 
 					var view = new HeaderWrapperView();
 					view.AddSubview(renderer.GetCell(cell, null, tableView));

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -378,7 +378,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		async void setTitleImage(ParentingViewController pack, FileImageSource titleIcon)
 		{
-			var source = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(titleIcon.GetType());
+			var source = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(titleIcon);
 			var image = await source.LoadImageAsync(titleIcon);
 			//UIImage ctor throws on file not found if MonoTouch.ObjCRuntime.Class.ThrowOnInitFailure is true;
 			pack.NavigationItem.TitleView = new UIImageView(image);
@@ -676,7 +676,7 @@ namespace Xamarin.Forms.Platform.iOS
 				try
 				{
 
-					var source = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(masterDetailPage.Master.Icon.GetType());
+					var source = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(masterDetailPage.Master.Icon);
 					var icon = await source.LoadImageAsync(masterDetailPage.Master.Icon);
 					containerController.NavigationItem.LeftBarButtonItem = new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, handler);
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -412,7 +412,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 		    if (!string.IsNullOrEmpty(page.Icon?.File))
 		    {
-				var source = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(page.Icon.GetType());
+				var source = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(page.Icon);
 				var icon = await source.LoadImageAsync(page.Icon);
 		        return Tuple.Create(icon, (UIImage)null);
 		    }

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var reusable = tableView.DequeueReusableCell(result.GetType().FullName);
 
-				var cellRenderer = Internals.Registrar.Registered.GetHandler<CellRenderer>(result.GetType());
+				var cellRenderer = Internals.Registrar.Registered.GetHandlerForObject<CellRenderer>(result);
 				return cellRenderer.GetCell(result, reusable, Table);
 			}
 			return null;

--- a/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
+++ b/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
@@ -109,7 +109,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var source = deepLinkUri.Thumbnail;
 			IImageSourceHandler handler;
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				UIImage uiimage;
 				try

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
@@ -1,4 +1,4 @@
-<Type Name="Registrar&lt;TRegistrable&gt;" FullName="Xamarin.Forms.Internals.Registrar&lt;TRegistrable&gt;">
+<<Type Name="Registrar&lt;TRegistrable&gt;" FullName="Xamarin.Forms.Internals.Registrar&lt;TRegistrable&gt;">
   <TypeSignature Language="C#" Value="public class Registrar&lt;TRegistrable&gt; where TRegistrable : class" />
   <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Registrar`1&lt;class TRegistrable&gt; extends System.Object" />
   <AssemblyInfo>
@@ -68,29 +68,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="GetHandlerType">
-      <MemberSignature Language="C#" Value="public Type GetHandlerType (Type viewType);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Type GetHandlerType(class System.Type viewType) cil managed" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Type</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="viewType" Type="System.Type" />
-      </Parameters>
-      <Docs>
-        <param name="viewType">For internal use by the Xamarin.Forms platform.</param>
-        <summary>For internal use by the Xamarin.Forms platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="GetHandlerForObject&lt;TOut&gt;">
       <MemberSignature Language="C#" Value="public TOut GetHandlerForObject&lt;TOut&gt; (object obj) where TOut : TRegistrable;" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance !!TOut GetHandlerForObject&lt;(!TRegistrable) TOut&gt;(class System.Object obj) cil managed" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance !!TOut GetHandlerForObject&lt;(!TRegistrable) TOut&gt;(object obj) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -116,9 +96,29 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="GetHandlerType">
+      <MemberSignature Language="C#" Value="public Type GetHandlerType (Type viewType);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Type GetHandlerType(class System.Type viewType) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Type</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="viewType" Type="System.Type" />
+      </Parameters>
+      <Docs>
+        <param name="viewType">For internal use by the Xamarin.Forms platform.</param>
+        <summary>For internal use by the Xamarin.Forms platform.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="GetHandlerTypeForObject">
       <MemberSignature Language="C#" Value="public Type GetHandlerTypeForObject (object obj);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Type GetHandlerTypeForObject(class System.Object obj) cil managed" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Type GetHandlerTypeForObject(object obj) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
@@ -1,4 +1,4 @@
-<<Type Name="Registrar&lt;TRegistrable&gt;" FullName="Xamarin.Forms.Internals.Registrar&lt;TRegistrable&gt;">
+<Type Name="Registrar&lt;TRegistrable&gt;" FullName="Xamarin.Forms.Internals.Registrar&lt;TRegistrable&gt;">
   <TypeSignature Language="C#" Value="public class Registrar&lt;TRegistrable&gt; where TRegistrable : class" />
   <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Registrar`1&lt;class TRegistrable&gt; extends System.Object" />
   <AssemblyInfo>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
@@ -88,6 +88,54 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="GetHandlerForObject&lt;TOut&gt;">
+      <MemberSignature Language="C#" Value="public TOut GetHandlerForObject&lt;TOut&gt; (object obj) where TOut : TRegistrable;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance !!TOut GetHandlerForObject&lt;(!TRegistrable) TOut&gt;(class System.Object obj) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>TOut</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TOut">
+          <Constraints>
+            <BaseTypeName>TRegistrable</BaseTypeName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="obj" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TOut">To be added.</typeparam>
+        <param name="obj">To be added.</param>
+        <summary>For internal use by the Xamarin.Forms platform.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetHandlerTypeForObject">
+      <MemberSignature Language="C#" Value="public Type GetHandlerTypeForObject (object obj);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Type GetHandlerTypeForObject(class System.Object obj) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Type</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="obj" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="obj">To be added.</param>
+        <summary>For internal use by the Xamarin.Forms platform.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Register">
       <MemberSignature Language="C#" Value="public void Register (Type tview, Type trender);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Register(class System.Type tview, class System.Type trender) cil managed" />


### PR DESCRIPTION
### Description of Change ###

Everywhere `Registrar.Registered.GetHandler` is called, try to use the `IReflectableType` to get type information instead of `GetType`.

This allows dynamic objects that implement their own types to be used by the Registrar.

There is already some precedent for support of dynamic objects: `BindingExpression.ApplyCore` does this same kind of check. This patch extends that support to the Registrar.

### API Changes ###

None

### Behavioral Changes ###

Users will be able to register dynamic objects in the Registrar where before they could not.

### PR Checklist ###

- [x] Has tests (2 new tests)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
