### PR TITLE
Fix NRE when background color of button set in FormsApplicationActivity

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ButtonBackgroundColorTest.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ButtonBackgroundColorTest.cs
@@ -1,0 +1,46 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Button)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 57717, "Setting background color on Button in Android FormsApplicationActivity causes NRE", PlatformAffected.Android)]
+	public class ButtonBackgroundColorTest : TestContentPage
+	{
+		const string ButtonText = "I am a button";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label { Text = "If you can see this, the test has passed." };
+
+			var button = new Button { Text = ButtonText, BackgroundColor = Color.CornflowerBlue };
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(button);
+
+			Content = layout;
+		}
+
+#if UITEST
+		[Test]
+		public void ButtonBackgroundColorAutomatedTest()
+		{
+			// With the original bug in place, we'll crash before we get this far
+			RunningApp.WaitForElement(ButtonText);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -213,6 +213,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55912.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57317.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57114.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ButtonBackgroundColorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34727.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -140,7 +140,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (Element == null || Control == null)
 				return;
 
-			_backgroundTracker.UpdateBackgroundColor();
+			_backgroundTracker?.UpdateBackgroundColor();
 		}
 
 		void UpdateAll()

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -96,13 +96,12 @@ namespace Xamarin.Forms.Platform.Android
 					_textColorSwitcher = new TextColorSwitcher(button.TextColors);
 					button.AddOnAttachStateChangeListener(this);
 				}
-				if (_backgroundTracker == null)
-					_backgroundTracker = new ButtonBackgroundTracker(Element, Control);
 			}
+
+			if (_backgroundTracker == null)
+				_backgroundTracker = new ButtonBackgroundTracker(Element, Control);
 			else
-			{
 				_backgroundTracker.Button = e.NewElement;
-			}
 
 			UpdateAll();
 		}
@@ -127,7 +126,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void UpdateBackgroundColor()
 		{
-			_backgroundTracker.UpdateBackgroundColor();
+			if (Element == null || Control == null)
+				return;
+
+			_backgroundTracker?.UpdateBackgroundColor();
 		}
 
 		void UpdateAll()


### PR DESCRIPTION
### Description of Change ###

Adds null checks on BackgroundTracker for pre-appcompat Button; also adjusts initialization timing to match AppCompat ButtonRenderer.

### Bugs Fixed ###

- [57717 – Setting background color on Button in Android FormsApplicationActivity causes NRE](https://bugzilla.xamarin.com/show_bug.cgi?id=57717)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
