### PR TITLE
Unsubscribe from IDefinition.SizeChanged event when set via indexer

### DIFF
--- a/Xamarin.Forms.Core/DefinitionCollection.cs
+++ b/Xamarin.Forms.Core/DefinitionCollection.cs
@@ -83,6 +83,7 @@ namespace Xamarin.Forms
 			get { return _internalList[index]; }
 			set
 			{
+				_internalList[index].SizeChanged -= OnItemSizeChanged;
 				_internalList[index] = value;
 				value.SizeChanged += OnItemSizeChanged;
 				OnItemSizeChanged(this, EventArgs.Empty);

--- a/Xamarin.Forms.Core/DefinitionCollection.cs
+++ b/Xamarin.Forms.Core/DefinitionCollection.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Forms
 			get { return _internalList[index]; }
 			set
 			{
-				if(index < _internalList.Count && _internalList[index] != null)
+				if(index < _internalList.Count && _internalList[index] != null && index >= 0)
 					_internalList[index].SizeChanged -= OnItemSizeChanged;
 
 				_internalList[index] = value;

--- a/Xamarin.Forms.Core/DefinitionCollection.cs
+++ b/Xamarin.Forms.Core/DefinitionCollection.cs
@@ -83,7 +83,9 @@ namespace Xamarin.Forms
 			get { return _internalList[index]; }
 			set
 			{
-				_internalList[index].SizeChanged -= OnItemSizeChanged;
+				if(index < _internalList.Count && _internalList[index] != null)
+					_internalList[index].SizeChanged -= OnItemSizeChanged;
+
 				_internalList[index] = value;
 				value.SizeChanged += OnItemSizeChanged;
 				OnItemSizeChanged(this, EventArgs.Empty);


### PR DESCRIPTION
### Description of Change ###

DefinitionCollection<T> did not unsubscribe to the SizeChanged event  when set via indexer. This could result in unnecessary layouting when for example the Width Property of a ColumnDefinition, that is no longer part of the ColumnDefinitions Collection of a Grid, changes.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
