### PR TITLE
[UWP] Make sure to update HitTestVisible when IsEnable changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzila57749.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzila57749.cs
@@ -1,0 +1,49 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 57749, "After enabling a disabled button it is not clickable", PlatformAffected.UWP)]
+	public class Bugzilla57749 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			button1.Text = "Click me";
+			button1.AutomationId = "btnClick";
+			button1.IsEnabled = false;
+			button1.Clicked += Button1_Clicked1;
+			this.Content = button1;
+		}
+		Button button1 = new Button();
+
+		private void Button1_Clicked1(object sender, EventArgs e)
+		{
+			this.DisplayAlert("Button test", "Button was clicked", "Ok");
+		}
+
+		protected async override void OnAppearing()
+		{
+			base.OnAppearing();
+			await Task.Delay(100);
+			button1.IsEnabled = true;
+		}
+
+#if UITEST
+		[Test]
+		public async void Bugzilla57749Test()
+		{
+			await Task.Delay(500);
+			RunningApp.Tap(c => c.Marked("btnClick"));
+			RunningApp.WaitForElement (q => q.Marked ("Button was clicked"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -306,6 +306,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54036.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56896.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40161.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzila57749.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementTracker.cs
@@ -229,6 +229,10 @@ namespace Xamarin.Forms.Platform.WinRT
 			{
 				UpdateInputTransparent(Element, Container);
 			}
+			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+			{
+				UpdateInputTransparent(Element, Container);
+			}
 		}
 
 		protected virtual void UpdateNativeControl()


### PR DESCRIPTION
### Description of Change ###

Just make sure we updated the HitTestVisible when IsEnabled changes 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=57749

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
