### PR TITLE
Add disposed check to EnsureLongClickCancellation

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57758.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57758.cs
@@ -1,0 +1,56 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Gestures)]
+	[Category(UITestCategories.Image)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 57758, "ObjectDisposedException for Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer", PlatformAffected.Android)]
+	public class Bugzilla57758 : TestContentPage
+	{
+		const string ImageId = "TestImageId";
+
+		protected override void Init()
+		{
+			var testImage = new Image { Source = "coffee.png", AutomationId = ImageId };
+
+			var layout = new StackLayout
+			{
+				Padding = new Thickness(0, 20, 0, 0),
+				Children =
+				{
+					testImage
+				}
+			};
+
+			var tapGesture = new TapGestureRecognizer
+			{
+				NumberOfTapsRequired = 1,
+				Command = new Command(() => layout.Children.Remove(testImage))
+			};
+
+			testImage.GestureRecognizers.Add(tapGesture);
+
+			Content = layout;
+		}
+
+#if UITEST
+		[Test]
+		public void RemovingImageWithGestureFromLayoutWithinGestureHandlerDoesNotCrash()
+		{
+			RunningApp.WaitForElement(ImageId);
+			RunningApp.Tap(ImageId);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -213,6 +213,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55912.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57317.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57114.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57758.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ButtonBackgroundColorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ViewCellExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ViewCellExtensions.cs
@@ -22,6 +22,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static void EnsureLongClickCancellation(this AView view, MotionEvent motionEvent, bool handled, VisualElement element)
 		{
+			if (view.IsDisposed())
+			{
+				return;
+			}
+
 			if (motionEvent.Action == MotionEventActions.Up && handled && view.LongClickable && element.IsInViewCell())
 			{
 				// In order for long presses/clicks (for opening context menus) to work in a ViewCell 


### PR DESCRIPTION
### Description of Change ###

If the handler for a tap gesture removes the renderer from the layout (which causes eager disposal to kick in), the renderer will be disposed by the time the `EnsureLongClickCancellation` method runs. This change adds a disposed check to `EnsureLongClickCancellation` to prevent an ObjectDisposedException in that situation.

### Bugs Fixed ###

- [57758 – ObjectDisposedException for Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer](https://bugzilla.xamarin.com/show_bug.cgi?id=57758)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
