### PR TITLE
[Android] Ignore PropertyChanged when Label is disposed

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -198,6 +198,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
+			if (_disposed)
+			   return;
+			   
 			ElementPropertyChanged?.Invoke(this, e);
 
 			if (e.PropertyName == Label.HorizontalTextAlignmentProperty.PropertyName || e.PropertyName == Label.VerticalTextAlignmentProperty.PropertyName)


### PR DESCRIPTION
### Description of Change ###

Added a dispose check on elementpropertyChanged on FastLabelRenderer

### Bugs Fixed ###

Cannot acces disposed object, like this one https://forums.xamarin.com/discussion/comment/283251/#Comment_283251

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X ] Rebased on top of master at time of PR
- [X ] Changes adhere to coding standard
- [X ] Consolidate commits as makes sense
