### PR TITLE
[Xaml] Dispose string readers as soon as we're done with them

### DIFF
--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -70,7 +70,8 @@ namespace Xamarin.Forms.Xaml
 
 		public static void Load(object view, string xaml)
 		{
-			using (var reader = XmlReader.Create(new StringReader(xaml)))
+			using (var textReader = new StringReader(xaml))
+			using (var reader = XmlReader.Create(textReader))
 			{
 				while (reader.Read())
 				{
@@ -100,7 +101,8 @@ namespace Xamarin.Forms.Xaml
 		public static object Create (string xaml, bool doNotThrow = false)
 		{
 			object inflatedView = null;
-			using (var reader = XmlReader.Create (new StringReader (xaml))) {
+			using (var textreader = new StringReader(xaml))
+			using (var reader = XmlReader.Create (textreader)) {
 				while (reader.Read ()) {
 					//Skip until element
 					if (reader.NodeType == XmlNodeType.Whitespace)


### PR DESCRIPTION
### Description of Change ###

While investigating https://bugzilla.xamarin.com/show_bug.cgi?id=43583 I found out that each view inflated from xaml was keeping alive a string corresponding to its xaml, even when the parsing was complete.

This should address this

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
    I'm currently running manual tests on the profiler, to see if it actually changes something
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense