### PR TITLE
Update FrameRenderer.cs

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -208,8 +208,6 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (cornerRadius == -1f)
 					cornerRadius = 5f; // default corner radius
-				else
-					cornerRadius = Forms.Context.ToPixels(cornerRadius);
 
 				DrawBackground(canvas, width, height, cornerRadius, pressed);
 				DrawOutline(canvas, width, height, cornerRadius);


### PR DESCRIPTION
Removed the cornerRadius conversion  to pixels in the DrawCanvas function.



### Description of Change ###

In both the DrawOutline and DrawBackground function the conversion is done as well, which caused it to happen twice, resulting in wrong radius.

### Bugs Fixed ###

- No filed bug yet 

### API Changes ###


### Behavioral Changes ###

correctly calculate corner radius on frame

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
