### PR TITLE
Fix accent color on some Samsung devices

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -156,7 +156,7 @@ namespace Xamarin.Forms
 			Color rc;
 			using (var value = new TypedValue())
 			{
-				if (Context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorAccent, value, true))	// Android 5.0+
+				if (Context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorAccent, value, true) && Forms.IsLollipopOrNewer)	// Android 5.0+
 				{
 					rc = Color.FromUint((uint)value.Data);
 				}


### PR DESCRIPTION
### Description of Change ###

On some Samsung devices with API 19 or lower (and possibly other devices), the accent color was being incorrectly resolved using the method for Android 5.0+ which caused some elements, such as TableSection Titles, to appear blank.

This fix adds a check to make sure we are running on API 21+ so those devices can use the fallback methods. No tests are included since any existing ones should cover this already.

Before fix: https://testcloud.xamarin.com/test/accentcolor_a0f83499-e3e6-4c40-bc4d-43ec4b028dd7/
After fix: https://testcloud.xamarin.com/test/accentcolor_7c220793-db86-48c1-bc1a-dec4ce402d1c/

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=53222

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
