### PR TITLE
[iOS] Fix for disposing a map causing a null reference

### DIFF
--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -198,8 +198,11 @@ namespace Xamarin.Forms.Maps.MacOS
 				var mkMapView = (MKMapView)Control;
 				mkMapView.RegionChanged -= MkMapViewOnRegionChanged;
 				mkMapView.GetViewForAnnotation = null;
-				mkMapView.Delegate.Dispose();
-				mkMapView.Delegate = null;
+				if (mkMapView.Delegate != null)
+				{
+					mkMapView.Delegate.Dispose();
+					mkMapView.Delegate = null;
+				}
 				mkMapView.RemoveFromSuperview();
 #if __MOBILE__
 				if (FormsMaps.IsiOs9OrNewer)


### PR DESCRIPTION
### Description of Change ###

Maps renderer on iOS has been throwing a NullReferenceException when disposing due to the delegate property being null.
I have noticed this when using Xamarin.Forms v2.3.5.239-pre3 in conjunction with the TKCustomMap library.
Added a null check on the Delegate property in the Dispose method of the MapRenderer to make sure it isn't null before calling it's Dispose method.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
