### PR TITLE
[Android] Prevent ObjectDisposed exceptions on Fast Renderers

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewObjectDisposed.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewObjectDisposed.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Object Disposed Exception in ScrollViewContainer", PlatformAffected.Android)]
+	public class ScrollViewObjectDisposed : TestContentPage
+	{
+		const string Instructions = "Tap the button. If the app does not crash and the red label displays \"Success\", this test has passed.";
+		const string Success = "Success";
+		const string TestButtonId = "TestButtonId";
+
+		Label _status = new Label() { Text = "Test is running...", BackgroundColor = Color.Red, TextColor = Color.White };
+
+		ScrollView _scroll = new ScrollView();
+
+		protected override void Init()
+		{
+			_scroll.Content = _status;
+
+			InitTest();
+		}
+
+		void InitTest()
+		{
+
+			Button nextButton = new Button { Text = "Next", AutomationId = TestButtonId };
+			nextButton.Clicked += NextButton_Clicked;
+
+			StackLayout stack = new StackLayout
+			{
+				Children = { new Label { Text = Instructions }, _scroll, nextButton }
+			};
+
+			Content = stack;
+		}
+
+		void NextButton_Clicked(object sender, EventArgs e)
+		{
+			_status.Text = "";
+
+			InitTest();
+
+			_status.Text = Success;
+		}
+
+#if UITEST
+		[Test]
+		public void ScrollViewObjectDisposedTest ()
+		{
+			RunningApp.Tap(q => q.Marked(TestButtonId));
+			RunningApp.WaitForElement(q => q.Marked(Success));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -308,6 +308,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56896.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40161.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzila57749.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ScrollViewObjectDisposed.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -189,6 +189,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				if (Element != null)
 				{
 					Element.PropertyChanged -= OnElementPropertyChanged;
+
+					if (Platform.GetRenderer(Element) == this)
+						Element.ClearValue(Platform.RendererProperty);
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -127,6 +127,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				if (Element != null)
 				{
 					Element.PropertyChanged -= OnElementPropertyChanged;
+
+					if (Platform.GetRenderer(Element) == this)
+						Element.ClearValue(Platform.RendererProperty);
 				}
 				
 			}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -41,6 +41,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				if (_element != null)
 				{
 					_element.PropertyChanged -= OnElementPropertyChanged;
+
+					if (Platform.GetRenderer(_element) == this)
+						_element.ClearValue(Platform.RendererProperty);
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -152,6 +152,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				if (Element != null)
 				{
 					Element.PropertyChanged -= OnElementPropertyChanged;
+
+					if (Platform.GetRenderer(Element) == this)
+						Element.ClearValue(Platform.RendererProperty);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

Calling `Element.ClearValue(Platform.RendererProperty);` when the fast renderers are disposed will prevent the disposed renderer from being inadvertently returned later.

### Bugs Fixed ###

Numerous; TBD.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
