### PR TITLE
[core] Prevent canonicalization of '*.[.]' and '-0'

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32871.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32871.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.ComponentModel;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 32871, "Numeric Keyboard does not work when text has a binding to a value", PlatformAffected.Default)]
+	public class Bugzilla32871 : TestContentPage
+	{
+
+		public static class Id
+		{
+			public const string ValueEntry = nameof(ValueEntry);
+			public const string ValueLabel = nameof(ValueLabel);
+			public const string TypeEntry = nameof(TypeEntry);
+			public const string AddHorizontal = nameof(AddHorizontal);
+			public const string TypeLabel = nameof(TypeLabel);
+			public const string BindButton = nameof(BindButton);
+		}
+
+		[Preserve(AllMembers = true)]
+		public class ViewModel<T> : INotifyPropertyChanged
+		{
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public void OnPropertyChanged(string propertyName)
+				=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+			public ViewModel() { }
+
+			public T _value;
+			public T Value
+			{
+				get { return _value; }
+				set
+				{
+					_value = value;
+					s_labelValue.Text = $"value: {value}";
+					OnPropertyChanged(nameof(Value));
+				}
+			}
+		}
+
+		public static Label s_labelValue;
+
+		protected override void Init()
+		{
+			var stack = new StackLayout();
+
+			// text to be coerced
+			var entryValue = new Entry() { AutomationId = Id.ValueEntry };
+			stack.Children.Add(entryValue);
+
+			// feedback of the value coerced from text
+			s_labelValue = new Label() { Text = "value: [none]", AutomationId = Id.ValueLabel };
+			stack.Children.Add(s_labelValue);
+
+			// the type being coerced from text
+			var entryType = new Entry() { AutomationId = Id.TypeEntry };
+			stack.Children.Add(entryType);
+
+			// feedback of the type being coerced from text
+			var labelType = new Label() { Text = "type: [none]", AutomationId = Id.TypeLabel };
+			stack.Children.Add(labelType);
+
+			// create view model of the type being coerced; clear text
+			var bindButton = new Button() { Text = "Bind", AutomationId = Id.BindButton };
+			stack.Children.Add(bindButton);
+			bindButton.Clicked += (o, e) =>
+			{
+				try
+				{
+					var type = Type.GetType(entryType.Text);
+					BindingContext = Activator.CreateInstance(
+						typeof(ViewModel<>).MakeGenericType(type)
+					);
+					entryValue.Text = string.Empty;
+					labelType.Text = $"type: {type.FullName}";
+				}
+				catch (Exception ex)
+				{
+					labelType.Text = $"type: {ex.Message}";
+				}
+
+				entryValue.SetBinding(Entry.TextProperty, "Value");
+			};
+
+			this.Content = stack;
+		}
+#if UITEST
+		[Test]
+		public void Issue32871Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(Id.BindButton));
+
+			var types = new Type[] {
+				typeof(double),
+				typeof(int),
+				typeof(float),
+				typeof(decimal),
+			};
+
+			var values = new string[] {
+				"0.1",
+				"0",
+				"-0.1",
+				"-1.1",
+				"-.1",
+				".1",
+				"00",
+				"01",
+			};
+
+			foreach (var type in types)
+				Theory(type, values);
+		}
+		public bool TryParse(Type type, string value, ref string result)
+		{
+
+			if (value.EndsWith("."))
+				return false;
+
+			if (value == "-0")
+				return false;
+
+			try
+			{
+				result = $"{Convert.ChangeType(value, type)}";
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+		public void Theory(Type type, string[] values)
+		{
+			RunningApp.ClearText(Id.TypeEntry);
+			RunningApp.EnterText(Id.TypeEntry, type.FullName);
+			RunningApp.Tap(Id.BindButton);
+			RunningApp.WaitForElement(q => q.Marked($"type: {type.FullName}"));
+
+			foreach (var value in values)
+				Theory(type, value);
+		}
+		public void Theory(Type type, string value)
+		{
+			try { Convert.ChangeType(value, type); } catch { return; }
+
+			Console.WriteLine($"TEST CASE: type={type.FullName}, value={value}");
+
+			RunningApp.ClearText(Id.ValueEntry);
+
+			var input = string.Empty;
+			var output = string.Empty;
+			foreach (var c in value)
+			{
+				input += c;
+				RunningApp.EnterText(Id.ValueEntry, $"{c}");
+
+				if (TryParse(type, input, ref output))
+					input = output;
+
+				if (string.IsNullOrEmpty(output))
+					continue;
+
+				RunningApp.WaitForElement(q => q.Marked($"value: {output}"));
+			}
+
+			if (!Equals(Convert.ChangeType(value, type), Convert.ChangeType(output, type)))
+				throw new Exception($"Value '{value}' entered as '{output}'.");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -152,6 +152,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42329.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42364.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42519.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32871.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43313.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43469.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla43516.cs" />


### PR DESCRIPTION
### Description of Change ###

User expects to be able to bind Entry to double, float, or decimal backed property and be able to enter "-0.1" and/or "0.1". What actually happens is that "-0" and "0." are both canonicalized to "0" preventing the user from entering their values. 

Under the hood, after each character is entered into the Entry the binding system attempts to convert the text to the bound property type. If successful then the text is replaced with the ToString value of the converted texted which is canonicalized. 

The fix is special case "-0" and "\d*." so that they no longer convert to 0.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=32871
Bug pointed out "\d*."; Testing found "-0" case

### API Changes ###

None

### Behavioral Changes ###

Entering "0." or "-0" into an Entry bound to a decimal, float, or double bound property will not convert to "0".

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
