### PR TITLE
Add try-catch when reading properties dictionary on Windows

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/WindowsSerializer.cs
+++ b/Xamarin.Forms.Platform.WinRT/WindowsSerializer.cs
@@ -29,8 +29,18 @@ namespace Xamarin.Forms.Platform.WinRT
 					if (stream.Length == 0)
 						return new Dictionary<string, object>(4);
 
-					var serializer = new DataContractSerializer(typeof(IDictionary<string, object>));
-					return (IDictionary<string, object>)serializer.ReadObject(stream);
+					try
+					{
+						var serializer = new DataContractSerializer(typeof(IDictionary<string, object>));
+						return (IDictionary<string, object>)serializer.ReadObject(stream);
+					}
+					catch (Exception e)
+					{
+						Debug.WriteLine("Could not deserialize properties: " + e.Message);
+						Log.Warning("Xamarin.Forms PropertyStore", $"Exception while reading Application properties: {e}");
+					}
+
+					return null;
 				}
 			}
 			catch (FileNotFoundException)


### PR DESCRIPTION
### Description of Change ###
After storing non-primitive types in the properties dictionary, future attempts to deserialize the dictionary on Windows would result in a crash. Android and iOS already had a try-catch when reading the properties dictionary that would prevent this crash and output the exception to the log. This just adds the same try-catch to Windows.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=32116

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
