### PR TITLE
[MacOS] Tabbed Page Top Offset Fix

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
@@ -101,8 +101,13 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (!Element.Bounds.IsEmpty)
 				View.Frame = new System.Drawing.RectangleF((float)Element.X, (float)Element.Y, (float)Element.Width, (float)Element.Height);
 
+            var topOffset = TabHolderHeight;
+			var tabStyle = Tabbed.OnThisPlatform().GetTabsStyle();
+            if (tabStyle == TabsStyle.Hidden || tabStyle == TabsStyle.OnNavigation)
+                topOffset = 0;
+
 			var frame = View.Frame;
-			Page.ContainerArea = new Rectangle(0, 0, frame.Width, frame.Height - TabHolderHeight);
+            Page.ContainerArea = new Rectangle(0, 0, frame.Width, frame.Height - topOffset);
 
 			if (!_queuedSize.IsZero)
 			{

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
@@ -101,13 +101,13 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (!Element.Bounds.IsEmpty)
 				View.Frame = new System.Drawing.RectangleF((float)Element.X, (float)Element.Y, (float)Element.Width, (float)Element.Height);
 
-            var topOffset = TabHolderHeight;
+			var topOffset = TabHolderHeight;
 			var tabStyle = Tabbed.OnThisPlatform().GetTabsStyle();
-            if (tabStyle == TabsStyle.Hidden || tabStyle == TabsStyle.OnNavigation)
-                topOffset = 0;
+			if (tabStyle == TabsStyle.Hidden || tabStyle == TabsStyle.OnNavigation)
+				topOffset = 0;
 
 			var frame = View.Frame;
-            Page.ContainerArea = new Rectangle(0, 0, frame.Width, frame.Height - topOffset);
+			Page.ContainerArea = new Rectangle(0, 0, frame.Width, frame.Height - topOffset);
 
 			if (!_queuedSize.IsZero)
 			{


### PR DESCRIPTION
### Description of Change ###

When you use TabsStyle.OnNavigation or TabsStyle.Hidden, you have a small offset at the top. This PR fixes the bug.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
