### PR TITLE
Use correct renderers for pre-AppCompat

### DIFF
--- a/Stubs/Xamarin.Forms.Platform.cs
+++ b/Stubs/Xamarin.Forms.Platform.cs
@@ -35,14 +35,14 @@ namespace Xamarin.Forms.Platform
 	[RenderWith (typeof (EditorRenderer))]
 	internal class _EditorRenderer { }
 #if __ANDROID__
-	[RenderWith (typeof (Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer))]
+	[RenderWith (typeof (Xamarin.Forms.Platform.Android.LabelRenderer))]
 #else
 	[RenderWith (typeof (LabelRenderer))]
 #endif
 	internal class _LabelRenderer { }
 
 #if __ANDROID__
-	[RenderWith(typeof(Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer))]
+	[RenderWith(typeof(Xamarin.Forms.Platform.Android.ImageRenderer))]
 #else
 	[RenderWith (typeof (ImageRenderer))]
 #endif

--- a/Stubs/Xamarin.Forms.Platform.cs
+++ b/Stubs/Xamarin.Forms.Platform.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Platform
 	[RenderWith (typeof (EditorRenderer))]
 	internal class _EditorRenderer { }
 #if __ANDROID__
-	[RenderWith (typeof (Xamarin.Forms.Platform.Android.LabelRenderer))]
+	[RenderWith(typeof(Xamarin.Forms.Platform.Android.LabelRenderer))]
 #else
 	[RenderWith (typeof (LabelRenderer))]
 #endif

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -22,6 +22,7 @@ using AColor = Android.Graphics.Color;
 using AlertDialog = Android.Support.V7.App.AlertDialog;
 using ARelativeLayout = Android.Widget.RelativeLayout;
 using Xamarin.Forms.Internals;
+using Debug = System.Diagnostics.Debug;
 
 #endregion
 
@@ -119,8 +120,10 @@ namespace Xamarin.Forms.Platform.Android
 				RegisterHandlerForDefaultRenderer(typeof(Button), typeof(FastRenderers.ButtonRenderer), typeof(ButtonRenderer));
                 RegisterHandlerForDefaultRenderer(typeof(Switch), typeof(AppCompat.SwitchRenderer), typeof(SwitchRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(Picker), typeof(AppCompat.PickerRenderer), typeof(PickerRenderer));
-				RegisterHandlerForDefaultRenderer(typeof(Frame), typeof(AppCompat.FrameRenderer), typeof(FrameRenderer));
+				RegisterHandlerForDefaultRenderer(typeof(Frame), typeof(FastRenderers.FrameRenderer), typeof(FrameRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(CarouselPage), typeof(AppCompat.CarouselPageRenderer), typeof(CarouselPageRenderer));
+				RegisterHandlerForDefaultRenderer(typeof(Label), typeof(FastRenderers.LabelRenderer), typeof(LabelRenderer));
+				RegisterHandlerForDefaultRenderer(typeof(Image), typeof(FastRenderers.ImageRenderer), typeof(ImageRenderer));
 
 				_renderersAdded = true;
 			}

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -22,7 +22,6 @@ using AColor = Android.Graphics.Color;
 using AlertDialog = Android.Support.V7.App.AlertDialog;
 using ARelativeLayout = Android.Widget.RelativeLayout;
 using Xamarin.Forms.Internals;
-using Debug = System.Diagnostics.Debug;
 
 #endregion
 


### PR DESCRIPTION
### Description of Change ###

Apps using FormsApplicationActivity were incorrectly getting the "fast" renderers for Label and Image. This change gives legacy apps the correct renderers and uses the "fast" renderers only for FormsAppCompatActivity.
