### PR TITLE
[macOS] Implements/Fixes Vertical Text Alignment in the Label Renderer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -85,14 +85,26 @@ namespace Xamarin.Forms.Platform.MacOS
 					Control.Frame = new RectangleF(0, 0, (nfloat)Element.Width, labelHeight);
 					break;
 				case TextAlignment.Center:
+
+#if __MOBILE__
 					Control.Frame = new RectangleF(0, 0, (nfloat)Element.Width, (nfloat)Element.Height);
-					break;
-				case TextAlignment.End:
-					nfloat yOffset = 0;
+#else
 					fitSize = Control.SizeThatFits(Element.Bounds.Size.ToSizeF());
 					labelHeight = (nfloat)Math.Min(Bounds.Height, fitSize.Height);
+					var yOffset = (int)(Element.Height / 2 - labelHeight / 2);
+					Control.Frame = new RectangleF(0, 0, (nfloat)Element.Width, (nfloat)Element.Height - yOffset);
+#endif
+					break;
+				case TextAlignment.End:
+					fitSize = Control.SizeThatFits(Element.Bounds.Size.ToSizeF());
+					labelHeight = (nfloat)Math.Min(Bounds.Height, fitSize.Height);
+#if __MOBILE__
+					nfloat yOffset = 0;
 					yOffset = (nfloat)(Element.Height - labelHeight);
 					Control.Frame = new RectangleF(0, yOffset, (nfloat)Element.Width, labelHeight);
+#else
+					Control.Frame = new RectangleF(0, 0, (nfloat)Element.Width, labelHeight);
+#endif
 					break;
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

This PR implements/fixes the vertical text alignment in the Label Renderer for macOS.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
