### PR TITLE
Disallow scrolling in ScrollView when IsEnabled set to False

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
@@ -1,0 +1,80 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.IsEnabled)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 999999, "ScrollView set to disabled will still allow scrolling", PlatformAffected.All)]
+	public class ScrollViewIsEnabled : TestNavigationPage
+	{
+		const string InitiallyEnabled = "Initially Enabled";
+		const string InitiallyNotEnabled = "Initially Not Enabled";
+
+		protected override void Init()
+		{
+			var initiallyEnabled = new Button { Text = InitiallyEnabled };
+			initiallyEnabled.Clicked += (sender, args) => { Navigation.PushAsync(ScrollViewTestPage(true)); };
+
+			var initiallyNotEnabled = new Button { Text = InitiallyNotEnabled };
+			initiallyNotEnabled.Clicked += (sender, args) => { Navigation.PushAsync(ScrollViewTestPage(false)); };
+
+			var layout = new StackLayout { Children = { initiallyNotEnabled, initiallyEnabled } };
+
+			var root = new ContentPage { Content = layout };
+
+			PushAsync(root);
+		}
+
+		static ContentPage ScrollViewTestPage(bool initiallyEnabled)
+		{
+			var scrollViewContents = new StackLayout();
+			for (int n = 0; n < 100; n++)
+			{
+				scrollViewContents.Children.Add(new Label() { Text = n.ToString() });
+			}
+
+			var sv = new ScrollView { Content = scrollViewContents, IsEnabled = initiallyEnabled };
+			var layout = new StackLayout { Margin = new Thickness(5, 40, 5, 0) };
+
+			var toggleButton = new Button { Text = $"Toggle IsEnabled (currently {sv.IsEnabled})" };
+
+			toggleButton.Clicked += (sender, args) =>
+			{
+				sv.IsEnabled = !sv.IsEnabled;
+				toggleButton.Text = $"Toggle IsEnabled (currently {sv.IsEnabled})";
+			};
+
+			var instructions = new Label
+			{
+				Text = @"Attempt to scroll the ScrollView below. 
+If 'IsEnabled' is false and the ScrollView scrolls, this test has failed. 
+If 'IsEnabled' is true and the ScrollView does not scroll, this test has failed. 
+Use the toggle button to check both values of 'IsEnabled'."
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(toggleButton);
+			layout.Children.Add(sv);
+
+			return new ContentPage { Content = layout };
+		}
+
+		//#if UITEST
+//		[Test]
+//		public void _$BZ$Test()
+//		{
+//			//RunningApp.WaitForElement(q => q.Marked(""));
+//		}
+//#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
@@ -19,6 +19,8 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		const string InitiallyEnabled = "Initially Enabled";
 		const string InitiallyNotEnabled = "Initially Not Enabled";
+		const string ToggleButton = "ToggleButton";
+		const string ScrollView = "TheScrollView";
 
 		protected override void Init()
 		{
@@ -43,10 +45,10 @@ namespace Xamarin.Forms.Controls.Issues
 				scrollViewContents.Children.Add(new Label() { Text = n.ToString() });
 			}
 
-			var sv = new ScrollView { Content = scrollViewContents, IsEnabled = initiallyEnabled };
+			var sv = new ScrollView { Content = scrollViewContents, IsEnabled = initiallyEnabled, AutomationId = ScrollView };
 			var layout = new StackLayout { Margin = new Thickness(5, 40, 5, 0) };
 
-			var toggleButton = new Button { Text = $"Toggle IsEnabled (currently {sv.IsEnabled})" };
+			var toggleButton = new Button { Text = $"Toggle IsEnabled (currently {sv.IsEnabled})", AutomationId = ToggleButton };
 
 			toggleButton.Clicked += (sender, args) =>
 			{
@@ -69,12 +71,60 @@ Use the toggle button to check both values of 'IsEnabled'."
 			return new ContentPage { Content = layout };
 		}
 
-		//#if UITEST
-//		[Test]
-//		public void _$BZ$Test()
-//		{
-//			//RunningApp.WaitForElement(q => q.Marked(""));
-//		}
-//#endif
+#if UITEST
+		[Test]
+		public void ScrollViewInitiallyEnabled()
+		{
+			RunningApp.WaitForElement(InitiallyEnabled);
+			RunningApp.Tap(InitiallyEnabled);
+			RunningApp.WaitForElement("1");
+			RunningApp.WaitForElement(ScrollView);
+			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
+			RunningApp.WaitForNoElement("1"); // Should have scrolled off screen
+		}
+
+		[Test]
+		public void ScrollViewInitiallyEnabledThenDisabled()
+		{
+			RunningApp.WaitForElement(InitiallyEnabled);
+			RunningApp.Tap(InitiallyEnabled);
+			RunningApp.WaitForElement(ToggleButton);
+			RunningApp.Tap(ToggleButton);
+			
+			// Scrolling should now be IsEnabled = false
+
+			RunningApp.WaitForElement("1");
+			RunningApp.WaitForElement(ScrollView);
+			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
+			RunningApp.WaitForElement("1"); // Should not have scrolled off screen
+		}
+
+		[Test]
+		public void ScrollViewInitiallyNotEnabled()
+		{
+			RunningApp.WaitForElement(InitiallyNotEnabled);
+			RunningApp.Tap(InitiallyNotEnabled);
+			RunningApp.WaitForElement("1");
+			RunningApp.WaitForElement(ScrollView);
+			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
+			RunningApp.WaitForElement("1"); // Should not have scrolled off screen
+		}
+
+		[Test]
+		public void ScrollViewInitiallyNotEnabledThenEnabled()
+		{
+			RunningApp.WaitForElement(InitiallyNotEnabled);
+			RunningApp.Tap(InitiallyNotEnabled);
+			RunningApp.WaitForElement(ToggleButton);
+			RunningApp.Tap(ToggleButton);
+
+			// Scrolling should now be IsEnabled = true
+
+			RunningApp.WaitForElement("1");
+			RunningApp.WaitForElement(ScrollView);
+			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
+			RunningApp.WaitForElement("1"); // Should not have scrolled off screen
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Controls.Issues
 		const string ToggleButton = "ToggleButton";
 		const string ScrollView = "TheScrollView";
 		const string FirstItem = "FirstItem";
+		const string Success = "Success";
 
 		protected override void Init()
 		{
@@ -66,9 +67,14 @@ If 'IsEnabled' is true and the ScrollView does not scroll, this test has failed.
 Use the toggle button to check both values of 'IsEnabled'."
 			};
 
+			var success = new Label();
+
 			layout.Children.Add(instructions);
 			layout.Children.Add(toggleButton);
+			layout.Children.Add(success);
 			layout.Children.Add(sv);
+
+			sv.Scrolled += (sender, args) => success.Text = Success;
 
 			return new ContentPage { Content = layout };
 		}
@@ -82,7 +88,7 @@ Use the toggle button to check both values of 'IsEnabled'."
 			RunningApp.WaitForElement(FirstItem);
 			RunningApp.WaitForElement(ScrollView);
 			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
-			RunningApp.WaitForNoElement(FirstItem); // Should have scrolled off screen
+			RunningApp.WaitForElement(Success); // If the ScrollView scrolled, the success label should be displayed
 		}
 
 		[Test]
@@ -98,7 +104,7 @@ Use the toggle button to check both values of 'IsEnabled'."
 			RunningApp.WaitForElement(FirstItem);
 			RunningApp.WaitForElement(ScrollView);
 			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
-			RunningApp.WaitForElement(FirstItem); // Should not have scrolled off screen
+			RunningApp.WaitForNoElement(Success); // Shouldn't have scrolled, so no success label should be displayed
 		}
 
 		[Test]
@@ -109,7 +115,7 @@ Use the toggle button to check both values of 'IsEnabled'."
 			RunningApp.WaitForElement(FirstItem);
 			RunningApp.WaitForElement(ScrollView);
 			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
-			RunningApp.WaitForElement(FirstItem); // Should not have scrolled off screen
+			RunningApp.WaitForNoElement(Success); // Shouldn't have scrolled, so no success label should be displayed
 		}
 
 		[Test]
@@ -125,7 +131,7 @@ Use the toggle button to check both values of 'IsEnabled'."
 			RunningApp.WaitForElement(FirstItem);
 			RunningApp.WaitForElement(ScrollView);
 			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
-			RunningApp.WaitForNoElement(FirstItem); // Should not have scrolled off screen
+			RunningApp.WaitForElement(Success); // If the ScrollView scrolled, the success label should be displayed
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var scrollViewContents = new StackLayout();
 			for (int n = 0; n < 100; n++)
 			{
-				scrollViewContents.Children.Add(new Label() { Text = n.ToString() });
+				scrollViewContents.Children.Add(new Label { Text = n.ToString() });
 			}
 
 			var sv = new ScrollView { Content = scrollViewContents, IsEnabled = initiallyEnabled, AutomationId = ScrollView };
@@ -123,7 +123,7 @@ Use the toggle button to check both values of 'IsEnabled'."
 			RunningApp.WaitForElement("1");
 			RunningApp.WaitForElement(ScrollView);
 			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
-			RunningApp.WaitForElement("1"); // Should not have scrolled off screen
+			RunningApp.WaitForNoElement("1"); // Should not have scrolled off screen
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 999999, "ScrollView set to disabled will still allow scrolling", PlatformAffected.All)]
+	[Issue(IssueTracker.None, 0112358, "ScrollView set to disabled will still allow scrolling", PlatformAffected.All)]
 	public class ScrollViewIsEnabled : TestNavigationPage
 	{
 		const string InitiallyEnabled = "Initially Enabled";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Controls.Issues
 		const string InitiallyNotEnabled = "Initially Not Enabled";
 		const string ToggleButton = "ToggleButton";
 		const string ScrollView = "TheScrollView";
+		const string FirstItem = "FirstItem";
 
 		protected override void Init()
 		{
@@ -40,6 +41,7 @@ namespace Xamarin.Forms.Controls.Issues
 		static ContentPage ScrollViewTestPage(bool initiallyEnabled)
 		{
 			var scrollViewContents = new StackLayout();
+			scrollViewContents.Children.Add(new Label { Text = FirstItem });
 			for (int n = 0; n < 100; n++)
 			{
 				scrollViewContents.Children.Add(new Label { Text = n.ToString() });
@@ -77,10 +79,10 @@ Use the toggle button to check both values of 'IsEnabled'."
 		{
 			RunningApp.WaitForElement(InitiallyEnabled);
 			RunningApp.Tap(InitiallyEnabled);
-			RunningApp.WaitForElement("1");
+			RunningApp.WaitForElement(FirstItem);
 			RunningApp.WaitForElement(ScrollView);
 			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
-			RunningApp.WaitForNoElement("1"); // Should have scrolled off screen
+			RunningApp.WaitForNoElement(FirstItem); // Should have scrolled off screen
 		}
 
 		[Test]
@@ -93,10 +95,10 @@ Use the toggle button to check both values of 'IsEnabled'."
 			
 			// Scrolling should now be IsEnabled = false
 
-			RunningApp.WaitForElement("1");
+			RunningApp.WaitForElement(FirstItem);
 			RunningApp.WaitForElement(ScrollView);
 			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
-			RunningApp.WaitForElement("1"); // Should not have scrolled off screen
+			RunningApp.WaitForElement(FirstItem); // Should not have scrolled off screen
 		}
 
 		[Test]
@@ -104,10 +106,10 @@ Use the toggle button to check both values of 'IsEnabled'."
 		{
 			RunningApp.WaitForElement(InitiallyNotEnabled);
 			RunningApp.Tap(InitiallyNotEnabled);
-			RunningApp.WaitForElement("1");
+			RunningApp.WaitForElement(FirstItem);
 			RunningApp.WaitForElement(ScrollView);
 			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
-			RunningApp.WaitForElement("1"); // Should not have scrolled off screen
+			RunningApp.WaitForElement(FirstItem); // Should not have scrolled off screen
 		}
 
 		[Test]
@@ -120,10 +122,10 @@ Use the toggle button to check both values of 'IsEnabled'."
 
 			// Scrolling should now be IsEnabled = true
 
-			RunningApp.WaitForElement("1");
+			RunningApp.WaitForElement(FirstItem);
 			RunningApp.WaitForElement(ScrollView);
 			RunningApp.ScrollDown(ScrollView, ScrollStrategy.Gesture);
-			RunningApp.WaitForNoElement("1"); // Should not have scrolled off screen
+			RunningApp.WaitForNoElement(FirstItem); // Should not have scrolled off screen
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -267,6 +267,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39829.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ScrollViewIsEnabled.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PlatformSpecifics_iOSTranslucentNavBarX.xaml.cs">
       <DependentUpon>PlatformSpecifics_iOSTranslucentNavBarX.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool _isBidirectional;
 		ScrollView _view;
 		int _previousBottom;
+		bool _isEnabled;
 
 		public ScrollViewRenderer() : base(Forms.Context)
 		{
@@ -79,8 +80,8 @@ namespace Xamarin.Forms.Platform.Android
 
 				LoadContent();
 				UpdateBackgroundColor();
-
 				UpdateOrientation();
+				UpdateIsEnabled();
 
 				element.SendViewInitialized(this);
 
@@ -129,6 +130,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override bool OnTouchEvent(MotionEvent ev)
 		{
+			if (!_isEnabled)
+				return false;
+
 			if (ShouldSkipOnTouch)
 			{
 				ShouldSkipOnTouch = false;
@@ -263,6 +267,18 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateBackgroundColor();
 			else if (e.PropertyName == ScrollView.OrientationProperty.PropertyName)
 				UpdateOrientation();
+			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+				UpdateIsEnabled();
+		}
+
+		void UpdateIsEnabled()
+		{
+			if (Element == null)
+			{
+				return;
+			}
+
+			_isEnabled = Element.IsEnabled;
 		}
 
 		void LoadContent()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -81,6 +81,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateDelaysContentTouches();
 				UpdateContentSize();
 				UpdateBackgroundColor();
+				UpdateIsEnabled();
 
 				OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
@@ -166,6 +167,18 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateContentSize();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
+			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+				UpdateIsEnabled();
+		}
+
+		void UpdateIsEnabled()
+		{
+			if (Element == null)
+			{
+				return;
+			}
+
+			ScrollEnabled = Element.IsEnabled;
 		}
 
 		void HandleScrollAnimationEnded(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

Prevents the user from scrolling a ScrollView which has `IsEnabled` set to `false`.

### Bugs Fixed ###

- https://forums.xamarin.com/discussion/comment/285062/#Comment_285062

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
