### PR TITLE
[UWP] Remove competing state recording Title visibility

### DIFF
--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -14,7 +14,6 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		Page _master;
 		Page _detail;
-		bool _showTitle;
 
 		VisualElementTracker<Page, FrameworkElement> _tracker;
 		
@@ -59,15 +58,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 		bool ITitleProvider.ShowTitle
 		{
-			get { return _showTitle; }
+			get { return Control.DetailTitleVisibility == Visibility.Visible; }
 
 			set
 			{
-				if (_showTitle == value)
-					return;
-
-				_showTitle = value;
-				Control.DetailTitleVisibility = _showTitle ? Visibility.Visible : Visibility.Collapsed;
+				Control.DetailTitleVisibility = value ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Cache of whether or not a UWP page's title was not invalidated. Remove the cache so the value is retrieved directly from the control (just like the surrounding properties). 

Cache was being invalidated via https://github.com/xamarin/Xamarin.Forms/blob/248d0176b5a437536f90e54ea5ea34e6b0d12099/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs#L307.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=51509

### API Changes ###

None

### Behavioral Changes ###

Honor value set via `NavigationPage.SetHasNavigationBar(..., false);`

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
