### PR TITLE
[Android] Set TimePicker Time Before Unfocusing

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -24,9 +24,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void TimePickerDialog.IOnTimeSetListener.OnTimeSet(ATimePicker view, int hourOfDay, int minute)
 		{
-			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
-
 			ElementController.SetValueFromRenderer(TimePicker.TimeProperty, new TimeSpan(hourOfDay, minute, 0));
+
+			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 			Control.ClearFocus();
 
 			if (Forms.IsLollipopOrNewer)


### PR DESCRIPTION
### Description of Change ###
On Android, users who checked TimePicker.Time in the Unfocused event would get the previously set Time instead of the newly chosen one. This fixes the issue by setting the Time property before setting the IsFocused property and brings it in line with the behavior of [DatePicker](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs#L108). 

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=58071

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
