### PR TITLE
[Android] Handle fragment removal inside of the RemovePage method

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PopAfterRemove.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PopAfterRemove.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 0101100101, "PopAsync crashing after RemovePage when support packages are updated to 25.1.1", PlatformAffected.Android)]
-	public class Bugzilla999999 : TestNavigationPage
+	public class PopAfterRemove : TestNavigationPage
 	{
 		ContentPage _intermediate1;
 		ContentPage _intermediate2;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PopAfterRemove.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PopAfterRemove.cs
@@ -10,11 +10,11 @@ using Xamarin.Forms.Core.UITests;
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
-	//[Category(UITestCategories.)]
+	[Category(UITestCategories.Navigation)]
 #endif
 
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 999999, "PopAsync crashing after RemovePage when support packages are updated to 25.1.1", PlatformAffected.Android)]
+	[Issue(IssueTracker.None, 0101100101, "PopAsync crashing after RemovePage when support packages are updated to 25.1.1", PlatformAffected.Android)]
 	public class Bugzilla999999 : TestNavigationPage
 	{
 		ContentPage _intermediate1;
@@ -32,22 +32,25 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		const string StartTest = "Start Test";
+		const string RootLabel = "Root";
 
 		ContentPage Last()
 		{
 			var test = new Button { Text = StartTest };
 
+			var instructions = new Label {Text = $"Tap the button labeled '{StartTest}'. The app should navigate to a page displaying the label '{RootLabel}'. If the application crashes, the test has failed." };
+
 			var layout = new StackLayout();
 
-			layout.Children.Add(new Label{Text = "Last"});
+			layout.Children.Add(instructions);
 			layout.Children.Add(test);
 
 			test.Clicked += (sender, args) =>
 			{
-				// TODO hartez 2017/07/11 20:51:46 Need to check both orders for intermediate pages, and also animated/not	
-				Navigation.RemovePage(_intermediate1);
 				Navigation.RemovePage(_intermediate2);
-				Navigation.PopAsync();
+				Navigation.RemovePage(_intermediate1);
+				
+				Navigation.PopAsync(true);
 			};
 
 			return new ContentPage { Content = layout };
@@ -55,7 +58,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		static ContentPage Root()
 		{
-			return new ContentPage { Content = new Label { Text = "Root" } };
+			return new ContentPage { Content = new Label { Text = RootLabel } };
 		}
 
 		static ContentPage Intermediate()
@@ -64,11 +67,13 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 #if UITEST
-		//[Test]
-		//public void _999999Test()
-		//{
-		//	//RunningApp.WaitForElement(q => q.Marked(""));
-		//}
+		[Test]
+		public void PopAsyncAfterRemovePageDoesNotCrash()
+		{
+			RunningApp.WaitForElement(StartTest);
+			RunningApp.Tap(StartTest);
+			RunningApp.WaitForElement(RootLabel);
+		}
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PopAfterRemove.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PopAfterRemove.cs
@@ -1,0 +1,74 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	//[Category(UITestCategories.)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 999999, "PopAsync crashing after RemovePage when support packages are updated to 25.1.1", PlatformAffected.Android)]
+	public class Bugzilla999999 : TestNavigationPage
+	{
+		ContentPage _intermediate1;
+		ContentPage _intermediate2;
+
+		protected override async void Init()
+		{
+			_intermediate1 = Intermediate();
+			_intermediate2 = Intermediate();
+
+			await PushAsync(Root());
+			await PushAsync(_intermediate1);
+			await PushAsync(_intermediate2);
+			await PushAsync(Last());
+		}
+
+		const string StartTest = "Start Test";
+
+		ContentPage Last()
+		{
+			var test = new Button { Text = StartTest };
+
+			var layout = new StackLayout();
+
+			layout.Children.Add(new Label{Text = "Last"});
+			layout.Children.Add(test);
+
+			test.Clicked += (sender, args) =>
+			{
+				// TODO hartez 2017/07/11 20:51:46 Need to check both orders for intermediate pages, and also animated/not	
+				Navigation.RemovePage(_intermediate1);
+				Navigation.RemovePage(_intermediate2);
+				Navigation.PopAsync();
+			};
+
+			return new ContentPage { Content = layout };
+		}
+
+		static ContentPage Root()
+		{
+			return new ContentPage { Content = new Label { Text = "Root" } };
+		}
+
+		static ContentPage Intermediate()
+		{
+			return new ContentPage { Content = new Label { Text = "Page" } };
+		}
+
+#if UITEST
+		//[Test]
+		//public void _999999Test()
+		//{
+		//	//RunningApp.WaitForElement(q => q.Marked(""));
+		//}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PopAfterRemove.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PopAfterRemove.cs
@@ -14,7 +14,9 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.None, 0101100101, "PopAsync crashing after RemovePage when support packages are updated to 25.1.1", PlatformAffected.Android)]
+	[Issue(IssueTracker.None, 0101100101, 
+		"PopAsync crashing after RemovePage when support packages are updated to 25.1.1",
+		PlatformAffected.Android)]
 	public class PopAfterRemove : TestNavigationPage
 	{
 		ContentPage _intermediate1;
@@ -38,7 +40,12 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var test = new Button { Text = StartTest };
 
-			var instructions = new Label {Text = $"Tap the button labeled '{StartTest}'. The app should navigate to a page displaying the label '{RootLabel}'. If the application crashes, the test has failed." };
+			var instructions = new Label
+			{
+				Text =
+					$"Tap the button labeled '{StartTest}'. The app should navigate to a page displaying the label " 
+					+ $"'{RootLabel}'. If the application crashes, the test has failed."
+			};
 
 			var layout = new StackLayout();
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -271,6 +271,7 @@
       <DependentUpon>PlatformSpecifics_iOSTranslucentNavBarX.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)PopAfterRemove.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPages\ScreenshotConditionalApp.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41842.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42277.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -33,6 +33,7 @@
 		public const string InputTransparent = "InputTransparent";
 		public const string IsEnabled = "IsEnabled";
 		public const string Gestures = "Gestures";
+		public const string Navigation = "Navigation";
 
 		public const string ManualReview = "ManualReview";
 	}

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		FragmentManager FragmentManager	=> _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
 
-		IPageController PageController => Element as IPageController;
+		IPageController PageController => Element;
 
 		bool ToolbarVisible
 		{
@@ -437,11 +437,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				ResetToolbar();
 		}
 
-		void FilterPageFragment(Page page)
-		{
-			_fragmentStack.RemoveAll(f => ((FragmentContainer)f).Page == page);
-		}
-
 		void HandleToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == MenuItem.IsEnabledProperty.PropertyName || e.PropertyName == MenuItem.TextProperty.PropertyName || e.PropertyName == MenuItem.IconProperty.PropertyName)
@@ -552,29 +547,49 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			_drawerToggle.DrawerIndicatorEnabled = true;
 		}
 
+		Fragment GetPageFragment(Page page)
+		{
+			for (int n = 0; n < _fragmentStack.Count; n++)
+			{
+				if ((_fragmentStack[n] as FragmentContainer)?.Page == page)
+				{
+					return _fragmentStack[n];
+				}
+			}
+
+			return null;
+		}
+
 		void RemovePage(Page page)
 		{
+			Fragment fragment = GetPageFragment(page);
+
+			if (fragment == null)
+			{
+				return;
+			}
+
+			// Go ahead and take care of the fragment bookkeeping for the page being removed
+			FragmentTransaction transaction = FragmentManager.BeginTransaction();
+			transaction.DisallowAddToBackStack();
+			transaction.Remove(fragment);
+			transaction.CommitAllowingStateLoss();
+			FragmentManager.ExecutePendingTransactions();
+
+			// And remove the fragment from our own stack
+			_fragmentStack.Remove(fragment);
+
+			// Now handle all the XF removal/cleanup
 			IVisualElementRenderer rendererToRemove = Android.Platform.GetRenderer(page);
 
 			if (rendererToRemove != null)
 			{
 				var containerToRemove = (PageContainer)rendererToRemove.View.Parent;
-
 				rendererToRemove.View?.RemoveFromParent();
-
 				rendererToRemove?.Dispose();
-
-				// This causes a NullPointerException in API 25.1+ when we later call ExecutePendingTransactions();
-				// We may want to remove this in the future if it is resolved in the Android SDK.
-				if ((int)Build.VERSION.SdkInt < 25)
-				{
-					containerToRemove?.RemoveFromParent();
-					containerToRemove?.Dispose();
-				}
+				containerToRemove?.RemoveFromParent();
+				containerToRemove?.Dispose();
 			}
-
-			// Also remove this page from the fragmentStack
-			FilterPageFragment(page);
 
 			Device.StartTimer(TimeSpan.FromMilliseconds(10), () =>
 			{


### PR DESCRIPTION
### Description of Change ###

Now handles fragment removal inside of the `RemovePage` method rather than leaving it pending for `SwitchContentAsync` to deal with later. 

### Bugs Fixed ###

- [53179 – PopAsync crashing after RemovePage when support packages are updated to 25.1.1](https://bugzilla.xamarin.com/show_bug.cgi?id=53179)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
