### PR TITLE
[39407] [iOS] Verify Picker selected index on close

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39407.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39407.cs
@@ -1,0 +1,30 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 39407, "Picker doesn't reset to source selected index when closed while spinning, via touch outside or Done button.", PlatformAffected.iOS)]
+	public class Bugzilla39407 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var picker = new Picker
+			{
+				ItemsSource = new string[] { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" }
+			};
+			Content = new StackLayout
+			{
+				Children =
+				{
+					picker
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -580,6 +580,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38731.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56710.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52700.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39407.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -86,6 +86,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
+			var s = (PickerSource)_picker.Model;
+			if (s.SelectedIndex != _picker.SelectedRowInComponent(0))
+			{
+				_picker.Select(s.SelectedIndex, 0, false);
+			}
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 		}
 


### PR DESCRIPTION
### Description of Change ###

When closing the Picker by tapping outside or hitting the Done button, verify the source selection index matches the UI control's selected row. When it is spinning during close, the animation completes offscreen and the next time it opens you see the wrong row selected.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=39407

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
