### PR TITLE
[macOS] BoxViewRenderer Color Fix

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/BoxViewRenderer.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			base.OnElementPropertyChanged(sender, e);
 			if (e.PropertyName == BoxView.ColorProperty.PropertyName)
-				SetBackgroundColor(Element.BackgroundColor);
+				SetBackgroundColor(Element.Color);
 			else if (e.PropertyName == VisualElement.IsVisibleProperty.PropertyName && Element.IsVisible)
 				SetNeedsDisplayInRect(Bounds);
 		}


### PR DESCRIPTION
### Description of Change ###

This PR fixes the BoxViewRenderer. It used the incorrect BackgroundColor Property and not the Color Property.


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
