### PR TITLE
[UWP] Prevent crash when using DateTime.MinValue for DatePicker

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/DatePickerRenderer.cs
@@ -90,13 +90,25 @@ namespace Xamarin.Forms.Platform.WinRT
 		void UpdateMaximumDate()
 		{
 			DateTime maxdate = Element.MaximumDate;
-			Control.MaxYear = new DateTimeOffset(maxdate.Date);
+			Control.MaxYear = new DateTimeOffset(maxdate);
 		}
 
 		void UpdateMinimumDate()
 		{
 			DateTime mindate = Element.MinimumDate;
-			Control.MinYear = new DateTimeOffset(mindate);
+
+			try
+			{
+				Control.MinYear = new DateTimeOffset(mindate);
+			}
+			catch (ArgumentOutOfRangeException)
+			{
+				// This will be thrown when mindate equals DateTime.MinValue and the UTC offset is positive
+				// because the resulting DateTimeOffset.UtcDateTime will be out of range. In that case let's
+				// specify the Kind as UTC so there is no offset.
+				mindate = DateTime.SpecifyKind(mindate, DateTimeKind.Utc);
+				Control.MinYear = new DateTimeOffset(mindate);
+			}
 		}
 
 		void UpdateTextColor()


### PR DESCRIPTION
### Description of Change ###

On UWP, if you try to set the DatePicker.MinimumDate to DateTime.MinValue when the UTC offset is positive an `ArgumentOutOfRangeException` is thrown because the time gets converted to UTC which makes it go out of range.

This fix catches the exception and specifies the date as UTC in order to prevent it from being converted.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=57855

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
