### PR TITLE
[macOS] ModalPage Resize Fix

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/ModalPageTracker.cs
+++ b/Xamarin.Forms.Platform.MacOS/ModalPageTracker.cs
@@ -41,6 +41,16 @@ namespace Xamarin.Forms.Platform.MacOS
 			return HideModalAsync(modal, animated);
 		}
 
+		internal void LayoutSubviews()
+		{
+			foreach(var modal in _modals)
+			{
+				var modalRenderer = Platform.GetRenderer(modal);
+				if(modalRenderer != null)
+					modalRenderer.SetElementSize(new Size(_renderer.View.Bounds.Width, _renderer.View.Bounds.Height));
+			}
+		}
+
 		public void Dispose()
 		{
 			Dispose(true);

--- a/Xamarin.Forms.Platform.MacOS/ModalPageTracker.cs
+++ b/Xamarin.Forms.Platform.MacOS/ModalPageTracker.cs
@@ -43,6 +43,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		internal void LayoutSubviews()
 		{
+			if (_renderer == null || _renderer.View == null)
+				return;
+			
 			foreach(var modal in _modals)
 			{
 				var modalRenderer = Platform.GetRenderer(modal);

--- a/Xamarin.Forms.Platform.MacOS/PlatformNavigation.cs
+++ b/Xamarin.Forms.Platform.MacOS/PlatformNavigation.cs
@@ -18,6 +18,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			_animateModals = true;
 		}
 
+		public ModalPageTracker ModalPageTracker => _modalTracker;
+
 		public IReadOnlyList<Page> ModalStack => _modalTracker.ModalStack;
 
 		public IReadOnlyList<Page> NavigationStack => new List<Page>();

--- a/Xamarin.Forms.Platform.MacOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/PlatformRenderer.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			base.ViewDidLayout();
 			Platform.LayoutSubviews();
+			_platformNavigation?.ModalPageTracker?.LayoutSubviews();
 		}
 
 		public override void ViewWillAppear()


### PR DESCRIPTION
### Description of Change ###

ModalPages and their children did not resize, when you changed the size of the main window. This PR fixes this bug.

### API Changes ###


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
