### PR TITLE
[macOS] Set tab order (e.g. for entries) on a Page

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/macOSSpecific/Page.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/macOSSpecific/Page.cs
@@ -1,0 +1,32 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.macOSSpecific
+{
+	using FormsElement = Forms.Page;
+
+	public static class Page
+	{
+		#region TabsStyle
+		public static readonly BindableProperty TabOrderProperty = BindableProperty.Create("TabOrder", typeof(VisualElement[]), typeof(Page), null);
+
+		public static VisualElement[] GetTabOrder(BindableObject element)
+		{
+			return (VisualElement[])element.GetValue(TabOrderProperty);
+		}
+
+		public static void SetTabOrder(BindableObject element, params VisualElement[] value)
+		{
+			element.SetValue(TabOrderProperty, value);
+		}
+
+		public static VisualElement[] GetTabOrder(this IPlatformElementConfiguration<macOS, FormsElement> config)
+		{
+			return GetTabOrder(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<macOS, FormsElement> SetTabOrder(this IPlatformElementConfiguration<macOS, FormsElement> config, params VisualElement[] value)
+		{
+			SetTabOrder(config.Element, value);
+			return config;
+		}
+		#endregion
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -462,6 +462,7 @@
     <Compile Include="Internals\ResourceLoader.cs" />
     <Compile Include="Xaml\TypeConversionExtensions.cs" />
     <Compile Include="Xaml\ValueConverterProvider.cs" />
+    <Compile Include="PlatformConfiguration\macOSSpecific\Page.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
@@ -185,11 +185,12 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		NSView GetNativeControl(VisualElement visualElement)
 		{
-			var subViews = Platform.GetRenderer(visualElement)?.NativeView?.Subviews;
+			var nativeView = Platform.GetRenderer(visualElement)?.NativeView;
+			var subViews = nativeView?.Subviews;
 			if (subViews != null && subViews.Length > 0)
 				return subViews[0];
 
-			return null;
+			return nativeView;
 		}
 
 		void UpdateTabOrder()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using AppKit;
+using Xamarin.Forms.PlatformConfiguration.macOSSpecific;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
@@ -67,6 +68,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 
 			_appeared = true;
+			UpdateTabOrder();
 			Page.SendAppearing();
 		}
 
@@ -159,6 +161,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateBackground();
 			else if (e.PropertyName == Page.TitleProperty.PropertyName)
 				UpdateTitle();
+			else if (e.PropertyName == PlatformConfiguration.macOSSpecific.Page.TabOrderProperty.PropertyName)
+				UpdateTabOrder();
 		}
 
 		void UpdateBackground()
@@ -177,6 +181,44 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (!string.IsNullOrWhiteSpace(((Page)Element).Title))
 				Title = ((Page)Element).Title;
+		}
+
+		NSView GetNativeControl(VisualElement visualElement)
+		{
+			var subViews = Platform.GetRenderer(visualElement)?.NativeView?.Subviews;
+			if (subViews != null && subViews.Length > 0)
+				return subViews[0];
+
+			return null;
+		}
+
+		void UpdateTabOrder()
+		{
+			var tabOrderElements = ((Page)Element).OnThisPlatform().GetTabOrder();
+			if(tabOrderElements != null && tabOrderElements.Length > 0)
+			{
+				var count = tabOrderElements.Length;
+
+				var first = GetNativeControl(tabOrderElements[0]);
+				var last = GetNativeControl(tabOrderElements[count - 1]);
+
+				if (first != null && last != null)
+				{
+					var previous = first;
+					for (int i = 1; i < count; i++)
+					{
+						var control = GetNativeControl(tabOrderElements[i]);
+						if (control != null)
+						{
+							previous.NextKeyView = control;
+							previous = control;
+						}
+					}
+
+					last.NextKeyView = first;
+					first.Window?.MakeFirstResponder(first);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This PR adds the option to set the tab order for elements on a page. After setting the tab order, you can cycle through these elements with the tab key.

### API Changes ###

`Page.On<macOS>().SetTabOrder(entry1, entry2, button1, ....)`

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
