### PR TITLE
[Maps] Change Map.LastMoveToRegion to public accessor

### DIFF
--- a/Xamarin.Forms.Maps/Map.cs
+++ b/Xamarin.Forms.Maps/Map.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -82,7 +82,7 @@ namespace Xamarin.Forms.Maps
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public MapSpan LastMoveToRegion { get; private set; }
+		public MapSpan LastMoveToRegion { get; set; }
 
 		IEnumerator IEnumerable.GetEnumerator()
 		{


### PR DESCRIPTION
### Description of Change ###

When using a custom map and renderer that inherit Map and MapRenderer the map will default it's centre to Rome when it is created from xaml.
This happens because the map has a property called `LastMoveToRegion` which can only be set internally and when using xaml to create the map gets set to Rome (See Map default constructor) and from the renderers `OnElementChanged` method there is a call made to `MoveToRegion`. Which is the only external place to set this property, however using a custom renderer we don't need to call `MoveToRegion` since we have access to the native map functions.

### API Changes ###

Changed:
 - internal MapSpan LastMoveToRegion => public MapSpan LastMoveToRegion

### Behavioral Changes ###

This change doesn't affect the behaviour of Xamarin.Forms.Maps at all but will help custom Map Renderers have more control over the map when navigating back and forward through pages with maps on them.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
