### PR TITLE
[macOS] Page.Alert return value fix

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -31,8 +31,11 @@ namespace Xamarin.Forms.Platform.MacOS
 			MessagingCenter.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
 			{
 				var alert = NSAlert.WithMessage(arguments.Title, arguments.Cancel, arguments.Accept, null, arguments.Message);
-				var result = alert.RunModal();
-				arguments.SetResult(result == 1);
+				var result = alert.RunSheetModal(NSApplication.SharedApplication.MainWindow);
+				if (arguments.Accept == null)
+					arguments.SetResult(result == 1);
+				else
+					arguments.SetResult(result == 0);
 			});
 
 			MessagingCenter.Subscribe(this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments arguments) =>

--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			MessagingCenter.Subscribe(this, Page.AlertSignalName, (Page sender, AlertArguments arguments) =>
 			{
 				var alert = NSAlert.WithMessage(arguments.Title, arguments.Cancel, arguments.Accept, null, arguments.Message);
-				var result = alert.RunSheetModal(NSApplication.SharedApplication.MainWindow);
+				var result = alert.RunSheetModal(PlatformRenderer.View.Window);
 				if (arguments.Accept == null)
 					arguments.SetResult(result == 1);
 				else
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					alert.Layout();
 				}
 
-				var result = (int)alert.RunSheetModal(NSApplication.SharedApplication.MainWindow);
+				var result = (int)alert.RunSheetModal(PlatformRenderer.View.Window);
 				var titleResult = string.Empty;
 				if (result == 1)
 					titleResult = arguments.Cancel;


### PR DESCRIPTION
### Description of Change ###

The return value of `await Page.Alert` was switched (returned true on no and false on yes). This PR fixes this bug.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
