### PR TITLE
[iOS Maps] Pin rendering customization

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.cs
@@ -144,7 +144,10 @@ namespace Xamarin.Forms.Controls
 
 		static void PinClicked (object sender, EventArgs e)
 		{
-			// yea!
+			Pin pin = (Pin)sender;
+			Application.Current.MainPage.DisplayAlert("Pin Click",
+				$"You clicked the {pin.Label} pin, located at {pin.Address}, or coordinates ({pin.Position.Latitude}, {pin.Position.Longitude})", 
+				"OK");
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UITests.Shared/PlatformQueries.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/PlatformQueries.cs
@@ -65,8 +65,10 @@ namespace Xamarin.Forms.Core.UITests
 		public static readonly string Image = "UIImageView";
 		public static readonly string Label = "UILabel";
 		public static readonly string ListView = "UITableView";
+		public static readonly string Map = "MKMapView";
 		public static readonly string OpenGLView = "GLKView";
 		public static readonly string Picker = "UITextField";
+		public static readonly string Pin = "MKPinAnnotationView";
 		public static readonly string ProgressBar = "UIProgressView";
 		public static readonly string SearchBar = "UISearchBar";
 		public static readonly string Slider = "UISlider";
@@ -86,8 +88,10 @@ namespace Xamarin.Forms.Core.UITests
 		public static readonly string Image = "android.widget.ImageView";
 		public static readonly string Label = "android.widget.TextView";
 		public static readonly string ListView = "android.widget.ListView";
+		public static readonly string Map = "android.gms.maps.GoogleMap";
 		public static readonly string OpenGLView = "android.widget.GLSurfaceView";
 		public static readonly string Picker = "android.widget.EditText";
+		public static readonly string Pin = "android.gms.maps.model.Marker";
 		public static readonly string ProgressBar = "android.widget.ProgressBar";
 		public static readonly string SearchBar = "android.widget.SearchView";
 		public static readonly string Slider = "android.widget.SeekBar";
@@ -121,6 +125,7 @@ namespace Xamarin.Forms.Core.UITests
 		// Controls
 		public static readonly Func<AppQuery, AppQuery> ActivityIndicator = q => q.ClassFull(PlatformViews.ActivityIndicator);
 		public static readonly Func<AppQuery, AppQuery> Button = q => q.ClassFull(PlatformViews.Button);
+		public static readonly Func<AppQuery, AppQuery> Pin = q => q.ClassFull(PlatformViews.Pin);
 
 #if __ANDROID__
 		public static Func<AppQuery, AppQuery> EntryWithPlaceholder(string text)

--- a/Xamarin.Forms.Core.UITests.Shared/Queries.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Queries.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Core.UITests
 		// Legacy galleries
 		public const string CellsGalleryLegacy = "* marked:'Cells Gallery - Legacy'";
 		public const string UnevenListGalleryLegacy = "* marked:'UnevenList Gallery - Legacy'";
+		public const string MapGalleryLegacy = "* marked:'Map Gallery - Legacy'";
 	}
 
 	internal static class Queries
@@ -85,8 +86,10 @@ namespace Xamarin.Forms.Core.UITests
 		public static readonly string Image = PlatformViews.Image;
 		public static readonly string Label = PlatformViews.Label;
 		public static readonly string ListView = PlatformViews.ListView;
+		public static readonly string Map = PlatformViews.Map;
 		public static readonly string OpenGLView = PlatformViews.OpenGLView;
 		public static readonly string Picker = PlatformViews.Picker;
+		public static readonly string Pin = PlatformViews.Pin;
 		public static readonly string ProgressBar = PlatformViews.ProgressBar;
 		public static readonly string SearchBar = PlatformViews.SearchBar;
 		public static readonly string Slider = PlatformViews.Slider;

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/MapUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/MapUITests.cs
@@ -17,12 +17,24 @@ namespace Xamarin.Forms.Core.UITests
 		    App.NavigateToGallery(GalleryQueries.MapGalleryLegacy);
 	    }
 
-		[Test]
-		public void MapGalleryPinClicked()
-		{
-			App.Tap(PlatformQueries.Pin);
-			App.Tap(c => c.Text("Colosseum"));
-			App.Screenshot("Alert displayed as result of PinClicked event");
-		}
-    }
+	    [Test]
+	    public void MapGalleryPinClicked()
+	    {
+		    App.Tap(PlatformQueries.Pin);
+
+		    App.WaitForElement(c => c.Text("Colosseum"));
+		    App.Tap(c => c.Text("Colosseum"));
+
+		    App.Screenshot("Alert displayed as result of PinClicked event");
+
+		    // Dismiss alert
+		    App.Tap(c => c.Text("OK"));
+	    }
+
+	    protected override void FixtureTeardown()
+	    {
+		    App.NavigateBack();
+		    base.FixtureTeardown();
+	    }
+	}
 }

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/MapUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/MapUITests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UITests
+{
+#if __ANDROID__ || __WINDOWS__
+	[Ignore("Test only meant for Mac and iOS, besides needing API keys for Android and Windows")]
+#endif
+	[TestFixture]
+	[Category(UITestCategories.Maps)]
+    internal class MapUITests : BaseTestFixture
+    {
+	    protected override void NavigateToGallery()
+	    {
+		    App.NavigateToGallery(GalleryQueries.MapGalleryLegacy);
+	    }
+
+		[Test]
+		public void MapGalleryPinClicked()
+		{
+			App.Tap(PlatformQueries.Pin);
+			App.Tap(c => c.Text("Colosseum"));
+			App.Screenshot("Alert displayed as result of PinClicked event");
+		}
+    }
+}

--- a/Xamarin.Forms.Core.UITests.Shared/Xamarin.Forms.Core.UITests.projitems
+++ b/Xamarin.Forms.Core.UITests.Shared/Xamarin.Forms.Core.UITests.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Tests\LabelUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\Legacy-CellsUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\Legacy-UnevenListTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tests\MapUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\PickerUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\ProgressBarUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\RootGalleryUITests.cs" />


### PR DESCRIPTION
### Description of Change ###

- #893 without breaking change to iOS MapRenderer base class.
- Continuation of #844 to create customization feature parity between Android and iOS.
- [Evolution Forum Post](https://forums.xamarin.com/discussion/91907/map-renderer-extensibility/)

### API Changes ###

Removed:
 - MapDelegate class -> Methods moved into MapRenderer class

Changed:
- private void AttachGestureToPin(MKPinAnnotationView mapPin, IMKAnnotation annotation) => protected void AttachGestureToPin(MKAnnotationView mapPin, IMKAnnotation annotation) 
  - So the Pin.Clicked event can be used when GetViewForAnnotation is overridden and/or native pin is rendered as a different subclass of MKAnnotationView

### Behavioral Changes ###

Should not change any existing functionality in the base library, makes it easier to customize pins when extending the iOS MapRenderer.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
