### PR TITLE
[Android] Prevent ObjectDisposedException in ButtonBackgroundTracker

### DIFF
--- a/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
@@ -48,9 +48,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else
 			{
-				if (_backgroundDrawable == null)
-					_backgroundDrawable = new ButtonDrawable();
-
+				_backgroundDrawable = new ButtonDrawable();
 				_backgroundDrawable.Button = _button;
 
 				if (_drawableEnabled)


### PR DESCRIPTION
### Description of Change ###

Fixes an ObjectDisposedException thrown in the `ButtonDrawable.Draw` method. The drawable is held by the class `ButtonBackgroundTracker` introduced in PR #941.

Inside the `UpdateDrawableMethod()`, the field `_backgroundDrawable` is used to hold a reference to the drawable. Previously, the drawable was only recreated if it was null however this **does not** account for edge cases where the object has been disposed but is not null.

To ensure we have a valid `ButtonDrawable`, we initialize a new instance.
Note: I experimented with simply checking the handle for IntPtr.Zero at this point, but this is not 100% effective. It appears there are certain cases whereby the object can be disposed between `_nativeButton.SetBackground(_backgroundDrawable);` and the native `Draw()' method being invoked.

This is particular noticeable when using advanced layout mechanisms such as Android's `RecyclerView`.

Note: This is the same as #1040 which was closed.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=57789

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense