### PR TITLE
[Android] Dispose check on GetDesiredSize() For FastButtonRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -91,6 +91,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
+			if (_isDisposed)
+			{
+				return new SizeRequest();
+			}
+		
 			UpdateText();
 
 			AView view = this;


### PR DESCRIPTION
return new SiseRequest if object is disposed

### Description of Change ###

Returns a new SiseRequest if button is disposed

### Bugs Fixed ###

https://forums.xamarin.com/discussion/comment/287671/#Comment_287671

### API Changes ###

none

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ x] Rebased on top of master at time of PR
- [ x] Changes adhere to coding standard
- [ x] Consolidate commits as makes sense
