### PR TITLE
[iOS] Fix regression introduced on #520

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -977,8 +977,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				SetCellBackgroundColor(cell, UIColor.Clear);
 
-				if (!cell.Selected)
-					_selectionFromNative = true;
+				_selectionFromNative = true;
 
 				tableView.EndEditing(true);
 				List.NotifyRowTapped(indexPath.Section, indexPath.Row, formsCell);


### PR DESCRIPTION
### Description of Change ###

The fix from #520 introduced a regression , since the flag _selectedFromNative was never set to true, so we were scrolling the item to the middle thinking it was  selected from the Forms side.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=58283

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense