### PR TITLE
[iOS] Clear state so we allow the SelectedItem to be set

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1030,6 +1030,12 @@ namespace Xamarin.Forms.Platform.iOS
 				return sl.Name;
 			}
 
+			public void Cleanup()
+			{
+				_selectionFromNative = false;
+				_isDragging = false;
+			}
+
 			public void UpdateGrouping()
 			{
 				UpdateShortNameListener();
@@ -1252,6 +1258,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewWillAppear(bool animated)
 		{
+			(TableView?.Source as ListViewRenderer.ListViewDataSource)?.Cleanup();
 			if (!_list.IsRefreshing || !_refresh.Refreshing) return;
 
 			// Restart the refreshing to get the animation to trigger


### PR DESCRIPTION
### Description of Change ###

Fixes issues where we leave some "state" on our ListViewSource 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=32956  (iOS)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense