### PR TITLE
Add support for backcompat hint flags

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -30,7 +30,7 @@ using Xamarin.Forms.Controls.Issues;
 
 [assembly: ExportRenderer(typeof(Bugzilla42000._42000NumericEntryNoDecimal), typeof(EntryRendererNoDecimal))]
 [assembly: ExportRenderer(typeof(Bugzilla42000._42000NumericEntryNoNegative), typeof(EntryRendererNoNegative))]
-[assembly: ExportRenderer(typeof(AndroidHelpText.HintLabel), typeof(HintLabel))]
+//[assembly: ExportRenderer(typeof(AndroidHelpText.HintLabel), typeof(HintLabel))]
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.NoFlashTestNavigationPage), typeof(Xamarin.Forms.ControlGallery.Android.NoFlashTestNavigationPage))]
 
@@ -524,13 +524,13 @@ namespace Xamarin.Forms.ControlGallery.Android
 	}
 
 
-	public class HintLabel : Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer
-	{
-		public HintLabel()
-		{
-			Hint = AndroidHelpText.HintLabel.Success;
-		}
-  }
+	//public class HintLabel : Xamarin.Forms.Platform.Android.AppCompat.LabelRenderer
+	//{
+	//	public HintLabel()
+	//	{
+	//		Hint = AndroidHelpText.HintLabel.Success;
+	//	}
+ // }
 
 	public class NoFlashTestNavigationPage : Xamarin.Forms.Platform.Android.AppCompat.NavigationPageRenderer
 	{

--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -42,7 +42,12 @@ namespace Xamarin.Forms.ControlGallery.Android
 			if (!Debugger.IsAttached)
 				Insights.Initialize(App.InsightsApiKey, ApplicationContext);
 
+#if TEST_EXPERIMENTAL_RENDERERS
+			Forms.SetFlags("FastRenderers_Experimental");
+#endif
+
 			Forms.Init(this, bundle);
+
 			FormsMaps.Init(this, bundle);
 			AndroidAppLinks.Init(this);
 			Forms.ViewInitialized += (sender, e) => {

--- a/Xamarin.Forms.ControlGallery.Android/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Properties/AssemblyInfo.cs
@@ -42,9 +42,3 @@ using Xamarin.Forms.ControlGallery.Android;
 
 // Deliberately broken image source and handler so we can test handling of image loading errors
 [assembly: ExportImageSourceHandler(typeof(FailImageSource), typeof(BrokenImageSourceHandler))]
-#if TEST_LEGACY_RENDERERS
-[assembly: ExportRenderer(typeof(Button), typeof(Xamarin.Forms.Platform.Android.AppCompat.ButtonRenderer))]
-[assembly: ExportRenderer(typeof(Image), typeof(Xamarin.Forms.Platform.Android.ImageRenderer))]
-[assembly: ExportRenderer(typeof(Label), typeof(Xamarin.Forms.Platform.Android.LabelRenderer))]
-[assembly: ExportRenderer(typeof(Frame), typeof(Xamarin.Forms.Platform.Android.AppCompat.FrameRenderer))]
-#endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AndroidHelpText.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/AndroidHelpText.cs
@@ -14,6 +14,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST && __ANDROID__
+	[Ignore("Ignoring this test until FastRenderers.LabelRenderer is no longer sealed")]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 0, "Android shows . in empty labels because of a11y Name/HelpText", PlatformAffected.Android)]
 	public class AndroidHelpText : TestContentPage

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -116,13 +116,22 @@ namespace Xamarin.Forms.Platform.Android
 				RegisterHandlerForDefaultRenderer(typeof(NavigationPage), typeof(NavigationPageRenderer), typeof(NavigationRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(TabbedPage), typeof(TabbedPageRenderer), typeof(TabbedRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(MasterDetailPage), typeof(MasterDetailPageRenderer), typeof(MasterDetailRenderer));
-				RegisterHandlerForDefaultRenderer(typeof(Button), typeof(FastRenderers.ButtonRenderer), typeof(ButtonRenderer));
                 RegisterHandlerForDefaultRenderer(typeof(Switch), typeof(AppCompat.SwitchRenderer), typeof(SwitchRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(Picker), typeof(AppCompat.PickerRenderer), typeof(PickerRenderer));
-				RegisterHandlerForDefaultRenderer(typeof(Frame), typeof(FastRenderers.FrameRenderer), typeof(FrameRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(CarouselPage), typeof(AppCompat.CarouselPageRenderer), typeof(CarouselPageRenderer));
-				RegisterHandlerForDefaultRenderer(typeof(Label), typeof(FastRenderers.LabelRenderer), typeof(LabelRenderer));
-				RegisterHandlerForDefaultRenderer(typeof(Image), typeof(FastRenderers.ImageRenderer), typeof(ImageRenderer));
+
+				if (Forms.Flags.Contains(Flags.FastRenderersExperimental))
+				{
+					RegisterHandlerForDefaultRenderer(typeof(Button), typeof(FastRenderers.ButtonRenderer), typeof(ButtonRenderer));
+					RegisterHandlerForDefaultRenderer(typeof(Label), typeof(FastRenderers.LabelRenderer), typeof(LabelRenderer));
+					RegisterHandlerForDefaultRenderer(typeof(Image), typeof(FastRenderers.ImageRenderer), typeof(ImageRenderer));
+					RegisterHandlerForDefaultRenderer(typeof(Frame), typeof(FastRenderers.FrameRenderer), typeof(FrameRenderer));
+				}
+				else
+				{
+					RegisterHandlerForDefaultRenderer(typeof(Button), typeof(AppCompat.ButtonRenderer), typeof(ButtonRenderer));
+					RegisterHandlerForDefaultRenderer(typeof(Frame), typeof(AppCompat.FrameRenderer), typeof(FrameRenderer));
+				}
 
 				_renderersAdded = true;
 			}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -13,7 +13,7 @@ using static System.String;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
-	public class ButtonRenderer : AppCompatButton, IVisualElementRenderer, AView.IOnAttachStateChangeListener,
+	internal sealed class ButtonRenderer : AppCompatButton, IVisualElementRenderer, AView.IOnAttachStateChangeListener,
 		AView.IOnFocusChangeListener, IEffectControlProvider, AView.IOnClickListener, AView.IOnTouchListener
 	{
 		float _defaultFontSize;
@@ -206,12 +206,12 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			return base.OnTouchEvent(e);
 		}
 
-		protected virtual Size MinimumSize()
+		Size MinimumSize()
 		{
 			return new Size();
 		}
 
-		protected virtual void OnElementChanged(ElementChangedEventArgs<Button> e)
+		void OnElementChanged(ElementChangedEventArgs<Button> e)
 		{
 			if (e.OldElement != null)
 			{
@@ -234,7 +234,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
 		}
 
-		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Button.TextProperty.PropertyName)
 			{
@@ -287,21 +287,21 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			base.OnLayout(changed, l, t, r, b);
 		}
 
-		protected void SetTracker(VisualElementTracker tracker)
+		void SetTracker(VisualElementTracker tracker)
 		{
 			_tracker = tracker;
 		}
 
-		protected void UpdateBackgroundColor()
+		void UpdateBackgroundColor()
 		{
 			_backgroundTracker.UpdateBackgroundColor();
 		}
 
-		internal virtual void OnNativeFocusChanged(bool hasFocus)
+		internal void OnNativeFocusChanged(bool hasFocus)
 		{
 		}
 
-		internal virtual void SendVisualElementInitialized(VisualElement element, AView nativeView)
+		internal void SendVisualElementInitialized(VisualElement element, AView nativeView)
 		{
 			element.SendViewInitialized(nativeView);
 		}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/GestureManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/GestureManager.cs
@@ -8,7 +8,7 @@ using Object = Java.Lang.Object;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
-	public class GestureManager : Object, global::Android.Views.View.IOnClickListener, global::Android.Views.View.IOnTouchListener
+	internal class GestureManager : Object, global::Android.Views.View.IOnClickListener, global::Android.Views.View.IOnTouchListener
 	{
 		IVisualElementRenderer _renderer;
 		readonly Lazy<GestureDetector> _gestureDetector;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -8,7 +8,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
-	public class ImageRenderer : AImageView, IVisualElementRenderer, IImageRendererController
+	internal sealed class ImageRenderer : AImageView, IVisualElementRenderer, IImageRendererController
 	{
 		bool _disposed;
 		Image _element;
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			base.Invalidate();
 		}
 
-		protected virtual async void OnElementChanged(ElementChangedEventArgs<Image> e)
+		async void OnElementChanged(ElementChangedEventArgs<Image> e)
 		{
 			await TryUpdateBitmap(e.OldElement);
 			UpdateAspect();
@@ -78,7 +78,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
             return handled ? result : base.OnTouchEvent(e);
         }
 
-		protected virtual Size MinimumSize()
+		Size MinimumSize()
 		{
 			return new Size();
 		}
@@ -148,7 +148,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		void IImageRendererController.SkipInvalidate() => _skipInvalidate = true;
 
-		protected AImageView Control => this;
+		AImageView Control => this;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;
@@ -157,7 +157,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 		}
 
-		protected virtual async void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		async void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Image.SourceProperty.PropertyName)
 				await TryUpdateBitmap();
@@ -167,7 +167,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			ElementPropertyChanged?.Invoke(this, e);
 		}
 
-		protected virtual async Task TryUpdateBitmap(Image previous = null)
+		async Task TryUpdateBitmap(Image previous = null)
 		{
 			// By default we'll just catch and log any exceptions thrown by UpdateBitmap so they don't bring down
 			// the application; a custom renderer can override this method and handle exceptions from
@@ -187,7 +187,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 		}
 
-		protected async Task UpdateBitmap(Image previous = null)
+		async Task UpdateBitmap(Image previous = null)
 		{
 			if (_element == null || _disposed)
 			{

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -9,7 +9,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
-	public class LabelRenderer : FormsTextView, IVisualElementRenderer
+	internal sealed class LabelRenderer : FormsTextView, IVisualElementRenderer
 	{
 		int? _defaultLabelFor;
 		bool _disposed;
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		ViewGroup IVisualElementRenderer.ViewGroup => null;
 
-		protected Label Element
+		Label Element
 		{
 			get { return _element; }
 			set
@@ -169,7 +169,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
             return handled ? result : base.OnTouchEvent(e);
         }
 
-        protected virtual void OnElementChanged(ElementChangedEventArgs<Label> e)
+        void OnElementChanged(ElementChangedEventArgs<Label> e)
 		{
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
 
@@ -199,7 +199,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 		}
 
-		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			ElementPropertyChanged?.Invoke(this, e);
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
@@ -7,7 +7,7 @@ using Object = Java.Lang.Object;
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
 	// TODO hartez 2017/03/03 14:11:17 It's weird that this class is called VisualElementRenderer but it doesn't implement that interface. The name should probably be different.
-	public class VisualElementRenderer : IDisposable, IEffectControlProvider
+	internal sealed class VisualElementRenderer : IDisposable, IEffectControlProvider
 	{
 		bool _disposed;
 		
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			GC.SuppressFinalize(this);
 		}
 
-		protected void Dispose(bool disposing)
+		void Dispose(bool disposing)
 		{
 			if (_disposed)
 				return;

--- a/Xamarin.Forms.Platform.Android/Flags.cs
+++ b/Xamarin.Forms.Platform.Android/Flags.cs
@@ -1,0 +1,7 @@
+namespace Xamarin.Forms
+{
+	internal static class Flags
+	{
+		internal const string FastRenderersExperimental = "FastRenderers_Experimental";
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -151,6 +151,19 @@ namespace Xamarin.Forms
 			IsInitialized = true;
 		}
 
+		static IReadOnlyList<string> s_flags;
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new List<string>().AsReadOnly());
+
+		public static void SetFlags(params string[] flags)
+		{
+			if (IsInitialized)
+			{
+				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
+			}
+
+			s_flags = flags.ToList().AsReadOnly();
+		}
+
 		static Color GetAccentColor()
 		{
 			Color rc;

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -129,6 +129,7 @@
     <Compile Include="FastRenderers\GestureManager.cs" />
     <Compile Include="FastRenderers\LabelRenderer.cs" />
     <Compile Include="FastRenderers\VisualElementRenderer.cs" />
+    <Compile Include="Flags.cs" />
     <Compile Include="FormsApplicationActivity.cs" />
     <Compile Include="AndroidActivity.cs" />
     <Compile Include="AndroidTicker.cs" />

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -67,6 +67,9 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Xamarin.Forms.Platform.iOS\Flags.cs">
+      <Link>Flags.cs</Link>
+    </Compile>
     <Compile Include="FormsApplicationDelegate.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PlatformRenderer.cs" />

--- a/Xamarin.Forms.Platform.UAP/Flags.cs
+++ b/Xamarin.Forms.Platform.UAP/Flags.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms
+{
+	internal static class Flags
+	{
+		
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/FormsUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsUWP.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms
+{
+	public static partial class Forms
+	{
+		static IReadOnlyList<string> s_flags;
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new List<string>().AsReadOnly());
+
+		public static void SetFlags(params string[] flags)
+		{
+			if (s_isInitialized)
+			{
+				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
+			}
+
+			s_flags = flags.ToList().AsReadOnly();
+		}
+
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -182,7 +182,9 @@
     <Compile Include="..\Xamarin.Forms.Platform.WinRT\LayoutExtensions.cs">
       <Link>LayoutExtensions.cs</Link>
     </Compile>
+    <Compile Include="Flags.cs" />
     <Compile Include="FormsPresenter.cs" />
+    <Compile Include="FormsUWP.cs" />
     <Compile Include="IToolBarForegroundBinder.cs" />
     <Compile Include="NativeBindingService.cs" />
     <Compile Include="NativeValueConverterService.cs" />

--- a/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
@@ -19,13 +19,15 @@ using Xamarin.Forms.Platform.WinRT;
 
 namespace Xamarin.Forms
 {
-	public static class Forms
+	public static partial class Forms
 	{
 		const string LogFormat = "[{0}] {1}";
 
 		static ApplicationExecutionState s_state;
 		static bool s_isInitialized;
 #if WINDOWS_UWP
+
+		
 		public static void Init(IActivatedEventArgs launchActivatedEventArgs, IEnumerable<Assembly> rendererAssemblies = null)
 #else
 		public static void Init(IActivatedEventArgs launchActivatedEventArgs)

--- a/Xamarin.Forms.Platform.iOS/Flags.cs
+++ b/Xamarin.Forms.Platform.iOS/Flags.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms
+{
+	internal static class Flags
+	{
+		
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -66,6 +66,19 @@ namespace Xamarin.Forms
 		}
 #endif
 
+		static IReadOnlyList<string> s_flags;
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new List<string>().AsReadOnly());
+
+		public static void SetFlags(params string[] flags)
+		{
+			if (IsInitialized)
+			{
+				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
+			}
+
+			s_flags = flags.ToList().AsReadOnly();
+		}
+
 		public static void Init()
 		{
 			if (IsInitialized)

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -134,6 +134,7 @@
     <Compile Include="ExportRendererAttribute.cs" />
     <Compile Include="Extensions\ArrayExtensions.cs" />
     <Compile Include="Extensions\PlatformConfigurationExtensions.cs" />
+    <Compile Include="Flags.cs" />
     <Compile Include="NativeViewWrapper.cs" />
     <Compile Include="NativeViewWrapperRenderer.cs" />
     <Compile Include="PlatformEffect.cs" />


### PR DESCRIPTION
### Description of Change ###

Add support for backwards-compatibility hint flags.

### API Changes ###

Added:
 - `public static void SetFlags(params string[] flags)` 

### Behavioral Changes ###

Android fast renderers now require setting flag `FastRenderers_Experimental`.


