### PR TITLE
Apply effects to fast renderers on Android

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Properties/AssemblyInfo.cs
@@ -6,7 +6,8 @@ using Xamarin.Forms.Controls;
 using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms;
 using Xamarin.Forms.ControlGallery.Android;
-       
+using Xamarin.Forms.Controls.Issues;
+
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
@@ -37,8 +38,10 @@ using Xamarin.Forms.ControlGallery.Android;
 [assembly: UsesPermission (Android.Manifest.Permission.Internet)]
 [assembly: UsesPermission (Android.Manifest.Permission.WriteExternalStorage)]
 
+
+
 [assembly: Android.App.MetaData("com.google.android.maps.v2.API_KEY", Value = "AIzaSyAdstcJQswxEjzX5YjLaMcu2aRVEBJw39Y")]
-[assembly: Xamarin.Forms.ResolutionGroupName ("XamControl")]
+[assembly: Xamarin.Forms.ResolutionGroupName (Xamarin.Forms.Controls.Issues.Effects.ResolutionGroupName)]
 
 // Deliberately broken image source and handler so we can test handling of image loading errors
 [assembly: ExportImageSourceHandler(typeof(FailImageSource), typeof(BrokenImageSourceHandler))]

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -191,6 +191,7 @@
     <Compile Include="_38989CustomRenderer.cs" />
     <Compile Include="BrokenImageSourceHandler.cs" />
     <Compile Include="_57114CustomRenderer.cs" />
+    <Compile Include="_58406EffectRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\default.css" />

--- a/Xamarin.Forms.ControlGallery.Android/_58406EffectRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_58406EffectRenderer.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Android.Widget;
+using Xamarin.Forms;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportEffect(typeof(Xamarin.Forms.ControlGallery.Android._58406EffectRenderer), Bugzilla58406.EffectName)]
+
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class _58406EffectRenderer : PlatformEffect
+	{
+		protected override void OnAttached()
+		{
+			var tv = Control as TextView;
+
+			if (tv == null)
+			{
+				return;
+			}
+
+			ReverseText(tv, tv.Text);
+			tv.TextChanged += OnTextChanged;
+		}
+
+		bool _ignoreNextTextChange;
+
+		void OnTextChanged(object sender, global::Android.Text.TextChangedEventArgs textChangedEventArgs)
+		{
+			var tv = sender as TextView;
+
+			if (tv == null)
+			{
+				return;
+			}
+
+			if (_ignoreNextTextChange)
+			{
+				_ignoreNextTextChange = false;
+				return;
+			}
+
+			_ignoreNextTextChange = true;
+
+			ReverseText(tv, textChangedEventArgs.Text.ToString());
+		}
+
+		static void ReverseText(TextView tv, string text)
+		{
+			var rev = new string(text.Reverse().ToArray());
+			tv.Text = rev;
+		}
+
+		protected override void OnDetached()
+		{
+			var tv = Control as TextView;
+			if (tv == null)
+			{
+				return;
+			}
+
+			tv.TextChanged -= OnTextChanged;
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/FocusEffect.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/FocusEffect.cs
@@ -10,7 +10,6 @@ using Xamarin.Forms;
 using Xamarin.Forms.ControlGallery.WindowsUniversal;
 using Xamarin.Forms.Platform.UWP;
 
-[assembly: ResolutionGroupName("Xamarin")]
 [assembly: ExportEffect(typeof(FocusEffect), "FocusEffect")]
 namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 {

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using Xamarin.Forms.Platform.UWP;
 
 // Deliberately broken image source and handler so we can test handling of image loading errors
 [assembly: ExportImageSourceHandler(typeof(FailImageSource), typeof(BrokenImageSourceHandler))]
+[assembly: Xamarin.Forms.ResolutionGroupName (Xamarin.Forms.Controls.Issues.Effects.ResolutionGroupName)]

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -121,6 +121,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="_57114Renderer.cs" />
+    <Compile Include="_58406EffectRenderer.cs" />
     <Content Include="coffee.png" />
     <Content Include="default.css" />
     <Content Include="invalidimage.jpg" />

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/_58406EffectRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/_58406EffectRenderer.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Xamarin.Forms;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.UWP;
+
+[assembly: ExportEffect(typeof(Xamarin.Forms.ControlGallery.WindowsUniversal._58406EffectRenderer), Bugzilla58406.EffectName)]
+
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	public class _58406EffectRenderer : PlatformEffect
+	{
+		protected override void OnAttached()
+		{
+			var textBlock = Control as TextBlock;
+
+			if (textBlock == null)
+			{
+				return;
+			}
+
+			textBlock.Text = new string(textBlock.Text.ToCharArray().Reverse().ToArray()); 
+		}
+
+		protected override void OnDetached()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using Xamarin.Forms.Controls;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion ("1.0.0.0")]
 [assembly: AssemblyFileVersion ("1.0.0.0")]
-[assembly: Xamarin.Forms.ResolutionGroupName("XamControl")]
+[assembly: Xamarin.Forms.ResolutionGroupName (Xamarin.Forms.Controls.Issues.Effects.ResolutionGroupName)]
 
 // Deliberately broken image source and handler so we can test handling of image loading errors
 [assembly: ExportImageSourceHandler(typeof(FailImageSource), typeof(BrokenImageSourceHandler))]

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
     <Compile Include="_57114Renderer.cs" />
+    <Compile Include="_58406EffectRenderer.cs" />
     <None Include="app.config" />
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Xamarin.Forms.ControlGallery.iOS/_58406EffectRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/_58406EffectRenderer.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportEffect(typeof(Xamarin.Forms.ControlGallery.iOS._58406EffectRenderer), Bugzilla58406.EffectName)]
+
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class _58406EffectRenderer : PlatformEffect
+	{
+		protected override void OnAttached()
+		{
+			var tv = Control as UILabel;
+
+			if (tv == null)
+			{
+				return;
+			}
+
+			tv.Text = new string(tv.Text.ToCharArray().Reverse().ToArray()); 
+		}
+
+		protected override void OnDetached()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45874.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45874.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var scrollView = new ScrollView { Content = label };
 
-			var effect = Effect.Resolve("XamControl.BorderEffect");
+			var effect = Effect.Resolve($"{Issues.Effects.ResolutionGroupName}.BorderEffect");
 
 			scrollView.Effects.Add(effect);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51505.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51505.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			var effect = Effect.Resolve("XamControl.BorderEffect");
+			var effect = Effect.Resolve($"{Issues.Effects.ResolutionGroupName}.BorderEffect");
 
 			var button = new Button { Text = "Click me", AutomationId = ButtonId };
 			button.Clicked += async (sender, e) =>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56609.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56609.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 				VerticalOptions = LayoutOptions.CenterAndExpand,
 				HorizontalOptions = LayoutOptions.CenterAndExpand
 			};
-			entry.Effects.Add(Effect.Resolve("Xamarin.FocusEffect"));
+			entry.Effects.Add(Effect.Resolve($"{Issues.Effects.ResolutionGroupName}.FocusEffect"));
 
 			Content = new StackLayout
 			{
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Controls.Issues
 	}
 	public class Bugzilla56609FocusEffect : RoutingEffect
 	{
-		public Bugzilla56609FocusEffect() : base("Xamarin.FocusEffect")
+		public Bugzilla56609FocusEffect() : base($"{Effects.ResolutionGroupName}.FocusEffect")
 		{
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58406.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58406.cs
@@ -1,0 +1,57 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Effects)]
+	[Category(UITestCategories.Label)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 58406, 
+		"Effect is never attached to Label, but is attached to Label subclass (Android)", PlatformAffected.Android)]
+	public class Bugzilla58406 : TestContentPage
+	{
+		public const string EffectName = "_58406Effect";
+		const string InitialText = "_58406";
+		const string ReversedText = "60485_";
+
+		[Preserve(AllMembers = true)]
+		public class _58406Effect : RoutingEffect
+		{
+			public _58406Effect() : base($"{Issues.Effects.ResolutionGroupName}.{EffectName}")
+			{
+			}
+		}
+
+		protected override void Init()
+		{
+			var label = new Label { Text = InitialText };
+			label.Effects.Add(Effect.Resolve($"{Issues.Effects.ResolutionGroupName}.{EffectName}"));
+
+			Content = new StackLayout
+			{
+				Padding = new Thickness(0, 20, 0, 0),
+				Children =
+				{
+					label
+				}
+			};
+		}
+
+#if UITEST 
+		[Test]
+		public void EffectAppliesToLabel()
+		{
+			RunningApp.WaitForElement(ReversedText);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms.Controls.Issues
+{
+	public static class Effects
+	{
+		public const string ResolutionGroupName = "XamControl";
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -215,6 +215,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57317.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57114.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57758.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58406.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ButtonBackgroundColorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />
@@ -225,6 +226,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38416.xaml.cs">
       <DependentUpon>Bugzilla38416.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Effects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FailImageSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GestureBubblingTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InputTransparentTests.cs" />

--- a/Xamarin.Forms.Controls/GalleryPages/ButtonGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ButtonGallery.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Controls
 			BackgroundColor = new Color (0.9);
 
 			var normal = new Button { Text = "Normal Button" };
-			normal.Effects.Add (Effect.Resolve ("XamControl.BorderEffect"));
+			normal.Effects.Add (Effect.Resolve ($"{Issues.Effects.ResolutionGroupName}.BorderEffect"));
 
 			var disabled = new Button { Text = "Disabled Button"};
 			var disabledswitch = new Switch ();

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -34,6 +34,7 @@
 		public const string IsEnabled = "IsEnabled";
 		public const string Gestures = "Gestures";
 		public const string Navigation = "Navigation";
+		public const string Effects = "Effects";
 
 		public const string ManualReview = "ManualReview";
 	}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using Android.Views;
+using Xamarin.Forms.Internals;
 using AView = Android.Views.View;
 using Object = Java.Lang.Object;
 
@@ -23,6 +24,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			_renderer.ElementChanged += OnElementChanged;
 			_gestureManager = new GestureManager(_renderer);
 			_automatiomPropertiesProvider = new AutomationPropertiesProvider(_renderer);
+
 			_effectControlProvider = new EffectControlProvider(_renderer?.View);
 		}
 
@@ -87,6 +89,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				e.NewElement.PropertyChanged += OnElementPropertyChanged;
 				UpdateBackgroundColor();
 			}
+
+			EffectUtilities.RegisterEffectControlProvider(this, e.OldElement, e.NewElement);
 		}
 
 		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Fixes a bug where Effects were never applied to the fast Label renderer on Android.

### Bugs Fixed ###

- [58406 – Effect is never attached to Label, but is attached to Label subclass (Android)](https://bugzilla.xamarin.com/show_bug.cgi?id=58406)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
