### PR TITLE
[Android] Enables custom images (especially SVG) through the new IImageSourceHandler

### DIFF
--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -24,6 +24,11 @@ namespace Xamarin.Forms.Platform.Android
 			if(drawable == null)
 			{
 				var bitmap = GetBitmap(resource, file) ?? BitmapFactory.DecodeFile(file);
+				if (bitmap == null)
+				{
+					var source = Registrar.Registered.GetHandler<IImageSourceHandler>(fileImageSource.GetType());
+					bitmap = source.LoadImageAsync(fileImageSource, Forms.Context).GetAwaiter().GetResult();
+				}
 				if (bitmap != null)
 					drawable = new BitmapDrawable(resource, bitmap);
 			}


### PR DESCRIPTION
### Description of Change ###

Enables custom images (especially SVG) through the new IImageSourceHandler to work with tab bar icons on Android (like it does on iOS). And also on cell adapters and navigation page menu.

No test: there is no existing test for IImageSourceHandler (or can't find where).

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
