### PR TITLE
[Android] Use 24-hour time format on TimePicker text if enabled

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		AlertDialog _dialog;
 		TextColorSwitcher _textColorSwitcher;
+		bool _is24HourFormat;
+		string _timeFormat;
 
 		public TimePickerRenderer()
 		{
@@ -50,7 +52,9 @@ namespace Xamarin.Forms.Platform.Android
 
 				textField.SetOnClickListener(TimePickerListener.Instance);
 				SetNativeControl(textField);
-				_textColorSwitcher = new TextColorSwitcher(textField.TextColors); 
+				_textColorSwitcher = new TextColorSwitcher(textField.TextColors);
+				_is24HourFormat	= DateFormat.Is24HourFormat(Context);
+				_timeFormat = _is24HourFormat ? "HH:mm" : Element.Format;
 			}
 
 			SetTime(e.NewElement.Time);
@@ -92,9 +96,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			TimePicker view = Element;
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
-
-			bool is24HourFormat = DateFormat.Is24HourFormat(Context);
-			_dialog = new TimePickerDialog(Context, this, view.Time.Hours, view.Time.Minutes, is24HourFormat);
+			
+			_dialog = new TimePickerDialog(Context, this, view.Time.Hours, view.Time.Minutes, _is24HourFormat);
 
 			if (Forms.IsLollipopOrNewer)
 				_dialog.CancelEvent += OnCancelButtonClicked;
@@ -109,7 +112,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void SetTime(TimeSpan time)
 		{
-			Control.Text = DateTime.Today.Add(time).ToString(Element.Format);
+			Control.Text = DateTime.Today.Add(time).ToString(_timeFormat);
 		}
 
 		void UpdateTextColor()


### PR DESCRIPTION
### Description of Change ###

A prior PR allowed for the use of 24-hour time on the `TimePicker`, but didn't set the text part of the control. While it's technically possible to add a test for this, it would be reliant upon knowing the setting of the device the test is being run on at the time, so it's been omitted for the moment.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=54645

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
