### PR TITLE
[Core] Add ListViewCachingStrategy.RecycleElementAndDataTemplate

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52487.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52487.cs
@@ -1,0 +1,1028 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Threading;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(
+		IssueTracker.Bugzilla,
+		52487,
+		"ListView with Recycle + HasUnevenRows generates lots (and lots!) of content view",
+		// https://bugzilla.xamarin.com/show_bug.cgi?id=52487
+		PlatformAffected.iOS
+	)]
+	public class Bugzilla52487 : TestContentPage
+	{
+#if __IOS__
+		const int MaxAskDelta = 0;
+		const int MaxViewDelta = 5;
+		const int MaxAttachDelta = 5;
+#elif __ANDROID__
+		const int MaxAskDelta = 0;
+		const int MaxViewDelta = 1;
+		const int MaxAttachDelta = 1;
+#else
+		const int MaxAskDelta = 0;
+		const int MaxViewDelta = int.MaxValue;
+		const int MaxAttachDelta = int.MaxValue;
+#endif
+
+		const int CountFontSize = 12;
+		const int CellFontSize = 12;
+		const int MinScrollDelta = 2;
+		const int ItemsCount = 1000;
+		const int GroupCount = 100;
+		const int DefaultItemHeight = 300 / 4;
+		const int MinimumItemHeight = 40;
+
+		// generate alternate item type when % item id is zero
+		const int ItemTypeModulous = 7;
+
+		// render half height when % item id is zero (RecycleElement or RecycleElementAndDataTemplate)
+		const int HalfHeightModulous = 5;
+
+		// select alternate cell type when % item id is zero (RecycleElement)
+		const int DataTemplateModulous = 3;
+
+		static Tuple<int, int, int> Mix = new Tuple<int, int, int>(255, 255, 100);
+		static Tuple<int, int, int> AltMix = new Tuple<int, int, int>(100, 100, 255);
+		static IEnumerable<Color> ColorGenerator(Tuple<int, int, int> mix)
+		{
+			double colorDelta = 0;
+			while (true)
+			{
+				colorDelta += 2 * Math.PI / 100;
+				var r = (Math.Sin(colorDelta) + 1) / 2 * 255;
+				var g = (Math.Sin(colorDelta * 2) + 1) / 2 * 255;
+				var b = (Math.Sin(colorDelta * 3) + 1) / 2 * 255;
+
+				if (mix != null)
+				{
+					r = (r + mix.Item1) / 2;
+					g = (g + mix.Item2) / 2;
+					b = (b + mix.Item3) / 2;
+				}
+
+				yield return Color.FromRgb((int)r, (int)g, (int)b);
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class LazyReadOnlyList<V> : IReadOnlyList<V>
+			where V : class
+		{
+			int _count;
+			object _context;
+			List<WeakReference<V>> _items;
+			Action<int> _onAsk;
+			Func<LazyReadOnlyList<V>, int, object, V> _activate;
+
+			internal LazyReadOnlyList(
+				int count,
+				object context,
+				Action<int> onAsk,
+				Func<LazyReadOnlyList<V>, int, object, V> activate)
+			{
+				_count = count;
+				_context = context;
+				_onAsk = onAsk;
+				_activate = activate;
+				_items = new List<WeakReference<V>>(
+					Enumerable.Range(0, count)
+					.Select(o => new WeakReference<V>(null))
+				);
+			}
+
+			protected object Context
+			{
+				get { return _context; }
+				set { _context = value; }
+			}
+			protected IEnumerable<WeakReference<V>> WeakItems =>
+				_items;
+
+			public V this[int index]
+			{
+				get
+				{
+					_onAsk(index);
+
+					var weakItem = _items[index];
+
+					V item;
+					if (!weakItem.TryGetTarget(out item))
+					{
+						_items[index] =
+							new WeakReference<V>(
+								item = _activate(this, index, _context));
+					}
+
+					return item;
+				}
+			}
+
+			public int Count
+				=> _count;
+
+			public IEnumerator<V> GetEnumerator()
+			{
+				for (var i = 0; i < Count; i++)
+					yield return this[i];
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+				=> GetEnumerator();
+		}
+
+		[Preserve(AllMembers = true)]
+		public abstract partial class ListViewSpy<T> : ListViewSpy
+		{
+			[Preserve(AllMembers = true)]
+			abstract class Selector : DataTemplateSelector
+			{
+				[Preserve(AllMembers = true)]
+				internal class SelectByData : Selector
+				{
+					public SelectByData() : base(
+						typeof(ItemViewCell.Selected.ByDataNormal),
+						typeof(ItemViewCell.Selected.ByDataAlternate)
+					)
+					{ }
+
+					protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+					{
+						// RecycleElement previously placed no restraint on the type of view 
+						// the resulting DataTemplate could return. So the resulting DataTemplate
+						// could randomly pick a view type to render items even between appearances
+						// on screen. 
+
+						// After this fix, the DataTempate will be required to return the same
+						// type of view although the type need not be a function of only the item type.
+						// So the type of view a DataTemplates chooses to return can be a function of
+						// the item _data_ and not only an items type.
+
+						__counter.OnSelectTemplate++;
+
+						// item could be either Item.Full type or Item.Half type...
+						if (!(item is Item.Normal) && !(item is Item.Alternate))
+							throw new ArgumentException();
+
+						// ... but selector chooses DataTemplate strictly via item _data_.
+						return ((Item)item).Id % DataTemplateModulous == 0 ?
+							_dataTemplateAlt : _dataTemplate;
+					}
+				}
+
+				[Preserve(AllMembers = true)]
+				internal class SelectByType : Selector
+				{
+					public SelectByType() : base(
+						typeof(ItemViewCell.Selected.ByTypeNormal),
+						typeof(ItemViewCell.Selected.ByTypeAlternate)
+					)
+					{ }
+
+					protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+					{
+						// RecycleElementAndDataTemplate requires that 
+						// DataTempalte be a function of the item _type_
+
+						__counter.OnSelectTemplate++;
+
+						if (item is Item.Normal)
+							return _dataTemplate;
+
+						if (item is Item.Alternate)
+							return _dataTemplateAlt;
+
+						throw new ArgumentException();
+					}
+				}
+
+				DataTemplate _dataTemplate;
+				DataTemplate _dataTemplateAlt;
+
+				public Selector(Type nomral, Type alternate)
+				{
+					// RecycleElementAndDataTemplate requires 
+					// that the DataTemplate use the .ctor that takes a type
+					_dataTemplate = new DataTemplate(nomral);
+					_dataTemplateAlt = new DataTemplate(alternate);
+				}
+			}
+
+			[Preserve(AllMembers = true)]
+			abstract class ItemViewCell : ViewCell
+			{
+				[Preserve(AllMembers = true)]
+				internal abstract class Selected : ItemViewCell
+				{
+					[Preserve(AllMembers = true)]
+					internal class ByTypeNormal : ByType
+					{
+						static Color NextColor() { Colors.MoveNext(); return Colors.Current; }
+						static readonly IEnumerator<Color> Colors = ColorGenerator(Mix).GetEnumerator();
+
+						public ByTypeNormal() : base(NextColor()) { }
+					}
+					[Preserve(AllMembers = true)]
+					internal class ByTypeAlternate : ByType
+					{
+						static Color NextColor() { Colors.MoveNext(); return Colors.Current; }
+						static readonly IEnumerator<Color> Colors = ColorGenerator(AltMix).GetEnumerator();
+
+						public ByTypeAlternate() : base(NextColor()) { }
+
+						protected override bool IsAlternate => true;
+					}
+					[Preserve(AllMembers = true)]
+					internal abstract class ByType : Selected
+					{
+						internal ByType(Color color)
+							: base(color) { }
+
+						protected override void OnBindingContextChanged()
+						{
+							base.OnBindingContextChanged();
+
+							if (BindingContext == null || !(BindingContext is ItemViewCell))
+								return;
+
+							// check that template is a function of the item type
+							var itemType = BindingContext.GetType();
+							var itemIsNormalType = itemType == typeof(Item.Normal);
+							var expectedTemplateType = itemIsNormalType ? typeof(ByTypeNormal) : typeof(ByTypeAlternate);
+
+							var templateType = GetType();
+							if (templateType != expectedTemplateType)
+								throw new ArgumentException(
+									$"BindingContext.GetType() = {itemType.Name}, " +
+									$"TemplateType {templateType.Name}!={expectedTemplateType.Name}");
+						}
+					}
+
+					[Preserve(AllMembers = true)]
+					internal class ByDataNormal : ByData
+					{
+						static Color NextColor() { Colors.MoveNext(); return Colors.Current; }
+						static readonly IEnumerator<Color> Colors = ColorGenerator(Mix).GetEnumerator();
+
+						public ByDataNormal() : base(NextColor()) { }
+					}
+					[Preserve(AllMembers = true)]
+					internal class ByDataAlternate : ByData
+					{
+						static Color NextColor() { Colors.MoveNext(); return Colors.Current; }
+						static readonly IEnumerator<Color> Colors = ColorGenerator(AltMix).GetEnumerator();
+
+						public ByDataAlternate() : base(NextColor()) { }
+
+						protected override bool IsAlternate => true;
+					}
+					[Preserve(AllMembers = true)]
+					internal abstract class ByData : Selected
+					{
+						internal ByData(Color color)
+							: base(color) { }
+
+						protected override void OnBindingContextChanged()
+						{
+							base.OnBindingContextChanged();
+
+							if (BindingContext == null)
+								return;
+
+							// check that template is a function of the item data
+							var isRemainderZero = BindingContext.Id % DataTemplateModulous == 0;
+							var expectedItemType = isRemainderZero ? typeof(Item.Alternate) : typeof(Item.Normal);
+							var expectedTemplateType = isRemainderZero ? typeof(ByDataAlternate) : typeof(ByDataNormal);
+
+							var templateType = GetType();
+							if (templateType != expectedTemplateType)
+								throw new ArgumentException(
+									$"Item.Id = {BindingContext?.Id}, " +
+									$"TemplateType {templateType.Name}!={expectedTemplateType.Name}");
+						}
+					}
+
+					internal Selected(Color color)
+						: base(color) { }
+				}
+
+				[Preserve(AllMembers = true)]
+				internal class Constant : ItemViewCell
+				{
+					static Color NextColor() { Colors.MoveNext(); return Colors.Current; }
+					static readonly IEnumerator<Color> Colors = ColorGenerator(Mix).GetEnumerator();
+
+					public Constant() : base(NextColor()) { }
+				}
+
+				readonly int _id;
+				readonly Label _label;
+
+				ItemViewCell(Color color)
+				{
+					_id = __counter.CellAlloc++;
+
+					View = _label = new Label
+					{
+						BackgroundColor = color,
+						VerticalTextAlignment = TextAlignment.Center,
+						HorizontalTextAlignment = TextAlignment.Center,
+						FontSize = CellFontSize
+					};
+
+					_label.SetBinding(HeightRequestProperty, nameof(Item.Value));
+				}
+
+				Item BindingContext
+					=> (Item)base.BindingContext;
+				int ItemId
+					=> BindingContext.Id;
+				int? ItemGroupId
+					=> BindingContext.GroupId;
+				bool IsAlternateItem
+					=> BindingContext is Item.Alternate;
+
+				protected virtual bool IsAlternate => false;
+
+				protected override void OnBindingContextChanged()
+				{
+					base.OnBindingContextChanged();
+
+					__counter.CellBind++;
+
+					if (BindingContext == null)
+						return;
+
+					// double check that item generator returned correct type of item
+					var isRemainderZero = BindingContext.Id % ItemTypeModulous == 0;
+					var expectedItemType = isRemainderZero ? typeof(Item.Alternate) : typeof(Item.Normal);
+					var itemType = BindingContext.GetType();
+					if (itemType != expectedItemType)
+						throw new ArgumentException(
+							$"Item.Id = {BindingContext?.Id}, ItemType {GetType().Name}!={expectedItemType.Name}");
+				}
+
+				protected override void OnAppearing()
+				{
+					_label.Text = ToString();
+					__counter.AttachCell(_id);
+				}
+
+				public new int Id
+					=> _id;
+
+				// cell type is (1) constant or a function of the the Item (2) data or (3) type
+				public override string ToString()
+					=> $"{ItemId}" +
+						(ItemGroupId == null ? "" : "/" + ItemGroupId) +
+							$"{(IsAlternateItem ? "*" : "")} ->" +
+								$" {_id}{(IsAlternate ? "*" : "")}";
+
+				~ItemViewCell()
+				{
+					int id;
+					__counter.CellFree++;
+					__counter.DetachCell(_id);
+					// update would be off UI thread
+				}
+			}
+
+			[Preserve(AllMembers = true)]
+			abstract class Item : INotifyPropertyChanged
+			{
+				[Preserve(AllMembers = true)]
+				internal class Normal : Item
+				{
+					internal Normal(int id, int? groupId, int height)
+						: base(id, groupId, height) { }
+				};
+
+				[Preserve(AllMembers = true)]
+				internal class Alternate : Item
+				{
+					internal Alternate(int id, int? groupId, int height)
+						: base(id, groupId, height) { }
+				};
+
+				internal static Item Create(LazyItemList list, int index, int height)
+				{
+
+					var id = list.ItemIdOffset + index;
+
+					if (id % ItemTypeModulous == 0)
+						return new Alternate(id, list.Id, height);
+
+					return new Normal(id, list.Id, height);
+				}
+
+				int _allocId;
+
+				int _id;
+				int _index;
+				int? _groupId;
+				int _height;
+
+				private Item(int id, int? groupId, int height)
+				{
+					_allocId = Interlocked.Increment(ref __counter.ItemAlloc);
+
+					if (id % HalfHeightModulous == 0)
+						height = height / 2;
+
+					_groupId = groupId;
+					_height = height;
+					_id = id;
+				}
+
+				public int Id
+					=> _id;
+				public int? GroupId
+					=> _groupId;
+				public int Value
+				{
+					get { return _height; }
+					set
+					{
+						_height = value;
+						OnPropertyChanged();
+					}
+				}
+
+				public event PropertyChangedEventHandler PropertyChanged;
+				protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+					=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+				public override string ToString()
+					=> _groupId == null ?
+						$"{Id}, value={Value}, _alloc={_allocId}" :
+						$"{Id}, group={GroupId}, value={Value}, _alloc={_allocId}";
+
+				~Item()
+				{
+					Interlocked.Increment(ref __counter.ItemFree);
+				}
+			}
+
+			interface IItemList : IEnumerable, IDisposable
+			{
+				void UpdateHeights(double multipule);
+				int Count { get; }
+				void Dispose();
+				Item this[int index] { get; }
+			}
+
+			[Preserve(AllMembers = true)]
+			class LazyItemList : LazyReadOnlyList<Item>, IItemList
+			{
+				int _itemIdOffset;
+				int? _id;
+				int _count;
+
+				internal LazyItemList(int count)
+					: this(null /* grouping disabled */, 0, count) { }
+				internal LazyItemList(int? id, int itemIdOffset, int count)
+					: base(count, DefaultItemHeight,
+						onAsk: o => __counter.ViewModelAsk.Add(o),
+						activate: (self, subIndex, height) =>
+							Item.Create(
+								list: (LazyItemList)self,
+								index: subIndex,
+								height: (int)height
+							)
+					)
+				{
+					_id = id;
+					_itemIdOffset = itemIdOffset;
+					_count = count;
+				}
+
+				protected int Context
+				{
+					get { return (int)base.Context; }
+					set { base.Context = value; }
+				}
+
+				public void UpdateHeights(double multipule)
+				{
+					if (multipule < 1 && Context < MinimumItemHeight)
+						return;
+
+					Context = (int)(Context * multipule);
+
+					foreach (var weakItem in WeakItems)
+					{
+						Item item;
+						if (!(weakItem.TryGetTarget(out item)))
+							continue;
+
+						item.Value = Context;
+					}
+				}
+				public int ItemIdOffset
+					=> _itemIdOffset;
+				public int? Id
+					=> _id;
+
+				public void Dispose()
+				{
+					foreach (var weakItem in WeakItems)
+						weakItem.SetTarget(null);
+				}
+
+				public override string ToString()
+					=> $"{_id}";
+			}
+
+			[Preserve(AllMembers = true)]
+			class LazyGroupedItemList : LazyReadOnlyList<LazyItemList>, IItemList
+			{
+				int _itemsPerGroup;
+
+				internal LazyGroupedItemList(int numberOfGroups, int count)
+					: base(numberOfGroups,
+						  context: null,
+						  onAsk: o => __counter.ViewModelAsk.Add(o),
+						  activate: (self, groupId, context) =>
+							new LazyItemList(
+								id: groupId,
+								itemIdOffset: groupId * (count / numberOfGroups),
+								count: count / numberOfGroups
+							)
+						)
+				{ _itemsPerGroup = count / numberOfGroups; }
+
+				Item IItemList.this[int index]
+				{
+					get
+					{
+						var group = index / _itemsPerGroup;
+						index = index % _itemsPerGroup;
+						return this[group][index];
+					}
+				}
+
+				public void UpdateHeights(double multipule)
+				{
+					foreach (var weakItem in WeakItems)
+					{
+						LazyItemList group;
+						if (!(weakItem.TryGetTarget(out group)))
+							continue;
+
+						group.UpdateHeights(multipule);
+					}
+				}
+
+				public void Dispose()
+				{
+					foreach (var weakItem in WeakItems)
+					{
+						LazyItemList group;
+						if (!(weakItem.TryGetTarget(out group)))
+							continue;
+
+						group.Dispose();
+					}
+				}
+			}
+
+			[Preserve(AllMembers = true)]
+			class SnapShot
+			{
+				Counter _counter;
+
+				internal int Views;
+				internal int Attached;
+				internal int Binds;
+				internal int Items;
+				internal int Asks;
+
+				public SnapShot(Counter counter)
+				{
+					_counter = counter;
+
+					Views = _counter.Views;
+					Attached = _counter.AttachedCells;
+					Binds = _counter.CellBind;
+					Items = _counter.Items;
+					Asks = _counter.OnSelectTemplate;
+				}
+
+				void Subtract()
+				{
+					Views = _counter.Views - Views;
+					Attached = _counter.AttachedCells - Attached;
+					Binds = _counter.CellBind - Binds;
+					Items = _counter.Items - Items;
+					Asks = _counter.OnSelectTemplate - Asks;
+				}
+
+				public void Update()
+					=> Subtract();
+			}
+
+			[Preserve(AllMembers = true)]
+			class Counter
+			{
+				internal int CellAlloc;
+				internal int CellFree;
+				internal int CellBind;
+
+				internal int ItemAlloc;
+				internal int ItemFree;
+				internal int OnSelectTemplate;
+				internal HashSet<int> ViewModelAsk
+					= new HashSet<int>();
+
+				HashSet<int> CellAttached
+					= new HashSet<int>();
+
+				internal int AttachedCells
+				{
+					get
+					{
+						lock (this)
+							return CellAttached.Count;
+					}
+				}
+				internal void AttachCell(int id)
+				{
+					lock (this)
+						CellAttached.Add(id);
+				}
+				internal void DetachCell(int id)
+				{
+					lock (this)
+						CellAttached.Remove(id);
+				}
+
+				internal int Views => CellAlloc - CellFree;
+				internal int Items => ItemAlloc - ItemFree;
+			}
+
+			[Preserve(AllMembers = true)]
+			class CounterView : StackLayout
+			{
+				static Label CreateLabel()
+					=> new Label() { FontSize = CountFontSize };
+
+				internal void Update()
+				{
+					ViewCountLabel.Text
+						= $"View={__counter.Views}";
+					AttachedCountLabel.Text
+						= $"Atch={__counter.AttachedCells}";
+					BindCountLabel.Text
+						= $"Bind={__counter.CellBind}";
+					ItemCountLabel.Text
+						= $"Item={__counter.Items}";
+					AskLabel.Text
+						= $"Ask={__counter.OnSelectTemplate}";
+				}
+
+				Label AttachedCountLabel = CreateLabel();
+				Label ViewCountLabel = CreateLabel();
+				Label BindCountLabel = CreateLabel();
+				Label ItemCountLabel = CreateLabel();
+				Label AskLabel = CreateLabel();
+
+				internal CounterView()
+				{
+					Children.Add(ViewCountLabel);
+					Children.Add(AttachedCountLabel);
+					Children.Add(BindCountLabel);
+					Children.Add(ItemCountLabel);
+					Children.Add(AskLabel);
+					Update();
+				}
+			}
+
+			// Cell is activated via DataTemplate using default ctor which
+			// makes it difficult to pass the counter to the cell. So we make
+			// it static to give cell access and create a different generic
+			// instantiation for each type of ListView to get different counters
+			static Counter __counter = new Counter();
+
+			ListView _listView;
+			int _appeared;
+			int _disappeared;
+			IItemList _itemsList;
+
+			public ListViewSpy()
+			{
+				__listViewSpyAlloc++;
+
+				var name = GetType().Name;
+
+				var hasUnevenRows = name.Contains("UnevenRows");
+
+				var isGrouped = name.Contains("Grouped");
+
+				_itemsList = isGrouped ? (IItemList)
+					new LazyGroupedItemList(GroupCount, ItemsCount) :
+					new LazyItemList(ItemsCount);
+
+				var strategy =
+					name.Contains("RecycleElementAndDataTemplate") ? ListViewCachingStrategy.RecycleElementAndDataTemplate :
+					name.Contains("RecycleElement") ? ListViewCachingStrategy.RecycleElement :
+					ListViewCachingStrategy.RetainElement;
+
+				var dataTemplate =
+					strategy == ListViewCachingStrategy.RecycleElement ? new Selector.SelectByData() :
+					strategy == ListViewCachingStrategy.RecycleElementAndDataTemplate ? new Selector.SelectByType() :
+					new DataTemplate(typeof(ItemViewCell.Constant));
+
+				_listView = new ListView(strategy)
+				{
+					HasUnevenRows = hasUnevenRows,
+					// see https://github.com/xamarin/Xamarin.Forms/pull/994/files
+					//RowHeight = 50,
+					ItemsSource = _itemsList,
+					ItemTemplate = dataTemplate,
+
+					IsGroupingEnabled = isGrouped,
+					GroupDisplayBinding = null,
+					GroupShortNameBinding = null,
+					GroupHeaderTemplate = null
+				};
+				Children.Add(_listView);
+
+				_listView.AutomationId = $"__ListView";
+
+				var counter = new CounterView();
+
+				_listView.ItemAppearing += (o, e) =>
+				{
+					_appeared = (e.Item as Item)?.Id ?? -1;
+					counter.Update();
+				};
+
+				_listView.ItemDisappearing += (o, e) =>
+				{
+					_disappeared = (e.Item as Item)?.Id ?? -1;
+					counter.Update();
+				};
+
+				Children.Add(counter);
+			}
+
+			void Scroll(int target)
+			{
+				var snapShot = new SnapShot(__counter);
+				_listView.ScrollTo(_itemsList[target], ScrollToPosition.MakeVisible, animated: true);
+				snapShot.Update();
+
+				// TEST
+				if (!_listView.IsGroupingEnabled &&
+					_listView.CachingStrategy == ListViewCachingStrategy.RecycleElementAndDataTemplate)
+				{
+					if (snapShot.Attached > MaxAttachDelta)
+						throw new Exception($"Attached Delta: {snapShot.Attached}");
+					if (snapShot.Views > MaxViewDelta)
+						throw new Exception($"Views Delta: {snapShot.Views}");
+					if (snapShot.Asks > MaxAskDelta)
+						throw new Exception($"Asks Delta: {snapShot.Asks}");
+				}
+			}
+
+			internal override void Down()
+			{
+				var target = Math.Max(_appeared, _disappeared);
+				target += Math.Abs(_appeared - _disappeared) + MinScrollDelta;
+				if (target >= _itemsList.Count)
+					target = _itemsList.Count - 1;
+
+				Scroll(target);
+			}
+			internal override void Up()
+			{
+				var target = Math.Min(_appeared, _disappeared);
+				target -= Math.Abs(_appeared - _disappeared) + MinScrollDelta;
+				if (target < 0)
+					target = 0;
+
+				Scroll(target);
+			}
+			internal override void UpdateHeights(double multipule)
+				=> _itemsList.UpdateHeights(multipule);
+
+			internal override void Dispose()
+				=> _itemsList.Dispose();
+
+			~ListViewSpy()
+			{
+				__listViewSpyFree++;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public abstract partial class ListViewSpy : StackLayout
+		{
+			[Preserve(AllMembers = true)]
+			internal sealed class Retain :
+				ListViewSpy<Retain>
+			{ }
+
+			[Preserve(AllMembers = true)]
+			internal sealed class UnevenRowsRecycleElement :
+				ListViewSpy<UnevenRowsRecycleElement>
+			{ }
+
+			[Preserve(AllMembers = true)]
+			internal sealed class UnevenRowsRecycleElementAndDataTemplate :
+				ListViewSpy<UnevenRowsRecycleElementAndDataTemplate>
+			{ }
+
+			[Preserve(AllMembers = true)]
+			internal sealed class EvenRowsRecycleElement :
+				ListViewSpy<EvenRowsRecycleElement>
+			{ }
+
+			[Preserve(AllMembers = true)]
+			internal sealed class EvenRowsRecycleElementAndDataTemplate :
+				ListViewSpy<EvenRowsRecycleElementAndDataTemplate>
+			{ }
+
+			[Preserve(AllMembers = true)]
+			internal sealed class GroupedRetain :
+				ListViewSpy<GroupedRetain>
+			{ }
+
+			[Preserve(AllMembers = true)]
+			internal sealed class GroupedUnevenRowsRecycleElement :
+				ListViewSpy<GroupedUnevenRowsRecycleElement>
+			{ }
+
+			[Preserve(AllMembers = true)]
+			internal sealed class GroupedUnevenRowsRecycleElementAndDataTemplate :
+				ListViewSpy<GroupedUnevenRowsRecycleElementAndDataTemplate>
+			{ }
+
+			[Preserve(AllMembers = true)]
+			internal sealed class GroupedEvenRowsRecycleElement :
+				ListViewSpy<GroupedEvenRowsRecycleElement>
+			{ }
+
+			[Preserve(AllMembers = true)]
+			internal sealed class GroupedEvenRowsRecycleElementAndDataTemplate :
+				ListViewSpy<GroupedEvenRowsRecycleElementAndDataTemplate>
+			{ }
+
+			internal abstract void Down();
+			internal abstract void Up();
+			internal abstract void UpdateHeights(double difference);
+			internal abstract void Dispose();
+		}
+
+		static int __listViewSpyAlloc;
+		static int __listViewSpyFree;
+		ListViewSpy[] __listViews;
+
+		IEnumerable<ListViewSpy> ListViews()
+			=> __listViews ?? Enumerable.Empty<ListViewSpy>();
+
+		void Update()
+			=> Title = $"ListViews={__listViewSpyAlloc - __listViewSpyFree}";
+
+		Grid RecycleListViews(bool group = false)
+		{
+			// reclaim
+			foreach (var o in ListViews())
+				o.Dispose();
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			__listViews = group ?
+				new ListViewSpy[]
+				{
+					new ListViewSpy.GroupedRetain(),
+					new ListViewSpy.GroupedEvenRowsRecycleElement(),
+					new ListViewSpy.GroupedEvenRowsRecycleElementAndDataTemplate(),
+					new ListViewSpy.GroupedUnevenRowsRecycleElement(),
+					new ListViewSpy.GroupedUnevenRowsRecycleElementAndDataTemplate(),
+				} :
+				new ListViewSpy[]
+				{
+					new ListViewSpy.Retain(),
+					new ListViewSpy.EvenRowsRecycleElement(),
+					new ListViewSpy.EvenRowsRecycleElementAndDataTemplate(),
+					new ListViewSpy.UnevenRowsRecycleElement(),
+					new ListViewSpy.UnevenRowsRecycleElementAndDataTemplate(),
+				};
+
+			var grid = new Grid();
+			foreach (var o in __listViews)
+				grid.Children.AddHorizontal(o);
+
+			Update();
+
+			return grid;
+		}
+
+		private class ButtonGird : Grid
+		{
+			Bugzilla52487 _test;
+
+			internal ButtonGird(Bugzilla52487 test)
+			{
+				_test = test;
+			}
+
+			private void ForEachListView(Action<ListViewSpy> onClick) 
+				=> _test.ListViews().ForEach(o => onClick(o));
+
+			public void Add(View view)
+				=> Children.AddHorizontal(view);
+
+			public Switch AddSwitch(Action<bool> onToggle)
+			{
+				var toggle = new Switch();
+				toggle.Toggled += (o, s) => onToggle(s.Value);
+				Add(toggle);
+				return toggle;
+			}
+
+			public Button AddButton(string text, Action onClick)
+			{
+				var button = new Button() { Text = text };
+				button.Clicked += (o, s) => onClick();
+				Add(button);
+				return button;
+			}
+
+			public Button AddButton(string text, Action<ListViewSpy> onClick)
+				=> AddButton(text, () => ForEachListView(onClick));
+
+			public Entry AddEntry()
+			{
+				var entry = new Entry();
+				Add(entry);
+				return entry;
+			}
+		}
+
+		protected override void Init()
+		{
+			var listViewGrid = new ContentView();
+			listViewGrid.Content = RecycleListViews(false);
+
+			var buttonsGrid = new ButtonGird(this);
+			var more = buttonsGrid.AddButton("More", x => x.UpdateHeights(2));
+			var less = buttonsGrid.AddButton($"Less", x => x.UpdateHeights(.5));
+			var up = buttonsGrid.AddButton("Up", x => x.Up());
+			var down = buttonsGrid.AddButton("Down", x => x.Down());
+			var group = buttonsGrid.AddSwitch(
+				isGrouped => listViewGrid.Content = RecycleListViews(isGrouped));
+
+			Content = new StackLayout
+			{
+				Children = {
+					listViewGrid,
+					buttonsGrid,
+				}
+			};
+
+			Update();
+		}
+		public static class Id
+		{
+			public static string Down = nameof(Down);
+		}
+#if UITEST
+		[Test]
+		public void Bugzilla52487Test()
+		{
+			try
+			{
+				RunningApp.WaitForElement(Id.Down);
+				RunningApp.Screenshot("Down");
+
+				RunningApp.Tap(Id.Down);
+			}
+
+			finally
+			{
+				RunningApp.Screenshot("Finally");
+			}
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -212,6 +212,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla54649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56609.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla55912.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52487.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57317.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57114.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57758.cs" />

--- a/Xamarin.Forms.Core.UnitTests/DataTemplateSelectorTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DataTemplateSelectorTests.cs
@@ -90,4 +90,69 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.Throws<NotSupportedException> (() => dts.SelectTemplate ((byte)0, null));
 		}
 	}
+
+	[TestFixture]
+	public class DataTemplateRecycleTests : BaseTestFixture
+	{
+		[TearDown]
+		public override void TearDown()
+		{
+			base.TearDown();
+			Device.PlatformServices = null;
+		}
+
+		[SetUp]
+		public override void Setup()
+		{
+			base.Setup();
+			Device.PlatformServices = new MockPlatformServices();
+		}
+
+		class TestDataTemplateSelector : DataTemplateSelector
+		{
+			readonly DataTemplate declarativeTemplate;
+			readonly DataTemplate proceduralTemplate;
+
+			public TestDataTemplateSelector ()
+			{
+				declarativeTemplate = new DataTemplate(typeof(ViewCell));
+				proceduralTemplate = new DataTemplate(() => new EntryCell());
+			}
+
+			protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+			{
+				Counter++;
+
+				if (item is string)
+					return declarativeTemplate;
+
+				return proceduralTemplate;
+			}
+
+			public int Counter = 0;
+		}
+
+		[Test]
+		public void ListViewSupport ()
+		{
+			var listView = new ListView(ListViewCachingStrategy.RecycleElementAndDataTemplate);
+			listView.ItemsSource = new object[] { "foo", "bar", 0 };
+
+			Assert.That(listView.CachingStrategy == 
+				ListViewCachingStrategy.RecycleElementAndDataTemplate);
+
+			var selector = new TestDataTemplateSelector();
+			listView.ItemTemplate = selector;
+			Assert.That(selector.Counter == 0);
+
+			Assert.IsInstanceOf<ViewCell>(listView.TemplatedItems[0]);
+			Assert.That(selector.Counter == 1);
+
+			Assert.IsInstanceOf<ViewCell>(listView.TemplatedItems[1]);
+			Assert.That(selector.Counter == 1);
+
+			Assert.Throws<NotSupportedException>(
+				() => { var o = listView.TemplatedItems[2]; });
+		}
+	}
 }

--- a/Xamarin.Forms.Core/DataTemplateExtensions.cs
+++ b/Xamarin.Forms.Core/DataTemplateExtensions.cs
@@ -5,14 +5,18 @@ namespace Xamarin.Forms.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class DataTemplateExtensions
 	{
-		public static object CreateContent(this DataTemplate self, object item, BindableObject container)
+		public static DataTemplate SelectDataTemplate(this DataTemplate self, object item, BindableObject container)
 		{
 			var selector = self as DataTemplateSelector;
-			if (selector != null)
-			{
-				self = selector.SelectTemplate(item, container);
-			}
-			return self.CreateContent();
+			if (selector == null)
+				return self;
+
+			return selector.SelectTemplate(item, container);
+		}
+
+		public static object CreateContent(this DataTemplate self, object item, BindableObject container)
+		{
+			return self.SelectDataTemplate(item, container).CreateContent();
 		}
 	}
 }

--- a/Xamarin.Forms.Core/DataTemplateSelector.cs
+++ b/Xamarin.Forms.Core/DataTemplateSelector.cs
@@ -1,15 +1,39 @@
 using System;
+using System.Collections.Generic;
 
 namespace Xamarin.Forms
 {
 	public abstract class DataTemplateSelector : DataTemplate
 	{
+		Dictionary<Type, DataTemplate> _dataTemplates = new Dictionary<Type, DataTemplate>();
+
 		public DataTemplate SelectTemplate(object item, BindableObject container)
 		{
-			DataTemplate result = OnSelectTemplate(item, container);
-			if (result is DataTemplateSelector)
-				throw new NotSupportedException("DataTemplateSelector.OnSelectTemplate must not return another DataTemplateSelector");
-			return result;
+			var listView = container as ListView;
+
+			var recycle = listView == null ? false :
+				(listView.CachingStrategy & ListViewCachingStrategy.RecycleElementAndDataTemplate) ==
+					ListViewCachingStrategy.RecycleElementAndDataTemplate;
+
+			DataTemplate dataTemplate = null;
+			if (recycle && _dataTemplates.TryGetValue(item.GetType(), out dataTemplate))
+				return dataTemplate;
+
+			dataTemplate = OnSelectTemplate(item, container);
+			if (dataTemplate is DataTemplateSelector)
+				throw new NotSupportedException(
+					"DataTemplateSelector.OnSelectTemplate must not return another DataTemplateSelector");
+
+			if (recycle)
+			{
+				if (!dataTemplate.CanRecycle)
+					throw new NotSupportedException(
+						"RecycleElementAndDataTemplate requires DataTemplate activated with ctor taking a type.");
+
+				_dataTemplates[item.GetType()] = dataTemplate;
+			}
+
+			return dataTemplate;
 		}
 
 		protected abstract DataTemplate OnSelectTemplate(object item, BindableObject container);

--- a/Xamarin.Forms.Core/ElementTemplate.cs
+++ b/Xamarin.Forms.Core/ElementTemplate.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Forms
 	{
 		List<Action<object, ResourcesChangedEventArgs>> _changeHandlers;
 		Element _parent;
+		bool _canRecycle; // aka IsDeclarative
 
 		internal ElementTemplate()
 		{
@@ -19,6 +20,8 @@ namespace Xamarin.Forms
 		{
 			if (type == null)
 				throw new ArgumentNullException("type");
+
+			_canRecycle = true;
 
 			LoadTemplate = () => Activator.CreateInstance(type);
 		}
@@ -46,6 +49,7 @@ namespace Xamarin.Forms
 			_changeHandlers.Add(onchanged);
 		}
 
+		internal bool CanRecycle => _canRecycle;
 		Element IElement.Parent
 		{
 			get { return _parent; }

--- a/Xamarin.Forms.Core/ITemplatedItemsList.cs
+++ b/Xamarin.Forms.Core/ITemplatedItemsList.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms
 
 		IListProxy ListProxy { get; }
 
+		DataTemplate SelectDataTemplate(object item);
 		int GetGlobalIndexForGroup(ITemplatedItemsList<TItem> group);
 		int GetGlobalIndexOfItem(object item);
 		ITemplatedItemsList<TItem> GetGroup(int index);

--- a/Xamarin.Forms.Core/ItemsView.cs
+++ b/Xamarin.Forms.Core/ItemsView.cs
@@ -86,13 +86,18 @@ namespace Xamarin.Forms
 			element.Parent = (Element)bindable;
 		}
 
-		static bool ValidateItemTemplate(BindableObject b, object v)
+		static bool ValidateItemTemplate(BindableObject bindable, object value)
 		{
-			var lv = b as ListView;
-			if (lv == null)
+			var listView = bindable as ListView;
+			if (listView == null)
 				return true;
 
-			return !(lv.CachingStrategy == ListViewCachingStrategy.RetainElement && lv.ItemTemplate is DataTemplateSelector);
+			var isRetainStrategy = listView.CachingStrategy == ListViewCachingStrategy.RetainElement;
+			var isDataTemplateSelector = listView.ItemTemplate is DataTemplateSelector;
+			if (isRetainStrategy && isDataTemplateSelector)
+				return false;
+
+			return true;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -73,7 +73,11 @@ namespace Xamarin.Forms
 
 		public ListView([Parameter("CachingStrategy")] ListViewCachingStrategy cachingStrategy) : this()
 		{
-			if (Device.RuntimePlatform == Device.Android || Device.RuntimePlatform == Device.iOS || Device.RuntimePlatform == Device.macOS)
+			// null => UnitTest "platform"
+			if (Device.RuntimePlatform == null || 
+				Device.RuntimePlatform == Device.Android || 
+				Device.RuntimePlatform == Device.iOS || 
+				Device.RuntimePlatform == Device.macOS)
 				CachingStrategy = cachingStrategy;
 		}
 

--- a/Xamarin.Forms.Core/ListViewCachingStrategy.cs
+++ b/Xamarin.Forms.Core/ListViewCachingStrategy.cs
@@ -1,8 +1,12 @@
+using System;
+
 namespace Xamarin.Forms
 {
+	[Flags]
 	public enum ListViewCachingStrategy
 	{
 		RetainElement = 0,
-		RecycleElement
+		RecycleElement = 1 << 0,
+		RecycleElementAndDataTemplate = RecycleElement | 1 << 1,
 	}
 }

--- a/Xamarin.Forms.Core/TemplatedItemsList.cs
+++ b/Xamarin.Forms.Core/TemplatedItemsList.cs
@@ -523,13 +523,19 @@ namespace Xamarin.Forms.Internals
 			return GetIndex(item);
 		}
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public DataTemplate SelectDataTemplate(object item)
+		{
+			return ItemTemplate.SelectDataTemplate(item, _itemsView);
+		}
+
 		public TItem CreateContent(int index, object item, bool insert = false)
 		{
 			TItem content = ItemTemplate != null ? (TItem)ItemTemplate.CreateContent(item, _itemsView) : _itemsView.CreateDefault(item);
 
 			content = UpdateContent(content, index, item);
 
-			if (CachingStrategy == ListViewCachingStrategy.RecycleElement)
+			if ((CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 				return content;
 
 			for (int i = _templatedObjects.Count; i <= index; i++)
@@ -891,7 +897,7 @@ namespace Xamarin.Forms.Internals
 
 		void OnGroupingEnabledChanged()
 		{
-			if (CachingStrategy == ListViewCachingStrategy.RecycleElement)
+			if ((CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 				_templatedObjects.Clear();
 
 			OnItemsSourceChanged(true);
@@ -963,7 +969,7 @@ namespace Xamarin.Forms.Internals
 				return;
 			}
 
-			if (CachingStrategy == ListViewCachingStrategy.RecycleElement)
+			if ((CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 			{
 				OnCollectionChanged(e);
 				return;

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -218,7 +218,7 @@ namespace Xamarin.Forms.Platform.Android
 			else
 				layout = new ConditionalFocusLayout(_context) { Orientation = Orientation.Vertical };
 
-			if (cachingStrategy == ListViewCachingStrategy.RecycleElement && convertView != null)
+			if (((cachingStrategy & ListViewCachingStrategy.RecycleElement) != 0) && convertView != null)
 			{
 				var boxedCell = convertView as INativeElementView;
 				if (boxedCell == null)
@@ -321,7 +321,7 @@ namespace Xamarin.Forms.Platform.Android
 				return leftOver > 0;
 			}
 
-			if (((IListViewController)list).CachingStrategy == ListViewCachingStrategy.RecycleElement)
+			if ((((IListViewController)list).CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 			{
 				if (_enabledCheckCell == null)
 					_enabledCheckCell = GetCellForPosition(position);
@@ -375,7 +375,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Cell cell = null;
 
-			if (Controller.CachingStrategy == ListViewCachingStrategy.RecycleElement)
+			if ((Controller.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 			{
 				AView cellOwner = view;
 				var layout = cellOwner as ConditionalFocusLayout;
@@ -461,7 +461,8 @@ namespace Xamarin.Forms.Platform.Android
 				if (global == position || cells.Count > 0)
 				{
 					//Always create a new cell if we are using the RecycleElement strategy
-					var headerCell = _listView.CachingStrategy == ListViewCachingStrategy.RecycleElement ? GetNewGroupHeaderCell(group) : group.HeaderContent;
+					var recycleElement = (_listView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0;
+					var headerCell = recycleElement ? GetNewGroupHeaderCell(group) : group.HeaderContent;
 					cells.Add(headerCell);
 
 					if (cells.Count == take)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ListViewDataSource.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ListViewDataSource.cs
@@ -162,7 +162,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				cell = GetCellForPath(indexPath, isHeader);
 				nativeCell = CellNSView.GetNativeCell(tableView, cell, templateId, isHeader);
 			}
-			else if (cachingStrategy == ListViewCachingStrategy.RecycleElement)
+			else if ((cachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 			{
 				nativeCell = tableView.MakeView(templateId, tableView);
 				if (nativeCell == null)

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -118,7 +118,8 @@ namespace Xamarin.Forms.Platform.iOS
 		public void Update(UITableView tableView, Cell cell, UITableViewCell nativeCell)
 		{
 			var parentListView = cell.RealParent as ListView;
-			var recycling = parentListView != null && parentListView.CachingStrategy == ListViewCachingStrategy.RecycleElement;
+			var recycling = parentListView != null && 
+				((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
 			if (_cell != cell && recycling)
 			{
 				if (_cell != null)
@@ -459,7 +460,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (e.PropertyName == "HasContextActions")
 			{
 				var parentListView = _cell.RealParent as ListView;
-				var recycling = parentListView != null && parentListView.CachingStrategy == ListViewCachingStrategy.RecycleElement;
+				var recycling = parentListView != null && 
+					((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
 				if (!recycling)
 					ReloadRow();
 			}
@@ -468,7 +470,8 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnContextItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			var parentListView = _cell.RealParent as ListView;
-			var recycling = parentListView != null && parentListView.CachingStrategy == ListViewCachingStrategy.RecycleElement;
+			var recycling = parentListView != null && 
+				((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
 			if (recycling)
 				Update(_tableView, _cell, ContentCell);
 			else
@@ -479,7 +482,8 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnMenuItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			var parentListView = _cell.RealParent as ListView;
-			var recycling = parentListView != null && parentListView.CachingStrategy == ListViewCachingStrategy.RecycleElement;
+			var recycling = parentListView != null && 
+				((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
 			if (recycling)
 				Update(_tableView, _cell, ContentCell);
 			else

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -25,7 +25,6 @@ namespace Xamarin.Forms.Platform.iOS
 		KeyboardInsetTracker _insetTracker;
 		RectangleF _previousFrame;
 		ScrollToRequestedEventArgs _requestedScroll;
-		bool _shouldEstimateRowHeight = true;
 
 		FormsUITableViewController _tableViewController;
 		ListView ListView => Element;
@@ -212,7 +211,6 @@ namespace Xamarin.Forms.Platform.iOS
 						Control.SetContentOffset(offset, true);
 					});
 				}
-				_shouldEstimateRowHeight = true;
 
 				var listView = e.NewElement;
 
@@ -366,35 +364,36 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateEstimatedRowHeight()
 		{
-			var rowHeight = Element.RowHeight;
-			if (Element.HasUnevenRows && rowHeight == -1)
-			{
-				var source = _dataSource as UnevenListViewDataSource;
+			if (_estimatedRowHeight)
+				return;
 
-				// We want to make sure we reset the cached defined row heights whenever this is called.
-				// Failing to do this will regress Bugzilla 43313 (strange animation when adding rows with uneven heights)
-				source?.CacheDefinedRowHeights();
-
-				if (_shouldEstimateRowHeight && !_estimatedRowHeight)
-				{
-					if (source != null)
-					{
-						Control.EstimatedRowHeight = source.GetEstimatedRowHeight(Control);
-						_estimatedRowHeight = true;
-					}
-					else
-					{
-						//We need to set a default estimated row height, because re-setting it later(when we have items on the TIL)
-						//will cause the UITableView to reload, and throw an Exception
-						Control.EstimatedRowHeight = DefaultRowHeight;
-					}
-				}
-			}
-			else if (!_estimatedRowHeight)
+			// if even rows OR uneven rows but user specified a row height anyway...
+			if (!Element.HasUnevenRows || Element.RowHeight != -1)
 			{
 				Control.EstimatedRowHeight = 0;
 				_estimatedRowHeight = true;
+				return;
 			}
+
+			var source = _dataSource as UnevenListViewDataSource;
+
+			// We want to make sure we reset the cached defined row heights whenever this is called.
+			// Failing to do this will regress Bugzilla 43313 
+			// (strange animation when adding rows with uneven heights)
+			//source?.CacheDefinedRowHeights();
+
+			if (source == null)
+			{
+				// We need to set a default estimated row height, 
+				// because re-setting it later(when we have items on the TIL)
+				// will cause the UITableView to reload, and throw an Exception
+				Control.EstimatedRowHeight = DefaultRowHeight;
+				return;
+			}
+
+			Control.EstimatedRowHeight = source.GetEstimatedRowHeight(Control);
+			_estimatedRowHeight = true;
+			return;
 		}
 
 		void UpdateFooter()
@@ -627,9 +626,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			IVisualElementRenderer _prototype;
 			bool _disposed;
-			bool _useEstimatedRowHeight;
-
-			ConcurrentDictionary<NSIndexPath, nfloat> _rowHeights = new ConcurrentDictionary<NSIndexPath, nfloat>();
+			Dictionary<object, Cell> _prototypicalCellByTypeOrDataTemplate = new Dictionary<object, Cell>();
 
 			public UnevenListViewDataSource(ListView list, FormsUITableViewController uiTableViewController) : base(list, uiTableViewController)
 			{
@@ -637,24 +634,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public UnevenListViewDataSource(ListViewDataSource source) : base(source)
 			{
-			}
-
-			internal void CacheDefinedRowHeights()
-			{
-				Task.Run(() =>
-				{
-					var templatedItems = TemplatedItemsView.TemplatedItems;
-
-					foreach (var cell in templatedItems)
-					{
-						if (_disposed)
-							return;
-
-						double? cellRenderHeight = cell?.RenderHeight;
-						if (cellRenderHeight > 0)
-							_rowHeights[cell.GetIndexPath()] = (nfloat)cellRenderHeight;
-					}
-				});
 			}
 
 			internal nfloat GetEstimatedRowHeight(UITableView table)
@@ -692,22 +671,42 @@ namespace Xamarin.Forms.Platform.iOS
 				return CalculateHeightForCell(table, firstCell);
 			}
 
-			public override nfloat EstimatedHeight(UITableView tableView, NSIndexPath indexPath)
+			internal override void InvalidatePrototypicalCellCache()
 			{
-				if (_useEstimatedRowHeight)
-					return tableView.EstimatedRowHeight;
+				_prototypicalCellByTypeOrDataTemplate.Clear();
+			}
 
-				// Note: It is *not* an optimization to first check if the array has any values.
-				nfloat specifiedRowHeight;
-				if (_rowHeights.TryGetValue(indexPath, out specifiedRowHeight) && specifiedRowHeight > 0)
-					return specifiedRowHeight;
+			internal Cell GetPrototypicalCell(NSIndexPath indexPath)
+			{
+				var itemTypeOrDataTemplate = default(object);
 
-				return UITableView.AutomaticDimension;
+				var cachingStrategy = List.CachingStrategy;
+				if (cachingStrategy == ListViewCachingStrategy.RecycleElement)
+					itemTypeOrDataTemplate = GetDataTemplateForPath(indexPath);
+
+				else if (cachingStrategy == ListViewCachingStrategy.RecycleElementAndDataTemplate)
+					itemTypeOrDataTemplate = GetItemTypeForPath(indexPath);
+
+				else // ListViewCachingStrategy.RetainElement
+					return GetCellForPath(indexPath);
+
+
+				Cell protoCell;
+				if (!_prototypicalCellByTypeOrDataTemplate.TryGetValue(itemTypeOrDataTemplate, out protoCell))
+				{
+					// cache prototypical cell by item type; Items of the same Type share
+					// the same DataTemplate (this is enforced by RecycleElementAndDataTemplate)
+					protoCell = GetCellForPath(indexPath);
+					_prototypicalCellByTypeOrDataTemplate[itemTypeOrDataTemplate] = protoCell;
+				}
+
+				var templatedItems = GetTemplatedItemsListForPath(indexPath);
+				return templatedItems.UpdateContent(protoCell, indexPath.Row);
 			}
 
 			public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
 			{
-				var cell = GetCellForPath(indexPath);
+				var cell = GetPrototypicalCell(indexPath);
 
 				if (List.RowHeight == -1 && cell.Height == -1 && cell is ViewCell)
 					return UITableView.AutomaticDimension;
@@ -745,7 +744,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					// Let the EstimatedHeight method know to use this value.
 					// Much more efficient than checking the value each time.
-					_useEstimatedRowHeight = true;
+					//_useEstimatedRowHeight = true;
 					return (nfloat)req.Request.Height;
 				}
 
@@ -818,6 +817,10 @@ namespace Xamarin.Forms.Platform.iOS
 				get { return UIColor.Clear; }
 			}
 
+			internal virtual void InvalidatePrototypicalCellCache()
+			{
+			}
+
 			public override void DraggingEnded(UIScrollView scrollView, bool willDecelerate)
 			{
 				_isDragging = false;
@@ -840,13 +843,14 @@ namespace Xamarin.Forms.Platform.iOS
 					cell = GetCellForPath(indexPath);
 					nativeCell = CellTableViewCell.GetNativeCell(tableView, cell);
 				}
-				else if (cachingStrategy == ListViewCachingStrategy.RecycleElement)
+				else if ((cachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 				{
 					var id = TemplateIdForPath(indexPath);
 					nativeCell = tableView.DequeueReusableCell(ContextActionsCell.Key + id);
 					if (nativeCell == null)
 					{
 						cell = GetCellForPath(indexPath);
+
 						nativeCell = CellTableViewCell.GetNativeCell(tableView, cell, true, id.ToString());
 					}
 					else
@@ -966,7 +970,7 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 
 				Cell formsCell = null;
-				if (List.CachingStrategy == ListViewCachingStrategy.RecycleElement)
+				if ((List.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 					formsCell = (Cell)((INativeElementView)cell).Element;
 
 				SetCellBackgroundColor(cell, UIColor.Clear);
@@ -1035,12 +1039,32 @@ namespace Xamarin.Forms.Platform.iOS
 				_uiTableView.ReloadData();
 			}
 
-			protected Cell GetCellForPath(NSIndexPath indexPath)
+			protected ITemplatedItemsList<Cell> GetTemplatedItemsListForPath(NSIndexPath indexPath)
 			{
 				var templatedItems = TemplatedItemsView.TemplatedItems;
 				if (List.IsGroupingEnabled)
-					templatedItems = (TemplatedItemsList<ItemsView<Cell>, Cell>)((IList)templatedItems)[indexPath.Section];
+					templatedItems = (ITemplatedItemsList<Cell>)((IList)templatedItems)[indexPath.Section];
 
+				return templatedItems;
+			}
+
+			protected DataTemplate GetDataTemplateForPath(NSIndexPath indexPath)
+			{
+				var templatedList = GetTemplatedItemsListForPath(indexPath);
+				var item = templatedList.ListProxy[indexPath.Row];
+				return templatedList.SelectDataTemplate(item);
+			}
+
+			protected Type GetItemTypeForPath(NSIndexPath indexPath)
+			{
+				var templatedList = GetTemplatedItemsListForPath(indexPath);
+				var item = templatedList.ListProxy[indexPath.Row];
+				return item.GetType();
+			}
+
+			protected Cell GetCellForPath(NSIndexPath indexPath)
+			{
+				var templatedItems = GetTemplatedItemsListForPath(indexPath);
 				var cell = templatedItems[indexPath.Row];
 				return cell;
 			}
@@ -1086,10 +1110,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (selector == null)
 					return DefaultItemTemplateId;
 
-				var templatedList = TemplatedItemsView.TemplatedItems;
-				if (List.IsGroupingEnabled)
-					templatedList = (TemplatedItemsList<ItemsView<Cell>, Cell>)((IList)templatedList)[indexPath.Section];
-
+				var templatedList = GetTemplatedItemsListForPath(indexPath);
 				var item = templatedList.ListProxy[indexPath.Row];
 
 				itemTemplate = selector.SelectTemplate(item, List);

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DataTemplateExtensions.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DataTemplateExtensions.xml
@@ -43,5 +43,29 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SelectDataTemplate">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.DataTemplate SelectDataTemplate (this Xamarin.Forms.DataTemplate self, object item, Xamarin.Forms.BindableObject container);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.DataTemplate SelectDataTemplate(class Xamarin.Forms.DataTemplate self, object item, class Xamarin.Forms.BindableObject container) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.DataTemplate</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="self" Type="Xamarin.Forms.DataTemplate" RefType="this" />
+        <Parameter Name="item" Type="System.Object" />
+        <Parameter Name="container" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="self">To be added.</param>
+        <param name="item">To be added.</param>
+        <param name="container">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TemplatedItemsList`2.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TemplatedItemsList`2.xml
@@ -558,6 +558,31 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SelectDataTemplate">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.DataTemplate SelectDataTemplate (object item);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.DataTemplate SelectDataTemplate(object item) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.DataTemplate</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="item">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="ShortName">
       <MemberSignature Language="C#" Value="public string ShortName { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string ShortName" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ITemplatedItemsList`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ITemplatedItemsList`1.xml
@@ -286,6 +286,26 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="SelectDataTemplate">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.DataTemplate SelectDataTemplate (object item);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.DataTemplate SelectDataTemplate(object item) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.DataTemplate</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="item">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="ShortNames">
       <MemberSignature Language="C#" Value="public System.Collections.Generic.IReadOnlyList&lt;string&gt; ShortNames { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.IReadOnlyList`1&lt;string&gt; ShortNames" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ListViewCachingStrategy.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ListViewCachingStrategy.xml
@@ -9,6 +9,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.Flags</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Enumerates caching strategies for a ListView.</summary>
     <remarks>
@@ -46,6 +51,20 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates that unneeded cells will have their binding contexts updated to that of a cell that is needed.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="RecycleElementAndDataTemplate">
+      <MemberSignature Language="C#" Value="RecycleElementAndDataTemplate" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ListViewCachingStrategy RecycleElementAndDataTemplate = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ListViewCachingStrategy</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="RetainElement">

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -1072,6 +1072,31 @@
     </ExtensionMethod>
     <ExtensionMethod>
       <Targets>
+        <Target Type="T:Xamarin.Forms.DataTemplate" />
+      </Targets>
+      <Member MemberName="SelectDataTemplate">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.DataTemplate SelectDataTemplate (this Xamarin.Forms.DataTemplate self, object item, Xamarin.Forms.BindableObject container);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.DataTemplate SelectDataTemplate(class Xamarin.Forms.DataTemplate self, object item, class Xamarin.Forms.BindableObject container) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.DataTemplate</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="self" Type="Xamarin.Forms.DataTemplate" RefType="this" />
+          <Parameter Name="item" Type="System.Object" />
+          <Parameter Name="container" Type="Xamarin.Forms.BindableObject" />
+        </Parameters>
+        <Docs>
+          <param name="self">To be added.</param>
+          <param name="item">To be added.</param>
+          <param name="container">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.Internals.DataTemplateExtensions" Member="M:Xamarin.Forms.Internals.DataTemplateExtensions.SelectDataTemplate(Xamarin.Forms.DataTemplate,System.Object,Xamarin.Forms.BindableObject)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
         <Target Type="T:Xamarin.Forms.Internals.DeviceOrientation" />
       </Targets>
       <Member MemberName="IsLandscape">


### PR DESCRIPTION
### Description of Change ###

Reduce ListView DataTemplate dynamism to enable caching DataTemplate by the type of the item in the ItemsSource. This in turn allows caching prototypical cells by the item type which are used under the hood to pre-compute height of a cell before scrolling on screen. 

One thing to keep in mind about iOS when doing a code reivew: When iOS returns a cell via `DequeueReusableCell` it will only reclaim the cell after it appears and disappears. So just getting a cell to measure but never attaching/rendering it _will leak the cell_. So if we're gonna create a cell just for measuring then we only want to create it once _per type_ instead of once _per index_ (although even once per index is better than what we do now which is create a new cell every time an index appears). 

Testing yet to do:
- [x] Improve existing strategy. 
- [x] Remove index -> type cache and instead re-ask for item each time and use it's type to hit type -> proto cell cache. 
- [x] Test multiple data templates.
- [ ] Test with image? 
- [ ] Test changing DataTemplateSelector invalidates cache of item types to prototypical cells.
- [x] Test grouping.
- [x] Re-test bug fixed by async height estimation to see if this fixes that bug so code added for that fix can be removed. See: https://github.com/xamarin/Xamarin.Forms/pull/994
- [x] Automate into a UITest
- [ ] _TBD_ "Flinging" a list view causes a ton of cells to be created and not reclaimed. Understanding why that happens may be a task for another day. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=52487

### API Changes ###

Added ListViewCachingStrategy.RecycleElementAndDataTemplate. When set OnSelectTemplate will be called once per item _type_ instead of once per _instance_. Consequently, a DataTemplate should be selected solely based on an items type and not any of it's data. Furthermore, the DataTemplate must be activated using the ctor that takes a Type.

One thing to note about iOS that drove the cache design: When iOS returns a

### Behavioral Changes ###

ListView activates only as many cells as are visible on screen. Finally. 

### PR Checklist ###

TODO: Commented out some code to fix other issues which may need to be added back if they're not fixed by this PR. 

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
