### PR TITLE
[Android] Fix ListView memory leak

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -40,6 +40,11 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (disposing)
 			{
+				if (Element != null)
+				{
+					Element.ItemsSource = null;
+				}
+
 				if (_headerView == null)
 					return;
 


### PR DESCRIPTION
### Description of Change ###

Fix ListView memory leak.

When push and pop a page which contain a ListView many times. The binding between ViewCell and ViewModel is not removed => access disposed object exception.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=45722

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
