### PR TITLE
[UWP] Controls are ignoring their rendering routines.

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -413,8 +413,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			Control.HorizontalAlignment = HorizontalAlignment.Stretch;
 			Control.VerticalAlignment = VerticalAlignment.Stretch;
 
-			Children.Add(control);
-
 			if (Element == null)
 				throw new InvalidOperationException(
 					"Cannot assign a native control without an Element; Renderer unbound and/or disposed. " +
@@ -425,7 +423,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 			control.GotFocus += OnControlGotFocus;
 			control.LostFocus += OnControlLostFocus;
-
+			Children.Add(control);
 			UpdateBackgroundColor();
 
 			if (Element != null && !string.IsNullOrEmpty(Element.AutomationId))


### PR DESCRIPTION
### Description of Change ###
Moved the native control to add AFTER the events were attached to.  The issue was their render routines were being ignored because they had loaded during or shortly after the Children.Add causing the Loaded event to never be caught.  This fixes that issue.  All our views load perfectly now.

No need for tests, this is a simple and obvious change.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=58630

### API Changes ###

None.

### Behavioral Changes ###

UWP Views will now update correctly when sizing the window, validation, to everyday loading of views.  You no longer need to force controls to update.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
