### PR TITLE
[A] Adjust Entry to avoid skipping upon completion via Enter key

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52299.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52299.cs
@@ -1,0 +1,41 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 52299, "[Android] Using a physical keyboard, setting Focus from an Entry's Completed handler fails", PlatformAffected.Android)]
+	public class Bugzilla52299 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var entry = new Entry { Placeholder = "One" };
+			var entry2 = new Entry { Placeholder = "Two" };
+			var entry3 = new Entry { Placeholder = "Three" };
+			var entry4 = new Entry { Placeholder = "Four" };
+
+			entry.Completed += (s, e) => { entry2.Focus(); };
+			entry2.Completed += (s, e) => { entry3.Focus(); };
+			entry3.Completed += (s, e) => { entry4.Focus(); };
+			Content = new ScrollView
+			{
+				Content = new StackLayout
+				{
+					Children =
+					{
+						new Label { Text = "Pressing Enter on a physical keyboard should not make the entry skip (e.g. One -> Three)" },
+						entry,
+						entry2,
+						entry3,
+						entry4
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -171,6 +171,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44500.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46363.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47548.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52299.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52419.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53834.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51536.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool TextView.IOnEditorActionListener.OnEditorAction(TextView v, ImeAction actionId, KeyEvent e)
 		{
 			// Fire Completed and dismiss keyboard for hardware / physical keyboards
-			if (actionId == ImeAction.Done || (actionId == ImeAction.ImeNull && e.KeyCode == Keycode.Enter))
+			if (actionId == ImeAction.Done || (actionId == ImeAction.ImeNull && e.KeyCode == Keycode.Enter && e.Action == KeyEventActions.Up))
 			{
 				Control.ClearFocus();
 				v.HideKeyboard();


### PR DESCRIPTION
### Description of Change ###

When multiple entries are on a page in Android and the completion sends focus from one to another (e.g. Field One -> Field Two), it can skip to the next entry if the Enter key on a physical keyboard is pressed (e.g. Field One -> Field Three). Checking for the `KeyEventAction` being `Up` opposed to `Down` can help alleviate this.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=52299

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
