### PR TITLE
[Internal] Fixed test StringFormatNonStringType failed, when current culture is not en-US or tr-TR.

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingBaseUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingBaseUnitTests.cs
@@ -166,17 +166,25 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void StringFormatNonStringType()
 		{
-			var property = BindableProperty.Create("Foo", typeof(string), typeof(MockBindable));
-			var binding = new Binding("Value", stringFormat: "{0:P2}");
+			var currentCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+			try
+			{
+				System.Threading.Thread.CurrentThread.CurrentCulture
+					= System.Globalization.CultureInfo.InvariantCulture;
 
-			var vm = new  { Value = 0.95d };
-			var bo = new MockBindable { BindingContext = vm };
-			bo.SetBinding(property, binding);
+				var property = BindableProperty.Create("Foo", typeof(string), typeof(MockBindable));
+				var binding = new Binding("Value", stringFormat: "{0:P2}");
 
-			if (System.Threading.Thread.CurrentThread.CurrentCulture.Name == "tr-TR")
-				Assert.That(bo.GetValue(property), Is.EqualTo("%95,00"));
-			else
+				var vm = new { Value = 0.95d };
+				var bo = new MockBindable { BindingContext = vm };
+				bo.SetBinding(property, binding);
+
 				Assert.That(bo.GetValue(property), Is.EqualTo("95.00 %"));
+			}
+			finally
+			{
+				System.Threading.Thread.CurrentThread.CurrentCulture = currentCulture;
+			}
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/BindingBaseUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingBaseUnitTests.cs
@@ -164,22 +164,24 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void StringFormatNonStringType()
+		[TestCase("en-US", "{0:P2}", 0.95d, ExpectedResult = "95.00 %")]
+		[TestCase("tr-TR", "{0:P2}", 0.95d, ExpectedResult = "%95,00" )]
+		public string StringFormatNonStringType(string culture, string format, object value)
 		{
 			var currentCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
 			try
 			{
 				System.Threading.Thread.CurrentThread.CurrentCulture
-					= System.Globalization.CultureInfo.InvariantCulture;
+					= System.Globalization.CultureInfo.GetCultureInfo(culture);
 
 				var property = BindableProperty.Create("Foo", typeof(string), typeof(MockBindable));
-				var binding = new Binding("Value", stringFormat: "{0:P2}");
+				var binding = new Binding("Value", stringFormat: format);
 
-				var vm = new { Value = 0.95d };
+				var vm = new { Value = value };
 				var bo = new MockBindable { BindingContext = vm };
 				bo.SetBinding(property, binding);
 
-				Assert.That(bo.GetValue(property), Is.EqualTo("95.00 %"));
+				return (string)bo.GetValue(property);
 			}
 			finally
 			{


### PR DESCRIPTION
### Description of Change ###

Using InvariantCulture instead of CurrentCulture.

### Bugs Fixed ###

- Provide links to bugs here

### API Changes ###

none

### Behavioral Changes ###
none

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
