### PR TITLE
Avoid exception when removing a page from navigation during Appearing handler

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RemovePageOnAppearing.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RemovePageOnAppearing.cs
@@ -15,8 +15,7 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 
 	[Preserve(AllMembers = true)]
-	// TODO hartez 2017/08/10 09:02:49 Don't forget to adjust the issue tracker and number	
-	[Issue(IssueTracker.Bugzilla, 9991134, "Removing page during OnAppearing throws exception", PlatformAffected.Android)]
+	[Issue(IssueTracker.None, 1134, "Removing page during OnAppearing throws exception", PlatformAffected.Android)]
 	public class RemovePageOnAppearing : TestContentPage
 	{
 		const string Success = "Success";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RemovePageOnAppearing.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RemovePageOnAppearing.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Navigation)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 9991134, "Removing page during OnAppearing throws exception", PlatformAffected.Android)]
+	public class RemovePageOnAppearing : TestNavigationPage
+	{
+		const string Success = "Success";
+
+		protected override async void Init()
+		{
+			await PushAsync(Root());
+			await PushAsync(Intermediate());
+			await PushAsync(new PageWhichRemovesAnEarlierPageOnAppearing());
+		}
+
+		static ContentPage Root()
+		{
+			return new ContentPage { Content = new Label {Text = "Root"} };
+		}
+
+		static ContentPage Intermediate()
+		{
+			return new ContentPage { Content = new Label {Text = "Intermediate page"} };
+		}
+
+		[Preserve(AllMembers = true)]
+		class PageWhichRemovesAnEarlierPageOnAppearing : ContentPage
+		{
+			public PageWhichRemovesAnEarlierPageOnAppearing()
+			{
+				var instructions = new Label { Text = "If you can see this, the test has passed" };
+
+				Content = new StackLayout() { Children = { instructions, new Label {Text = Success}  }};
+			}
+
+			protected override void OnAppearing()
+			{
+				var toRemove = Navigation.NavigationStack.Skip(1).First();
+
+				// toRemove should be the IntermediatePage
+				Navigation.RemovePage(toRemove);
+
+				base.OnAppearing();
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void RemovePageOnAppearingDoesNotCrash()
+		{
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RemovePageOnAppearing.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RemovePageOnAppearing.cs
@@ -15,16 +15,21 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 
 	[Preserve(AllMembers = true)]
+	// TODO hartez 2017/08/10 09:02:49 Don't forget to adjust the issue tracker and number	
 	[Issue(IssueTracker.Bugzilla, 9991134, "Removing page during OnAppearing throws exception", PlatformAffected.Android)]
-	public class RemovePageOnAppearing : TestNavigationPage
+	public class RemovePageOnAppearing : TestContentPage
 	{
 		const string Success = "Success";
 
-		protected override async void Init()
+		protected override void Init()
 		{
-			await PushAsync(Root());
-			await PushAsync(Intermediate());
-			await PushAsync(new PageWhichRemovesAnEarlierPageOnAppearing());
+			Appearing += async (sender, args) =>
+			{
+				var nav = new NavigationPage(Root());
+				Application.Current.MainPage = nav;
+				await nav.PushAsync(Intermediate());
+				await nav.PushAsync(new PageWhichRemovesAnEarlierPageOnAppearing());	
+			};
 		}
 
 		static ContentPage Root()
@@ -44,7 +49,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				var instructions = new Label { Text = "If you can see this, the test has passed" };
 
-				Content = new StackLayout() { Children = { instructions, new Label {Text = Success}  }};
+				Content = new StackLayout { Children = { instructions, new Label { Text = Success } } };
 			}
 
 			protected override void OnAppearing()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -268,6 +268,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39829.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RemovePageOnAppearing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollViewIsEnabled.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PlatformSpecifics_iOSTranslucentNavBarX.xaml.cs">
       <DependentUpon>PlatformSpecifics_iOSTranslucentNavBarX.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -574,7 +574,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			transaction.DisallowAddToBackStack();
 			transaction.Remove(fragment);
 			transaction.CommitAllowingStateLoss();
-			FragmentManager.ExecutePendingTransactions();
 
 			// And remove the fragment from our own stack
 			_fragmentStack.Remove(fragment);


### PR DESCRIPTION
### Description of Change ###

Remove unnecessary call to `ExecutePendingTransactions` which causes a "recursive entry to executePendingTransactions" error for Android Support libraries version 23 when removing a page from the navigation stack in response to another page's `Appearing` event. With Android Support libraries version 25 and up, this was throwing an exception with the error "FragmentManager is already executing transactions"; this change also fixes that issue.

### Bugs Fixed ###

- Problem caused by previous fix to [53179 – PopAsync crashing after RemovePage when support packages are updated to 25.1.1](https://bugzilla.xamarin.com/show_bug.cgi?id=53179#c42)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
