### PR TITLE
[iOS] Prevent ListView HasUnevenRows crash when template w/container Element is swapped

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58645.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58645.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Bugzilla, 58645, "[iOS] NRE Thrown When ListView Items Are Replaced By Items With a Different Template", PlatformAffected.iOS)]
 	public class Bugzilla58645 : TestContentPage
 	{
+		const string ButtonId = "button";
 		ObservableCollection<string> Items { get; set; }
 
 		protected override void Init()
@@ -33,6 +34,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var switchBtn = new Button
 			{
 				Text = "Switch Items",
+				AutomationId = ButtonId,
 				Command = new Command(() =>
 				{
 					Items.Clear();
@@ -44,6 +46,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Children =
 				{
+					new Label { Text = "Tap the 'Switch Items' button. If the app does not crash, this test has passed." },
 					switchBtn,
 					myListView
 				}
@@ -129,9 +132,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla58645Test()
 		{
-			//RunningApp.Screenshot ("I am at Issue 1");
-			//RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
-			//RunningApp.Screenshot ("I see the Label");
+			RunningApp.WaitForElement(q => q.Marked(ButtonId));
+			RunningApp.Tap(q => q.Marked(ButtonId));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58645.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58645.cs
@@ -1,0 +1,138 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 58645, "[iOS] NRE Thrown When ListView Items Are Replaced By Items With a Different Template", PlatformAffected.iOS)]
+	public class Bugzilla58645 : TestContentPage
+	{
+		ObservableCollection<string> Items { get; set; }
+
+		protected override void Init()
+		{
+			Items = new ObservableCollection<string> { "Item 1A", "Item 2A", "Item 3A" };
+
+			var myListView = new ListView
+			{
+				HasUnevenRows = true,
+				ItemsSource = Items,
+				ItemTemplate = new LayoutTemplateSelector
+				{
+					LayoutA = new DataTemplate(typeof(LayoutA)),
+					LayoutB = new DataTemplate(typeof(LayoutB))
+				}
+			};
+
+			var switchBtn = new Button
+			{
+				Text = "Switch Items",
+				Command = new Command(() =>
+				{
+					Items.Clear();
+					Items.Add("Item 1B");
+				})
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					switchBtn,
+					myListView
+				}
+			};
+		}
+
+		public class LayoutA : ViewCell
+		{
+			public LayoutA()
+			{
+				var layout = new Grid
+				{
+					Padding = new Thickness(14),
+					ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = GridLength.Auto },
+					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }
+				},
+					RowDefinitions =
+				{
+					new RowDefinition { Height = GridLength.Auto }
+				}
+				};
+
+				var mainLabel = new Label();
+				mainLabel.SetBinding(Label.TextProperty, ".");
+
+				var sw = new Switch();
+				layout.Children.Add(mainLabel, 0, 0);
+				layout.Children.Add(sw, 2, 0);
+				View = layout;
+			}
+		}
+
+		public class LayoutB : ViewCell
+		{
+			public LayoutB()
+			{
+				var layout = new Grid
+				{
+					Padding = new Thickness(14),
+					ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = GridLength.Auto },
+					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }
+				},
+					RowDefinitions =
+				{
+					new RowDefinition { Height = GridLength.Auto }
+				}
+				};
+
+				var mainLabel = new Label();
+				mainLabel.SetBinding(Label.TextProperty, ".");
+
+				var secondLabel = new Label
+				{
+					Text = "B"
+				};
+
+				layout.Children.Add(mainLabel, 0, 0);
+				layout.Children.Add(secondLabel, 2, 0);
+				View = layout;
+			}
+		}
+
+		public class LayoutTemplateSelector : DataTemplateSelector
+		{
+			public DataTemplate LayoutA { get; set; }
+			public DataTemplate LayoutB { get; set; }
+
+			protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+			{
+				if (item == null)
+					return LayoutA;
+
+				var text = (string)item;
+				return text.Contains("A") ? LayoutA : LayoutB;
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla58645Test()
+		{
+			//RunningApp.Screenshot ("I am at Issue 1");
+			//RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
+			//RunningApp.Screenshot ("I see the Label");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -314,6 +314,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40161.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzila57749.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollViewObjectDisposed.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58645.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.iOS/RendererPool.cs
+++ b/Xamarin.Forms.Platform.iOS/RendererPool.cs
@@ -91,7 +91,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					PushRenderer(childRenderer);
 
-					if (ReferenceEquals(childRenderer, Platform.GetRenderer(childRenderer.Element)))
+					// The ListView CalculateHeightForCell method can create renderers and dispose its child renderers before this is called.
+					// Thus, it is possible that this work is already completed.
+					if (childRenderer.Element != null && ReferenceEquals(childRenderer, Platform.GetRenderer(childRenderer.Element)))
 						childRenderer.Element.ClearValue(Platform.RendererProperty);
 				}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -739,14 +739,8 @@ namespace Xamarin.Forms.Platform.iOS
 						// Clear renderer from descendent; this will not happen in Dispose as normal because we need to
 						// unhook the Element from the renderer before disposing it.
 						descendant.ClearValue(Platform.RendererProperty);
-
-						if (renderer != null)
-						{
-							// Unhook Element (descendant) from renderer before Disposing so we don't set the Element to null
-							renderer.SetElement(null);
-							renderer.Dispose();
-							renderer = null;
-						}
+						renderer?.Dispose();
+						renderer = null;
 					}
 
 					// Let the EstimatedHeight method know to use this value.

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -251,11 +251,11 @@ namespace Xamarin.Forms.Platform.MacOS
 					_packager = null;
 				}
 
-				// The ListView can create renderers and unhook them from the Element before Dispose is called.
+				// The ListView can create renderers and unhook them from the Element before Dispose is called in CalculateHeightForCell.
 				// Thus, it is possible that this work is already completed.
 				if (Element != null)
 				{
-					Platform.SetRenderer(Element, null);
+					Element.ClearValue(Platform.RendererProperty);
 					SetElement(null);
 				}
 			}


### PR DESCRIPTION
### Description of Change ###

This fixes the same issue that was fixed by #894, except it includes scenarios where the `ItemTemplate`s have container `Element`s (e.g., `Grid`s).

This is related to the memory leak fixes in #524, which introduced disposal of the trial renderers that are created when measuring the height of a cell for a `ListView`. This eager disposal of the renderers and unhooking from the Elements was not yet accounted for in the `VisualElementRenderer` (fixed by #894) or the `VisualElementTracker` (fixed by this PR).

### Bugs Fixed ###

- [Bug 58645 - [iOS] NRE Thrown When ListView Items Are Replaced By Items With a Different Template](https://bugzilla.xamarin.com/show_bug.cgi?id=58645) **(regression in 2.3.5 prerelease)**

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
