### PR TITLE
macOS: Make ListViewDataSource public

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ListViewDataSource.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ListViewDataSource.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
-	internal class ListViewDataSource : NSTableViewSource
+	public class ListViewDataSource : NSTableViewSource
 	{
 		IVisualElementRenderer _prototype;
 		const int DefaultItemTemplateId = 1;


### PR DESCRIPTION
### Description of Change ###

Is it possible to make ListViewDataSource public? This makes it really easy to use it in custom ListViews, otherwise you have to copy lots of code into your own project and even that doesn't work at all, as there are function calls to other internal methods.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
