### PR TITLE
Automatically add XAML items to Sdk-style projects

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -118,12 +118,14 @@
 
     <!--Xaml PCL Stuff-->
     <file src="Xamarin.Forms.targets" target="build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms$IdAppend$.targets" />
+    <file src="Xamarin.Forms.props" target="build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms$IdAppend$.props" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Build.Tasks.dll" target="build\portable-win+net45+wp80+win81+wpa81" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Core.dll" target="build\portable-win+net45+wp80+win81+wpa81" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Xaml.dll" target="build\portable-win+net45+wp80+win81+wpa81" />
 
     <!--Xaml netstandard Stuff-->
     <file src="Xamarin.Forms.targets" target="build\netstandard1.0\Xamarin.Forms$IdAppend$.targets" />
+    <file src="Xamarin.Forms.props" target="build\netstandard1.0\Xamarin.Forms$IdAppend$.props" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Build.Tasks.dll" target="build\netstandard1.0" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Core.dll" target="build\netstandard1.0" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Xaml.dll" target="build\netstandard1.0" />

--- a/.nuspec/Xamarin.Forms.props
+++ b/.nuspec/Xamarin.Forms.props
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<!--
+	When using Sdk-style projects and default embedded resource items are enabled, automatically
+	add the XAML files and fix up item metadata to pair them with code files.
+	This is in the props file, not the targets file, so that projects can remove/update these items.
+	The default value for EnableDefaultXamlItems is set in the targets, which works because
+	the property evaluation pass comes before the item evaluation pass.
+	-->
+	<ItemGroup Condition="'$(EnableDefaultItems)'=='True' and '$(EnableDefaultXamlItems)'=='True' and '$(EnableDefaultEmbeddedResourceItems)'=='True'">
+		<None Remove="**\*.xaml" Condition="'$(EnableDefaultNoneItems)'=='True'" />
+		<Compile Update="**\*.xaml$(DefaultLanguageSourceExtension)" DependentUpon="%(Filename)" SubType="Code" />
+		<EmbeddedResource Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
+	</ItemGroup>
+
+</Project>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -2,7 +2,11 @@
 	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.XamlGTask" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
 	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.FixedCreateCSharpManifestResourceName" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
 	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.XamlCTask" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
-  
+
+	<PropertyGroup>
+		<EnableDefaultXamlItems Condition="'$(EnableDefaultXamlItems)'==''">True</EnableDefaultXamlItems>
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<CoreCompileDependsOn>
 			XamlG;


### PR DESCRIPTION
### Description of Change ###

By default, Compile/EmbeddedResource/None items are added to Sdk-style projects by wildcard. Use the same logic to add XAML files and fix up the item metadata.

No tests as there's no test infrastructure for the MSBuild targets.

### Behavioral Changes ###

Sdk-style (i.e. netstandard) projects that list these items explicitly will get an error about duplicate items and will have to remove them.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
