### PR TITLE
Fix NRE when removing multiple pages in NavigationPageRenderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53179.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53179.cs
@@ -26,7 +26,11 @@ namespace Xamarin.Forms.Controls.Issues
 				rmBtn.Clicked += (sender, e) =>
 				{
 					var stackSize = Navigation.NavigationStack.Count;
+					Navigation.RemovePage(Navigation.NavigationStack[stackSize - 2])
+
+					stackSize = Navigation.NavigationStack.Count;
 					Navigation.RemovePage(Navigation.NavigationStack[stackSize - 2]);
+
 					popBtn.IsVisible = true;
 					rmBtn.IsVisible = false;
 				};
@@ -34,7 +38,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 				switch (index)
 				{
-					case 3:
+					case 4:
 						nextBtn.IsVisible = false;
 						popBtn.IsVisible = false;
 						break;

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -569,6 +569,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				return;
 			}
 
+#if DEBUG
+			// Enables logging of moveToState operations to logcat
+			FragmentManager.EnableDebugLogging(true);
+#endif
+
 			// Go ahead and take care of the fragment bookkeeping for the page being removed
 			FragmentTransaction transaction = FragmentManager.BeginTransaction();
 			transaction.DisallowAddToBackStack();
@@ -577,18 +582,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			// And remove the fragment from our own stack
 			_fragmentStack.Remove(fragment);
-
-			// Now handle all the XF removal/cleanup
-			IVisualElementRenderer rendererToRemove = Android.Platform.GetRenderer(page);
-
-			if (rendererToRemove != null)
-			{
-				var containerToRemove = (PageContainer)rendererToRemove.View.Parent;
-				rendererToRemove.View?.RemoveFromParent();
-				rendererToRemove?.Dispose();
-				containerToRemove?.RemoveFromParent();
-				containerToRemove?.Dispose();
-			}
 
 			Device.StartTimer(TimeSpan.FromMilliseconds(10), () =>
 			{


### PR DESCRIPTION
…ges with Android Support 25+

### Description of Change ###

The RemovePage method was doing some cleanup of the Page's container and renderer after removing the Page's Fragment; however, that same cleanup is already being done by the FragmentContainer itself. Aside from a very small performance hit, this isn't normally an issue, but when removing multiple pages the additional cleanup code can cause a NullReferenceException. 

This change removes the unnecessary cleanup code from RemovePage.

### Bugs Fixed ###

- [53179 – PopAsync crashing after RemovePage when support packages are updated to 25.1.1](https://bugzilla.xamarin.com/show_bug.cgi?id=53179#c52)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
