### PR TITLE
[MacOS] Fix bugzilla58779

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58779.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58779.cs
@@ -1,0 +1,67 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 58779, "[MacOS] DisplayActionSheet on MacOS needs scroll bars if list is long", PlatformAffected.All)]
+	public class Bugzilla58779 : TestContentPage
+	{
+        const string ButtonId = "button";
+
+		protected override void Init()
+		{
+            Button button = new Button
+            {
+                Text = "Click Here",
+                Font = Font.SystemFontOfSize(NamedSize.Large),
+                BorderWidth = 1,
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.CenterAndExpand,
+                AutomationId = ButtonId,
+            };
+
+            // The root page of your application
+            var content = new StackLayout {
+                VerticalOptions = LayoutOptions.Center,
+                Children = {
+                    new Label {
+                        HorizontalTextAlignment = TextAlignment.Center,
+                        Text = "Tap on the button to show the DisplayActionSheet with 15 items"
+                    },
+                    new Label {
+                        HorizontalTextAlignment = TextAlignment.Center,
+                        Text = "The list of items should be scrollable and Cancel should be visible"
+                    },
+                    button
+
+                }
+            };
+
+            button.Clicked += (sender, e) => {
+                String[] string_array = {"1","2","3","4","5","6","7","8","9","10","11","12","13","14","15"};
+                this.DisplayActionSheet("title","cancel","destruction",string_array);
+            };
+
+            Content = content;
+        }
+
+
+#if UITEST
+		[Test]
+		public void Bugzilla58779Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(ButtonId));
+			RunningApp.Tap(q => q.Marked(ButtonId));
+            RunningApp.Screenshot ("Check list fits on screen");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58779.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58779.cs
@@ -11,47 +11,47 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-    [Issue(IssueTracker.Bugzilla, 58779, "[MacOS] DisplayActionSheet on MacOS needs scroll bars if list is long", PlatformAffected.All)]
+	[Issue(IssueTracker.Bugzilla, 58779, "[MacOS] DisplayActionSheet on MacOS needs scroll bars if list is long", PlatformAffected.All)]
 	public class Bugzilla58779 : TestContentPage
 	{
-        const string ButtonId = "button";
+		const string ButtonId = "button";
 
 		protected override void Init()
 		{
-            Button button = new Button
-            {
-                Text = "Click Here",
-                Font = Font.SystemFontOfSize(NamedSize.Large),
-                BorderWidth = 1,
-                HorizontalOptions = LayoutOptions.Center,
-                VerticalOptions = LayoutOptions.CenterAndExpand,
-                AutomationId = ButtonId,
-            };
+			Button button = new Button
+			{
+				Text = "Click Here",
+				Font = Font.SystemFontOfSize(NamedSize.Large),
+				BorderWidth = 1,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+				AutomationId = ButtonId,
+			};
 
-            // The root page of your application
-            var content = new StackLayout {
-                VerticalOptions = LayoutOptions.Center,
-                Children = {
-                    new Label {
-                        HorizontalTextAlignment = TextAlignment.Center,
-                        Text = "Tap on the button to show the DisplayActionSheet with 15 items"
-                    },
-                    new Label {
-                        HorizontalTextAlignment = TextAlignment.Center,
-                        Text = "The list of items should be scrollable and Cancel should be visible"
-                    },
-                    button
+			// The root page of your application
+			var content = new StackLayout {
+				VerticalOptions = LayoutOptions.Center,
+				Children = {
+					new Label {
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "Tap on the button to show the DisplayActionSheet with 15 items"
+					},
+					new Label {
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "The list of items should be scrollable and Cancel should be visible"
+					},
+					button
 
-                }
-            };
+				}
+			};
 
-            button.Clicked += (sender, e) => {
-                String[] string_array = {"1","2","3","4","5","6","7","8","9","10","11","12","13","14","15"};
-                this.DisplayActionSheet("title","cancel","destruction",string_array);
-            };
+			button.Clicked += (sender, e) => {
+				String[] string_array = {"1","2","3","4","5","6","7","8","9","10","11","12","13","14","15"};
+				this.DisplayActionSheet("title","cancel","destruction",string_array);
+			};
 
-            Content = content;
-        }
+			Content = content;
+		}
 
 
 #if UITEST
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement(q => q.Marked(ButtonId));
 			RunningApp.Tap(q => q.Marked(ButtonId));
-            RunningApp.Screenshot ("Check list fits on screen");
+			RunningApp.Screenshot ("Check list fits on screen");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -592,6 +592,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52700.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39407.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ButtonFastRendererTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58779.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -44,14 +44,14 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (arguments.Buttons != null)
 				{
 					NSView extraButtons = GetExtraButton(arguments);
-                    if (extraButtons.Frame.Height > 400) {
-					    NSScrollView scrollView = new NSScrollView();
-                        scrollView.Frame = new RectangleF(0, 0, extraButtons.Frame.Width, 400);
-					    scrollView.DocumentView = extraButtons;
-					    alert.AccessoryView = scrollView;
-                    } else {
-                        alert.AccessoryView = extraButtons;
-                    }
+					if (extraButtons.Frame.Height > 400) {
+						NSScrollView scrollView = new NSScrollView();
+						scrollView.Frame = new RectangleF(0, 0, extraButtons.Frame.Width, 400);
+						scrollView.DocumentView = extraButtons;
+						alert.AccessoryView = scrollView;
+					} else {
+						alert.AccessoryView = extraButtons;
+					}
 					alert.Layout();
 				}
 

--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Platform.MacOS
 						NSScrollView scrollView = new NSScrollView();
 						scrollView.Frame = new RectangleF(0, 0, extraButtons.Frame.Width, 400);
 						scrollView.DocumentView = extraButtons;
+						scrollView.HasVerticalScroller = true;
 						alert.AccessoryView = scrollView;
 					} else {
 						alert.AccessoryView = extraButtons;

--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -43,10 +43,11 @@ namespace Xamarin.Forms.Platform.MacOS
 				var alert = NSAlert.WithMessage(arguments.Title, arguments.Cancel, arguments.Destruction, null, "");
 				if (arguments.Buttons != null)
 				{
+					int maxScrollHeight = (int)(0.6 * NSScreen.MainScreen.Frame.Height);
 					NSView extraButtons = GetExtraButton(arguments);
-					if (extraButtons.Frame.Height > 400) {
+					if (extraButtons.Frame.Height > maxScrollHeight) {
 						NSScrollView scrollView = new NSScrollView();
-						scrollView.Frame = new RectangleF(0, 0, extraButtons.Frame.Width, 400);
+						scrollView.Frame = new RectangleF(0, 0, extraButtons.Frame.Width, maxScrollHeight);
 						scrollView.DocumentView = extraButtons;
 						scrollView.HasVerticalScroller = true;
 						alert.AccessoryView = scrollView;

--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -43,7 +43,15 @@ namespace Xamarin.Forms.Platform.MacOS
 				var alert = NSAlert.WithMessage(arguments.Title, arguments.Cancel, arguments.Destruction, null, "");
 				if (arguments.Buttons != null)
 				{
-					alert.AccessoryView = GetExtraButton(arguments);
+					NSView extraButtons = GetExtraButton(arguments);
+                    if (extraButtons.Frame.Height > 400) {
+					    NSScrollView scrollView = new NSScrollView();
+                        scrollView.Frame = new RectangleF(0, 0, extraButtons.Frame.Width, 400);
+					    scrollView.DocumentView = extraButtons;
+					    alert.AccessoryView = scrollView;
+                    } else {
+                        alert.AccessoryView = extraButtons;
+                    }
 					alert.Layout();
 				}
 


### PR DESCRIPTION
### Description of Change ###

Xamarin Forms Mac OS X bug fix.
DisplayActionSheet shows a list of items the user can select from.
If the list is long (e.g. 15 items) the Popup went off the bottom of the Mac Desktop.
Not all items can be selected.
The cancel button goes off the bottom of the screen

### Bugs Fixed ###

Bugzilla 58779

### API Changes ###

None

### Behavioral Changes ###

A NSScrollView is used to allow long lists of items to fit on the Mac Desktop

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense