### PR TITLE
[Android] Make Android ListView- and GroupedListViewAdapter inheritable

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/GroupedListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/GroupedListViewAdapter.cs
@@ -8,7 +8,7 @@ using AListView = Android.Widget.ListView;
 namespace Xamarin.Forms.Platform.Android
 {
 
-	internal class GroupedListViewAdapter : ListViewAdapter, ISectionIndexer
+	public class GroupedListViewAdapter : ListViewAdapter, ISectionIndexer
 	{
 		class SectionData
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -12,7 +12,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal class ListViewAdapter : CellAdapter
+	public class ListViewAdapter : CellAdapter
 	{
 		const int DefaultGroupHeaderTemplateId = 0;
 		const int DefaultItemTemplateId = 1;


### PR DESCRIPTION
### Description of Change ###

This just changes the accessibility if the Android `ListViewAdapter.cs` and `GroupedListViewAdapter.cs` from `internal` to `public`.

### API Changes ###

List all API changes here (or just put None), example:

Changed:
 - internal class ListViewAdapter => public class ListViewAdapter
 - internal class GroupedListViewAdapter => public class GroupedListViewAdapter

### Behavioral Changes ###

As we tried to implement a custom adapter for Android lists in Xamarin.Forms, we noticed the very top-level adapters were internal, giving us no opportunity to inherit from them. Manipulating some adapter sepcific behaviors (i.e. custom implementation of [Context Actions)](https://developer.xamarin.com/guides/xamarin-forms/user-interface/listview/interactivity/#Context_Actions) and inject this through renderers is not possible at the moment. 

As I do not see any reason, why they are internal (CellAdapter is public, too). I think it won't hurt to make them public. Correct me If I am wrong, please.

### PR Checklist ###

- [ ] ~Has tests (if omitted, state reason in description)~ because: not really testable
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
