### PR TITLE
[UWP] Adjust PR #762 to instead use Element.Focused

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52266.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52266.cs
@@ -18,14 +18,19 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				ItemsSource = new string[] { "A", "B", "C" }
 			};
+			var picker2 = new Picker
+			{
+				ItemsSource = new string[] { "D", "E", "F" }
+			};
 			Content = new StackLayout
 			{
 				Children =
 				{
 					picker,
+					picker2,
 					new Button
 					{
-						Text = "Click to focus the picker",
+						Text = "Click to focus the first picker",
 						Command = new Command(() =>
 						{
 							picker.Focus();

--- a/Xamarin.Forms.Platform.WinRT/FormsComboBox.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsComboBox.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media.Animation;
 
 #if WINDOWS_UWP
@@ -18,6 +19,10 @@ namespace Xamarin.Forms.Platform.WinRT
 		internal bool IsFullScreen => Device.Idiom == TargetIdiom.Phone && Items != null && Items.Count > 5;
 
 		internal bool IsOpeningAnimated { get; private set; }
+
+		internal Popup Popup { get; private set; }
+
+		internal bool IsPopupOpen { get; private set; }
 
 		protected override void OnApplyTemplate()
 		{
@@ -48,6 +53,12 @@ namespace Xamarin.Forms.Platform.WinRT
 					closedSignalAnimation.Completed += (sender, o) => OnClosedAnimationStarted();
 					IsClosingAnimated = true;
 				}
+			}
+			Popup = (Popup)GetTemplateChild("Popup");
+			if (Popup != null)
+			{
+				Popup.Opened += (s, e) => IsPopupOpen = true;
+				Popup.Closed += (s, e) => IsPopupOpen = false;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.WinRT/FormsComboBox.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsComboBox.cs
@@ -20,9 +20,9 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		internal bool IsOpeningAnimated { get; private set; }
 
-		internal Popup Popup { get; private set; }
-
 		internal bool IsPopupOpen { get; private set; }
+
+		Popup Popup { get; set; }
 
 		protected override void OnApplyTemplate()
 		{

--- a/Xamarin.Forms.Platform.WinRT/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/PickerRenderer.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
 
@@ -19,7 +20,6 @@ namespace Xamarin.Forms.Platform.WinRT
 	{
 		bool _isAnimating;
 		Brush _defaultBrush;
-		bool _dropDownWasOpened;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					Control.DropDownClosed -= OnDropDownOpenStateChanged;
 					Control.OpenAnimationCompleted -= ControlOnOpenAnimationCompleted;
 					Control.Loaded -= ControlOnLoaded;
-					Control.GotFocus -= ControlOnGotFocus;
+					Element.Focused -= OnElementFocused;
 				}
 			}
 
@@ -53,7 +53,7 @@ namespace Xamarin.Forms.Platform.WinRT
 					Control.OpenAnimationCompleted += ControlOnOpenAnimationCompleted;
 					Control.ClosedAnimationStarted += ControlOnClosedAnimationStarted;
 					Control.Loaded += ControlOnLoaded;
-					Control.GotFocus += ControlOnGotFocus;
+					e.NewElement.Focused += OnElementFocused;
 				}
 
 				Control.ItemsSource = ((LockableObservableListWrapper)Element.Items)._list;
@@ -63,6 +63,12 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 
 			base.OnElementChanged(e);
+		}
+
+		void OnElementFocused(object sender, FocusEventArgs e)
+		{
+			if (!Control.IsPopupOpen && Control.FocusState != FocusState.Keyboard)
+				Control.IsDropDownOpen = true;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -105,19 +111,6 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 		}
 
-		void ControlOnGotFocus(object sender, RoutedEventArgs routedEventArgs)
-		{
-			// The FormsComboBox is separate from the Popup/dropdown that it uses to select an item,
-			// and the behavior here is changed to be similar to the other platforms where focusing the
-			// Picker opens the dropdown (with the exception where if focus was given via keyboard, such
-			// as tabbing through controls). The _dropDownWasOpened flag is reset to false in the case that
-			// the FormsComboBox regained focus after the dropdown closed.
-			if (!_dropDownWasOpened && Control.FocusState != FocusState.Keyboard)
-				Control.IsDropDownOpen = true;
-			else
-				_dropDownWasOpened = false;
-		}
-
 		void OnControlSelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 			if (Element != null)
@@ -145,9 +138,6 @@ namespace Xamarin.Forms.Platform.WinRT
 				_isAnimating = false;
 				// and force the final redraw
 				((IVisualElementController)Element)?.InvalidateMeasure(InvalidationTrigger.MeasureChanged);
-
-				// Related to ControlOnGotFocus, _dropDownWasOpened is set to true
-				_dropDownWasOpened = true;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

This is a potential different approach to the bug in #762 which was using `GotFocus` as the hook for focusing on the picker, which could cause issues when doing something such as tabbing between them; the normal UWP behavior doesn't open the dropdown. Basing the behavior on `Element.Focused` instead and ignoring `FocusState.Keyboard` lets the user tab between controls on the screen without opening the Picker. We can also grab the `Popup` (dropdown) part of the `ComboBox` template and use its open/closed events to track its state. This is similar to the original PR since without checking it the dropdown will just repeatedly open due to how focus works.

Related to the `FocusState`, if the user does something such as pressing enter on a button to call `Focus()` on a `Picker`, it will behave similarly to if it was tabbed to as we check for the `Keyboard` type. It's a small edge quirk, but in some ways is consistent with keyboard behavior in general.

### Bugs Fixed ###

#762

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
