### PR TITLE
[Internal] Fix loading props file on older MSBuild versions

### DIFF
--- a/.nuspec/Xamarin.Forms.DefaultItems.props
+++ b/.nuspec/Xamarin.Forms.DefaultItems.props
@@ -1,8 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<ItemGroup>
-		<None Remove="**\*.xaml" Condition="'$(EnableDefaultNoneItems)'=='True'" />
-		<Compile Update="**\*.xaml$(DefaultLanguageSourceExtension)" DependentUpon="%(Filename)" SubType="Code" />
 		<EmbeddedResource Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
 	</ItemGroup>
 

--- a/.nuspec/Xamarin.Forms.DefaultItems.props
+++ b/.nuspec/Xamarin.Forms.DefaultItems.props
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<ItemGroup>
+		<None Remove="**\*.xaml" Condition="'$(EnableDefaultNoneItems)'=='True'" />
+		<Compile Update="**\*.xaml$(DefaultLanguageSourceExtension)" DependentUpon="%(Filename)" SubType="Code" />
+		<EmbeddedResource Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
+	</ItemGroup>
+
+</Project>

--- a/.nuspec/Xamarin.Forms.DefaultItems.targets
+++ b/.nuspec/Xamarin.Forms.DefaultItems.targets
@@ -1,0 +1,15 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<!--
+	NOTE: we cannot update/remove existing default items in our props file, as it is
+	imported *before* the default items are created by Microsoft.NET.Sdk.DefaultItems.props.
+	Doing it here works, but means that it will override things users do in their csproj.
+	Unfortunately there is no way to work around this without adding a new extension point to
+	the sdk props.
+	-->
+	<ItemGroup>
+		<Compile Update="**\*.xaml$(DefaultLanguageSourceExtension)" DependentUpon="%(Filename)" SubType="Code" />
+		<None Remove="**\*.xaml" Condition="'$(EnableDefaultNoneItems)'=='True'" />
+	</ItemGroup>
+
+</Project>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -118,7 +118,6 @@
 
     <!--Xaml PCL Stuff-->
     <file src="Xamarin.Forms.targets" target="build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms$IdAppend$.targets" />
-    <file src="Xamarin.Forms.props" target="build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms$IdAppend$.props" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Build.Tasks.dll" target="build\portable-win+net45+wp80+win81+wpa81" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Core.dll" target="build\portable-win+net45+wp80+win81+wpa81" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Xaml.dll" target="build\portable-win+net45+wp80+win81+wpa81" />
@@ -126,6 +125,7 @@
     <!--Xaml netstandard Stuff-->
     <file src="Xamarin.Forms.targets" target="build\netstandard1.0\Xamarin.Forms$IdAppend$.targets" />
     <file src="Xamarin.Forms.props" target="build\netstandard1.0\Xamarin.Forms$IdAppend$.props" />
+    <file src="Xamarin.Forms.DefaultItems.props" target="build\netstandard1.0\Xamarin.Forms.DefaultItems.props" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Build.Tasks.dll" target="build\netstandard1.0" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Core.dll" target="build\netstandard1.0" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Xaml.dll" target="build\netstandard1.0" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -124,6 +124,7 @@
 
     <!--Xaml netstandard Stuff-->
     <file src="Xamarin.Forms.targets" target="build\netstandard1.0\Xamarin.Forms$IdAppend$.targets" />
+    <file src="Xamarin.Forms.DefaultItems.targets" target="build\netstandard1.0\Xamarin.Forms.DefaultItems.targets" />
     <file src="Xamarin.Forms.props" target="build\netstandard1.0\Xamarin.Forms$IdAppend$.props" />
     <file src="Xamarin.Forms.DefaultItems.props" target="build\netstandard1.0\Xamarin.Forms.DefaultItems.props" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\Xamarin.Forms.Build.Tasks.dll" target="build\netstandard1.0" />

--- a/.nuspec/Xamarin.Forms.props
+++ b/.nuspec/Xamarin.Forms.props
@@ -10,7 +10,6 @@
 	The actual item groups are in a separate conditionally-imported file as they use constructs that
 	are not compatible with older MSBuild versions.
 	-->
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.props"
-	        Condition="'$(EnableDefaultItems)'=='' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.props" Condition="'$(_DefaultXamlItemsEnabled)'=='True" />
 
 </Project>

--- a/.nuspec/Xamarin.Forms.props
+++ b/.nuspec/Xamarin.Forms.props
@@ -6,11 +6,11 @@
 	This is in the props file, not the targets file, so that projects can remove/update these items.
 	The default value for EnableDefaultXamlItems is set in the targets, which works because
 	the property evaluation pass comes before the item evaluation pass.
+
+	The actual item groups are in a separate conditionally-imported file as they use constructs that
+	are not compatible with older MSBuild versions.
 	-->
-	<ItemGroup Condition="'$(EnableDefaultItems)'=='True' and '$(EnableDefaultXamlItems)'=='True' and '$(EnableDefaultEmbeddedResourceItems)'=='True'">
-		<None Remove="**\*.xaml" Condition="'$(EnableDefaultNoneItems)'=='True'" />
-		<Compile Update="**\*.xaml$(DefaultLanguageSourceExtension)" DependentUpon="%(Filename)" SubType="Code" />
-		<EmbeddedResource Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
-	</ItemGroup>
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.props"
+	        Condition="'$(EnableDefaultItems)'=='' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'" />
 
 </Project>

--- a/.nuspec/Xamarin.Forms.props
+++ b/.nuspec/Xamarin.Forms.props
@@ -10,6 +10,6 @@
 	The actual item groups are in a separate conditionally-imported file as they use constructs that
 	are not compatible with older MSBuild versions.
 	-->
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.props" Condition="'$(_DefaultXamlItemsEnabled)'=='True" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.props" Condition="'$(_DefaultXamlItemsEnabled)'=='True'" />
 
 </Project>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -9,7 +9,7 @@
 		<_DefaultXamlItemsEnabled Condition="'$(EnableDefaultItems)'=='' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">True</_DefaultXamlItemsEnabled>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.targets" Condition="'$(_DefaultXamlItemsEnabled)'=='True" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.targets" Condition="$(_DefaultXamlItemsEnabled)'=='True" />
 
 	<PropertyGroup>
 		<CoreCompileDependsOn>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -9,7 +9,7 @@
 		<_DefaultXamlItemsEnabled Condition="'$(EnableDefaultItems)'=='' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">True</_DefaultXamlItemsEnabled>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.targets" Condition="$(_DefaultXamlItemsEnabled)'=='True" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.targets" Condition="'$(_DefaultXamlItemsEnabled)'=='True'" />
 
 	<PropertyGroup>
 		<CoreCompileDependsOn>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -5,7 +5,11 @@
 
 	<PropertyGroup>
 		<EnableDefaultXamlItems Condition="'$(EnableDefaultXamlItems)'==''">True</EnableDefaultXamlItems>
+		<_DefaultXamlItemsEnabled>False</_DefaultXamlItemsEnabled>
+		<_DefaultXamlItemsEnabled Condition="'$(EnableDefaultItems)'=='' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">True</_DefaultXamlItemsEnabled>
 	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.targets" Condition="'$(_DefaultXamlItemsEnabled)'=='True" />
 
 	<PropertyGroup>
 		<CoreCompileDependsOn>


### PR DESCRIPTION
### Description of Change ###

Fixes installing XF NuGet on VS2015

### Bugs Fixed ###

- https://forums.xamarin.com/discussion/101625/xamarin-forms-2-4-0-266-pre1-the-attribute-remove-in-element-is-unrecognized
- https://bugzilla.xamarin.com/show_bug.cgi?id=58897
- https://bugzilla.xamarin.com/show_bug.cgi?id=58893

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
