### PR TITLE
[UWP] Adjust setting of Slider's BackgroundColor

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/SliderRenderer.cs
@@ -71,6 +71,22 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 		}
 
+		protected override void UpdateBackgroundColor()
+		{
+			if (Control != null)
+			{
+				Color backgroundColor = Element.BackgroundColor;
+				if (!backgroundColor.IsDefault)
+				{
+					Control.Background = backgroundColor.ToBrush();
+				}
+				else
+				{
+					Control.ClearValue(Windows.UI.Xaml.Controls.Control.BackgroundProperty);
+				}
+			}
+		}
+
 		protected override bool PreventGestureBubbling { get; set; } = true;
 
 		void OnNativeValueChanged(object sender, RangeBaseValueChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Setting the `BackgroundColor` on a `Slider` in UWP would also set it on the entire control's `Panel` via `UpdateBackgroundColor` in the `VisualElementRenderer`. Overriding this method on the renderer and removing the latter half of it prevents this from occurring, and only sets the color on the "rail" (`HorizontalTrackRect`) of the `Slider`, which is the correct behavior. No specific reproduction has been added as the behavior can be observed on the Slider Gallery page in the control gallery.

![slider](https://user-images.githubusercontent.com/1251024/29585578-a2bcae18-8755-11e7-90b0-a72f84261334.PNG)

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=57787

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
