### PR TITLE
[Android] Restore and obsolete EditorEditText and EntryEditText controls

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -11,9 +11,7 @@ using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
 {
-#pragma warning disable 618 // Have to continue using EditorEditText for now because third-party code may depend on it
-	public class EditorRenderer : ViewRenderer<Editor, EditorEditText>, ITextWatcher
-#pragma warning restore 618
+	public class EditorRenderer : ViewRenderer<Editor, FormsEditText>, ITextWatcher
 	{
 		ColorStateList _defaultColors;
 		bool _disposed;
@@ -42,12 +40,10 @@ namespace Xamarin.Forms.Platform.Android
 				((IElementController)Element).SetValueFromRenderer(Editor.TextProperty, s.ToString());
 		}
 	
-#pragma warning disable 618 // Have to continue using EditorEditText for now because third-party code may depend on it
-		protected override EditorEditText CreateNativeControl()
+		protected override FormsEditText CreateNativeControl()
 		{
-			return new EditorEditText(Context);
+			return new FormsEditText(Context);
 		}
-#pragma warning restore 618
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element.Text != s.ToString())
 				((IElementController)Element).SetValueFromRenderer(Editor.TextProperty, s.ToString());
 		}
-	
+
 		protected override FormsEditText CreateNativeControl()
 		{
 			return new FormsEditText(Context);

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -11,7 +11,9 @@ using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class EditorRenderer : ViewRenderer<Editor, FormsEditText>, ITextWatcher
+#pragma warning disable 618 // Have to continue using EditorEditText for now because third-party code may depend on it
+	public class EditorRenderer : ViewRenderer<Editor, EditorEditText>, ITextWatcher
+#pragma warning restore 618
 	{
 		ColorStateList _defaultColors;
 		bool _disposed;
@@ -39,11 +41,13 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element.Text != s.ToString())
 				((IElementController)Element).SetValueFromRenderer(Editor.TextProperty, s.ToString());
 		}
-
-		protected override FormsEditText CreateNativeControl()
+	
+#pragma warning disable 618 // Have to continue using EditorEditText for now because third-party code may depend on it
+		protected override EditorEditText CreateNativeControl()
 		{
-			return new FormsEditText(Context);
+			return new EditorEditText(Context);
 		}
+#pragma warning restore 618
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
 		{
@@ -51,7 +55,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			HandleKeyboardOnFocus = true;
 
-			FormsEditText edit = Control;
+			var edit = Control;
 			if (edit == null)
 			{
 				edit = CreateNativeControl();

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -13,9 +13,7 @@ using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
 {
-#pragma warning disable 618 // Have to continue using EntryEditText for now because third-party code may depend on it
-	public class EntryRenderer : ViewRenderer<Entry, EntryEditText>, ITextWatcher, TextView.IOnEditorActionListener
-#pragma warning restore 618
+	public class EntryRenderer : ViewRenderer<Entry, FormsEditText>, ITextWatcher, TextView.IOnEditorActionListener
 	{
 		ColorStateList _hintTextColorDefault;
 		ColorStateList _textColorDefault;
@@ -55,12 +53,10 @@ namespace Xamarin.Forms.Platform.Android
 			((IElementController)Element).SetValueFromRenderer(Entry.TextProperty, s.ToString());
 		}
 
-#pragma warning disable 618 // Have to continue using EntryEditText for now because third-party code may depend on it
-		protected override EntryEditText CreateNativeControl()
+		protected override FormsEditText CreateNativeControl()
 		{
-			return new EntryEditText(Context);
+			return new FormsEditText(Context);
 		}
-#pragma warning restore 618
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -13,7 +13,9 @@ using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class EntryRenderer : ViewRenderer<Entry, FormsEditText>, ITextWatcher, TextView.IOnEditorActionListener
+#pragma warning disable 618 // Have to continue using EntryEditText for now because third-party code may depend on it
+	public class EntryRenderer : ViewRenderer<Entry, EntryEditText>, ITextWatcher, TextView.IOnEditorActionListener
+#pragma warning restore 618
 	{
 		ColorStateList _hintTextColorDefault;
 		ColorStateList _textColorDefault;
@@ -53,10 +55,12 @@ namespace Xamarin.Forms.Platform.Android
 			((IElementController)Element).SetValueFromRenderer(Entry.TextProperty, s.ToString());
 		}
 
-		protected override FormsEditText CreateNativeControl()
+#pragma warning disable 618 // Have to continue using EntryEditText for now because third-party code may depend on it
+		protected override EntryEditText CreateNativeControl()
 		{
-			return new FormsEditText(Context);
+			return new EntryEditText(Context);
 		}
+#pragma warning restore 618
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsEditText.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.Android
 		internal event EventHandler OnKeyboardBackPressed;
 	}
 
-	[Obsolete("As of 2.4 this class has been replaced with Xamarin.Forms.Platform.Android.FormsEditText")]
+	[Obsolete("EntryEditText is obsolete as of version 2.4.0. Please use Xamarin.Forms.Platform.Android.FormsEditText instead.")]
 	public class EntryEditText : FormsEditText
 	{
 		internal EntryEditText(Context context) : base(context)
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Platform.Android
 		}
 	}
 
-	[Obsolete("As of 2.4 this class has been replaced with Xamarin.Forms.Platform.Android.FormsEditText")]
+	[Obsolete("EditorEditText is obsolete as of version 2.4.0. Please use Xamarin.Forms.Platform.Android.FormsEditText instead.")]
 	public class EditorEditText : FormsEditText
 	{
 		internal EditorEditText(Context context) : base(context)

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsEditText.cs
@@ -41,4 +41,20 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal event EventHandler OnKeyboardBackPressed;
 	}
+
+	[Obsolete("As of 2.4 this class has been replaced with Xamarin.Forms.Platform.Android.FormsEditText")]
+	public class EntryEditText : FormsEditText
+	{
+		internal EntryEditText(Context context) : base(context)
+		{
+		}
+	}
+
+	[Obsolete("As of 2.4 this class has been replaced with Xamarin.Forms.Platform.Android.FormsEditText")]
+	public class EditorEditText : FormsEditText
+	{
+		internal EditorEditText(Context context) : base(context)
+		{
+		}
+	}
 }


### PR DESCRIPTION
### Description of Change ###

Restore the `EntryEditText` and `EditorEditText` classes to avoid breaking dependencies on them. Marks those classes as `Obsolete`.

### Bugs Fixed ###

- [58966 – [Android] EntryEditText and EditorEditText have been removed which is a breaking change](https://bugzilla.xamarin.com/show_bug.cgi?id=58966)

