### PR TITLE
[Android] make NavigationBar support Transluscent status

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		ActionBarDrawerToggle _drawerToggle;
 		FragmentManager _fragmentManager;
 		int _lastActionBarHeight = -1;
+		int _statusbarHeight;
 		AToolbar _toolbar;
 		ToolbarTracker _toolbarTracker;
 		DrawerMultiplexedListener _drawerListener;
@@ -387,7 +388,27 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (actionBarHeight <= 0)
 				return Device.Info.CurrentOrientation.IsPortrait() ? (int)Context.ToPixels(56) : (int)Context.ToPixels(48);
 
+			if (((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentStatus))
+			{
+				if (_toolbar.PaddingTop == 0)
+					_toolbar.SetPadding(0, GetStatusBarHeight(), 0, 0);
+					
+				return actionBarHeight + GetStatusBarHeight();
+			}
+			
 			return actionBarHeight;
+		}
+		
+		int GetStatusBarHeight()
+		{
+			if (_statusbarHeight > 0)
+				return _statusbarHeight;
+			
+			int resourceId = Resources.GetIdentifier("status_bar_height", "dimen", "android");
+			if (resourceId > 0)
+				_statusbarHeight = Resources.GetDimensionPixelSize(resourceId);
+
+			return _statusbarHeight;
 		}
 
 		void AnimateArrowIn()


### PR DESCRIPTION
If the app has flag Transluscentstatus then we should support that when creating the navbar. Now that we dont draw a statusbarunderlay anymore this opens up to many interesting UI possibilities

### Description of Change ###

Adds a padding and adjusts the height of the Navigationbar if Transluscentstatus flag is set to true.

### Bugs Fixed ###

- none

### API Changes ###

none


Changed:
 The way we calculate the height for the navigationbar.
 Adds padding to the navigationbar
Changes are only made if TransluscentStatus = true

### Behavioral Changes ###

Now this is possible
https://forums.xamarin.com/discussion/comment/293844/#Comment_293844
by adding this is MainActivity
```
 Window.AddFlags(WindowManagerFlags.TranslucentStatus);
```

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X ] Rebased on top of master at time of PR
- [ X] Changes adhere to coding standard
- [ X] Consolidate commits as makes sense
