### PR TITLE
[android] fix binding warnings from FormsViewGroup

### DIFF
--- a/Xamarin.Forms.Platform.Android.FormsViewGroup/Xamarin.Forms.Platform.Android.FormsViewGroup.csproj
+++ b/Xamarin.Forms.Platform.Android.FormsViewGroup/Xamarin.Forms.Platform.Android.FormsViewGroup.csproj
@@ -52,6 +52,7 @@
     <Reference Include="Mono.Android" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs">


### PR DESCRIPTION
### Description of Change ###

Building Xamarin.Forms gives warnings such as:
```
BINDINGSGENERATOR (0, 0)
BINDINGSGENERATOR(0,0): Warning BG8800: Unknown parameter type
System.Xml.XmlReader in method CreateFromXml in managed type
Android.Content.Res.ColorStateList.
BINDINGSGENERATOR (0, 0)
BINDINGSGENERATOR(0,0): Warning BG8800: Unknown parameter type
System.Xml.XmlReader in method CreateFromXml in managed type
Android.Content.Res.ColorStateList.
BINDINGSGENERATOR (0, 0)
BINDINGSGENERATOR(0,0): Warning BG8800: Unknown parameter type
System.Xml.XmlReader in method ParseBundleExtras in managed type
Android.Content.Res.Resources.
BINDINGSGENERATOR (0, 0)
BINDINGSGENERATOR(0,0): Warning BG8800: Unknown parameter type
System.Xml.XmlReader in method CreateFromXml in managed type
Android.Graphics.Drawables.Drawable.
```

For now you can just add a reference to System.Xml to fix this.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

Unit tests are probably not needed here.

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
