### PR TITLE
[Android] Fix NRE when page is being disposed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59097.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59097.cs
@@ -1,0 +1,49 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 59097, "[Android] Calling PopAsync via TapGestureRecognizer causes an application crash", PlatformAffected.Android)]
+	public class Bugzilla59097 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			Navigation.PushAsync(new ContentPage { Content = new Label { Text = "previous page " } });
+			Navigation.PushAsync(new ToPopPage());
+		}
+
+		public class ToPopPage : ContentPage
+		{
+			public ToPopPage()
+			{
+				var boxView = new BoxView { WidthRequest = 100, HeightRequest = 100, Color = Color.Red, AutomationId = "boxView" };
+				var tapGesture = new TapGestureRecognizer { NumberOfTapsRequired = 1, Command = new Command(PopPageBack) };
+				boxView.GestureRecognizers.Add(tapGesture);
+				var layout = new StackLayout();
+				layout.Children.Add(boxView);
+				Content = layout;
+			}
+
+			async void PopPageBack(object obj)
+			{
+				await Navigation.PopAsync(true);
+			}
+		}
+
+
+#if UITEST
+		[Test]
+		public void Bugzilla59097Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("boxView"));
+			RunningApp.Tap(q => q.Marked("boxView"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -318,6 +318,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzila57749.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollViewObjectDisposed.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58645.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59097.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
+++ b/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
@@ -179,6 +179,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool HasDoubleTapHandler()
 		{
+			if (_tapGestureRecognizers == null)
+				return false;
 			return _tapGestureRecognizers(2).Any();
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Fix NRE when page is being disposed 

needs to be on 2.4.0

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=59097

### API Changes ###

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
