### PR TITLE
[UWP] Center Image when Aspect is Aspect.Fit (Bug 58987)

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/ImageRenderer.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			}
 
 			Control.Stretch = GetStretch(Element.Aspect);
-			if (Element.Aspect == Aspect.AspectFill) // Then Center Crop
+			if (Element.Aspect == Aspect.AspectFill || Element.Aspect == Aspect.AspectFit) // Then Center Crop
 			{
 				Control.HorizontalAlignment = HorizontalAlignment.Center;
 				Control.VerticalAlignment = VerticalAlignment.Center;


### PR DESCRIPTION
### Description of Change ###

Added Aspect.AspectFit to the aspect ratios that will center the image in the containing view.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=58987

### API Changes ###

Changed:
 - Xamarin.Forms.Platform.UWP.ImageRenderer.UpdateAspect 

### Behavioral Changes ###

This will center an Image in UWP when the image uses all of the default layout options, i.e. only an ImageSource is set, everything else is default. Before this PR, the image would be centered by default on Android and iOS but left or top aligned on UWP. 

### PR Checklist ###
 My first PR so forgive me if I am not sure how to properly do 1, 2, and 4
- [ ] Has tests (if omitted, state reason in description)
Not sure best way to test this. 
- [ ] Rebased on top of master at time of PR
- [*] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense