### PR TITLE
[Android] Run gesture code on OnTouchEvent

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57515.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57515.cs
@@ -1,0 +1,109 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 57515, "PinchGestureRecognizer not getting called on Android ", PlatformAffected.Android)]
+	public class Bugzilla57515 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			Content = new PinchToZoomContainer
+			{
+				Content = new Image
+				{
+					Source = ImageSource.FromFile("oasis.jpg")
+				}
+			};
+		}
+
+		class PinchToZoomContainer : ContentView
+		{
+			double currentScale = 1;
+			double startScale = 1;
+			double xOffset = 0;
+			double yOffset = 0;
+
+			public PinchToZoomContainer()
+			{
+				var pinchGesture = new PinchGestureRecognizer();
+				pinchGesture.PinchUpdated += OnPinchUpdated;
+				GestureRecognizers.Add(pinchGesture);
+			}
+
+			void OnPinchUpdated(object sender, PinchGestureUpdatedEventArgs e)
+			{
+				if (e.Status == GestureStatus.Started)
+				{
+					// Store the current scale factor applied to the wrapped user interface element,
+					// and zero the components for the center point of the translate transform.
+					startScale = Content.Scale;
+					Content.AnchorX = 0;
+					Content.AnchorY = 0;
+				}
+				if (e.Status == GestureStatus.Running)
+				{
+					// Calculate the scale factor to be applied.
+					currentScale += (e.Scale - 1) * startScale;
+					currentScale = Math.Max(1, currentScale);
+
+					// The ScaleOrigin is in relative coordinates to the wrapped user interface element,
+					// so get the X pixel coordinate.
+					double renderedX = Content.X + xOffset;
+					double deltaX = renderedX / Width;
+					double deltaWidth = Width / (Content.Width * startScale);
+					double originX = (e.ScaleOrigin.X - deltaX) * deltaWidth;
+
+					// The ScaleOrigin is in relative coordinates to the wrapped user interface element,
+					// so get the Y pixel coordinate.
+					double renderedY = Content.Y + yOffset;
+					double deltaY = renderedY / Height;
+					double deltaHeight = Height / (Content.Height * startScale);
+					double originY = (e.ScaleOrigin.Y - deltaY) * deltaHeight;
+
+					// Calculate the transformed element pixel coordinates.
+					double targetX = xOffset - (originX * Content.Width) * (currentScale - startScale);
+					double targetY = yOffset - (originY * Content.Height) * (currentScale - startScale);
+
+					// Apply translation based on the change in origin.
+					Content.TranslationX = targetX.Clamp(-Content.Width * (currentScale - 1), 0);
+					Content.TranslationY = targetY.Clamp(-Content.Height * (currentScale - 1), 0);
+
+					// Apply scale factor
+					Content.Scale = currentScale;
+				}
+				if (e.Status == GestureStatus.Completed)
+				{
+					// Store the translation delta's of the wrapped user interface element.
+					xOffset = Content.TranslationX;
+					yOffset = Content.TranslationY;
+				}
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla57515Test()
+		{
+			RunningApp.Screenshot ("I am at Issue 1");
+			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
+			RunningApp.Screenshot ("I see the Label");
+		}
+#endif
+	}
+
+	public static class DoubleExtensions
+	{
+		public static double Clamp(this double self, double min, double max)
+		{
+			return Math.Min(max, Math.Max(self, min));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57515.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57515.cs
@@ -17,8 +17,10 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			Content = new PinchToZoomContainer
 			{
+				AutomationId = "zoomContainer",
 				Content = new Image
 				{
+					AutomationId = "zoomImg",
 					Source = ImageSource.FromFile("oasis.jpg")
 				}
 			};
@@ -92,9 +94,13 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla57515Test()
 		{
-			RunningApp.Screenshot ("I am at Issue 1");
-			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
-			RunningApp.Screenshot ("I see the Label");
+			
+			var img = RunningApp.Query("zoomImg")[0];
+			var rect1 = img.Rect;
+			RunningApp.PinchToZoomIn(c => c.Marked("zoomContainer"));
+			var img2 = RunningApp.Query("zoomImg")[0];
+			var rect2 = img2.Rect;
+			Assert.LessOrEqual(rect2.X, rect1.X);
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -318,6 +318,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzila57749.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollViewObjectDisposed.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58645.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57515.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -100,6 +100,11 @@ namespace Xamarin.Forms.Platform.Android
 			return base.OnInterceptTouchEvent(ev);
 		}
 
+		public override bool OnTouchEvent(MotionEvent e)
+		{
+			return (this as IOnTouchListener).OnTouch(this,e);
+		}
+
 		bool AView.IOnTouchListener.OnTouch(AView v, MotionEvent e)
 		{
 			if (!Element.IsEnabled)


### PR DESCRIPTION
### Description of Change ###

When we had some fixes for InputTransparent we regressed a issue with gestures.. #808 

Seems that shortcutting the OnTouchEvent on de DefaultRenderer isn't firing the method `IOnTouchListener.OnTouch` where we have the code to handle Gestures. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=57515


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense