### PR TITLE
Better XF .targets errors reporting

### DIFF
--- a/.nuspec/Xamarin.Forms.Debug.targets
+++ b/.nuspec/Xamarin.Forms.Debug.targets
@@ -1,83 +1,27 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.XamlGTask" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
-	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.XamlCTask" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
 	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.DebugXamlCTask" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
-	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.FixedCreateCSharpManifestResourceName" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
+
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.targets" />
 
 	<PropertyGroup>
-		<CoreCompileDependsOn>
-			XamlG;
-			$(CoreCompileDependsOn);
-		</CoreCompileDependsOn>
+		<XFKeepXamlResources>True</XFKeepXamlResources>
+		<XFVerbosity>4</XFVerbosity>
 	</PropertyGroup>
 
 	<PropertyGroup>
 		<CompileDependsOn>
 			$(CompileDependsOn);
-			XamlC;
 			GenerateDebugCode;
 		</CompileDependsOn>
 	</PropertyGroup>
-
-	<Target Name="UpdateDesignTimeXaml" DependsOnTargets="XamlG"/>
-
-	<Target Name="XamlG" DependsOnTargets="$(XamlGDependsOn)"/>
-
-	<PropertyGroup>
-		<XamlGDependsOn>
-			_PreXamlG;
-			_CollectXamlFiles;
-			_CoreXamlG;
-		</XamlGDependsOn>
-	</PropertyGroup>
-
-	<Target Name="_PreXamlG">
-		<MakeDir Directories="$(IntermediateOutputPath)"/>
-	</Target>
-
-	<Target Name="_CollectXamlFiles">
-		<ItemGroup>
-			<_XamlResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.xaml' AND '$(DefaultLanguageSourceExtension)' == '.cs'"/>
-		</ItemGroup>
-		<FixedCreateCSharpManifestResourceName ResourceFiles="@(_XamlResources)" RootNamespace="$(RootNamespace)">
-			<Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="XamlFiles" />
-		</FixedCreateCSharpManifestResourceName>
-		<ItemGroup>
-			<XamlGFiles Include="@(XamlFiles->'$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)')"/>
-			<Compile Include="@(XamlGFiles)"/>
-			<FileWrites Include="@(XamlGFiles)"/>
-		</ItemGroup>
-	</Target>
-
-	<Target Name="_CoreXamlG"
-		Inputs = "@(XamlFiles)"
-		Outputs = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
-		<XamlGTask
-			Source="@(XamlFiles)"
-			Language = "$(Language)"
-			AssemblyName = "$(AssemblyName)"
-			OutputFile = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
-		</XamlGTask>
-	</Target>
 
 	<!-- duplicate legacy InitializeComponent, create a ctor with bool param -->
 	<Target Name="GenerateDebugCode">
 		<DebugXamlCTask 
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
-			Verbosity = "4"
+			Verbosity = "$(XFVerbosity)"
 			DebugSymbols = "$(DebugSymbols)"
 			DebugType = "$(DebugType)"/>
-	</Target>
-
-	<Target Name="XamlC">
-		<XamlCTask
-			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
-			ReferencePath = "@(ReferencePath)"
-			DebugSymbols = "$(DebugSymbols)"
-			DebugType = "$(DebugType)"
-			Verbosity = "4"
-			KeepXamlResources = "true"
-			OptimizeIL = "true" />
 	</Target>
 </Project>

--- a/.nuspec/Xamarin.Forms.Debug.targets
+++ b/.nuspec/Xamarin.Forms.Debug.targets
@@ -1,12 +1,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.DebugXamlCTask" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.targets" />
-
 	<PropertyGroup>
 		<XFKeepXamlResources>True</XFKeepXamlResources>
 		<XFVerbosity>4</XFVerbosity>
 	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.targets" />
 
 	<PropertyGroup>
 		<CompileDependsOn>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -1,7 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.XamlGTask" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
-	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.FixedCreateCSharpManifestResourceName" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
 	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.XamlCTask" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
+	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.FixedCreateCSharpManifestResourceName" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
+	<UsingTask TaskName="Xamarin.Forms.Build.Tasks.GetTasksAbi" AssemblyFile="Xamarin.Forms.Build.Tasks.dll"/>
 
 	<PropertyGroup>
 		<EnableDefaultXamlItems Condition="'$(EnableDefaultXamlItems)'==''">True</EnableDefaultXamlItems>
@@ -17,18 +18,18 @@
 			$(CoreCompileDependsOn);
 		</CoreCompileDependsOn>
 	</PropertyGroup>
-  
+
 	<PropertyGroup>
 		<CompileDependsOn>
 			$(CompileDependsOn);
 			XamlC;
 		</CompileDependsOn>
 	</PropertyGroup>
-  
+
 	<Target Name="UpdateDesignTimeXaml" DependsOnTargets="XamlG"/>
-  
+
 	<Target Name="XamlG" DependsOnTargets="$(XamlGDependsOn)"/>
-  
+
 	<PropertyGroup>
 		<XamlGDependsOn>
 			_PreXamlG;
@@ -36,7 +37,32 @@
 			_CoreXamlG;
 		</XamlGDependsOn>
 	</PropertyGroup>
-  
+
+	<PropertyGroup>
+		<_XFTargetsImportedAgain Condition="'$(_XFTargetsImported)'=='True'">True</_XFTargetsImportedAgain>
+		<_XFTargetsImported>True</_XFTargetsImported>
+	</PropertyGroup>
+
+	<Target Name="_ValidateXFTasks" BeforeTargets="_CheckForInvalidConfigurationAndPlatform" Condition="'$(XFDisableTargetsValidation)' != 'True'">
+		<Error
+			Text="Xamarin.Forms targets have been imported multiple times. Please check your project file and remove the duplicate import(s)."
+			Code="XF001"
+			Condition="'$(_XFTargetsImportedAgain)' == 'True'" />
+
+		<GetTasksAbi>
+			<Output TaskParameter="AbiVersion" PropertyName="_XFTasksAbi" />
+		</GetTasksAbi >
+
+		<PropertyGroup>
+			<_XFTasksExpectedAbi>1</_XFTasksExpectedAbi>
+		</PropertyGroup>
+
+		<Error
+			Text="Xamarin.Forms tasks do not match targets. Please ensure that all projects reference the same version of Xamarin.Forms, and if the error persists, please restart the IDE."
+			Code="XF002"
+			Condition="'$(_XFTasksAbi)' != '$(_XFTasksExpectedAbi)'" />
+	</Target>
+
 	<Target Name="_PreXamlG">
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 	</Target>
@@ -54,7 +80,7 @@
 			<FileWrites Include="@(XamlGFiles)"/>
 		</ItemGroup>
 	</Target>
-  
+
 	<Target Name="_CoreXamlG"
 		Inputs = "@(XamlFiles)"
 		Outputs = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
@@ -65,14 +91,19 @@
 			OutputFile = "$(IntermediateOutputPath)%(ManifestResourceName).g$(DefaultLanguageSourceExtension)">
 		</XamlGTask>
 	</Target>
-  
+
+	<PropertyGroup>
+		<XFVerbosity Condition="'$(XFVerbosity)' == ''">2</XFVerbosity>
+	</PropertyGroup>
+
 	<Target Name="XamlC">
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
-			Verbosity = "2"
+			Verbosity = "$(XFVerbosity)"
 			OptimizeIL = "true"
 			DebugSymbols = "$(DebugSymbols)"
-			DebugType = "$(DebugType)"/>
+			DebugType = "$(DebugType)"
+			KeepXamlResources = "$(XFKeepXamlResources)" />
 	</Target>
 </Project>

--- a/PagesGallery/PagesGallery.UWP/PagesGallery.UWP.csproj
+++ b/PagesGallery/PagesGallery.UWP/PagesGallery.UWP.csproj
@@ -19,6 +19,7 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageCertificateKeyFile>Xamarin.Forms.ControlGallery.WindowsUniversal_TemporaryKey.pfx</PackageCertificateKeyFile>
     <PackageCertificateThumbprint>D160433BDC22781DEAE0558325140B91C02A6A20</PackageCertificateThumbprint>
+    <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>

--- a/PagesGallery/PagesGallery/PagesGallery.csproj
+++ b/PagesGallery/PagesGallery/PagesGallery.csproj
@@ -16,6 +16,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Build.Tasks/GetTasksAbi.cs
+++ b/Xamarin.Forms.Build.Tasks/GetTasksAbi.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Forms.Build.Tasks
+{
+	public class GetTasksAbi : Task
+	{
+		[Output]
+		public string AbiVersion { get; } = "1";
+
+		public override bool Execute()
+			=> true;
+	}
+}

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -111,6 +111,7 @@
     <Compile Include="CompiledConverters\ListStringTypeConverter.cs" />
     <Compile Include="CompiledMarkupExtensions\TypeExtension.cs" />
     <Compile Include="CompiledMarkupExtensions\NullExtension.cs" />
+    <Compile Include="GetTasksAbi.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -18,6 +18,7 @@
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -10,6 +10,7 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
### Description of Change ###

Generate errors at build if:
- multiple `Xamarin.Forms.targets` files are referenced
- the version of the `.targets` doesn't match the `Tasks.dll`

Note that this, as itself, is an ABI change and will generate its own lot of bug reports...

This PR was manually tested. No monkey was harmed during this process.

### Bugs Fixed ###

None. But will help debug user issues in the future.

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense