### PR TITLE
Allow duplicate issue numbers per tracker

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53179.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53179.cs
@@ -9,7 +9,8 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 53179, "PopAsync crashing after RemovePage when support packages are updated to 25.1.1", PlatformAffected.Android)]
+	[Issue(IssueTracker.Bugzilla, 53179, 
+		"PopAsync crashing after RemovePage when support packages are updated to 25.1.1", PlatformAffected.Android)]
 	public class Bugzilla53179 : TestNavigationPage
 	{
 		class TestPage : ContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53179_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53179_1.cs
@@ -14,10 +14,10 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.None, 0101100101, 
+	[Issue(IssueTracker.Bugzilla, 53179, 
 		"PopAsync crashing after RemovePage when support packages are updated to 25.1.1",
-		PlatformAffected.Android)]
-	public class PopAfterRemove : TestNavigationPage
+		PlatformAffected.Android, issueTestNumber: 1)]
+	public class Bugzilla53179_1 : TestNavigationPage
 	{
 		ContentPage _intermediate1;
 		ContentPage _intermediate2;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53179_2.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53179_2.cs
@@ -15,8 +15,9 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.None, 1134, "Removing page during OnAppearing throws exception", PlatformAffected.Android)]
-	public class RemovePageOnAppearing : TestContentPage
+	[Issue(IssueTracker.Bugzilla, 53179, "Removing page during OnAppearing throws exception", PlatformAffected.Android,
+		issueTestNumber: 2)]
+	public class Bugzilla53179_2 : TestContentPage
 	{
 		const string Success = "Success";
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Controls
 				typeIssueAttribute.IssueNumber != 1461 &&
 				typeIssueAttribute.IssueNumber != 342)
 			{
-				cellName = typeIssueAttribute.IssueTracker.ToString().Substring(0, 1) + typeIssueAttribute.IssueNumber.ToString();
+				cellName = typeIssueAttribute.DisplayName;
 			}
 			else {
 				cellName = typeIssueAttribute.Description;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -271,13 +271,13 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39829.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)RemovePageOnAppearing.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53179_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollViewIsEnabled.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PlatformSpecifics_iOSTranslucentNavBarX.xaml.cs">
       <DependentUpon>PlatformSpecifics_iOSTranslucentNavBarX.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)PopAfterRemove.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53179_1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPages\ScreenshotConditionalApp.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41842.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42277.cs" />

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -48,33 +48,44 @@ namespace Xamarin.Forms.CustomAttributes
 	{
 		bool _modal;
 
-		public IssueAttribute (IssueTracker issueTracker, int issueNumber, string description, NavigationBehavior navigationBehavior = NavigationBehavior.Default)
+		public IssueAttribute (IssueTracker issueTracker, int issueNumber, string description, 
+			NavigationBehavior navigationBehavior = NavigationBehavior.Default, int issueTestNumber = 0)
 		{
 			IssueTracker = issueTracker;
 			IssueNumber = issueNumber;
 			Description = description;
 			PlatformsAffected = PlatformAffected.Default;
 			NavigationBehavior = navigationBehavior;
+			IssueTestNumber = issueTestNumber;
 		}
 
-		public IssueAttribute (IssueTracker issueTracker, int issueNumber, string description, PlatformAffected platformsAffected, NavigationBehavior navigationBehavior = NavigationBehavior.Default)
+		public IssueAttribute (IssueTracker issueTracker, int issueNumber, string description, 
+			PlatformAffected platformsAffected, NavigationBehavior navigationBehavior = NavigationBehavior.Default, 
+			int issueTestNumber = 0)
 		{
 			IssueTracker = issueTracker;
 			IssueNumber = issueNumber;
 			Description = description;
 			PlatformsAffected = platformsAffected;
 			NavigationBehavior = navigationBehavior;
+			IssueTestNumber = issueTestNumber;
 		}
 
 		public IssueTracker IssueTracker { get; }
 
 		public int IssueNumber { get; }
 
+		public int IssueTestNumber { get; }
+
 		public string Description { get; }
 
 		public PlatformAffected PlatformsAffected { get; }
 
 		public NavigationBehavior NavigationBehavior { get; }
+
+		public string DisplayName => IssueTestNumber == 0
+			? $"{IssueTracker.ToString().Substring(0, 1)}{IssueNumber}"
+			: $"{IssueTracker.ToString().Substring(0, 1)}{IssueNumber} ({IssueTestNumber})";
 	}
 
 	[Conditional ("DEBUG")]


### PR DESCRIPTION
### Description of Change ###

The way the UI test navigation in Control Gallery works has historically required a single issue number per tracker (e.g., `Bugzilla` and `53179`). When a single tracker ticker requires multiple tests with multiple test pages, we can't track each one against that issue number because it breaks the Control Gallery. So we end up with other test classes which don't bear a clear relationship to the tracked issue. See https://bugzilla.xamarin.com/show_bug.cgi?id=53179#c68 and https://bugzilla.xamarin.com/show_bug.cgi?id=53179#c71 for an example. 

This change allows multiple test pages to track against the same tracker/issue number combination; it provides an additional option attribute value `issueTestNumber`; uniqueness is now enforced on tracker/issue/issueTestNumber. 

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=53179#c71

### API Changes ###

None

### Behavioral Changes ###

None 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
