### PR TITLE
[Core] Removed rounding in AbsoluteLayout

### DIFF
--- a/Xamarin.Forms.Core/AbsoluteLayout.cs
+++ b/Xamarin.Forms.Core/AbsoluteLayout.cs
@@ -224,7 +224,7 @@ namespace Xamarin.Forms
 
 			if (widthIsProportional)
 			{
-				result.Width = Math.Round(region.Width * bounds.Width);
+				result.Width = region.Width * bounds.Width;
 			}
 			else if (bounds.Width != AutoSize)
 			{
@@ -233,7 +233,7 @@ namespace Xamarin.Forms
 
 			if (heightIsProportional)
 			{
-				result.Height = Math.Round(region.Height * bounds.Height);
+				result.Height = region.Height * bounds.Height;
 			}
 			else if (bounds.Height != AutoSize)
 			{
@@ -265,7 +265,7 @@ namespace Xamarin.Forms
 
 			if (xIsProportional)
 			{
-				result.X = Math.Round((region.Width - result.Width) * bounds.X);
+				result.X = (region.Width - result.Width) * bounds.X;
 			}
 			else
 			{
@@ -274,7 +274,7 @@ namespace Xamarin.Forms
 
 			if (yIsProportional)
 			{
-				result.Y = Math.Round((region.Height - result.Height) * bounds.Y);
+				result.Y = (region.Height - result.Height) * bounds.Y;
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change ###
Removed rounding in AbsoluteLayout to ensure Android devices with certain sizes can still use proportional sizes to fill the device screen.

### Bugs Fixed ###
[https://bugzilla.xamarin.com/show_bug.cgi?id=40092]( https://bugzilla.xamarin.com/show_bug.cgi?id=40092)

### API Changes ###
None

### Behavioral Changes ###

People who previously had a 1px gap when using AbosluteLayouts with proportional x,y,width,height on Android will now potentially have their layouts become 1px different in size or position on certain devices. This shouldn't be a breaking change as previously they would have had a white line instead.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
