### PR TITLE
Prevent possible crash when Picker is unfocused in FormsApplicationActivity

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -142,7 +142,7 @@ namespace Xamarin.Forms.Platform.Android
 			_dialog = builder.Create();
 			_dialog.DismissEvent += (sender, args) =>
 			{
-				ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
+				ElementController?.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 			};
 			_dialog.Show();
 		}


### PR DESCRIPTION
### Description of Change ###

This fixes a regression on Android pre-AppCompat where an app would crash if the Page's Content changed when a Picker was unfocused. No additional tests added since this was caught by existing ones.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=36681

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
