### PR TITLE
[Evolution] Merged Dictionaries

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
@@ -125,13 +125,20 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 			}
 
-			//Set ResourcesDictionaries to their parents
+			//Set ResourcesDictionaries to their parents and MergedDictionaries
 			XmlName propertyName;
-			if (SetPropertiesVisitor.TryGetPropertyName(node, parentNode, out propertyName) &&
-			    (propertyName.LocalName == "Resources" || propertyName.LocalName.EndsWith(".Resources", StringComparison.Ordinal)) &&
-				(Context.Variables[node].VariableType.FullName == "Xamarin.Forms.ResourceDictionary" ||
-					Context.Variables[node].VariableType.Resolve().BaseType.FullName == "Xamarin.Forms.ResourceDictionary"))
+			if (SetPropertiesVisitor.TryGetPropertyName(node, parentNode, out propertyName)) {
+				if ((propertyName.LocalName == "Resources" || propertyName.LocalName == "MergedDictionaries" || propertyName.LocalName.EndsWith(".Resources", StringComparison.Ordinal)) &&
+				(Context.Variables[node].VariableType.FullName == "Xamarin.Forms.ResourceDictionary" || Context.Variables[node].VariableType.Resolve().BaseType.FullName == "Xamarin.Forms.ResourceDictionary"))
 				Context.IL.Append(SetPropertiesVisitor.SetPropertyValue(Context.Variables[(IElementNode)parentNode], propertyName, node, Context, node));
+			}
+
+			if (IsCollectionItem(node, parentNode) && parentNode is IListNode) {
+				if (SetPropertiesVisitor.TryGetPropertyName(parentNode, parentNode.Parent, out propertyName) && propertyName.LocalName == "MergedDictionaries") {
+					Context.IL.Append(SetPropertiesVisitor.SetPropertyValue(Context.Variables[(IElementNode)parentNode.Parent], propertyName, node, Context, node));
+				}
+			}
+
 		}
 
 		public void Visit(RootNode node, INode parentNode)

--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -348,7 +348,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TryGetValueLookupInMerged()
 		{
-			var rd = new ResourceDictionary { 
+			var rd = new ResourceDictionary {
 				{"baz", "BAZ"},
 				{"qux", "QUX"},
 			};
@@ -357,6 +357,58 @@ namespace Xamarin.Forms.Core.UnitTests
 			object _;
 			Assert.That(rd.TryGetValue("foo", out _), Is.True);
 			Assert.That(rd.TryGetValue("baz", out _), Is.True);
-}
+		}
+
+		[Test]
+		public void MergedDictionaryResourcesAreFound()
+		{
+			var rd0 = new ResourceDictionary();
+			rd0.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar" } });
+
+			object value;
+			Assert.True(rd0.TryGetValue("foo", out value));
+			Assert.AreEqual("bar", value);
+		}
+
+		[Test]
+		public void MergedDictionaryResourcesAreFoundLastDictionaryTakesPriority()
+		{
+			var rd0 = new ResourceDictionary();
+			rd0.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar" } });
+			rd0.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar1" } });
+			rd0.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar2" } });
+
+			object value;
+			Assert.True(rd0.TryGetValue("foo", out value));
+			Assert.AreEqual("bar2", value);
+		}
+
+		[Test]
+		public void CountDoesNotIncludeMergedDictionaries()
+		{
+			var rd = new ResourceDictionary {
+				{"baz", "Baz"},
+				{"qux", "Qux"},
+			};
+			rd.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar" } });
+
+			Assert.That(rd.Count, Is.EqualTo(2));
+		}
+
+		[Test]
+		public void ClearMergedDictionaries()
+		{
+			var rd = new ResourceDictionary {
+				{"baz", "Baz"},
+				{"qux", "Qux"},
+			};
+			rd.MergedDictionaries.Add(new ResourceDictionary() { { "foo", "bar" } });
+
+			Assert.That(rd.Count, Is.EqualTo(2));
+
+			rd.MergedDictionaries.Clear();
+
+			Assert.That(rd.MergedDictionaries.Count, Is.EqualTo(0));
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NUnit.Framework;
 using System.Collections.Generic;
 using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -409,6 +410,62 @@ namespace Xamarin.Forms.Core.UnitTests
 			rd.MergedDictionaries.Clear();
 
 			Assert.That(rd.MergedDictionaries.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void AddingMergedRDTriggersValueChanged()
+		{
+			var rd = new ResourceDictionary();
+			var label = new Label {
+				Resources = rd
+			};
+			label.SetDynamicResource(Label.TextProperty, "foo");
+			Assert.That(label.Text, Is.EqualTo(Label.TextProperty.DefaultValue));
+
+			rd.MergedDictionaries.Add(new ResourceDictionary { { "foo", "Foo"} });
+			Assert.That(label.Text, Is.EqualTo("Foo"));
+		}
+
+		[Test]
+		//this is to keep the alignment with resources removed from RD
+		public void RemovingMergedRDDoesntTriggersValueChanged()
+		{
+			var rd = new ResourceDictionary {
+				MergedDictionaries = {
+					new ResourceDictionary {
+						{ "foo", "Foo" }
+					}
+				}
+			};
+			var label = new Label {
+				Resources = rd,
+			};
+
+			label.SetDynamicResource(Label.TextProperty, "foo");
+			Assert.That(label.Text, Is.EqualTo("Foo"));
+
+			rd.MergedDictionaries.Clear();
+			Assert.That(label.Text, Is.EqualTo("Foo"));
+		}
+
+		[Test]
+		public void AddingResourceInMergedRDTriggersValueChanged()
+		{
+			var rd0 = new ResourceDictionary ();
+			var rd = new ResourceDictionary {
+				MergedDictionaries = {
+					rd0
+				}
+			};
+
+			var label = new Label {
+				Resources = rd,
+			};
+			label.SetDynamicResource(Label.TextProperty, "foo");
+			Assert.That(label.Text, Is.EqualTo(Label.TextProperty.DefaultValue));
+
+			rd0.Add("foo", "Foo");
+			Assert.That(label.Text, Is.EqualTo("Foo"));
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/MergedResourceDictionaries.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/MergedResourceDictionaries.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.MergedResourceDictionaries">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <local:SharedResourceDictionary/>
+                <ResourceDictionary MergedWith="local:SharedResourceDictionary2"/>
+            </ResourceDictionary.MergedDictionaries>
+            <x:String x:Key="foo">Foo</x:String>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <StackLayout>
+        <Label
+            x:Name="label0"
+            Style="{StaticResource sharedfoo}"
+            Text="{StaticResource foo}"
+            BackgroundColor="{StaticResource AlmostBlack}"/>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/MergedResourceDictionaries.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MergedResourceDictionaries.xaml.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class MergedResourceDictionaries : ContentPage
+	{
+		public MergedResourceDictionaries()
+		{
+			InitializeComponent();
+		}
+
+		public MergedResourceDictionaries(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void MergedResourcesAreFound(bool useCompiledXaml)
+			{
+				MockCompiler.Compile(typeof(MergedResourceDictionaries));
+				var layout = new MergedResourceDictionaries(useCompiledXaml);
+				Assert.That(layout.label0.Text, Is.EqualTo("Foo"));
+				Assert.That(layout.label0.TextColor, Is.EqualTo(Color.Pink));
+				Assert.That(layout.label0.BackgroundColor, Is.EqualTo(Color.FromHex("#111")));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/SharedResourceDictionary2.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/SharedResourceDictionary2.xaml
@@ -1,6 +1,8 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.SharedResourceDictionary2">
 	<Style x:Key="sharedStyle2" TargetType="Label">
 		<Setter Property="TextColor" Value="Purple"/>
 	</Style>
+    <Color x:Key="AlmostBlack">#111</Color>
+
 </ResourceDictionary>

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -500,7 +500,10 @@
       <DependentUpon>Bz57574.xaml</DependentUpon>
     </Compile>
     <Compile Include="Issues\Bz58922.xaml.cs">
-			<DependentUpon>Bz58922.xaml</DependentUpon>
+      <DependentUpon>Bz58922.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="MergedResourceDictionaries.xaml.cs" >
+      <DependentUpon>MergedResourceDictionaries.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -919,7 +922,10 @@
     <EmbeddedResource Include="Issues\Bz58922.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-	</ItemGroup>
+    <EmbeddedResource Include="MergedResourceDictionaries.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
+++ b/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
@@ -44,7 +44,6 @@ namespace Xamarin.Forms.Xaml
 					return;
 				ApplyPropertiesVisitor.SetPropertyValue(source, propertyName, value, Context.RootElement, node, Context, node);
 			}
-
 		}
 
 		public void Visit(MarkupNode node, INode parentNode)
@@ -105,7 +104,7 @@ namespace Xamarin.Forms.Xaml
 			if (ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out propertyName))
 			{
 				if ((propertyName.LocalName == "Resources" ||
-					 propertyName.LocalName == "MergedDictionaries" ||
+				     propertyName.LocalName == "MergedDictionaries" ||
 					 propertyName.LocalName.EndsWith(".Resources", StringComparison.Ordinal)) && value is ResourceDictionary)
 				{
 					var source = Values[parentNode];

--- a/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
+++ b/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml.Internals;
 
@@ -106,10 +105,23 @@ namespace Xamarin.Forms.Xaml
 			if (ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out propertyName))
 			{
 				if ((propertyName.LocalName == "Resources" ||
-				     propertyName.LocalName.EndsWith(".Resources", StringComparison.Ordinal)) && value is ResourceDictionary)
+					 propertyName.LocalName == "MergedDictionaries" ||
+					 propertyName.LocalName.EndsWith(".Resources", StringComparison.Ordinal)) && value is ResourceDictionary)
 				{
 					var source = Values[parentNode];
 					ApplyPropertiesVisitor.SetPropertyValue(source, propertyName, value, Context.RootElement, node, Context, node);
+				}
+			}
+
+			//Add ResourceDictionary into MergedDictionaries
+			XmlName parentPropertyName;
+			if (parentNode is IListNode && ApplyPropertiesVisitor.TryGetPropertyName(parentNode, parentNode.Parent, out parentPropertyName))
+			{
+				if (parentPropertyName.LocalName == "MergedDictionaries")
+				{
+					var source = Values[parentNode.Parent];
+					node.Parent = node.Parent.Parent;
+					ApplyPropertiesVisitor.SetPropertyValue(source, parentPropertyName, value, Context.RootElement, node, Context, node);
 				}
 			}
 		}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
@@ -246,6 +246,22 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="MergedDictionaries">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.ICollection&lt;Xamarin.Forms.ResourceDictionary&gt; MergedDictionaries { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.ICollection`1&lt;class Xamarin.Forms.ResourceDictionary&gt; MergedDictionaries" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.ICollection&lt;Xamarin.Forms.ResourceDictionary&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="MergedWith">
       <MemberSignature Language="C#" Value="public Type MergedWith { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class System.Type MergedWith" />


### PR DESCRIPTION
**NOTE0: this PR replaces #869**
**NOTE1: Do not squash merge to preserve author information. Thanks**

### Description of Change ###

The addition of Multiple MergedDictionaries into ResourceDictionary, as discussed in the Evolution forum: https://forums.xamarin.com/discussion/86308/multiple-merged-dictionaries. Allows multiple ResourceDictionaries to be added to the VisualElement root Resources property.

### Bugs Fixed ###

- N/A

### API Changes ###

Added:
 - ICollection<ResourceDictionary> MergedDictionaries // In ResourceDictionary.cs

### Behavioral Changes ###

The addition, of adding multiple ResourceDictionaries into a ResourceDictionary. No behavioral changes to existing functionality were made.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

