### PR TITLE
[UWP] Use RawPixelsPerViewPixel for ScalingFactor

### DIFF
--- a/Xamarin.Forms.Platform.UAP/WindowsDeviceInfo.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsDeviceInfo.cs
@@ -45,6 +45,9 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			get
 			{
+#if WINDOWS_UWP
+				return DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+#else
 				ResolutionScale scale = _information.ResolutionScale;
 				switch (scale)
 				{
@@ -64,6 +67,7 @@ namespace Xamarin.Forms.Platform.UWP
 					default:
 						return 1;
 				}
+#endif
 			}
 		}
 

--- a/Xamarin.Forms.Platform.UAP/WindowsDeviceInfo.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsDeviceInfo.cs
@@ -45,29 +45,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			get
 			{
-#if WINDOWS_UWP
-				return DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
-#else
-				ResolutionScale scale = _information.ResolutionScale;
-				switch (scale)
-				{
-					case ResolutionScale.Scale120Percent:
-						return 1.2;
-					case ResolutionScale.Scale140Percent:
-						return 1.4;
-					case ResolutionScale.Scale150Percent:
-						return 1.5;
-					case ResolutionScale.Scale160Percent:
-						return 1.6;
-					case ResolutionScale.Scale180Percent:
-						return 1.8;
-					case ResolutionScale.Scale225Percent:
-						return 2.25;
-					case ResolutionScale.Scale100Percent:
-					default:
-						return 1;
-				}
-#endif
+				return ((int)_information.ResolutionScale) / 100d;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

UWP contains APIs relating to scale that aren't available on 8.1, namely `RawPixelsPerViewPixel` which simplifies getting the return value that we can use for the platform instead of checking `ResolutionScale` values.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=59404

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
