### PR TITLE
[iOS] Can activate ContextActions on ListViews reliably again

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46363.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla46363.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Category(UITestCategories.Gestures)]
 	[Category(UITestCategories.ListView)]
 	[Category(UITestCategories.Cells)]
+	[Category(UITestCategories.ContextActions)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58875.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla58875.cs
@@ -1,0 +1,111 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ListView)]
+	[Category(UITestCategories.ContextActions)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 58875, "Back navigation disables Context Action in whole app, if Context Action left open", PlatformAffected.iOS)]
+	public class Bugzilla58875 : TestNavigationPage
+	{
+		const string Button1Id = "Button1Id";
+		const string ContextAction = "More";
+		const string Target = "Swipe me";
+
+		protected override void Init()
+		{
+			var page1 = new Page1();
+			Navigation.PushAsync(new NavigationPage(page1));
+		}
+
+		[Preserve(AllMembers = true)]
+		class ListViewPage : ContentPage
+		{
+			public ListViewPage()
+			{
+				BindingContext = this;
+
+				var listView = new ListView(ListViewCachingStrategy.RecycleElement)
+				{
+					ItemTemplate = new DataTemplate(() =>
+					{
+						var label = new Label { };
+						label.SetBinding(Label.TextProperty, ".");
+						var viewcell = new ViewCell
+						{
+							View = new StackLayout { Children = { label } }
+						};
+						viewcell.ContextActions.Add(new MenuItem { Text = ContextAction });
+						viewcell.ContextActions.Add(new MenuItem { Text = "Delete", IsDestructive = true });
+						return viewcell;
+					})
+				};
+
+				listView.SetBinding(ListView.ItemsSourceProperty, nameof(Items));
+
+				Items = new ObservableCollection<string> {
+						"Item 1",
+						Target,
+						"Item 3",
+						"Swipe me too, leave me open",
+						"Swipe left -> right (trigger back navigation)"
+				};
+
+				Content = listView;
+			}
+
+			public ObservableCollection<string> Items { get; set; }
+		}
+
+		[Preserve(AllMembers = true)]
+		class Page1 : ContentPage
+		{
+			public Page1()
+			{
+				var button = new Button { Text = "Tap me", AutomationId = Button1Id };
+				button.Clicked += Button_Clicked;
+				Content = button;
+			}
+
+			void Button_Clicked(object sender, System.EventArgs e)
+			{
+				var listPage = new ListViewPage();
+				Navigation.PushAsync(listPage);
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla58875Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(Button1Id));
+			RunningApp.Tap(q => q.Marked(Button1Id));
+			RunningApp.WaitForElement(q => q.Marked(Target));
+			RunningApp.ActivateContextMenu(Target);
+			RunningApp.WaitForElement(q => q.Marked(ContextAction));
+			RunningApp.Back();
+
+#if __ANDROID__
+			RunningApp.Back();
+#endif
+
+			RunningApp.WaitForElement(q => q.Marked(Button1Id));
+			RunningApp.Tap(q => q.Marked(Button1Id));
+			RunningApp.WaitForElement(q => q.Marked(Target));
+			RunningApp.ActivateContextMenu(Target);
+			RunningApp.WaitForElement(q => q.Marked(ContextAction));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -322,6 +322,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ScrollViewObjectDisposed.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58645.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59097.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58875.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -8,6 +8,7 @@
 		public const string BoxView = "BoxView";
 		public const string Button = "Button";
 		public const string Cells = "Cells";
+		public const string ContextActions = "ContextActions";
 		public const string DatePicker = "DatePicker";
 		public const string DisplayAlert = "DisplayAlert";
 		public const string Editor = "Editor";

--- a/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
@@ -203,7 +203,9 @@ namespace Xamarin.Forms.Platform.iOS
 				return false;
 
 			UIScrollView scrollViewBeingScrolled;
-			if (!s_scrollViewBeingScrolled.TryGetTarget(out scrollViewBeingScrolled) || ReferenceEquals(scrollViewBeingScrolled, scrollView) || !ReferenceEquals(((ContextScrollViewDelegate)scrollViewBeingScrolled.Delegate)._table, ((ContextScrollViewDelegate)scrollView.Delegate)._table))
+			if (!s_scrollViewBeingScrolled.TryGetTarget(out scrollViewBeingScrolled) 
+				|| ReferenceEquals(scrollViewBeingScrolled, scrollView) 
+				|| !ReferenceEquals(((ContextScrollViewDelegate)scrollViewBeingScrolled.Delegate)?._table, ((ContextScrollViewDelegate)scrollView.Delegate)?._table))
 				return false;
 
 			scrollView.SetContentOffset(new PointF(0, 0), false);
@@ -221,6 +223,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				ClosedCallback = null;
 
+				s_scrollViewBeingScrolled = null;
 				_table = null;
 				_backgroundView = null;
 				_container = null;


### PR DESCRIPTION
### Description of Change ###

#578 added a static `WeakReference` to the `UIScrollView` to check against and prevent multiple `ContextAction`s from being activated at once. This was not being set to `null` on `Dispose`, so if the `ListView` was on a page that was popped and then pushed again, subsequent attempts to activate `ContextAction`s would fail, since the reference was now out of sync. Now nulling the static `WeakReference` to resolve this.

#885 built upon the original fix in #578, but as Ruddy2007 mentioned in that PR, this change caused possible `NullReferenceException`s. Added null checks to resolve this.

### Bugs Fixed ###

- [Bug 58875 - Back navigation disables Context Action in whole app, if Context Action left open](https://bugzilla.xamarin.com/show_bug.cgi?id=58875)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
