### PR TITLE
[Android] - CanExecuteChanged raises a NullReferenceException

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59580.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59580.cs
@@ -1,0 +1,55 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using System.Linq;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 59580, "Raising Command.CanExecutChanged causes crash on Android",
+		PlatformAffected.Android)]
+	public class Bugzilla59580 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var tableView = new TableView();
+			var tableSection = new TableSection();
+			var switchCell = new TextCell
+			{
+				AutomationId = "Cell",
+				Text = "Cell"
+			};
+
+			var menuItem = new MenuItem
+			{
+				AutomationId = "Fire CanExecuteChanged",
+				Text = "Fire CanExecuteChanged",
+				Command = new DelegateCommand(_ =>
+					((DelegateCommand)switchCell.ContextActions.Single().Command).RaiseCanExecuteChanged()),
+				IsDestructive = true
+			};
+			switchCell.ContextActions.Add(menuItem);
+			tableSection.Add(switchCell);
+			tableView.Root.Add(tableSection);
+			Content = tableView;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue59580Test()
+		{
+			RunningApp.WaitForElement(c => c.Marked("Cell"));
+
+			RunningApp.ActivateContextMenu("Cell");
+
+			RunningApp.WaitForElement(c => c.Marked("Fire CanExecuteChanged"));
+			RunningApp.Tap(c => c.Marked("Fire CanExecuteChanged"));
+			RunningApp.WaitForElement("Cell");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -220,6 +220,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58833.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51427.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59248.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ButtonBackgroundColorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -265,7 +265,8 @@ namespace Xamarin.Forms.Platform.Android
 		void OnContextActionCommandCanExecuteChanged(object sender, EventArgs eventArgs)
 		{
 			_actionModeNeedsUpdates = true;
-			_actionMode.Invalidate();
+			_actionMode?.Invalidate();
+			_supportActionMode?.Invalidate();
 		}
 
 		void OnContextActionPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Added null check in Xamarin.Forms.Platform.Android.CellAdapter and added call to _supportActionMode?.Invalidate()

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=56274

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
