### PR TITLE
[C] Use ReferenceEquals to compare BindingContext **Behavior change**

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindableObjectUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindableObjectUnitTests.cs
@@ -123,6 +123,36 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(count, 1);
 		}
 
+		class MockVMEquals {
+			public string Key { get; set; }
+			public string Text { get; set; }
+			public override bool Equals(object obj)
+			{
+				var other = obj as MockVMEquals;
+				if (other == null)
+					return false;
+				return Key == other.Key;
+			}
+
+			public override int GetHashCode()
+			{
+				return base.GetHashCode();
+			}
+		}
+
+		[Test]
+		//https://bugzilla.xamarin.com/show_bug.cgi?id=59507
+		public void BindingContextChangedCompareReferences()
+		{
+			var mock = new MockBindable();
+			mock.BindingContext = new MockVMEquals { Key = "Foo", Text = "Foo" };
+			mock.BindingContextChanged += (sender, args) => Assert.Pass();
+
+			mock.BindingContext = new MockVMEquals { Key = "Foo", Text = "Bar" };
+
+			Assert.Fail("The BindingContextChanged event was not fired.");
+		}
+
 		[Test]
 		public void ParentAndChildBindingContextChanged()
 		{

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xamarin.Forms.Internals;
 
@@ -552,7 +553,7 @@ namespace Xamarin.Forms
 			bool clearOneWayBindings = (attributes & SetValueFlags.ClearOneWayBindings) != 0;
 			bool clearTwoWayBindings = (attributes & SetValueFlags.ClearTwoWayBindings) != 0;
 
-			bool same = Equals(value, original);
+			bool same = ReferenceEquals(context.Property, BindingContextProperty) ? ReferenceEquals(value, original) : Equals(value, original);
 			if (!silent && (!same || raiseOnEqual))
 			{
 				if (property.PropertyChanging != null)


### PR DESCRIPTION
### Description of Change ###

[C] Use ReferenceEquals to compare BindingContext

This is a breaking behavioral change, but unlikely to affect anyone, and it puts us il line with other platforms supporting bindings.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=59507

### API Changes ###

/

### Behavioral Changes ###

While changing a BindingContext with overridden Equals(), Binding weren't updated. Some people might do that on purpose, but I really doubt it's the case...

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense