### PR TITLE
Prevent Flags/IsInitialized check from crashing Android app on restart

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -165,7 +165,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 					uiModeManager.DisableCarMode(DisableCarModeFlags.None);
 				}
 				
-				uiModeManager.EnableCarMode(EnableCarModeFlags.GoCarHome);
+				uiModeManager.EnableCarMode(EnableCarModeFlags.None);
 
 				// And put things back to normal so we can keep running tests
 				uiModeManager.DisableCarMode(DisableCarModeFlags.None);

--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -13,6 +13,7 @@ using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms.Platform.Android.AppLinks;
 using Android.Content;
+using Android.Content.Res;
 using Android.Views;
 using AColor = Android.Graphics.Color;
 
@@ -145,6 +146,30 @@ namespace Xamarin.Forms.ControlGallery.Android
 		public void Reset()
 		{
 			_app.Reset();
+		}
+
+		void SetUpForceRestartTest()
+		{
+			// Listen for messages from the app restart test
+			MessagingCenter.Subscribe<RestartAppTest>(this, RestartAppTest.ForceRestart, (e) =>
+			{
+				// We can force a restart by making a configuration change; in this case, we'll enter
+				// Car Mode. (The easy way to do this is to change the orientation, but ControlGallery
+				// handles orientation changes so they don't cause a restart.)
+
+				var uiModeManager = UiModeManager.FromContext(this);
+
+				if (uiModeManager.CurrentModeType == UiMode.TypeCar)
+				{
+					// If for some reason we're already in card mode, disable it
+					uiModeManager.DisableCarMode(DisableCarModeFlags.None);
+				}
+				
+				uiModeManager.EnableCarMode(EnableCarModeFlags.GoCarHome);
+
+				// And put things back to normal so we can keep running tests
+				uiModeManager.DisableCarMode(DisableCarModeFlags.None);
+			});
 		}
 	}
 }

--- a/Xamarin.Forms.ControlGallery.Android/Activity1.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Activity1.cs
@@ -161,7 +161,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 				if (uiModeManager.CurrentModeType == UiMode.TypeCar)
 				{
-					// If for some reason we're already in card mode, disable it
+					// If for some reason we're already in car mode, disable it
 					uiModeManager.DisableCarMode(DisableCarModeFlags.None);
 				}
 				

--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -43,10 +43,10 @@ namespace Xamarin.Forms.ControlGallery.Android
 			if (!Debugger.IsAttached)
 				Insights.Initialize(App.InsightsApiKey, ApplicationContext);
 
-			Forms.SetFlags("Fake_Flag"); // So we can test for flag initialization issues
-
 #if TEST_EXPERIMENTAL_RENDERERS
 			Forms.SetFlags("FastRenderers_Experimental");
+#else
+			Forms.SetFlags("Fake_Flag"); // So we can test for flag initialization issues
 #endif
 
 			Forms.Init(this, bundle);

--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -17,8 +17,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 	[Activity(Label = "Control Gallery", Icon = "@drawable/icon", Theme = "@style/MyTheme",
 		MainLauncher = true, HardwareAccelerated = true, 
-		ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation
-		)]
+		ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
 	[IntentFilter(new[] { Intent.ActionView },
 		Categories = new[]
 		{

--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -17,7 +17,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 	[Activity(Label = "Control Gallery", Icon = "@drawable/icon", Theme = "@style/MyTheme",
 		MainLauncher = true, HardwareAccelerated = true, 
-		ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+		ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation
+		)]
 	[IntentFilter(new[] { Intent.ActionView },
 		Categories = new[]
 		{
@@ -42,6 +43,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			if (!Debugger.IsAttached)
 				Insights.Initialize(App.InsightsApiKey, ApplicationContext);
+
+			Forms.SetFlags("Fake_Flag"); // So we can test for flag initialization issues
 
 #if TEST_EXPERIMENTAL_RENDERERS
 			Forms.SetFlags("FastRenderers_Experimental");
@@ -70,6 +73,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			// Listen for the message from the status bar color toggle test
 			MessagingCenter.Subscribe<AndroidStatusBarColor>(this, AndroidStatusBarColor.Message, color => SetStatusBarColor(global::Android.Graphics.Color.Red));
+
+			SetUpForceRestartTest();
 
 			LoadApplication(_app);
 		}

--- a/Xamarin.Forms.ControlGallery.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsApplicationActivity.cs
@@ -6,6 +6,7 @@ using Android.Content.PM;
 using Android.OS;
 using Java.Interop;
 using Xamarin.Forms.Controls;
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.Android;
 
 namespace Xamarin.Forms.ControlGallery.Android
@@ -22,6 +23,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			if (!Debugger.IsAttached)
 				Insights.Initialize(App.InsightsApiKey, ApplicationContext);
+
+			Forms.SetFlags("Fake_Flag"); // So we can test for flag initialization issues
 
 			Forms.Init(this, bundle);
 			FormsMaps.Init(this, bundle);
@@ -42,6 +45,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
 			MessagingCenter.Subscribe<NativeBindingGalleryPage>(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
+
+			SetUpForceRestartTest();
 
 			LoadApplication(app);
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RestartAppTest.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RestartAppTest.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Padding = new Thickness(0, 20, 0, 0),
 				Children =
 				{
-					new Label { Text = "11" }
+					new Label { Text = Success }
 				}
 			};
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RestartAppTest.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RestartAppTest.cs
@@ -1,0 +1,47 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.LifeCycle)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 11, "Config changes which restart the app should not crash", 
+		PlatformAffected.Android)]
+	public class RestartAppTest : TestContentPage 
+	{
+		public const string ForceRestart = "ForceRestart";
+		public const string Success = "Success";
+
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Padding = new Thickness(0, 20, 0, 0),
+				Children =
+				{
+					new Label { Text = "11" }
+				}
+			};
+
+			MessagingCenter.Send(this, ForceRestart);
+		}
+
+#if UITEST
+		[Test]
+		public void ForcingRestartDoesNotCauseCrash()
+		{
+			// If the app hasn't crashed, this test has passed
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -281,6 +281,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla53179_1.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RestartAppTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPages\ScreenshotConditionalApp.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41842.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42277.cs" />

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Forms
 		public static Context Context { get; internal set; }
 
 		public static bool IsInitialized { get; private set; }
+		static bool FlagsSet { get; set; }
 
 		internal static bool IsLollipopOrNewer
 		{
@@ -156,12 +157,20 @@ namespace Xamarin.Forms
 
 		public static void SetFlags(params string[] flags)
 		{
+			if (FlagsSet)
+			{
+				// Don't try to set the flags again if they've already been set
+				// (e.g., during a configuration change where OnCreate runs again)
+				return;
+			}
+
 			if (IsInitialized)
 			{
 				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
 			}
 
 			s_flags = flags.ToList().AsReadOnly();
+			FlagsSet = true;
 		}
 
 		static Color GetAccentColor()


### PR DESCRIPTION
### Description of Change ###

The first call to the `Forms.SetFlags` must come before `Forms.Init`; otherwise it throws an `InvalidOperationException`. However, Android apps can restart (and call `OnCreate` again) due to configuration changes (e.g., plugging in a hardware keyboard). The second call to `OnCreate` (and subsequent second call to `SetFlags`) was triggering the `InvalidOperationException` after a configuration change and crashing the application.

This change ensures that only the first call to `SetFlags` must come before `Init`; subsequent calls are ignored.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
