### PR TITLE
[Android] Add platform specific for Elevation

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39331.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39331.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 #if UITEST
 using Xamarin.UITest;
@@ -46,6 +48,10 @@ namespace Xamarin.Forms.Controls.Issues
 				IsVisible = false,
 				InputTransparent = false
 			};
+
+			// Bump up elevation on Android to cover FastRenderer Button
+			((BoxView)_busyBackground).On<Android>().SetElevation(10f);
+
 			layout.Children.Add (_busyBackground, new Rectangle (0, 0, 1, 1), AbsoluteLayoutFlags.SizeProportional);
 
 			Content = layout;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40173.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40173.cs
@@ -1,5 +1,7 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 #if UITEST
 using NUnit.Framework;
@@ -51,17 +53,22 @@ namespace Xamarin.Forms.Controls.Issues
 
 			testButton.Clicked += (sender, args) => outputLabel.Text = CantTouchFailText;
 
+			var boxView = new BoxView
+			{
+				AutomationId = "nontransparentBoxView",
+				Color = Color.Pink.MultiplyAlpha(0.5)
+			};
+
+			// Bump up the elevation on Android so the Button is covered (FastRenderers)
+			boxView.On<Android>().SetElevation(10f);
+
 			var testGrid = new Grid
 			{
 				AutomationId = "testgrid",
 				Children =
 				{
 					testButton,
-					new BoxView
-					{
-						AutomationId = "nontransparentBoxView",
-						Color = Color.Pink.MultiplyAlpha(0.5)
-					}
+					boxView
 				}
 			};
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ButtonFastRendererTest.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ButtonFastRendererTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 #if UITEST
 using NUnit.Framework;
@@ -21,6 +23,10 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var label = new Label { Text = Running };
 			var img = new Image { Source = "cover1.jpg", HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
+
+			// Give the image sufficient elevation to cover the FastRenderer Button
+			img.On<Android>().SetElevation(9f);
+
 			var btn = new Button { AutomationId = btnId, Text = "hello", HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
 			btn.Clicked += (sender, e) => { label.Text = Success; };
 			var grd = new Grid();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TransparentOverlayTests.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using System.Linq;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
@@ -155,6 +157,9 @@ namespace Xamarin.Forms.Controls.Issues
 				InputTransparent = inputTransparent,
 				Opacity = opacity
 			};
+
+			// Bump up the elevation to cover FastRenderer buttons
+			layout.On<Android>().SetElevation(10f);
 
 			grid.Children.Add(button);
 			Grid.SetRow(button, 3);

--- a/Xamarin.Forms.Core/AbsoluteLayout.cs
+++ b/Xamarin.Forms.Core/AbsoluteLayout.cs
@@ -6,17 +6,25 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	public class AbsoluteLayout : Layout<View>
+	public class AbsoluteLayout : Layout<View>, IElementConfiguration<AbsoluteLayout>
 	{
 		public static readonly BindableProperty LayoutFlagsProperty = BindableProperty.CreateAttached("LayoutFlags", typeof(AbsoluteLayoutFlags), typeof(AbsoluteLayout), AbsoluteLayoutFlags.None);
 
 		public static readonly BindableProperty LayoutBoundsProperty = BindableProperty.CreateAttached("LayoutBounds", typeof(Rectangle), typeof(AbsoluteLayout), new Rectangle(0, 0, AutoSize, AutoSize));
 
 		readonly AbsoluteElementCollection _children;
+		readonly Lazy<PlatformConfigurationRegistry<AbsoluteLayout>> _platformConfigurationRegistry;
 
 		public AbsoluteLayout()
 		{
 			_children = new AbsoluteElementCollection(InternalChildren, this);
+			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<AbsoluteLayout>>(() => 
+				new PlatformConfigurationRegistry<AbsoluteLayout>(this));
+		}
+
+		public IPlatformElementConfiguration<T, AbsoluteLayout> On<T>() where T : IConfigPlatform
+		{
+			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
 		public static double AutoSize

--- a/Xamarin.Forms.Core/Grid.cs
+++ b/Xamarin.Forms.Core/Grid.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	public partial class Grid : Layout<View>, IGridController
+	public partial class Grid : Layout<View>, IGridController, IElementConfiguration<Grid>
 	{
 		public static readonly BindableProperty RowProperty = BindableProperty.CreateAttached("Row", typeof(int), typeof(Grid), default(int), validateValue: (bindable, value) => (int)value >= 0);
 
@@ -52,10 +52,18 @@ namespace Xamarin.Forms
 			});
 
 		readonly GridElementCollection _children;
+		readonly Lazy<PlatformConfigurationRegistry<Grid>> _platformConfigurationRegistry;
 
 		public Grid()
 		{
 			_children = new GridElementCollection(InternalChildren, this) { Parent = this };
+			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Grid>>(() => 
+				new PlatformConfigurationRegistry<Grid>(this));
+		}
+
+		public IPlatformElementConfiguration<T, Grid> On<T>() where T : IConfigPlatform
+		{
+			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
 		public new IGridList<View> Children

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Elevation.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Elevation.cs
@@ -1,29 +1,27 @@
 ﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
 {
-	using FormsElement = VisualElement;
-
 	public static class Elevation
 	{
 		public static readonly BindableProperty ElevationProperty =
 			BindableProperty.Create("Elevation", typeof(float?),
 				typeof(Elevation));
 
-		public static float? GetElevation<T>(T element) where T : FormsElement
+		public static float? GetElevation(VisualElement element) 
 		{
 			return (float?)element.GetValue(ElevationProperty);
 		}
 
-		public static void SetElevation<T>(T element, float? value) where T : FormsElement
+		public static void SetElevation(VisualElement element, float? value)
 		{
 			element.SetValue(ElevationProperty, value);
 		}
 
-		public static float? GetElevation(this IPlatformElementConfiguration<Android, FormsElement> config)
+		public static float? GetElevation(this IPlatformElementConfiguration<Android, VisualElement> config)
 		{
 			return GetElevation(config.Element);
 		}
 
-		public static IPlatformElementConfiguration<Android, FormsElement> SetElevation(this IPlatformElementConfiguration<Android, FormsElement> config, float? value) 
+		public static IPlatformElementConfiguration<Android, VisualElement> SetElevation(this IPlatformElementConfiguration<Android, VisualElement> config, float? value) 
 		{
 			SetElevation(config.Element, value);
 			return config;

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Elevation.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Elevation.cs
@@ -1,0 +1,32 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using FormsElement = VisualElement;
+
+	public static class Elevation
+	{
+		public static readonly BindableProperty ElevationProperty =
+			BindableProperty.Create("Elevation", typeof(float?),
+				typeof(Elevation));
+
+		public static float? GetElevation<T>(T element) where T : FormsElement
+		{
+			return (float?)element.GetValue(ElevationProperty);
+		}
+
+		public static void SetElevation<T>(T element, float? value) where T : FormsElement
+		{
+			element.SetValue(ElevationProperty, value);
+		}
+
+		public static float? GetElevation(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetElevation(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetElevation(this IPlatformElementConfiguration<Android, FormsElement> config, float? value) 
+		{
+			SetElevation(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/RelativeLayout.cs
+++ b/Xamarin.Forms.Core/RelativeLayout.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	public class RelativeLayout : Layout<View>
+	public class RelativeLayout : Layout<View>, IElementConfiguration<RelativeLayout>
 	{
 		public static readonly BindableProperty XConstraintProperty = BindableProperty.CreateAttached("XConstraint", typeof(Constraint), typeof(RelativeLayout), null, propertyChanged: ConstraintChanged);
 
@@ -22,12 +22,21 @@ namespace Xamarin.Forms
 		readonly RelativeElementCollection _children;
 
 		IEnumerable<View> _childrenInSolveOrder;
+		readonly Lazy<PlatformConfigurationRegistry<RelativeLayout>> _platformConfigurationRegistry;
 
 		public RelativeLayout()
 		{
 			VerticalOptions = HorizontalOptions = LayoutOptions.FillAndExpand;
 			_children = new RelativeElementCollection(InternalChildren, this);
 			_children.Parent = this;
+
+			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<RelativeLayout>>(() => 
+				new PlatformConfigurationRegistry<RelativeLayout>(this));
+		}
+
+		public IPlatformElementConfiguration<T, RelativeLayout> On<T>() where T : IConfigPlatform
+		{
+			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
 		public new IRelativeList<View> Children

--- a/Xamarin.Forms.Core/StackLayout.cs
+++ b/Xamarin.Forms.Core/StackLayout.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	public class StackLayout : Layout<View>
+	public class StackLayout : Layout<View>, IElementConfiguration<StackLayout>
 	{
 		public static readonly BindableProperty OrientationProperty = BindableProperty.Create("Orientation", typeof(StackOrientation), typeof(StackLayout), StackOrientation.Vertical,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((StackLayout)bindable).InvalidateLayout());
@@ -13,6 +13,18 @@ namespace Xamarin.Forms
 			propertyChanged: (bindable, oldvalue, newvalue) => ((StackLayout)bindable).InvalidateLayout());
 
 		LayoutInformation _layoutInformation = new LayoutInformation();
+		readonly Lazy<PlatformConfigurationRegistry<StackLayout>> _platformConfigurationRegistry;
+
+		public StackLayout()
+		{
+			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<StackLayout>>(() => 
+				new PlatformConfigurationRegistry<StackLayout>(this));
+		}
+
+		public IPlatformElementConfiguration<T, StackLayout> On<T>() where T : IConfigPlatform
+		{
+			return _platformConfigurationRegistry.Value.On<T>();
+		}
 
 		public StackOrientation Orientation
 		{

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -97,6 +97,7 @@
     <Compile Include="LockableObservableListWrapper.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\Application.cs" />
+    <Compile Include="PlatformConfiguration\AndroidSpecific\BoxView.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\TabbedPage.cs" />
     <Compile Include="PlatformConfiguration\ExtensionPoints.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />
@@ -479,7 +480,5 @@
   </PropertyGroup>
   <ItemGroup />
   <ItemGroup />
-  <ItemGroup>
-    <Folder Include="Xaml\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -97,7 +97,7 @@
     <Compile Include="LockableObservableListWrapper.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\Application.cs" />
-    <Compile Include="PlatformConfiguration\AndroidSpecific\BoxView.cs" />
+    <Compile Include="PlatformConfiguration\AndroidSpecific\Elevation.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\TabbedPage.cs" />
     <Compile Include="PlatformConfiguration\ExtensionPoints.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />

--- a/Xamarin.Forms.Platform.Android/Elevation.cs
+++ b/Xamarin.Forms.Platform.Android/Elevation.cs
@@ -1,0 +1,25 @@
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal static class ElevationHelper
+	{
+		internal static void SetElevation(global::Android.Views.View view, VisualElement element)
+		{
+			if (view == null || element == null || !Forms.IsLollipopOrNewer)
+			{
+				return;
+			}
+
+			var iec = element as IElementConfiguration<VisualElement>;
+			var elevation = iec?.On<PlatformConfiguration.Android>().GetElevation();
+
+			if (!elevation.HasValue)
+			{
+				return;
+			}
+
+			view.Elevation = elevation.Value;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -229,6 +229,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				UpdateInputTransparent();
 				UpdateBackgroundColor();
 				UpdateDrawable();
+
+				ElevationHelper.SetElevation(this, e.NewElement);
 			}
 
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -163,6 +163,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				UpdateShadow();
 				UpdateBackgroundColor();
 				UpdateCornerRadius();
+
+				ElevationHelper.SetElevation(this, e.NewElement);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -68,6 +68,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			UpdateAspect();
 			this.EnsureId();
 
+			ElevationHelper.SetElevation(this, e.NewElement);
+
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
 		}
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -200,6 +200,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				if (e.OldElement?.HorizontalTextAlignment != e.NewElement.HorizontalTextAlignment
 				 || e.OldElement?.VerticalTextAlignment != e.NewElement.VerticalTextAlignment)
 					UpdateGravity();
+
+				ElevationHelper.SetElevation(this, e.NewElement);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -28,15 +28,6 @@ namespace Xamarin.Forms.Platform.Android
 			_motionEventHelper.UpdateElement(e.NewElement);
 
 			UpdateBackgroundColor();
-
-			//if (Forms.IsLollipopOrNewer)
-			//{
-			//	var elevation = e.NewElement.OnThisPlatform().GetElevation();
-			//	if (elevation.HasValue)
-			//	{
-			//		Elevation = elevation.Value;
-			//	}
-			//}
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Android.Views;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -27,6 +28,15 @@ namespace Xamarin.Forms.Platform.Android
 			_motionEventHelper.UpdateElement(e.NewElement);
 
 			UpdateBackgroundColor();
+
+			if (Forms.IsLollipopOrNewer)
+			{
+				var elevation = e.NewElement.OnThisPlatform().GetElevation();
+				if (elevation.HasValue)
+				{
+					Elevation = elevation.Value;
+				}
+			}
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -29,14 +29,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			UpdateBackgroundColor();
 
-			if (Forms.IsLollipopOrNewer)
-			{
-				var elevation = e.NewElement.OnThisPlatform().GetElevation();
-				if (elevation.HasValue)
-				{
-					Elevation = elevation.Value;
-				}
-			}
+			//if (Forms.IsLollipopOrNewer)
+			//{
+			//	var elevation = e.NewElement.OnThisPlatform().GetElevation();
+			//	if (elevation.HasValue)
+			//	{
+			//		Elevation = elevation.Value;
+			//	}
+			//}
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms.Platform.Android
 		public static IVisualElementRenderer GetRenderer(this VisualElement self)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException(nameof(self));
 
 			IVisualElementRenderer renderer = Platform.GetRenderer(self);
 

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -260,22 +260,22 @@ namespace Xamarin.Forms.Platform.Android
 
 			ElementChanged?.Invoke(this, e);
 
-			if (Forms.IsLollipopOrNewer)
+			UpdateElevation();
+		}
+
+		protected virtual void UpdateElevation()
+		{
+			if (Element == null || !Forms.IsLollipopOrNewer)
 			{
-				var iec = e.NewElement as IElementConfiguration<VisualElement>;
+				return;
+			}
 
-				if (iec == null)
-				{
-					return;
-				}
+			var iec = Element as IElementConfiguration<VisualElement>;
+			var elevation = iec?.On<PlatformConfiguration.Android>().GetElevation();
 
-				var android = iec.On<PlatformConfiguration.Android>();
-
-				var elevation = android.GetElevation();
-				if (elevation.HasValue)
-				{
-					Elevation = elevation.Value;
-				}
+			if (elevation != null)
+			{
+				Elevation = elevation.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -6,6 +6,7 @@ using Android.Support.V4.View;
 using Android.Views;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.Android.FastRenderers;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
@@ -258,6 +259,24 @@ namespace Xamarin.Forms.Platform.Android
 				handler(this, args);
 
 			ElementChanged?.Invoke(this, e);
+
+			if (Forms.IsLollipopOrNewer)
+			{
+				var iec = e.NewElement as IElementConfiguration<VisualElement>;
+
+				if (iec == null)
+				{
+					return;
+				}
+
+				var android = iec.On<PlatformConfiguration.Android>();
+
+				var elevation = android.GetElevation();
+				if (elevation.HasValue)
+				{
+					Elevation = elevation.Value;
+				}
+			}
 		}
 
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -5,8 +5,6 @@ using System.ComponentModel;
 using Android.Support.V4.View;
 using Android.Views;
 using Xamarin.Forms.Internals;
-using Xamarin.Forms.Platform.Android.FastRenderers;
-using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
@@ -260,25 +258,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			ElementChanged?.Invoke(this, e);
 
-			UpdateElevation();
+			ElevationHelper.SetElevation(this, e.NewElement);
 		}
-
-		protected virtual void UpdateElevation()
-		{
-			if (Element == null || !Forms.IsLollipopOrNewer)
-			{
-				return;
-			}
-
-			var iec = Element as IElementConfiguration<VisualElement>;
-			var elevation = iec?.On<PlatformConfiguration.Android>().GetElevation();
-
-			if (elevation != null)
-			{
-				Elevation = elevation.Value;
-			}
-		}
-
+		
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -103,6 +103,7 @@
     <Compile Include="AndroidTitleBarVisibility.cs" />
     <Compile Include="AppCompat\FrameRenderer.cs" />
     <Compile Include="ButtonBackgroundTracker.cs" />
+    <Compile Include="Elevation.cs" />
     <Compile Include="Extensions\JavaObjectExtensions.cs" />
     <Compile Include="FastRenderers\AutomationPropertiesProvider.cs" />
     <Compile Include="FastRenderers\ButtonRenderer.cs" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/Elevation.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/Elevation.xml
@@ -1,0 +1,116 @@
+<Type Name="Elevation" FullName="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Elevation">
+  <TypeSignature Language="C#" Value="public static class Elevation" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Elevation extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="ElevationProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ElevationProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ElevationProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetElevation">
+      <MemberSignature Language="C#" Value="public static Nullable&lt;float&gt; GetElevation (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype System.Nullable`1&lt;float32&gt; GetElevation(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.VisualElement&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Nullable&lt;System.Single&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetElevation">
+      <MemberSignature Language="C#" Value="public static Nullable&lt;float&gt; GetElevation (Xamarin.Forms.VisualElement element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype System.Nullable`1&lt;float32&gt; GetElevation(class Xamarin.Forms.VisualElement element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Nullable&lt;System.Single&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.VisualElement" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetElevation">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt; SetElevation (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt; config, Nullable&lt;float&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.VisualElement&gt; SetElevation(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.VisualElement&gt; config, valuetype System.Nullable`1&lt;float32&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Nullable&lt;System.Single&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetElevation">
+      <MemberSignature Language="C#" Value="public static void SetElevation (Xamarin.Forms.VisualElement element, Nullable&lt;float&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetElevation(class Xamarin.Forms.VisualElement element, valuetype System.Nullable`1&lt;float32&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.VisualElement" />
+        <Parameter Name="value" Type="System.Nullable&lt;System.Single&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/AbsoluteLayout.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/AbsoluteLayout.xml
@@ -1,6 +1,6 @@
 <Type Name="AbsoluteLayout" FullName="Xamarin.Forms.AbsoluteLayout">
-  <TypeSignature Language="C#" Value="public class AbsoluteLayout : Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit AbsoluteLayout extends Xamarin.Forms.Layout`1&lt;class Xamarin.Forms.View&gt;" />
+  <TypeSignature Language="C#" Value="public class AbsoluteLayout : Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.AbsoluteLayout&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit AbsoluteLayout extends Xamarin.Forms.Layout`1&lt;class Xamarin.Forms.View&gt; implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.AbsoluteLayout&gt;" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -17,7 +17,11 @@
       <BaseTypeArgument TypeParamName="T">Xamarin.Forms.View</BaseTypeArgument>
     </BaseTypeArguments>
   </Base>
-  <Interfaces />
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.AbsoluteLayout&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
   <Docs>
     <summary>Positions child elements at absolute positions.</summary>
     <remarks>
@@ -417,6 +421,31 @@
         <summary>Implements the attached property that contains the <see cref="T:Xamarin.Forms.AbsoluteLayoutFlags" /> values for child elements.</summary>
         <remarks>The interface for this property is defined by the <see cref="M:Xamarin.Forms.AbsoluteLayout.GetLayoutFlags" /> and <see cref="M:Xamarin.Forms.AbsoluteLayout.SetLayoutFlags" /> methods.
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="On&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.AbsoluteLayout&gt; On&lt;T&gt; () where T : Xamarin.Forms.IConfigPlatform;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.IPlatformElementConfiguration`2&lt;!!T, class Xamarin.Forms.AbsoluteLayout&gt; On&lt;(class Xamarin.Forms.IConfigPlatform) T&gt;() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.AbsoluteLayout&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T">
+          <Constraints>
+            <InterfaceName>Xamarin.Forms.IConfigPlatform</InterfaceName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters />
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildAdded">

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Grid.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Grid.xml
@@ -1,6 +1,6 @@
 <Type Name="Grid" FullName="Xamarin.Forms.Grid">
-  <TypeSignature Language="C#" Value="public class Grid : Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;, Xamarin.Forms.IGridController" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Grid extends Xamarin.Forms.Layout`1&lt;class Xamarin.Forms.View&gt; implements class Xamarin.Forms.IGridController" />
+  <TypeSignature Language="C#" Value="public class Grid : Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.Grid&gt;, Xamarin.Forms.IGridController" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Grid extends Xamarin.Forms.Layout`1&lt;class Xamarin.Forms.View&gt; implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.Grid&gt;, class Xamarin.Forms.IGridController" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -18,6 +18,9 @@
     </BaseTypeArguments>
   </Base>
   <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.Grid&gt;</InterfaceName>
+    </Interface>
     <Interface>
       <InterfaceName>Xamarin.Forms.IGridController</InterfaceName>
     </Interface>
@@ -620,6 +623,31 @@ namespace FormsGallery
         <summary>
           <para>Lays out the child elements when the layout is invalidated.</para>
         </summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="On&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.Grid&gt; On&lt;T&gt; () where T : Xamarin.Forms.IConfigPlatform;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.IPlatformElementConfiguration`2&lt;!!T, class Xamarin.Forms.Grid&gt; On&lt;(class Xamarin.Forms.IConfigPlatform) T&gt;() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.Grid&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T">
+          <Constraints>
+            <InterfaceName>Xamarin.Forms.IConfigPlatform</InterfaceName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters />
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/RelativeLayout.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/RelativeLayout.xml
@@ -1,6 +1,6 @@
 <Type Name="RelativeLayout" FullName="Xamarin.Forms.RelativeLayout">
-  <TypeSignature Language="C#" Value="public class RelativeLayout : Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit RelativeLayout extends Xamarin.Forms.Layout`1&lt;class Xamarin.Forms.View&gt;" />
+  <TypeSignature Language="C#" Value="public class RelativeLayout : Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.RelativeLayout&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit RelativeLayout extends Xamarin.Forms.Layout`1&lt;class Xamarin.Forms.View&gt; implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.RelativeLayout&gt;" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -17,7 +17,11 @@
       <BaseTypeArgument TypeParamName="T">Xamarin.Forms.View</BaseTypeArgument>
     </BaseTypeArguments>
   </Base>
-  <Interfaces />
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.RelativeLayout&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.Layout`1" /> that uses <see cref="T:Xamarin.Forms.Constraint" />s to layout its children.</summary>
     <remarks>
@@ -333,6 +337,31 @@ public class RelativeLayoutExample : ContentPage
         <param name="width">The width of the rectangle into which the children will be laid out.</param>
         <param name="height">The height of the rectangle into which the children will be laid out.</param>
         <summary>Lays out the <see cref="P:Xamarin.Forms.RelativeLayout.Children" /> in the specified rectangle.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="On&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.RelativeLayout&gt; On&lt;T&gt; () where T : Xamarin.Forms.IConfigPlatform;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.IPlatformElementConfiguration`2&lt;!!T, class Xamarin.Forms.RelativeLayout&gt; On&lt;(class Xamarin.Forms.IConfigPlatform) T&gt;() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.RelativeLayout&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T">
+          <Constraints>
+            <InterfaceName>Xamarin.Forms.IConfigPlatform</InterfaceName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters />
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/StackLayout.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/StackLayout.xml
@@ -1,6 +1,6 @@
 <Type Name="StackLayout" FullName="Xamarin.Forms.StackLayout">
-  <TypeSignature Language="C#" Value="public class StackLayout : Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit StackLayout extends Xamarin.Forms.Layout`1&lt;class Xamarin.Forms.View&gt;" />
+  <TypeSignature Language="C#" Value="public class StackLayout : Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;, Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.StackLayout&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit StackLayout extends Xamarin.Forms.Layout`1&lt;class Xamarin.Forms.View&gt; implements class Xamarin.Forms.IElementConfiguration`1&lt;class Xamarin.Forms.StackLayout&gt;" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Forms.Core</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -18,7 +18,11 @@
       <BaseTypeArgument TypeParamName="T">Xamarin.Forms.View</BaseTypeArgument>
     </BaseTypeArguments>
   </Base>
-  <Interfaces />
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IElementConfiguration&lt;Xamarin.Forms.StackLayout&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
   <Docs>
     <summary>A <see cref="T:Xamarin.Forms.Layout`1" /> that positions child elements in a single line which can be oriented vertically or horizontally.</summary>
     <remarks>
@@ -211,6 +215,31 @@ var stackLayout = new StackLayout {
         <param name="height">A value representing the height of the child region bounding box.</param>
         <summary>Positions and sizes the children of a StackLayout.</summary>
         <remarks>Implementors wishing to change the default behavior of a StackLayout should override this method. It is suggested to still call the base method and modify its calculated results.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="On&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.StackLayout&gt; On&lt;T&gt; () where T : Xamarin.Forms.IConfigPlatform;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.IPlatformElementConfiguration`2&lt;!!T, class Xamarin.Forms.StackLayout&gt; On&lt;(class Xamarin.Forms.IConfigPlatform) T&gt;() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.StackLayout&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T">
+          <Constraints>
+            <InterfaceName>Xamarin.Forms.IConfigPlatform</InterfaceName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters />
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -501,6 +501,7 @@
     </Namespace>
     <Namespace Name="Xamarin.Forms.PlatformConfiguration.AndroidSpecific">
       <Type Name="Application" Kind="Class" />
+      <Type Name="Elevation" Kind="Class" />
       <Type Name="ListView" Kind="Class" />
       <Type Name="TabbedPage" Kind="Class" />
       <Type Name="WindowSoftInputModeAdjust" Kind="Enumeration" />
@@ -1764,6 +1765,50 @@
           <summary>Sets a value that controls whether the soft input mode of the provided platform configuration pans or resizes its content to allow the display of the on-screen input UI.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Application" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Application.UseWindowSoftInputModeAdjust(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application},Xamarin.Forms.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="GetElevation">
+        <MemberSignature Language="C#" Value="public static Nullable&lt;float&gt; GetElevation (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype System.Nullable`1&lt;float32&gt; GetElevation(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.VisualElement&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Nullable&lt;System.Single&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Elevation" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Elevation.GetElevation(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetElevation">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt; SetElevation (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt; config, Nullable&lt;float&gt; value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.VisualElement&gt; SetElevation(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.VisualElement&gt; config, valuetype System.Nullable`1&lt;float32&gt; value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement&gt;" RefType="this" />
+          <Parameter Name="value" Type="System.Nullable&lt;System.Single&gt;" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Elevation" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Elevation.SetElevation(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.VisualElement},System.Nullable{System.Single})" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>


### PR DESCRIPTION
### Description of Change ###

Adds a platform specific value of `Elevation` (a `float?`) to `VisualElement` on Android. This allows the end user to control the immediate value of [Elevation](https://developer.android.com/reference/android/view/View.html#attr_android:elevation) on Android where necessary. 

This value has no effect on pre-Lollipop Android. 

### Bugs Fixed ###

- Allows users to fix Fast button renderer popping up 'above' elements which should be higher in the z-order (e.g., see tests for Bugzilla39331 and Bugzilla40173)

### API Changes ###

Added:
- `public static float? GetElevation(VisualElement element)`
- `public static void SetElevation(VisualElement element, float? value)`
- `public static float? GetElevation(this IPlatformElementConfiguration<Android, VisualElement> config)`
- `public static IPlatformElementConfiguration<Android, VisualElement> SetElevation(this IPlatformElementConfiguration<Android, VisualElement> config, float? value)` 

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
