### PR TITLE
Add ProjectCapability to targets file

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -25,6 +25,10 @@
 		</CompileDependsOn>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<ProjectCapability Include="XamarinForms" />
+	</ItemGroup>
+
 	<Target Name="UpdateDesignTimeXaml" DependsOnTargets="XamlG"/>
 
 	<Target Name="XamlG" DependsOnTargets="$(XamlGDependsOn)"/>


### PR DESCRIPTION
### Description of Change ###

Adds a ProjectCapability to the targets file so that tooling can pick up X.F. compatible projects in net standard projects.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
