### PR TITLE
[MacOS] Navigation Transition Style

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
@@ -1,0 +1,56 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.macOSSpecific
+{
+	using FormsElement = Forms.NavigationPage;
+
+	public static class NavigationPage
+	{
+		public static readonly BindableProperty NavigationTransitionPushStyleProperty = BindableProperty.Create("NavigationTransitionPushStyle", typeof(NavigationTransitionStyle), typeof(NavigationPage), NavigationTransitionStyle.SlideForward);
+		public static readonly BindableProperty NavigationTransitionPopStyleProperty = BindableProperty.Create("NavigationTransitionPopStyle", typeof(NavigationTransitionStyle), typeof(NavigationPage), NavigationTransitionStyle.SlideBackward);
+
+		#region PushStyle
+		public static NavigationTransitionStyle GetNavigationTransitionPushStyle(BindableObject element)
+		{
+			return (NavigationTransitionStyle)element.GetValue(NavigationTransitionPushStyleProperty);
+		}
+
+		public static void SetNavigationTransitionPushStyle(BindableObject element, NavigationTransitionStyle value)
+		{
+			element.SetValue(NavigationTransitionPushStyleProperty, value);
+		}
+
+		public static NavigationTransitionStyle GetNavigationTransitionPushStyle(this IPlatformElementConfiguration<macOS, FormsElement> config)
+		{
+			return GetNavigationTransitionPushStyle(config.Element);
+		}
+		#endregion
+
+		#region PopStyle
+		public static NavigationTransitionStyle GetNavigationTransitionPopStyle(BindableObject element)
+		{
+			return (NavigationTransitionStyle)element.GetValue(NavigationTransitionPopStyleProperty);
+		}
+
+		public static void SetNavigationTransitionPopStyle(BindableObject element, NavigationTransitionStyle value)
+		{
+			element.SetValue(NavigationTransitionPopStyleProperty, value);
+		}
+
+		public static NavigationTransitionStyle GetNavigationTransitionPopStyle(this IPlatformElementConfiguration<macOS, FormsElement> config)
+		{
+			return GetNavigationTransitionPopStyle(config.Element);
+		}
+		#endregion
+
+		public static void SetNavigationTransitionStyle(BindableObject element, NavigationTransitionStyle pushStyle, NavigationTransitionStyle popStyle)
+		{
+			SetNavigationTransitionPushStyle(element, pushStyle);
+			SetNavigationTransitionPopStyle(element, popStyle);
+		}
+
+		public static IPlatformElementConfiguration<macOS, FormsElement> SetNavigationTransitionStyle(this IPlatformElementConfiguration<macOS, FormsElement> config, NavigationTransitionStyle pushStyle, NavigationTransitionStyle popStyle)
+		{
+			SetNavigationTransitionStyle(config.Element, pushStyle, popStyle);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/macOSSpecific/NavigationTransitionStyle.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/macOSSpecific/NavigationTransitionStyle.cs
@@ -1,0 +1,14 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.macOSSpecific
+{
+	public enum NavigationTransitionStyle
+	{
+		None,
+		Crossfade,
+		SlideUp,
+		SlideDown,
+		SlideLeft,
+		SlideRight,
+		SlideForward,
+		SlideBackward
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -465,6 +465,8 @@
     <Compile Include="Xaml\ValueConverterProvider.cs" />
     <Compile Include="PlatformConfiguration\macOSSpecific\Page.cs" />
     <Compile Include="CompressedLayout.cs" />
+    <Compile Include="PlatformConfiguration\macOSSpecific\NavigationPage.cs" />
+    <Compile Include="PlatformConfiguration\macOSSpecific\NavigationTransitionStyle.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
@@ -7,6 +7,7 @@ using AppKit;
 using CoreAnimation;
 using Foundation;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration.macOSSpecific;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
@@ -263,6 +264,30 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 		}
 
+		NSViewControllerTransitionOptions ToViewControllerTransitionOptions(NavigationTransitionStyle transitionStyle)
+		{
+			switch (transitionStyle)
+			{
+				case NavigationTransitionStyle.Crossfade:
+					return NSViewControllerTransitionOptions.Crossfade;
+				case NavigationTransitionStyle.SlideBackward:
+					return NSViewControllerTransitionOptions.SlideBackward;
+				case NavigationTransitionStyle.SlideDown:
+					return NSViewControllerTransitionOptions.SlideDown;
+				case NavigationTransitionStyle.SlideForward:
+					return NSViewControllerTransitionOptions.SlideForward;
+				case NavigationTransitionStyle.SlideLeft:
+					return NSViewControllerTransitionOptions.SlideLeft;
+				case NavigationTransitionStyle.SlideRight:
+					return NSViewControllerTransitionOptions.SlideRight;
+				case NavigationTransitionStyle.SlideUp:
+					return NSViewControllerTransitionOptions.SlideUp;
+
+				default:
+					return NSViewControllerTransitionOptions.None;
+			}
+		}
+
 		async Task<bool> PopPageAsync(Page page, bool animated)
 		{
 			if (page == null)
@@ -281,8 +306,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (animated)
 			{
 				var previousPageRenderer = Platform.GetRenderer(previousPage);
+				var transitionStyle = NavigationPage.OnThisPlatform().GetNavigationTransitionPopStyle();
+
 				return await this.HandleAsyncAnimation(target.ViewController, previousPageRenderer.ViewController,
-					NSViewControllerTransitionOptions.SlideBackward, () => Platform.DisposeRendererAndChildren(target), true);
+					ToViewControllerTransitionOptions(transitionStyle), () => Platform.DisposeRendererAndChildren(target), true);
 			}
 
 			RemovePage(page, false);
@@ -313,8 +340,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 			var vco = Platform.GetRenderer(oldPage);
 			AddChildViewController(vc.ViewController);
+
+            var transitionStyle = NavigationPage.OnThisPlatform().GetNavigationTransitionPushStyle();
 			return await this.HandleAsyncAnimation(vco.ViewController, vc.ViewController,
-				NSViewControllerTransitionOptions.SlideForward, () => page?.SendAppearing(), true);
+				ToViewControllerTransitionOptions(transitionStyle), () => page?.SendAppearing(), true);
 		}
 
 		void UpdateBackgroundColor()

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.macOSSpecific/NavigationPage.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.macOSSpecific/NavigationPage.xml
@@ -1,0 +1,217 @@
+<Type Name="NavigationPage" FullName="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationPage">
+  <TypeSignature Language="C#" Value="public static class NavigationPage" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit NavigationPage extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>The navigation page instance that Xamarin.Forms created on the macOS platform.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetNavigationTransitionPopStyle">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPopStyle (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPopStyle(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">The platform specific element on which to perform the operation.</param>
+        <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is popped from the navigation stack.</summary>
+        <returns>The NavigationTransitionStyle value that tells the current transition when a page is popped from the navigation stack.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetNavigationTransitionPopStyle">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPopStyle (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPopStyle(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.macOS, class Xamarin.Forms.NavigationPage&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+        <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is popped from the navigation stack.</summary>
+        <returns>The NavigationTransitionStyle value that tells the current transition when a page is popped from the navigation stack.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetNavigationTransitionPushStyle">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPushStyle (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPushStyle(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">The platform specific element on which to perform the operation.</param>
+        <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is push on the navigation stack.</summary>
+        <returns>The NavigationTransitionStyle value that tells the current transition when a page is pushed on the navigation stack.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetNavigationTransitionPushStyle">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPushStyle (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPushStyle(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.macOS, class Xamarin.Forms.NavigationPage&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+        <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is pushed on the navigation stack.</summary>
+        <returns>The NavigationTransitionStyle value that tells the current transition when a page is pushed on the navigation stack.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NavigationTransitionPopStyleProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty NavigationTransitionPopStyleProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty NavigationTransitionPopStyleProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Backing store for the attached property that controls the transition style of the platform-specific navigation page when a page is popped from the navigation stack.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NavigationTransitionPushStyleProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty NavigationTransitionPushStyleProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty NavigationTransitionPushStyleProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Backing store for the attached property that controls the transition style of the platform-specific navigation page when a page is pushed on the navigation stack.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetNavigationTransitionPopStyle">
+      <MemberSignature Language="C#" Value="public static void SetNavigationTransitionPopStyle (Xamarin.Forms.BindableObject element, Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetNavigationTransitionPopStyle(class Xamarin.Forms.BindableObject element, valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle" />
+      </Parameters>
+      <Docs>
+        <param name="element">The platform specific element on which to perform the operation.</param>
+        <param name="value">The new transition style.</param>
+        <summary>Sets the transition style which is used, when popping from the navigation stack.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetNavigationTransitionPushStyle">
+      <MemberSignature Language="C#" Value="public static void SetNavigationTransitionPushStyle (Xamarin.Forms.BindableObject element, Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetNavigationTransitionPushStyle(class Xamarin.Forms.BindableObject element, valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle" />
+      </Parameters>
+      <Docs>
+        <param name="element">The platform specific element on which to perform the operation.</param>
+        <param name="value">The new transition style.</param>
+        <summary>Sets the transition style which is used, when pushing pages on the navigation stack.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetNavigationTransitionStyle">
+      <MemberSignature Language="C#" Value="public static void SetNavigationTransitionStyle (Xamarin.Forms.BindableObject element, Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle pushStyle, Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle popStyle);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetNavigationTransitionStyle(class Xamarin.Forms.BindableObject element, valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle pushStyle, valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle popStyle) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="pushStyle" Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle" />
+        <Parameter Name="popStyle" Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle" />
+      </Parameters>
+      <Docs>
+        <param name="element">The platform specific element on which to perform the operation.</param>
+        <param name="pushStyle">The new transition style when a page is pushed on the navigation stack.</param>
+        <param name="popStyle">The new transition style when a page is popped from the navigation stack.</param>
+        <summary>Sets the transition style which is used, when popping and pushing pages on the navigation stack.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetNavigationTransitionStyle">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt; SetNavigationTransitionStyle (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt; config, Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle pushStyle, Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle popStyle);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.macOS, class Xamarin.Forms.NavigationPage&gt; SetNavigationTransitionStyle(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.macOS, class Xamarin.Forms.NavigationPage&gt; config, valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle pushStyle, valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle popStyle) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt;" RefType="this" />
+        <Parameter Name="pushStyle" Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle" />
+        <Parameter Name="popStyle" Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle" />
+      </Parameters>
+      <Docs>
+        <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+        <param name="pushStyle">The new transition style when a page is pushed on the navigation stack.</param>
+        <param name="popStyle">The new transition style when a page is popped from the navigation stack.</param>
+        <summary>Sets the transition style which is used, when popping and pushing pages on the navigation stack.</summary>
+        <returns>The updated configuration object on which developers can make successive method calls.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.macOSSpecific/NavigationTransitionStyle.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.macOSSpecific/NavigationTransitionStyle.xml
@@ -1,0 +1,129 @@
+<Type Name="NavigationTransitionStyle" FullName="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle">
+  <TypeSignature Language="C#" Value="public enum NavigationTransitionStyle" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed NavigationTransitionStyle extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>Enumerates navigation transition styles.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Crossfade">
+      <MemberSignature Language="C#" Value="Crossfade" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle Crossfade = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates a crossfade transition.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="None">
+      <MemberSignature Language="C#" Value="None" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle None = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates no transition.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SlideBackward">
+      <MemberSignature Language="C#" Value="SlideBackward" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle SlideBackward = int32(7)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates a slide backward transition.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SlideDown">
+      <MemberSignature Language="C#" Value="SlideDown" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle SlideDown = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates a slide down transition.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SlideForward">
+      <MemberSignature Language="C#" Value="SlideForward" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle SlideForward = int32(6)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates a slide forward transition.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SlideLeft">
+      <MemberSignature Language="C#" Value="SlideLeft" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle SlideLeft = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates a slide left transition.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SlideRight">
+      <MemberSignature Language="C#" Value="SlideRight" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle SlideRight = int32(5)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates a slide right transition.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SlideUp">
+      <MemberSignature Language="C#" Value="SlideUp" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle SlideUp = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Indicates a slide up transition.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.macOSSpecific/Page.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.macOSSpecific/Page.xml
@@ -10,7 +10,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
+    <summary>The page instance that Xamarin.Forms created on the macOS platform..</summary>
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
@@ -28,9 +28,9 @@
         <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
       </Parameters>
       <Docs>
-        <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="element">The platform specific element on which to perform the operation.</param>
+        <summary>Returns the tab order of the visual elements on a page as array.</summary>
+        <returns>An array of VisualElement.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -48,9 +48,9 @@
         <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.Page&gt;" RefType="this" />
       </Parameters>
       <Docs>
-        <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+        <summary>Returns the tab order of the visual elements on a page as array.</summary>
+        <returns>An array of VisualElement.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -75,9 +75,9 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="element">To be added.</param>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
+        <param name="element">The platform specific element on which to perform the operation.</param>
+        <param name="value">An array of VisualElement.</param>
+        <summary>Sets the tab order of visual elements on a page. Users can cycle through these elements with the tab key.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -102,10 +102,10 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="config">To be added.</param>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+        <param name="value">An array of VisualElement.</param>
+        <summary>Sets the tab order of visual elements on a page. Users can cycle through these elements with the tab key.</summary>
+        <returns>The platform specific configuration that contains the element on which to perform the operation.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -120,7 +120,7 @@
         <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Backing store for the attached property that holds the tab order of the visual elements.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -523,6 +523,8 @@
       <Type Name="VisualElement" Kind="Class" />
     </Namespace>
     <Namespace Name="Xamarin.Forms.PlatformConfiguration.macOSSpecific">
+      <Type Name="NavigationPage" Kind="Class" />
+      <Type Name="NavigationTransitionStyle" Kind="Enumeration" />
       <Type Name="Page" Kind="Class" />
       <Type Name="TabbedPage" Kind="Class" />
     </Namespace>
@@ -2425,6 +2427,73 @@
       <Targets>
         <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
       </Targets>
+      <Member MemberName="GetNavigationTransitionPopStyle">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPopStyle (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPopStyle(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.macOS, class Xamarin.Forms.NavigationPage&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+          <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is popped from the navigation stack.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationPage" Member="M:Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationPage.GetNavigationTransitionPopStyle(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="GetNavigationTransitionPushStyle">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPushStyle (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle GetNavigationTransitionPushStyle(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.macOS, class Xamarin.Forms.NavigationPage&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+          <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is pushed on the navigation stack.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationPage" Member="M:Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationPage.GetNavigationTransitionPushStyle(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetNavigationTransitionStyle">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt; SetNavigationTransitionStyle (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt; config, Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle pushStyle, Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle popStyle);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.macOS, class Xamarin.Forms.NavigationPage&gt; SetNavigationTransitionStyle(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.macOS, class Xamarin.Forms.NavigationPage&gt; config, valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle pushStyle, valuetype Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle popStyle) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage&gt;" RefType="this" />
+          <Parameter Name="pushStyle" Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle" />
+          <Parameter Name="popStyle" Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle" />
+        </Parameters>
+        <Docs>
+          <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+          <param name="pushStyle">The new transition style when a page is pushed on the navigation stack.</param>
+          <param name="popStyle">The new transition style when a page is popped from the navigation stack.</param>
+          <summary>Sets the transition style which is used, when popping and pushing pages on the navigation stack.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationPage" Member="M:Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationPage.SetNavigationTransitionStyle(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.NavigationPage},Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle,Xamarin.Forms.PlatformConfiguration.macOSSpecific.NavigationTransitionStyle)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
       <Member MemberName="GetTabOrder">
         <MemberSignature Language="C#" Value="public static Xamarin.Forms.VisualElement[] GetTabOrder (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.Page&gt; config);" />
         <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.VisualElement[] GetTabOrder(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.macOS, class Xamarin.Forms.Page&gt; config) cil managed" />
@@ -2436,8 +2505,8 @@
           <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.Page&gt;" RefType="this" />
         </Parameters>
         <Docs>
-          <param name="config">To be added.</param>
-          <summary>To be added.</summary>
+          <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+          <summary>Returns the tab order of the visual elements on a page as array.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.Page" Member="M:Xamarin.Forms.PlatformConfiguration.macOSSpecific.Page.GetTabOrder(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.Page})" />
       </Member>
@@ -2464,9 +2533,9 @@
           </Parameter>
         </Parameters>
         <Docs>
-          <param name="config">To be added.</param>
-          <param name="value">To be added.</param>
-          <summary>To be added.</summary>
+          <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
+          <param name="value">An array of VisualElement.</param>
+          <summary>Sets the tab order of visual elements on a page. Users can cycle through these elements with the tab key.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.PlatformConfiguration.macOSSpecific.Page" Member="M:Xamarin.Forms.PlatformConfiguration.macOSSpecific.Page.SetTabOrder(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.macOS,Xamarin.Forms.Page},Xamarin.Forms.VisualElement[])" />
       </Member>


### PR DESCRIPTION
### Description of Change ###

This PR adds the option to set the transition style on a NavigationPage for pushing and popping pages. (old request was https://github.com/xamarin/Xamarin.Forms/pull/1043). Now with docs. I also added the docs for the TabOrder Extension on macOS that I wrote. I didn't want to create a separate PR for this, but I can do it, if required.

### API Changes ###

On<Xamarin.Forms.PlatformConfiguration.macOS> ().SetNavigationTransitionStyle (NavigationTransitionStyle.Crossfade, NavigationTransitionStyle.SlideUp);


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
