### PR TITLE
[macOS] Make Platform.RendererProperty public

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	public class Platform : BindableObject, IPlatform, IDisposable
 	{
-		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer",
+		public static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer",
 			typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),
 			propertyChanged: (bindable, oldvalue, newvalue) =>
 			{


### PR DESCRIPTION
### Description of Change ###

Here's the reason for this: I want to write my own ListView, making ListViewDataSource was rejected (https://github.com/xamarin/Xamarin.Forms/pull/1098), therefore I had to copy this code into my project. But I can't compile this piece of code, as RenderProperty is internal:

```
var target = viewCell.View;
target.ClearValue(Platform.RendererProperty);
foreach (var descendant in target.Descendants())
	descendant.ClearValue(Platform.RendererProperty);
```

RenderProperty is static readonly, therefore people should not be able to break anything. Especially, as Platform.CreateRenderer, Platform.GetRenderer and Platform.SetRenderer are public. I could probably use Platform.SetRenderer(target, null), but I don't know if this is produces the same result as ClearValue.

### API Changes ###

Changed:
 - internal Platform.RenderProperty => public Platform.RenderProperty


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
