### PR TITLE
[iOS] Redirect PreferredStatusBarStyle to the Child View Controller

### DIFF
--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Linq;
 using UIKit;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
@@ -95,6 +96,17 @@ namespace Xamarin.Forms.Platform.iOS
 				_modal = null;
 			base.Dispose(disposing);
 		}
+
+		public override void ViewDidLoad()
+		{
+			base.ViewDidLoad();
+			SetNeedsStatusBarAppearanceUpdate();
+		}
+
+		public override UIViewController ChildViewControllerForStatusBarStyle()
+		{
+			return ChildViewControllers?.LastOrDefault();
+		}
 	}
 
 	internal class PlatformRenderer : UIViewController
@@ -127,6 +139,11 @@ namespace Xamarin.Forms.Platform.iOS
 		public override UIViewController ChildViewControllerForStatusBarHidden()
 		{
 			return (UIViewController)Platform.GetRenderer(this.Platform.Page);
+		}
+
+		public override UIViewController ChildViewControllerForStatusBarStyle()
+		{
+			return ChildViewControllers?.LastOrDefault();
 		}
 
 		public override bool ShouldAutorotate()
@@ -166,6 +183,12 @@ namespace Xamarin.Forms.Platform.iOS
 			View.BackgroundColor = UIColor.White;
 			Platform.WillAppear();
 			base.ViewWillAppear(animated);
+		}
+
+		public override void ViewDidLoad()
+		{
+			base.ViewDidLoad();
+			SetNeedsStatusBarAppearanceUpdate();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

UIApplication.StatusBarStyle is deprecated since iOS 9 (https://developer.apple.com/documentation/uikit/uiapplication/1622988-statusbarstyle) and doesn't work on Xamarin.Forms at all. If you use the black navigation bar style or a dark background color for the navigation page, the status bar always uses the default black color.

This PR simply redirects the calls to UIViewController.PreferredStatusBarStyle from the PlatformRenderer to the top view controller (NavigationRenderer or PageRenderer), therefore you can set the status bar color in your own renderer/ViewController:

```
	public class ExtNavigationRenderer : NavigationRenderer
	{
		public override UIStatusBarStyle PreferredStatusBarStyle()
		{
			return UIStatusBarStyle.LightContent;
		}
	}
```


### Behavioral Changes ###

There should be none.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
