### PR TITLE
[Xaml] Chain op_implicit for OnPlatform (if needed)

### DIFF
--- a/Xamarin.Forms.Core/BindableProperty.cs
+++ b/Xamarin.Forms.Core/BindableProperty.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms
 {
@@ -321,14 +322,9 @@ namespace Xamarin.Forms
 			}
 			else if (!ReturnTypeInfo.IsAssignableFrom(valueType.GetTypeInfo()))
 			{
-				// Is there an implicit cast operator ?
-				MethodInfo cast = type.GetRuntimeMethod("op_Implicit", new[] { valueType });
-				if (cast != null && cast.ReturnType != type)
-					cast = null;
-				if (cast == null)
-					cast = valueType.GetRuntimeMethod("op_Implicit", new[] { valueType });
-				if (cast != null && cast.ReturnType != type)
-					cast = null;
+				var cast = type.GetImplicitConversionOperator(fromType: valueType, toType: type)
+						?? valueType.GetImplicitConversionOperator(fromType: valueType, toType: type);
+
 				if (cast == null)
 					return false;
 

--- a/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
+++ b/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
@@ -193,17 +193,14 @@ namespace Xamarin.Forms.Xaml
 
 		internal static MethodInfo GetImplicitConversionOperator(this Type onType, Type fromType, Type toType)
 		{
-			foreach (var mi in onType.GetRuntimeMethods()) {
-				if (!mi.IsSpecialName) continue;
-				if (mi.Name != "op_Implicit") continue;
-				if (!mi.IsPublic) continue;
-				if (!toType.IsAssignableFrom(mi.ReturnType)) continue;
-				var parameters = mi.GetParameters();
-				if (parameters.Length != 1) continue;
-				if (parameters[0].ParameterType != fromType) continue;
-				return mi;
-			}
-			return null;
+			var mi = onType.GetRuntimeMethod("op_Implicit", new[] { fromType });
+			if (mi == null) return null;
+			if (!mi.IsSpecialName) return null;
+			if (!mi.IsPublic) return null;
+			if (!mi.IsStatic) return null;
+			if (!toType.IsAssignableFrom(mi.ReturnType)) return null;
+
+			return mi;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
+++ b/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
@@ -173,31 +173,9 @@ namespace Xamarin.Forms.Xaml
 
 			//if there's an implicit conversion, convert
 			if (value != null) {
-				MethodInfo opImplicit = null;
-				foreach (var mi in value.GetType().GetRuntimeMethods()) {
-					if (!mi.IsSpecialName) continue;
-					if (mi.Name != "op_Implicit") continue;
-					if (!mi.IsPublic) continue;
-					if (!toType.IsAssignableFrom(mi.ReturnType)) continue;
-					var parameters = mi.GetParameters();
-					if (parameters.Length != 1) continue;
-					if (parameters[0].ParameterType != value.GetType()) continue;
-					opImplicit = mi;
-					break;
-				}
-				if (opImplicit == null) {
-					foreach (var mi in toType.GetRuntimeMethods()) {
-						if (!mi.IsSpecialName) continue;
-						if (mi.Name != "op_Implicit") continue;
-						if (!mi.IsPublic) continue;
-						if (!toType.IsAssignableFrom(mi.ReturnType)) continue;
-						var parameters = mi.GetParameters();
-						if (parameters.Length != 1) continue;
-						if (parameters[0].ParameterType != value.GetType()) continue;
-						opImplicit = mi;
-						break;
-					}
-				}
+				var opImplicit =   value.GetType().GetImplicitConversionOperator(fromType: value.GetType(), toType: toType)
+								?? toType.GetImplicitConversionOperator(fromType: value.GetType(), toType: toType);
+
 				if (opImplicit != null) {
 					value = opImplicit.Invoke(null, new[] { value });
 					return value;
@@ -211,6 +189,21 @@ namespace Xamarin.Forms.Xaml
 				return nativeValue;
 
 			return value;
+		}
+
+		internal static MethodInfo GetImplicitConversionOperator(this Type onType, Type fromType, Type toType)
+		{
+			foreach (var mi in onType.GetRuntimeMethods()) {
+				if (!mi.IsSpecialName) continue;
+				if (mi.Name != "op_Implicit") continue;
+				if (!mi.IsPublic) continue;
+				if (!toType.IsAssignableFrom(mi.ReturnType)) continue;
+				var parameters = mi.GetParameters();
+				if (parameters.Length != 1) continue;
+				if (parameters[0].ParameterType != fromType) continue;
+				return mi;
+			}
+			return null;
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz59818.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz59818.xaml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Bz59818">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <OnPlatform x:Key="NumberColumnWidth" x:TypeArguments="x:Double">
+                <On Platform="iOS" Value="100" />
+            </OnPlatform>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <Grid x:Name="grid">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="{StaticResource NumberColumnWidth}" />
+        </Grid.ColumnDefinitions>
+    </Grid>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz59818.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz59818.xaml.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz59818 : ContentPage
+	{
+		public Bz59818()
+		{
+			InitializeComponent();
+		}
+
+		public Bz59818(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void Bz59818(bool useCompiledXaml)
+			{
+				((MockPlatformServices)Device.PlatformServices).RuntimePlatform = Device.iOS;
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(Bz59818));
+				var layout = new Bz59818(useCompiledXaml);
+				Assert.That(layout.grid.ColumnDefinitions[0].Width, Is.EqualTo(new GridLength(100)));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz59818.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz59818.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using NUnit.Framework;
 using Xamarin.Forms.Core.UnitTests;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -19,25 +21,43 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		class Tests
 		{
+			IReadOnlyList<string> _flags;
+
 			[SetUp]
 			public void Setup()
 			{
 				Device.PlatformServices = new MockPlatformServices();
+				_flags = Device.Flags;
+				if (Device.Flags == null)
+					Device.SetFlags(new List<string>().AsReadOnly());
 			}
 
 			[TearDown]
 			public void TearDown()
 			{
 				Device.PlatformServices = null;
+				Device.SetFlags(_flags);
 			}
 
-			[TestCase(true)]
-			[TestCase(false)]
-			public void Bz59818(bool useCompiledXaml)
+			[TestCase(true, "xamlDoubleImplicitOpHack")]
+			[TestCase(false, "xamlDoubleImplicitOpHack")]
+			[TestCase(true, null)]
+			[TestCase(false, null)]
+			public void Bz59818(bool useCompiledXaml, string flag)
 			{
+				Device.SetFlags(new List<string>(Device.Flags) {
+					flag
+				}.AsReadOnly());
+
 				((MockPlatformServices)Device.PlatformServices).RuntimePlatform = Device.iOS;
-				if (useCompiledXaml)
-					MockCompiler.Compile(typeof(Bz59818));
+
+				if (flag != "xamlDoubleImplicitOpHack") {
+					if (useCompiledXaml)
+						Assert.Throws<InvalidCastException>(() => new Bz59818(useCompiledXaml));
+					else
+						Assert.Throws<XamlParseException>(() => new Bz59818(useCompiledXaml));
+					return;
+				}
 				var layout = new Bz59818(useCompiledXaml);
 				Assert.That(layout.grid.ColumnDefinitions[0].Width, Is.EqualTo(new GridLength(100)));
 			}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -505,6 +505,9 @@
     <Compile Include="MergedResourceDictionaries.xaml.cs">
       <DependentUpon>MergedResourceDictionaries.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz59818.xaml.cs">
+      <DependentUpon>Bz59818.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -923,6 +926,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="MergedResourceDictionaries.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz59818.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -206,7 +206,9 @@ namespace Xamarin.Forms.Xaml
 				for (var i = 0; i < p.Length; i++) {
 					if ((p [i].ParameterType.IsAssignableFrom(types [i])))
 						continue;
-					var op_impl = p [i].ParameterType.GetRuntimeMethod("op_Implicit", new [] { types [i]});
+					var op_impl =  p[i].ParameterType.GetImplicitConversionOperator(fromType: types[i], toType: p[i].ParameterType)
+								?? types[i].GetImplicitConversionOperator(fromType: types[i], toType: p[i].ParameterType);
+
 					if (op_impl == null)
 						return false;
 					arguments [i] = op_impl.Invoke(null, new [] { arguments [i]});

--- a/Xamarin.Forms.Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -43,15 +43,34 @@ namespace Xamarin.Forms.Xaml
 				if (resource.GetType().GetTypeInfo().IsGenericType && (resource.GetType().GetGenericTypeDefinition() == typeof(OnPlatform<>) || resource.GetType().GetGenericTypeDefinition() == typeof(OnIdiom<>))) {
 					// This is only there to support our backward compat story with pre 2.3.3 compiled Xaml project who was not providing TargetProperty
 					var method = resource.GetType().GetRuntimeMethod("op_Implicit", new[] { resource.GetType() });
-					resource = method.Invoke(resource, new[] { resource });
+					resource = method.Invoke(null, new[] { resource });
 				}
 				return resource;
 			}
 			if (propertyType.IsAssignableFrom(resource.GetType()))
 				return resource;
-			var implicit_op = resource.GetType().GetRuntimeMethod("op_Implicit", new [] { resource.GetType() });
-			if (implicit_op != null && propertyType.IsAssignableFrom(implicit_op.ReturnType))
+			var implicit_op =  resource.GetType().GetImplicitConversionOperator(fromType: resource.GetType(), toType: propertyType)
+							?? propertyType.GetImplicitConversionOperator(fromType: resource.GetType(), toType: propertyType);
+			if (implicit_op != null)
 				return implicit_op.Invoke(resource, new [] { resource });
+
+			//Special case for https://bugzilla.xamarin.com/show_bug.cgi?id=59818
+			//On OnPlatform, check for an opImplicit from the targetType
+			if (resource.GetType().GetTypeInfo().IsGenericType && (resource.GetType().GetGenericTypeDefinition() == typeof(OnPlatform<>))) {
+				var tType = resource.GetType().GenericTypeArguments[0];
+				var opImplicit =   tType.GetImplicitConversionOperator(fromType: tType, toType: propertyType)
+								?? propertyType.GetImplicitConversionOperator(fromType: tType, toType: propertyType);
+
+				if (opImplicit != null) {
+					//convert the OnPlatform<T> to T
+					var opPlatformImplicitConversionOperator = resource.GetType().GetImplicitConversionOperator(fromType: resource.GetType(), toType: tType);
+					resource = opPlatformImplicitConversionOperator.Invoke(null, new[] { resource });
+
+					//and convert to toType
+					resource = opImplicit.Invoke(null, new[] { resource });
+					return resource;
+				}
+			}
 
 			return resource;
 		}

--- a/Xamarin.Forms.Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Xml;
+using System.Linq;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Xaml
@@ -56,7 +57,9 @@ namespace Xamarin.Forms.Xaml
 
 			//Special case for https://bugzilla.xamarin.com/show_bug.cgi?id=59818
 			//On OnPlatform, check for an opImplicit from the targetType
-			if (resource.GetType().GetTypeInfo().IsGenericType && (resource.GetType().GetGenericTypeDefinition() == typeof(OnPlatform<>))) {
+				if (Xamarin.Forms.Device.Flags.Contains("xamlDoubleImplicitOpHack")
+				    && resource.GetType().GetTypeInfo().IsGenericType
+				    && (resource.GetType().GetGenericTypeDefinition() == typeof(OnPlatform<>))) {
 				var tType = resource.GetType().GenericTypeArguments[0];
 				var opImplicit =   tType.GetImplicitConversionOperator(fromType: tType, toType: propertyType)
 								?? propertyType.GetImplicitConversionOperator(fromType: tType, toType: propertyType);


### PR DESCRIPTION
### Description of Change ###

[Xaml] Chain op_implicit for OnPlatform (if flag is set)

NOTE: you have to set the flag "xamlDoubleImplicitOpHack" for this to work

For OnPlatform<T>, if a conversion for T to the destination type exists,
first convert OnPlatform<T> to T, the T to the dest type

Also unify the way we look for op_implicit operators

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=59818

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense