### PR TITLE
[Core] Add extra method that allows to specify default value for CanExecute on a Command

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32899.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32899.cs
@@ -1,0 +1,117 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Windows.Input;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 32899, "Setting button's IsEnabled to false does not disable button", PlatformAffected.Android)]
+	public class Bugzilla32899 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		const string ButtonScanID = "btnScan";
+		protected override void Init()
+		{
+			BindingContext = new ViewModelTest();
+
+			var lbl = new Label
+			{
+
+			};
+
+			lbl.SetBinding(Label.TextProperty, nameof(ViewModelTest.LblText));
+
+
+			var btn1 = new Button
+			{
+				Text = "Change IsEnabled"
+			};
+
+			btn1.SetBinding(Button.CommandProperty, nameof(ViewModelTest.IsEnableCommand));
+
+			var btn = new Button
+			{
+				Text = "Scan",
+				AutomationId = ButtonScanID,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+
+			};
+
+			//order is important here 
+			btn.SetBinding(VisualElement.IsEnabledProperty, nameof(ViewModelTest.ShouldBeEnabled));
+			btn.SetBinding(Button.CommandProperty, nameof(ViewModelTest.StopScanningCommand));
+		
+			var layout = new StackLayout();
+			layout.Children.Add(lbl);
+			layout.Children.Add(btn1);
+			layout.Children.Add(btn);
+			Content = layout;
+		}
+
+		[Preserve(AllMembers = true)]
+		class ViewModelTest : ViewModel
+		{
+			public const string Sucess = "Sucess";
+			public ViewModelTest()
+			{
+				ShouldBeEnabled = false;
+				StopScanningCommand = new Command((obj) =>
+				{
+					 LblText = Sucess;
+				});
+
+				IsEnableCommand = new Command((obj) => {
+					ShouldBeEnabled = !ShouldBeEnabled;
+				});
+			}
+
+			ICommand _stopScanningCommand;
+			public ICommand StopScanningCommand
+			{
+				get { return _stopScanningCommand; }
+				set
+				{
+					_stopScanningCommand = value;
+					OnPropertyChanged();
+				}
+			}
+
+			ICommand _isEnableCommand;
+			public ICommand IsEnableCommand
+			{
+				get { return _isEnableCommand; }
+				set
+				{
+					_isEnableCommand = value;
+					OnPropertyChanged();
+				}
+			}
+
+			string _lblText;
+			public string LblText
+			{
+				get { return _lblText; }
+				set
+				{
+					_lblText = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla32899Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked (ButtonScanID));
+			RunningApp.Tap(q => q.Marked(ButtonScanID));
+			RunningApp.WaitForNoElement (ViewModelTest.Sucess);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -603,6 +603,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ButtonFastRendererTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DesktopSupportTestPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58779.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla32899.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
@@ -227,5 +227,28 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(layout1.Position, bcl.Position);
 			Assert.AreEqual(layout1.Spacing, bcl.Spacing);
 		}
+
+		[Test]
+		public void EnabledAndCommandCanExecuteWorksWithIsEnabledFirst()
+		{
+			var button = new Button();
+
+			bool result = false;
+
+			var bindingContext = new
+			{
+				Command = new Command(() => { }),
+				IsButtonEnabled = result
+			};
+
+			//order is important
+			button.SetBinding(Button.IsEnabledProperty, "IsButtonEnabled");
+			button.SetBinding(Button.CommandProperty, "Command");
+	
+			button.BindingContext = bindingContext;
+
+			Assert.False(button.IsEnabled);
+		}
+
 	}	
 }

--- a/Xamarin.Forms.Core.UnitTests/CommandTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/CommandTests.cs
@@ -89,6 +89,19 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void CanExecuteWithDefaultValue([Values(true, false)] bool expected)
+		{
+			bool canExecuteRan = false;
+			var cmd = new Command(() => { }, () => {
+				canExecuteRan = true;
+				return expected;
+			});
+
+			Assert.AreEqual(expected, cmd.CanExecute(null,expected));
+			Assert.True(canExecuteRan);
+		}
+
+		[Test]
 		public void ChangeCanExecute ()
 		{
 			bool signaled = false;

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -188,8 +188,8 @@ namespace Xamarin.Forms
 		void CommandCanExecuteChanged(object sender, EventArgs eventArgs)
 		{
 			ICommand cmd = Command;
-			if (cmd != null)
-				IsEnabledCore = cmd.CanExecute(CommandParameter);
+			if(cmd != null)
+				IsEnabledCore = (cmd as Command)?.CanExecute(CommandParameter, IsEnabled) ?? cmd.CanExecute(CommandParameter);
 		}
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -94,10 +94,15 @@ namespace Xamarin.Forms
 
 		public bool CanExecute(object parameter)
 		{
+			return CanExecute(parameter, true);
+		}
+
+		public bool CanExecute(object parameter, bool defaultCanExecute)
+		{
 			if (_canExecute != null)
 				return _canExecute(parameter);
 
-			return true;
+			return defaultCanExecute;
 		}
 
 		public event EventHandler CanExecuteChanged;

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Command.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Command.xml
@@ -173,6 +173,28 @@ var button = new Button {
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="CanExecute">
+      <MemberSignature Language="C#" Value="public bool CanExecute (object parameter, bool defaultCanExecute);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance bool CanExecute(object parameter, bool defaultCanExecute) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="parameter" Type="System.Object" />
+        <Parameter Name="defaultCanExecute" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="parameter">To be added.</param>
+        <param name="defaultCanExecute">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="CanExecuteChanged">
       <MemberSignature Language="C#" Value="public event EventHandler CanExecuteChanged;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler CanExecuteChanged" />


### PR DESCRIPTION
### Description of Change ###

This pr resolves a issue where our `CanExecute(obj)` method on the `Command` will always return true if a `CanExecute` delegate wasn't specified. 
The problem happens that in a `Button` we don't have no way to figure if a user specified or not that delegate on a `Command`, and we need to decide to either respect the IsEnabled property from the button or the result of the command can execute. 

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=32899

### API Changes ###

Adding to `Command`
Added:
 - public bool CanExecute(object parameter, bool defaultCanExecute)

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense