### PR TITLE
[Android] Remove NavigationPage fragments after everything else is disposed 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45702.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45702.cs
@@ -1,0 +1,37 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 45702, "Disabling back press on modal page causes app to crash", PlatformAffected.Android)]
+	public class Bugzilla45702 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			Navigation.PushAsync(new NavigationPage(new MasterDetailPage() { Master = new ContentPage() { Title = "Master" }, Detail = new DetailPage() }));
+
+			MessagingCenter.Subscribe<DetailPage>(this, "switch", SwitchControl);
+		}
+
+		void SwitchControl(object sender)
+		{
+			Application.Current.MainPage = new NavigationPage(new ContentPage { Content = new Label { Text = "Success" } });
+		}
+
+		class DetailPage : ContentPage
+		{
+			public DetailPage()
+			{
+				var button = new Button { Text = "Click me" };
+				button.Clicked += Button_Clicked;
+				Content = button;
+			}
+
+			void Button_Clicked(object sender, System.EventArgs e)
+			{
+				MessagingCenter.Send(this, "switch");
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -333,6 +333,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla27731.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59097.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58875.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45702.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59718.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60382.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Controls
 			SetMainPage(CreateDefaultMainPage());
 
 			//// Uncomment to verify that there is no gray screen displayed between the blue splash and red MasterDetailPage.
-			//MainPage = new Bugzilla44596SplashPage(() =>
+			//SetMainPage(new Bugzilla44596SplashPage(() =>
 			//{
 			//	var newTabbedPage = new TabbedPage();
 			//	newTabbedPage.Children.Add(new ContentPage { BackgroundColor = Color.Red, Content = new Label { Text = "yay" } });
@@ -42,7 +42,10 @@ namespace Xamarin.Forms.Controls
 			//		Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
 			//		Detail = newTabbedPage
 			//	};
-			//});
+			//}));
+
+			//// Uncomment to verify that there is no crash when switching MainPage from MDP inside NavPage
+			//SetMainPage(new Bugzilla45702());
 		}
 
 		public Page CreateDefaultMainPage()

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -128,20 +128,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				_disposed = true;
 
-				// API only exists on newer android YAY
-				if ((int)Build.VERSION.SdkInt >= 17)
-				{
-					FragmentManager fm = FragmentManager;
-
-					if (!fm.IsDestroyed)
-					{
-						FragmentTransaction trans = fm.BeginTransaction();
-						foreach (Fragment fragment in _fragmentStack)
-							trans.Remove(fragment);
-						trans.CommitAllowingStateLoss();
-						fm.ExecutePendingTransactions();
-					}
-				}
 
 				if (_toolbarTracker != null)
 				{
@@ -206,6 +192,21 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 
 				Device.Info.PropertyChanged -= DeviceInfoPropertyChanged;
+
+				// API only exists on newer android YAY
+				if ((int)Build.VERSION.SdkInt >= 17)
+				{
+					FragmentManager fm = FragmentManager;
+
+					if (!fm.IsDestroyed)
+					{
+						FragmentTransaction trans = fm.BeginTransaction();
+						foreach (Fragment fragment in _fragmentStack)
+							trans.Remove(fragment);
+						trans.CommitAllowingStateLoss();
+						fm.ExecutePendingTransactions();
+					}
+				}
 			}
 
 			base.Dispose(disposing);


### PR DESCRIPTION
### Description of Change ###

Moved code that removed fragments upon `NavigationPage` `dispose` to the end of method. This will allow children to be disposed before the fragments are removed so that when we call their `dispose` methods, we don't get an invalid handle exception.

### Bugs Fixed ###

- [Bug 45702 - Disabling back press on modal page causes app to crash](https://bugzilla.xamarin.com/show_bug.cgi?id=45702)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (MANUAL, must be MainPage)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
