### PR TITLE
[*] Expose the Flags to the Core

### DIFF
--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -83,6 +83,7 @@ namespace Xamarin.Forms
 			set { s_platformServices = value; }
 		}
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IReadOnlyList<string> Flags { get; private set; }
 
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Reflection;
@@ -80,6 +81,14 @@ namespace Xamarin.Forms
 				return s_platformServices;
 			}
 			set { s_platformServices = value; }
+		}
+
+		public static IReadOnlyList<string> Flags { get; private set; }
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetFlags(IReadOnlyList<string> flags)
+		{
+			Flags = flags;
 		}
 
 		public static void BeginInvokeOnMainThread(Action action)

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -149,6 +149,7 @@ namespace Xamarin.Forms
 			// We want this to be updated when we have a new activity (e.g. on a configuration change)
 			// because Device.Info watches for orientation changes and we need a current activity for that
 			Device.Info = new AndroidDeviceInfo(activity);
+			Device.SetFlags(s_flags);
 
 			var ticker = Ticker.Default as AndroidTicker;
 			if (ticker != null)

--- a/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
@@ -49,6 +49,9 @@ namespace Xamarin.Forms
 
 			Device.SetIdiom(TargetIdiom.Tablet);
 			Device.PlatformServices = new WindowsPlatformServices(Window.Current.Dispatcher);
+#if WINDOWS_UWP
+			Device.SetFlags(s_flags);
+#endif
 			Device.Info = new WindowsDeviceInfo();
 
 #if WINDOWS_UWP

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -93,6 +93,7 @@ namespace Xamarin.Forms
 #else
 			Device.SetIdiom(TargetIdiom.Desktop);
 #endif
+			Device.SetFlags(s_flags);
 			Device.PlatformServices = new IOSPlatformServices();
 			Device.Info = new IOSDeviceInfo();
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
@@ -71,6 +71,22 @@ Device.BeginInvokeOnMainThread (() => {
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="Flags">
+      <MemberSignature Language="C#" Value="public static System.Collections.Generic.IReadOnlyList&lt;string&gt; Flags { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property class System.Collections.Generic.IReadOnlyList`1&lt;string&gt; Flags" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IReadOnlyList&lt;System.String&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="GetAssemblies">
       <MemberSignature Language="C#" Value="public static System.Reflection.Assembly[] GetAssemblies ();" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Reflection.Assembly[] GetAssemblies() cil managed" />
@@ -465,6 +481,30 @@ button.HeightRequest = Device.OnPlatform (20,30,30);
       <Docs>
         <summary>Gets the kind of device that Xamarin.Forms is currently working on.</summary>
         <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetFlags">
+      <MemberSignature Language="C#" Value="public static void SetFlags (System.Collections.Generic.IReadOnlyList&lt;string&gt; flags);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetFlags(class System.Collections.Generic.IReadOnlyList`1&lt;string&gt; flags) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="flags" Type="System.Collections.Generic.IReadOnlyList&lt;System.String&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="flags">To be added.</param>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Device.xml
@@ -78,6 +78,11 @@ Device.BeginInvokeOnMainThread (() => {
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Collections.Generic.IReadOnlyList&lt;System.String&gt;</ReturnType>
       </ReturnValue>


### PR DESCRIPTION
Expose the Flags to the Core, through Device

as we aren't sure yet if this is the best API ever, decorate it with a nice [STAND BACK] attribute

New API:

```
[EditorBrowsable(EditorBrowsableState.Never)]
public static IReadOnlyList<string> Device.Flags { get; private set; }

[EditorBrowsable(EditorBrowsableState.Never)]
public static void Device.SetFlags(IReadOnlyList<string> flags)
```