### PR TITLE
[iOS] CGColor creation fixed

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -25,7 +25,11 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public static CGColor ToCGColor(this Color color)
 		{
-			return new CGColor((float)color.R, (float)color.G, (float)color.B, (float)color.A);
+#if __MOBILE__
+			return color.ToUIColor().CGColor;
+#else
+            return color.ToNSColor().CGColor;
+#endif
 		}
 
 		public static Color ToColor(this UIColor color)


### PR DESCRIPTION
### Description of Change ###

I've replaced the ToCGColor extension function so developers can get the desired color on controls that uses CGColor, for example Frame. No special tests needed since it depends on existing methods.

### Bugs Fixed ###

Can't find any specific bug report so far, but here is a library that shows the problem: https://github.com/GalaxiaGuy/xamarin-forms-frame-color

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [-] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense