### PR TITLE
[UWP] Fixed inconsistency on UWP's DatePicker and the other OS's.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60001.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60001.cs
@@ -1,0 +1,34 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+// Apply the default category of "Issues" to all of the tests in this assembly
+// We use this as a catch-all for tests which haven't been individually categorized
+#if UITEST
+[assembly: NUnit.Framework.Category("Issues")]
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60001, "[UWP] Inconsistency with DatePicker ", PlatformAffected.UWP)]
+	public class Bugzilla60001 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			StackLayout layout = new StackLayout() { Orientation = StackOrientation.Vertical };
+			DatePicker picker = new DatePicker();
+			picker.Date = new DateTime(2017, 10, 7, 0, 0, 0, DateTimeKind.Utc);
+			Label label = new Label() { Text = "On Droid this will show as 10/7/2017, on UWP it will show as 10/06/2017.  Local TimeZone for this test was EDT.", LineBreakMode = LineBreakMode.WordWrap };
+			layout.Children.Add(picker);
+			layout.Children.Add(label);
+			// Initialize ui here instead of ctor
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -231,6 +231,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59248.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59457.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60001.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60056.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60122.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_0.cs" />

--- a/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
@@ -77,17 +77,20 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnControlDateChanged(object sender, DatePickerValueChangedEventArgs e)
 		{
-			Element.Date = e.NewDate.Date;
-			DateTime currentDate = Element.Date;
-			if (currentDate != e.NewDate.Date) // Match coerced value
-				UpdateDate(currentDate);
+			if (Element == null)
+				return;
 
-			((IVisualElementController)Element).InvalidateMeasure(InvalidationTrigger.SizeRequestChanged);
+			if (Element.Date.CompareTo(e.NewDate.Date) != 0)
+			{
+				Element.Date = e.NewDate.Date;
+				((IVisualElementController)Element).InvalidateMeasure(InvalidationTrigger.SizeRequestChanged);
+			}
 		}
 
 		void UpdateDate(DateTime date)
 		{
-			Control.Date = date;
+			if (Control != null)
+				Control.Date = new DateTimeOffset(new DateTime(date.Ticks, DateTimeKind.Unspecified));
 		}
 
 		void UpdateFlowDirection()
@@ -130,17 +133,16 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateMaximumDate()
 		{
-			DateTime maxdate = Element.MaximumDate;
-			Control.MaxYear = new DateTimeOffset(maxdate);
+			if (Element != null && Control != null)
+				Control.MaxYear = new DateTimeOffset(new DateTime(Element.MaximumDate.Ticks, DateTimeKind.Unspecified));			
 		}
 
 		void UpdateMinimumDate()
 		{
-			DateTime mindate = Element.MinimumDate;
-
 			try
 			{
-				Control.MinYear = new DateTimeOffset(mindate);
+				if (Element != null && Control != null)
+					Control.MinYear = new DateTimeOffset(new DateTime(Element.MinimumDate.Ticks, DateTimeKind.Unspecified));
 			}
 			catch (ArgumentOutOfRangeException)
 			{

--- a/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
@@ -139,6 +139,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateMinimumDate()
 		{
+			DateTime mindate = Element.MinimumDate;
+
 			try
 			{
 				if (Element != null && Control != null)


### PR DESCRIPTION
### Description of Change ###

Changed the DateTimeOffset on DatePickerRenderer.UWP to create a new date based on an unspecified time zone.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60001

### API Changes ###

None.

### Behavioral Changes ###

The DatePicker on UWP should show the same value as the other OS's.  There may be other ways to fix this issue, maybe changing the other OS's to match UWP?  Or another way to reset the DateTimeKind.  This worked for us in a jiffy.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
