### PR TITLE
[UWP] Fixed issue where Label.FormattedText was crashing.

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/LabelRenderer.cs
@@ -263,7 +263,8 @@ namespace Xamarin.Forms.Platform.WinRT
 
 					for (var i = 0; i < formatted.Spans.Count; i++)
 					{
-						textBlock.Inlines.Add(formatted.Spans[i].ToRun());
+						if (formatted.Spans[i].Text != null)
+							textBlock.Inlines.Add(formatted.Spans[i].ToRun());
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Change ###

If a Label.FormattedText line contained a null (say from a binding), UWP would crash.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60002

### API Changes ###

None.

### Behavioral Changes ###

Using a null in a span of the Label.FormattedText property will now no longer crash UWP.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
