### PR TITLE
[UWP] Issue where in some weird circumstances(Custom controls) grabbi…

### DIFF
--- a/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.WinRT/VisualElementRenderer.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Forms.Platform.WinRT
 
 		public virtual SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			if (Children.Count == 0)
+			if (Children.Count == 0 || Control == null)
 				return new SizeRequest();
 
 			var constraint = new Windows.Foundation.Size(widthConstraint, heightConstraint);


### PR DESCRIPTION
…ng a desired size could cause a null reference exception.

### Description of Change ###

Added a null check in GetDesiredSize() on Control.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60004

### API Changes ###

None.

### Behavioral Changes ###

Small null check.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
