### PR TITLE
[UWP]  Fix for UWP crashing on load when compiled with .NET Native fo…

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
+++ b/Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
@@ -29,6 +29,8 @@
 
   	<!-- add directives for your library here -->
     <Namespace Name="Windows.UI.Xaml.Automation.Peers" MarshalObject="Required All"/>
-  
+    <Type Name="Xamarin.Forms.Platform.UWP.WindowsPlatformServices" Activate="Required All"/>
+    <Type Name="Xamarin.Forms.Platform.UWP.WindowsBasePlatformServices" Activate="Required All"/>
+    <Type Name="Xamarin.Forms.Platform.UWP.WindowsPlatform" Activate="Required All"/>
   </Library>
 </Directives>


### PR DESCRIPTION
…r the store.

### Description of Change ###

UWP will crash when loading anything from the WindowsPlatform classes like Forms.Init.  When compiled for the Microsoft Store, Xamarin.Forms apps with crash immediately.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60005

### API Changes ###

None.

### Behavioral Changes ###

Xamarin.Forms apps can now be submitted to the Microsoft Store.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
