### PR TITLE
[MacOS] make OnElementChanged and OnElementPropertyChanged protected virtual

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/CarouselPageRenderer.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			Init();
 
-			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
+			RaiseElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 		}
 
 		public void SetElementSize(Size size)
@@ -98,7 +98,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				if (Carousel != null)
 				{
-					Carousel.PropertyChanged -= OnPropertyChanged;
+					Carousel.PropertyChanged -= OnElementPropertyChanged;
 					Carousel.PagesChanged -= OnPagesChanged;
 				}
 
@@ -129,9 +129,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.Dispose(disposing);
 		}
 
-		void OnElementChanged(VisualElementChangedEventArgs e)
+		void RaiseElementChanged(VisualElementChangedEventArgs e)
 		{
+			OnElementChanged(e);
 			ElementChanged?.Invoke(this, e);
+		}
+
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
+		{
 		}
 
 		void ConfigureNSPageController()
@@ -154,7 +159,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			UpdateBackground();
 			UpdateSource();
 
-			Carousel.PropertyChanged += OnPropertyChanged;
+			Carousel.PropertyChanged += OnElementPropertyChanged;
 			Carousel.PagesChanged += OnPagesChanged;
 		}
 
@@ -178,7 +183,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			UpdateSource();
 		}
 
-		void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(TabbedPage.CurrentPage))
 				UpdateCurrentPage();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				if (Element != null)
 				{
-					Element.PropertyChanged -= HandlePropertyChanged;
+					Element.PropertyChanged -= OnElementPropertyChanged;
 					Element = null;
 				}
 
@@ -68,7 +68,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			UpdateControllers();
 
-			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
+			HandleElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
 			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);
 		}
@@ -79,15 +79,20 @@ namespace Xamarin.Forms.Platform.MacOS
 			UpdateChildrenLayout();
 		}
 
-		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
+		void HandleElementChanged(VisualElementChangedEventArgs e)
 		{
 			if (e.OldElement != null)
-				e.OldElement.PropertyChanged -= HandlePropertyChanged;
+				e.OldElement.PropertyChanged -= OnElementPropertyChanged;
 
 			if (e.NewElement != null)
-				e.NewElement.PropertyChanged += HandlePropertyChanged;
+				e.NewElement.PropertyChanged += OnElementPropertyChanged;
 
+			OnElementChanged(e);
 			ElementChanged?.Invoke(this, e);
+		}
+
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
+		{
 		}
 
 		protected virtual double MasterWidthPercentage => 0.3;
@@ -119,7 +124,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				SplitViewItems[0].MaximumThickness = SplitViewItems[0].MinimumThickness = (nfloat)masterWidth;
 		}
 
-		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (_tracker == null)
 				return;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			Init();
 
-			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
+			RaiseElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
 			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);
 		}
@@ -90,7 +90,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					NavigationPage?.SendDisappearing();
 					((Element as IPageContainer<Page>)?.CurrentPage as Page)?.SendDisappearing();
-					Element.PropertyChanged -= HandlePropertyChanged;
+					Element.PropertyChanged -= OnElementPropertyChanged;
 					Element = null;
 				}
 
@@ -126,15 +126,20 @@ namespace Xamarin.Forms.Platform.MacOS
 			NavigationPage?.SendAppearing();
 		}
 
-		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
+		void RaiseElementChanged(VisualElementChangedEventArgs e)
 		{
 			if (e.OldElement != null)
-				e.OldElement.PropertyChanged -= HandlePropertyChanged;
+				e.OldElement.PropertyChanged -= OnElementPropertyChanged;
 
 			if (e.NewElement != null)
-				e.NewElement.PropertyChanged += HandlePropertyChanged;
+				e.NewElement.PropertyChanged += OnElementPropertyChanged;
 
+			OnElementChanged(e);
 			ElementChanged?.Invoke(this, e);
+		}
+
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
+		{
 		}
 
 		protected virtual void ConfigurePageRenderer()
@@ -364,7 +369,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			Platform.NativeToolbarTracker.UpdateToolBar();
 		}
 
-		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (_tracker == null)
 				return;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			Element = element;
 			UpdateTitle();
 
-			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
+			RaiseElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
 			if (Element != null && !string.IsNullOrEmpty(Element.AutomationId))
 				SetAutomationId(Element.AutomationId);
@@ -125,9 +125,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.Dispose(disposing);
 		}
 
+		void RaiseElementChanged(VisualElementChangedEventArgs e)
+		{
+			OnElementChanged(e);
+			ElementChanged?.Invoke(this, e);
+		}
+
 		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
 		{
-			ElementChanged?.Invoke(this, e);
 		}
 
 		void SetAutomationId(string id)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
@@ -93,7 +93,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (disposing && !_disposed)
 			{
-				Element.PropertyChanged -= OnHandlePropertyChanged;
+				Element.PropertyChanged -= OnElementPropertyChanged;
 				Platform.SetRenderer(Element, null);
 				if (_appeared)
 					Page.SendDisappearing();
@@ -125,7 +125,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.Dispose(disposing);
 		}
 
-		void OnElementChanged(VisualElementChangedEventArgs e)
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
 		{
 			ElementChanged?.Invoke(this, e);
 		}
@@ -145,7 +145,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			_packager = new VisualElementPackager(this);
 			_packager.Load();
 
-			Element.PropertyChanged += OnHandlePropertyChanged;
+			Element.PropertyChanged += OnElementPropertyChanged;
 			_tracker = new VisualElementTracker(this);
 
 			_events = new EventTracker(this);
@@ -153,7 +153,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			_init = true;
 		}
 
-		void OnHandlePropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackground();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateContentSize();
 				UpdateBackgroundColor();
 
-				OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
+				RaiseElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 			}
 		}
 
@@ -111,9 +111,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.Dispose(disposing);
 		}
 
+		void RaiseElementChanged(VisualElementChangedEventArgs e)
+		{
+			OnElementChanged(e);
+			ElementChanged?.Invoke(this, e);
+		}
+
 		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
 		{
-			ElementChanged?.Invoke(this, e);
 		}
 
 		void PackContent()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -47,13 +47,13 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (oldElement != null)
 			{
-				oldElement.PropertyChanged -= HandlePropertyChanged;
+				oldElement.PropertyChanged -= OnElementPropertyChanged;
 				((ScrollView)oldElement).ScrollToRequested -= OnScrollToRequested;
 			}
 
 			if (element != null)
 			{
-				element.PropertyChanged += HandlePropertyChanged;
+				element.PropertyChanged += OnElementPropertyChanged;
 				((ScrollView)element).ScrollToRequested += OnScrollToRequested;
 				if (_tracker == null)
 				{
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.Dispose(disposing);
 		}
 
-		void OnElementChanged(VisualElementChangedEventArgs e)
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
 		{
 			ElementChanged?.Invoke(this, e);
 		}
@@ -144,7 +144,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 		}
 
-		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == ScrollView.ContentSizeProperty.PropertyName)
 				UpdateContentSize();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (oldElement != null)
 			{
-				oldElement.PropertyChanged -= OnPropertyChanged;
+				oldElement.PropertyChanged -= OnElementPropertyChanged;
 				var tabbedPage = oldElement as TabbedPage;
 				if (tabbedPage != null) tabbedPage.PagesChanged -= OnPagesChanged;
 			}
@@ -56,13 +56,13 @@ namespace Xamarin.Forms.Platform.MacOS
 				}
 			}
 
-			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
+			RaiseElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
 			ConfigureTabView();
 
 			OnPagesChanged(null, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 
-			Tabbed.PropertyChanged += OnPropertyChanged;
+			Tabbed.PropertyChanged += OnElementPropertyChanged;
 			Tabbed.PagesChanged += OnPagesChanged;
 
 			UpdateBarBackgroundColor();
@@ -148,7 +148,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				_disposed = true;
 				Page.SendDisappearing();
-				Tabbed.PropertyChanged -= OnPropertyChanged;
+				Tabbed.PropertyChanged -= OnElementPropertyChanged;
 				Tabbed.PagesChanged -= OnPagesChanged;
 
 				if (_tracker != null)
@@ -187,9 +187,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			TabView.TabViewType = NSTabViewType.NSNoTabsNoBorder;
 		}
 
+		void RaiseElementChanged(VisualElementChangedEventArgs e)
+		{
+			OnElementChanged(e);
+			ElementChanged?.Invoke(this, e);
+		}
+
 		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
 		{
-			ElementChanged?.Invoke(this, e);
 		}
 
 		protected virtual NSTabViewItem GetTabViewItem(Page page, IVisualElementRenderer pageRenderer)
@@ -263,7 +268,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			SetSelectedTabViewItem();
 		}
 
-		void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(TabbedPage.CurrentPage))
 			{


### PR DESCRIPTION
### Description of Change ###

In Xamarin.Forms.Platform.MacOS the PageRenderer and ScrollViewRenderer did not have the usual protected virtual methods OnElementChanged and OnElementPropertyChanged. They were private and partly wrong named. Therefore users could not inherit from those renderers and use them as every other renderer on every other platform.

### API Changes ###

Changed:
 - PageRenderer: void OnElementChanged => protected virtual void OnElementChanged
 - PageRenderer: void OnHandlePropertyChanged => protected virtual void OnElementPropertyChanged
 - ScrollViewRenderer: void OnElementChanged => protected virtual void OnElementChanged
 - ScrollViewRenderer: void HandlePropertyChanged => protected virtual void OnElementPropertyChanged

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
