### PR TITLE
Revert PR #882

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -185,7 +185,7 @@
 						              IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
 						              IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
 						              Margin="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}" Grid.Row="1"
-						              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+						              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" VerticalAlignment="Bottom"
 						              VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}" ZoomMode="Disabled" />
 						<ContentControl x:Name="PlaceholderTextContentPresenter" Grid.ColumnSpan="2"
 						                Content="{TemplateBinding PlaceholderText}"


### PR DESCRIPTION
### Description of Change ###

PR #882 made a change to the template for the `TextBox` control, but in cases where the TextBox/Entry had a tall height, it would only modify the vertical alignment of the the placeholder and not the actual text, as seen below:

![before](https://user-images.githubusercontent.com/1251024/31354579-dea9ece0-ad04-11e7-933f-3f6ca7e4d94b.JPG)

![after](https://user-images.githubusercontent.com/1251024/31354583-e0ae4914-ad04-11e7-8ec2-fcd26c9fe354.JPG)

After entering text, it would still appear the same as the first photo. By default a TextBlock in UWP will place both the text and placeholder text at the top. The original report mentioned a misalignment, but using its code compared to a default UWP TextBox of the same height looks to be virtually identical, with a pixel's difference if anything (in the below case, it is Forms UWP below standard UWP):

![compare](https://user-images.githubusercontent.com/1251024/31354737-74881746-ad05-11e7-83db-75dbc6cf0412.JPG)

Ultimately we need to revert this original change because of the negative impact it has on the Entry.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60041

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
