### PR TITLE
Checking IsDestroyed before using FragmentManager in Dispose()

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -136,7 +136,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (disposing)
 			{
-				if (_currentFragment != null)
+				if (_currentFragment != null && !FragmentManager.IsDestroyed)
 				{
 					FragmentTransaction transaction = FragmentManager.BeginTransaction();
 					transaction.Remove(_currentFragment);

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -128,14 +128,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				_disposed = true;
 
-				var activity = (FormsAppCompatActivity)Context;
-
 				// API only exists on newer android YAY
 				if ((int)Build.VERSION.SdkInt >= 17)
 				{
-					if (!activity.IsDestroyed)
+					FragmentManager fm = FragmentManager;
+
+					if (!fm.IsDestroyed)
 					{
-						FragmentManager fm = FragmentManager;
 						FragmentTransaction trans = fm.BeginTransaction();
 						foreach (Fragment fragment in _fragmentStack)
 							trans.Remove(fragment);


### PR DESCRIPTION
### Description of Change ###

Adds a check for `IsDestroyed` before cleaning up `MasterDetailContainer` in `Dispose()` to avoid the exception thrown in [59996](https://bugzilla.xamarin.com/show_bug.cgi?id=59996).

### Bugs Fixed ###

- [59996 – Race condition when disposing MasterDetailPageRenderer on Android app restart](https://bugzilla.xamarin.com/show_bug.cgi?id=59996)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
