### PR TITLE
[UWP] Optimized ZIndexing for a thirty-nine percent speed boot on loa…

### DIFF
--- a/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Platform.UWP
 		readonly int _rowSpan;
 		bool _disposed;
 		bool _isLoaded;
+		bool _isZChanged;
 
 		public VisualElementPackager(IVisualElementRenderer renderer)
 		{
@@ -95,7 +96,13 @@ namespace Xamarin.Forms.Platform.UWP
 					continue;
 				}
 
-				Canvas.SetZIndex(childRenderer.ContainerElement, z + 1);
+				if (Canvas.GetZIndex(childRenderer.ContainerElement) != (z + 1))
+				{
+					if (!_isZChanged)
+						_isZChanged = true;
+
+					Canvas.SetZIndex(childRenderer.ContainerElement, z + 1);
+				}
 			}
 		}
 
@@ -120,7 +127,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_panel.Children.Add(childRenderer.ContainerElement);
 
-			EnsureZIndex();
+			if (_isZChanged)
+				EnsureZIndex();
 		}
 
 		void OnChildRemoved(object sender, ElementEventArgs e)


### PR DESCRIPTION
…ding views.

### Description of Change ###

Setting the Z-Index of UI Elements in UWP can be very costly.  I tracked a 39% improvement in speed loading views.  This will only set the Z-Index when the developer explicitly raises or lowers an element rather than every time any element is added to the tree and re-setting all its siblings.


### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60143

### API Changes ###

None.

### Behavioral Changes ###

Views by my calculations (stopwatch) are now loading 39% faster.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
