### PR TITLE
[Android] Deduplicate AutomationPropertiesProvider

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -1,11 +1,125 @@
 using System;
 using System.ComponentModel;
 using Android.Widget;
+using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
 	internal class AutomationPropertiesProvider : IDisposable 
 	{
+		internal static void SetAutomationId(AView control, VisualElement element, string value = null)
+		{
+			if (element == null || control == null)
+			{
+				return;
+			}
+
+			value = element.AutomationId;
+
+			if (!string.IsNullOrEmpty(value))
+			{
+				control.ContentDescription = value;
+			}
+		}
+
+		internal static void SetContentDescription(
+			AView control, 
+			VisualElement element, 
+			ref string defaultContentDescription,
+			ref string defaultHint)
+		{
+			if (element == null || control == null)
+			{
+				return;
+			}
+
+			if (SetHint(control, element, ref defaultHint))
+			{
+				return;
+			}
+
+			if (defaultContentDescription == null)
+			{
+				defaultContentDescription = control.ContentDescription;
+			}
+
+			string value = ConcatenateNameAndHelpText(element);
+
+			if (!string.IsNullOrWhiteSpace(value))
+			{
+				control.ContentDescription = value;
+			}
+			else
+			{
+				control.ContentDescription = defaultContentDescription;
+			}
+		}
+
+		internal static void SetFocusable(AView control, VisualElement element, ref bool? defaultFocusable)
+		{
+			if (element == null || control == null)
+			{
+				return;
+			}
+
+			if (!defaultFocusable.HasValue)
+			{
+				defaultFocusable = control.Focusable;
+			}
+
+			control.Focusable =
+				(bool)((bool?)element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? defaultFocusable);
+		}
+
+		internal static void SetLabeledBy(AView control, VisualElement element)
+		{
+			if (element == null || control == null)
+				return;
+
+			var elemValue = (VisualElement)element.GetValue(AutomationProperties.LabeledByProperty);
+
+			if (elemValue != null)
+			{
+				var id = control.Id;
+				if (id == AView.NoId)
+					id = control.Id = Platform.GenerateViewId();
+
+				var renderer = elemValue?.GetRenderer();
+				renderer?.SetLabelFor(id);
+			}
+		}
+
+		static bool SetHint(AView Control, VisualElement Element, ref string defaultHint)
+		{
+			if (Element == null || Control == null)
+			{
+				return false;
+			}
+
+			var textView = Control as TextView;
+			if (textView == null)
+			{
+				return false;
+			}
+
+			// Let the specified Title/Placeholder take precedence, but don't set the ContentDescription (won't work anyway)
+			if (((Element as Picker)?.Title ?? (Element as Entry)?.Placeholder) != null)
+			{
+				return true;
+			}
+
+			if (defaultHint == null)
+			{
+				defaultHint = textView.Hint;
+			}
+
+			string value = ConcatenateNameAndHelpText(Element);
+
+			textView.Hint = !string.IsNullOrWhiteSpace(value) ? value : defaultHint;
+
+			return true;
+		}
+
 		string _defaultContentDescription;
 		bool? _defaultFocusable;
 		string _defaultHint;
@@ -20,7 +134,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			_renderer.ElementChanged += OnElementChanged;
 		}
 
-		global::Android.Views.View Control => _renderer?.View;
+		AView Control => _renderer?.View;
 
 		VisualElement Element => _renderer?.Element;
 
@@ -49,95 +163,16 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		}
 
 		void SetAutomationId()
-		{
-			if (Element == null || Control == null)
-			{
-				return;
-			}
-
-			string value = Element.AutomationId;
-
-			if (!string.IsNullOrEmpty(value))
-			{
-				Control.ContentDescription = value;
-			}
-		}
+			=> SetAutomationId(Control, Element);
 
 		void SetContentDescription()
-		{
-			if (Element == null || Control == null)
-			{
-				return;
-			}
-
-			if (SetHint())
-			{
-				return;
-			}
-
-			if (_defaultContentDescription == null)
-			{
-				_defaultContentDescription = Control.ContentDescription;
-			}
-
-			string value = ConcatenateNameAndHelpText(Element);
-
-			if (!string.IsNullOrWhiteSpace(value))
-			{
-				Control.ContentDescription = value;
-			}
-			else
-			{
-				Control.ContentDescription = _defaultContentDescription;
-			}
-		}
+			=> SetContentDescription(Control, Element, ref _defaultContentDescription, ref _defaultHint);
 
 		void SetFocusable()
-		{
-			if (Element == null || Control == null)
-			{
-				return;
-			}
-
-			if (!_defaultFocusable.HasValue)
-			{
-				_defaultFocusable = Control.Focusable;
-			}
-
-			Control.Focusable =
-				(bool)((bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? _defaultFocusable);
-		}
+			=> SetFocusable(Control, Element, ref _defaultFocusable);
 
 		bool SetHint()
-		{
-			if (Element == null || Control == null)
-			{
-				return false;
-			}
-
-			var textView = Control as TextView;
-			if (textView == null)
-			{
-				return false;
-			}
-
-			// Let the specified Title/Placeholder take precedence, but don't set the ContentDescription (won't work anyway)
-			if (((Element as Picker)?.Title ?? (Element as Entry)?.Placeholder) != null)
-			{
-				return true;
-			}
-
-			if (_defaultHint == null)
-			{
-				_defaultHint = textView.Hint;
-			}
-
-			string value = ConcatenateNameAndHelpText(Element);
-
-			textView.Hint = !string.IsNullOrWhiteSpace(value) ? value : _defaultHint;
-
-			return true;
-		}
+			=> SetHint(Control, Element, ref _defaultHint);
 
 		internal static string ConcatenateNameAndHelpText(Element Element)
 		{
@@ -153,22 +188,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		}
 
 		void SetLabeledBy()
-		{
-			if (Element == null || Control == null)
-				return;
-
-			var elemValue = (VisualElement)Element.GetValue(AutomationProperties.LabeledByProperty);
-
-			if (elemValue != null)
-			{
-				var id = Control.Id;
-				if (id == global::Android.Views.View.NoId)
-					id = Control.Id = Platform.GenerateViewId();
-
-				var renderer = elemValue?.GetRenderer();
-				renderer?.SetLabelFor(id);
-			}
-		}
+			=> SetLabeledBy(Control, Element);
 
 		void OnElementChanged(object sender, VisualElementChangedEventArgs e)
 		{

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -7,6 +7,7 @@ using Android.Support.V4.View;
 using Android.Views;
 using Xamarin.Forms.Internals;
 using AView = Android.Views.View;
+using Xamarin.Forms.Platform.Android.FastRenderers;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -314,65 +315,13 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		protected virtual void SetAutomationId(string id)
-		{
-			ContentDescription = id;
-		}
+			=> AutomationPropertiesProvider.SetAutomationId(this, Element, id);
 
 		protected virtual void SetContentDescription()
-		{
-			if (Element == null)
-				return;
-
-			if (SetHint())
-				return;
-
-			if (_defaultContentDescription == null)
-				_defaultContentDescription = ContentDescription;
-
-			var elemValue = FastRenderers.AutomationPropertiesProvider.ConcatenateNameAndHelpText(Element);
-
-			if (!string.IsNullOrWhiteSpace(elemValue))
-				ContentDescription = elemValue;
-			else
-				ContentDescription = _defaultContentDescription;
-		}
+			=> AutomationPropertiesProvider.SetContentDescription(this, Element, ref _defaultContentDescription, ref _defaultHint);
 
 		protected virtual void SetFocusable()
-		{
-			if (Element == null)
-				return;
-
-			if (!_defaultFocusable.HasValue)
-				_defaultFocusable = Focusable;
-
-			Focusable = (bool)((bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? _defaultFocusable);
-		}
-
-		protected virtual bool SetHint()
-		{
-			if (Element == null)
-				return false;
-
-			var textView = this as global::Android.Widget.TextView;
-			if (textView == null)
-				return false;
-
-			// Let the specified Title/Placeholder take precedence, but don't set the ContentDescription (won't work anyway)
-			if (((Element as Picker)?.Title ?? (Element as Entry)?.Placeholder ?? (Element as EntryCell)?.Placeholder) != null)
-				return true;
-
-			if (_defaultHint == null)
-				_defaultHint = textView.Hint;
-
-			var elemValue = FastRenderers.AutomationPropertiesProvider.ConcatenateNameAndHelpText(Element);
-
-			if (!string.IsNullOrWhiteSpace(elemValue))
-				textView.Hint = elemValue;
-			else
-				textView.Hint = _defaultHint;
-
-			return true;
-		}
+			=> AutomationPropertiesProvider.SetFocusable(this, Element, ref _defaultFocusable);
 
 		void UpdateInputTransparent()
 		{
@@ -401,11 +350,6 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		void IVisualElementRenderer.SetLabelFor(int? id)
-		{
-			if (_defaultLabelFor == null)
-				_defaultLabelFor = LabelFor;
-
-			LabelFor = (int)(id ?? _defaultLabelFor);
-		}
+			=> LabelFor = id ?? LabelFor;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -21,8 +21,7 @@ namespace Xamarin.Forms.Platform.Android
 		string _defaultContentDescription;
 		bool? _defaultFocusable;
 		string _defaultHint;
-		int? _defaultLabelFor;
-		
+
 		VisualElementPackager _packager;
 		PropertyChangedEventHandler _propertyChangeHandler;
 


### PR DESCRIPTION
Expected fast renderers to reuse slow renderer code where possible. Actually found duplication. This is an attempt to de-duplicate the automation code and establish a precedent for code reuse going forward. 