### PR TITLE
Clear MainPage renderer if exists after reload

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -126,6 +126,13 @@ namespace Xamarin.Forms.Platform.Android
 
 			application.PropertyChanged += AppOnPropertyChanged;
 
+			var iver = Platform.GetRenderer(application.MainPage);
+			if (iver != null)
+			{
+				iver.Dispose();
+				application.MainPage.ClearValue(Platform.RendererProperty);
+			}
+
 			SetMainPage();
 		}
 


### PR DESCRIPTION
### Description of Change ###

Customer expected MainPage could be re-initialized after reloading app. Actually, existence of a renderer for the MainPage prevented MainPage from being attached the the new activity. This is "correct" (although still a regression) as the old MainPage renderer existed in a different context. 

The "fix" is to clear the MainPage renderer so a new renderer is created in the correct context. I say, "fix" because it does not reuse the existing renderer so the customer will not see the same performance benefit however it'll likely have saved the customer from even more insidious bugs stemming from using views from a deleted context. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=59882

### API Changes ###

None

### Behavioral Changes ###

Allow MainPage to be re-initialized after re-launch.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
