### PR TITLE
[iOS11] Don't pass infinite value to UISearchBar width

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -119,6 +119,14 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateCancelButton();
 		}
 
+		public override CoreGraphics.CGSize SizeThatFits(CoreGraphics.CGSize size)
+		{
+			if (nfloat.IsInfinity(size.Width))
+				size.Width = nfloat.MaxValue;
+			
+			return base.SizeThatFits(size);
+		}
+
 		void OnCancelClicked(object sender, EventArgs args)
 		{
 			ElementController.SetValueFromRenderer(SearchBar.TextProperty, null);


### PR DESCRIPTION
### Description of Change ###

This issue only happens with the IOS11 SDK there no documentation about this changed, but seems be related to way UIView layouts respect size that fits now of controls. 

Tests are in our Searchbar View tests that were broken on iOS11

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=59595

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense