### PR TITLE
[UWP] Inherit from Panel on WrapperControl

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60056.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60056.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
 							Margin = 20,
 							Children =
 							{
-								new Label {  Text = "I should be indended" },
+								new Label {  Text = "I should be indented" },
 								new Button { Margin = 5, Text = "I should be further indented" }
 							}
 						}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60056.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60056.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60056, "[UWP] ViewCell ignores margins of it's child", PlatformAffected.UWP)]
+	public class Bugzilla60056 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new ListView
+			{
+				ItemsSource = new string[] { "A", "B", "C" },
+				ItemTemplate = new DataTemplate(() =>
+				{
+					return new ViewCell
+					{
+						View = new StackLayout
+						{
+							Margin = 20,
+							Children =
+							{
+								new Label {  Text = "I should be indended" },
+								new Button { Margin = 5, Text = "I should be further indented" }
+							}
+						}
+					};
+				})
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -222,6 +222,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51427.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59248.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60056.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60122.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_0.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_1.cs" />

--- a/Xamarin.Forms.Platform.WinRT/ViewToRendererConverter.cs
+++ b/Xamarin.Forms.Platform.WinRT/ViewToRendererConverter.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.WinRT
 			throw new NotSupportedException();
 		}
 
-		class WrapperControl : Canvas
+		class WrapperControl : Panel
 		{
 			readonly View _view;
 


### PR DESCRIPTION
### Description of Change ###

PR #731 intended to resolve an issue where `Label` text inside a `ListView` could vanish in certain circumstances. A side effect occurred in the change whereby inheriting from `Canvas` (which [uses absolute positioning](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.Canvas#Remarks)) caused the outermost view to not respect margins given to it. Changing the inheritance of `WrapperControl` from `Canvas` to `Panel` appears to resolve this issue.

Before:
![before](https://user-images.githubusercontent.com/1251024/31679724-00ae245a-b340-11e7-95a8-8a1b7ba51e07.JPG)

After:
![after](https://user-images.githubusercontent.com/1251024/31679732-0a825b2c-b340-11e7-81f9-d48b85a8ada6.JPG)


### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60056

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
