### PR TITLE
Stop forcing FormsTextBox content to ForegroundFocusBrush on UWP

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -178,7 +178,7 @@
 						                  Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" FontWeight="Normal"
 						                  Margin="0,0,0,8" Grid.Row="0" Visibility="Collapsed" x:DeferLoadStrategy="Lazy" />
 						<ScrollViewer x:Name="ContentElement" AutomationProperties.AccessibilityView="Raw"
-                                      Foreground="{TemplateBinding ForegroundFocusBrush}"
+                                     
 						              HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
 						              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
 						              IsTabStop="False" IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"

--- a/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.WinRT/FormsTextBox.cs
@@ -24,19 +24,27 @@ namespace Xamarin.Forms.Platform.WinRT
 	{
 		const char ObfuscationCharacter = '●';
 
-		public static readonly DependencyProperty PlaceholderForegroundBrushProperty = DependencyProperty.Register(nameof(PlaceholderForegroundBrush), typeof(Brush), typeof(FormsTextBox),
-			new PropertyMetadata(default(Brush)));
+		public static readonly DependencyProperty PlaceholderForegroundBrushProperty = 
+			DependencyProperty.Register(nameof(PlaceholderForegroundBrush), typeof(Brush), typeof(FormsTextBox),
+				new PropertyMetadata(default(Brush), FocusPropertyChanged));
 
-		public static readonly DependencyProperty PlaceholderForegroundFocusBrushProperty = DependencyProperty.Register(nameof(PlaceholderForegroundFocusBrush), typeof(Brush), typeof(FormsTextBox),
-			new PropertyMetadata(default(Brush)));
+		public static readonly DependencyProperty PlaceholderForegroundFocusBrushProperty = 
+			DependencyProperty.Register(nameof(PlaceholderForegroundFocusBrush), typeof(Brush), typeof(FormsTextBox),
+				new PropertyMetadata(default(Brush), FocusPropertyChanged));
 
-		public static readonly DependencyProperty ForegroundFocusBrushProperty = DependencyProperty.Register(nameof(ForegroundFocusBrush), typeof(Brush), typeof(FormsTextBox), new PropertyMetadata(default(Brush)));
+		public static readonly DependencyProperty ForegroundFocusBrushProperty = 
+			DependencyProperty.Register(nameof(ForegroundFocusBrush), typeof(Brush), typeof(FormsTextBox), 
+				new PropertyMetadata(default(Brush), FocusPropertyChanged));
 
-		public static readonly DependencyProperty BackgroundFocusBrushProperty = DependencyProperty.Register(nameof(BackgroundFocusBrush), typeof(Brush), typeof(FormsTextBox), new PropertyMetadata(default(Brush)));
+		public static readonly DependencyProperty BackgroundFocusBrushProperty = 
+			DependencyProperty.Register(nameof(BackgroundFocusBrush), typeof(Brush), typeof(FormsTextBox), 
+				new PropertyMetadata(default(Brush), FocusPropertyChanged));
 
-		public static readonly DependencyProperty IsPasswordProperty = DependencyProperty.Register(nameof(IsPassword), typeof(bool), typeof(FormsTextBox), new PropertyMetadata(default(bool), OnIsPasswordChanged));
+		public static readonly DependencyProperty IsPasswordProperty = DependencyProperty.Register(nameof(IsPassword), 
+			typeof(bool), typeof(FormsTextBox), new PropertyMetadata(default(bool), OnIsPasswordChanged));
 
-		public new static readonly DependencyProperty TextProperty = DependencyProperty.Register(nameof(Text), typeof(string), typeof(FormsTextBox), new PropertyMetadata("", TextPropertyChanged));
+		public new static readonly DependencyProperty TextProperty = DependencyProperty.Register(nameof(Text), 
+			typeof(string), typeof(FormsTextBox), new PropertyMetadata("", TextPropertyChanged));
 
 		InputScope passwordInputScope;
 		Border _borderElement;
@@ -373,6 +381,22 @@ namespace Xamarin.Forms.Platform.WinRT
 				IsSpellCheckEnabled = _cachedSpellCheckSetting;
 				IsTextPredictionEnabled = _cachedPredictionsSetting;
 			}
+		}
+
+		static void FocusPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			// If we're modifying the properties related to the focus state of the control (e.g., 
+			// ForegroundFocusBrush), the changes won't be reflected immediately because they are only applied
+			// when the Windows.UI.XAML.VisualStateManager moves to the "Focused" state. So we have to force a 
+			// "refresh" of the Focused state by going to that state again
+
+			var control = dependencyObject as Control;
+			if (control == null || control.FocusState == FocusState.Unfocused)
+			{
+				return;
+			}
+
+			VisualStateManager.GoToState(control, "Focused", false);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

The FormsTextboxStyle control template was applying the FocusForegroundBrush property to the textbox's ContentElement even when the textbox was not focused.  This caused the incorrect text color to be applied to the textbox when focus was lost. In "Light" mode, this is mostly okay because the two color values are the same, but in "Dark" mode the focus color matches the textbox background, so the text disappears.

This change removes the incorrect value from the style and adds some logic to fix the original problem the incorrect style attempted to address.

No automated tests, because we don't have a way to check for text color changes. To test manually, change `RequestedTheme="Light"` to `RequestedTheme="Dark"` in Control Gallery and run it, then browse to the Entry Gallery.

Before the change:

<img src="https://www.dropbox.com/s/m2rt8msmpxoscys/entry_phone_dark_before.gif?raw=1" width=200/>

<img src="https://www.dropbox.com/s/lx3aka2b9p0cvkk/entry_desktop_dark_before.gif?raw=1" width=200/>

After the change:

<img src="https://www.dropbox.com/s/85hfowpyew1gn5g/entry_phone_dark_after.gif?raw=1" width=200/>

<img src="https://www.dropbox.com/s/gxyb1ox2u405kp6/entry_desktop_dark_after.gif?raw=1" width=200/>

### Bugs Fixed ###

- [58145 – [UWP] Entry text not visible when using dark theme](https://bugzilla.xamarin.com/show_bug.cgi?id=58145)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
