### PR TITLE
[iOS11] Fix Secondary toolbar items iOS11

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -154,7 +154,8 @@ namespace Xamarin.Forms.ControlGallery.iOS
 
 		public override bool FinishedLaunching(UIApplication uiApplication, NSDictionary launchOptions)
 		{
-			App.IOSVersion = int.Parse(UIDevice.CurrentDevice.SystemVersion.Substring(0, 1));
+			var versionPart = UIDevice.CurrentDevice.SystemVersion.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+			App.IOSVersion = int.Parse(versionPart[0]);
 
 			Xamarin.Calabash.Start();
 			Forms.Init();
@@ -386,6 +387,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		{
 			_app.Reset();
 			return String.Empty;
+		}
+
+		[Export("iOSVersion")]
+		public int iOSVersion()
+		{
+			return App.IOSVersion;
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -80,6 +80,11 @@ namespace Xamarin.Forms.Controls
 			var app = ConfigureApp.iOS.InstalledApp(AppPaths.BundleId).Debug()
 				//Uncomment to run from a specific iOS SIM, get the ID from XCode -> Devices
 				.StartApp(Xamarin.UITest.Configuration.AppDataMode.DoNotClear);
+			int _iosVersion;
+			if (int.TryParse(app.Invoke("iOSVersion").ToString(), out _iosVersion))
+			{
+				iOSVersion = _iosVersion;
+			}
 
 			// Running on the simulator
 			//var app = ConfigureApp.iOS
@@ -90,6 +95,8 @@ namespace Xamarin.Forms.Controls
 
 			return app;
 		}
+
+		public static int iOSVersion { get; private set; }
 #endif
 
 #if __MACOS__

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using Xamarin.Forms.Controls;
 using Xamarin.Forms.CustomAttributes;
 
 using Xamarin.UITest.Queries;
@@ -38,8 +39,13 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			App.NavigateToGallery(GalleryQueries.ToolbarItemGallery);
 #if __IOS__
-			btn1Id = "toolbaritem_primary";
-			btn4Id = "toolbaritem_secondary2";
+			btn1Id = "menuIcon";
+			btn4Id = "tb4";
+			if (AppSetup.iOSVersion  >= 9)
+			{
+				btn1Id = "toolbaritem_primary";
+				btn4Id = "toolbaritem_secondary2";
+			}
 #endif
 		}
 

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -38,8 +38,8 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			App.NavigateToGallery(GalleryQueries.ToolbarItemGallery);
 #if __IOS__
-			btn1Id = "menuIcon";
-			btn4Id = "tb4";
+			btn1Id = "toolbaritem_primary";
+			btn4Id = "toolbaritem_secondary2";
 #endif
 		}
 
@@ -50,6 +50,7 @@ namespace Xamarin.Forms.Core.UITests
 #if __MACOS__
 			App.Tap(c => c.Button().Index(4));
 #else
+			App.WaitForElement(btn1Id);
 			App.Tap(c => c.Marked(btn1Id));
 #endif
 			var textLabel = App.Query((arg) => arg.Marked("label_id"))[0];
@@ -64,6 +65,7 @@ namespace Xamarin.Forms.Core.UITests
 #if __ANDROID__
 			//App.Query (c => c.Marked (btn4Id))[0];
 #else
+			App.WaitForElement(btn4Id);
 			App.Tap(c => c.Marked(btn4Id));
 			var textLabel = App.Query((arg) => arg.Marked("label_id"))[0];
 			Assert.False(textLabel.Text == "tb4");

--- a/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ToolbarItemExtensions.cs
@@ -147,7 +147,7 @@ namespace Xamarin.Forms.Platform.iOS
 				readonly UIImageView _imageView;
 				readonly UILabel _label;
 
-				public SecondaryToolbarItemContent() : base(new RectangleF(0, 0, 75, 20))
+				public SecondaryToolbarItemContent()
 				{
 					BackgroundColor = UIColor.Clear;
 					_imageView = new UIImageView { BackgroundColor = UIColor.Clear };

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -717,22 +717,29 @@ namespace Xamarin.Forms.Platform.iOS
 				base.LayoutSubviews();
 				if (Items == null || Items.Length == 0)
 					return;
-				nfloat padding = 11f;
-				var itemWidth = (Bounds.Width - padding) / Items.Length - padding;
+				LayoutToolbarItems(Bounds.Width, Bounds.Height, 0);
+			}
+
+			void LayoutToolbarItems(nfloat toolbarWidth, nfloat toolbarHeight, nfloat padding)
+			{
 				var x = padding;
-				var itemH = Bounds.Height - 10;
+				var y = 0;
+				var itemH = toolbarHeight;
+				var itemW = toolbarWidth / Items.Length;
+
 				foreach (var item in Items)
 				{
-					var frame = new RectangleF(x, 5, itemWidth, itemH);
+					var frame = new RectangleF(x, y, itemW, itemH);
 					item.CustomView.Frame = frame;
-					x += itemWidth + padding;
+					x += itemW + padding;
 				}
-				x = itemWidth + padding * 1.5f;
-				var y = Bounds.GetMidY();
+
+				x = itemW + padding * 1.5f;
+				y = (int)Bounds.GetMidY();
 				foreach (var l in _lines)
 				{
 					l.Center = new PointF(x, y);
-					x += itemWidth + padding;
+					x += itemW + padding;
 				}
 			}
 


### PR DESCRIPTION

### Description of Change ###

On iOS11 secondary buttons are rendererd off screen. We fix this by removing hardcoded values.

With change  (check iOS version on the details of the image) 

<img width="931" alt="screen shot 2017-10-18 at 23 57 01" src="https://user-images.githubusercontent.com/1235097/31746612-2a186406-b460-11e7-9a11-63cbed00081a.png">
<img width="925" alt="screen shot 2017-10-18 at 23 36 04" src="https://user-images.githubusercontent.com/1235097/31746205-13cca380-b45e-11e7-9799-6fd3088c6939.png">
<img width="913" alt="screen shot 2017-10-18 at 23 39 10" src="https://user-images.githubusercontent.com/1235097/31746206-13ea699c-b45e-11e7-8c0f-96fffb51606d.png">
<img width="895" alt="screen shot 2017-10-18 at 23 41 56" src="https://user-images.githubusercontent.com/1235097/31746207-14090d8e-b45e-11e7-93c8-c3137009c536.png">

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense