### PR TITLE
[iOS] Delay for ScrollTo to work on iOS11

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Forms
 #if __MOBILE__
 		static bool? s_isiOS9OrNewer;
 		static bool? s_isiOS10OrNewer;
+		static bool? s_isiOS11OrNewer;
 #endif
 		static Forms()
 		{
@@ -62,6 +63,16 @@ namespace Xamarin.Forms
 				if (!s_isiOS10OrNewer.HasValue)
 					s_isiOS10OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(10, 0);
 				return s_isiOS10OrNewer.Value;
+			}
+		}
+
+		internal static bool IsiOS11OrNewer
+		{
+			get
+			{
+				if (!s_isiOS11OrNewer.HasValue)
+					s_isiOS11OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(11, 0);
+				return s_isiOS11OrNewer.Value;
 			}
 		}
 #endif

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -333,7 +333,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Control.TableHeaderView = _headerRenderer.NativeView;
 		}
 
-		void OnScrollToRequested(object sender, ScrollToRequestedEventArgs e)
+		async void OnScrollToRequested(object sender, ScrollToRequestedEventArgs e)
 		{
 			if (Superview == null)
 			{
@@ -357,6 +357,11 @@ namespace Xamarin.Forms.Platform.iOS
 				if (index != -1)
 				{
 					Control.Layer.RemoveAllAnimations();
+					//iOS11 hack
+					if(Forms.IsiOS11OrNewer)
+					{
+						await Task.Delay(1);
+					}
 					Control.ScrollToRow(NSIndexPath.FromRowSection(index, 0), position, e.ShouldAnimate);
 				}
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override CoreGraphics.CGSize SizeThatFits(CoreGraphics.CGSize size)
 		{
-			if (nfloat.IsInfinity(size.Width))
+			if (nfloat.IsInfinity(size.Width) && Forms.IsiOS11OrNewer)
 				size.Width = nfloat.MaxValue;
 			
 			return base.SizeThatFits(size);


### PR DESCRIPTION
### Description of Change ###

There seems to be a issue with ScrollToRow on iOS11, there are other native users complain about similar issues:

https://stackoverflow.com/questions/46075517/uitableview-scrolltorow-no-longer-works-on-ios-11-right-after-adding-a-new-row
http://www.openradar.me/34865052

Adding a small delay just on iOS11 seems to fix the issue, also take note issue only is evidente when using ScrollTo with no animation

Also added the check just for iOS11 to UISearchBar fix i did on #1203

### Bugs Fixed ###

- Fixes 32462 test on iOS11

### API Changes ###

Internal API to check iOS11

Added:
 - bool iOS11OrNewer { get ;}

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense