### PR TITLE
[Android] Clear MainPage renderer if exists after reload (non-appCompat)

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -62,8 +62,16 @@ namespace Xamarin.Forms.ControlGallery.Android
 			// uncomment to verify turning off title bar works. This is not intended to be dynamic really.
 			//Forms.SetTitleBarVisibility (AndroidTitleBarVisibility.Never);
 
-			_app = new App();
-			
+			if (RestartAppTest.App != null)
+			{
+				_app = (App)RestartAppTest.App;
+				RestartAppTest.Reinit = true;
+			}
+			else
+			{
+				_app = new App();
+			}
+
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RestartAppTest.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RestartAppTest.cs
@@ -18,14 +18,22 @@ namespace Xamarin.Forms.Controls.Issues
 		PlatformAffected.Android)]
 	public class RestartAppTest : TestContentPage 
 	{
+		public static object App;
+		public static bool Reinit;
+
 		public const string ForceRestart = "ForceRestart";
 		public const string Success = "Android CoreGallery";
+		public const string ReinitOk = "Tap Reinit, back out of app, relaunch, and expect 'true': {0}";
 		public const string RestartButton = "Restart";
+		public const string ReinitButton = "Reinit";
 
 		protected override void Init()
 		{
-			var restartButton = new Button { Text = "Restart", AutomationId = RestartButton };
+			var restartButton = new Button { Text = RestartButton, AutomationId = RestartButton };
 			restartButton.Clicked += (sender, e) => MessagingCenter.Send(this, ForceRestart);
+
+			var reinitButton = new Button { Text = ReinitButton, AutomationId = RestartButton };
+			reinitButton.Clicked += (sender, e) => App = Application.Current;
 
 			Content = new StackLayout
 			{
@@ -33,7 +41,9 @@ namespace Xamarin.Forms.Controls.Issues
 				Children =
 				{
 					new Label { Text = Success },
-					restartButton
+					new Label { Text = string.Format(ReinitOk, Reinit) },
+					restartButton,
+					reinitButton
 				}
 			};
 		}

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -89,6 +89,15 @@ namespace Xamarin.Forms.Platform.Android
 
 			application.PropertyChanged += AppOnPropertyChanged;
 
+			if (application?.MainPage != null)
+			{
+				var iver = Platform.GetRenderer(application.MainPage);
+				if (iver != null) {
+					iver.Dispose();
+					application.MainPage.ClearValue(Platform.RendererProperty);
+				}
+			}
+
 			SetMainPage();
 		}
 


### PR DESCRIPTION
### Description of Change ###

See also: https://github.com/xamarin/Xamarin.Forms/pull/1200

Customer expected MainPage could be re-initialized after reloading app. Actually, existence of a renderer for the MainPage prevented MainPage from being attached to the new activity. Preventing the MainPage from being attached is correct as the old MainPage renderer existed in a different context. 

The fix is to clear the MainPage renderer so a new renderer is created in the correct context. This fix will not reuse the existing renderer so the customer will _not_ see the same performance benefit as was achieved previously. However that performance gain was likely hiding more insidious bugs stemming from using views from a deleted context. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=59882

### API Changes ###

None

### Behavioral Changes ###

Allow MainPage to be re-initialized after re-launch.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
