### PR TITLE
Improve 'ResourceDictionary' class

### DIFF
--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms
 					return;
 
 				_mergedInstance = s_instances.GetValue(_mergedWith, (key) => (ResourceDictionary)Activator.CreateInstance(key));
-				OnValuesChanged(_mergedInstance.ToArray());
+				OnValuesChanged(_mergedInstance);
 			}
 		}
 
@@ -74,7 +74,7 @@ namespace Xamarin.Forms
 					var rd = (ResourceDictionary)item;
 					_collectionTrack.Add(rd);
 					rd.ValuesChanged += Item_ValuesChanged;
-					OnValuesChanged(rd.ToArray());
+					OnValuesChanged(rd);
 				}
 			}
 
@@ -92,7 +92,7 @@ namespace Xamarin.Forms
 
 		void Item_ValuesChanged(object sender, ResourcesChangedEventArgs e)
 		{
-			OnValuesChanged(e.Values.ToArray());
+			OnValuesChanged(e.Values);
 		}
 
 		void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
@@ -226,17 +226,14 @@ namespace Xamarin.Forms
 			}
 		}
 
-		void OnValueChanged(string key, object value)
-		{
+		void OnValueChanged(string key, object value) =>
 			OnValuesChanged(new KeyValuePair<string, object>(key, value));
-		}
 
-		void OnValuesChanged(params KeyValuePair<string, object>[] values)
-		{
-			if (values == null || values.Length == 0)
-				return;
-			ValuesChanged?.Invoke(this, new ResourcesChangedEventArgs(values));
-		}
+		void OnValuesChanged(KeyValuePair<string, object> value) =>
+			ValuesChanged?.Invoke(this, new ResourcesChangedEventArgs(new[] {value}));
+
+		void OnValuesChanged(IEnumerable<KeyValuePair<string, object>> values) =>
+			ValuesChanged?.Invoke(this, new ResourcesChangedEventArgs(values.Select(v => v)));
 
 		event EventHandler<ResourcesChangedEventArgs> ValuesChanged;
 	}

--- a/Xamarin.Forms.Core/packages.config
+++ b/Xamarin.Forms.Core/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Net.Compilers" version="2.4.0" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
+</packages>


### PR DESCRIPTION
### Description of Change ###

Add C# 7 support for old build tools by adding https://www.nuget.org/packages/Microsoft.Net.Compilers/

Improve ResourceDictionary class code:
- use 'dictionary.TryGetValue' method into indexer instead constructions 'if (dictionary.ContainsKey(key)) return dictionary[key];'
- avoid redundant 'ToArray' call when use private method 'OnValuesChanged'
- apply C# 7 code style

### Bugs Fixed ###

none

### API Changes ###

none

### Behavioral Changes ###

'ResourceDictionary' class improvements
- more optimal memory usage in some cases
- best performance of indexer
- new laconic C# 7 code style 

### PR Checklist ###

- [+] Has tests (if omitted, state reason in description)
- [+] Rebased on top of master at time of PR
- [+] Changes adhere to coding standard
- [+] Consolidate commits as makes sense
