### PR TITLE
[Core] Allow Merged Dirctionaries hierarchically merging

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -481,5 +481,17 @@ namespace Xamarin.Forms.Core.UnitTests
 			rd[commonKey] = "Value";
 			Assert.That(rd[commonKey], Is.EqualTo("Value"));
 		}
+
+		[Test]
+		public void MergedDictionariesDeepSublevels()
+		{
+			var rd0 = new ResourceDictionary();
+			var rd1 = new ResourceDictionary();
+			var rd2 = new ResourceDictionary { { "Key2", "Level2" } };
+			rd1.MergedDictionaries.Add(rd2);
+			rd0.MergedDictionaries.Add(rd1);
+
+			Assert.That(rd0["Key2"], Is.EqualTo("Level2"));
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -476,9 +476,13 @@ namespace Xamarin.Forms.Core.UnitTests
 			var rd1 = new ResourceDictionary { { commonKey, "Value1" } };
 
 			var rd = new ResourceDictionary { MergedDictionaries = { rd0, rd1 } };
+
+			Assert.That(rd0.ContainsKey(commonKey), Is.EqualTo(true));
 			Assert.That(rd[commonKey], Is.EqualTo("Value1"));
 
 			rd[commonKey] = "Value";
+
+			Assert.That(rd0.ContainsKey(commonKey), Is.EqualTo(true));
 			Assert.That(rd[commonKey], Is.EqualTo("Value"));
 		}
 
@@ -491,6 +495,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			rd1.MergedDictionaries.Add(rd2);
 			rd0.MergedDictionaries.Add(rd1);
 
+			Assert.That(rd0.ContainsKey("Key2"), Is.EqualTo(true));
 			Assert.That(rd0["Key2"], Is.EqualTo("Level2"));
 		}
 	}

--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -467,5 +467,19 @@ namespace Xamarin.Forms.Core.UnitTests
 			rd0.Add("foo", "Foo");
 			Assert.That(label.Text, Is.EqualTo("Foo"));
 		}
+
+		[Test]
+		public void MergedDictionariesOverriding()
+		{
+			var commonKey = "CommonKey";
+			var rd0 = new ResourceDictionary { { commonKey, "Value0" } };
+			var rd1 = new ResourceDictionary { { commonKey, "Value1" } };
+
+			var rd = new ResourceDictionary { MergedDictionaries = { rd0, rd1 } };
+			Assert.That(rd[commonKey], Is.EqualTo("Value1"));
+
+			rd[commonKey] = "Value";
+			Assert.That(rd[commonKey], Is.EqualTo("Value"));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -200,19 +200,12 @@ namespace Xamarin.Forms
 
 		public bool TryGetValue(string key, out object value)
 		{
-			return _innerDictionary.TryGetValue(key, out value)
-				|| (_mergedInstance != null && _mergedInstance.TryGetValue(key, out value))
-				|| (_mergedDictionaries != null && TryGetMergedDictionaryValue(key, out value));
-		}
-
-		bool TryGetMergedDictionaryValue(string key, out object value)
-		{
-			foreach (var dictionary in _mergedDictionaries.Reverse())
-				if (dictionary.TryGetValue(key, out value))
-					return true;
-
-			value = null;
-			return false;
+			object outValue;
+			var containsKey = _innerDictionary.TryGetValue(key, out outValue)
+				|| _mergedInstance != null && _mergedInstance.TryGetValue(key, out outValue)
+				|| _mergedDictionaries != null && _mergedDictionaries.Reverse().Any(d => d.TryGetValue(key, out outValue));
+			value = outValue;
+			return containsKey;
 		}
 
 		event EventHandler<ResourcesChangedEventArgs> IResourceDictionary.ValuesChanged

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms
 					return;
 
 				_mergedInstance = s_instances.GetValue(_mergedWith, (key) => (ResourceDictionary)Activator.CreateInstance(key));
-				OnValuesChanged(_mergedInstance.ToArray());
+				OnValuesChanged(_mergedInstance);
 			}
 		}
 
@@ -73,7 +73,7 @@ namespace Xamarin.Forms
 					var rd = (ResourceDictionary)item;
 					_collectionTrack.Add(rd);
 					rd.ValuesChanged += Item_ValuesChanged;
-					OnValuesChanged(rd.ToArray());
+					OnValuesChanged(rd);
 				}
 			}
 
@@ -91,7 +91,7 @@ namespace Xamarin.Forms
 
 		void Item_ValuesChanged(object sender, ResourcesChangedEventArgs e)
 		{
-			OnValuesChanged(e.Values.ToArray());
+			OnValuesChanged(e.Values);
 		}
 
 		void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
@@ -241,11 +241,14 @@ namespace Xamarin.Forms
 			OnValuesChanged(new KeyValuePair<string, object>(key, value));
 		}
 
-		void OnValuesChanged(params KeyValuePair<string, object>[] values)
+		void OnValuesChanged(KeyValuePair<string, object> pair)
 		{
-			if (values == null || values.Length == 0)
-				return;
-			ValuesChanged?.Invoke(this, new ResourcesChangedEventArgs(values));
+			ValuesChanged?.Invoke(this, new ResourcesChangedEventArgs(new[] { pair }));
+		}
+
+		void OnValuesChanged(IEnumerable<KeyValuePair<string, object>> pairs)
+		{
+			ValuesChanged?.Invoke(this, new ResourcesChangedEventArgs(pairs.Select(p => p)));
 		}
 
 		event EventHandler<ResourcesChangedEventArgs> ValuesChanged;

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -141,7 +141,7 @@ namespace Xamarin.Forms
 
 		public bool ContainsKey(string key)
 		{
-			return _innerDictionary.ContainsKey(key);
+			return TryGetValue(key, out var _);
 		}
 
 		[IndexerName("Item")]

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -149,14 +149,8 @@ namespace Xamarin.Forms
 		{
 			get
 			{
-				if (_innerDictionary.ContainsKey(index))
-					return _innerDictionary[index];
-				if (_mergedInstance != null && _mergedInstance.ContainsKey(index))
-					return _mergedInstance[index];
-				if (_mergedDictionaries != null)
-					foreach (var dict in _mergedDictionaries.Reverse())
-						if (dict.ContainsKey(index))
-							return dict[index];
+				object value;
+				if (TryGetValue(index, out value)) return value;
 				throw new KeyNotFoundException($"The resource '{index}' is not present in the dictionary.");
 			}
 			set


### PR DESCRIPTION
### Description of Change ###

Current implementation of Merged Dictionaries on master can not merge dictionaries hierarchically. Just try to run following test method on master, current brunch and WPF or UWP.

	    public static void MergedDictionariesDeepSublevels()
	    {
		    var rd0 = new ResourceDictionary();
		    var rd1 = new ResourceDictionary { { "Key1", "Level1" } };
		    var rd2 = new ResourceDictionary { { "Key2", "Level2" } };

		    rd0.MergedDictionaries.Add(rd1);
		    rd1.MergedDictionaries.Add(rd2);

		    Assert.That(rd0["Key1"], "Level1");
		    Assert.That(rd0["Key2"], "Level2"); // <= fail on master, work on WPF or UWP

		    //Assert.That(rd0.ContainsKey("Key1"), Is.EqualTo(true));
		    //Assert.That(rd0.ContainsKey("Key2"), Is.EqualTo(true));
	    }

Reopen
https://github.com/xamarin/Xamarin.Forms/pull/1215

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=60316 
fixed by commit https://github.com/xamarin/Xamarin.Forms/pull/1218/commits/e22367ebe90783579fa4a7b3b66da196d41a1960
possible, it needs to fix ContainsKey method too https://github.com/xamarin/Xamarin.Forms/pull/1218/commits/bebf303ffa0f187b769a712273e3b92c35d1c587