### PR TITLE
[Xaml] still load Xaml from old assemblies...

### DIFF
--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -154,7 +154,7 @@ namespace Xamarin.Forms.Xaml
 			var assembly = typeInfo.Assembly;
 			var resourceId = typeInfo.GetCustomAttribute<XamlResourceIdAttribute>()?.ResourceId;
 			if (resourceId == null)
-				return null;
+				return LegacyGetXamlForType(type);
 
 			using (var stream = assembly.GetManifestResourceStream(resourceId)) {
 				if (stream != null)
@@ -166,6 +166,109 @@ namespace Xamarin.Forms.Xaml
 
 			var alternateXaml = ResourceLoader.ResourceProvider?.Invoke(resourceId);
 			return alternateXaml ?? xaml;
+		}
+
+		//if the assembly was generated using a version of XamlG that doesn't outputs XamlResourceIdAttributes, we still need to find the resource, and load it
+		static readonly Dictionary<Type, string> XamlResources = new Dictionary<Type, string>();		
+		static string LegacyGetXamlForType(Type type)
+		{
+			var assembly = type.GetTypeInfo().Assembly;
+
+			string resourceId;
+			if (XamlResources.TryGetValue(type, out resourceId)) {
+				var result = ReadResourceAsXaml(type, assembly, resourceId);
+				if (result != null)
+					return result;
+			}
+
+			var likelyResourceName = type.Name + ".xaml";
+			var resourceNames = assembly.GetManifestResourceNames();
+			string resourceName = null;
+
+			// first pass, pray to find it because the user named it correctly
+
+			foreach (var resource in resourceNames) {
+				if (ResourceMatchesFilename(assembly, resource, likelyResourceName)) {
+					resourceName = resource;
+					var xaml = ReadResourceAsXaml(type, assembly, resource);
+					if (xaml != null)
+						return xaml;
+				}
+			}
+
+			// okay maybe they at least named it .xaml
+
+			foreach (var resource in resourceNames) {
+				if (!resource.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				resourceName = resource;
+				var xaml = ReadResourceAsXaml(type, assembly, resource);
+				if (xaml != null)
+					return xaml;
+			}
+
+			foreach (var resource in resourceNames) {
+				if (resource.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				resourceName = resource;
+				var xaml = ReadResourceAsXaml(type, assembly, resource, true);
+				if (xaml != null)
+					return xaml;
+			}
+
+			return null;
+		}
+
+		//legacy...
+		static bool ResourceMatchesFilename(Assembly assembly, string resource, string filename)
+		{
+			try {
+				var info = assembly.GetManifestResourceInfo(resource);
+
+				if (!string.IsNullOrEmpty(info.FileName) &&
+					string.Compare(info.FileName, filename, StringComparison.OrdinalIgnoreCase) == 0)
+					return true;
+			}
+			catch (PlatformNotSupportedException) {
+				// Because Win10 + .NET Native
+			}
+
+			if (resource.EndsWith("." + filename, StringComparison.OrdinalIgnoreCase) ||
+				string.Compare(resource, filename, StringComparison.OrdinalIgnoreCase) == 0)
+				return true;
+
+			return false;
+		}
+
+		//part of the legacy as well...
+		static string ReadResourceAsXaml(Type type, Assembly assembly, string likelyTargetName, bool validate = false)
+		{
+			using (var stream = assembly.GetManifestResourceStream(likelyTargetName))
+			using (var reader = new StreamReader(stream)) {
+				if (validate) {
+					// terrible validation of XML. Unfortunately it will probably work most of the time since comments
+					// also start with a <. We can't bring in any real deps.
+
+					var firstNonWhitespace = (char)reader.Read();
+					while (char.IsWhiteSpace(firstNonWhitespace))
+						firstNonWhitespace = (char)reader.Read();
+
+					if (firstNonWhitespace != '<')
+						return null;
+
+					stream.Seek(0, SeekOrigin.Begin);
+				}
+
+				var xaml = reader.ReadToEnd();
+
+				var pattern = String.Format("x:Class *= *\"{0}\"", type.FullName);
+				var regex = new Regex(pattern, RegexOptions.ECMAScript);
+				if (regex.IsMatch(xaml) || xaml.Contains(String.Format("x:Class=\"{0}\"", type.FullName)))
+					return xaml;
+			}
+			return null;
 		}
 
 		public class RuntimeRootNode : RootNode


### PR DESCRIPTION
### Description of Change ###

if the project references an assembly that was generated using a Xamlg version not creating XamlResourceId, we need to fallback to the old logic to load xaml controls from those assemblies.

### Bugs Fixed ###

- not reported yet

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
