### PR TITLE
[Core, iOS] Allocate prototypical view for RetainElement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ classic_obj
 *.log
 *.userprefs
 *.suo
+_docs.xml
 UpgradeLog*
 *UpgradeReport*
 *.user

--- a/Xamarin.Forms.Core/ITemplatedItemsList.cs
+++ b/Xamarin.Forms.Core/ITemplatedItemsList.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Collections;
 
+
 namespace Xamarin.Forms
 {
 	public interface ITemplatedItemsList<TItem> : IReadOnlyList<TItem>, INotifyCollectionChanged where TItem : BindableObject
@@ -27,6 +28,7 @@ namespace Xamarin.Forms
 		Tuple<int, int> GetGroupAndIndexOfItem(object group, object item);
 		int GetGroupIndexFromGlobal(int globalIndex, out int leftOver);
 		int IndexOf(TItem item);
+		TItem ActivateContent(int index, object item = null);
 		TItem UpdateContent(TItem content, int index);
 		TItem UpdateHeader(TItem content, int groupIndex);
 	}

--- a/Xamarin.Forms.Core/TemplatedItemsList.cs
+++ b/Xamarin.Forms.Core/TemplatedItemsList.cs
@@ -529,11 +529,18 @@ namespace Xamarin.Forms.Internals
 			return ItemTemplate.SelectDataTemplate(item, _itemsView);
 		}
 
-		public TItem CreateContent(int index, object item, bool insert = false)
+		public TItem ActivateContent(int index, object item)
 		{
 			TItem content = ItemTemplate != null ? (TItem)ItemTemplate.CreateContent(item, _itemsView) : _itemsView.CreateDefault(item);
 
 			content = UpdateContent(content, index, item);
+
+			return content;
+		}
+
+		public TItem CreateContent(int index, object item, bool insert = false)
+		{
+			var content = ActivateContent(index, item);
 
 			if ((CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 				return content;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -663,7 +663,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 
 				// We're going to base our estimate off of the first cell
-				var firstCell = templatedItems.First();
+				var firstCell = templatedItems.ActivateContent(0, templatedItems.ListProxy[0]);
 
 				// Let's skip this optimization for grouped lists. It will likely cause more trouble than it's worth.
 				if (firstCell.Height > 0 && !List.IsGroupingEnabled)
@@ -754,7 +754,8 @@ namespace Xamarin.Forms.Platform.iOS
 					// Let the EstimatedHeight method know to use this value.
 					// Much more efficient than checking the value each time.
 					//_useEstimatedRowHeight = true;
-					return (nfloat)req.Request.Height;
+					var height = (nfloat)req.Request.Height;
+					return height > 1 ? height : DefaultRowHeight;
 				}
 
 				var renderHeight = cell.RenderHeight;

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TemplatedItemsList`2.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/TemplatedItemsList`2.xml
@@ -56,6 +56,28 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
+    <Member MemberName="ActivateContent">
+      <MemberSignature Language="C#" Value="public TItem ActivateContent (int index, object item);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance !TItem ActivateContent(int32 index, object item) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>TItem</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="index" Type="System.Int32" />
+        <Parameter Name="item" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="index">To be added.</param>
+        <param name="item">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="CollectionChanged">
       <MemberSignature Language="C#" Value="public event System.Collections.Specialized.NotifyCollectionChangedEventHandler CollectionChanged;" />
       <MemberSignature Language="ILAsm" Value=".event class System.Collections.Specialized.NotifyCollectionChangedEventHandler CollectionChanged" />
@@ -103,10 +125,10 @@
         <Parameter Name="insert" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="index">For internal use by the Xamarin.Forms platform.</param>
-        <param name="item">For internal use by the Xamarin.Forms platform.</param>
-        <param name="insert">For internal use by the Xamarin.Forms platform.</param>
-        <summary>For internal use by the Xamarin.Forms platform.</summary>
+        <param name="index">To be added.</param>
+        <param name="item">To be added.</param>
+        <param name="insert">To be added.</param>
+        <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ITemplatedItemsList`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ITemplatedItemsList`1.xml
@@ -32,6 +32,28 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
+    <Member MemberName="ActivateContent">
+      <MemberSignature Language="C#" Value="public TItem ActivateContent (int index, object item = null);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance !TItem ActivateContent(int32 index, object item) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>TItem</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="index" Type="System.Int32" />
+        <Parameter Name="item" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="index">To be added.</param>
+        <param name="item">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="BindingContext">
       <MemberSignature Language="C#" Value="public object BindingContext { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance object BindingContext" />

--- a/xtc-manual-ios.bat
+++ b/xtc-manual-ios.bat
@@ -1,0 +1,10 @@
+REM e61c8dbb 
+dir Xamarin.Forms.ControlGallery.iOS\bin\iPhone\Debug\XamarinFormsControlGalleryiOS.ipa
+packages\Xamarin.UITest.2.1.4\tools\test-cloud.exe ^
+submit Xamarin.Forms.ControlGallery.iOS\bin\iPhone\Debug\XamarinFormsControlGalleryiOS.ipa 13d622b3fbb487d8f5d0791278f0908d ^
+--devices e61c8dbb ^
+--series "refs/pull/1226/merge" ^
+--locale "en_US" ^
+--user kingces95@gmail.com ^
+--assembly-dir Xamarin.Forms.Core.iOS.UITests\bin\Debug\ ^
+--category manual


### PR DESCRIPTION
### Description of Change ###

Expect to be able to re-init ListView content. Actually, when using RetainElement, we experience an expectation due to use of a disposed view. The view in question was disposed by logic that used it to compute an estimated row height. That logic did expect the view to be recycled as part of pooling (resetting the Element). The fix is to allocate a view that does not participate in pooling.   

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=59813

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
