### PR TITLE
[Android] Use non-deprecated constructor for GestureDetector

### DIFF
--- a/Xamarin.Forms.Platform.Android/GestureManager.cs
+++ b/Xamarin.Forms.Platform.Android/GestureManager.cs
@@ -85,10 +85,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		GestureDetector InitializeTapAndPanDetector()
 		{
+			var context = Control.Context;
 			var listener = new InnerGestureListener(new TapGestureHandler(() => View),
-				new PanGestureHandler(() => View, Control.Context.FromPixels));
+				new PanGestureHandler(() => View, context.FromPixels));
 
-			return new GestureDetector(Control.Context, listener);
+			return new GestureDetector(context, listener);
 		}
 
 		ScaleGestureDetector InitializeScaleDetector()

--- a/Xamarin.Forms.Platform.Android/GestureManager.cs
+++ b/Xamarin.Forms.Platform.Android/GestureManager.cs
@@ -93,8 +93,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		ScaleGestureDetector InitializeScaleDetector()
 		{
-			var listener = new InnerScaleListener(new PinchGestureHandler(() => View), Control.Context.FromPixels);
-			var detector = new ScaleGestureDetector(Control.Context, listener, Control.Handler);
+			var context = Control.Context;
+			var listener = new InnerScaleListener(new PinchGestureHandler(() => View), context.FromPixels);
+			var detector = new ScaleGestureDetector(context, listener, Control.Handler);
 			ScaleGestureDetectorCompat.SetQuickScaleEnabled(detector, true);
 
 			return detector;

--- a/Xamarin.Forms.Platform.Android/GestureManager.cs
+++ b/Xamarin.Forms.Platform.Android/GestureManager.cs
@@ -88,7 +88,7 @@ namespace Xamarin.Forms.Platform.Android
 			var listener = new InnerGestureListener(new TapGestureHandler(() => View),
 				new PanGestureHandler(() => View, Control.Context.FromPixels));
 
-			return new GestureDetector(listener);
+			return new GestureDetector(Control.Context, listener);
 		}
 
 		ScaleGestureDetector InitializeScaleDetector()


### PR DESCRIPTION
### Description of Change ###

Forms is using a deprecated constructor for GestureDetector which doesn't load up the scaled version of the touch slop value. Because of this, some percentage of taps are being incorrectly recognized as fling gestures. This change updates to a Context-specific constructor which loads the correct touch slop value for the device.

(FTR, "touch slop" is [Android's term](https://android.googlesource.com/platform/frameworks/base.git/+/master/core/java/android/view/GestureDetector.java#419), not mine. But it _is_ fun to say.)

Whether a user encounters the bug depends on the device's physical size, display density, the user's finger size, and the user's tapping style. So automated tests for this are pretty much out of the question, unless we install varying sizes of robot fingers in the Test Cloud lab.

### Bugs Fixed ###

- [59863 – TapGestureRecognizer extremely finicky](https://bugzilla.xamarin.com/show_bug.cgi?id=59863) 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
