### PR TITLE
[XamlC] fix parent walking in compiled BPConverter with ListNode

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BindablePropertyConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BindablePropertyConverter.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Core.XamlC
 
 			var parts = value.Split('.');
 			if (parts.Length == 1) {
-				var parent = node.Parent?.Parent as IElementNode;
+				var parent = node.Parent?.Parent as IElementNode ?? (node.Parent?.Parent as IListNode)?.Parent as IElementNode;
 				if ((node.Parent as ElementNode)?.XmlType.NamespaceUri == XamlParser.XFUri &&
 				    ((node.Parent as ElementNode)?.XmlType.Name == "Setter" || (node.Parent as ElementNode)?.XmlType.Name == "PropertyCondition")) {
 					if (parent.XmlType.NamespaceUri == XamlParser.XFUri &&

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60203.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60203.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Bz60203" >
+    <Label x:Name="label">
+        <Label.Triggers>
+            <MultiTrigger TargetType="Label">
+                <MultiTrigger.Conditions>
+                    <BindingCondition Binding="{Binding Text}" Value="Foo"/>
+                    <PropertyCondition Property="TextColor" Value="Blue" />
+                </MultiTrigger.Conditions>
+                <Setter Property="BackgroundColor" Value="Pink" />
+            </MultiTrigger>
+        </Label.Triggers>
+    </Label>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60203.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60203.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz60203 : ContentPage
+	{
+		public Bz60203()
+		{
+			InitializeComponent();
+		}
+
+		public Bz60203(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void CanCompileMultiTriggersWithDifferentConditions(bool useCompiledXaml)
+			{
+				var layout = new Bz60203(useCompiledXaml);
+				Assert.That(layout.label.BackgroundColor, Is.EqualTo(BackgroundColorProperty.DefaultValue));
+				layout.BindingContext = new { Text = "Foo" };
+				layout.label.TextColor = Color.Blue;
+				Assert.That(layout.label.BackgroundColor, Is.EqualTo(Color.Pink));
+			}
+
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -507,6 +507,9 @@
     <Compile Include="ResourceLoader.xaml.cs" >
       <DependentUpon>ResourceLoader.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz60203.xaml.cs">
+      <DependentUpon>Bz60203.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -942,6 +945,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="ResourceLoader.xaml" >
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz60203.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

[XamlC] fix parent walking in compiledBPConverter with ListNode

it's about time I kill the ListNode... but not this time, yet

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=60203

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense