### PR TITLE
[Xaml[C]] ResourceDictionary.Source

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BindablePropertyConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BindablePropertyConverter.cs
@@ -12,8 +12,10 @@ namespace Xamarin.Forms.Core.XamlC
 {
 	class BindablePropertyConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			if (IsNullOrEmpty(value)) {
 				yield return Instruction.Create(OpCodes.Ldnull);
 				yield break;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BindingTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BindingTypeConverter.cs
@@ -7,13 +7,16 @@ using Mono.Cecil.Cil;
 using Xamarin.Forms.Xaml;
 
 using static System.String;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Core.XamlC
 {
 	class BindingTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			if (IsNullOrEmpty(value))
 				throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(Binding)}", node);
 

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
@@ -7,13 +7,16 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Core.XamlC
 {
 	class BoundsTypeConverter : ICompiledTypeConverter
 	{
-		IEnumerable<Instruction> ICompiledTypeConverter.ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		IEnumerable<Instruction> ICompiledTypeConverter.ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			if (string.IsNullOrEmpty(value))
 				throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(Rectangle)}", node);
 

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ColorTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ColorTypeConverter.cs
@@ -6,13 +6,16 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Core.XamlC
 {
 	class ColorTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			do {
 				if (string.IsNullOrEmpty(value))
 					break;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
@@ -6,13 +6,16 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Core.XamlC
 {
 	class ConstraintTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			double size;
 
 			if (string.IsNullOrEmpty(value) || !double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out size))

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ICompiledTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ICompiledTypeConverter.cs
@@ -3,12 +3,13 @@ using Mono.Cecil.Cil;
 using Mono.Cecil;
 using Xamarin.Forms.Xaml;
 using System;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Xaml
 {
 	interface ICompiledTypeConverter
 	{
-		IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node);
+		IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node);
 	}
 }
 
@@ -17,7 +18,7 @@ namespace Xamarin.Forms.Core.XamlC
 	//only used in unit tests to make sure the compiled InitializeComponent is invoked
 	class IsCompiledTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
 			if (value != "IsCompiled?")
 				throw new Exception();

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/LayoutOptionsConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/LayoutOptionsConverter.cs
@@ -6,13 +6,16 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Core.XamlC
 {
 	class LayoutOptionsConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			do {
 				if (string.IsNullOrEmpty(value))
 					break;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ListStringTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ListStringTypeConverter.cs
@@ -12,8 +12,10 @@ namespace Xamarin.Forms.Core.XamlC
 {
 	class ListStringTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			if (value == null) {
 				yield return Instruction.Create(OpCodes.Ldnull);
 				yield break;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using Xamarin.Forms.Build.Tasks;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Core.XamlC
+{
+	class RDSourceTypeConverter : ICompiledTypeConverter
+	{
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
+		{
+			var module = context.Body.Method.Module;
+			var body = context.Body;
+
+			INode rootNode = node;
+			while (!(rootNode is ILRootNode))
+				rootNode = rootNode.Parent;
+
+			var rdNode = node.Parent as IElementNode;
+
+			var rootNs = ((ILRootNode)rootNode).TypeReference.GetCustomAttribute(module.ImportReference(typeof(XamlResourceIdAttribute))).ConstructorArguments[0].Value as string;
+			var rootResourceId = ((ILRootNode)rootNode).TypeReference.GetCustomAttribute(module.ImportReference(typeof(XamlResourceIdAttribute))).ConstructorArguments[1].Value as string;
+			var uri = new Uri(value, UriKind.RelativeOrAbsolute);
+			var resourceId = ResourceDictionary.RDSourceTypeConverter.ComputeResourceId(uri, rootResourceId, rootNs);
+
+			//abuse the converter, produce some side effect, but leave the stack untouched
+			//public void SetAndLoadSource(Uri value, string resourceID, Assembly assembly, System.Xml.IXmlLineInfo lineInfo)
+			yield return Instruction.Create(OpCodes.Ldloc, context.Variables[rdNode]); //the resourcedictionary
+			foreach (var instruction in (new UriTypeConverter()).ConvertFromString(value, context, node))
+				yield return instruction; //the Uri
+
+			//keep the Uri for later
+			yield return Instruction.Create(OpCodes.Dup);
+			var uriVarDef = new VariableDefinition(module.ImportReference(typeof(Uri)));
+			body.Variables.Add(uriVarDef);
+			yield return Instruction.Create(OpCodes.Stloc, uriVarDef);
+
+			yield return Instruction.Create(OpCodes.Ldstr, resourceId); //resourceId
+
+			var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
+			var getAssembly = module.ImportReference(typeof(Type).GetProperty("Assembly").GetGetMethod());
+			yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReference(((ILRootNode)rootNode).TypeReference));
+			yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
+			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(getAssembly)); //assembly
+
+			foreach (var instruction in node.PushXmlLineInfo(context))
+				yield return instruction; //lineinfo
+
+			var setAndLoadSource = module.ImportReference(typeof(ResourceDictionary).GetMethod("SetAndLoadSource"));
+			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(setAndLoadSource));
+
+			//ldloc the stored uri as return value
+			yield return Instruction.Create(OpCodes.Ldloc, uriVarDef);
+		}
+	}
+}

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+
+using static Mono.Cecil.Cil.Instruction;
+using static Mono.Cecil.Cil.OpCodes;
 
 using Xamarin.Forms.Build.Tasks;
 using Xamarin.Forms.Xaml;
@@ -22,39 +26,62 @@ namespace Xamarin.Forms.Core.XamlC
 
 			var rdNode = node.Parent as IElementNode;
 
-			var rootNs = ((ILRootNode)rootNode).TypeReference.GetCustomAttribute(module.ImportReference(typeof(XamlResourceIdAttribute))).ConstructorArguments[0].Value as string;
-			var rootResourceId = ((ILRootNode)rootNode).TypeReference.GetCustomAttribute(module.ImportReference(typeof(XamlResourceIdAttribute))).ConstructorArguments[1].Value as string;
+			var rootTargetPath = GetPathForType(module, ((ILRootNode)rootNode).TypeReference);
 			var uri = new Uri(value, UriKind.RelativeOrAbsolute);
-			var resourceId = ResourceDictionary.RDSourceTypeConverter.ComputeResourceId(uri, rootResourceId, rootNs);
 
+			var resourceId = ResourceDictionary.RDSourceTypeConverter.GetResourceId(uri, rootTargetPath, s => GetResourceIdForPath(module, s));
 			//abuse the converter, produce some side effect, but leave the stack untouched
 			//public void SetAndLoadSource(Uri value, string resourceID, Assembly assembly, System.Xml.IXmlLineInfo lineInfo)
-			yield return Instruction.Create(OpCodes.Ldloc, context.Variables[rdNode]); //the resourcedictionary
+			yield return Create(Ldloc, context.Variables[rdNode]); //the resourcedictionary
 			foreach (var instruction in (new UriTypeConverter()).ConvertFromString(value, context, node))
 				yield return instruction; //the Uri
 
 			//keep the Uri for later
-			yield return Instruction.Create(OpCodes.Dup);
+			yield return Create(Dup);
 			var uriVarDef = new VariableDefinition(module.ImportReference(typeof(Uri)));
 			body.Variables.Add(uriVarDef);
-			yield return Instruction.Create(OpCodes.Stloc, uriVarDef);
+			yield return Create(Stloc, uriVarDef);
 
-			yield return Instruction.Create(OpCodes.Ldstr, resourceId); //resourceId
+			yield return Create(Ldstr, resourceId); //resourceId
 
 			var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
 			var getAssembly = module.ImportReference(typeof(Type).GetProperty("Assembly").GetGetMethod());
-			yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReference(((ILRootNode)rootNode).TypeReference));
-			yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(getAssembly)); //assembly
+			yield return Create(Ldtoken, module.ImportReference(((ILRootNode)rootNode).TypeReference));
+			yield return Create(Call, module.ImportReference(getTypeFromHandle));
+			yield return Create(Callvirt, module.ImportReference(getAssembly)); //assembly
 
 			foreach (var instruction in node.PushXmlLineInfo(context))
 				yield return instruction; //lineinfo
 
 			var setAndLoadSource = module.ImportReference(typeof(ResourceDictionary).GetMethod("SetAndLoadSource"));
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(setAndLoadSource));
+			yield return Create(Callvirt, module.ImportReference(setAndLoadSource));
 
 			//ldloc the stored uri as return value
-			yield return Instruction.Create(OpCodes.Ldloc, uriVarDef);
+			yield return Create(Ldloc, uriVarDef);
+		}
+
+		static string GetPathForType(ModuleDefinition module, TypeReference type)
+		{
+			foreach (var ca in type.Module.GetCustomAttributes()) {
+				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReference(typeof(XamlResourceIdAttribute))))
+					continue;
+				if (!TypeRefComparer.Default.Equals(ca.ConstructorArguments[2].Value as TypeReference, type))
+					continue;
+				return ca.ConstructorArguments[1].Value as string;
+			}
+			return null;
+		}
+
+		static string GetResourceIdForPath(ModuleDefinition module, string path)
+		{
+			foreach (var ca in module.GetCustomAttributes()) {
+				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReference(typeof(XamlResourceIdAttribute))))
+					continue;
+				if (ca.ConstructorArguments[1].Value as string != path)
+					continue;
+				return ca.ConstructorArguments[0].Value as string;
+			}
+			return null;
 		}
 	}
 }

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Core.XamlC
 			var rdNode = node.Parent as IElementNode;
 
 			var rootTargetPath = GetPathForType(module, ((ILRootNode)rootNode).TypeReference);
-			var uri = new Uri(value, UriKind.RelativeOrAbsolute);
+			var uri = new Uri(value, UriKind.Relative);
 
 			var resourceId = ResourceDictionary.RDSourceTypeConverter.GetResourceId(uri, rootTargetPath, s => GetResourceIdForPath(module, s));
 			//abuse the converter, produce some side effect, but leave the stack untouched

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RectangleTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RectangleTypeConverter.cs
@@ -6,13 +6,16 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Core.XamlC
 {
 	class RectangleTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			if (string.IsNullOrEmpty(value))
 				throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(Rectangle)}", node);
 			double x, y, w, h;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ThicknessTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ThicknessTypeConverter.cs
@@ -6,13 +6,16 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Core.XamlC
 {
 	class ThicknessTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			if (!string.IsNullOrEmpty(value)) {
 				double l, t, r, b;
 				var thickness = value.Split(',');

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/TypeTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/TypeTypeConverter.cs
@@ -12,8 +12,10 @@ namespace Xamarin.Forms.Core.XamlC
 {
 	class TypeTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			if (string.IsNullOrEmpty(value))
 				goto error;
 
@@ -40,5 +42,4 @@ namespace Xamarin.Forms.Core.XamlC
 			throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(Type)}", node);
 		}
 	}
-
 }

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/UriTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/UriTypeConverter.cs
@@ -5,13 +5,16 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Core.XamlC
 {
 	class UriTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
+			var module = context.Body.Method.Module;
+
 			if (string.IsNullOrWhiteSpace(value)) {
 				yield return Instruction.Create(OpCodes.Ldnull);
 				yield break;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/UriTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/UriTypeConverter.cs
@@ -4,6 +4,10 @@ using System.Linq;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+
+using static Mono.Cecil.Cil.Instruction;
+using static Mono.Cecil.Cil.OpCodes;
+
 using Xamarin.Forms.Xaml;
 using Xamarin.Forms.Build.Tasks;
 
@@ -16,16 +20,16 @@ namespace Xamarin.Forms.Core.XamlC
 			var module = context.Body.Method.Module;
 
 			if (string.IsNullOrWhiteSpace(value)) {
-				yield return Instruction.Create(OpCodes.Ldnull);
+				yield return Create(Ldnull);
 				yield break;
 			}
 
 			var uriCtor = module.ImportReference(typeof(Uri)).Resolve().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 2 && md.Parameters[1].ParameterType.FullName == "System.UriKind");
 			var uriCtorRef = module.ImportReference(uriCtor);
 
-			yield return Instruction.Create(OpCodes.Ldstr, value);
-			yield return Instruction.Create(OpCodes.Ldc_I4_0); //UriKind.RelativeOrAbsolute
-			yield return Instruction.Create(OpCodes.Newobj, uriCtorRef);
+			yield return Create(Ldstr, value);
+			yield return Create(Ldc_I4_0); //UriKind.RelativeOrAbsolute
+			yield return Create(Newobj, uriCtorRef);
 		}
 	}
 }

--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Forms.Build.Tasks
 				var compiledConverter = Activator.CreateInstance (compiledConverterType);
 				var converter = typeof(ICompiledTypeConverter).GetMethods ().FirstOrDefault (md => md.Name == "ConvertFromString");
 				var instructions = (IEnumerable<Instruction>)converter.Invoke (compiledConverter, new object[] {
-					node.Value as string, context.Body.Method.Module, node as BaseNode});
+					node.Value as string, context, node as BaseNode});
 				foreach (var i in instructions)
 					yield return i;
 				if (targetTypeRef.IsValueType && boxValueTypes)
@@ -310,20 +310,18 @@ namespace Xamarin.Forms.Build.Tasks
 			var module = context.Body.Method.Module;
 
 			var xmlLineInfo = node as IXmlLineInfo;
-			if (xmlLineInfo == null)
-			{
+			if (xmlLineInfo == null) {
 				yield return Instruction.Create(OpCodes.Ldnull);
 				yield break;
 			}
 			MethodReference ctor;
-			if (xmlLineInfo.HasLineInfo())
-			{
+			if (xmlLineInfo.HasLineInfo()) {
 				yield return Instruction.Create(OpCodes.Ldc_I4, xmlLineInfo.LineNumber);
 				yield return Instruction.Create(OpCodes.Ldc_I4, xmlLineInfo.LinePosition);
-				ctor = module.ImportReference(typeof (XmlLineInfo).GetConstructor(new[] { typeof (int), typeof (int) }));
+				ctor = module.ImportReference(typeof(XmlLineInfo).GetConstructor(new[] { typeof(int), typeof(int) }));
 			}
 			else
-				ctor = module.ImportReference(typeof (XmlLineInfo).GetConstructor(new Type[] { }));
+				ctor = module.ImportReference(typeof(XmlLineInfo).GetConstructor(new Type[] { }));
 			yield return Instruction.Create(OpCodes.Newobj, ctor);
 		}
 

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -101,6 +101,7 @@
     <Compile Include="CompiledMarkupExtensions\NullExtension.cs" />
     <Compile Include="GetTasksAbi.cs" />
     <Compile Include="CompiledConverters\UriTypeConverter.cs" />
+    <Compile Include="CompiledConverters\RDSourceTypeConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -63,7 +63,12 @@ namespace Xamarin.Forms
 			if (_mergedWith != null)
 				throw new ArgumentException("Source can not be used with MergedWith");
 
-			_mergedInstance = DependencyService.Get<IResourcesLoader>().CreateResourceDictionary(resourceID, assembly, lineInfo);
+			//this will return a type if the RD as an x:Class element, and codebehind
+			var type = XamlResourceIdAttribute.GetTypeForResourceId(assembly, resourceID);
+			if (type != null) 
+				_mergedInstance = s_instances.GetValue(type, (key) => (ResourceDictionary)Activator.CreateInstance(key));
+			else
+				_mergedInstance = DependencyService.Get<IResourcesLoader>().CreateResourceDictionary(resourceID, assembly, lineInfo);
 			OnValuesChanged(_mergedInstance.ToArray());
 		}
 

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -311,7 +311,7 @@ namespace Xamarin.Forms
 
 				var lineInfo = (serviceProvider.GetService(typeof(Xaml.IXmlLineInfoProvider)) as Xaml.IXmlLineInfoProvider)?.XmlLineInfo;
 				var rootTargetPath = XamlResourceIdAttribute.GetPathForType(rootObjectType);
-				var uri = new Uri(value, UriKind.Relative); //we don't want file:// uris, aven if they start with '/'
+				var uri = new Uri(value, UriKind.Relative); //we don't want file:// uris, even if they start with '/'
 				var resourceId = GetResourceId(uri, rootTargetPath,
 											   s => XamlResourceIdAttribute.GetResourceIdForPath(rootObjectType.GetTypeInfo().Assembly, s));
 				targetRD.SetAndLoadSource(uri, resourceId, rootObjectType.GetTypeInfo().Assembly, lineInfo);

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -461,6 +461,7 @@
     <Compile Include="CompressedLayout.cs" />
     <Compile Include="PlatformConfiguration\macOSSpecific\NavigationPage.cs" />
     <Compile Include="PlatformConfiguration\macOSSpecific\NavigationTransitionStyle.cs" />
+    <Compile Include="Xaml\IResourcesLoader.cs" />
     <Compile Include="Xaml\XamlResourceIdAttribute.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/Xamarin.Forms.Core/Xaml/IResourcesLoader.cs
+++ b/Xamarin.Forms.Core/Xaml/IResourcesLoader.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Reflection;
+using System.Xml;
+
+namespace Xamarin.Forms
+{
+	interface IResourcesLoader
+	{
+		ResourceDictionary CreateResourceDictionary(string resourceID, Assembly assembly, IXmlLineInfo lineInfo);
+	}
+}

--- a/Xamarin.Forms.Core/Xaml/XamlResourceIdAttribute.cs
+++ b/Xamarin.Forms.Core/Xaml/XamlResourceIdAttribute.cs
@@ -45,5 +45,14 @@ namespace Xamarin.Forms.Xaml
 			}
 			return null;
 		}
+
+		internal static Type GetTypeForResourceId(Assembly assembly, string resourceId)
+		{
+			foreach (var xria in assembly.GetCustomAttributes<XamlResourceIdAttribute>()) {
+				if (xria.ResourceId == resourceId)
+					return xria.Type;
+			}
+			return null;
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Xaml/XamlResourceIdAttribute.cs
+++ b/Xamarin.Forms.Core/Xaml/XamlResourceIdAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace Xamarin.Forms.Xaml
 {
@@ -14,6 +15,35 @@ namespace Xamarin.Forms.Xaml
 			ResourceId = resourceId;
 			Path = path;
 			Type = type;
+		}
+
+		internal static string GetResourceIdForType(Type type)
+		{
+			var assembly = type.GetTypeInfo().Assembly;
+			foreach (var xria in assembly.GetCustomAttributes<XamlResourceIdAttribute>()) {
+				if (xria.Type == type)
+					return xria.ResourceId;
+			}
+			return null;
+		}
+
+		internal static string GetPathForType(Type type)
+		{
+			var assembly = type.GetTypeInfo().Assembly;
+			foreach (var xria in assembly.GetCustomAttributes<XamlResourceIdAttribute>()) {
+				if (xria.Type == type)
+					return xria.Path;
+			}
+			return null;
+		}
+
+		internal static string GetResourceIdForPath(Assembly assembly, string path)
+		{
+			foreach (var xria in assembly.GetCustomAttributes<XamlResourceIdAttribute>()) {
+				if (xria.Path == path)
+					return xria.ResourceId;
+			}
+			return null;
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/DefaultCtorRouting.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DefaultCtorRouting.xaml.cs
@@ -5,6 +5,7 @@ using Mono.Cecil.Cil;
 using NUnit.Framework;
 using Xamarin.Forms.Core.UnitTests;
 using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -53,7 +54,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			return false;
 		}
 
-		public IEnumerable<Instruction> ConvertFromString(string value, ModuleDefinition module, BaseNode node)
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
 			if (value != "IsCompiled?")
 				throw new Exception();

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz43733.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz43733.xaml.cs
@@ -47,7 +47,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			{
 				Application.Current = new MockApplication {
 					Resources = new ResourceDictionary {
+#pragma warning disable 618
 						MergedWith = typeof(Bz43733Rd),
+#pragma warning restore 618
 					}
 				};
 				var p = new Bz43733(useCompiledXaml);

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage 
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Xaml.UnitTests.ResourceDictionaryWithSource">
+    <ContentPage.Resources>
+        <ResourceDictionary Source="./SharedResourceDictionary.xaml" />
+    </ContentPage.Resources>
+    <Label x:Name="label" Style="{StaticResource sharedfoo}"/>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml
@@ -4,7 +4,11 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Xamarin.Forms.Xaml.UnitTests.ResourceDictionaryWithSource">
     <ContentPage.Resources>
-        <ResourceDictionary Source="./SharedResourceDictionary.xaml" />
+        <ResourceDictionary Source="./SharedResourceDictionary.xaml">
+            <ResourceDictionary Source="./SharedResourceDictionary.xaml" x:Key="relURI"/>
+            <ResourceDictionary Source="/SharedResourceDictionary.xaml" x:Key="absURI"/>
+            <ResourceDictionary Source="SharedResourceDictionary.xaml" x:Key="shortURI"/>
+        </ResourceDictionary>
     </ContentPage.Resources>
     <Label x:Name="label" Style="{StaticResource sharedfoo}"/>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class ResourceDictionaryWithSource : ContentPage
+	{
+		public ResourceDictionaryWithSource()
+		{
+			InitializeComponent();
+		}
+
+		public ResourceDictionaryWithSource(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void RDWithSourceAreFound(bool useCompiledXaml)
+			{
+				var layout = new ResourceDictionaryWithSource(useCompiledXaml);
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.Pink));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml.cs
@@ -31,12 +31,23 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Device.PlatformServices = null;
 			}
 
-			[TestCase(false)]
-			[TestCase(true)]
+			[TestCase(false), TestCase(true)]
 			public void RDWithSourceAreFound(bool useCompiledXaml)
 			{
 				var layout = new ResourceDictionaryWithSource(useCompiledXaml);
 				Assert.That(layout.label.TextColor, Is.EqualTo(Color.Pink));
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void RelativeAndAbsoluteURI(bool useCompiledXaml)
+			{
+				var layout = new ResourceDictionaryWithSource(useCompiledXaml);
+				Assert.That(((ResourceDictionary)layout.Resources["relURI"]).Source, Is.EqualTo(new Uri("./SharedResourceDictionary.xaml", UriKind.Relative)));
+				Assert.That(((ResourceDictionary)layout.Resources["relURI"])["sharedfoo"], Is.TypeOf<Style>());
+				Assert.That(((ResourceDictionary)layout.Resources["absURI"]).Source, Is.EqualTo(new Uri("/SharedResourceDictionary.xaml", UriKind.Relative)));
+				Assert.That(((ResourceDictionary)layout.Resources["absURI"])["sharedfoo"], Is.TypeOf<Style>());
+				Assert.That(((ResourceDictionary)layout.Resources["shortURI"]).Source, Is.EqualTo(new Uri("SharedResourceDictionary.xaml", UriKind.Relative)));
+				Assert.That(((ResourceDictionary)layout.Resources["shortURI"])["sharedfoo"], Is.TypeOf<Style>());
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/TestSharedResourceDictionary.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/TestSharedResourceDictionary.xaml.cs
@@ -24,7 +24,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Device.PlatformServices = new MockPlatformServices();
 				Application.Current = new MockApplication {
 					Resources = new ResourceDictionary {
+#pragma warning disable 618
 						MergedWith = typeof(MyRD)
+#pragma warning restore 618
 					}
 				};
 			}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -495,6 +495,9 @@
     <Compile Include="Issues\Bz59818.xaml.cs">
       <DependentUpon>Bz59818.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ResourceDictionaryWithSource.xaml.cs" >
+      <DependentUpon>ResourceDictionaryWithSource.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -916,6 +919,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz59818.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ResourceDictionaryWithSource.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/ResourcesLoader.cs
+++ b/Xamarin.Forms.Xaml/ResourcesLoader.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Xamarin.Forms;
+using System.Xml;
+
+[assembly:Dependency(typeof(Xamarin.Forms.Xaml.ResourcesLoader))]
+namespace Xamarin.Forms.Xaml
+{
+	class ResourcesLoader : IResourcesLoader
+	{
+		public ResourceDictionary CreateResourceDictionary(string resourceID, Assembly assembly, IXmlLineInfo lineInfo)
+		{
+			using (var stream = assembly.GetManifestResourceStream(resourceID)) {
+				if (stream == null)
+					throw new XamlParseException($"No resource found for '{resourceID}'.", lineInfo);
+				using (var reader = new StreamReader(stream)) {
+					var rd = new ResourceDictionary();
+					rd.LoadFromXaml(reader.ReadToEnd());
+					return rd;
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
+++ b/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
@@ -71,6 +71,7 @@
     <Compile Include="TypeArgumentsParser.cs" />
     <Compile Include="PruneIgnoredNodesVisitor.cs" />
     <Compile Include="XamlFilePathAttribute.cs" />
+    <Compile Include="ResourcesLoader.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -150,16 +150,9 @@ namespace Xamarin.Forms.Xaml
 				return xaml;
 #pragma warning restore 0618
 
-			var typeInfo = type.GetTypeInfo();
-			var assembly = typeInfo.Assembly;
 
-			string resourceId = null;
-			foreach (var xria in assembly.GetCustomAttributes<XamlResourceIdAttribute>()) {
-				if (xria.Type != type)
-					continue;
-				resourceId = xria.ResourceId;
-				break;
-			}
+			var assembly = type.GetTypeInfo().Assembly;
+			var resourceId = XamlResourceIdAttribute.GetResourceIdForType(type);
 
 			if (resourceId == null)
 				return LegacyGetXamlForType(type);

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary+RDSourceTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary+RDSourceTypeConverter.xml
@@ -1,0 +1,101 @@
+<Type Name="ResourceDictionary+RDSourceTypeConverter" FullName="Xamarin.Forms.ResourceDictionary+RDSourceTypeConverter">
+  <TypeSignature Language="C#" Value="public class ResourceDictionary.RDSourceTypeConverter : Xamarin.Forms.TypeConverter, Xamarin.Forms.IExtendedTypeConverter" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit ResourceDictionary/RDSourceTypeConverter extends Xamarin.Forms.TypeConverter implements class Xamarin.Forms.IExtendedTypeConverter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.IExtendedTypeConverter</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public RDSourceTypeConverter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="public override object ConvertFromInvariantString (string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance object ConvertFromInvariantString(string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IExtendedTypeConverter.ConvertFrom">
+      <MemberSignature Language="C#" Value="object IExtendedTypeConverter.ConvertFrom (System.Globalization.CultureInfo culture, object value, IServiceProvider serviceProvider);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance object Xamarin.Forms.IExtendedTypeConverter.ConvertFrom(class System.Globalization.CultureInfo culture, object value, class System.IServiceProvider serviceProvider) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="culture" Type="System.Globalization.CultureInfo" />
+        <Parameter Name="value" Type="System.Object" />
+        <Parameter Name="serviceProvider" Type="System.IServiceProvider" />
+      </Parameters>
+      <Docs>
+        <param name="culture">To be added.</param>
+        <param name="value">To be added.</param>
+        <param name="serviceProvider">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.IExtendedTypeConverter.ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="object IExtendedTypeConverter.ConvertFromInvariantString (string value, IServiceProvider serviceProvider);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance object Xamarin.Forms.IExtendedTypeConverter.ConvertFromInvariantString(string value, class System.IServiceProvider serviceProvider) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+        <Parameter Name="serviceProvider" Type="System.IServiceProvider" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <param name="serviceProvider">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
@@ -271,6 +271,9 @@
       </AssemblyInfo>
       <Attributes>
         <Attribute>
+          <AttributeName>System.Obsolete("Use Source")</AttributeName>
+        </Attribute>
+        <Attribute>
           <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.TypeTypeConverter))</AttributeName>
         </Attribute>
       </Attributes>
@@ -307,6 +310,57 @@
         <summary>Removes the key and value identified by <paramref name="key" /> from the <see cref="T:Xamarin.Forms.ResourceDictionary" />.</summary>
         <returns>
           <see langword="true" /> if the key existed and the removal was successful.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetAndLoadSource">
+      <MemberSignature Language="C#" Value="public void SetAndLoadSource (Uri value, string resourceID, System.Reflection.Assembly assembly, System.Xml.IXmlLineInfo lineInfo);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SetAndLoadSource(class System.Uri value, string resourceID, class System.Reflection.Assembly assembly, class System.Xml.IXmlLineInfo lineInfo) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Uri" />
+        <Parameter Name="resourceID" Type="System.String" />
+        <Parameter Name="assembly" Type="System.Reflection.Assembly" />
+        <Parameter Name="lineInfo" Type="System.Xml.IXmlLineInfo" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <param name="resourceID">To be added.</param>
+        <param name="assembly">To be added.</param>
+        <param name="lineInfo">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Source">
+      <MemberSignature Language="C#" Value="public Uri Source { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Uri Source" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.ResourceDictionary/RDSourceTypeConverter))</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Uri</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -361,6 +361,7 @@
       <Type Name="RenderWithAttribute" Kind="Class" />
       <Type Name="ResolutionGroupNameAttribute" Kind="Class" />
       <Type Name="ResourceDictionary" Kind="Class" />
+      <Type Name="ResourceDictionary+RDSourceTypeConverter" Kind="Class" />
       <Type Name="RoutingEffect" Kind="Class" />
       <Type Name="RowDefinition" Kind="Class" />
       <Type Name="RowDefinitionCollection" Kind="Class" />

--- a/docs/Xamarin.Forms.Xaml/index.xml
+++ b/docs/Xamarin.Forms.Xaml/index.xml
@@ -48,6 +48,9 @@
           <AttributeName>System.Runtime.Versioning.TargetFramework(".NETPortable,Version=v4.5,Profile=Profile259", FrameworkDisplayName=".NET Portable Subset")</AttributeName>
         </Attribute>
         <Attribute>
+          <AttributeName>Xamarin.Forms.Dependency(typeof(Xamarin.Forms.Xaml.ResourcesLoader))</AttributeName>
+        </Attribute>
+        <Attribute>
           <AttributeName>Xamarin.Forms.Internals.Preserve</AttributeName>
         </Attribute>
         <Attribute>


### PR DESCRIPTION
### Description of Change ###

Allow setting a Source to a ResourceDictionary. Source is an Uri, relative or absolute, that points to a resource in the same assembly.

Restriction: this can only be used from within Xaml

MergedWith is deprecated (obsolete).

Oh, and you no longer have to create code behind for resource dictionaries ! But if you do, we will use it

TODO:
- compile the RD with XamlC using xml processing instructions (see #1241)

### Bugs Fixed ###

/

### API Changes ###

Added:
 - Uri ResourceDictionary.Source {get; set;}

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense