### PR TITLE
[Xaml] create the [XamlResourceId] at assembly level

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -43,18 +43,19 @@ namespace Xamarin.Forms.Build.Tasks
 			return result;
 		}
 
-		internal bool Execute(ITaskItem xamlFile, string targetPath)
+		internal bool Execute(ITaskItem xamlFile, string outputFile)
 		{
 			Log.LogMessage("Source: {0}", xamlFile.ItemSpec);
-			Log.LogMessage("Language: {0}", Language);
-			Log.LogMessage("ResourceID: {0}", xamlFile.GetMetadata("ManifestResourceName"));
-			Log.LogMessage("AssemblyName: {0}", AssemblyName);
-			Log.LogMessage("OutputFile {0}", targetPath);
+			Log.LogMessage(" Language: {0}", Language);
+			Log.LogMessage(" ResourceID: {0}", xamlFile.GetMetadata("ManifestResourceName"));
+			Log.LogMessage(" TargetPath: {0}", xamlFile.GetMetadata("TargetPath"));
+			Log.LogMessage(" AssemblyName: {0}", AssemblyName);
+			Log.LogMessage(" OutputFile {0}", outputFile);
 
 			try
 			{
-				GenerateFile(xamlFile.ItemSpec, xamlFile.GetMetadata("ManifestResourceName"), targetPath);
-				_generatedCodeFiles.Add(new TaskItem(Microsoft.Build.Evaluation.ProjectCollection.Escape(targetPath)));
+				GenerateFile(xamlFile.ItemSpec, xamlFile.GetMetadata("ManifestResourceName"), xamlFile.GetMetadata("TargetPath"), outputFile);
+				_generatedCodeFiles.Add(new TaskItem(Microsoft.Build.Evaluation.ProjectCollection.Escape(outputFile)));
 				return true;
 			}
 			catch (XmlException xe)
@@ -126,7 +127,7 @@ namespace Xamarin.Forms.Build.Tasks
 						new CodeAttributeArgument(new CodePrimitiveExpression("0.0.0.0")));
 
 		internal static void GenerateCode(string rootType, string rootNs, CodeTypeReference baseType,
-		                                  IEnumerable<CodeMemberField> namedFields, string xamlFile, string resourceId, string outFile)
+		                                  IEnumerable<CodeMemberField> namedFields, string xamlFile, string resourceId, string targetPath, string outFile)
 		{
 			//Create the target directory if required
 			Directory.CreateDirectory(Path.GetDirectoryName(outFile));
@@ -138,6 +139,12 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 
 			var ccu = new CodeCompileUnit();
+			ccu.AssemblyCustomAttributes.Add(
+			new CodeAttributeDeclaration(new CodeTypeReference($"global::{typeof(XamlResourceIdAttribute).FullName}"),
+										 new CodeAttributeArgument(new CodePrimitiveExpression(resourceId)),
+										 new CodeAttributeArgument(new CodePrimitiveExpression(targetPath)),
+										 new CodeAttributeArgument(new CodeTypeOfExpression($"global::{rootNs}.{rootType}"))
+										));
 			var declNs = new CodeNamespace(rootNs);
 			ccu.Namespaces.Add(declNs);
 
@@ -146,9 +153,6 @@ namespace Xamarin.Forms.Build.Tasks
 				CustomAttributes = {
 					new CodeAttributeDeclaration(new CodeTypeReference($"global::{typeof(XamlFilePathAttribute).FullName}"),
 						 new CodeAttributeArgument(new CodePrimitiveExpression(xamlFile))),
-					new CodeAttributeDeclaration(new CodeTypeReference($"global::{typeof(XamlResourceIdAttribute).FullName}"),
-					                             new CodeAttributeArgument(new CodePrimitiveExpression(rootNs)),
-					                             new CodeAttributeArgument(new CodePrimitiveExpression(resourceId))),
 				}
 			};
 			declType.BaseTypes.Add(baseType);
@@ -186,7 +190,7 @@ namespace Xamarin.Forms.Build.Tasks
 				Provider.GenerateCodeFromCompileUnit(ccu, writer, new CodeGeneratorOptions());
 		}
 
-		internal static void GenerateFile(string xamlFile, string resourceId, string outFile)
+		internal static void GenerateFile(string xamlFile, string resourceId, string targetPath, string outFile)
 		{
 			string rootType, rootNs;
 			CodeTypeReference baseType;
@@ -195,7 +199,7 @@ namespace Xamarin.Forms.Build.Tasks
 			using (StreamReader reader = File.OpenText(xamlFile))
 				ParseXaml(reader, out rootType, out rootNs, out baseType, out namedFields);
 
-			GenerateCode(rootType, rootNs, baseType, namedFields, Path.GetFullPath(xamlFile), resourceId, outFile);
+			GenerateCode(rootType, rootNs, baseType, namedFields, Path.GetFullPath(xamlFile), resourceId, targetPath, outFile);
 		}
 
 		static IEnumerable<CodeMemberField> GetCodeMemberFields(XmlNode root, XmlNamespaceManager nsmgr)

--- a/Xamarin.Forms.Core/Xaml/XamlResourceIdAttribute.cs
+++ b/Xamarin.Forms.Core/Xaml/XamlResourceIdAttribute.cs
@@ -2,16 +2,18 @@
 
 namespace Xamarin.Forms.Xaml
 {
-	[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+	[AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = true)]
 	public sealed class XamlResourceIdAttribute : Attribute
 	{
-		public string RootNamespace { get; set; }
 		public string ResourceId { get; set; }
+		public string Path { get; set; }
+		public Type Type { get; set; }
 
-		public XamlResourceIdAttribute(string rootNamespace, string resourceId)
+		public XamlResourceIdAttribute(string resourceId, string path, Type type)
 		{
-			RootNamespace = rootNamespace;
 			ResourceId = resourceId;
+			Path = path;
+			Type = type;
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.Xamlg/Xamlg.cs
+++ b/Xamarin.Forms.Xaml.Xamlg/Xamlg.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Forms.Xaml
 				else
 					n = string.Concat(Path.GetFileName(f), ".g.", XamlGTask.Provider.FileExtension);
 
-				XamlGTask.GenerateFile(f, f, n);
+				XamlGTask.GenerateFile(f, f, f, n);
 			}
 		}
 

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -152,7 +152,15 @@ namespace Xamarin.Forms.Xaml
 
 			var typeInfo = type.GetTypeInfo();
 			var assembly = typeInfo.Assembly;
-			var resourceId = typeInfo.GetCustomAttribute<XamlResourceIdAttribute>()?.ResourceId;
+
+			string resourceId = null;
+			foreach (var xria in assembly.GetCustomAttributes<XamlResourceIdAttribute>()) {
+				if (xria.Type != type)
+					continue;
+				resourceId = xria.ResourceId;
+				break;
+			}
+
 			if (resourceId == null)
 				return LegacyGetXamlForType(type);
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Xaml/XamlResourceIdAttribute.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Xaml/XamlResourceIdAttribute.xml
@@ -11,7 +11,7 @@
   <Interfaces />
   <Attributes>
     <Attribute>
-      <AttributeName>System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)</AttributeName>
+      <AttributeName>System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple=true, Inherited=false)</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>
@@ -20,20 +20,38 @@
   </Docs>
   <Members>
     <Member MemberName=".ctor">
-      <MemberSignature Language="C#" Value="public XamlResourceIdAttribute (string rootNamespace, string resourceId);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string rootNamespace, string resourceId) cil managed" />
+      <MemberSignature Language="C#" Value="public XamlResourceIdAttribute (string resourceId, string path, Type type);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string resourceId, string path, class System.Type type) cil managed" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Parameters>
-        <Parameter Name="rootNamespace" Type="System.String" />
         <Parameter Name="resourceId" Type="System.String" />
+        <Parameter Name="path" Type="System.String" />
+        <Parameter Name="type" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="rootNamespace">To be added.</param>
         <param name="resourceId">To be added.</param>
+        <param name="path">To be added.</param>
+        <param name="type">To be added.</param>
         <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Path">
+      <MemberSignature Language="C#" Value="public string Path { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string Path" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -53,15 +71,15 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="RootNamespace">
-      <MemberSignature Language="C#" Value="public string RootNamespace { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance string RootNamespace" />
+    <Member MemberName="Type">
+      <MemberSignature Language="C#" Value="public Type Type { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Type Type" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.String</ReturnType>
+        <ReturnType>System.Type</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>To be added.</summary>


### PR DESCRIPTION
### Description of Change ###

[Xaml] create the [XamlResourceId] at assembly level

this allows, as before, finding the resource for a type, but also find the type of a resource or from a pack-like uri

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense