### PR TITLE
[Android] Rename CreateRenderer overload for backward compatibility with previewer

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -264,7 +264,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (Android.Platform.GetRenderer(page) != null)
 				return;
 
-			IVisualElementRenderer renderView = Android.Platform.CreateRenderer(page, _context);
+			IVisualElementRenderer renderView = Android.Platform.CreateRenderer2(page, _context);
 			Android.Platform.SetRenderer(page, renderView);
 
 			if (layout)
@@ -341,7 +341,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				_backgroundView.SetWindowBackground();
 				AddView(_backgroundView);
 
-				_renderer = Android.Platform.CreateRenderer(modal, context);
+				_renderer = Android.Platform.CreateRenderer2(modal, context);
 				Android.Platform.SetRenderer(modal, _renderer);
 
 				AddView(_renderer.View);

--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (cell.View == null)
 				throw new InvalidOperationException($"ViewCell must have a {nameof(cell.View)}");
 
-			IVisualElementRenderer view = Platform.CreateRenderer(cell.View, context);
+			IVisualElementRenderer view = Platform.CreateRenderer2(cell.View, context);
 			Platform.SetRenderer(cell.View, view);
 			cell.View.IsPlatformEnabled = true;
 			var c = new ViewCellContainer(context, view, cell, ParentView, unevenRows, rowHeight);
@@ -180,7 +180,7 @@ namespace Xamarin.Forms.Platform.Android
 				_view.View.Dispose();
 
 				_viewCell = cell;
-				_view = Platform.CreateRenderer(_viewCell.View, Context);
+				_view = Platform.CreateRenderer2(_viewCell.View, Context);
 
 				Platform.SetRenderer(_viewCell.View, _view);
 				AddView(_view.View);

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -300,13 +300,15 @@ namespace Xamarin.Forms.Platform.Android
 			throw new InvalidOperationException("RemovePage is not supported globally on Android, please use a NavigationPage.");
 		}
 
-		[Obsolete("CreateRenderer(VisualElement) is obsolete as of version 3.0. Please use CreateRenderer(VisualElement, Context) instead.")]
+		[Obsolete("CreateRenderer(VisualElement) is obsolete as of version 3.0. Please use " 
+			+ nameof(CreateRenderer2) + "(VisualElement, Context) instead.")]
 		public static IVisualElementRenderer CreateRenderer(VisualElement element)
 		{
-			return CreateRenderer(element, Forms.Context);
+			return CreateRenderer2(element, Forms.Context);
 		}
 
-		public static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
+		// This method has to have a different name than CreateRenderer for legacy previewer compatibility reasons
+		public static IVisualElementRenderer CreateRenderer2(VisualElement element, Context context)
 		{
 			IVisualElementRenderer renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType(), context) 
 				?? new DefaultRenderer(context);
@@ -556,7 +558,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (GetRenderer(view) != null)
 				return;
 
-			IVisualElementRenderer renderView = CreateRenderer(view, _context);
+			IVisualElementRenderer renderView = CreateRenderer2(view, _context);
 			SetRenderer(view, renderView);
 
 			if (layout)
@@ -787,7 +789,7 @@ namespace Xamarin.Forms.Platform.Android
 			IVisualElementRenderer modalRenderer = GetRenderer(modal);
 			if (modalRenderer == null)
 			{
-				modalRenderer = CreateRenderer(modal, _context);
+				modalRenderer = CreateRenderer2(modal, _context);
 				SetRenderer(modal, modalRenderer);
 
 				if (modal.BackgroundColor == Color.Default && modal.BackgroundImage == null)

--- a/Xamarin.Forms.Platform.Android/Renderers/CarouselPageAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CarouselPageAdapter.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			ContentPage child = _page.Children.ElementAt(position);
 			if (Platform.GetRenderer(child) == null)
-				Platform.SetRenderer(child, Platform.CreateRenderer(child, _context));
+				Platform.SetRenderer(child, Platform.CreateRenderer2(child, _context));
 
 			IVisualElementRenderer renderer = Platform.GetRenderer(child);
 			renderer.View.RemoveFromParent();

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -324,7 +324,7 @@ namespace Xamarin.Forms.Platform.Android
 				_footerRenderer.SetElement(footer);
 			else
 			{
-				_footerRenderer = Platform.CreateRenderer(footer, Context);
+				_footerRenderer = Platform.CreateRenderer2(footer, Context);
 				if (_footerView != null)
 					_footerView.Child = _footerRenderer;
 			}
@@ -356,7 +356,7 @@ namespace Xamarin.Forms.Platform.Android
 				_headerRenderer.SetElement(header);
 			else
 			{
-				_headerRenderer = Platform.CreateRenderer(header, Context);
+				_headerRenderer = Platform.CreateRenderer2(header, Context);
 				if (_headerView != null)
 					_headerView.Child = _headerRenderer;
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailContainer.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			IVisualElementRenderer renderer = Platform.GetRenderer(childView);
 			if (renderer == null)
-				Platform.SetRenderer(childView, renderer = Platform.CreateRenderer(childView, Context));
+				Platform.SetRenderer(childView, renderer = Platform.CreateRenderer2(childView, Context));
 
 			if (renderer.View.Parent != this)
 			{

--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
@@ -213,7 +213,7 @@ namespace Xamarin.Forms.Platform.Android
 			IVisualElementRenderer rendererToAdd = Platform.GetRenderer(view);
 			bool existing = rendererToAdd != null;
 			if (!existing)
-				Platform.SetRenderer(view, rendererToAdd = Platform.CreateRenderer(view, Context));
+				Platform.SetRenderer(view, rendererToAdd = Platform.CreateRenderer2(view, Context));
 
 			Page pageToRemove = _current;
 			IVisualElementRenderer rendererToRemove = pageToRemove == null ? null : Platform.GetRenderer(pageToRemove);

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				IVisualElementRenderer renderer;
 				if ((renderer = Platform.GetRenderer(_childView)) == null)
-					Platform.SetRenderer(_childView, renderer = Platform.CreateRenderer(_childView, Context));
+					Platform.SetRenderer(_childView, renderer = Platform.CreateRenderer2(_childView, Context));
 
 				if (renderer.View.Parent != null)
 					renderer.View.RemoveFromParent();

--- a/Xamarin.Forms.Platform.Android/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TabbedRenderer.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			if (Platform.GetRenderer(view) == null)
-				Platform.SetRenderer(view, Platform.CreateRenderer(view, Context));
+				Platform.SetRenderer(view, Platform.CreateRenderer2(view, Context));
 
 			AddView(Platform.GetRenderer(view).View);
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (renderer == null)
 				{
 					Performance.Start("New renderer");
-				renderer = Platform.CreateRenderer(view, _renderer.View.Context);
+				renderer = Platform.CreateRenderer2(view, _renderer.View.Context);
 					Performance.Stop("New renderer");
 				}
 


### PR DESCRIPTION
### Description of Change ###

Having a second public overload of CreateRenderer causes problems for the previewer when it reflects on the method name; to maintain backward compatibility we need to use a different name for the new overload of the method.

### Bugs Fixed ###

- Allows vNext to work with the existing previewer.

### API Changes ###

`public static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)` => `public static IVisualElementRenderer CreateRenderer2(VisualElement element, Context context)`

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
