### PR TITLE
[Android] Call out correct version for new Obsolete messages

### DIFF
--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Maps.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use MapRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use MapRenderer(Context) instead.")]
 		public MapRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ButtonRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ButtonRenderer(Context) instead.")]
 		public ButtonRenderer() 
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use CarouselPageRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use CarouselPageRenderer(Context) instead.")]
 		public CarouselPageRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FrameRenderer.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		    
 	    }
 
-	    [Obsolete("This constructor is obsolete as of version 3.0. Please use FrameRenderer(Context) instead.")]
+	    [Obsolete("This constructor is obsolete as of version 2.5. Please use FrameRenderer(Context) instead.")]
 	    public FrameRenderer()
 	    {
 		   

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use MasterDetailPageRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use MasterDetailPageRenderer(Context) instead.")]
 		public MasterDetailPageRenderer() : base(Forms.Context)
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Device.Info.PropertyChanged += DeviceInfoPropertyChanged;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use NavigationPageRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use NavigationPageRenderer(Context) instead.")]
 		public NavigationPageRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use PickerRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use PickerRenderer(Context) instead.")]
 		public PickerRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use SwitchRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use SwitchRenderer(Context) instead.")]
 		public SwitchRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use TabbedPageRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use TabbedPageRenderer(Context) instead.")]
 		public TabbedPageRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/AppCompat/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ViewRenderer.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ViewRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ViewRenderer(Context) instead.")]
 		protected ViewRenderer() 
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			Initialize();
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ButtonRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ButtonRenderer(Context) instead.")]
 		public ButtonRenderer() : base(Forms.Context)
 		{
 			_automationPropertiesProvider = new AutomationPropertiesProvider(this);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			_effectControlProvider = new EffectControlProvider(this);
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use FrameRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use FrameRenderer(Context) instead.")]
 		public FrameRenderer() : base(Forms.Context)
 		{
 			_gestureManager = new GestureManager(this);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ImageRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ImageRenderer(Context) instead.")]
 		public ImageRenderer() : base(Forms.Context)
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			_visualElementRenderer = new VisualElementRenderer(this);
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use LabelRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use LabelRenderer(Context) instead.")]
 		public LabelRenderer(): base(Forms.Context)
 		{
 			_labelTextColorDefault = TextColors;

--- a/Xamarin.Forms.Platform.Android/NativeViewWrapperRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/NativeViewWrapperRenderer.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use NativeViewWrapperRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use NativeViewWrapperRenderer(Context) instead.")]
 		public NativeViewWrapperRenderer()
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1075,7 +1075,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			bool _notReallyHandled;
 
-			[Obsolete("This constructor is obsolete as of version 3.0. Please use DefaultRenderer(Context) instead.")]
+			[Obsolete("This constructor is obsolete as of version 2.5. Please use DefaultRenderer(Context) instead.")]
 			public DefaultRenderer()
 			{
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ActivityIndicatorRenderer.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ActivityIndicatorRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ActivityIndicatorRenderer(Context) instead.")]
 		public ActivityIndicatorRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use BoxRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use BoxRenderer(Context) instead.")]
 		public BoxRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ButtonRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ButtonRenderer(Context) instead.")]
 		public ButtonRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CarouselPageRenderer.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use CarouselPageRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use CarouselPageRenderer(Context) instead.")]
 		public CarouselPageRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.Android
 				Device.Info.PropertyChanged += DeviceInfoPropertyChanged;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use DatePickerRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use DatePickerRenderer(Context) instead.")]
 		public DatePickerRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use EditorRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use EditorRenderer(Context) instead.")]
 		public EditorRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use EntryRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use EntryRenderer(Context) instead.")]
 		public EntryRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use FrameRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use FrameRenderer(Context) instead.")]
 		public FrameRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ImageRenderer.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ImageRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ImageRenderer(Context) instead.")]
 		public ImageRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use LabelRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use LabelRenderer(Context) instead.")]
 		public LabelRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ListViewRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ListViewRenderer(Context) instead.")]
 		public ListViewRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use MasterDetailRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use MasterDetailRenderer(Context) instead.")]
 		public MasterDetailRenderer() : base(Forms.Context)
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationMenuRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationMenuRenderer.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use NavigationMenuRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use NavigationMenuRenderer(Context) instead.")]
 		public NavigationMenuRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use NavigationRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use NavigationRenderer(Context) instead.")]
 		public NavigationRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/OpenGLViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/OpenGLViewRenderer.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use OpenGLViewRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use OpenGLViewRenderer(Context) instead.")]
 		public OpenGLViewRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use PageRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use PageRenderer(Context) instead.")]
 		public PageRenderer()
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use PickerRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use PickerRenderer(Context) instead.")]
 		public PickerRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ProgressBarRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ProgressBarRenderer(Context) instead.")]
 		public ProgressBarRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ScrollViewRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ScrollViewRenderer(Context) instead.")]
 		public ScrollViewRenderer() : base(Forms.Context)
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use SearchBarRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use SearchBarRenderer(Context) instead.")]
 		public SearchBarRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use SliderRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use SliderRenderer(Context) instead.")]
 		public SliderRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/StepperRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/StepperRenderer.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use StepperRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use StepperRenderer(Context) instead.")]
 		public StepperRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use SwitchRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use SwitchRenderer(Context) instead.")]
 		public SwitchRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TabbedRenderer.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use TabbedRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use TabbedRenderer(Context) instead.")]
 		public TabbedRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use TableViewRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use TableViewRenderer(Context) instead.")]
 		public TableViewRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use TimePickerRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use TimePickerRenderer(Context) instead.")]
 		public TimePickerRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Platform.Android
 			AutoPackage = false;
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use WebViewRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use WebViewRenderer(Context) instead.")]
 		public WebViewRenderer()
 		{
 			AutoPackage = false;

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ViewRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ViewRenderer(Context) instead.")]
 		protected ViewRenderer()
 		{
 		}
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use ViewRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use ViewRenderer(Context) instead.")]
 		protected ViewRenderer() 
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -63,7 +63,7 @@ namespace Xamarin.Forms.Platform.Android
 			return base.DispatchTouchEvent(e);
 		}		  		
 
-		[Obsolete("This constructor is obsolete as of version 3.0. Please use VisualElementRenderer(Context) instead.")]
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use VisualElementRenderer(Context) instead.")]
 		protected VisualElementRenderer() : this(Forms.Context)
 		{
 		}


### PR DESCRIPTION
### Description of Change ###

Obsolete messages for new renderer constructors in Android were using a placeholder version number; this change updates the messages to the correct version number.

