### PR TITLE
[UWP] Bug 57674 - XF.UWP ListView not honoring INotifyCollectionChanged 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57674.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57674.cs
@@ -1,0 +1,100 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System;
+using System.Collections;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 57674, "ListView not honoring INotifyCollectionChanged ", PlatformAffected.UWP)]
+    public class Bugzilla57674 : TestContentPage
+    {
+        private MyCollection _myCollection;
+        protected override void Init()
+        {
+            // Initialize ui here instead of ctor
+            _myCollection = new MyCollection();
+
+            var stackLayout = new StackLayout();
+            var button = new Button
+            {
+                AutomationId = "IssueButton",
+                Text = "Add new element to ListView"
+            };
+            button.Clicked += Button_Clicked;
+            stackLayout.Children.Add(button);
+
+            stackLayout.Children.Add(new ListView
+            {
+                AutomationId = "IssueListView",
+                ItemsSource = _myCollection
+            });
+
+            Content = stackLayout;
+        }
+
+        private void Button_Clicked(object sender, EventArgs e)
+        {
+            _myCollection.AddNewItem();
+        }
+
+#if UITEST
+        [Test]
+        public void Bugzilla57674Test()
+        {
+            RunningApp.Screenshot("Initial Status");
+            RunningApp.WaitForElement(q => q.Marked("IssueListView"));
+            RunningApp.Tap(a => a.Button("IssueButton"));
+            RunningApp.Screenshot("Element Added to List");
+        }
+#endif
+    }
+
+    internal class MyCollection : IEnumerable<string>, INotifyCollectionChanged
+    {
+        private List<string> _internalList = new List<string>();
+        public MyCollection()
+        {
+        }
+
+        public IEnumerable<string> GetItems()
+        {
+            foreach (var item in _internalList)
+            {
+                yield return item;
+            }
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return GetItems().GetEnumerator();
+        }
+
+        internal void AddNewItem()
+        {
+            var index = _internalList.Count;
+            var item = Guid.NewGuid().ToString();
+            _internalList.Add(item);
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
+        }
+
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        protected void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+        {
+            CollectionChanged?.Invoke(this, e);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57674.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57674.cs
@@ -12,89 +12,83 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-    [Preserve(AllMembers = true)]
-    [Issue(IssueTracker.Bugzilla, 57674, "ListView not honoring INotifyCollectionChanged ", PlatformAffected.UWP)]
-    public class Bugzilla57674 : TestContentPage
-    {
-        private MyCollection _myCollection;
-        protected override void Init()
-        {
-            // Initialize ui here instead of ctor
-            _myCollection = new MyCollection();
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 57674, "ListView not honoring INotifyCollectionChanged ", PlatformAffected.UWP)]
+	public class Bugzilla57674 : TestContentPage
+	{
+		MyCollection _myCollection;
+		protected override void Init()
+		{
+			// Initialize ui here instead of ctor
+			_myCollection = new MyCollection();
 
-            var stackLayout = new StackLayout();
-            var button = new Button
-            {
-                AutomationId = "IssueButton",
-                Text = "Add new element to ListView"
-            };
-            button.Clicked += Button_Clicked;
-            stackLayout.Children.Add(button);
+			var stackLayout = new StackLayout();
+			var button = new Button {
+				AutomationId = "IssueButton",
+				Text = "Add new element to ListView"
+			};
+			button.Clicked += (object sender, EventArgs e) => _myCollection.AddNewItem();
 
-            stackLayout.Children.Add(new ListView
-            {
-                AutomationId = "IssueListView",
-                ItemsSource = _myCollection
-            });
+			stackLayout.Children.Add(button);
 
-            Content = stackLayout;
-        }
+			stackLayout.Children.Add(new ListView {
+				AutomationId = "IssueListView",
+				ItemsSource = _myCollection
+			});
 
-        private void Button_Clicked(object sender, EventArgs e)
-        {
-            _myCollection.AddNewItem();
-        }
+			Content = stackLayout;
+		}
 
 #if UITEST
-        [Test]
-        public void Bugzilla57674Test()
-        {
-            RunningApp.Screenshot("Initial Status");
-            RunningApp.WaitForElement(q => q.Marked("IssueListView"));
-            RunningApp.Tap(a => a.Button("IssueButton"));
-            RunningApp.Screenshot("Element Added to List");
-        }
+		[Test]
+		public void Bugzilla57674Test()
+		{
+			RunningApp.Screenshot("Initial Status");
+			RunningApp.WaitForElement(q => q.Marked("IssueListView"));
+			RunningApp.Tap(a => a.Button("IssueButton"));
+			RunningApp.Screenshot("Element Added to List");
+		}
 #endif
-    }
+	}
 
-    internal class MyCollection : IEnumerable<string>, INotifyCollectionChanged
-    {
-        private List<string> _internalList = new List<string>();
-        public MyCollection()
-        {
-        }
+	public class MyCollection : IEnumerable<string>, INotifyCollectionChanged
+	{
+		readonly List<string> _internalList = new List<string>();
+		public MyCollection()
+		{
+		}
 
-        public IEnumerable<string> GetItems()
-        {
-            foreach (var item in _internalList)
-            {
-                yield return item;
-            }
-        }
+		public IEnumerable<string> GetItems()
+		{
+			foreach (var item in _internalList)
+			{
+				yield return item;
+			}
+		}
 
-        public IEnumerator<string> GetEnumerator()
-        {
-            return GetItems().GetEnumerator();
-        }
+		public IEnumerator<string> GetEnumerator()
+		{
+			return GetItems().GetEnumerator();
+		}
 
-        internal void AddNewItem()
-        {
-            var index = _internalList.Count;
-            var item = Guid.NewGuid().ToString();
-            _internalList.Add(item);
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
-        }
+		public void AddNewItem()
+		{
+			int index = _internalList.Count;
+			string item = Guid.NewGuid().ToString();
+			_internalList.Add(item);
+			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
+		}
 
-        public event NotifyCollectionChangedEventHandler CollectionChanged;
+		public event NotifyCollectionChangedEventHandler CollectionChanged;
 
-        protected void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
-        {
-            CollectionChanged?.Invoke(this, e);
-        }
+		protected void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+		{
+			CollectionChanged?.Invoke(this, e);
+		}
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-    }
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -223,6 +223,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57317.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57114.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57515.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57758.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla57910.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58406.cs" />

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -48,7 +48,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 				if (List == null)
 				{
-					List = new WListView {
+					List = new WListView 
+					{
 						IsSynchronizedWithCurrentItem = false,
 						ItemTemplate = (Windows.UI.Xaml.DataTemplate)WApp.Current.Resources["CellTemplate"],
 						HeaderTemplate = (Windows.UI.Xaml.DataTemplate)WApp.Current.Resources["View"],
@@ -321,7 +322,8 @@ namespace Xamarin.Forms.Platform.UWP
 			if (viewer == null)
 			{
 				RoutedEventHandler loadedHandler = null;
-				loadedHandler = async (o, e) => {
+				loadedHandler = async (o, e) => 
+				{
 					List.Loaded -= loadedHandler;
 
 					// Here we try to avoid an exception, see explanation at bottom

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -37,14 +37,16 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				e.OldElement.ItemSelected -= OnElementItemSelected;
 				e.OldElement.ScrollToRequested -= OnElementScrollToRequested;
-			}
+                ((ITemplatedItemsView<Cell>)e.OldElement).TemplatedItems.CollectionChanged -= OnCollectionChanged;
+            }
 
 			if (e.NewElement != null)
 			{
 				e.NewElement.ItemSelected += OnElementItemSelected;
 				e.NewElement.ScrollToRequested += OnElementScrollToRequested;
+                ((ITemplatedItemsView<Cell>)e.NewElement).TemplatedItems.CollectionChanged += OnCollectionChanged;
 
-				if (List == null)
+                if (List == null)
 				{
 					List = new WListView
 					{
@@ -72,7 +74,12 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        void OnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            List.DataContext = new CollectionViewSource { Source = Element.ItemsSource, IsSourceGrouped = Element.IsGroupingEnabled };
+        }
+
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
 

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -37,19 +37,18 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				e.OldElement.ItemSelected -= OnElementItemSelected;
 				e.OldElement.ScrollToRequested -= OnElementScrollToRequested;
-                ((ITemplatedItemsView<Cell>)e.OldElement).TemplatedItems.CollectionChanged -= OnCollectionChanged;
-            }
+				((ITemplatedItemsView<Cell>)e.OldElement).TemplatedItems.CollectionChanged -= OnCollectionChanged;
+			}
 
 			if (e.NewElement != null)
 			{
 				e.NewElement.ItemSelected += OnElementItemSelected;
 				e.NewElement.ScrollToRequested += OnElementScrollToRequested;
-                ((ITemplatedItemsView<Cell>)e.NewElement).TemplatedItems.CollectionChanged += OnCollectionChanged;
+				((ITemplatedItemsView<Cell>)e.NewElement).TemplatedItems.CollectionChanged += OnCollectionChanged;
 
-                if (List == null)
+				if (List == null)
 				{
-					List = new WListView
-					{
+					List = new WListView {
 						IsSynchronizedWithCurrentItem = false,
 						ItemTemplate = (Windows.UI.Xaml.DataTemplate)WApp.Current.Resources["CellTemplate"],
 						HeaderTemplate = (Windows.UI.Xaml.DataTemplate)WApp.Current.Resources["View"],
@@ -74,12 +73,12 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-        void OnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            List.DataContext = new CollectionViewSource { Source = Element.ItemsSource, IsSourceGrouped = Element.IsGroupingEnabled };
-        }
+		void OnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			List.DataContext = new CollectionViewSource { Source = Element.ItemsSource, IsSourceGrouped = Element.IsGroupingEnabled };
+		}
 
-        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
 
@@ -322,8 +321,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (viewer == null)
 			{
 				RoutedEventHandler loadedHandler = null;
-				loadedHandler = async (o, e) =>
-				{
+				loadedHandler = async (o, e) => {
 					List.Loaded -= loadedHandler;
 
 					// Here we try to avoid an exception, see explanation at bottom


### PR DESCRIPTION
### Description of Change ###

The ListView Renderer for UWP was not managing the OnCollectionChanged event.
Adding a new method and subscribing it to the respective handler to manage the OnCollectionChanged event

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=57674

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
