### PR TITLE
[Android] Change overload of CreateRenderer to internal for previewer compatibility

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -306,7 +306,7 @@ namespace Xamarin.Forms.Platform.Android
 			return CreateRenderer(element, Forms.Context);
 		}
 
-		public static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
+		internal static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
 		{
 			IVisualElementRenderer renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType(), context) 
 				?? new DefaultRenderer(context);


### PR DESCRIPTION
### Description of Change ###

This changes one of the overloads of `CreateRenderer` to `internal` to avoid confusing the previewer during reflection. 

Trying this out as an alternative to #1233.

### API Changes ###

`public static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)` =>
`internal static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)`

### Behavioral Changes ###

Third-party code using `CreateRenderer` will not have access to the new version of the method for the time being. This is expected to have limited impact, as the new version of the method is only necessary to ensure controls work with multi-activity applications in embedding scenarios.

In the future, changes to previewer should allow us to make the overload public.


