### PR TITLE
Allow RecycleElement with null Template

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60382.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60382.cs
@@ -1,0 +1,46 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60123, "Rui's issue", PlatformAffected.Default)]
+	public class Bugzilla60123 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			// Initialize ui here instead of ctor
+			var items = new List<string>();
+			for (int i = 0; i < 100; i++)
+			{
+				items.Add(i.ToString());
+			}
+
+			var listView = new ListView(ListViewCachingStrategy.RecycleElement) 
+			{
+				BackgroundColor = Color.Yellow,
+				AutomationId = "ListView"
+			};
+
+			listView.ItemsSource = items;
+
+			Content = listView;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked ("ListView"));
+			RunningApp.ScrollDown("ListView");
+			RunningApp.WaitForElement(q => q.Marked("ListView"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -334,6 +334,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59097.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58875.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59718.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60382.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 {
 	internal class ListViewAdapter : CellAdapter
 	{
+		static readonly object DefaultItemTypeOrDataTemplate = new object();
 		const int DefaultGroupHeaderTemplateId = 0;
 		const int DefaultItemTemplateId = 1;
 
@@ -359,6 +360,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			else // ListViewCachingStrategy.RetainElement
 				return GetCellForPosition(indexPath);
+
+			if (itemTypeOrDataTemplate == null)
+				itemTypeOrDataTemplate = DefaultItemTypeOrDataTemplate;
 
 			Cell protoCell;
 			if (!_prototypicalCellByTypeOrDataTemplate.TryGetValue(itemTypeOrDataTemplate, out protoCell))


### PR DESCRIPTION
### Description of Change ###

Expected RecycleElement with null DataTemplateSelector to not throw exception on Android. Actually throws an exception. Simply, supply a dummy prototypical cell that does nothing (context insensitive).

### Bugs Fixed ###

Found while investigating 60382 (which turned out to be by design)
https://bugzilla.xamarin.com/show_bug.cgi?id=60382

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
