### PR TITLE
[UWP] Force SetupContent call on ListView items

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60033.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60033.cs
@@ -1,0 +1,78 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60033, "[UWP] ListView override void SetupContent not triggered", PlatformAffected.UWP)]
+	public class Bugzilla60033 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var items = new ObservableCollection<string>() { "A", "B", "C" };
+			var lv = new Bugzilla60033ListView()
+			{
+				ItemsSource = items
+			};
+			var setupContentCallCount = new Label();
+			
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = "The below count should start at 3 for each SetupContent call (as well as when reset), and increase when 'Add item' is clicked."
+					},
+					setupContentCallCount,
+					lv,
+					new Button
+					{
+						Text = "Add item",
+						Command = new Command(() => {
+							((ObservableCollection<string>)lv.ItemsSource).Add("Item");
+							setupContentCallCount.Text = lv.SetupContentCallCount.ToString();
+						})
+					},
+					new Button
+					{
+						Text = "Reset list",
+						Command = new Command(() => {
+							lv.SetupContentCallCount = 0;
+							var newItems = new ObservableCollection<string>() { "A", "B", "C" };
+							lv.ItemsSource = newItems;
+							setupContentCallCount.Text = lv.SetupContentCallCount.ToString();
+						})
+					}
+				}
+			};
+
+			Appearing += (s, e) =>
+			{
+				setupContentCallCount.Text = lv.SetupContentCallCount.ToString();
+			};
+		}
+
+		public class Bugzilla60033ListView : ListView
+		{
+			public int SetupContentCallCount { get; set; }
+			
+			public Bugzilla60033ListView() : base()
+			{
+			}
+
+			protected override void SetupContent(Cell cell, int index)
+			{
+				base.SetupContent(cell, index);
+				SetupContentCallCount++;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -222,6 +222,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51427.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59248.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60033.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60056.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60122.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_0.cs" />


### PR DESCRIPTION
### Description of Change ###

`ListView`s in UWP are presently not calling `SetupContent` on the initial items; the simplest fix without making any major changes appears to be iterating through the `TemplatedItems` to force a call to `GetOrCreateContent` which then calls `SetupContent`.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60033

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
