### PR TITLE
[iOS] Don't crash when grouped ListView uses ObservableCollection

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 56771, "Multi-item add in INotifyCollectionChanged causes a NSInternalInconsistencyException in bindings on iOS", PlatformAffected.iOS)]
-	public class Bugzilla56771 : TestContentPage.
+	public class Bugzilla56771 : TestContentPage
 	{
 		const string BtnAdd = "btnAdd";
 		OptimizedCollection<string> data = new OptimizedCollection<string>();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
@@ -1,0 +1,133 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 56771, "Multi-item add in INotifyCollectionChanged causes a NSInternalInconsistencyException in bindings on iOS", PlatformAffected.iOS)]
+	public class Bugzilla56771 : TestContentPage.
+	{
+		const string BtnAdd = "btnAdd";
+		OptimizedCollection<string> data = new OptimizedCollection<string>();
+		int i = 4;
+
+		private void InitializeData()
+		{
+
+			data.Add("Item 1");
+			data.Add("Item 2");
+			data.Add("Item 3");
+			data.Add("Item 4");
+			BindingContext = data;
+		}
+
+		protected override void Init()
+		{
+			var button = new Button
+			{
+				Text = "Add 2",
+				AutomationId = BtnAdd,
+				Command = new Command(() =>
+				{
+					data.AddRange($"Item {++i}", $"Item {++i}");
+				})
+			};
+			var button1 = new Button
+			{
+				Text = "Remove 2",
+				Command = new Command(() =>
+				{
+					if (data.Count > 1)
+					{
+						data.RemoveRangeAt(0, 2);
+					}
+				})
+			};
+			var button2 = new Button
+			{
+				Text = "Clear",
+				Command = new Command(() =>
+				{
+					data.RemoveRangeAt(0, data.Count);
+				})
+			};
+			var listView = new ListView { };
+			listView.SetBinding(ListView.ItemsSourceProperty, ".");
+
+			Content = new StackLayout
+			{
+				Children = { new Label { Text = "Clicking the Add 2 button should cause an ArgumentException. This is expected." }, button, button1, button2, listView }
+			};
+
+			InitializeData();
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla56771Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(BtnAdd));
+			Assert.Throws(typeof(ArgumentException), () => RunningApp.Tap(q => q.Marked(BtnAdd)));
+		}
+#endif
+
+		public class OptimizedCollection<T> : ObservableCollection<T>
+		{
+			public OptimizedCollection()
+			{
+			}
+
+			protected override void ClearItems()
+			{
+				base.ClearItems();
+			}
+
+			public void AddRange(params T[] items)
+			{
+				InsertRangeAt(this.Count, items);
+			}
+
+			public void InsertRangeAt(int startIndex, params T[] items)
+			{
+				int idx = this.Count;
+				foreach (var item in items)
+				{
+					base.Items.Insert(startIndex++, item);
+				}
+				if (idx < Count)
+				{
+					OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, changedItems: items.ToList(), startingIndex: startIndex));
+					OnPropertyChanged(new PropertyChangedEventArgs(nameof(Count)));
+					OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+				}
+			}
+
+			public void RemoveRangeAt(int startIndex, int count)
+			{
+				if (count > 0)
+				{
+					List<T> removedItems = new List<T>(count);
+					for (int i = 0; i < count; i++)
+					{
+						removedItems.Add(base.Items[startIndex]);
+						base.Items.RemoveAt(startIndex);
+					}
+					OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, changedItems: removedItems, startingIndex: startIndex++));
+					OnPropertyChanged(new PropertyChangedEventArgs(nameof(Count)));
+					OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Forms.Controls.Issues
 			InitializeData();
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		public void Bugzilla56771Test()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Bugzilla, 56771, "Multi-item add in INotifyCollectionChanged causes a NSInternalInconsistencyException in bindings on iOS", PlatformAffected.iOS)]
 	public class Bugzilla56771 : TestContentPage
 	{
+		const string Success = "Success";
 		const string BtnAdd = "btnAdd";
 		OptimizedCollection<string> data = new OptimizedCollection<string>();
 		int i = 4;
@@ -34,13 +35,21 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
+			var label = new Label { Text = "Click the Add 2 button." };
 			var button = new Button
 			{
 				Text = "Add 2",
 				AutomationId = BtnAdd,
 				Command = new Command(() =>
 				{
-					data.AddRange($"Item {++i}", $"Item {++i}");
+					try
+					{
+						data.AddRange($"Item {++i}", $"Item {++i}");
+					}
+					catch (ArgumentException)
+					{
+						label.Text = Success;
+					}
 				})
 			};
 			var button1 = new Button
@@ -67,7 +76,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Content = new StackLayout
 			{
-				Children = { new Label { Text = "Clicking the Add 2 button should cause an ArgumentException. This is expected." }, button, button1, button2, listView }
+				Children = { label, button, button1, button2, listView }
 			};
 
 			InitializeData();
@@ -78,12 +87,12 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Bugzilla56771Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(BtnAdd));
-			try { RunningApp.Tap(q => q.Marked(BtnAdd)); }
-			catch (ArgumentException) { Assert.Pass(); }
-			Assert.Fail($"Expected {nameof(ArgumentException)}");
+			RunningApp.Tap(q => q.Marked(BtnAdd)); 
+			RunningApp.WaitForElement(q => q.Marked(Success));
 		}
 #endif
 
+		[Preserve(AllMembers = true)]
 		public class OptimizedCollection<T> : ObservableCollection<T>
 		{
 			public OptimizedCollection()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
@@ -78,7 +78,9 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Bugzilla56771Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(BtnAdd));
-			Assert.Throws<ArgumentException>(() => RunningApp.Tap(q => q.Marked(BtnAdd)));
+			try { RunningApp.Tap(q => q.Marked(BtnAdd)); }
+			catch (ArgumentException) { Assert.Pass(); }
+			Assert.Fail($"Expected {nameof(ArgumentException)}");
 		}
 #endif
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Bugzilla56771Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(BtnAdd));
-			Assert.Throws(typeof(ArgumentException), () => RunningApp.Tap(q => q.Marked(BtnAdd)));
+			Assert.Throws<ArgumentException>(() => RunningApp.Tap(q => q.Marked(BtnAdd)));
 		}
 #endif
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59896.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59896.cs
@@ -1,0 +1,99 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 59896, "v2.4.0: Adding inserting section to ListView causes crash IF first section is empty ", PlatformAffected.iOS)]
+	public class Bugzilla59896 : TestContentPage
+	{
+		const string btnAdd = "btnAdd";
+		int _newGroupIndex = 0;
+
+		protected override void Init()
+		{
+			var group1 = new Group("group A");
+			var group2 = new Group("group C")
+			{
+				"item 1", "item 2"
+			};
+			var source = new ObservableCollection<Group>
+			{
+				group1, group2
+			};
+
+			var button = new Button
+			{
+				Text = "Add Group between A & C",
+				AutomationId = btnAdd
+			};
+
+			button.Clicked += (sender, e) =>
+			{
+				var group = new Group("New Group " + _newGroupIndex)
+				{
+					"new Group["+_newGroupIndex+" ].A", "new Group["+_newGroupIndex+" ].B",
+				};
+				_newGroupIndex++;
+				source.Insert(1, group);
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+					{
+						new Label { Text = "Clicking the Add Group between A & C button should NOT cause an ArgumentException." },
+						button,
+						new ListView
+						{
+							ItemsSource = source,
+							GroupDisplayBinding = new Binding("Title"),
+							IsGroupingEnabled = true
+						}
+					}
+			};
+
+		}
+
+		public class Group : List<string>
+		{
+			public string Title
+			{
+				get;
+				set;
+			}
+
+			public Group() { }
+
+			public Group(string title)
+			{
+				Title = title;
+			}
+		}
+
+		public class GroupHeaderView
+		{
+			public GroupHeaderView()
+			{
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla59896Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(btnAdd));
+			RunningApp.Tap(q => q.Marked(btnAdd));
+		}
+#endif
+	}
+
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59896.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59896.cs
@@ -62,6 +62,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		}
 
+		[Preserve(AllMembers = true)]
 		public class Group : List<string>
 		{
 			public string Title
@@ -78,6 +79,7 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
+		[Preserve(AllMembers = true)]
 		public class GroupHeaderView
 		{
 			public GroupHeaderView()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -334,6 +334,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59097.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58875.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59718.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59896.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56771.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60382.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -512,10 +512,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var groupReset = resetWhenGrouped && Element.IsGroupingEnabled;
 
-			var lastIndex = Control.NumberOfRowsInSection(section);
-			if (e.NewStartingIndex > lastIndex || e.OldStartingIndex > lastIndex)
-				throw new ArgumentException(
-					$"Index '{Math.Max(e.NewStartingIndex, e.OldStartingIndex)}' is greater than the number of rows '{lastIndex}'.");
+			if (!groupReset)
+			{
+				var lastIndex = Control.NumberOfRowsInSection(section);
+				if (e.NewStartingIndex > lastIndex || e.OldStartingIndex > lastIndex)
+					throw new ArgumentException(
+						$"Index '{Math.Max(e.NewStartingIndex, e.OldStartingIndex)}' is greater than the number of rows '{lastIndex}'.");
+			}
 
 			switch (e.Action)
 			{


### PR DESCRIPTION
### Description of Change ###

#948 added an informational exception to help users diagnose indexing issues when adding items. However, the logic throws unnecessarily when the ListView is grouped. This change will simply skip the index check if the ListView is grouped.

Also added a UI test for 56771 to ensure that this doesn't break the original intention of the informational exception.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=59896

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
