### PR TITLE
[docs] BindingMode typo fix.

### DIFF
--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/BindingMode.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/BindingMode.xml
@@ -102,7 +102,7 @@ Debug.WriteLine (viewmodel.Name); //prints "Foo"
         <ReturnType>Xamarin.Forms.BindingMode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Indicates that the binding should only propagates changes from source (usually the View Model) to target (the BindableObject). This is the default mode for most BindableProperty values.</summary>
+        <summary>Indicates that the binding should only propagate changes from source (usually the View Model) to target (the BindableObject). This is the default mode for most BindableProperty values.</summary>
       </Docs>
     </Member>
     <Member MemberName="OneWayToSource">
@@ -122,7 +122,7 @@ Debug.WriteLine (viewmodel.Name); //prints "Foo"
         <ReturnType>Xamarin.Forms.BindingMode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Indicates that the binding should only propagates changes from target (the BindableObject) to source (usually the View Model). This is mainly used for read-only BindableProperty values.</summary>
+        <summary>Indicates that the binding should only propagate changes from target (the BindableObject) to source (usually the View Model). This is mainly used for read-only BindableProperty values.</summary>
       </Docs>
     </Member>
     <Member MemberName="TwoWay">
@@ -142,7 +142,7 @@ Debug.WriteLine (viewmodel.Name); //prints "Foo"
         <ReturnType>Xamarin.Forms.BindingMode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Indicates that the binding should propagates changes from source (usually the View Model) to target (the BindableObject) in both directions.</summary>
+        <summary>Indicates that the binding should propagate changes from source (usually the View Model) to target (the BindableObject) in both directions.</summary>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
### Description of Change ###

Fix a typo noticed in the [BindingMode API docs](https://developer.xamarin.com/api/field/Xamarin.Forms.BindingMode.OneWayToSource/).

### Bugs Fixed ###

none filed

### API Changes ###

not applicable

### Behavioral Changes ###

none

### PR Checklist ###

- [ ] ~Has tests (if omitted, state reason in description)~ not applicable
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
