### PR TITLE
Make it possible to customise the window on iOS

### DIFF
--- a/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
@@ -9,20 +9,20 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class FormsApplicationDelegate : UIApplicationDelegate
 	{
-        Application _application;
+		Application _application;
 		bool _isSuspended;
 		UIWindow _window;
-        public override UIWindow Window
-        {
-            get
-            {
-                return _window;
-            }
-            set
-            {
-                _window = value;
-            }
-        }
+		public override UIWindow Window
+		{
+			get
+			{
+				return _window;
+			}
+			set
+			{
+				_window = value;
+			}
+		}
 
 		protected FormsApplicationDelegate()
 		{
@@ -48,8 +48,8 @@ namespace Xamarin.Forms.Platform.iOS
 			// prepare you apps window and views for display
 			// keep lightweight, anything long winded should be executed asynchronously on a secondary thread.
 			// application:didFinishLaunchingWithOptions
-            if(Window == null)
-                Window = new UIWindow(UIScreen.MainScreen.Bounds);
+			if(Window == null)
+				Window = new UIWindow(UIScreen.MainScreen.Bounds);
 
 			if (_application == null)
 				throw new InvalidOperationException("You MUST invoke LoadApplication () before calling base.FinishedLaunching ()");
@@ -168,7 +168,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void SetMainPage()
 		{
 			UpdateMainPage();
-            Window.MakeKeyAndVisible();
+			Window.MakeKeyAndVisible();
 		}
 
 		void UpdateMainPage()
@@ -176,10 +176,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_application.MainPage == null)
 				return;
 
-            if(Window.RootViewController is PlatformRenderer platformRenderer)
-                ((IDisposable)platformRenderer.Platform).Dispose();
+			if(Window.RootViewController is PlatformRenderer platformRenderer)
+				((IDisposable)platformRenderer.Platform).Dispose();
 
-            Window.RootViewController = _application.MainPage.CreateViewController();
+			Window.RootViewController = _application.MainPage.CreateViewController();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// prepare you apps window and views for display
 			// keep lightweight, anything long winded should be executed asynchronously on a secondary thread.
 			// application:didFinishLaunchingWithOptions
-			if(Window == null)
+			if (Window == null)
 				Window = new UIWindow(UIScreen.MainScreen.Bounds);
 
 			if (_application == null)
@@ -176,7 +176,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_application.MainPage == null)
 				return;
 
-			if(Window.RootViewController is PlatformRenderer platformRenderer)
+			var platformRenderer = Window.RootViewController as PlatformRenderer;
+			if (platformRenderer != null)
 				((IDisposable)platformRenderer.Platform).Dispose();
 
 			Window.RootViewController = _application.MainPage.CreateViewController();

--- a/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
@@ -9,9 +9,20 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class FormsApplicationDelegate : UIApplicationDelegate
 	{
-		Application _application;
+        Application _application;
 		bool _isSuspended;
 		UIWindow _window;
+        public override UIWindow Window
+        {
+            get
+            {
+                return _window;
+            }
+            set
+            {
+                _window = value;
+            }
+        }
 
 		protected FormsApplicationDelegate()
 		{
@@ -37,7 +48,8 @@ namespace Xamarin.Forms.Platform.iOS
 			// prepare you apps window and views for display
 			// keep lightweight, anything long winded should be executed asynchronously on a secondary thread.
 			// application:didFinishLaunchingWithOptions
-			_window = new UIWindow(UIScreen.MainScreen.Bounds);
+            if(Window == null)
+                Window = new UIWindow(UIScreen.MainScreen.Bounds);
 
 			if (_application == null)
 				throw new InvalidOperationException("You MUST invoke LoadApplication () before calling base.FinishedLaunching ()");
@@ -156,7 +168,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void SetMainPage()
 		{
 			UpdateMainPage();
-			_window.MakeKeyAndVisible();
+            Window.MakeKeyAndVisible();
 		}
 
 		void UpdateMainPage()
@@ -164,12 +176,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_application.MainPage == null)
 				return;
 
-			var platformRenderer = (PlatformRenderer)_window.RootViewController;
+            if(Window.RootViewController is PlatformRenderer platformRenderer)
+                ((IDisposable)platformRenderer.Platform).Dispose();
 
-			if (platformRenderer != null)
-				((IDisposable)platformRenderer.Platform).Dispose();
-
-			_window.RootViewController = _application.MainPage.CreateViewController();
+            Window.RootViewController = _application.MainPage.CreateViewController();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This changes the way the window is used in iOS in a backwards compatible way.

### Bugs Fixed ###

It was not possible to swap out the current root for a native Xamarin ViewController, and then navigate back to a Forms one.

Also when changing the MainPage on a custom window it would crash because it would not implement PlatformRenderer. The new check prevents this.

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - Window { get; set; }

### Behavioral Changes ###

This will not change any behaviour but just enable to work easier with Native views, especially in MvvmCross.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
