### PR TITLE
[XamlG] do not mess with path separators

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -37,6 +37,10 @@ namespace Xamarin.Forms.Build.Tasks
 
 			foreach (var xamlFile in XamlFiles) {
 				var targetPath = Path.Combine(OutputPath, xamlFile.GetMetadata("TargetPath") + ".g.cs");
+				if (Path.DirectorySeparatorChar == '/' && targetPath.Contains(@"\"))
+					targetPath = targetPath.Replace('\\','/');
+				else if (Path.DirectorySeparatorChar == '\\' && targetPath.Contains(@"/"))
+					targetPath = targetPath.Replace('/', '\\');
 				result &= Execute(xamlFile, targetPath);
 			}
 


### PR DESCRIPTION
### Description of Change ###

when the targetPath contains a `\`, the output file name might end up wrong on Mac.
this fixes it

I'm not able to reproduce it in our test project, only on @davidortinau's.

### Bugs Fixed ###

- 🐞 ask @davidortinau 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense