### PR TITLE
[XamlG] only use forward slashes in XamlResource paths

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -142,7 +142,7 @@ namespace Xamarin.Forms.Build.Tasks
 			ccu.AssemblyCustomAttributes.Add(
 			new CodeAttributeDeclaration(new CodeTypeReference($"global::{typeof(XamlResourceIdAttribute).FullName}"),
 										 new CodeAttributeArgument(new CodePrimitiveExpression(resourceId)),
-										 new CodeAttributeArgument(new CodePrimitiveExpression(targetPath)),
+										 new CodeAttributeArgument(new CodePrimitiveExpression(targetPath.Replace('\\', '/'))), //use forward slashes, paths are uris-like
 										 new CodeAttributeArgument(new CodeTypeOfExpression($"global::{rootNs}.{rootType}"))
 										));
 			var declNs = new CodeNamespace(rootNs);


### PR DESCRIPTION
### Description of Change ###

[XamlG] only use forward slashes in XamlResource paths

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense