### PR TITLE
Fix implicit conversion from null Uri to ImageSource

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ImageSourceTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ImageSourceTests.cs
@@ -56,6 +56,15 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void TestImplicitStringConversionWhenNull()
+		{
+			string s = null;
+			var sut = (ImageSource)s;
+			Assert.That (sut, Is.InstanceOf<FileImageSource> ());
+			Assert.IsNull (((FileImageSource)sut).File);
+		}
+
+		[Test]
 		public void TestImplicitUriConversion ()
 		{
 			var image = new Image { Source = new Uri ("http://xamarin.com/img.png") };
@@ -74,10 +83,19 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void TestImplicitUriConversionWhenNull()
+		{
+			Uri u = null;
+			var sut = (ImageSource)u;
+			Assert.That(sut, Is.InstanceOf<FileImageSource>());
+			Assert.IsNull(((FileImageSource)sut).File);
+		}
+
+		[Test]
 		public void TestSetStringValue ()
 		{
 			var image = new Image ();
-			image.SetValue (Image.SourceProperty, "foo.png");		
+			image.SetValue (Image.SourceProperty, "foo.png");
 			Assert.IsNotNull (image.Source);
 			Assert.That (image.Source, Is.InstanceOf<FileImageSource> ());
 			Assert.AreEqual ("foo.png", ((FileImageSource)(image.Source)).File);
@@ -92,7 +110,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			image.BindingContext = "foo.png";
 			Assert.IsNotNull (image.Source);
 			Assert.That (image.Source, Is.InstanceOf<FileImageSource> ());
-			Assert.AreEqual ("foo.png", ((FileImageSource)(image.Source)).File);		
+			Assert.AreEqual ("foo.png", ((FileImageSource)(image.Source)).File);
 		}
 
 		[Test]
@@ -119,7 +137,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual ("http://xamarin.com/img.png", ((UriImageSource)(image.Source)).Uri.AbsoluteUri);
 		}
 
-		class MockImageSource : ImageSource 
+		class MockImageSource : ImageSource
 		{
 		}
 

--- a/Xamarin.Forms.Core/ImageSource.cs
+++ b/Xamarin.Forms.Core/ImageSource.cs
@@ -105,6 +105,9 @@ namespace Xamarin.Forms
 
 		public static implicit operator ImageSource(Uri uri)
 		{
+			if (uri == null)
+				return FromFile(null);
+
 			if (!uri.IsAbsoluteUri)
 				throw new ArgumentException("uri is relative");
 			return FromUri(uri);


### PR DESCRIPTION
### Description of Change ###

Ensure the implicit conversion from `Uri` to `ImageSource` exhibits the same behavior as implicitly converting from `string` to `ImageSource` in the case where the input is `null`.

### Bugs Fixed ###

Currently, implicitly converting a `null` `Uri` to an `ImageSource` is throwing a `NullReferenceException`. This PR fixes that.

### API Changes ###

None

### Behavioral Changes ###

No longer any need to work around the bug like this:

```C#
someImage.Source = someUri?.ToString();
```

One can now just do this:

```C#
someImage.Source = someUri;
```

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
