### PR TITLE
[iOS] Fix NRE when Grouped ListView w/DataTemplateSelector has uneven rows

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60524.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60524.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Bugzilla, 60524, "NRE when rendering ListView with grouping enabled and HasUnevenRows set to true", PlatformAffected.iOS)]
 	public class Bugzilla60524 : TestNavigationPage
 	{
+		[Preserve(AllMembers = true)]
 		public class GroupedItemsPage : ContentPage
 		{
 			private ObservableCollection<Grouping<string, GroupedItem>> model;
@@ -66,7 +67,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Content = content;
 			}
 		}
-
+		[Preserve(AllMembers = true)]
 		public class GroupedItemsDataTemplateSelector : Xamarin.Forms.DataTemplateSelector
 		{
 			private readonly DataTemplate firstGroupTemplate;
@@ -96,7 +97,7 @@ namespace Xamarin.Forms.Controls.Issues
 				return model.Group == "Group 1" ? this.firstGroupTemplate : this.secondGroupTemplate;
 			}
 		}
-
+		[Preserve(AllMembers = true)]
 		public class GroupedItem
 		{
 			public string Group { get; set; }
@@ -109,6 +110,7 @@ namespace Xamarin.Forms.Controls.Issues
 				this.Item = item;
 			}
 		}
+		[Preserve(AllMembers = true)]
 		public class Grouping<K, T> : ObservableCollection<T>
 		{
 			public K Key { get; private set; }
@@ -144,7 +146,7 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			}
 		}
-
+		[Preserve(AllMembers = true)]
 		public class GroupingKey
 		{
 			public string Title { get; private set; }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60524.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60524.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60524, "NRE when rendering ListView with grouping enabled and HasUnevenRows set to true", PlatformAffected.iOS)]
+	public class Bugzilla60524 : TestNavigationPage
+	{
+		public class GroupedItemsPage : ContentPage
+		{
+			private ObservableCollection<Grouping<string, GroupedItem>> model;
+			private ListView listView;
+
+			public GroupedItemsPage()
+			{
+				listView = new ListView(ListViewCachingStrategy.RetainElement) { HasUnevenRows = true };
+				listView.IsGroupingEnabled = true;
+				listView.ItemTemplate = new GroupedItemsDataTemplateSelector();
+
+				var headerCell = new DataTemplate(typeof(TextCell));
+				headerCell.SetBinding(TextCell.TextProperty, "Key");
+				this.listView.GroupHeaderTemplate = headerCell;
+
+				this.model = new ObservableCollection<Grouping<string, GroupedItem>>();
+				this.GetItems();
+
+				this.SetMainContent();
+			}
+
+			private void GetItems()
+			{
+				var firstGroup = new Grouping<string, GroupedItem>("Group 1", new List<GroupedItem> {
+				new GroupedItem("Group 1", "Item 1"),
+				new GroupedItem("Group 1", "Item 2")
+			});
+
+				var secondGroup = new Grouping<string, GroupedItem>("Group 2", new List<GroupedItem> {
+				new GroupedItem("Group 2", "Item 3"),
+				new GroupedItem("Group 2", "Item 4")
+			});
+
+				model.Add(firstGroup);
+				model.Add(secondGroup);
+
+				this.listView.ItemsSource = model;
+			}
+
+			private void SetMainContent()
+			{
+				var content = new StackLayout
+				{
+					VerticalOptions = LayoutOptions.FillAndExpand,
+					Children = { new Label { Text = "If this page does not crash, this test has passed." }, this.listView }
+				};
+
+				Content = content;
+			}
+		}
+
+		public class GroupedItemsDataTemplateSelector : Xamarin.Forms.DataTemplateSelector
+		{
+			private readonly DataTemplate firstGroupTemplate;
+			private readonly DataTemplate secondGroupTemplate;
+
+			public GroupedItemsDataTemplateSelector()
+			{
+				// Retain instances
+				var firstTemplate = new DataTemplate(typeof(TextCell));
+				firstTemplate.SetBinding(TextCell.TextProperty, "Item");
+				this.firstGroupTemplate = firstTemplate;
+
+				var secondTemplate = new DataTemplate(typeof(ImageCell));
+				secondTemplate.SetBinding(ImageCell.TextProperty, "Item");
+				this.secondGroupTemplate = secondTemplate;
+			}
+
+			protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+			{
+				var model = item as GroupedItem;
+
+				if (model == null)
+				{
+					return null;
+				}
+
+				return model.Group == "Group 1" ? this.firstGroupTemplate : this.secondGroupTemplate;
+			}
+		}
+
+		public class GroupedItem
+		{
+			public string Group { get; set; }
+
+			public string Item { get; set; }
+
+			public GroupedItem(string group, string item)
+			{
+				this.Group = group;
+				this.Item = item;
+			}
+		}
+		public class Grouping<K, T> : ObservableCollection<T>
+		{
+			public K Key { get; private set; }
+
+			public IList<T> Values
+			{
+				get { return this.Items; }
+			}
+
+			public Grouping(K key, IEnumerable<T> items)
+			{
+				Key = key;
+				foreach (var item in items)
+				{
+					this.Items.Add(item);
+				}
+			}
+
+			public Grouping(IGrouping<K, T> grouping)
+			{
+				Key = grouping.Key;
+				foreach (var item in grouping)
+				{
+					this.Items.Add(item);
+				}
+			}
+
+			public void AddRange(IList<T> values)
+			{
+				foreach (var item in values)
+				{
+					this.Items.Add(item);
+				}
+			}
+		}
+
+		public class GroupingKey
+		{
+			public string Title { get; private set; }
+
+			public string Abbreviation { get; private set; }
+
+			public GroupingKey(string Title, string abbrevation)
+			{
+				this.Title = Title;
+				this.Abbreviation = abbrevation;
+			}
+		}
+
+		protected override void Init()
+		{
+			Navigation.PushAsync(new GroupedItemsPage());
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla60524Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Group 1"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -335,6 +335,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58875.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59718.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60382.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -358,7 +358,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					Control.Layer.RemoveAllAnimations();
 					//iOS11 hack
-					if(Forms.IsiOS11OrNewer)
+					if (Forms.IsiOS11OrNewer)
 					{
 						await Task.Delay(1);
 					}
@@ -663,10 +663,16 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 
 				// We're going to base our estimate off of the first cell
-				var firstCell = templatedItems.ActivateContent(0, templatedItems.ListProxy[0]);
+				Cell firstCell;
+				var isGroupingEnabled = List.IsGroupingEnabled;
+
+				if (isGroupingEnabled)
+					firstCell = templatedItems.ActivateContent(0, templatedItems.GetGroup(0)?.ListProxy[0]);
+				else
+					firstCell = templatedItems.ActivateContent(0, templatedItems.ListProxy[0]);
 
 				// Let's skip this optimization for grouped lists. It will likely cause more trouble than it's worth.
-				if (firstCell.Height > 0 && !List.IsGroupingEnabled)
+				if (firstCell?.Height > 0 && !isGroupingEnabled)
 				{
 					// Seems like we've got cells which already specify their height; since the heights are known,
 					// we don't need to use estimatedRowHeight at all; zero will disable it and use the known heights.
@@ -883,7 +889,7 @@ namespace Xamarin.Forms.Platform.iOS
 				PreserveActivityIndicatorState(cell);
 				return nativeCell;
 			}
-		
+
 			public override nfloat GetHeightForHeader(UITableView tableView, nint section)
 			{
 				if (List.IsGroupingEnabled)


### PR DESCRIPTION
### Description of Change ###

#1226 improved the estimation for iOS row heights when `HasUnevenRows` is true, but it did not account for grouped `ListView`s using `DataTemplateSelector`s. This change will get the first item in the first group to inflate the `DataTemplate` instead of the first group.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=60524

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
