### PR TITLE
Fix row height estimation when grouping enabled

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -663,7 +663,14 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 
 				// We're going to base our estimate off of the first cell
+				if (List.IsGroupingEnabled)
+					templatedItems = templatedItems.GetGroup(0);
+				if (templatedItems == null)
+					return DefaultRowHeight;
+
 				var firstCell = templatedItems.ActivateContent(0, templatedItems.ListProxy[0]);
+				if (firstCell == null)
+					return DefaultRowHeight;
 
 				// Let's skip this optimization for grouped lists. It will likely cause more trouble than it's worth.
 				if (firstCell.Height > 0 && !List.IsGroupingEnabled)


### PR DESCRIPTION
### Description of Change ###

When getting the first item in a grouped ItemsList the group must be dug through else the item representing a group will be unexpectedly passed to the DataTemplateSelector.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60524

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
