### PR TITLE
[Xaml] fix loading RD without codebehind

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
@@ -30,6 +30,8 @@ namespace Xamarin.Forms.Core.XamlC
 			var uri = new Uri(value, UriKind.Relative);
 
 			var resourceId = ResourceDictionary.RDSourceTypeConverter.GetResourceId(uri, rootTargetPath, s => GetResourceIdForPath(module, s));
+			if (resourceId == null)
+				throw new XamlParseException($"Resource '{value}' not found.", node);
 			//abuse the converter, produce some side effect, but leave the stack untouched
 			//public void SetAndLoadSource(Uri value, string resourceID, Assembly assembly, System.Xml.IXmlLineInfo lineInfo)
 			yield return Create(Ldloc, context.Variables[rdNode]); //the resourcedictionary

--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -21,6 +21,10 @@ namespace Xamarin.Forms.Build.Tasks
 
 		public bool Equals(TypeReference x, TypeReference y)
 		{
+			if (x == null)
+				return y == null;
+			if (y == null)
+				return x == null;
 			if (x.FullName != y.FullName)
 				return false;
 			var xasm = GetAssembly(x);

--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -45,7 +45,6 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 				catch (XmlException xe) {
 					Log.LogError(null, null, null, xamlFile.ItemSpec, xe.LineNumber, xe.LinePosition, 0, 0, xe.Message, xe.HelpLink, xe.Source);
-
 					success = false;
 				}
 				catch (Exception e) {

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -314,6 +314,9 @@ namespace Xamarin.Forms
 				var uri = new Uri(value, UriKind.Relative); //we don't want file:// uris, even if they start with '/'
 				var resourceId = GetResourceId(uri, rootTargetPath,
 											   s => XamlResourceIdAttribute.GetResourceIdForPath(rootObjectType.GetTypeInfo().Assembly, s));
+				if (resourceId == null)
+					throw new XamlParseException($"Resource '{value}' not found.", lineInfo);
+
 				targetRD.SetAndLoadSource(uri, resourceId, rootObjectType.GetTypeInfo().Assembly, lineInfo);
 				return uri;
 			}

--- a/Xamarin.Forms.Xaml.UnitTests/AppResources/Colors.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/AppResources/Colors.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"> 
+  <Color x:Key="AccentColor">#FF4B14</Color>
+  <Color x:Key="BlackOpacityColor">#99253748</Color>
+  <Color x:Key="BlackTextColor">#253748</Color>
+  <Color x:Key="BackgroundColor">#F8F8F8</Color>
+  <Color x:Key="PinkColor">#ED0241</Color>
+  <Color x:Key="GrayColor">#ACB1B4</Color>
+  <Color x:Key="DarkColor">#203446</Color>
+  <Color x:Key="WhiteColor">#FFFFFF</Color>
+  <Color x:Key="GreenColor">#368F95</Color>
+
+  <Color x:Key="Primary">#FF96F3</Color>
+  <Color x:Key="PrimaryDark">#1976D2</Color>
+  <Color x:Key="Accent">#96d1ff</Color>
+  <Color x:Key="LightBackgroundColor">#FAFAFA</Color>
+  <Color x:Key="DarkBackgroundColor">#C0C0C0</Color>
+  <Color x:Key="MediumGrayTextColor">#4d4d4d</Color>
+  <Color x:Key="LightTextColor">#999999</Color>
+</ResourceDictionary>

--- a/Xamarin.Forms.Xaml.UnitTests/AppResources/CompiledColors.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/AppResources/CompiledColors.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"> 
+  <Color x:Key="AccentColor">#FF4B14</Color>
+  <Color x:Key="BlackOpacityColor">#99253748</Color>
+  <Color x:Key="BlackTextColor">#253748</Color>
+  <Color x:Key="BackgroundColor">#F8F8F8</Color>
+  <Color x:Key="PinkColor">#ED0241</Color>
+  <Color x:Key="GrayColor">#ACB1B4</Color>
+  <Color x:Key="DarkColor">#203446</Color>
+  <Color x:Key="WhiteColor">#FFFFFF</Color>
+  <Color x:Key="GreenColor">#368F95</Color>
+
+  <Color x:Key="Primary">#FF96F3</Color>
+  <Color x:Key="PrimaryDark">#1976D2</Color>
+  <Color x:Key="Accent">#96d1ff</Color>
+  <Color x:Key="LightBackgroundColor">#FAFAFA</Color>
+  <Color x:Key="DarkBackgroundColor">#C0C0C0</Color>
+  <Color x:Key="MediumGrayTextColor">#4d4d4d</Color>
+  <Color x:Key="LightTextColor">#999999</Color>
+</ResourceDictionary>

--- a/Xamarin.Forms.Xaml.UnitTests/RDWithoutCodeBehind.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/RDWithoutCodeBehind.xaml
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<?xaml-comp compile="true" ?>
-<ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms"
-		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
-	<Style x:Key="foo" TargetType="Label">
-		<Setter Property="TextColor" Value="Orange" />
-		<Setter Property="Text" Value="Pumpkin" />
-	</Style>
-</ResourceDictionary>

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithInvalidSource.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithInvalidSource.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage 
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Xaml.UnitTests.ResourceDictionaryWithInvalidSource">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary Source="foobar.xaml" x:Key="foobar"/>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithInvalidSource.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithInvalidSource.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class ResourceDictionaryWithInvalidSource : ContentPage
+	{
+		public ResourceDictionaryWithInvalidSource()
+		{
+			InitializeComponent();
+		}
+
+		public ResourceDictionaryWithInvalidSource(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixtureAttribute]
+		public class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void InvalidSourceThrows(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws(new XamlParseExceptionConstraint(8, 33), () => MockCompiler.Compile(typeof(ResourceDictionaryWithInvalidSource)));
+				else
+					Assert.Throws(new XamlParseExceptionConstraint(8, 33), () => new ResourceDictionaryWithInvalidSource(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml
@@ -8,6 +8,8 @@
             <ResourceDictionary Source="./SharedResourceDictionary.xaml" x:Key="relURI"/>
             <ResourceDictionary Source="/SharedResourceDictionary.xaml" x:Key="absURI"/>
             <ResourceDictionary Source="SharedResourceDictionary.xaml" x:Key="shortURI"/>
+            <ResourceDictionary Source="./AppResources/Colors.xaml" x:Key="Colors" />
+            <ResourceDictionary Source="./AppResources/CompiledColors.xaml" x:Key="CompiledColors" />
         </ResourceDictionary>
     </ContentPage.Resources>
     <Label x:Name="label" Style="{StaticResource sharedfoo}"/>

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml.cs
@@ -34,6 +34,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TestCase(false), TestCase(true)]
 			public void RDWithSourceAreFound(bool useCompiledXaml)
 			{
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(ResourceDictionaryWithSource));
 				var layout = new ResourceDictionaryWithSource(useCompiledXaml);
 				Assert.That(layout.label.TextColor, Is.EqualTo(Color.Pink));
 			}
@@ -48,6 +50,30 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.That(((ResourceDictionary)layout.Resources["absURI"])["sharedfoo"], Is.TypeOf<Style>());
 				Assert.That(((ResourceDictionary)layout.Resources["shortURI"]).Source, Is.EqualTo(new Uri("SharedResourceDictionary.xaml", UriKind.Relative)));
 				Assert.That(((ResourceDictionary)layout.Resources["shortURI"])["sharedfoo"], Is.TypeOf<Style>());
+				Assert.That(((ResourceDictionary)layout.Resources["Colors"])["MediumGrayTextColor"], Is.TypeOf<Color>());
+				Assert.That(((ResourceDictionary)layout.Resources["CompiledColors"])["MediumGrayTextColor"], Is.TypeOf<Color>());
+			}
+
+			[Test]
+			public void XRIDIsGeneratedForRDWithoutCodeBehind()
+			{
+				var asm = typeof(ResourceDictionaryWithSource).Assembly;
+				var resourceId = XamlResourceIdAttribute.GetResourceIdForPath(asm, "AppResources/Colors.xaml");
+				Assert.That(resourceId, Is.Not.Null);
+				var type = XamlResourceIdAttribute.GetTypeForResourceId(asm, resourceId);
+				Assert.That(type, Is.Null);
+			}
+
+			[Test]
+			public void CodeBehindIsGeneratedForRDWithXamlComp()
+			{
+				var asm = typeof(ResourceDictionaryWithSource).Assembly;
+				var resourceId = XamlResourceIdAttribute.GetResourceIdForPath(asm, "AppResources/CompiledColors.xaml");
+				Assert.That(resourceId, Is.Not.Null);
+				var type = XamlResourceIdAttribute.GetTypeForResourceId(asm, resourceId);
+				Assert.That(type, Is.Not.Null);
+				var rd = Activator.CreateInstance(type);
+				Assert.That(rd as ResourceDictionary, Is.Not.Null);
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -498,6 +498,9 @@
     <Compile Include="ResourceDictionaryWithSource.xaml.cs">
       <DependentUpon>ResourceDictionaryWithSource.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ResourceDictionaryWithInvalidSource.xaml.cs">
+      <DependentUpon>ResourceDictionaryWithInvalidSource.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -924,7 +927,11 @@
     <EmbeddedResource Include="ResourceDictionaryWithSource.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-    <EmbeddedResource Include="RDWithoutCodeBehind.xaml" />
+    <EmbeddedResource Include="AppResources\Colors.xaml" />
+    <EmbeddedResource Include="AppResources\CompiledColors.xaml" />
+    <EmbeddedResource Include="ResourceDictionaryWithInvalidSource.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
@@ -959,5 +966,8 @@
     <EmbeddedResource Include="AutomationProperties.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="AppResources\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###

- Fix an issue while trying to load a RD without code behind through Source.
- Always generate [XamlResourceId] even for RD without a x:Class
- throw a meaningful error if the RD isn't found.
- add more tests

### Bugs Fixed ###

- 🐞 add @davidortinau 

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense