### PR TITLE
[iOS] Fix entry renderer font size

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla123456.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla123456.cs
@@ -1,0 +1,74 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 59925, "Issue Description", PlatformAffected.Default)]
+	public class Bugzilla59925 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		const int Delta = 1;
+		Entry _entry;
+
+		private void ChangeFontSize(int delta) 
+		{
+			_entry.FontSize += delta;
+		}
+
+		protected override void Init()
+		{
+			_entry = new Entry 
+			{
+				Text = "Hello World!"
+			};
+
+			var buttonBigger = new Button 
+			{
+				Text = "Bigger",
+			};
+			buttonBigger.Clicked += (x, o) => ChangeFontSize(Delta);
+
+			var buttonSmaller = new Button 
+			{
+				Text = "Smaller"
+			};
+			buttonSmaller.Clicked += (x, o) => ChangeFontSize(-Delta);
+
+			var stack = new StackLayout 
+			{
+				Children = {
+					buttonBigger,
+					buttonSmaller,
+					_entry
+				}
+			};
+
+			// Initialize ui here instead of ctor
+			Content = stack;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue123456Test ()
+		{
+			RunningApp.Screenshot ("I am at Issue 123456");
+			RunningApp.WaitForElement (q => q.Marked ("Bigger"));
+			RunningApp.Screenshot ("0");
+
+			RunningApp.Tap ("Bigger");
+			RunningApp.Screenshot("1");
+
+			RunningApp.Tap ("Bigger");
+			RunningApp.Screenshot("2");
+
+			RunningApp.Tap ("Bigger");
+			RunningApp.Screenshot("3");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59925.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59925.cs
@@ -1,0 +1,74 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 59925, "Font size does not change vertical height of Entry on iOS", PlatformAffected.Default)]
+	public class Bugzilla59925 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		const int Delta = 1;
+		Entry _entry;
+
+		private void ChangeFontSize(int delta) 
+		{
+			_entry.FontSize += delta;
+		}
+
+		protected override void Init()
+		{
+			_entry = new Entry 
+			{
+				Text = "Hello World!"
+			};
+
+			var buttonBigger = new Button 
+			{
+				Text = "Bigger",
+			};
+			buttonBigger.Clicked += (x, o) => ChangeFontSize(Delta);
+
+			var buttonSmaller = new Button 
+			{
+				Text = "Smaller"
+			};
+			buttonSmaller.Clicked += (x, o) => ChangeFontSize(-Delta);
+
+			var stack = new StackLayout 
+			{
+				Children = {
+					buttonBigger,
+					buttonSmaller,
+					_entry
+				}
+			};
+
+			// Initialize ui here instead of ctor
+			Content = stack;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue123456Test ()
+		{
+			RunningApp.Screenshot ("I am at Issue 59925");
+			RunningApp.WaitForElement (q => q.Marked ("Bigger"));
+			RunningApp.Screenshot ("0");
+
+			RunningApp.Tap ("Bigger");
+			RunningApp.Screenshot("1");
+
+			RunningApp.Tap ("Bigger");
+			RunningApp.Screenshot("2");
+
+			RunningApp.Tap ("Bigger");
+			RunningApp.Screenshot("3");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -342,6 +342,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56771.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60382.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60524.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59925.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1146,8 +1146,6 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				return result;
-					{
-					}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fix entry renderer font size

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=59925

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
