### PR TITLE
[XamlG] use random file names while used by UpdateDesignTimeXaml

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -32,7 +32,12 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 
 			foreach (var xamlFile in XamlFiles) {
-				var outputFile = Path.Combine(OutputPath, $"{xamlFile.GetMetadata("TargetPath")}.g.cs");
+				//when invoked from `UpdateDesigntimeXaml` target, the `TargetPath` isn't set, use a random one instead
+				var targetPath = xamlFile.GetMetadata("TargetPath");
+				if (string.IsNullOrWhiteSpace(targetPath))
+					targetPath = $".{Path.GetRandomFileName()}";
+
+				var outputFile = Path.Combine(OutputPath, $"{targetPath}.g.cs");
 				if (Path.DirectorySeparatorChar == '/' && outputFile.Contains(@"\"))
 					outputFile = outputFile.Replace('\\','/');
 				else if (Path.DirectorySeparatorChar == '\\' && outputFile.Contains(@"/"))


### PR DESCRIPTION
### Description of Change ###

For some reason, `UpdateDesignTimeXaml` target doesn't set all the metadata we rely on for generating the file path. Use a hidden random file name instead. Those files won't anyway end up in the final build artifact.

### Bugs Fixed ###

- the one reported by @hartez 

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
