### PR TITLE
[Xaml[C]] allow adding elements to attached BP

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60575.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60575.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Bz60575">
+    <local:Bz60575Helpers.Collection>
+        <x:String>foo</x:String>
+        <x:String>bar</x:String>
+    </local:Bz60575Helpers.Collection>
+    <local:Bz60575.Collection>
+        <x:String>foo</x:String>
+        <x:String>bar</x:String>
+        <x:String>qux</x:String>
+    </local:Bz60575.Collection>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60575.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60575.xaml.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Bz60575Helpers
+	{
+		public static readonly BindableProperty CollectionProperty =
+			BindableProperty.Create("Collection", typeof(IList<string>), typeof(Bz60575Helpers), default(IList<string>), defaultValueCreator: (b) => new List<string>());
+
+		public static IList<string> GetCollection(BindableObject bindable)
+		{
+			return (IList<string>)bindable.GetValue(CollectionProperty);
+		}
+
+		public static void SetCollection(BindableObject bindable, IList<string> value)
+		{
+			bindable.SetValue(CollectionProperty, value);
+		}
+
+
+	}
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Bz60575:ContentPage
+	{
+		public Bz60575()
+		{
+			InitializeComponent();
+		}
+
+		public Bz60575(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		public static readonly BindableProperty CollectionProperty =
+			BindableProperty.Create("Collection", typeof(IList<string>), typeof(Bz60575), default(IList<string>), defaultValueCreator: (b) => new List<string>());
+
+		public IList<string> Collection {
+			get { return (IList<string>)GetValue(CollectionProperty); }
+			set { SetValue(CollectionProperty, value); }
+		}
+
+		[TestFixture]
+		class Tests
+		{
+
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void CollectionProperties(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(Bz60575));
+				var layout = new Bz60575(useCompiledXaml);
+
+				//attached BP
+				var col = layout.GetValue(Bz60575Helpers.CollectionProperty) as IList<string>;
+				Assert.That(col.Count, Is.EqualTo(2));
+
+				//normal BP
+				Assert.That(layout.Collection.Count, Is.EqualTo(3));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60575.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60575.xaml.cs
@@ -18,10 +18,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		{
 			bindable.SetValue(CollectionProperty, value);
 		}
-
-
 	}
-	[XamlCompilation(XamlCompilationOptions.Skip)]
+
 	public partial class Bz60575:ContentPage
 	{
 		public Bz60575()
@@ -45,7 +43,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		class Tests
 		{
-
 			[SetUp]
 			public void Setup()
 			{
@@ -61,8 +58,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TestCase(true), TestCase(false)]
 			public void CollectionProperties(bool useCompiledXaml)
 			{
-				if (useCompiledXaml)
-					MockCompiler.Compile(typeof(Bz60575));
 				var layout = new Bz60575(useCompiledXaml);
 
 				//attached BP

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -501,6 +501,9 @@
     <Compile Include="ResourceDictionaryWithInvalidSource.xaml.cs">
       <DependentUpon>ResourceDictionaryWithInvalidSource.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz60575.xaml.cs" >
+      <DependentUpon>Bz60575.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -930,6 +933,9 @@
     <EmbeddedResource Include="AppResources\Colors.xaml" />
     <EmbeddedResource Include="AppResources\CompiledColors.xaml" />
     <EmbeddedResource Include="ResourceDictionaryWithInvalidSource.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz60575.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

The logic for adding elements to collection was always relying on a backing property, even for bindable. Those properties aren't obviously found for attached BPs. This PR fixes that.


### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=60575

### API Changes ###

### Behavioral Changes ###

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense