### PR TITLE
[iOS] Check for iOS8 before changing control flow direction

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/FlowDirectionExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/FlowDirectionExtensions.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal static void UpdateFlowDirection(this UIView view, IVisualElementController controller)
 		{
-			if (controller == null || view == null)
+			if (controller == null || view == null || !(UIDevice.CurrentDevice.CheckSystemVersion(9, 0)))
 				return;
 
 

--- a/Xamarin.Forms.Platform.iOS/Extensions/FlowDirectionExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/FlowDirectionExtensions.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal static void UpdateFlowDirection(this UIView view, IVisualElementController controller)
 		{
-			if (controller == null || view == null || !(UIDevice.CurrentDevice.CheckSystemVersion(9, 0)))
+			if (controller == null || view == null || !Forms.IsiOS9OrNewer)
 				return;
 
 


### PR DESCRIPTION
### Description of Change ###

`UISemanticContentAttribute` was added in iOS9, so we need to avoid calling it in lower versions.

Continuation of #1222.

### Bugs Fixed ###

- Failing UI tests on master

### API Changes ###

None

### Behavioral Changes ###

Native controls on iOS <8 may not fully respect the `FlowDirection` value.

### PR Checklist ###

- [x] Has tests (iOS 8 won't crash anymore)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
