### PR TITLE
[iOS] Disable iOS Map pooling; Add null check

### DIFF
--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -372,7 +372,8 @@ namespace Xamarin.Forms.Maps.MacOS
 					break;
 				case NotifyCollectionChangedAction.Reset:
 					var mapView = (MKMapView)Control;
-					mapView.RemoveAnnotations(mapView.Annotations);
+					if (mapView.Annotations?.Length > 0)
+						mapView.RemoveAnnotations(mapView.Annotations);
 					AddPins((IList)(Element as Map).Pins);
 					break;
 				case NotifyCollectionChangedAction.Move:


### PR DESCRIPTION
### Description of Change ###

Expected to be able to reset a iOS map view pulled from the recycled pool but actually that threw an exception because recycled map views have null annotation arrays. Added a null check. Also had to disable the pool as the recycled map views failed to render. 

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60140

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
