### PR TITLE
[C] replace EntryCell.LabelColor by TextColor

### DIFF
--- a/Xamarin.Forms.Core/Cells/EntryCell.cs
+++ b/Xamarin.Forms.Core/Cells/EntryCell.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms
 {
-	public class EntryCell : Cell, IEntryCellController
+	public class EntryCell : Cell, ITextElement, IEntryCellController
 	{
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(EntryCell), null, BindingMode.TwoWay);
 
@@ -11,7 +11,10 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create("Placeholder", typeof(string), typeof(EntryCell), null);
 
-		public static readonly BindableProperty LabelColorProperty = BindableProperty.Create("LabelColor", typeof(Color), typeof(EntryCell), Color.Default);
+		[Obsolete("LabelColorProperty is obsolete as of version 2.5.0. Please use TextColorProperty instead.")]
+		public static readonly BindableProperty LabelColorProperty = TextElement.TextColorProperty;
+
+		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
 		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create("Keyboard", typeof(Keyboard), typeof(EntryCell), Keyboard.Default);
 
@@ -39,10 +42,17 @@ namespace Xamarin.Forms
 			set { SetValue(LabelProperty, value); }
 		}
 
+		[Obsolete("LabelColor is obsolete as of version 2.5.0. Please use TextColor instead.")]
 		public Color LabelColor
 		{
 			get { return (Color)GetValue(LabelColorProperty); }
 			set { SetValue(LabelColorProperty, value); }
+		}
+
+		public Color TextColor
+		{
+			get => (Color)GetValue(TextElement.TextColorProperty);
+			set => SetValue(TextElement.TextColorProperty, value);
 		}
 
 		public string Placeholder
@@ -79,6 +89,13 @@ namespace Xamarin.Forms
 			var label = (EntryCell)bindable;
 #pragma warning disable 0618 // retain until XAlign removed
 			label.OnPropertyChanged(nameof(XAlign));
+#pragma warning restore
+		}
+
+		void ITextElement.OnTextColorPropertyChanged(Color oldValue, Color newValue)
+		{
+#pragma warning disable 0618 // retain until LabelColor removed
+			OnPropertyChanged(nameof(LabelColor));
 #pragma warning restore
 		}
 	}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/EntryCell.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/EntryCell.xml
@@ -273,6 +273,11 @@ namespace FormsGallery
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("LabelColor is obsolete as of version 2.5.0. Please use TextColor instead.")</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.Color</ReturnType>
       </ReturnValue>
@@ -296,6 +301,11 @@ namespace FormsGallery
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("LabelColorProperty is obsolete as of version 2.5.0. Please use TextColorProperty instead.")</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
       </ReturnValue>
@@ -416,6 +426,37 @@ namespace FormsGallery
         </value>
         <remarks>
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TextColor">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Color TextColor { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Color TextColor" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TextColorProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty TextColorProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty TextColorProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextProperty">


### PR DESCRIPTION
### Description of Change ###

deprecate EntryCell.LabelColor for TextColor to match other controls

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
