### PR TITLE
[iOS] Revert iOS11 safe area fix on ViewCell

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -30,16 +30,6 @@ namespace Xamarin.Forms.Platform.iOS
 			return cell;
 		}
 
-		public override void SetBackgroundColor(UITableViewCell tableViewCell, Cell cell, UIColor color)
-		{
-			if (cell is ViewCell && Forms.IsiOS11OrNewer)
-			{
-				color = (cell as ViewCell).View.BackgroundColor == Color.Default ? color : (cell as ViewCell).View.BackgroundColor.ToUIColor();
-				tableViewCell.BackgroundColor = color;
-			}
-			base.SetBackgroundColor(tableViewCell, cell, color);
-		}
-
 		static void UpdateIsEnabled(ViewTableCell cell, ViewCell viewCell)
 		{
 			cell.UserInteractionEnabled = viewCell.IsEnabled;
@@ -93,12 +83,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 				var contentFrame = ContentView.Frame;
 				var view = ViewCell.View;
-
-				if (Forms.IsiOS11OrNewer)
-				{
-					var rect = new Rectangle(ContentView.LayoutMargins.Left, 0, contentFrame.Width - ContentView.LayoutMargins.Left, contentFrame.Height);
-					contentFrame = rect.ToRectangleF();
-				}
 
 				Layout.LayoutChildIntoBoundingRegion(view, contentFrame.ToRectangle());
 


### PR DESCRIPTION
### Description of Change ###

Revert change  from #1238 related with ViewCell padding on iPhoneX. 

Users can use safe are from the `Page` to set padding on cells. 

**Before**
![simulator screen shot - iphone x - 2017-11-14 at 00 50 03](https://user-images.githubusercontent.com/1235097/32757296-c75c6ffc-c8d6-11e7-91f2-2cc7a6cce606.png)

![simulator screen shot - iphone x - 2017-11-14 at 00 51 34](https://user-images.githubusercontent.com/1235097/32757312-d72665e6-c8d6-11e7-85d2-6175b2256c24.png)

**After**
![simulator screen shot - iphone x - 2017-11-14 at 00 53 01](https://user-images.githubusercontent.com/1235097/32757331-ebd4bce0-c8d6-11e7-9621-cce55775f398.png)

![simulator screen shot - iphone x - 2017-11-14 at 00 51 15](https://user-images.githubusercontent.com/1235097/32757300-c9be927a-c8d6-11e7-9e49-6cdac9068e15.png)



### Bugs Fixed ###

- https://forums.xamarin.com/discussion/comment/306004/#Comment_306004

### API Changes ###

None

### Behavioral Changes ###

Cells will not auto adjust to safe area, user is now responsible of handling the padding for now. 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense