### PR TITLE
[Xaml[C]] route loading of RD through ResourceLoader

### DIFF
--- a/Xamarin.Forms.Core/Internals/ResourceLoader.cs
+++ b/Xamarin.Forms.Core/Internals/ResourceLoader.cs
@@ -3,6 +3,7 @@ namespace Xamarin.Forms.Internals
 {
 	public static class ResourceLoader
 	{
+		//takes a resource path, returns string content
 		public static Func<string, string> ResourceProvider { get; internal set; }
 		internal static Action<Exception> ExceptionHandler { get; set; }
 	}

--- a/Xamarin.Forms.Core/Xaml/IResourcesLoader.cs
+++ b/Xamarin.Forms.Core/Xaml/IResourcesLoader.cs
@@ -6,6 +6,6 @@ namespace Xamarin.Forms
 {
 	interface IResourcesLoader
 	{
-		ResourceDictionary CreateResourceDictionary(string resourceID, Assembly assembly, IXmlLineInfo lineInfo);
+		ResourceDictionary CreateResourceDictionary(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo);
 	}
 }

--- a/Xamarin.Forms.Core/Xaml/XamlResourceIdAttribute.cs
+++ b/Xamarin.Forms.Core/Xaml/XamlResourceIdAttribute.cs
@@ -54,5 +54,14 @@ namespace Xamarin.Forms.Xaml
 			}
 			return null;
 		}
+
+		internal static Type GetTypeForPath(Assembly assembly, string path)
+		{
+			foreach (var xria in assembly.GetCustomAttributes<XamlResourceIdAttribute>()) {
+				if (xria.Path == path)
+					return xria.Type;
+			}
+			return null;
+		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceDictionaryWithSource.xaml.cs
@@ -34,8 +34,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TestCase(false), TestCase(true)]
 			public void RDWithSourceAreFound(bool useCompiledXaml)
 			{
-				if (useCompiledXaml)
-					MockCompiler.Compile(typeof(ResourceDictionaryWithSource));
 				var layout = new ResourceDictionaryWithSource(useCompiledXaml);
 				Assert.That(layout.label.TextColor, Is.EqualTo(Color.Pink));
 			}

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceLoader.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceLoader.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage 
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Xaml.UnitTests.ResourceLoader">
+    <ContentPage.Resources>
+        <ResourceDictionary Source="AppResources/Colors.xaml" />
+    </ContentPage.Resources>
+    <Label x:Name="label" TextColor="{StaticResource GreenColor}"/>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceLoader.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceLoader.xaml.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class ResourceLoader : ContentPage
+	{
+		public ResourceLoader()
+		{
+			InitializeComponent();
+		}
+
+		public ResourceLoader(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = null;
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void XamlLoadingUsesResourceLoader(bool useCompiledXaml)
+			{
+				var layout = new ResourceLoader(useCompiledXaml);
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.FromHex("#368F95")));
+
+				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = path => {
+					if (path == "ResourceLoader.xaml")
+						return @"
+<ContentPage 
+	xmlns=""http://xamarin.com/schemas/2014/forms""
+	xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+	x:Class=""Xamarin.Forms.Xaml.UnitTests.ResourceLoader"" >
+  
+	<Label x:Name = ""label"" TextColor = ""Pink"" />
+</ContentPage >";
+					return null;
+				};
+				layout = new ResourceLoader(useCompiledXaml);
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.Pink));
+
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void RDLoadingUsesResourceLoader(bool useCompiledXaml)
+			{
+				var layout = new ResourceLoader(useCompiledXaml);
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.FromHex("#368F95")));
+
+				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = path => {
+					if (path == "AppResources/Colors.xaml")
+						return @"
+<ResourceDictionary
+	xmlns=""http://xamarin.com/schemas/2014/forms""
+	xmlns:x = ""http://schemas.microsoft.com/winfx/2009/xaml"" >
+	<Color x:Key = ""GreenColor"" >#36FF95</Color>
+</ResourceDictionary >";
+					return null;
+				};
+				layout = new ResourceLoader(useCompiledXaml);
+
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.FromHex("#36FF95")));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -501,8 +501,11 @@
     <Compile Include="ResourceDictionaryWithInvalidSource.xaml.cs">
       <DependentUpon>ResourceDictionaryWithInvalidSource.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Issues\Bz60575.xaml.cs" >
+    <Compile Include="Issues\Bz60575.xaml.cs">
       <DependentUpon>Bz60575.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ResourceLoader.xaml.cs" >
+      <DependentUpon>ResourceLoader.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -936,6 +939,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz60575.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ResourceLoader.xaml" >
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/ResourcesLoader.cs
+++ b/Xamarin.Forms.Xaml/ResourcesLoader.cs
@@ -9,11 +9,22 @@ namespace Xamarin.Forms.Xaml
 {
 	class ResourcesLoader : IResourcesLoader
 	{
-		public ResourceDictionary CreateResourceDictionary(string resourceID, Assembly assembly, IXmlLineInfo lineInfo)
+		public ResourceDictionary CreateResourceDictionary(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo)
 		{
-			using (var stream = assembly.GetManifestResourceStream(resourceID)) {
+			var resourceId = XamlResourceIdAttribute.GetResourceIdForPath(assembly, resourcePath);
+			if (resourceId == null)
+				throw new XamlParseException($"Resource '{resourcePath}' not found.", lineInfo);
+
+			var alternateResource = Xamarin.Forms.Internals.ResourceLoader.ResourceProvider?.Invoke(resourcePath);
+			if (alternateResource != null) {
+				var rd = new ResourceDictionary();
+				rd.LoadFromXaml(alternateResource);
+				return rd;
+			}
+
+			using (var stream = assembly.GetManifestResourceStream(resourceId)) {
 				if (stream == null)
-					throw new XamlParseException($"No resource found for '{resourceID}'.", lineInfo);
+					throw new XamlParseException($"No resource found for '{resourceId}'.", lineInfo);
 				using (var reader = new StreamReader(stream)) {
 					var rd = new ResourceDictionary();
 					rd.LoadFromXaml(reader.ReadToEnd());

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -165,7 +165,7 @@ namespace Xamarin.Forms.Xaml
 					xaml = null;
 			}
 
-			var alternateXaml = ResourceLoader.ResourceProvider?.Invoke(resourceId);
+			var alternateXaml = ResourceLoader.ResourceProvider?.Invoke(XamlResourceIdAttribute.GetPathForType(type));
 			return alternateXaml ?? xaml;
 		}
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
@@ -314,8 +314,8 @@
       </Docs>
     </Member>
     <Member MemberName="SetAndLoadSource">
-      <MemberSignature Language="C#" Value="public void SetAndLoadSource (Uri value, string resourceID, System.Reflection.Assembly assembly, System.Xml.IXmlLineInfo lineInfo);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SetAndLoadSource(class System.Uri value, string resourceID, class System.Reflection.Assembly assembly, class System.Xml.IXmlLineInfo lineInfo) cil managed" />
+      <MemberSignature Language="C#" Value="public void SetAndLoadSource (Uri value, string resourcePath, System.Reflection.Assembly assembly, System.Xml.IXmlLineInfo lineInfo);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SetAndLoadSource(class System.Uri value, string resourcePath, class System.Reflection.Assembly assembly, class System.Xml.IXmlLineInfo lineInfo) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -336,7 +336,7 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <param name="resourceID">To be added.</param>
+        <param name="resourcePath">To be added.</param>
         <param name="assembly">To be added.</param>
         <param name="lineInfo">To be added.</param>
         <summary>To be added.</summary>


### PR DESCRIPTION
### Description of Change ###

[Xaml[C]] route loading of RD through ResourceLoader
 - allows the Previewer to inject modified RD (without code-behind) without recompiling
 - will allow CSS to work in the previewer
 - add tests for ResourceLoader

### Bugs Fixed ###

/

### API Changes ###

ResourceLoader now takes a path (vs a ResourceId). That's no problem as it's internal API, and the previewer doesn't use that yet.

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense