### PR TITLE
[iOS] Fix issue when enabling SafeArea and scrolling 

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/LargeTitlesPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/LargeTitlesPageiOS.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Input;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
@@ -45,12 +47,39 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 							navPage.On<iOS>().SetPrefersLargeTitles(!navPage.On<iOS>().PrefersLargeTitles());
 						} )
 					},
+
+					new Button
+					{
+						Text = "UseLargeTitles on Navigation with safe Area",
+						Command = new Command( () =>{
+							var navPage = (Parent as NavigationPage);
+							navPage.On<iOS>().SetPrefersLargeTitles(true);
+							var page = new ContentPage { Title = "New Title", BackgroundColor = Color.Red };
+							page.On<iOS>().SetUseSafeArea(true);
+							var listView = new ListView(ListViewCachingStrategy.RecycleElementAndDataTemplate)
+							{
+								HasUnevenRows = true,
+								VerticalOptions = LayoutOptions.FillAndExpand
+							};
+
+							listView.ItemTemplate = new DataTemplate(()=>{
+								var cell = new ViewCell();
+								cell.View = new Label { Text ="Hello", FontSize = 30};
+								return cell;
+							});
+							listView.ItemsSource = Enumerable.Range(1, 40);
+							listView.Header = new Label { BackgroundColor = Color.Pink , Text = "I'm a header, background is red"};
+							listView.Footer = new Label { BackgroundColor = Color.Yellow , Text = "I'm a footer, you should see no white below me"};
+							page.Content = listView;
+							navPage.PushAsync(page);
+						} )
+					},
 					offscreenPageLimit
 				}
 			};
 
 			var restoreButton = new Button { Text = "Back To Gallery" };
-			restoreButton.Clicked +=  async (sender, args) => await Navigation.PopAsync();
+			restoreButton.Clicked += async (sender, args) => await Navigation.PopAsync();
 			content.Children.Add(restoreButton);
 
 			Content = content;

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Forms.Controls
 
 		public PlatformSpecificsGallery()
 		{
+			Title = "PlatformSpecificsGallery";
 			var mdpiOSButton = new Button { Text = "MasterDetailPage (iOS)" };
 			var mdpWindowsButton = new Button { Text = "MasterDetailPage (Windows)" };
 			var npiOSButton = new Button() { Text = "NavigationPage (iOS)" };

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -149,6 +149,8 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
+			if (Current == null)
+				return;
 			UpdateToolBarVisible();
 
 			var navBarFrameBottom = Math.Min(NavigationBar.Frame.Bottom, 140);
@@ -718,7 +720,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			nfloat navBottom = NavigationBar.Frame.Bottom;
 
-			if (_navigationBottom != navBottom)
+			if (_navigationBottom != navBottom && Current != null)
 				ViewDidLayoutSubviews();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Forms.Platform.iOS
 		UIViewController[] _removeControllers;
 		UIToolbar _secondaryToolbar;
 		VisualElementTracker _tracker;
+		nfloat _navigationBottom = 0;
+
 
 		public NavigationRenderer()
 		{
@@ -149,9 +151,8 @@ namespace Xamarin.Forms.Platform.iOS
 			base.ViewDidLayoutSubviews();
 			UpdateToolBarVisible();
 
-			//var navBarFrameBotton = Forms.IsiOS11OrNewer ? View.SafeAreaInsets.Top : NavigationBar.Frame.Bottom;
-			var navBarFrameBotton = NavigationBar.Frame.Bottom;
-
+			var navBarFrameBottom = Math.Min(NavigationBar.Frame.Bottom, 140);
+			_navigationBottom = (nfloat)navBarFrameBottom;
 			var toolbar = _secondaryToolbar;
 			// Use 0 if the NavBar is hidden or will be hidden
 			var toolbarY = NavigationBarHidden || NavigationBar.Translucent || !NavigationPage.GetHasNavigationBar(Current) ? 0 : navBarFrameBotton;
@@ -713,6 +714,14 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		internal void ValidateInsets()
+		{
+			nfloat navBottom = NavigationBar.Frame.Bottom;
+
+			if (_navigationBottom != navBottom)
+				ViewDidLayoutSubviews();
+		}
+
 		class SecondaryToolbar : UIToolbar
 		{
 			readonly List<UIView> _lines = new List<UIView>();
@@ -840,6 +849,15 @@ namespace Xamarin.Forms.Platform.iOS
 				var handler = Disappearing;
 				if (handler != null)
 					handler(this, EventArgs.Empty);
+			}
+
+			public override void ViewWillLayoutSubviews()
+			{
+				base.ViewWillLayoutSubviews();
+
+				NavigationRenderer n;
+				if (_navigation.TryGetTarget(out n))
+					n.ValidateInsets();
 			}
 
 			public override void ViewDidLayoutSubviews()

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -155,7 +155,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_navigationBottom = (nfloat)navBarFrameBottom;
 			var toolbar = _secondaryToolbar;
 			// Use 0 if the NavBar is hidden or will be hidden
-			var toolbarY = NavigationBarHidden || NavigationBar.Translucent || !NavigationPage.GetHasNavigationBar(Current) ? 0 : navBarFrameBotton;
+			var toolbarY = NavigationBarHidden || NavigationBar.Translucent || !NavigationPage.GetHasNavigationBar(Current) ? 0 : navBarFrameBottom;
 			toolbar.Frame = new RectangleF(0, toolbarY, View.Frame.Width, toolbar.Frame.Height);
 
 			double trueBottom = toolbar.Hidden ? toolbarY : toolbar.Frame.Bottom;


### PR DESCRIPTION
### Description of Change ###

Since on iOS11 the NavigationBar has a interaction with UIScrollView it will change it's size, Forms needs to be able to handle that. 


### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60659

BEFORE

![simulator screen shot - iphone x - 2017-11-14 at 18 51 18](https://user-images.githubusercontent.com/1235097/32798559-f76c638c-c96c-11e7-8d66-f6d603042ae9.png)
![simulator screen shot - iphone x - 2017-11-14 at 18 51 29](https://user-images.githubusercontent.com/1235097/32798560-f78b4cf2-c96c-11e7-963d-bac4e49f07ce.png)

AFTER

![simulator screen shot - iphone x - 2017-11-14 at 18 49 12](https://user-images.githubusercontent.com/1235097/32798570-00a89556-c96d-11e7-98ac-052e9106947d.png)
![simulator screen shot - iphone x - 2017-11-14 at 18 49 21](https://user-images.githubusercontent.com/1235097/32798571-00cb45f6-c96d-11e7-9b8c-8b7fde55731d.png)


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense