### PR TITLE
[Core, iOS] Fix 59896; Add empty listView group twice

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60524.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60524.cs
@@ -40,16 +40,20 @@ namespace Xamarin.Forms.Controls.Issues
 
 			private void GetItems()
 			{
+				var zeroGroup = new Grouping<string, GroupedItem>("Group 0", new List<GroupedItem> {
+				});
+
 				var firstGroup = new Grouping<string, GroupedItem>("Group 1", new List<GroupedItem> {
-				new GroupedItem("Group 1", "Item 1"),
-				new GroupedItem("Group 1", "Item 2")
-			});
+					new GroupedItem("Group 1", "Item 1"),
+					new GroupedItem("Group 1", "Item 2")
+				});
 
 				var secondGroup = new Grouping<string, GroupedItem>("Group 2", new List<GroupedItem> {
-				new GroupedItem("Group 2", "Item 3"),
-				new GroupedItem("Group 2", "Item 4")
-			});
+					new GroupedItem("Group 2", "Item 3"),
+					new GroupedItem("Group 2", "Item 4")
+				});
 
+				model.Add(zeroGroup);
 				model.Add(firstGroup);
 				model.Add(secondGroup);
 

--- a/Xamarin.Forms.Core/IListProxy.cs
+++ b/Xamarin.Forms.Core/IListProxy.cs
@@ -8,5 +8,6 @@ namespace Xamarin.Forms
 	{
 		event NotifyCollectionChangedEventHandler CollectionChanged;
 		IEnumerable ProxiedEnumerable { get; }
+		bool TryGetValue(int index, out object value);
 	}
 }

--- a/Xamarin.Forms.Core/ListProxy.cs
+++ b/Xamarin.Forms.Core/ListProxy.cs
@@ -436,6 +436,9 @@ namespace Xamarin.Forms
 
 		#region IList
 
+		bool IListProxy.TryGetValue(int index, out object value)
+			=> TryGetValue(index, out value);
+
 		object IList.this[int index]
 		{
 			get { return this[index]; }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -666,13 +666,16 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 
 				// We're going to base our estimate off of the first cell
-				Cell firstCell;
 				var isGroupingEnabled = List.IsGroupingEnabled;
 
 				if (isGroupingEnabled)
-					firstCell = templatedItems.ActivateContent(0, templatedItems.GetGroup(0)?.ListProxy[0]);
-				else
-					firstCell = templatedItems.ActivateContent(0, templatedItems.ListProxy[0]);
+					templatedItems = templatedItems.GetGroup(0);
+
+				object item = null;
+				if (templatedItems == null || templatedItems.ListProxy.TryGetValue(0, out item) == false)
+					return DefaultRowHeight;
+
+				var firstCell = templatedItems.ActivateContent(0, item);
 
 				// Let's skip this optimization for grouped lists. It will likely cause more trouble than it's worth.
 				if (firstCell?.Height > 0 && !isGroupingEnabled)

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/IListProxy.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/IListProxy.xml
@@ -46,5 +46,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="TryGetValue">
+      <MemberSignature Language="C#" Value="public bool TryGetValue (int index, out object value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance bool TryGetValue(int32 index, object value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="index" Type="System.Int32" />
+        <Parameter Name="value" Type="System.Object&amp;" RefType="out" />
+      </Parameters>
+      <Docs>
+        <param name="index">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>


### PR DESCRIPTION
### Description of Change ###

Expect adding two empty groups to a ListView won't crash app. Actually crashes. Test TryGetValue for null instead of indexing with bad index.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=59896

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
