### PR TITLE
[Xaml] use [Before|After]Targets to avoid being overridden

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -52,14 +52,7 @@
 	<!-- XamlG -->
 	<Target Name="UpdateDesignTimeXaml" DependsOnTargets="XamlG"/>
 
-	<PropertyGroup>
-		<CoreCompileDependsOn>
-			XamlG;
-			$(CoreCompileDependsOn);
-		</CoreCompileDependsOn>
-	</PropertyGroup>
-
-	<Target Name="XamlG">
+	<Target Name="XamlG" BeforeTargets="BeforeCompile">
 		<XamlGTask
 			XamlFiles="@(EmbeddedResource)" Condition="'%(Extension)' == '.xaml' AND '$(DefaultLanguageSourceExtension)' == '.cs'"
 			Language = "$(Language)"
@@ -72,17 +65,10 @@
 
 	<!-- XamlC -->
 	<PropertyGroup>
-		<CompileDependsOn>
-			$(CompileDependsOn);
-			XamlC;
-		</CompileDependsOn>
-	</PropertyGroup>
-
-	<PropertyGroup>
 		<XFVerbosity Condition="'$(XFVerbosity)' == ''">2</XFVerbosity>
 	</PropertyGroup>
 
-	<Target Name="XamlC">
+	<Target Name="XamlC" AfterTargets="AfterCompile">
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"


### PR DESCRIPTION
### Description of Change ###

On `netstandard` the imports are imported before the common targets (except with `package.config`).

As the default `*DependsOn` properties are not additive, our values gets replaced
```
Property reassignment: $(CoreCompileDependsOn)="_ComputeNonExistentFileProperty;ResolveCodeAnalysisRuleSet"
(previous value: "
            XamlG;
            ;
        ") at /Library/Frameworks/Mono.framework/Versions/5.4.1/lib/mono/msbuild/15.0/bin/Microsoft.CSharp.CurrentVersion.targets (175,9)
```

use AfterTargets and BeforeTargets to avoid that.

see also https://github.com/Microsoft/msbuild/issues/1468#issuecomment-269560176

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense