### PR TITLE
[iOS] Check for SelectedIndex value in OnEnded

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -87,6 +87,8 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
 			var s = (PickerSource)_picker.Model;
+			if (s.SelectedIndex == -1)
+				return;
 			if (s.SelectedIndex != _picker.SelectedRowInComponent(0))
 			{
 				_picker.Select(s.SelectedIndex, 0, false);


### PR DESCRIPTION
### Description of Change ###

While looking into a separate issue, a scenario was found where an empty `Picker` could be tapped/swiped at and then closed, causing a crash in `OnEnded` as it attempts to select row -1. 

The `Picker` page in the gallery is empty by default; attempting to reproduce the issue without this fix should cause a crash there.

### Bugs Fixed ###

N/A

### API Changes ###

None

### Behavioral Changes ###

I don't believe this should affect the original fix from #1054; only the scenario where the list is empty and nothing is selected.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
