### PR TITLE
[XamlC] treat netstandard types as mscorlib

### DIFF
--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -28,11 +28,16 @@ namespace Xamarin.Forms.Build.Tasks
 			if (x.FullName != y.FullName)
 				return false;
 			var xasm = GetAssembly(x);
-			if (xasm.StartsWith("System.Runtime", StringComparison.Ordinal) || xasm.StartsWith("mscorlib", StringComparison.Ordinal))
-				xasm = "mscorlib";
 			var yasm = GetAssembly(y);
-			if (yasm.StartsWith("System.Runtime", StringComparison.Ordinal) || yasm.StartsWith("mscorlib", StringComparison.Ordinal))
-				yasm = "mscorlib";
+
+			//standard types comes from either mscorlib. System.Runtime or netstandard. Assume they are equivalent
+			if (   (xasm.StartsWith("System.Runtime", StringComparison.Ordinal)
+					|| xasm.StartsWith("mscorlib", StringComparison.Ordinal)
+					|| xasm.StartsWith("netstandard", StringComparison.Ordinal))
+				&& (xasm.StartsWith("System.Runtime", StringComparison.Ordinal)
+					|| xasm.StartsWith("mscorlib", StringComparison.Ordinal)
+					|| xasm.StartsWith("netstandard", StringComparison.Ordinal)))
+				return true;
 			return xasm == yasm;
 		}
 


### PR DESCRIPTION
### Description of Change ###

If the end user project type differs from Core's type, the compiler can
be confused while comparing base styles, like System.Double.

this fixes that by assuming System.Runtime, mscorlib and netstandard
types are equivalent (because they are)

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense