### PR TITLE
[Xaml] find BP defined on base types

### DIFF
--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -252,7 +252,7 @@ namespace Xamarin.Forms.Xaml
 			bool throwOnError = false)
 		{
 			var bindableFieldInfo =
-				elementType.GetFields().FirstOrDefault(fi => fi.Name == localName + "Property" && fi.IsStatic && fi.IsPublic);
+				elementType.GetFields(BindingFlags.Static | BindingFlags.Public|BindingFlags.FlattenHierarchy).FirstOrDefault(fi => fi.Name == localName + "Property");
 
 			Exception exception = null;
 			if (exception == null && bindableFieldInfo == null) {


### PR DESCRIPTION
### Description of Change ###

when using netstandard, GetFields() acts differently than on other
platforms, and the public static types aren't returned by default. Pass
some BindingFlags to get them,

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
