### PR TITLE
[Android] AppCompat NavigationBar should handle Transluscent Flags

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -627,6 +627,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			_toolbar = null;
 
 			SetupToolbar();
+			
+			// if the old toolbar had padding from transluscentflags, set it to the new toolbar
+			if (oldToolbar.PaddingTop != 0)
+				_toolbar.SetPadding(0, oldToolbar.PaddingTop, 0, 0);
+			
 			RegisterToolbar();
 			UpdateToolbar();
 			UpdateMenu();

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		ActionBarDrawerToggle _drawerToggle;
 		FragmentManager _fragmentManager;
 		int _lastActionBarHeight = -1;
+		int _statusbarHeight;
 		AToolbar _toolbar;
 		ToolbarTracker _toolbarTracker;
 		DrawerMultiplexedListener _drawerListener;
@@ -395,6 +396,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (actionBarHeight <= 0)
 				return Device.Info.CurrentOrientation.IsPortrait() ? (int)Context.ToPixels(56) : (int)Context.ToPixels(48);
+			
+			if (((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentStatus) || ((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentNavigation))
+			{
+				if (_toolbar.PaddingTop == 0)
+					_toolbar.SetPadding(0, GetStatusBarHeight(), 0, 0);
+
+				return actionBarHeight + GetStatusBarHeight();
+			}
 
 			return actionBarHeight;
 		}
@@ -409,6 +418,18 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			valueAnim.SetDuration(200);
 			valueAnim.Update += (s, a) => icon.Progress = (float)a.Animation.AnimatedValue;
 			valueAnim.Start();
+		}
+		
+		int GetStatusBarHeight()
+		{
+			if (_statusbarHeight > 0)
+				return _statusbarHeight;
+
+			int resourceId = Resources.GetIdentifier("status_bar_height", "dimen", "android");
+			if (resourceId > 0)
+				_statusbarHeight = Resources.GetDimensionPixelSize(resourceId);
+
+			return _statusbarHeight;
 		}
 
 		void AnimateArrowOut()


### PR DESCRIPTION
### Description of Change ###

When using either TransluscentStatus or TransluscentNavigation flags on Android the content will be layed out under the statusbar (not below as it would without them). This PR adds padding and height to NavigationBar if any of those flags are set. The padding is calculated based on the statusbar height.
Now we can finally use the flags mentioned on android to create stunning looking UI.

To use any of the flags just set this in MainActivity OnCreate()

```
	Window.AddFlags(WindowManagerFlags.TranslucentNavigation);
	Window.AddFlags(WindowManagerFlags.TranslucentStatus);
```
Before we added a statusbarunderlay = we couldnt layout stuff under the statusbar even with those flags, but that got removed in 2.3.4 (i think). Now the only thing stopping us is the adjusting padding and height, thats what this PR solves for NavigationBar.

Here are som images:

**BEFORE with transluscentNavigation**
![before_trans_nav](https://user-images.githubusercontent.com/10244000/32980857-6fdcd046-cc6e-11e7-863c-de0612f0b4b7.PNG)

**AFTER with transluscentNavigation**
![after_trans_nav](https://user-images.githubusercontent.com/10244000/32980866-9829702c-cc6e-11e7-805d-72850c54f0e9.PNG)

**BEFORE with both transluscent statusbar and navigation**
![before_trans_both](https://user-images.githubusercontent.com/10244000/32980876-c04e07a2-cc6e-11e7-9450-d4ad6a25f22d.PNG)

**After with both transluscent statusbar and navigation**
![after_trans_both](https://user-images.githubusercontent.com/10244000/32980882-d04495ea-cc6e-11e7-86e5-a9392b24cbea.PNG)

**Drawer looks nice on MDP with trascuscentstatusbar!**
![after_drawer_trans_status](https://user-images.githubusercontent.com/10244000/32980892-041efe3c-cc6f-11e7-9cc1-7f590e30ca09.PNG)

**Drawer looks nice on MDP with trascuscent flags! (this is KitKat)**
![kitkat_drawer_open](https://user-images.githubusercontent.com/10244000/32980911-43dbfb92-cc6f-11e7-836a-43b37a76b551.PNG)

**Kitkat with no transluscentflags**
![kitkat_noflags](https://user-images.githubusercontent.com/10244000/32980919-67020652-cc6f-11e7-86a7-6c9774bfa29b.PNG)

**BEFORE Kitkat with both flags transluscentflags**
![kitkat_before_both](https://user-images.githubusercontent.com/10244000/32980929-90358012-cc6f-11e7-8d7f-a2eb11d93174.PNG)


**AFTER Kitkat with both flags transluscentflags**
![kitkat_after_both](https://user-images.githubusercontent.com/10244000/32980922-7536eab2-cc6f-11e7-8bf5-06eda270af94.PNG)



### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X ] Rebased on top of master at time of PR
- [X ] Changes adhere to coding standard
- [X ] Consolidate commits as makes sense
