### PR TITLE
[iOS] Update status bar color while page is appearing

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -28,7 +28,6 @@ namespace Xamarin.Forms.Platform.iOS
 		VisualElementTracker _tracker;
 		nfloat _navigationBottom = 0;
 
-
 		public NavigationRenderer()
 		{
 			MessagingCenter.Subscribe<IVisualElementRenderer>(this, UpdateToolbarButtons, sender =>
@@ -133,6 +132,13 @@ namespace Xamarin.Forms.Platform.iOS
 			base.ViewDidAppear(animated);
 
 			View.SetNeedsLayout();
+		}
+
+		public override void ViewWillAppear(bool animated)
+		{
+			base.ViewWillAppear(animated);
+
+			SetStatusBarStyle();
 		}
 
 		public override void ViewDidDisappear(bool animated)
@@ -468,7 +474,6 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationBar.PrefersLargeTitles = navPage.OnThisPlatform().PrefersLargeTitles();
 		}	
 
-
 		void UpdateTranslucent()
 		{
 			NavigationBar.Translucent = ((NavigationPage)Element).OnThisPlatform().IsNavigationBarTranslucent();
@@ -621,13 +626,18 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationBar.LargeTitleTextAttributes = NavigationBar.TitleTextAttributes;      
 			}
 
-
 			var statusBarColorMode = (Element as NavigationPage).OnThisPlatform().GetStatusBarTextColorMode();
 
 			// set Tint color (i. e. Back Button arrow and Text)
 			NavigationBar.TintColor = barTextColor == Color.Default || statusBarColorMode == StatusBarTextColorMode.DoNotAdjust
 				? UINavigationBar.Appearance.TintColor
 				: barTextColor.ToUIColor();
+		}
+
+		void SetStatusBarStyle()
+		{
+			var barTextColor = ((NavigationPage)Element).BarTextColor;
+			var statusBarColorMode = (Element as NavigationPage).OnThisPlatform().GetStatusBarTextColorMode();
 
 			if (statusBarColorMode == StatusBarTextColorMode.DoNotAdjust || barTextColor.Luminosity <= 0.5)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -445,7 +445,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor();
 			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName || e.PropertyName == PlatformConfiguration.iOSSpecific.NavigationPage.StatusBarTextColorModeProperty.PropertyName)
+			{
 				UpdateBarTextColor();
+				SetStatusBarStyle();
+			}
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
 			else if (e.PropertyName == NavigationPage.CurrentPageProperty.PropertyName)
@@ -456,7 +459,6 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateCurrentPagePreferredStatusBarUpdateAnimation();
 			else if (e.PropertyName == PrefersLargeTitlesProperty.PropertyName)
 				UpdateUseLargeTitles();
-			
 		}
 
 		void UpdateCurrentPagePreferredStatusBarUpdateAnimation()


### PR DESCRIPTION
### Description of Change ###

iOS status bar color is being set when View is loading and when `BarTextColor` property changes. This means that if a page is popped off the stack, the status bar color is not syncing with the previous page.

See the changes made to bring `ViewWillAppear` into the equation.

Previously, users would have to set this color in `OnAppearing` via a message/dependency service call. I'm not sure if the current logic should stay intact or change.

Also note that there are other properties in `ViewDidLoad` that could potentially be updated in `ViewWillAppear`.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=60716

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
