### PR TITLE
Update Platform Create Renderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -306,7 +306,7 @@ namespace Xamarin.Forms.Platform.Android
 			return CreateRenderer(element, Forms.Context);
 		}
 
-		internal static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
+		public static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
 		{
 			IVisualElementRenderer renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType(), context) 
 				?? new DefaultRenderer(context);


### PR DESCRIPTION


### Description of Change ###

Platform.CreateRenderer(VisualElement element) is marked as obsolete but the replacing method Platform.IVisualElementRenderer CreateRenderer(VisualElement element, Context context) marked as internal so the user can not use it.

### Bugs Fixed ###

- 

### API Changes ###
Changed:
 - internal static internal static IVisualElementRenderer CreateRenderer(VisualElement element, Context context) => public static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)

### Behavioral Changes ###

I don't think there will be any behavioral changes. Just changing the access modifier so the obsolete method can be replaced with the new one.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x ] Rebased on top of master at time of PR
- [x ] Changes adhere to coding standard
- [ x] Consolidate commits as makes sense
