### PR TITLE
[UWP] Bug 60755 - ExportRendererAttribute's namespace on UWP is inconsistent with other platforms

### DIFF
--- a/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
@@ -36,7 +36,10 @@ namespace Xamarin.Forms
 			Registrar.RegisterAll (new[] {
 				typeof (ExportRendererAttribute),
 				typeof (ExportCellAttribute),
-				typeof (ExportImageSourceHandlerAttribute)
+				typeof (ExportImageSourceHandlerAttribute),
+				typeof (Xamarin.Forms.ExportRendererAttribute),
+				typeof (Xamarin.Forms.ExportCellAttribute),
+				typeof (Xamarin.Forms.ExportImageSourceHandlerAttribute)
 			});
 
 			MessagingCenter.Subscribe<Page, bool> (Device.PlatformServices, Page.BusySetSignalName, OnPageBusy);

--- a/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
@@ -37,9 +37,9 @@ namespace Xamarin.Forms
 				typeof (ExportRendererAttribute),
 				typeof (ExportCellAttribute),
 				typeof (ExportImageSourceHandlerAttribute),
-				typeof (Xamarin.Forms.ExportRendererAttribute),
-				typeof (Xamarin.Forms.ExportCellAttribute),
-				typeof (Xamarin.Forms.ExportImageSourceHandlerAttribute)
+				typeof (Platform.WinRT.ExportRendererAttribute),
+				typeof (Platform.WinRT.ExportCellAttribute),
+				typeof (Platform.WinRT.ExportImageSourceHandlerAttribute)
 			});
 
 			MessagingCenter.Subscribe<Page, bool> (Device.PlatformServices, Page.BusySetSignalName, OnPageBusy);

--- a/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using Windows.ApplicationModel.Activation;
 using Windows.Phone.UI.Input;
@@ -36,10 +36,7 @@ namespace Xamarin.Forms
 			Registrar.RegisterAll (new[] {
 				typeof (ExportRendererAttribute),
 				typeof (ExportCellAttribute),
-				typeof (ExportImageSourceHandlerAttribute),
-				typeof (Platform.WinRT.ExportRendererAttribute),
-				typeof (Platform.WinRT.ExportCellAttribute),
-				typeof (Platform.WinRT.ExportImageSourceHandlerAttribute)
+				typeof (ExportImageSourceHandlerAttribute)
 			});
 
 			MessagingCenter.Subscribe<Page, bool> (Device.PlatformServices, Page.BusySetSignalName, OnPageBusy);

--- a/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Phone/Forms.cs
@@ -36,7 +36,10 @@ namespace Xamarin.Forms
 			Registrar.RegisterAll (new[] {
 				typeof (ExportRendererAttribute),
 				typeof (ExportCellAttribute),
-				typeof (ExportImageSourceHandlerAttribute)
+				typeof (ExportImageSourceHandlerAttribute),
+				typeof (Platform.WinRT.ExportRendererAttribute),
+				typeof (Platform.WinRT.ExportCellAttribute),
+				typeof (Platform.WinRT.ExportImageSourceHandlerAttribute)
 			});
 
 			MessagingCenter.Subscribe<Page, bool> (Device.PlatformServices, Page.BusySetSignalName, OnPageBusy);

--- a/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
@@ -76,7 +76,14 @@ namespace Xamarin.Forms
 			Registrar.ExtraAssemblies = rendererAssemblies?.ToArray();
 #endif
 
-			Registrar.RegisterAll(new[] { typeof(ExportRendererAttribute), typeof(ExportCellAttribute), typeof(ExportImageSourceHandlerAttribute) });
+			Registrar.RegisterAll(new[] {
+				typeof (ExportRendererAttribute),
+				typeof (ExportCellAttribute),
+				typeof (ExportImageSourceHandlerAttribute),
+				typeof (Xamarin.Forms.ExportRendererAttribute),
+				typeof (Xamarin.Forms.ExportCellAttribute),
+				typeof (Xamarin.Forms.ExportImageSourceHandlerAttribute)
+			});
 
 			IsInitialized = true;
 			s_state = launchActivatedEventArgs.PreviousExecutionState;

--- a/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
+++ b/Xamarin.Forms.Platform.WinRT.Tablet/Forms.cs
@@ -14,10 +14,10 @@ using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
 #if WINDOWS_UWP
 using Xamarin.Forms.Platform.UWP;
-
+using PlatformNamespace = Xamarin.Forms.Platform.UWP;
 #else
 using Xamarin.Forms.Platform.WinRT;
-
+using PlatformNamespace = Xamarin.Forms.Platform.WinRT;
 #endif
 
 namespace Xamarin.Forms
@@ -80,9 +80,9 @@ namespace Xamarin.Forms
 				typeof (ExportRendererAttribute),
 				typeof (ExportCellAttribute),
 				typeof (ExportImageSourceHandlerAttribute),
-				typeof (Xamarin.Forms.ExportRendererAttribute),
-				typeof (Xamarin.Forms.ExportCellAttribute),
-				typeof (Xamarin.Forms.ExportImageSourceHandlerAttribute)
+				typeof (PlatformNamespace::ExportRendererAttribute),
+				typeof (PlatformNamespace::ExportCellAttribute),
+				typeof (PlatformNamespace::ExportImageSourceHandlerAttribute)
 			});
 
 			IsInitialized = true;

--- a/Xamarin.Forms.Platform.WinRT/ExportRendererAttribute.cs
+++ b/Xamarin.Forms.Platform.WinRT/ExportRendererAttribute.cs
@@ -32,3 +32,30 @@ namespace Xamarin.Forms.Platform.WinRT
 		}
 	}
 }
+
+namespace Xamarin.Forms
+{
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	public sealed class ExportRendererAttribute : HandlerAttribute
+	{
+		public ExportRendererAttribute(Type handler, Type target) : base(handler, target)
+		{
+		}
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	public sealed class ExportCellAttribute : HandlerAttribute
+	{
+		public ExportCellAttribute(Type handler, Type target) : base(handler, target)
+		{
+		}
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	public sealed class ExportImageSourceHandlerAttribute : HandlerAttribute
+	{
+		public ExportImageSourceHandlerAttribute(Type handler, Type target) : base(handler, target)
+		{
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Added Xamarin.Forms.ExportRendererAttribute for consistency with other platforms.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60755

### API Changes ###

Added:
 - class ExportRendererAttribute
 - class ExportCellAttribute
 - class ExportImageSourceHandlerAttribute

Changed:
(None)

### Behavioral Changes ###

Nope

### PR Checklist ###

- [ ] Has tests (Adding classes don't need tests?)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard (Literal copy from above code in same file)
- [x] Consolidate commits as makes sense

