### PR TITLE
[Tests] make sure the test pass even if the locale is wrong

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingBaseUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingBaseUnitTests.cs
@@ -175,10 +175,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var bo = new MockBindable { BindingContext = vm };
 			bo.SetBinding(property, binding);
 
-			if (culture == "tr-TR")
-				Assert.That(bo.GetValue(property), Is.EqualTo("%95,00"));
-			else
-				Assert.That(bo.GetValue(property), Is.EqualTo("95.00 %"));
+			Assert.That(bo.GetValue(property), Is.EqualTo(string.Format(new System.Globalization.CultureInfo(culture),"{0:P2}",.95d))); //%95,00 or 95.00%
 		}
 
 		[Test]


### PR DESCRIPTION
### Description of Change ###

[Tests] make sure the test pass even if the locale is wrongly implemented on the platform

win 10 creator update, against all odds and documentation, somehow decided that P2 formatting in English and invariant culture should be displayed `95.00%` and no longer `95.00 %` as it as the case before, and as documented (https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#PFormatString).
Describe your changes here.

### Bugs Fixed ###


### API Changes ###


### Behavioral Changes ###


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense