### PR TITLE
[Android] Remove extra scrolling when ScrollOrientation is Both

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774.cs
@@ -1,0 +1,73 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 960774, "Some scrolling thing", PlatformAffected.Android)]
+	public class Bugzilla60774 : TestContentPage
+	{
+		ScrollOrientation _currentOrientation;
+		Grid _host;
+		Label _labelOrientation;
+
+		protected override void Init()
+		{
+			var grid = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition()
+				}
+			};
+
+
+			var layout = new StackLayout();
+
+			var button = new Button { Text = "Change Orientation" };
+			button.Clicked += (sender, args) => ChangeOrientation();
+
+			_labelOrientation = new Label { Text = "" };
+
+			layout.Children.Add(button);
+			layout.Children.Add(_labelOrientation);
+
+			_host = new Grid();
+			Grid.SetRow(_host, 1);
+
+			grid.Children.Add(layout);
+			grid.Children.Add(_host);
+
+			Content = grid;
+
+			_currentOrientation = ScrollOrientation.Both;
+			ChangeOrientation();
+		}
+
+		void ChangeOrientation()
+		{
+			_host.Children.Clear();
+			_currentOrientation = _currentOrientation == ScrollOrientation.Vertical
+				? ScrollOrientation.Both
+				: ScrollOrientation.Vertical;
+
+			var al = new AbsoluteLayout();
+			for (var i = 0; i < 100; i++)
+			{
+				var label = new Label { Text = "label " + i };
+				AbsoluteLayout.SetLayoutBounds(label, new Rectangle(0, i * 50, 100, 30));
+				al.Children.Add(label);
+			}
+
+			var sv = new ScrollView
+			{
+				Orientation = _currentOrientation,
+				Content = al
+			};
+
+			_host.Children.Add(sv);
+			_labelOrientation.Text = "Current orientation is: " + _currentOrientation;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 960774, "Some scrolling thing", PlatformAffected.Android)]
+	[Issue(IssueTracker.Bugzilla, 60774, "[Android] ScrollOrientation.Both doubles the distance of scrolling", PlatformAffected.Android)]
 	public class Bugzilla60774 : TestContentPage
 	{
 		ScrollOrientation _currentOrientation;
@@ -21,7 +21,6 @@ namespace Xamarin.Forms.Controls.Issues
 					new RowDefinition()
 				}
 			};
-
 
 			var layout = new StackLayout();
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774.cs
@@ -3,8 +3,10 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+	// Manual test to verify that ScrollOrientation.Both scrolls at the correct speed vertically
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 60774, "[Android] ScrollOrientation.Both doubles the distance of scrolling", PlatformAffected.Android)]
+	[Issue(IssueTracker.Bugzilla, 60774, "[Android] ScrollOrientation.Both doubles the distance of scrolling", 
+		PlatformAffected.Android)]
 	public class Bugzilla60774 : TestContentPage
 	{
 		ScrollOrientation _currentOrientation;
@@ -67,6 +69,127 @@ namespace Xamarin.Forms.Controls.Issues
 
 			_host.Children.Add(sv);
 			_labelOrientation.Text = "Current orientation is: " + _currentOrientation;
+		}
+	}
+
+	// Manual test to verify that ScrollOrientation.Both scrolls at the correct speed horizontally
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60774, "[Android] ScrollOrientation.Both doubles the distance of scrolling", 
+		PlatformAffected.Android, issueTestNumber: 1)]
+	public class Bugzilla60774_1 : TestContentPage
+	{
+		ScrollOrientation _currentOrientation;
+		Grid _host;
+		Label _labelOrientation;
+
+		protected override void Init()
+		{
+			var grid = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition()
+				}
+			};
+
+			var layout = new StackLayout();
+
+			var button = new Button { Text = "Change Orientation" };
+			button.Clicked += (sender, args) => ChangeOrientation();
+
+			_labelOrientation = new Label { Text = "" };
+
+			layout.Children.Add(button);
+			layout.Children.Add(_labelOrientation);
+
+			_host = new Grid();
+			Grid.SetRow(_host, 1);
+
+			grid.Children.Add(layout);
+			grid.Children.Add(_host);
+
+			Content = grid;
+
+			_currentOrientation = ScrollOrientation.Both;
+			ChangeOrientation();
+		}
+
+		void ChangeOrientation()
+		{
+			_host.Children.Clear();
+			_currentOrientation = _currentOrientation == ScrollOrientation.Horizontal
+				? ScrollOrientation.Both
+				: ScrollOrientation.Horizontal;
+
+			var al = new AbsoluteLayout();
+			for (var i = 0; i < 100; i++)
+			{
+				var label = new Label { Text = $"{i} label", Margin = 10 };
+				AbsoluteLayout.SetLayoutBounds(label, new Rectangle(i * 50, 50, 30, 200));
+				al.Children.Add(label);
+			}
+
+			var sv = new ScrollView
+			{
+				Orientation = _currentOrientation,
+				Content = al
+			};
+
+			_host.Children.Add(sv);
+			_labelOrientation.Text = "Current orientation is: " + _currentOrientation;
+		}
+	}
+
+	// Manual test to make sure diagonal scrolling works at the correct speed 
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60774, "[Android] ScrollOrientation.Both doubles the distance of scrolling", 
+		PlatformAffected.Android, issueTestNumber: 2)]
+	public class Bugzilla60774_2 : TestContentPage
+	{
+		Grid _host;
+
+		protected override void Init()
+		{
+			var grid = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition()
+				}
+			};
+
+			var layout = new StackLayout();
+
+			_host = new Grid();
+			Grid.SetRow(_host, 1);
+
+			grid.Children.Add(layout);
+			grid.Children.Add(_host);
+
+			Content = grid;
+
+			AddContent();
+		}
+
+		void AddContent()
+		{
+			_host.Children.Clear();
+
+			var al = new AbsoluteLayout();
+			
+			var label = new Label { Text = "Make sure we can scroll this diagonally", FontSize = 72, Margin = 300 };
+			AbsoluteLayout.SetLayoutBounds(label, new Rectangle(0, 0, 2000, 2000));
+			al.Children.Add(label);
+
+			var sv = new ScrollView
+			{
+				Orientation = ScrollOrientation.Both,
+				Content = al
+			};
+
+			_host.Children.Add(sv);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774_1.cs
@@ -3,11 +3,12 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-	// Manual test to verify that ScrollOrientation.Both scrolls at the correct speed vertically
+	// Manual test to verify that ScrollOrientation.Both scrolls at the correct speed horizontally
+
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 60774, "[Android] ScrollOrientation.Both doubles the distance of scrolling", 
-		PlatformAffected.Android)]
-	public class Bugzilla60774 : TestContentPage
+		PlatformAffected.Android, issueTestNumber: 1)]
+	public class Bugzilla60774_1 : TestContentPage
 	{
 		ScrollOrientation _currentOrientation;
 		Grid _host;
@@ -15,7 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			Title = "ScrollOrientation Vertical/Both";
+			Title = "ScrollOrientation Horizontal/Both";
 
 			var grid = new Grid
 			{
@@ -30,8 +31,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var instructions = new Label
 			{
-				Text = "Scroll the text vertically. Tap 'Change Orientation' to change the ScrollView orientation " 
-						+ "to 'Both'. Scroll the text vertically again - the text should scroll at the same rate. " 
+				Text = "Scroll the text horizontally. Tap 'Change Orientation' to change the ScrollView orientation " 
+						+ "to 'Both'. Scroll the text horizontally again - the text should scroll at the same rate. " 
 						+ "If the text scrolls more quickly in one orientation, the test has failed."
 			};
 
@@ -59,15 +60,15 @@ namespace Xamarin.Forms.Controls.Issues
 		void ChangeOrientation()
 		{
 			_host.Children.Clear();
-			_currentOrientation = _currentOrientation == ScrollOrientation.Vertical
+			_currentOrientation = _currentOrientation == ScrollOrientation.Horizontal
 				? ScrollOrientation.Both
-				: ScrollOrientation.Vertical;
+				: ScrollOrientation.Horizontal;
 
 			var al = new AbsoluteLayout();
 			for (var i = 0; i < 100; i++)
 			{
-				var label = new Label { Text = "label " + i };
-				AbsoluteLayout.SetLayoutBounds(label, new Rectangle(0, i * 50, 100, 30));
+				var label = new Label { Text = $"{i} label", Margin = 10 };
+				AbsoluteLayout.SetLayoutBounds(label, new Rectangle(i * 50, 50, 30, 200));
 				al.Children.Add(label);
 			}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774_2.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60774_2.cs
@@ -1,0 +1,60 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	// Manual test to make sure diagonal scrolling works at the correct speed 
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60774, "[Android] ScrollOrientation.Both doubles the distance of scrolling", 
+		PlatformAffected.Android, issueTestNumber: 2)]
+	public class Bugzilla60774_2 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "ScrollOrientation Both";
+
+			var grid = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition()
+				}
+			};
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Text = "Move the label around. It should be able to move in any direction, with uniform speed. " 
+						+ "If it moves twice as fast vertically as horizontally or vice versa, the test has failed. " 
+						+ "If the label cannot move diagonally, the test has failed."
+			};
+
+			layout.Children.Add(instructions);
+			grid.Children.Add(layout);
+			
+			var host = new Grid();
+			Grid.SetRow(host, 1);
+			
+			grid.Children.Add(host);
+
+			Content = grid;
+
+			var al = new AbsoluteLayout();
+			
+			var label = new Label { Text = "Move this label around", FontSize = 72, Margin = 300 };
+			AbsoluteLayout.SetLayoutBounds(label, new Rectangle(0, 0, 2000, 2000));
+			al.Children.Add(label);
+
+			var sv = new ScrollView
+			{
+				Orientation = ScrollOrientation.Both,
+				Content = al
+			};
+
+			host.Children.Add(sv);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -239,6 +239,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60563.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60774.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60774_1.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60774_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ButtonBackgroundColorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -238,6 +238,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60563.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60774.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ButtonBackgroundColorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
@@ -46,13 +46,15 @@ namespace Xamarin.Forms.Platform.Android
 			// on the initial direction of movement (i.e., horizontal/vertical).
 			if (IsBidirectional)
 			{
-				float dX = _renderer.LastX - ev.RawX;
+				float dY = _renderer.LastY - ev.RawY;
 
 				_renderer.LastY = ev.RawY;
 				_renderer.LastX = ev.RawX;
 				if (ev.Action == MotionEventActions.Move)
 				{
-					ScrollBy((int)dX, 0);
+					var parent = (global::Android.Widget.ScrollView)Parent;
+					parent.ScrollBy(0, (int)dY);
+					// Fall through to base.OnTouchEvent, it'll take care of the X scrolling 					
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
@@ -47,13 +47,11 @@ namespace Xamarin.Forms.Platform.Android
 			if (IsBidirectional)
 			{
 				float dX = _renderer.LastX - ev.RawX;
-				float dY = _renderer.LastY - ev.RawY;
+
 				_renderer.LastY = ev.RawY;
 				_renderer.LastX = ev.RawX;
 				if (ev.Action == MotionEventActions.Move)
 				{
-					var parent = (global::Android.Widget.ScrollView)Parent;
-					parent.ScrollBy(0, (int)dY);
 					ScrollBy((int)dX, 0);
 				}
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -153,12 +153,11 @@ namespace Xamarin.Forms.Platform.Android
 			if (_isBidirectional && !Element.InputTransparent)
 			{
 				float dX = LastX - ev.RawX;
-				float dY = LastY - ev.RawY;
+
 				LastY = ev.RawY;
 				LastX = ev.RawX;
 				if (ev.Action == MotionEventActions.Move)
 				{
-					ScrollBy(0, (int)dY);
 					foreach (AHorizontalScrollView child in this.GetChildrenOfType<AHorizontalScrollView>())
 					{
 						child.ScrollBy((int)dX, 0);

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -163,8 +163,10 @@ namespace Xamarin.Forms.Platform.Android
 						child.ScrollBy((int)dX, 0);
 						break;
 					}
+					// Fall through to base.OnTouchEvent, it'll take care of the Y scrolling				
 				}
 			}
+
 			return base.OnTouchEvent(ev);
 		}
 


### PR DESCRIPTION
## Description of Change ###

With `ScrollOrientation` set to `Both`, the `ScrollViewRenderer` and `AHorizontalScrollView` controls are forcing extra scrolling in the X/Y-direction rather then letting the base implementations take care of it, resulting in extra scrolling. This change removes the extraneous calls to `ScrollBy`.

Can't think of a way to reliably UI test this on Android at all resolutions. Manual test screens for horizontal, vertical, and diagonal scrolling are included

### Bugs Fixed ###

- [60774 – [Android] ScrollOrientation.Both doubles the distance of scrolling](https://bugzilla.xamarin.com/show_bug.cgi?id=60774)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
