### PR TITLE
[iOS] Device.OpenUriAction can open tel URIs with spaces again

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
@@ -45,21 +45,18 @@ namespace Xamarin.Forms.Controls.Issues
 
 		#if UITEST
 		[Test]
-		[Ignore("Fails on ios 7.1")]
 		public void Bugzilla29247Test ()
 		{
 			RunningApp.Tap (q => q.Marked ("btnOpenUri1"));
 		}
 
 		[Test]
-		[Ignore("Fails on ios 7.1")]
 		public void Bugzilla29247EncodedParamsTest ()
 		{
 			RunningApp.Tap (q => q.Marked ("btnOpenUri2"));
 		}
 
 		[Test]
-		[Ignore("Fails on ios 7.1")]
 		public void Bugzilla29247DecodeParamsTest ()
 		{
 			RunningApp.Tap (q => q.Marked ("btnOpenUri3"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
@@ -17,8 +17,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = new StackLayout
 			{
 				Children = {
-					new Button { Text = "Call 123 4567", AutomationId = "tel", Command = new Command(() => Device.OpenUri(new System.Uri("tel:123 4567"))) },
-					new Button { Text = "Go to https://bugzilla.xamarin.com/show_bug.cgi?id=60691", AutomationId = "web", Command = new Command(() => Device.OpenUri(new System.Uri("https://bugzilla.xamarin.com/show_bug.cgi?id=60691"))) }
+					new Button { Text = "Call 123 4567", AutomationId = "tel", Command = new Command(() => Device.OpenUri(new System.Uri("tel:123 4567"))) }
 				}
 			};
 		}
@@ -30,14 +29,6 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(q => q.Marked("tel"));
 			RunningApp.Tap(q => q.Marked("tel"));
 			RunningApp.Screenshot("Should have loaded phone with 123-4567");
-		}
-
-		[Test]
-		public void Bugzilla60691_Web()
-		{
-			RunningApp.WaitForElement(q => q.Marked("web"));
-			RunningApp.Tap(q => q.Marked("web"));
-			RunningApp.Screenshot("Should have loaded bugzilla 60691");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
@@ -1,0 +1,44 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60691, "Device.OpenUri(new Uri(\"tel: 123 456\")) crashes the app (space in phone number)", PlatformAffected.iOS)]
+	public class Bugzilla60691 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children = {
+					new Button { Text = "Call 123 4567", AutomationId = "tel", Command = new Command(() => Device.OpenUri(new System.Uri("tel:123 4567"))) },
+					new Button { Text = "Go to https://bugzilla.xamarin.com/show_bug.cgi?id=60691", AutomationId = "web", Command = new Command(() => Device.OpenUri(new System.Uri("https://bugzilla.xamarin.com/show_bug.cgi?id=60691"))) }
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla60691_Tel()
+		{
+			RunningApp.WaitForElement(q => q.Marked("tel"));
+			RunningApp.Tap(q => q.Marked("tel"));
+			RunningApp.Screenshot("Should have loaded phone with 123-4567");
+		}
+
+		[Test]
+		public void Bugzilla60691_Web()
+		{
+			RunningApp.WaitForElement(q => q.Marked("web"));
+			RunningApp.Tap(q => q.Marked("web"));
+			RunningApp.Screenshot("Should have loaded bugzilla 60691");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -343,6 +343,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60382.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59925.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -266,7 +266,12 @@ namespace Xamarin.Forms
 
 			public void OpenUriAction(Uri uri)
 			{
-				var url = NSUrl.FromString(uri.OriginalString) ?? new NSUrl(uri.Scheme, uri.Host, uri.PathAndQuery);
+				NSUrl url;
+
+				if (uri.Scheme == "tel")
+					url = new NSUrl(uri.AbsoluteUri);
+				else
+					url = NSUrl.FromString(uri.OriginalString) ?? new NSUrl(uri.Scheme, uri.Host, uri.PathAndQuery);
 #if __MOBILE__
 				UIApplication.SharedApplication.OpenUrl(url);
 #else


### PR DESCRIPTION
### Description of Change ###

#734 enabled users to open URLs on iOS while properly passing the query strings.

`NSUrl` is not happy when `tel` paths have spaces, however, so it crashes when attempting to parse it. 

Since `tel` paths won't have query strings, using the `AbsoluteUri` to let it encode properly.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=60691

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
