### PR TITLE
Auto merged ResourceDictionaries

### DIFF
--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -279,6 +279,11 @@ namespace Xamarin.Forms
 			}
 		}
 
+		public void Add(ResourceDictionary mergedResourceDictionary)
+		{
+			MergedDictionaries.Add(mergedResourceDictionary);
+		}
+
 		void OnValueChanged(string key, object value)
 		{
 			OnValuesChanged(new KeyValuePair<string, object>(key, value));

--- a/Xamarin.Forms.Xaml.UnitTests/AutoMergedResourceDictionaries.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/AutoMergedResourceDictionaries.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Xaml.UnitTests.AutoMergedResourceDictionaries">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Color x:Key="notpink">Purple</Color>
+            <Color x:Key="pink">Pink</Color>
+            <ResourceDictionary Source="AppResources/Colors.xaml" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <Label x:Name="label" TextColor="{StaticResource notpink}" BackgroundColor="{StaticResource Primary}"/>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/AutoMergedResourceDictionaries.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/AutoMergedResourceDictionaries.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class AutoMergedResourceDictionaries : ContentPage
+	{
+		public AutoMergedResourceDictionaries()
+		{
+			InitializeComponent();
+		}
+
+		public AutoMergedResourceDictionaries(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[SetUp]
+			public void SetUp()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void AutoMergedRd(bool useCompiledXaml)
+			{
+				var layout = new AutoMergedResourceDictionaries(useCompiledXaml);
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.Purple));
+				Assert.That(layout.label.BackgroundColor, Is.EqualTo(Color.FromHex("#FF96F3")));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -513,6 +513,9 @@
     <Compile Include="ImplicitResourceDictionaries.xaml.cs">
       <DependentUpon>ImplicitResourceDictionaries.xaml</DependentUpon>
     </Compile>
+    <Compile Include="AutoMergedResourceDictionaries.xaml.cs" >
+      <DependentUpon>AutoMergedResourceDictionaries.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -954,6 +957,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="ImplicitResourceDictionaries.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="AutoMergedResourceDictionaries.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -600,6 +600,8 @@ namespace Xamarin.Forms.Xaml
 				resourceDictionary.Add(xKey, value);
 			else if (value is Style)
 				resourceDictionary.Add((Style)value);
+			else if (value is ResourceDictionary)
+				resourceDictionary.Add((ResourceDictionary)value);
 			else {
 				exception = new XamlParseException("resources in ResourceDictionary require a x:Key attribute", lineInfo);
 				return false;

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ResourceDictionary.xml
@@ -53,6 +53,25 @@
       </Docs>
     </Member>
     <Member MemberName="Add">
+      <MemberSignature Language="C#" Value="public void Add (Xamarin.Forms.ResourceDictionary mergedResourceDictionary);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Add(class Xamarin.Forms.ResourceDictionary mergedResourceDictionary) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="mergedResourceDictionary" Type="Xamarin.Forms.ResourceDictionary" />
+      </Parameters>
+      <Docs>
+        <param name="mergedResourceDictionary">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Add">
       <MemberSignature Language="C#" Value="public void Add (Xamarin.Forms.Style style);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Add(class Xamarin.Forms.Style style) cil managed" />
       <MemberType>Method</MemberType>


### PR DESCRIPTION
### Description of Change ###

Allow RD to be implicitly merged, without declaring the MergedDictionaries property. This makes this Xaml valid

```
<ContentPage 
    xmlns="http://xamarin.com/schemas/2014/forms"
    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
    x:Class="Xamarin.Forms.Xaml.UnitTests.AutoMergedResourceDictionaries">
    <ContentPage.Resources>
        <ResourceDictionary>
            <Color x:Key="notpink">Purple</Color>
            <Color x:Key="pink">Pink</Color>
            <ResourceDictionary Source="AppResources/Colors.xaml" />
        </ResourceDictionary>
    </ContentPage.Resources>
    <Label x:Name="label" TextColor="{StaticResource notpink}" BackgroundColor="{StaticResource Primary}"/>
</ContentPage>
```

#### Pros:
 - not breaking
 - less verbose (combine with #1295)

#### Cons:
 - that syntax doesn't work on UWP 

### Bugs Fixed ###

/

### API Changes ###

Added:
 - void ResourceDictionary.Add(ResourceDictionary);

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
