### PR TITLE
[Xaml[C]] avoid processing nested RD multiple times

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
@@ -46,9 +46,14 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 			}
 
-			if (parentNode is IElementNode && IsResourceDictionary((IElementNode)parentNode))
+			//Only proceed further if the node is a keyless RD
+			if (   parentNode is IElementNode
+				&& IsResourceDictionary((IElementNode)parentNode)
+				&& !((IElementNode)parentNode).Properties.ContainsKey(XmlName.xKey))
 				node.Accept(new SetPropertiesVisitor(Context, stopOnResourceDictionary: false), parentNode);
-			else if (parentNode is ListNode && IsResourceDictionary((IElementNode)parentNode.Parent))
+			else if (   parentNode is ListNode
+					 && IsResourceDictionary((IElementNode)parentNode.Parent)
+					 && !((IElementNode)parentNode.Parent).Properties.ContainsKey(XmlName.xKey))
 				node.Accept(new SetPropertiesVisitor(Context, stopOnResourceDictionary: false), parentNode);
 		}
 

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60788.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60788.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Bz60788">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary x:Key="RedTextBlueBackground">
+                <Style TargetType="StackLayout">
+                    <Setter Property="BackgroundColor" Value="Blue" />
+                </Style>
+                <Style TargetType="Label">
+                    <Setter Property="TextColor" Value="Red" />
+                </Style>
+                <Color x:Key="notpink">Purple</Color>
+            </ResourceDictionary>
+            <ResourceDictionary x:Key="BlueTextRedBackground">
+                <Style TargetType="StackLayout">
+                    <Setter Property="BackgroundColor" Value="Red" />
+                </Style>
+                <Style TargetType="Label">
+                    <Setter Property="TextColor" Value="Blue" />
+                </Style>
+                <Color x:Key="notpink">Purple</Color>
+            </ResourceDictionary>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60788.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz60788.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Bz60788 : ContentPage
+	{
+		public Bz60788()
+		{
+			InitializeComponent();
+		}
+
+		public Bz60788(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void KeyedRDWithImplicitStyles(bool useCompiledXaml)
+			{
+				var layout = new Bz60788(useCompiledXaml);
+				Assert.That(layout.Resources.Count, Is.EqualTo(2));
+				Assert.That(((ResourceDictionary)layout.Resources["RedTextBlueBackground"]).Count, Is.EqualTo(3));
+				Assert.That(((ResourceDictionary)layout.Resources["BlueTextRedBackground"]).Count, Is.EqualTo(3));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -508,6 +508,9 @@
     <Compile Include="Issues\Bz59818.xaml.cs">
       <DependentUpon>Bz59818.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Bz60788.xaml.cs">
+      <DependentUpon>Bz60788.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -929,6 +932,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Bz59818.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Bz60788.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
+++ b/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
@@ -47,10 +47,14 @@ namespace Xamarin.Forms.Xaml
 				}
 			}
 
-			//Only proceed further if the node is a RD
-			if (parentNode is IElementNode && typeof(ResourceDictionary).IsAssignableFrom(Context.Types[((IElementNode)parentNode)]))
+			//Only proceed further if the node is a keyless RD
+			if (   parentNode is IElementNode
+				&& typeof(ResourceDictionary).IsAssignableFrom(Context.Types[((IElementNode)parentNode)])
+				&& !((IElementNode)parentNode).Properties.ContainsKey(XmlName.xKey))
 				node.Accept(new ApplyPropertiesVisitor(Context, stopOnResourceDictionary: false), parentNode);
-			else if (parentNode is ListNode && typeof(ResourceDictionary).IsAssignableFrom(Context.Types[((IElementNode)parentNode.Parent)]))
+			else if (   parentNode is ListNode
+					 && typeof(ResourceDictionary).IsAssignableFrom(Context.Types[((IElementNode)parentNode.Parent)])
+					 && !((IElementNode)parentNode.Parent).Properties.ContainsKey(XmlName.xKey))
 				node.Accept(new ApplyPropertiesVisitor(Context, stopOnResourceDictionary: false), parentNode);
 		}
 


### PR DESCRIPTION
### Description of Change ###

With changes introduced to FillRDVisitor, it can happen that nested RD are processed multiple times, hence creating duplicate keys. This prevents that.

**NOTE0**: this PR is against the 2.5.0 branch. once merged, it needs to be merged back to master.
**NOTE1**: should be included in next -sr

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=60788

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of ~~master~~ **15-5** at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
