### PR TITLE
[Android] Make new CreateRenderer overload public - fixes #60815

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -308,7 +308,7 @@ namespace Xamarin.Forms.Platform.Android
 			return CreateRenderer(element, Forms.Context);
 		}
 
-		internal static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
+		public static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
 		{
 			IVisualElementRenderer renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType(), context) 
 				?? new DefaultRenderer(context);


### PR DESCRIPTION
### Description of Change ###

Old public method has been marked as obsolete, but the replacement method is internal instead of public.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60815

### API Changes ###

Changed accessibility of Android.Platform.CreateRenderer to public
