### PR TITLE
Create renderer with context

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -302,7 +302,7 @@ namespace Xamarin.Forms.Platform.Android
 			throw new InvalidOperationException("RemovePage is not supported globally on Android, please use a NavigationPage.");
 		}
 
-		[Obsolete("CreateRenderer(VisualElement) is obsolete as of version 2.5. Please use CreateRenderer(VisualElement, Context) instead.")]
+		[Obsolete("CreateRenderer(VisualElement) is obsolete as of version 2.5. Please use CreateRendererWithContext(VisualElement, Context) instead.")]
 		public static IVisualElementRenderer CreateRenderer(VisualElement element)
 		{
 			return CreateRenderer(element, Forms.Context);
@@ -315,6 +315,11 @@ namespace Xamarin.Forms.Platform.Android
 			renderer.SetElement(element);
 
 			return renderer;
+		}
+
+		public static IVisualElementRenderer CreateRendererWithContext(VisualElement element, Context context)
+		{
+			return CreateRenderer(element, context);
 		}
 
 		public static IVisualElementRenderer GetRenderer(VisualElement bindable)

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -319,6 +319,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static IVisualElementRenderer CreateRendererWithContext(VisualElement element, Context context)
 		{
+			// This is an interim method to allow public access to CreateRenderer(element, context), which we 
+			// can't make public yet because it will break the previewer
 			return CreateRenderer(element, context);
 		}
 


### PR DESCRIPTION
### Description of Change ###

For previewer compatibility reasons, we were not able to make the new overload of `CreateRenderer` public. However, we also marked the old overload `Obsolete` with instructions to use the new overload, which is not accessible. This means that

1. Our obsolete message instructions are wrong
2. Third party controls with custom renderers can't work correctly with embedding in multi-activity applications 
3. People with "treat warnings as errors" turned on will have to disable the warning for the old overload

Eventually we will be making the new overload public, but until then we need to provide some way of accessing the correct overload. Thus, `CreateRendererWithContext`.

### Bugs Fixed ###

- [60815 – New CreateRenderer overload not public](https://bugzilla.xamarin.com/show_bug.cgi?id=60815)
- [60797 – New version of Platform.CreateRenderer() is internal](https://bugzilla.xamarin.com/show_bug.cgi?id=60797)

### API Changes ###

Added:
 - public static IVisualElementRenderer CreateRendererWithContext(VisualElement element, Context context)

