### PR TITLE
[iOS] ListView should not explicitly remove subviews coming from renderers

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60563.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60563.cs
@@ -1,0 +1,92 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60563, "ActivityIndicator in ListView causes SIGSEGV crash in iOS 8", PlatformAffected.iOS)]
+	public class Bugzilla60563 : TestNavigationPage
+	{
+		const string btnGoToList = "btnGoToList";
+		const string spinner = "spinner";
+
+		protected override void Init()
+		{
+			Navigation.PushAsync(new NavigationPage(new StartPage()));
+		}
+
+		[Preserve(AllMembers = true)]
+		class ListPage : ContentPage
+		{
+			public ListPage()
+			{
+				Title = "List";
+				Content = new ListView
+				{
+					HasUnevenRows = false,
+					RowHeight = 50,
+					ItemTemplate = new DataTemplate(() => { return new SpinnerViewCell(); }),
+					ItemsSource = new List<int> { 1, 2, 3, 4, 5 },
+				};
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class SpinnerViewCell : ViewCell
+		{
+			public SpinnerViewCell()
+			{
+				var indicator = new ActivityIndicator
+				{
+					IsRunning = true,
+					AutomationId = spinner
+				};
+				var layout = new RelativeLayout();
+				layout.Children.Add(indicator, x: () => 0, y: () => 0);
+				View = indicator;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class StartPage : ContentPage
+		{
+			public StartPage()
+			{
+				var button = new Button
+				{
+					Text = "Go To List",
+					BackgroundColor = Color.Beige,
+					HeightRequest = 40,
+					WidthRequest = 100,
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					AutomationId = btnGoToList
+				};
+				button.Clicked += (sender, e) => Navigation.PushAsync(new ListPage());
+
+				Title = "Home";
+				Content = new StackLayout { Children = { new Label { Text = "Click the button to go to a ListView with an ActivityIndicator, then go back to this page. If the app does not crash, this test has passed." }, button } };
+			}
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void Bugzilla60563Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(btnGoToList));
+			RunningApp.Tap(q => q.Marked(btnGoToList));
+			RunningApp.WaitForElement(q => q.Marked(spinner));
+			RunningApp.Back();
+			RunningApp.WaitForElement(q => q.Marked(btnGoToList));
+			RunningApp.Tap(q => q.Marked(btnGoToList));
+			RunningApp.WaitForElement(q => q.Marked(spinner));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -226,6 +226,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_0.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59863_2.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60563.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ButtonBackgroundColorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CarouselAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla34561.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -102,10 +102,19 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void DisposeSubviews(UIView view)
 		{
-			foreach (UIView subView in view.Subviews)
-				DisposeSubviews(subView);
+			var ver = view as IVisualElementRenderer;
 
-			view.RemoveFromSuperview();
+			if (ver == null)
+			{
+				// VisualElementRenderers should implement their own dispose methods that will appropriately dispose and remove their child views.
+				// Attempting to do this work twice could cause a SIGSEGV (only observed in iOS8), so don't do this work here.
+				// Non-renderer views, such as separator lines, etc., can be removed here.
+				foreach (UIView subView in view.Subviews)
+					DisposeSubviews(subView);
+
+				view.RemoveFromSuperview();
+			}
+
 			view.Dispose();
 		}
 


### PR DESCRIPTION
### Description of Change ###

#524 added logic on iOS that will remove all `Subview`s of a `ListView` from their parents to prevent memory leaks. On iOS 8, this caused a SIGSEGV for `ActivityIndicator`s. The actual fault appears to be an iOS issue whereby the `UIActivityIndicatorView` is being accessed by the OS after it has been set to `nil` by `RemoveFromSuperview`. 

This change will adjust the aggressive `DisposeSubviews` method to only remove views that are not `IVisualElementRenderer`s, with the assumption that the renderers themselves should handle the disposal and removal of their own views. This effectively prevents the SIGSEGV by not calling `RemoveFromSuperview` on `ActivityIndicatorRenderer` and puts the onus on the renderers to take care of that.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=60563

### API Changes ###

None

### Behavioral Changes ###

May reintroduce some memory leaks if renderers inside of `ListView`s do not properly dispose themselves.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
