### PR TITLE
[iOS] Device.OpenUriAction can open tel URIs with spaces again

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
@@ -45,21 +45,18 @@ namespace Xamarin.Forms.Controls.Issues
 
 		#if UITEST
 		[Test]
-		[Ignore("Fails on ios 7.1")]
 		public void Bugzilla29247Test ()
 		{
 			RunningApp.Tap (q => q.Marked ("btnOpenUri1"));
 		}
 
 		[Test]
-		[Ignore("Fails on ios 7.1")]
 		public void Bugzilla29247EncodedParamsTest ()
 		{
 			RunningApp.Tap (q => q.Marked ("btnOpenUri2"));
 		}
 
 		[Test]
-		[Ignore("Fails on ios 7.1")]
 		public void Bugzilla29247DecodeParamsTest ()
 		{
 			RunningApp.Tap (q => q.Marked ("btnOpenUri3"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
@@ -9,13 +9,14 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-	[Preserve (AllMembers = true)]
-	[Issue (IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params", PlatformAffected.iOS )]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params", PlatformAffected.iOS)]
 	public class Bugzilla29247 : TestContentPage
 	{
-		protected override void Init ()
+		protected override void Init()
 		{
-			Content = new StackLayout {
+			Content = new StackLayout
+			{
 				VerticalOptions = LayoutOptions.Center,
 				Children = {
 					new Label {
@@ -28,11 +29,74 @@ namespace Xamarin.Forms.Controls.Issues
 						Text = "Without Params (Works)",
 						AutomationId = "btnOpenUri1",
 						Command = new Command (() => Device.OpenUri (new Uri ("http://www.bing.com")))
+					}
+				}
+			};
+		}
+
+#if UITEST
+		protected override bool Isolate => true;
+
+		[Test]
+		public void Bugzilla29247Test ()
+		{
+			RunningApp.WaitForElement(q => q.Marked("btnOpenUri1"));
+			RunningApp.Tap (q => q.Marked ("btnOpenUri1"));
+		}
+#endif
+	}
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params 2", PlatformAffected.iOS)]
+	public class Bugzilla29247_2 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children = {
+					new Label {
+#pragma warning disable 618
+						XAlign = TextAlignment.Center,
+#pragma warning restore 618
+						Text = "Welcome to Xamarin Forms!"
 					},
 					new Button {
 						Text = "With encoded Params (Breaks)",
 						AutomationId = "btnOpenUri2",
 						Command = new Command (() => Device.OpenUri (new Uri ("http://www.bing.com/search?q=xamarin%20bombs%20on%20this")))
+					}
+				}
+			};
+		}
+
+#if UITEST
+		protected override bool Isolate => true;
+
+		[Test]
+		public void Bugzilla29247EncodedParamsTest ()
+		{
+			RunningApp.WaitForElement(q => q.Marked("btnOpenUri2"));
+			RunningApp.Tap (q => q.Marked ("btnOpenUri2"));
+		}
+
+#endif
+	}
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params 3", PlatformAffected.iOS)]
+	public class Bugzilla29247_3 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children = {
+					new Label {
+#pragma warning disable 618
+						XAlign = TextAlignment.Center,
+#pragma warning restore 618
+						Text = "Welcome to Xamarin Forms!"
 					},
 					new Button {
 						Text = "With decoded Params (Breaks)",
@@ -43,20 +107,8 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 		}
 
-		#if UITEST
-		[Test]
-		public void Bugzilla29247Test ()
-		{
-			RunningApp.WaitForElement(q => q.Marked("btnOpenUri1"));
-			RunningApp.Tap (q => q.Marked ("btnOpenUri1"));
-		}
-
-		[Test]
-		public void Bugzilla29247EncodedParamsTest ()
-		{
-			RunningApp.WaitForElement(q => q.Marked("btnOpenUri2"));
-			RunningApp.Tap (q => q.Marked ("btnOpenUri2"));
-		}
+#if UITEST
+		protected override bool Isolate => true;
 
 		[Test]
 		public void Bugzilla29247DecodeParamsTest ()
@@ -64,6 +116,6 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(q => q.Marked("btnOpenUri3"));
 			RunningApp.Tap (q => q.Marked ("btnOpenUri3"));
 		}
-		#endif
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params", PlatformAffected.iOS, issueTestNumber: 1)]
 	public class Bugzilla29247 : TestContentPage
 	{
 		protected override void Init()
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	}
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params 2", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params 2", PlatformAffected.iOS, issueTestNumber: 2)]
 	public class Bugzilla29247_2 : TestContentPage
 	{
 		protected override void Init()
@@ -83,7 +83,7 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	}
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params 3", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params 3", PlatformAffected.iOS, issueTestNumber: 3)]
 	public class Bugzilla29247_3 : TestContentPage
 	{
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
@@ -47,18 +47,21 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla29247Test ()
 		{
+			RunningApp.WaitForElement(q => q.Marked("btnOpenUri1"));
 			RunningApp.Tap (q => q.Marked ("btnOpenUri1"));
 		}
 
 		[Test]
 		public void Bugzilla29247EncodedParamsTest ()
 		{
+			RunningApp.WaitForElement(q => q.Marked("btnOpenUri2"));
 			RunningApp.Tap (q => q.Marked ("btnOpenUri2"));
 		}
 
 		[Test]
 		public void Bugzilla29247DecodeParamsTest ()
 		{
+			RunningApp.WaitForElement(q => q.Marked("btnOpenUri3"));
 			RunningApp.Tap (q => q.Marked ("btnOpenUri3"));
 		}
 		#endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
@@ -23,6 +23,8 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 #if UITEST
+		protected override bool Isolate => true;
+
 		[Test]
 		public void Bugzilla60691_Tel()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
@@ -17,8 +17,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = new StackLayout
 			{
 				Children = {
-					new Button { Text = "Call 123 4567", AutomationId = "tel", Command = new Command(() => Device.OpenUri(new System.Uri("tel:123 4567"))) },
-					new Button { Text = "Go to https://bugzilla.xamarin.com/show_bug.cgi?id=60691", AutomationId = "web", Command = new Command(() => Device.OpenUri(new System.Uri("https://bugzilla.xamarin.com/show_bug.cgi?id=60691"))) }
+					new Button { Text = "Call 123 4567", AutomationId = "tel", Command = new Command(() => Device.OpenUri(new System.Uri("tel:123 4567"))) }
 				}
 			};
 		}
@@ -30,14 +29,6 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(q => q.Marked("tel"));
 			RunningApp.Tap(q => q.Marked("tel"));
 			RunningApp.Screenshot("Should have loaded phone with 123-4567");
-		}
-
-		[Test]
-		public void Bugzilla60691_Web()
-		{
-			RunningApp.WaitForElement(q => q.Marked("web"));
-			RunningApp.Tap(q => q.Marked("web"));
-			RunningApp.Screenshot("Should have loaded bugzilla 60691");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
@@ -1,0 +1,44 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60691, "Device.OpenUri(new Uri(\"tel: 123 456\")) crashes the app (space in phone number)", PlatformAffected.iOS)]
+	public class Bugzilla60691 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children = {
+					new Button { Text = "Call 123 4567", AutomationId = "tel", Command = new Command(() => Device.OpenUri(new System.Uri("tel:123 4567"))) },
+					new Button { Text = "Go to https://bugzilla.xamarin.com/show_bug.cgi?id=60691", AutomationId = "web", Command = new Command(() => Device.OpenUri(new System.Uri("https://bugzilla.xamarin.com/show_bug.cgi?id=60691"))) }
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla60691_Tel()
+		{
+			RunningApp.WaitForElement(q => q.Marked("tel"));
+			RunningApp.Tap(q => q.Marked("tel"));
+			RunningApp.Screenshot("Should have loaded phone with 123-4567");
+		}
+
+		[Test]
+		public void Bugzilla60691_Web()
+		{
+			RunningApp.WaitForElement(q => q.Marked("web"));
+			RunningApp.Tap(q => q.Marked("web"));
+			RunningApp.Screenshot("Should have loaded bugzilla 60691");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
@@ -1,5 +1,6 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
 
 #if UITEST
 using Xamarin.UITest;
@@ -26,10 +27,13 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override bool Isolate => true;
 
 		[Test]
-		public void Bugzilla60691_Tel()
+		[Ignore("This test opens a system dialog in iOS11+ that cannot be dismissed by UITest and covers subsequent tests.")]
+		public async void Bugzilla60691_Tel()
 		{
 			RunningApp.WaitForElement(q => q.Marked("tel"));
 			RunningApp.Tap(q => q.Marked("tel"));
+
+			await Task.Delay(500);
 			RunningApp.Screenshot("Should have loaded phone with 123-4567");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue1583Test ()
 		{
-			RunningApp.WaitForElement (q => q.Marked ("webview"));
+			RunningApp.WaitForElement (q => q.Marked ("webview"), "Could not find webview", System.TimeSpan.FromSeconds(60), null, null);
 			RunningApp.Screenshot ("I didn't crash and i can see Skøyen");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -406,6 +406,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60382.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59925.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1326.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1436.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1567.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Core.UITests
 		}
 
 		[Test]
-		public void ToolbarButtonsExist()
+		public void ToolbarButtons_1_Exist()
 		{
 			ShouldHideMenu();
 #if __MACOS__
@@ -137,7 +137,7 @@ namespace Xamarin.Forms.Core.UITests
 		}
 
 		[Test]
-		public void ToolbarButtonsOrder()
+		public void ToolbarButtons_2_Order()
 		{
 			ShouldHideMenu();
 #if __MACOS__

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -258,7 +258,12 @@ namespace Xamarin.Forms
 
 			public void OpenUriAction(Uri uri)
 			{
-				var url = NSUrl.FromString(uri.OriginalString) ?? new NSUrl(uri.Scheme, uri.Host, uri.PathAndQuery);
+				NSUrl url;
+
+				if (uri.Scheme == "tel")
+					url = new NSUrl(uri.AbsoluteUri);
+				else
+					url = NSUrl.FromString(uri.OriginalString) ?? new NSUrl(uri.Scheme, uri.Host, uri.PathAndQuery);
 #if __MOBILE__
 				UIApplication.SharedApplication.OpenUrl(url);
 #else


### PR DESCRIPTION
### Description of Change ###

#734 enabled users to open URLs on iOS while properly passing the query strings.

`NSUrl` is not happy when `tel` paths have spaces, however, so it crashes when attempting to parse it. 

Since `tel` paths won't have query strings, using the `AbsoluteUri` to let it encode properly.

Note: this is #1296 pointed at 15-5.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=60691
- fixes #1651

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
