### PR TITLE
Include .pdb in Maps nuget; Touchup create-nuget.bat

### DIFF
--- a/.create-nuget.bat
+++ b/.create-nuget.bat
@@ -1,10 +1,16 @@
+@echo off
 if "%DEBUG_VERSION%"=="" set DEBUG_VERSION=0
 set /a DEBUG_VERSION=%DEBUG_VERSION%+1
+set NUGET_EXE=%NUGET_DIR%4.1.0\NuGet.exe
 pushd docs
 ..\tools\mdoc\mdoc.exe export-msxdoc -o Xamarin.Forms.Core.xml Xamarin.Forms.Core
 ..\tools\mdoc\mdoc.exe export-msxdoc -o Xamarin.Forms.Xaml.xml Xamarin.Forms.Xaml
 ..\tools\mdoc\mdoc.exe export-msxdoc -o Xamarin.Forms.Maps.xml Xamarin.Forms.Maps
 popd
 pushd .nuspec
-..\.nuget\NuGet.exe pack Xamarin.Forms.nuspec -properties configuration=debug;platform=anycpu -Version 9.9.%DEBUG_VERSION%
+%NUGET_EXE% pack Xamarin.Forms.nuspec -properties configuration=debug;platform=anycpu -Version 9.9.%DEBUG_VERSION%
+if "%CREATE_MAP_NUGET%" NEQ "" (
+REM Requires building x86, x64, AMD
+	%NUGET_EXE% pack Xamarin.Forms.Maps.nuspec -properties configuration=debug;platform=anycpu -Version 9.9.%DEBUG_VERSION%
+)
 popd

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ bin
 obj
 classic_bin
 classic_obj
+*.nupkg
+/docs/*.xml
 *.dll
 *.mdb
 *.exe

--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -38,14 +38,19 @@
   </metadata>
   <files>
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\netstandard2.0" />
+    <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.*pdf" target="lib\netstandard2.0" />
     <file src="..\docs\Xamarin.Forms.Maps.xml" target="lib\netstandard2.0" />
 
     <file src="..\Xamarin.Forms.Maps.Android\bin\$Configuration$\Xamarin.Forms.Maps.Android.dll" target="lib\MonoAndroid10" />
+    <file src="..\Xamarin.Forms.Maps.Android\bin\$Configuration$\Xamarin.Forms.Maps.Android.*pdb" target="lib\MonoAndroid10" />
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\MonoAndroid10" />
+    <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.*pdb" target="lib\MonoAndroid10" />
     <file src="..\docs\Xamarin.Forms.Maps.xml" target="lib\MonoAndroid10" />
 
     <file src="..\Xamarin.Forms.Maps.iOS\bin\iPhoneSimulator\$Configuration$\Xamarin.Forms.Maps.iOS.dll" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.*pdb" target="lib\Xamarin.iOS10" />
+
     <file src="..\docs\Xamarin.Forms.Maps.xml" target="lib\Xamarin.iOS10" />
 
     <file src="..\Xamarin.Forms.Maps.UWP\bin\$Configuration$\Xamarin.Forms.Maps.UWP.dll" target="lib\uap10.0" />


### PR DESCRIPTION
### Description of Change ###

No code changes. 

Including debug sysmbols in Maps nuget (just like Core nuget) to aid in debugging maps bugs.

Rename `create-nuget.bat` to `.create-nuget.bat` and add env var to find nuget.exe as that's been stripped from the repository. 

Git ignore nuget packages and the doc xml generated in order to create nuget packages.

### Bugs Fixed ###

Work done in response to bug https://bugzilla.xamarin.com/show_bug.cgi?id=60140.

### API Changes ###

None.

### Behavioral Changes ###

None.