### PR TITLE
[C] bind to ValueTuples

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2172,8 +2172,10 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 
 			label.SetBinding(Label.TextProperty, "Tuple.Foo");
-
 			Assert.AreEqual("FOO", label.Text);
+			label.SetBinding(Label.TextProperty, "Tuple[1]");
+			Assert.AreEqual("BAR", label.Text);
+
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2158,5 +2158,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			parent.Content = view;
 			Assert.That(model.Count, Is.EqualTo(1));
 		}
+
+		class MockValueTupleContext
+		{
+			public (string Foo, string Bar) Tuple { get; set; }
+		}
+
+		[Test]
+		public void ValueTupleAsBindingContext()
+		{
+			var label = new Label {
+				BindingContext = new MockValueTupleContext { Tuple = (Foo: "FOO", Bar: "BAR")},
+			};
+
+			label.SetBinding(Label.TextProperty, "Tuple.Foo");
+
+			Assert.AreEqual("FOO", label.Text);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -382,8 +382,11 @@ namespace Xamarin.Forms
 					var nextPart = part.NextPart;
 					var name = nextPart.Content;
 					var index = tupleEltNames.TransformNames.IndexOf(name);
-					nextPart.IsIndexer = true;
-					nextPart.Content = index.ToString();
+					if (index >= 0)
+					{
+						nextPart.IsIndexer = true;
+						nextPart.Content = index.ToString();
+					}
 				}
 			}
 		}

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Xamarin.Forms.Internals;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms
 {
@@ -290,8 +291,16 @@ namespace Xamarin.Forms
 				part.IndexerName = indexerName;
 
 				property = sourceType.GetDeclaredProperty(indexerName);
-				if (property == null)
+				if (property == null) //is the indexer defined on the base class?
 					property = sourceType.BaseType.GetProperty(indexerName);
+				if (property == null) //is the indexer defined on implemented interface ?
+				{
+					foreach (var implementedInterface in sourceType.ImplementedInterfaces) {
+						property = implementedInterface.GetProperty(indexerName);
+						if (property != null)
+							break;
+					}
+				}
 
 				if (property != null)
 				{
@@ -353,6 +362,28 @@ namespace Xamarin.Forms
 							}
 						}
 					}
+				}
+
+				TupleElementNamesAttribute tupleEltNames;
+				if (   property != null
+				    && part.NextPart != null
+					&& property.PropertyType.IsGenericType
+					&& (   property.PropertyType.GetGenericTypeDefinition() == typeof(ValueTuple<>)
+						|| property.PropertyType.GetGenericTypeDefinition() == typeof(ValueTuple<,>)
+						|| property.PropertyType.GetGenericTypeDefinition() == typeof(ValueTuple<,,>)
+						|| property.PropertyType.GetGenericTypeDefinition() == typeof(ValueTuple<,,,>)
+						|| property.PropertyType.GetGenericTypeDefinition() == typeof(ValueTuple<,,,,>)
+						|| property.PropertyType.GetGenericTypeDefinition() == typeof(ValueTuple<,,,,,>)
+						|| property.PropertyType.GetGenericTypeDefinition() == typeof(ValueTuple<,,,,,,>)
+						|| property.PropertyType.GetGenericTypeDefinition() == typeof(ValueTuple<,,,,,,,>))
+					&& (tupleEltNames = property.GetCustomAttribute(typeof(TupleElementNamesAttribute)) as TupleElementNamesAttribute) != null)
+				{
+					//modify the nextPart to access the tuple item via the ITuple indexer
+					var nextPart = part.NextPart;
+					var name = nextPart.Content;
+					var index = tupleEltNames.TransformNames.IndexOf(name);
+					nextPart.IsIndexer = true;
+					nextPart.Content = index.ToString();
 				}
 			}
 		}
@@ -502,13 +533,13 @@ namespace Xamarin.Forms
 
 			public object BindablePropertyField { get; set; }
 
-			public string Content { get; }
+			public string Content { get; internal set; }
 
 			public string IndexerName { get; set; }
 
 			public bool IsBindablePropertySetter { get; set; }
 
-			public bool IsIndexer { get; }
+			public bool IsIndexer { get; internal set; }
 
 			public bool IsSelf { get; }
 


### PR DESCRIPTION
### Description of Change ###

Allow ValueTuple shorthand names to be used in Binding paths.

```
public class Person {
    public (string First, string Last) Name { get; set; }
}
```

Allow this kind of Binding path
```
<Label Text="{Binding Name.First}" />
```

It also allows to bind to anonymous tuples using the indexer (that should have worked already, but wasn't). This is possible as ValueTuple implements `ITuple`.
```
<Label Text="{Binding Name[0]}" />
```

### Bugs Fixed ###

/

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense