### PR TITLE
[C] Adding deconstructors for common structs

### DIFF
--- a/Xamarin.Forms.Core/Point.cs
+++ b/Xamarin.Forms.Core/Point.cs
@@ -91,5 +91,11 @@ namespace Xamarin.Forms
 		{
 			return Math.Sqrt(Math.Pow(X - other.X, 2) + Math.Pow(Y - other.Y, 2));
 		}
+
+		public void Deconstruct(out double x, out double y)
+		{
+			x = X;
+			y = Y;
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Rectangle.cs
+++ b/Xamarin.Forms.Core/Rectangle.cs
@@ -240,5 +240,13 @@ namespace Xamarin.Forms
 		{
 			return new Rectangle(Math.Round(X), Math.Round(Y), Math.Round(Width), Math.Round(Height));
 		}
+
+		public void Deconstruct(out double x, out double y, out double width, out double height)
+		{
+			x = X;
+			y = Y;
+			width = Width;
+			height = Height;
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Size.cs
+++ b/Xamarin.Forms.Core/Size.cs
@@ -106,5 +106,11 @@ namespace Xamarin.Forms
 		{
 			return string.Format("{{Width={0} Height={1}}}", _width.ToString(CultureInfo.InvariantCulture), _height.ToString(CultureInfo.InvariantCulture));
 		}
+
+		public void Deconstruct(out double width, out double height)
+		{
+			width = Width;
+			height = Height;
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Thickness.cs
+++ b/Xamarin.Forms.Core/Thickness.cs
@@ -88,5 +88,13 @@ namespace Xamarin.Forms
 		{
 			return !left.Equals(right);
 		}
+
+		public void Deconstruct(out double left, out double top, out double right, out double bottom)
+		{
+			left = Left;
+			top = Top;
+			right = Right;
+			bottom = Bottom;
+		}
 	}
 }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -710,10 +710,7 @@ namespace Xamarin.Forms
 
 		internal void MockBounds(Rectangle bounds)
 		{
-			_mockX = bounds.X;
-			_mockY = bounds.Y;
-			_mockWidth = bounds.Width;
-			_mockHeight = bounds.Height;
+			(_mockX, _mockY, _mockWidth, _mockHeight) = bounds;
 		}
 
 		internal virtual void OnConstraintChanged(LayoutConstraint oldConstraint, LayoutConstraint newConstraint)

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Point.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Point.xml
@@ -75,6 +75,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Deconstruct">
+      <MemberSignature Language="C#" Value="public void Deconstruct (out double x, out double y);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Deconstruct(float64 x, float64 y) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="System.Double&amp;" RefType="out" />
+        <Parameter Name="y" Type="System.Double&amp;" RefType="out" />
+      </Parameters>
+      <Docs>
+        <param name="x">To be added.</param>
+        <param name="y">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Distance">
       <MemberSignature Language="C#" Value="public double Distance (Xamarin.Forms.Point other);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float64 Distance(valuetype Xamarin.Forms.Point other) cil managed" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Rectangle.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Rectangle.xml
@@ -212,6 +212,31 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Deconstruct">
+      <MemberSignature Language="C#" Value="public void Deconstruct (out double x, out double y, out double width, out double height);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Deconstruct(float64 x, float64 y, float64 width, float64 height) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="System.Double&amp;" RefType="out" />
+        <Parameter Name="y" Type="System.Double&amp;" RefType="out" />
+        <Parameter Name="width" Type="System.Double&amp;" RefType="out" />
+        <Parameter Name="height" Type="System.Double&amp;" RefType="out" />
+      </Parameters>
+      <Docs>
+        <param name="x">To be added.</param>
+        <param name="y">To be added.</param>
+        <param name="width">To be added.</param>
+        <param name="height">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Equals">
       <MemberSignature Language="C#" Value="public override bool Equals (object obj);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance bool Equals(object obj) cil managed" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Size.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Size.xml
@@ -51,6 +51,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Deconstruct">
+      <MemberSignature Language="C#" Value="public void Deconstruct (out double width, out double height);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Deconstruct(float64 width, float64 height) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="width" Type="System.Double&amp;" RefType="out" />
+        <Parameter Name="height" Type="System.Double&amp;" RefType="out" />
+      </Parameters>
+      <Docs>
+        <param name="width">To be added.</param>
+        <param name="height">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Equals">
       <MemberSignature Language="C#" Value="public override bool Equals (object obj);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance bool Equals(object obj) cil managed" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Thickness.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Thickness.xml
@@ -124,6 +124,31 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Deconstruct">
+      <MemberSignature Language="C#" Value="public void Deconstruct (out double left, out double top, out double right, out double bottom);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Deconstruct(float64 left, float64 top, float64 right, float64 bottom) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="left" Type="System.Double&amp;" RefType="out" />
+        <Parameter Name="top" Type="System.Double&amp;" RefType="out" />
+        <Parameter Name="right" Type="System.Double&amp;" RefType="out" />
+        <Parameter Name="bottom" Type="System.Double&amp;" RefType="out" />
+      </Parameters>
+      <Docs>
+        <param name="left">To be added.</param>
+        <param name="top">To be added.</param>
+        <param name="right">To be added.</param>
+        <param name="bottom">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Equals">
       <MemberSignature Language="C#" Value="public override bool Equals (object obj);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance bool Equals(object obj) cil managed" />


### PR DESCRIPTION
### Description of Change ###

[C] Adding deconstructors for common structs

### Bugs Fixed ###

/

### API Changes ###

Added:
 - `Thickness.Decontruct(out double, out double, out double, out double)`
 - `Rectangle.Decontruct(out double, out double, out double, out double)`
 - `Point.Decontruct(out double, out double)`
 - `Size.Decontruct(out double, out double)`

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense