### PR TITLE
[UWP] Set ListView SelectedItem when constructing page

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1356.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1356.cs
@@ -1,0 +1,37 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1356, "[UWP] A selected item in a ListView is not highlighted when constructing the page", PlatformAffected.UWP)]
+	public class Issue1356 : TestContentPage
+	{
+		ObservableCollection<string> items = new ObservableCollection<string>() { "A", "B", "C" };
+
+		ListView listView;
+		protected override void Init()
+		{
+			listView = new ListView
+			{
+				ItemsSource = items
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					listView,
+					new Label { Text = "Item 'B' should be highlighted when loading this page" }
+				}
+			};
+			listView.SelectedItem = items[1];
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -255,6 +255,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1024.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1025.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1026.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1356.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -64,6 +64,9 @@ namespace Xamarin.Forms.Platform.UWP
 				// WinRT throws an exception if you set ItemsSource directly to a CVS, so bind it.
 				List.DataContext = new CollectionViewSource { Source = Element.ItemsSource, IsSourceGrouped = Element.IsGroupingEnabled };
 
+				if (Element.SelectedItem != null)
+					OnElementItemSelected(null, new SelectedItemChangedEventArgs(Element.SelectedItem));
+
 				UpdateGrouping();
 				UpdateHeader();
 				UpdateFooter();


### PR DESCRIPTION
### Description of Change ###

Per #1356, the when setting a ListView's SelectedItem while constructing the page, the item would be visually highlighted on Android/iOS, but not UWP. Some code existed previously in the ListViewRenderer that (at least for 8.1) allowed the behavior to function as expected, and appears to correct this particular issue.

### Bugs Fixed ###

#1356 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
