### PR TITLE
Add implicit color conversion to .NET Standard's System.Drawing.Color

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
@@ -290,6 +290,12 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void TestDefaultColorToSystemDrawingColorEmpty()
+		{
+			Assert.AreEqual(System.Drawing.Color.Empty, (System.Drawing.Color)Color.Default);
+		}
+
+		[Test]
 		public void TestImplicitConversionFromSystemDrawingColor()
 		{
 			System.Drawing.Color sdColor = System.Drawing.Color.FromArgb(32, 64, 128, 255);
@@ -298,6 +304,12 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(.25, color.R, .01);
 			Assert.AreEqual(.5, color.G, .01);
 			Assert.AreEqual(1, color.B, .01);
+		}
+
+		[Test]
+		public void TestSystemDrawingColorEmptyToColorDefault()
+		{
+			Assert.AreEqual(Color.Default, (Color)System.Drawing.Color.Empty);
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
@@ -277,5 +277,27 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (Color.Default, default(Color));
 			Assert.AreEqual (Color.Default, new Color ());
 		}
+		
+		[Test]
+		public void TestImplicitConversionToSystemDrawingColor()
+		{
+			var color = Color.FromRgba(0.2, 0.3, 0.4, 0.5);
+			System.Drawing.Color sdColor = color;
+			Assert.AreEqual(51, sdColor.R);
+			Assert.AreEqual(76, sdColor.G);
+			Assert.AreEqual(102, sdColor.B);
+			Assert.AreEqual(127, sdColor.A);
+		}
+
+		[Test]
+		public void TestImplicitConversionFromSystemDrawingColor()
+		{
+			System.Drawing.Color sdColor = System.Drawing.Color.FromArgb(32, 64, 128, 255);
+			Color color = sdColor;
+			Assert.AreEqual(.125, color.A, .01);
+			Assert.AreEqual(.25, color.R, .01);
+			Assert.AreEqual(.5, color.G, .01);
+			Assert.AreEqual(1, color.B, .01);
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -43,6 +43,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -394,7 +394,7 @@ namespace Xamarin.Forms
 
 		public static implicit operator System.Drawing.Color(Color color)
 		{
-			return System.Drawing.Color.FromArgb((byte)(color._a * 255), (byte)(color._g * 255), (byte)(color._b * 255), (byte)(color._a * 255));
+			return System.Drawing.Color.FromArgb((byte)(color._a * 255), (byte)(color._r * 255), (byte)(color._g * 255), (byte)(color._b * 255));
 		}
 
 		public static implicit operator Color(System.Drawing.Color color)

--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -392,6 +392,16 @@ namespace Xamarin.Forms
 			return new Color(h, s, l, a, Mode.Hsl);
 		}
 
+		public static implicit operator System.Drawing.Color(Color color)
+		{
+			return System.Drawing.Color.FromArgb((byte)(color._a * 255), (byte)(color._g * 255), (byte)(color._b * 255), (byte)(color._a * 255));
+		}
+
+		public static implicit operator Color(System.Drawing.Color color)
+		{
+			return FromRgba(color.R, color.G, color.B, color.A);
+		}
+
 		#region Color Definitions
 
 		// matches colors in WPF's System.Windows.Media.Colors

--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -394,11 +394,15 @@ namespace Xamarin.Forms
 
 		public static implicit operator System.Drawing.Color(Color color)
 		{
+			if (color.IsDefault)
+				return System.Drawing.Color.Empty;
 			return System.Drawing.Color.FromArgb((byte)(color._a * 255), (byte)(color._r * 255), (byte)(color._g * 255), (byte)(color._b * 255));
 		}
 
 		public static implicit operator Color(System.Drawing.Color color)
 		{
+			if (color.IsEmpty)
+				return Color.Default;
 			return FromRgba(color.R, color.G, color.B, color.A);
 		}
 


### PR DESCRIPTION
### Description of Change ###

This change simplifies working with colors in a .NET Standard way by adding implicit conversion between the two color types:
```
Xamarin.Forms.Color c1 = Xamarin.Forms.Color.FromRgba(1, 1, 1, 1);
System.Drawing.Color c2 = c1;
Xamarin.Forms.Color c3 = c2;
if (c2 == c1)
{
   // Colors are equal
}
```

This came out of this discussion: https://github.com/xamarin/Xamarin.Forms/pull/1306#issuecomment-350355271

### Bugs Fixed ###

- N/A

### API Changes ###

Added:
 - `public static implicit operator System.Drawing.Color(Xamarin.Forms.Color color)`
 - `public static implicit operator Xamarin.Forms.Color(System.Drawing.Color color)`

### Behavioral Changes ###

None.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
