### PR TITLE
[Android] Changes to incorporate synchronized transaction commits

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -118,6 +118,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			fragmentTransaction.Add(Id, fragment);
 			fragmentTransaction.SetTransition((int)FragmentTransit.None);
 
+			// The view we're hosting in the fragment was never created (possibly we're already 		
+			// navigating to another page?) so there's nothing to commit synchronously.
 			if (_pageContainer == null)
 			{
 				// We don't currently support fragment restoration 

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -141,8 +141,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			fragmentTransaction.Remove(_currentFragment);
 			fragmentTransaction.SetTransition((int)FragmentTransit.None);
 
-			// This is a removal of a fragment that's not going on the back stack; there's no reason to care
-			// whether its state gets successfully saved, since we'll never restore it. Ergo, CommitAllowingStateLoss
 			CommitTransaction(fragmentTransaction);
 
 			_currentFragment = null;
@@ -150,6 +148,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void CommitTransaction(FragmentTransaction fragmentTransaction)
 		{
+			// We're performing a removal of a fragment that's not going on the back stack; there's no reason to care
+			// whether its state gets saved successfully since we'll never restore it. Ergo, commit by allowing state loss.
+
 			if (Build.VERSION.SdkInt >= BuildVersionCodes.N)
 				fragmentTransaction.CommitNowAllowingStateLoss();
 			else

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -204,16 +204,30 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 					if (!fm.IsDestroyed)
 					{
-						FragmentTransaction trans = fm.BeginTransaction();
+						FragmentTransaction fragmentTransaction = fm.BeginTransaction();
 						foreach (Fragment fragment in _fragmentStack)
-							trans.Remove(fragment);
-						trans.CommitAllowingStateLoss();
-						fm.ExecutePendingTransactions();
+							fragmentTransaction.Remove(fragment);
+
+						CommitTransaction(fragmentTransaction);
 					}
 				}
 			}
 
 			base.Dispose(disposing);
+		}
+
+		void CommitTransaction(FragmentTransaction fragmentTransaction)
+		{
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.N)
+				fragmentTransaction.CommitNowAllowingStateLoss();
+			else
+			{
+				fragmentTransaction.CommitAllowingStateLoss();
+				new Handler(Looper.MainLooper).PostAtFrontOfQueue(() =>
+				{
+					FragmentManager.ExecutePendingTransactions();
+				});
+			}
 		}
 
 		protected override void OnAttachedToWindow()


### PR DESCRIPTION
### Description of Change ###

Re-doing #451. `CommitNowAllowingStateLoss()` can be used for single transactions that need immediate execution where we have not added transactions to the back stack.

Ref: https://medium.com/@bherbst/the-many-flavors-of-commit-186608a015b1

See comments for further discussion.

### Bugs Fixed ###

- N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
