### PR TITLE
[iOS] PickerRenderer EditingChanged detach

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -184,6 +184,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					Control.EditingDidBegin -= OnStarted;
 					Control.EditingDidEnd -= OnEnded;
+					Control.EditingChanged -= OnEditing;
 				}
 
 				if(Element != null)


### PR DESCRIPTION
### Description of Change ###

iOS.PickerRenderer was attaching to EditingChanged, but it wasn't detaching from it.

### Bugs Fixed ###

- I didn't create any bug on Bugzilla, I just noticed it when adapting this component.

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
