### PR TITLE
[Tizen] Add Tizen stuff to NuGet packages

### DIFF
--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -34,6 +34,9 @@
         <dependency id="Xamarin.Android.Support.v7.AppCompat" version="25.4.0.2"/>
         <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
       </group>
+      <group targetFramework="tizen40">
+        <dependency id="Tizen.NET" version="4.0.0"/>
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -51,18 +54,21 @@
     <file src="..\Xamarin.Forms.Maps.UWP\bin\$Configuration$\Xamarin.Forms.Maps.UWP.dll" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Maps.UWP\bin\$Configuration$\Xamarin.Forms.Maps.UWP.pri" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\uap10.0" />
-	
-	 <file src="..\Xamarin.Forms.Maps.MacOS\bin\$Configuration$\Xamarin.Forms.Maps.macOS.dll" target="lib\Xamarin.Mac" />
+
+    <file src="..\Xamarin.Forms.Maps.MacOS\bin\$Configuration$\Xamarin.Forms.Maps.macOS.dll" target="lib\Xamarin.Mac" />
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\Xamarin.Mac" />
     <file src="..\docs\Xamarin.Forms.Maps.xml" target="lib\Xamarin.Mac" />
 
-    <!-- Xaml Design-time Stuff 
+    <file src="..\Xamarin.Forms.Maps.Tizen\bin\$Configuration$\tizen40\Xamarin.Forms.Maps.Tizen.dll" target="lib\tizen40" />
+    <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\tizen40" />
+    <file src="..\docs\Xamarin.Forms.Maps.xml" target="lib\tizen40" />
+
+    <!-- Xaml Design-time Stuff
     <file src="..\Xamarin.Forms.Maps.Design\bin\$Configuration$\Xamarin.Forms.Maps.Design.dll" target="lib\portable-win+net45+wp80+win81+wpa81\Design" />
     <file src="..\Xamarin.Forms.Maps.Design\bin\$Configuration$\Xamarin.Forms.Maps.Design.dll" target="lib\netstandard1.0" />
     <file src="..\Xamarin.Forms.Maps.Design\bin\$Configuration$\Xamarin.Forms.Maps.Design.dll" target="lib\MonoAndroid10\Design" />
     <file src="..\Xamarin.Forms.Maps.Design\bin\$Configuration$\Xamarin.Forms.Maps.Design.dll" target="lib\Xamarin.iOS10\Design" />
     <file src="..\Xamarin.Forms.Maps.Design\bin\$Configuration$\Xamarin.Forms.Maps.Design.dll" target="lib\uap10.0\Design" />
-	-->
-   
+    -->
   </files>
 </package>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -34,6 +34,9 @@
         <dependency id="Xamarin.Android.Support.v7.CardView" version="25.4.0.2"/>
         <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="25.4.0.2"/>
       </group>
+      <group targetFramework="tizen40">
+        <dependency id="Tizen.NET" version="4.0.0"/>
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -183,5 +186,18 @@
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\zh-Hans\Xamarin.Forms.Platform.iOS.resources.dll" target="lib\Xamarin.iOS10\zh-Hans" />
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\zh-Hant\Xamarin.Forms.Platform.iOS.resources.dll" target="lib\Xamarin.iOS10\zh-Hant" />
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\zh-HK\Xamarin.Forms.Platform.iOS.resources.dll" target="lib\Xamarin.iOS10\zh-HK" />
+
+    <!--Tizen-->
+    <file src="..\Xamarin.Forms.Platform.Tizen\bin\$Configuration$\tizen40\Xamarin.Forms.Platform.Tizen.dll" target="lib\tizen40" />
+    <file src="..\Xamarin.Forms.Platform.Tizen\bin\$Configuration$\tizen40\Xamarin.Forms.Platform.Tizen.*pdb" target="lib\tizen40" />
+    <file src="..\Xamarin.Forms.Platform.Tizen\bin\$Configuration$\tizen40\Xamarin.Forms.Platform.Tizen.dll" target="lib\tizen40" />
+    <file src="..\Xamarin.Forms.Platform.Tizen\bin\$Configuration$\tizen40\Xamarin.Forms.Platform.dll" target="lib\tizen40" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\tizen40" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\tizen40" />
+    <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\tizen40" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\tizen40" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\tizen40" />
+    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\tizen40" />
   </files>
+
 </package>


### PR DESCRIPTION
### Description of Change ###

Add Tizen related files (dll, pdb, xml) to nuget packages. 
- Xamarin.Forms.Platform.Tizen.dll, .pdb --> (tizen40) Xamarin.Forms.nupkg
- Xamarin.Forms.Maps.Tizen.dll, .pdb --> (tizen40) Xamarin.Forms.Maps.nupkg

### Bugs Fixed ###

- N/A

### API Changes ###

- N/A

### Behavioral Changes ###

Tizen app developer only needs to refer to Xamarin.Forms nuget package without Xamarin.Forms.Platform.Tizen.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
