### PR TITLE
[C] no need to use reflection for GetCallingAssembly

### DIFF
--- a/Xamarin.Forms.Core/ImageSource.cs
+++ b/Xamarin.Forms.Core/ImageSource.cs
@@ -68,20 +68,7 @@ namespace Xamarin.Forms
 
 		public static ImageSource FromResource(string resource, Assembly sourceAssembly = null)
 		{
-			if (sourceAssembly == null)
-			{
-				MethodInfo callingAssemblyMethod = typeof(Assembly).GetTypeInfo().GetDeclaredMethod("GetCallingAssembly");
-				if (callingAssemblyMethod != null)
-				{
-					sourceAssembly = (Assembly)callingAssemblyMethod.Invoke(null, new object[0]);
-				}
-				else
-				{
-					Log.Warning("Warning", "Can not find CallingAssembly, pass resolvingType to FromResource to ensure proper resolution");
-					return null;
-				}
-			}
-
+			sourceAssembly = sourceAssembly ?? Assembly.GetCallingAssembly();
 			return FromStream(() => sourceAssembly.GetManifestResourceStream(resource));
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -28,9 +28,6 @@ namespace Xamarin.Forms
 {
 	public static class Forms
 	{
-		//Preserve GetCallingAssembly
-		static readonly bool nevertrue = false;
-
 		public static bool IsInitialized { get; private set; }
 
 #if __MOBILE__
@@ -38,11 +35,6 @@ namespace Xamarin.Forms
 		static bool? s_isiOS10OrNewer;
 		static bool? s_isiOS11OrNewer;
 #endif
-		static Forms()
-		{
-			if (nevertrue)
-				Assembly.GetCallingAssembly();
-		}
 
 #if __MOBILE__
 		internal static bool IsiOS9OrNewer


### PR DESCRIPTION
### Description of Change ###

As `GetCallingAssembly` wasn't available in PCL profiles, but actually there in all the final platforms we were using, we were finding it through reflection.

Now that we've moved to `netstandard2.0` that API is available. It also looks like the previous one could cause problems in some (new) conditions.

### Bugs Fixed ###

- fixes #1362 

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense