### PR TITLE
[Android] Descriptive exception when ItemViewType >= ViewTypeCount

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -180,6 +180,13 @@ namespace Xamarin.Forms.Platform.Android
 				key = _dataTemplateIncrementer;
 				_templateToId[itemTemplate] = key;
 			}
+
+			if (key >= ViewTypeCount) 
+			{
+				throw new Exception($"ItemTemplate count has exceeded the limit of {ViewTypeCount}" + Environment.NewLine +
+									 "Please make sure to reuse DataTemplate objects");
+			}
+
 			return key;
 		}
 


### PR DESCRIPTION
### Description of Change ###

If the application creates too many DataTemplates, it will crash with a very weird exception like this:
`java.lang.ArrayIndexOutOfBoundsException: length=23; index=26`

I spent a few hours trying to figure this out. Basically, in my client's application `DateTemplateSelector` returned a new `DataTemplate` object on each `OnSelectTemplate` call. This caused `_dataTemplateIncrementer` to overflow and return an invalid `key`.

### Bugs Fixed ###

### API Changes ###

### Behavioral Changes ###

Descriptive Exception will be thrown instead of java.lang.ArrayIndexOutOfBoundsException

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
Not sure if needed
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
