### PR TITLE
[Xaml] execute XamlG and XamlC on UWP SAP

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -60,7 +60,17 @@
 	<!-- XamlG -->
 	<Target Name="UpdateDesignTimeXaml" DependsOnTargets="XamlG"/>
 
-	<Target Name="XamlG" BeforeTargets="BeforeCompile">
+	<PropertyGroup>
+		<CoreCompileDependsOn>
+			XamlG;
+			$(CoreCompileDependsOn);
+		</CoreCompileDependsOn>
+	</PropertyGroup>
+
+	<Target Name="XamlG" BeforeTargets="BeforeCompile" Condition="'$(_XamlGAlreadyExecuted)'!='true'">
+		<PropertyGroup>
+			<_XamlGAlreadyExecuted>true</_XamlGAlreadyExecuted>
+		</PropertyGroup>
 		<XamlGTask
 			XamlFiles="@(EmbeddedResource)" Condition="'%(Extension)' == '.xaml' AND '$(DefaultLanguageSourceExtension)' == '.cs'"
 			Language = "$(Language)"
@@ -74,9 +84,16 @@
 	<!-- XamlC -->
 	<PropertyGroup>
 		<XFVerbosity Condition="'$(XFVerbosity)' == ''">2</XFVerbosity>
+		<CompileDependsOn>
+			$(CompileDependsOn);
+			XamlC;
+		</CompileDependsOn>
 	</PropertyGroup>
 
-	<Target Name="XamlC" AfterTargets="AfterCompile">
+	<Target Name="XamlC" AfterTargets="AfterCompile" Condition="'$(_XamlCAlreadyExecuted)'!='true'">
+		<PropertyGroup>
+			<_XamlCAlreadyExecuted>true</_XamlCAlreadyExecuted>
+		</PropertyGroup>
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"


### PR DESCRIPTION
### Description of Change ###

Execute XamlG and XamlC either on [After|Before]Compile or on [Core]CompileDependsOn overrides. This allows building UWP Shared Assets Projects, as in those projects some compilation is done before the `BeforeCompile` target.

Make sure XamlC and XamlG are only ran once per project

### Bugs Fixed ###

- fixes #1358 

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense