### PR TITLE
Use GlobalAssemblyInfo on tizen backend

### DIFF
--- a/Xamarin.Forms.Maps.Tizen/Xamarin.Forms.Maps.Tizen.csproj
+++ b/Xamarin.Forms.Maps.Tizen/Xamarin.Forms.Maps.Tizen.csproj
@@ -2,7 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Tizen.NET" Version="4.0.0" />

--- a/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
+++ b/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
@@ -2,7 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Tizen.NET" Version="4.0.0" />


### PR DESCRIPTION
### Description of Change ###

This PR is for using `GlobalAssemblyInfo` on `Xamarin.Forms.Platform.Tizen.csproj` and `Xamarin.Forms.Maps.Tizen.csproj`.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

Tizen backend asssembly version will be detemined by GlobalAssemblyInfo

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
