### PR TITLE
[Core] Fixed invocation of the IButtonController methods when IsEnabled is false

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
@@ -35,42 +35,57 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void TestClickedvent ()
+		[TestCase(true)]
+		[TestCase(false)]
+		public void TestClickedvent (bool isEnabled)
 		{
-			var view = new Button ();
+			var view = new Button()
+			{
+				IsEnabled= isEnabled,
+			};
 
 			bool activated = false;
 			view.Clicked += (sender, e) => activated = true;
 
 			((IButtonController) view).SendClicked ();
 
-			Assert.True (activated);
+			Assert.True (activated == isEnabled ? true : false);
 		}
 
 		[Test]
-		public void TestPressedEvent ()
+		[TestCase(true)]
+		[TestCase(false)]
+		public void TestPressedEvent (bool isEnabled)
 		{
-			var view = new Button();
+			var view = new Button()
+			{
+				IsEnabled = isEnabled,
+			};
 
 			bool pressed = false;
 			view.Pressed += (sender, e) => pressed = true;
 
 			((IButtonController)view).SendPressed();
 
-			Assert.True(pressed);
+			Assert.True(pressed == isEnabled ? true : false);
 		}
 
 		[Test]
-		public void TestReleasedEvent ()
+		[TestCase(true)]
+		[TestCase(false)]
+		public void TestReleasedEvent (bool isEnabled)
 		{
-			var view = new Button();
+			var view = new Button()
+			{
+				IsEnabled = isEnabled,
+			};
 
 			bool released = false;
 			view.Released += (sender, e) => released = true;
 
 			((IButtonController)view).SendReleased();
 
-			Assert.True(released);
+			Assert.True(released == isEnabled ? true : false);
 		}
 
 		protected override Button CreateSource()
@@ -218,6 +233,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			AssertButtonContentLayoutsEqual(new Button.ButtonContentLayout(Button.ButtonContentLayout.ImagePosition.Bottom, 0), converter.ConvertFromInvariantString("Bottom, 0"));
 
 			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString(""));
+		}
+
+		[Test]
+		public void ButtonClickWhenCommandCanExecuteFalse()
+		{
+			bool invoked = false;
+			var button = new Button()
+			{
+				Command = new Command(() => invoked = true
+				, () => false),
+			};
+
+			(button as IButtonController)
+				?.SendClicked();
+			
+			Assert.False(invoked);
 		}
 
 		private void AssertButtonContentLayoutsEqual(Button.ButtonContentLayout layout1, object layout2)

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -113,20 +113,29 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendClicked()
 		{
-			Command?.Execute(CommandParameter);
-			Clicked?.Invoke(this, EventArgs.Empty);
+			if (IsEnabled == true)
+			{
+				Command?.Execute(CommandParameter);
+				Clicked?.Invoke(this, EventArgs.Empty);
+			}
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendPressed()
 		{
-			Pressed?.Invoke(this, EventArgs.Empty);
+			if (IsEnabled == true)
+			{
+				Pressed?.Invoke(this, EventArgs.Empty); 
+			}
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendReleased()
 		{
-			Released?.Invoke(this, EventArgs.Empty);
+			if (IsEnabled == true)
+			{
+				Released?.Invoke(this, EventArgs.Empty);
+			}
 		}
 
 		public FontAttributes FontAttributes


### PR DESCRIPTION
### Description of Change ###

When Button IsEnabled is false and invoked  IButtonController methods, the events and Commad.Execute do not fired.

### Bugs Fixed ###

- Commad.Execute is calling when invoke IButtonController.SendClicked and IsEnabled is false

### API Changes ###
(none)
### Behavioral Changes ###
(none)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
