### PR TITLE
[iOS] Include margins when measuring ViewCell renderers

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1326.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1326.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1326, "ListView word wrap in Label causing ViewCells to overlap", PlatformAffected.iOS)]
+	public class Issue1326 : TestContentPage
+	{
+		private MyItemsViewModel _model = new MyItemsViewModel();
+
+		protected override void Init()
+		{
+			DataTemplate MyItemsDataTemplate = new DataTemplate(() => new MyViewCell());
+
+			ListView listView = new ListView
+			{
+				ItemTemplate = MyItemsDataTemplate,
+				SeparatorVisibility = SeparatorVisibility.None,
+				HasUnevenRows = true,
+				IsPullToRefreshEnabled = false
+			};
+			listView.SetBinding(ListView.ItemsSourceProperty, new Binding(nameof(MyItemsViewModel.MyItems)));
+
+			Content = new StackLayout { Children = { new Label { Text = "If the text in the cells below is overlapping, this test has failed." }, listView } };
+
+			_model.MyItems.Add(new MyItem() { Description = "Record 1. OK" });
+			_model.MyItems.Add(new MyItem() { Description = "Record 2. Abcde ab ab abcdefg.   x.  Xxxxxx Z.  Zzzzz" });
+			_model.MyItems.Add(new MyItem() { Description = "Record 3. This one gets partially stomped on." });
+			_model.MyItems.Add(new MyItem() { Description = "Record 4. OK" });
+
+			Content.BindingContext = _model;
+		}
+
+		class MyItem
+		{
+			public String Description { get; set; }
+		}
+
+		class MyItemsViewModel
+		{
+			public List<MyItem> MyItems { get; set; } = new List<MyItem>();
+		}
+
+		class MyViewCell : ViewCell
+		{
+			Label label;
+
+			public MyViewCell()
+			{
+				label = new Label
+				{
+					Margin = new Thickness(0, 3, 0, 3),
+					LineBreakMode = LineBreakMode.WordWrap,
+					HorizontalOptions = LayoutOptions.Start,
+					VerticalTextAlignment = TextAlignment.Start,
+					FontFamily = "HelveticaNeue-Light",
+					FontSize = 16
+				};
+				label.SetBinding(Label.TextProperty, new Binding(nameof(MyItem.Description)));
+
+				View = new StackLayout
+				{
+					Margin = new Thickness(15, 8, 10, 0),
+					Children = { label },
+				};
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -350,6 +350,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60382.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59925.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1326.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				double width = size.Width;
 				var height = size.Height > 0 ? size.Height : double.PositiveInfinity;
-				var result = renderer.Element.Measure(width, height);
+				var result = renderer.Element.Measure(width, height, MeasureFlags.IncludeMargins);
 
 				// make sure to add in the separator if needed
 				var finalheight = (float)result.Request.Height + (SupressSeparator ? 0f : 1f) / UIScreen.MainScreen.Scale;


### PR DESCRIPTION
### Description of Change ###

`Label`s in a hierarchy that utilizes margins can sometimes wrap in a `ViewCell`, and the `ViewCell` will not appear to resize properly to contain the full text. This is because the `ViewCellRenderer` was not measuring its content with the content's `Margin`s, so the `ViewCell` thought it had enough room to display the text without wrapping, thus the `Height` was incorrect.

Now measuring the contents of a `ViewCell` with the `Margin`s included.

Before:
![before](https://user-images.githubusercontent.com/7827070/34174199-fe3645f6-e4ac-11e7-8687-d309a3d1d2b5.PNG)

After:
![after](https://user-images.githubusercontent.com/7827070/34174209-0590b9c6-e4ad-11e7-9c72-c45a39410fa3.PNG)

### Bugs Fixed ###

- fixes #1326

### API Changes ###

None

### Behavioral Changes ###

It is possible for any `ViewCell` to be a different size now if the contents included `Margin`s. This should ideally lead to a better representation of the `ViewCell`'s true size.

### PR Checklist ###

- [x] Has tests (manual)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
