### PR TITLE
Fixed  missing notification PropertyChanging and PropertyChanged of BindingContext

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -112,6 +112,8 @@ namespace Xamarin.Forms
 			if (bpContext != null && oldContext == null)
 				oldContext = bpContext.Value;
 
+			bindable.OnPropertyChanging(nameof(BindingContext));
+
 			if (bpContext != null && bpContext.Binding != null)
 			{
 				bpContext.Binding.Context = value;
@@ -123,6 +125,7 @@ namespace Xamarin.Forms
 			}
 
 			bindable.ApplyBindings(skipBindingContext:false, fromBindingContextChanged:true);
+			bindable.OnPropertyChanged(nameof(BindingContext));
 			bindable.OnBindingContextChanged();
 		}
 

--- a/Xamarin.Forms.Xaml.UnitTests/BindingContexEvents.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingContexEvents.xaml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.BindingContexEvents">
+  <ContentView.Content>
+      <StackLayout>
+          <Button Text="Hello Xamarin.Forms!" 
+				 x:Name="Button"/>
+      </StackLayout>
+  </ContentView.Content>
+</ContentView>

--- a/Xamarin.Forms.Xaml.UnitTests/BindingContexEvents.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingContexEvents.xaml.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class BindingContexEvents : ContentView
+	{
+		public BindingContexEvents()
+		{
+			InitializeComponent();
+		}
+
+		class Test: BaseTestFixture
+		{
+			[Test]
+			public void ParentAndChildBindingContextChanged()
+			{
+				int countPropertyChanged = 0
+					, countDataContexChanged = 0
+					, countPropertyChanging = 0;
+
+
+				var parent = new BindingContexEvents();
+				var child = parent.Button;
+				child.PropertyChanging += (sender, args) => { if (args.PropertyName == "BindingContext") ++countPropertyChanging; };
+				child.PropertyChanged += (sender, args) => { if (args.PropertyName == "BindingContext") ++countPropertyChanged; };
+				child.BindingContextChanged += (sender, args) => { ++countDataContexChanged; };
+
+				parent.BindingContext = new object();
+				Assert.AreEqual(1, countDataContexChanged);
+				Assert.AreEqual(1, countPropertyChanging);
+				Assert.AreEqual(1, countPropertyChanged);				
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -101,6 +101,9 @@
     <Compile Include="AutomationProperties.xaml.cs">
       <DependentUpon>AutomationProperties.xaml</DependentUpon>
     </Compile>
+    <Compile Include="BindingContexEvents.xaml.cs">
+      <DependentUpon>BindingContexEvents.xaml</DependentUpon>
+    </Compile>
     <Compile Include="FontConverterTests.cs" />
     <Compile Include="Issues\Bz43450.xaml.cs">
       <DependentUpon>Bz43450.xaml</DependentUpon>
@@ -1044,5 +1047,10 @@
   <ItemGroup>
     <Folder Include="css\" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <EmbeddedResource Include="BindingContexEvents.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>
+


### PR DESCRIPTION
### Description of Change ###
Fixed  missing notification PropertyChanging and PropertyChanged of BindalbeObjcet that inherit BindingContext, when BindingContex of parent change
Describe your changes here.

### Bugs Fixed ###

[Forum discussion](https://forums.xamarin.com/discussion/comment/312503/#Comment_312503)

### API Changes ###

none

### Behavioral Changes ###

none

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
