### PR TITLE
[Android] Handle LongPress correctly in ViewCell with TapGesture content

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1331.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1331.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls;assembly=Xamarin.Forms.Controls"
+             x:Class="Xamarin.Forms.Controls.Issues.GitHub1331">
+	<ContentPage.Content>
+		<StackLayout>
+			
+			<Label x:Name="Result" Text="Running..."></Label>
+
+			<ListView ItemsSource="{Binding Items}">
+				<ListView.ItemTemplate>
+					<DataTemplate>
+						<ViewCell>
+							<Cell.ContextActions>
+								<MenuItem Text="Context Action" />
+							</Cell.ContextActions>
+							<StackLayout Orientation="Horizontal">
+								<Label Text="{Binding Text}" HorizontalOptions="FillAndExpand"
+										VerticalOptions="Fill" VerticalTextAlignment="Center" Margin="10"/>
+								<Label Text="{Binding ActionText}" VerticalOptions="Fill" 
+										VerticalTextAlignment="Center" Margin="10" BackgroundColor="CornflowerBlue">
+									<Label.GestureRecognizers>
+										<TapGestureRecognizer Command="{Binding ActionTappedCommand}" />
+									</Label.GestureRecognizers>
+								</Label>
+							</StackLayout>
+						</ViewCell>
+					</DataTemplate>
+				</ListView.ItemTemplate>
+			</ListView>
+		</StackLayout>
+	</ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1331.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1331.xaml.cs
@@ -19,7 +19,6 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1331, "[Android] ViewCell shows ContextActions on tap instead of long press", 
 		PlatformAffected.Android)]
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class GitHub1331 : TestContentPage
 	{
 		const string Action = "Action 1";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1331.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1331.xaml.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Gestures)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1331, "[Android] ViewCell shows ContextActions on tap instead of long press", 
+		PlatformAffected.Android)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class GitHub1331 : TestContentPage
+	{
+		const string Action = "Action 1";
+		const string ActionItemTapped = "Action Item Tapped";
+		const string CellItem = "item 1";
+
+		public GitHub1331 ()
+		{
+#if APP
+			InitializeComponent ();
+
+			var mainViewModel = new GH1331ViewModel
+			{
+				Items = new ObservableCollection<GH1331ItemViewModel>(new[]
+				{
+					new GH1331ItemViewModel
+					{
+						Text = CellItem,
+						ActionText = Action,
+						ActionTappedCommand =
+							new Command(() => Result.Text = ActionItemTapped)
+					},
+					new GH1331ItemViewModel
+					{
+						Text = "item 2",
+						ActionText = "Action 2",
+						ActionTappedCommand =
+							new Command(() => DisplayAlert("Action tapped", "item 2", "Cancel"))
+					},
+					new GH1331ItemViewModel
+					{
+						Text = "item 3",
+						ActionText = "Action 3",
+						ActionTappedCommand =
+							new Command(() => DisplayAlert("Action tapped", "item 3", "Cancel"))
+					}
+				})
+			};
+
+			BindingContext = mainViewModel;
+
+			Title = "GH 1331";
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+
+		[Preserve(AllMembers = true)]
+		class GH1331ViewModel
+		{
+			public ObservableCollection<GH1331ItemViewModel> Items { get; set; }
+		}
+
+		[Preserve(AllMembers = true)]
+		class GH1331ItemViewModel
+		{
+			public string Text { get; set; }
+			public string ActionText { get; set; }
+			public ICommand ActionTappedCommand { get; set; }
+		}
+
+#if UITEST && __ANDROID__ // This test only makes sense on platforms using Long Press to activate context menus
+		[Test]
+		public void SingleTapOnCellDoesNotActivateContext()
+		{
+			RunningApp.WaitForElement(Action);
+			
+			RunningApp.Tap(Action);
+			RunningApp.WaitForElement(ActionItemTapped);
+
+			// Tapping the part of the cell without a tap gesture should *not* display the context action
+			RunningApp.Tap(CellItem);
+			RunningApp.WaitForNoElement("Context Action");
+
+			// But a Long Press *should* still display the context action
+			RunningApp.TouchAndHold(CellItem);
+			RunningApp.WaitForElement("Context Action");
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -251,6 +251,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FailImageSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GestureBubblingTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GitHub1331.xaml.cs">
+      <DependentUpon>GitHub1331.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)InputTransparentTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsInvokeRequiredRaceCondition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsPasswordToggleTest.cs" />
@@ -788,6 +791,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla45722Xaml0.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)GitHub1331.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -127,13 +127,24 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (!Enabled)
 					return true;
+				
+				return base.OnInterceptTouchEvent(ev);
+			}
+
+			public override bool DispatchTouchEvent(MotionEvent e)
+			{
+				// Give the child controls a shot at the event (in case they've get Tap gestures and such
+				var handled = base.DispatchTouchEvent(e);
 
 				if (_watchForLongPress)
 				{
-					LongPressGestureDetector.OnTouchEvent(ev);
+					// Feed the gestue through the LongPress detector; for this to wor we *must* return true 
+					// afterward (or the LPGD goes nuts and immediately fires onLongPress)
+					LongPressGestureDetector.OnTouchEvent(e);
+					return true;
 				}
 
-				return base.OnInterceptTouchEvent(ev);
+				return handled;
 			}
 
 			public void Update(ViewCell cell)

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -161,8 +161,6 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateFooter();
 				UpdateIsSwipeToRefreshEnabled();
 				UpdateFastScrollEnabled();
-
-
 			}
 		}
 
@@ -176,6 +174,7 @@ namespace Xamarin.Forms.Platform.Android
 			var position = Control.GetPositionForView(viewCell);
 			var id = Control.GetItemIdAtPosition(position);
 
+			viewCell.PerformHapticFeedback(FeedbackConstants.ContextClick);
 			_adapter.OnItemLongClick(Control, viewCell, position, id);
 		}
 


### PR DESCRIPTION
### Description of Change ###

ViewCells on Android which have TapGestures on Views in their content have to handle the LongPress gesture (for context actions) manually; the LongClickListener is cancelled out by the listener for the TapGesture. The LongPress handling worked fine when the View with the TapGesture totally filled the ViewCell. But when only part of the ViewCell was filled, the remaining section of the ViewCell triggered the LongPress incorrectly (on a single tap). This change fixes that issue.

### Bugs Fixed ###

- [60850 – [Android] ViewCell containing View with TapRecognizer shows ContextActions on every tap](https://bugzilla.xamarin.com/show_bug.cgi?id=60850)
- [[Android] ViewCell shows ContextActions on tap instead of long press · Issue #1331 · xamarin/Xamarin.Forms](https://github.com/xamarin/Xamarin.Forms/issues/1331) fixes #1331

### API Changes ###

None 

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
