### PR TITLE
[Core] AutoCommandExtension

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
@@ -35,42 +35,57 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void TestClickedvent ()
+		[TestCase(true)]
+		[TestCase(false)]
+		public void TestClickedvent (bool isEnabled)
 		{
-			var view = new Button ();
+			var view = new Button()
+			{
+				IsEnabled= isEnabled,
+			};
 
 			bool activated = false;
 			view.Clicked += (sender, e) => activated = true;
 
 			((IButtonController) view).SendClicked ();
 
-			Assert.True (activated);
+			Assert.True (activated == isEnabled ? true : false);
 		}
 
 		[Test]
-		public void TestPressedEvent ()
+		[TestCase(true)]
+		[TestCase(false)]
+		public void TestPressedEvent (bool isEnabled)
 		{
-			var view = new Button();
+			var view = new Button()
+			{
+				IsEnabled = isEnabled,
+			};
 
 			bool pressed = false;
 			view.Pressed += (sender, e) => pressed = true;
 
 			((IButtonController)view).SendPressed();
 
-			Assert.True(pressed);
+			Assert.True(pressed == isEnabled ? true : false);
 		}
 
 		[Test]
-		public void TestReleasedEvent ()
+		[TestCase(true)]
+		[TestCase(false)]
+		public void TestReleasedEvent (bool isEnabled)
 		{
-			var view = new Button();
+			var view = new Button()
+			{
+				IsEnabled = isEnabled,
+			};
 
 			bool released = false;
 			view.Released += (sender, e) => released = true;
 
 			((IButtonController)view).SendReleased();
 
-			Assert.True(released);
+			Assert.True(released == isEnabled ? true : false);
 		}
 
 		protected override Button CreateSource()
@@ -218,6 +233,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			AssertButtonContentLayoutsEqual(new Button.ButtonContentLayout(Button.ButtonContentLayout.ImagePosition.Bottom, 0), converter.ConvertFromInvariantString("Bottom, 0"));
 
 			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString(""));
+		}
+
+		[Test]
+		public void ButtonClickWhenCommandCanExecuteFalse()
+		{
+			bool invoked = false;
+			var button = new Button()
+			{
+				Command = new Command(() => invoked = true
+				, () => false),
+			};
+
+			(button as IButtonController)
+				?.SendClicked();
+			
+			Assert.False(invoked);
 		}
 
 		private void AssertButtonContentLayoutsEqual(Button.ButtonContentLayout layout1, object layout2)

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -113,20 +113,29 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendClicked()
 		{
-			Command?.Execute(CommandParameter);
-			Clicked?.Invoke(this, EventArgs.Empty);
+			if (IsEnabled == true)
+			{
+				Command?.Execute(CommandParameter);
+				Clicked?.Invoke(this, EventArgs.Empty);
+			}
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendPressed()
 		{
-			Pressed?.Invoke(this, EventArgs.Empty);
+			if (IsEnabled == true)
+			{
+				Pressed?.Invoke(this, EventArgs.Empty); 
+			}
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendReleased()
 		{
-			Released?.Invoke(this, EventArgs.Empty);
+			if (IsEnabled == true)
+			{
+				Released?.Invoke(this, EventArgs.Empty);
+			}
 		}
 
 		public FontAttributes FontAttributes

--- a/Xamarin.Forms.Xaml.UnitTests/AutoCommand.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/AutoCommand.xaml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+	xmlns:sys="clr-namespace:System;assembly=mscorlib"
+	x:Class="Xamarin.Forms.Xaml.UnitTests.AutoCommand">
+  <ContentView.Content>
+      <StackLayout>
+			<Label Text="Enable Button 1" />
+			<Switch IsToggled ="{Binding EnableButton1}"/>
+			<Label Text="Enable Button 2" />
+			<Switch IsToggled ="{Binding EnableButton2}"/>
+			<Button Command="{AutoCommand DoButton1}"
+					Text="Button 1"
+					x:Name="Button1"/>
+			<Button Command="{AutoCommand DoButton2}" 
+					CommandParameter="Button 2"
+					x:Name="Button2"/>
+			<Button Command="{AutoCommand DoAll}}"
+					x:Name="ButtonDoAll"/>
+			<Button Command="{AutoCommand InvalidMethod}"
+					x:Name="ButtonInvalid"/>
+		</StackLayout>
+  </ContentView.Content>
+</ContentView>

--- a/Xamarin.Forms.Xaml.UnitTests/AutoCommand.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/AutoCommand.xaml.cs
@@ -1,0 +1,302 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	partial class AutoCommand : ContentView
+	{
+		public AutoCommand()
+		{
+			InitializeComponent();
+		}
+
+		public AutoCommand(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		class Tests : Core.UnitTests.BaseTestFixture
+		{
+			[TestCaseSource(nameof(Command_Execution_Test_Data))]
+			public void Command_Execution(bool useCompiledXaml
+				, bool enableButton1
+				, bool enableButton2
+				, IEnumerable<string> expectedCallsStack)
+			{
+				var vm = new MockViewModel(0);
+
+				var layout = new AutoCommand(useCompiledXaml)
+				{
+					BindingContext = vm,
+				};
+
+				vm.EnableButton1 = enableButton1;
+				vm.EnableButton2 = enableButton2;
+
+				(layout.Button1 as IButtonController)
+					?.SendClicked();
+				(layout.Button2 as IButtonController)
+					?.SendClicked();
+				(layout.ButtonDoAll as IButtonController)
+					?.SendClicked();
+				(layout.ButtonInvalid as IButtonController)
+					?.SendClicked();
+
+				CollectionAssert.AreEqual(expectedCallsStack
+					, vm.CallsStack);
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void BindingContext_Changing(bool useCompiledXaml)
+			{
+				var layout = new AutoCommand(useCompiledXaml);
+
+				var vm1 = new MockViewModel(1)
+				{
+					EnableButton1 = true,
+				};
+
+				var vm2 = new MockViewModel(2)
+				{
+					EnableButton1 = true,
+				};
+
+				layout.BindingContext = vm1;
+
+				(layout.Button1 as IButtonController)
+					?.SendClicked();
+
+				Assert.True("VM1 Call DoButton1 with null" == vm1.CallsStack.LastOrDefault());
+
+				layout.BindingContext = vm2;
+
+				(layout.Button1 as IButtonController)
+					?.SendClicked();
+
+				Assert.True("VM2 Call DoButton1 with null" == vm2.CallsStack.LastOrDefault());
+
+				Assert.False("VM2 Call DoButton1 with null" == vm1.CallsStack.LastOrDefault());
+			}
+
+			static IEnumerable Command_Execution_Test_Data()
+			{
+				return Concatenate(
+					Command_Execution_Test_Data(useCompiledXaml:false),
+					Command_Execution_Test_Data(useCompiledXaml:true)
+					);					
+			}
+
+			static IEnumerable Command_Execution_Test_Data(bool useCompiledXaml)
+			{
+				yield return new object[]
+				{
+					useCompiledXaml,	// useCompiledXaml 
+					false,				// enableButton1
+					false,				// enableButton1
+					new string[]	    // expectedCallsStack
+					{
+						"VM0 Call CanDoButton1 with null",		// It's calling from Command BindigProperty ctor
+						"VM0 Call CanDoButton2 with Button 2",	// It's calling from Command BindigProperty ctor	
+						"VM0 Call CanDoAll with null",			// It's calling from Command BindigProperty ctor
+					}
+				};
+				yield return new object[]
+				{
+					useCompiledXaml,	// useCompiledXaml 
+					true,				// enableButton1
+					false,				// enableButton1
+					new string[]	    // expectedCallsStack
+					{
+						"VM0 Call CanDoButton1 with null",		// It's calling from Command BindigProperty ctor
+						"VM0 Call CanDoButton2 with Button 2",	// It's calling from Command BindigProperty ctor	
+						"VM0 Call CanDoAll with null",			// It's calling from Command BindigProperty ctor
+						"VM0 Set EnableButton1 with True",
+						"VM0 Call CanDoButton1 with null",
+						"VM0 Call CanDoAll with null",
+						"VM0 Call DoButton1 with null",
+					}
+				};
+				yield return new object[]
+				{
+					useCompiledXaml,	// useCompiledXaml 
+					false,				// enableButton1
+					true,				// enableButton1
+					new string[]	    // expectedCallsStack
+					{
+						"VM0 Call CanDoButton1 with null",		// It's calling from Command BindigProperty ctor
+						"VM0 Call CanDoButton2 with Button 2",	// It's calling from Command BindigProperty ctor	
+						"VM0 Call CanDoAll with null",			// It's calling from Command BindigProperty ctor
+						"VM0 Set EnableButton2 with True",
+						"VM0 Call CanDoButton2 with Button 2",
+						"VM0 Call CanDoAll with null",
+						"VM0 Call DoButton2 with Button 2",
+					}
+				};
+				yield return new object[]
+				{
+					useCompiledXaml,	// useCompiledXaml 
+					true,				// enableButton1
+					true,				// enableButton1
+					new string[]	    // expectedCallsStack
+					{
+						"VM0 Call CanDoButton1 with null",		// It's calling from Command BindigProperty ctor
+						"VM0 Call CanDoButton2 with Button 2",	// It's calling from Command BindigProperty ctor	
+						"VM0 Call CanDoAll with null",			// It's calling from Command BindigProperty ctor
+						"VM0 Set EnableButton1 with True",
+						"VM0 Call CanDoButton1 with null",
+						"VM0 Call CanDoAll with null",
+						"VM0 Set EnableButton2 with True",
+						"VM0 Call CanDoButton2 with Button 2",
+						"VM0 Call CanDoAll with null",
+						"VM0 Call DoButton1 with null",
+						"VM0 Call DoButton2 with Button 2",
+						"VM0 Call DoAll with null",
+					}
+				};
+			}
+		}
+
+		class MockViewModel : INotifyPropertyChanged
+		{
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			int _Id;
+			IList<string> _callsStack =
+				new List<string>();
+			public MockViewModel(int id)
+			{
+				_Id = id;
+			}
+
+			public IEnumerable<string> CallsStack
+			{
+				get { return _callsStack.ToArray(); }
+			}
+
+			public void ClearMessages()
+			{
+				_callsStack.Clear();
+			}
+
+			bool _enableButton1;
+			public bool EnableButton1
+			{
+				get { return _enableButton1; }
+				set
+				{
+					if (_enableButton1 == value)
+						return;
+					_enableButton1 = value;
+					_callsStack
+						.Add($"VM{_Id} Set {nameof(EnableButton1)} with {value}");
+					OnPropertyChanged();
+				}
+			}
+
+			bool _enableButton2;
+			public bool EnableButton2
+			{
+				get { return _enableButton2; }
+				set
+				{
+					if (_enableButton2 == value)
+						return;
+					_enableButton2 = value;
+					_callsStack
+						.Add($"VM{_Id} Set {nameof(EnableButton2)} with {value}");
+					OnPropertyChanged();
+				}
+			}
+
+			[DependedOn(nameof(EnableButton1))]
+			bool CanDoButton1(object parameter)
+			{
+				_callsStack
+					.Add($"VM{_Id} Call {nameof(CanDoButton1)} with {parameter ?? "null"}");
+				return EnableButton1;
+			}
+
+			void DoButton1(object parameter)
+			{
+				_callsStack
+					.Add($"VM{_Id} Call {nameof(DoButton1)} with {parameter ?? "null"}");
+
+			}
+
+			[DependedOn(nameof(EnableButton1))]
+			bool CanDoButton1(string parameter)
+			{
+				_callsStack
+					.Add($"VM{_Id} Call {nameof(CanDoButton1)} with string {parameter ?? "null"}");
+				return EnableButton1;
+			}
+
+			void DoButton1(string parameter)
+			{
+				_callsStack
+					.Add($"VM{_Id} Call {nameof(DoButton1)} with string {parameter ?? "null"}");
+			}
+
+
+			[DependedOn(nameof(EnableButton2))]
+			bool CanDoButton2(object parameter)
+			{
+				_callsStack
+					.Add($"VM{_Id} Call {nameof(CanDoButton2)} with {parameter ?? "null"}");
+				return EnableButton2;
+			}
+
+			void DoButton2(object parameter)
+			{
+				_callsStack
+					.Add($"VM{_Id} Call {nameof(DoButton2)} with {parameter ?? "null"}");
+
+			}
+
+			[DependedOn(nameof(EnableButton1))]
+			[DependedOn(nameof(EnableButton2))]
+			bool CanDoAll(object parameter)
+			{
+				_callsStack
+					.Add($"VM{_Id} Call {nameof(CanDoAll)} with {parameter ?? "null"}");
+
+				return EnableButton1 && EnableButton2;
+			}
+
+			void DoAll(object parameter)
+			{
+				_callsStack
+					.Add($"VM{_Id} Call {nameof(DoAll)} with {parameter ?? "null"}");
+			}
+
+
+			protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
+		}
+
+		static IEnumerable Concatenate(params IEnumerable[] enumerables)
+		{
+			if (enumerables == null)
+			{
+				throw new ArgumentNullException(nameof(enumerables));
+			}
+
+			foreach (var enumerator in enumerables.Select(e=>e.GetEnumerator()))
+			{
+				while (enumerator.MoveNext())
+				{
+					yield return enumerator.Current;
+				} 
+			}	
+		}
+
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -1044,5 +1044,12 @@
   <ItemGroup>
     <Folder Include="css\" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>         
+    <EmbeddedResource Include="AutoCommand.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <Compile Include="AutoCommand.xaml.cs">
+      <DependentUpon>AutoCommand.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Xaml/DependedOnAttribute.cs
+++ b/Xamarin.Forms.Xaml/DependedOnAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Xamarin.Forms.Xaml
+{
+	[AttributeUsage(AttributeTargets.Method
+		, Inherited = true
+		, AllowMultiple = true)]
+	sealed public class DependedOnAttribute : Attribute
+	{
+
+		public DependedOnAttribute(string propertyName)
+		{
+			PropertyName = propertyName;
+		}
+
+		public string PropertyName { get; private set; }
+	}
+}

--- a/Xamarin.Forms.Xaml/MarkupExtensions/AutoCommandExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/AutoCommandExtension.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Windows.Input;
+
+namespace Xamarin.Forms.Xaml
+{
+	[ContentProperty("Command")]
+	public sealed class AutoCommandExtension : IMarkupExtension<ICommand>
+	{
+		static readonly ICommand EmptyCommand =
+			new Command(() => { });
+
+		PropertyChangedEventHandler invalidateCanExecuteHandler;
+
+		[DefaultValue(null)]
+		public string Command { get; set; }
+
+		[DefaultValue(null)]
+		public object Source { get; set; }
+
+		ICommand IMarkupExtension<ICommand>.ProvideValue(IServiceProvider serviceProvider)
+		{
+			BindableObject target = null;
+			BindableProperty targetProperty = null;
+			if (string.IsNullOrWhiteSpace(Command) == false
+				&& this.TryGetTargetItems(serviceProvider, out target, out targetProperty)
+				&& targetProperty.ReturnType == typeof(ICommand))
+			{
+				OnDataContextChanged(target, targetProperty);
+
+			}
+			return EmptyCommand;
+		}
+
+		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
+		{
+			return (this as IMarkupExtension<ICommand>).ProvideValue(serviceProvider);
+		}
+
+		private bool TryGetTargetItems(IServiceProvider provider, out BindableObject target, out BindableProperty dp)
+		{
+			return this.TryGetTargetItems<BindableObject>(provider, out target, out dp);
+		}
+
+		private void OnDataContextChanged(BindableObject target, BindableProperty targetProperty)
+		{
+			//CleanUp
+			target.PropertyChanging += (s, e) =>
+			{
+				if (e.PropertyName == "BindingContext")
+				{
+					OnUnregisterCommand(target
+						, targetProperty
+						, target.BindingContext);
+				}
+			};
+
+			//Setup
+			target.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == "BindingContext")
+				{
+					OnRegisterCommand(target
+						, targetProperty
+						, target.BindingContext);
+				}
+			};
+		}
+
+		void OnUnregisterCommand(BindableObject target, BindableProperty targetProperty, object oldDataContext)
+		{
+			if (oldDataContext is INotifyPropertyChanged inpc)
+			{
+				inpc.PropertyChanged -= invalidateCanExecuteHandler;
+				invalidateCanExecuteHandler = null;
+			} 
+			(target.GetValue(targetProperty) as Command)
+				?.ChangeCanExecute();
+			target.SetValue(targetProperty, EmptyCommand);
+		}
+
+		void OnRegisterCommand(BindableObject target, BindableProperty targetProperty, object newDataContext)
+		{
+			if (string.IsNullOrWhiteSpace(this.Command) == false)
+			{
+				//Search dataContext 
+				var methodPath = this.Command;
+				var nestedPath = methodPath
+					.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+				var dataContext = Source ?? newDataContext;
+				var pathLevel = 0;
+
+				while (dataContext != null && pathLevel < nestedPath.Length - 1)
+				{
+					var currentProperty = nestedPath[pathLevel];
+					var dataContextType = dataContext.GetType();
+					var pi = dataContextType.GetProperty(currentProperty);
+					if (pi == null)
+					{
+						dataContext = null;
+						break;
+					}
+					dataContext = pi.GetValue(dataContext, null);
+					pathLevel++;
+					methodPath = nestedPath[pathLevel];
+				}
+
+				if (dataContext == null)
+				{
+					//TODO: Throw Exception???
+					return;
+				}
+
+				// Search Execution Method
+				var executeMethod = GetMethod(dataContext
+					, methodPath);
+
+				if (executeMethod == null)
+				{
+					//TODO: Throw Exception???
+					return;
+				}
+
+				//Search CanExecuteMethod
+				var canExecuteMethod = GetMethod(dataContext
+					, "Can" + methodPath
+					, m => m.ReturnType == typeof(bool));
+
+				Command command = null;
+				var onExecute = CreateExecute(dataContext,
+					executeMethod);
+				if (canExecuteMethod == null)
+				{
+					command = new Command(onExecute);
+				}
+				else
+				{
+					var onCanExecute = CreateCanExecute(dataContext,
+						canExecuteMethod);
+					command = new Command(onExecute
+						, onCanExecute);
+
+					// Check CanExcute Dependecy for invlidated
+					if (dataContext is INotifyPropertyChanged inpc)
+					{
+						var dependencyProperties = canExecuteMethod
+							.GetCustomAttributes(typeof(DependedOnAttribute), true)
+							.OfType<DependedOnAttribute>()
+							.Select(x => x.PropertyName)
+							.ToArray();
+						invalidateCanExecuteHandler = (s, e) =>
+							{
+								if (string.IsNullOrWhiteSpace(e.PropertyName)
+									|| dependencyProperties.Contains(e.PropertyName))
+								{
+									command.ChangeCanExecute();
+								}
+							};
+						inpc.PropertyChanged += invalidateCanExecuteHandler;
+					}
+
+				}
+				target.SetValue(targetProperty, command);
+			}
+		}
+
+		private bool TryGetTargetItems<T>(IServiceProvider provider, out T target, out BindableProperty dp)
+			where T : BindableObject
+		{
+			target = null;
+			dp = null;
+			if (provider == null) return false;
+
+			//create a binding and assign it to the target
+			var service = provider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+			if (service == null) return false;
+
+			//we need dependency objects / properties
+			target = service.TargetObject as T;
+			dp = service.TargetProperty as BindableProperty;
+			return target != null && dp != null;
+		}
+
+		static System.Reflection.MethodInfo GetMethod(object dataContext
+			, string methodPath
+			, Func<System.Reflection.MethodInfo, bool> filter = null)
+		{
+			if (filter == null)
+			{
+				filter = m => m.Name == methodPath
+					&& m.GetParameters().Length == 1
+					&& m.GetParameters()[0].ParameterType == typeof(object);
+			}
+			else
+			{
+				var t = filter;
+				filter = m => m.Name == methodPath
+					&& m.GetParameters().Length == 1
+					&& m.GetParameters()[0].ParameterType == typeof(object)
+					&& t(m);
+			}
+			return dataContext.GetType()
+				.GetMethods(System.Reflection.BindingFlags.Public
+					| System.Reflection.BindingFlags.NonPublic
+					| System.Reflection.BindingFlags.Instance)
+				.FirstOrDefault(filter);
+		}
+
+		static Action<object> CreateExecute(object target
+			, System.Reflection.MethodInfo method)
+		{
+
+			var parameter = Expression.Parameter(typeof(object), "parameter");
+
+			var instance = Expression.Convert
+			(
+				Expression.Constant(target),
+				method.DeclaringType
+			);
+
+			var call = Expression.Call
+			(
+				instance,
+				method,
+				parameter
+			);
+
+			return Expression
+				.Lambda<Action<object>>(call, parameter)
+				.Compile();
+		}
+
+		static Func<object, bool> CreateCanExecute(object target
+			, System.Reflection.MethodInfo method)
+		{
+			var parameter = Expression.Parameter(typeof(object), "parameter");
+			var instance = Expression.Convert
+			(
+				Expression.Constant(target),
+				method.DeclaringType
+			);
+			var call = Expression.Call
+			(
+				instance,
+				method,
+				parameter
+			);
+			return Expression
+				.Lambda<Func<object, bool>>(call, parameter)
+				.Compile();
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/MarkupExtensions/AutoCommandExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/AutoCommandExtension.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Xaml
 			{
 				inpc.PropertyChanged -= invalidateCanExecuteHandler;
 				invalidateCanExecuteHandler = null;
-			} 
+			}
 			(target.GetValue(targetProperty) as Command)
 				?.ChangeCanExecute();
 			target.SetValue(targetProperty, EmptyCommand);
@@ -137,7 +137,7 @@ namespace Xamarin.Forms.Xaml
 					command = new Command(onExecute
 						, onCanExecute);
 
-					// Check CanExcute Dependecy for invlidated
+					// Check CanExcute Dependecy for invalidated
 					if (dataContext is INotifyPropertyChanged inpc)
 					{
 						var dependencyProperties = canExecuteMethod

--- a/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/AutoCommandExtension.xml
+++ b/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/AutoCommandExtension.xml
@@ -1,0 +1,116 @@
+<Type Name="AutoCommandExtension" FullName="Xamarin.Forms.Xaml.AutoCommandExtension">
+  <TypeSignature Language="C#" Value="public sealed class AutoCommandExtension : Xamarin.Forms.Xaml.IMarkupExtension&lt;System.Windows.Input.ICommand&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit AutoCommandExtension extends System.Object implements class Xamarin.Forms.Xaml.IMarkupExtension, class Xamarin.Forms.Xaml.IMarkupExtension`1&lt;class System.Windows.Input.ICommand&gt;" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Xaml</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Xamarin.Forms.Xaml.IMarkupExtension&lt;System.Windows.Input.ICommand&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.ContentProperty("Command")</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>For internal use by the XAML infrastructure.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public AutoCommandExtension ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>For internal use by the XAML infrastructure.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Command">
+      <MemberSignature Language="C#" Value="public string Command { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string Command" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Set or Get the name of method to discovery in viewmodel.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Source">
+      <MemberSignature Language="C#" Value="public object Source { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance object Source" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>For internal use by the XAML infrastructure.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Xaml.IMarkupExtension.ProvideValue">
+      <MemberSignature Language="C#" Value="object IMarkupExtension.ProvideValue (IServiceProvider serviceProvider);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance object Xamarin.Forms.Xaml.IMarkupExtension.ProvideValue(class System.IServiceProvider serviceProvider) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.4.0.0</AssemblyVersion>
+        <AssemblyVersion>1.5.0.0</AssemblyVersion>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="serviceProvider" Type="System.IServiceProvider" />
+      </Parameters>
+      <Docs>
+        <param name="serviceProvider">For internal use by the XAML infrastructure.</param>
+        <summary>For internal use by the XAML infrastructure.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Xamarin.Forms.Xaml.IMarkupExtension&lt;System.Windows.Input.ICommand&gt;.ProvideValue">
+      <MemberSignature Language="C#" Value="System.Windows.Input.ICommand IMarkupExtension&lt;BindingBase&gt;.ProvideValue (IServiceProvider serviceProvider);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class System.Windows.Input.ICommand Xamarin.Forms.Xaml.IMarkupExtension&lt;System.Windows.Input.ICommand&gt;.ProvideValue(class System.IServiceProvider serviceProvider) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.4.0.0</AssemblyVersion>
+        <AssemblyVersion>1.5.0.0</AssemblyVersion>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.Input.ICommand</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="serviceProvider" Type="System.IServiceProvider" />
+      </Parameters>
+      <Docs>
+        <param name="serviceProvider">For internal use by the XAML infrastructure.</param>
+        <summary>For internal use by the XAML infrastructure.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/DependedOnAttribute.xml
+++ b/docs/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml/DependedOnAttribute.xml
@@ -1,0 +1,53 @@
+<Type Name="DependedOnAttribute" FullName="Xamarin.Forms.Xaml.DependedOnAttribute">
+  <TypeSignature Language="C#" Value="public sealed class DependedOnAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit DependedOnAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Xaml</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=true, Inherited=true)</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>This attribute is applied to the ViewModel method with this signature : bool Can [CommandName] (object parameter). Tells at <see cref="T:Xamarin.Forms.Xaml.AutoCommandExtension" /> to re-evaluate the decorated method when the indicated ViewModel property changes.</summary>
+    <remarks>The ViewModel must implement <see cref="T:System.ComponentModel.INotifyPropertyChanged" />.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public DependedOnAttribute (string propertyName);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string propertyName) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="propertyName" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="propertyName">The property name of the ViewModel.</param>
+        <summary>Set the name of the properties that execute the decorated method when property changes.</summary>
+        <remarks>if is null or String.Empty any changes of properties of ViewModel running decorated method.</remarks>
+      </Docs>
+    </Member>
+	<Member MemberName="PropertyName">
+      <MemberSignature Language="C#" Value="public string PropertyName { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string PropertyName" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Get the name of the properties that execute the decorated method when property changes.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Xaml/index.xml
+++ b/docs/Xamarin.Forms.Xaml/index.xml
@@ -73,7 +73,9 @@
   <Types>
     <Namespace Name="Xamarin.Forms.Xaml">
       <Type Name="ArrayExtension" Kind="Class" />
+      <Type Name="AutoCommandExtension" Kind="Class" />	  
       <Type Name="BindingExtension" Kind="Class" />
+	  <Type Name="DependedOnAttribute" Kind="Class" />
       <Type Name="DynamicResourceExtension" Kind="Class" />
       <Type Name="Extensions" Kind="Class" />
       <Type Name="NullExtension" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###

AutoCommand Extension allows to simplify the use of the Command through conventions, making the ViewModel more readable.

AutoCommand searches on viewModel the methods that have the following signature:

bool Can[CommadName] (object parameter); 

void [CommandName](object parameter)

where [CommandName] is the value of the Commad parameter of AutoCommand

Example:
```xml
  ...
  <StackLayout>
        <Label Text="Enable Button 1" />
	<Switch IsToggled ="{Binding EnableExecute}"/>
	<Label Text="Enable Button 2" />
        <Button Command="{AutoCommand Do}"
    		      Text="Execute"/>
   </StackLayout>
  ...
```

```csharp
class ViewModel : INotifyPropertyChanged
{
	public event PropertyChangedEventHandler PropertyChanged;
	bool  _enableExecute;
	public bool  EnableExecute
	{
		get { return _enableExecute; }
		set
		{
			if (_enableExecute == value)
				return;
			__enableExecute = value;
			OnPropertyChanged();
		}
	}

	[DependedOn(nameof(EnableExecute))]
	bool CanDo(object parameter)
	{
		return EnableExecute;
	}

	void Do(object parameter)
	{

	}
	protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
	{
		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
	}
}
```
### Bugs Fixed ###

none

### API Changes ###

List all API changes here:

Added:
 -AutoCommandExtension 
 -DependedOn

### Behavioral Changes ###

none

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

  