### PR TITLE
[Tizen] Add support for hint flags for tizen backend

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Flags.cs
+++ b/Xamarin.Forms.Platform.Tizen/Flags.cs
@@ -1,0 +1,7 @@
+namespace Xamarin.Forms
+{
+	internal static class Flags
+	{
+
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -133,6 +133,19 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 		}
 
+		static IReadOnlyList<string> s_flags;
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new List<string>().AsReadOnly());
+
+		public static void SetFlags(params string[] flags)
+		{
+			if (IsInitialized)
+			{
+				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
+			}
+
+			s_flags = flags.ToList().AsReadOnly();
+		}
+
 		public static void SetTitleBarVisibility(TizenTitleBarVisibility visibility)
 		{
 			TitleBarVisibility = visibility;
@@ -178,6 +191,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 
 			Device.Info = new Forms.TizenDeviceInfo();
+			Device.SetFlags(s_flags);
 
 			if (!Forms.IsInitialized)
 			{


### PR DESCRIPTION
### Description of Change ###

Add support for backwards-compatibility hint flags for Tizen backend. This PR is extension of #1074 and #1181.

### Bugs Fixed ###

None

### API Changes ###

Added:
 - `public static void SetFlags(params string[] flags)`

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
