### PR TITLE
[iOS] Added icon to context menu actions instead of text **Behavior change**

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -407,9 +407,12 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				button.SetBackgroundImage(DestructiveBackground, UIControlState.Normal);
 
-			button.SetTitle(item.Text, UIControlState.Normal);
-			button.TitleEdgeInsets = new UIEdgeInsets(0, 15, 0, 15);
+			if (item.Icon != null)
+				button.SetImage(new UIImage(item.Icon.File), UIControlState.Normal);
+			else
+				button.SetTitle(item.Text, UIControlState.Normal);
 
+			button.TitleEdgeInsets = new UIEdgeInsets(0, 15, 0, 15);
 			button.Enabled = item.IsEnabled;
 
 			return button;


### PR DESCRIPTION
### Description of Change ###
Changed context action menu of ViewCells to Icons like it is in native apps and on Android instead of Text.

### Bugs Fixed ###

- None

### API Changes ###

- None

### Behavioral Changes ###
Instead of text the icon will appear in context actions like it is on Android.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
