### PR TITLE
[iOS] Fix for assigning wrong element type to a recycled renderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1414.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1414.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1414, "InvalidCastException when scrolling and refreshing TableView", PlatformAffected.iOS)]
+	public class Issue1414 : TestContentPage
+	{
+		ViewCell BuildCell(int sectionIndex, int cellIndex)
+		{
+			var grid = new Grid
+			{
+				ColumnDefinitions = {
+					new ColumnDefinition { Width = GridLength.Star },
+					new ColumnDefinition { Width = GridLength.Star }
+				},
+				AutomationId = $"Grid:{sectionIndex}:{cellIndex}"
+			};
+
+			if (cellIndex % 2 == 0)
+			{
+				grid.AddChild(new Label { Text = $"Label {cellIndex}" }, 0, 0);
+				grid.AddChild(new Label { Text = $"Label {cellIndex}" }, 1, 0);
+				grid.BackgroundColor = Color.Fuchsia;
+			}
+			else
+			{
+				grid.AddChild(new Label { Text = $"Label {cellIndex}" }, 0, 0);
+				grid.AddChild(new Entry { Text = $"Entry {cellIndex}" }, 1, 0);
+				grid.BackgroundColor = Color.Yellow;
+			}
+
+			return new ViewCell
+			{
+				View = grid,
+				AutomationId = $"Cell:{sectionIndex}:{cellIndex}"
+			};
+		}
+
+		protected override void Init()
+		{
+			var tableView = new Xamarin.Forms.TableView
+			{
+				HasUnevenRows = true,
+				Intent = TableIntent.Form,
+				Root = new TableRoot(),
+				AutomationId = "TableView"
+			};
+
+			for (int sectionIndex = 0; sectionIndex < 5; sectionIndex++)
+			{
+				var section = new TableSection($"Section {sectionIndex}");
+
+				for (int cellIndex = 0; cellIndex < 25; cellIndex++)
+				{
+					section.Add(BuildCell(sectionIndex, cellIndex));
+				}
+
+				tableView.Root.Add(section);
+			}
+
+			Content = tableView;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1414Test()
+		{
+			RunningApp.Screenshot("Start G1414");
+			RunningApp.WaitForElement(q => q.Marked("TableView"));
+			RunningApp.ScrollDownTo("Grid:4:24", strategy: ScrollStrategy.Gesture, swipeSpeed: 1000, swipePercentage: 0.9);
+			RunningApp.Screenshot("Scrolled to end without crashing!");
+			RunningApp.ScrollUpTo("Grid:0:0", strategy: ScrollStrategy.Gesture, swipeSpeed: 1000, swipePercentage: 0.9);
+			RunningApp.Screenshot("Scrolled to top without crashing!");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1414.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1414.cs
@@ -24,26 +24,25 @@ namespace Xamarin.Forms.Controls.Issues
 					new ColumnDefinition { Width = GridLength.Star },
 					new ColumnDefinition { Width = GridLength.Star }
 				},
-				AutomationId = $"Grid:{sectionIndex}:{cellIndex}"
+				AutomationId = $"Row-{sectionIndex}-{cellIndex}"
 			};
 
 			if (cellIndex % 2 == 0)
 			{
-				grid.AddChild(new Label { Text = $"Label {cellIndex}" }, 0, 0);
-				grid.AddChild(new Label { Text = $"Label {cellIndex}" }, 1, 0);
+				grid.AddChild(new Label { Text = $"Cell {sectionIndex}-{cellIndex}" }, 0, 0);
+				grid.AddChild(new Label { Text = $"Label" }, 1, 0);
 				grid.BackgroundColor = Color.Fuchsia;
 			}
 			else
 			{
-				grid.AddChild(new Label { Text = $"Label {cellIndex}" }, 0, 0);
-				grid.AddChild(new Entry { Text = $"Entry {cellIndex}" }, 1, 0);
+				grid.AddChild(new Label { Text = $"Cell {sectionIndex}-{cellIndex}" }, 0, 0);
+				grid.AddChild(new Entry { Text = $"Entry" }, 1, 0);
 				grid.BackgroundColor = Color.Yellow;
 			}
 
 			return new ViewCell
 			{
 				View = grid,
-				AutomationId = $"Cell:{sectionIndex}:{cellIndex}"
 			};
 		}
 
@@ -78,9 +77,11 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.Screenshot("Start G1414");
 			RunningApp.WaitForElement(q => q.Marked("TableView"));
-			RunningApp.ScrollDownTo("Grid:4:24", strategy: ScrollStrategy.Gesture, swipeSpeed: 1000, swipePercentage: 0.9);
+
+			var tableFrame = RunningApp.Query(q => q.Marked("TableView"))[0].Rect;
+			RunningApp.ScrollForElement("* marked:'Row-4-24'", new Drag(tableFrame, Drag.Direction.BottomToTop, Drag.DragLength.Long));
 			RunningApp.Screenshot("Scrolled to end without crashing!");
-			RunningApp.ScrollUpTo("Grid:0:0", strategy: ScrollStrategy.Gesture, swipeSpeed: 1000, swipePercentage: 0.9);
+			RunningApp.ScrollForElement("* marked:'Row-0-0'", new Drag(tableFrame, Drag.Direction.TopToBottom, Drag.DragLength.Long));
 			RunningApp.Screenshot("Scrolled to top without crashing!");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -377,6 +377,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1329.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1384.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1400.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1414.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1461.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1497.xaml.cs">
       <DependentUpon>Issue1497.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -149,6 +149,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (oldElement == newElement)
 				return;
 
+
+			_element = newElement;
+
 			if (oldElement != null)
 			{
 				oldElement.ChildAdded -= OnChildAdded;
@@ -174,8 +177,6 @@ namespace Xamarin.Forms.Platform.MacOS
 					}
 				}
 			}
-
-			_element = newElement;
 
 			if (newElement != null)
 			{


### PR DESCRIPTION
### Description of Change ###

Fixes an issue in the iOS `VisualElementPackager` which allows recycled renderers to be assigned elements of the wrong type. The regression was caused by [this change](https://github.com/xamarin/Xamarin.Forms/pull/1136/files#diff-e7ceab256a6b8ec5ca5f9ddc81304defR16) which uses `_element` rather than `Renderer.Element` to look for child elements. When a renderer's element changes, `VisualElementPackager.SetElement` could [update the render pool](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs#L160) before it [assigns `_element`](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs#L178) which causes the wrong children to be compared.

This PR assigns `_element` earlier in `VisualElementPackager.SetElement` which ensures we're using the current element before updating the renderer pool.

I don't know the extent of the issue since the `VisualElementPackager` is pretty low level, but so far I've only seen it when scrolling or reloading a large table view. The attached test case uses a `TableView` containing alternating `ViewCell[Grid[Label,Label]]` and `ViewCell[Grid[Label,Entry]]` cells. Scrolling quickly through the table would inevitably crash when a `LabelRenderer` is assigned an `Entry`.

### Bugs Fixed ###
Fixes #1414
Fixes #1424 

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###

- [x] Has test
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
