### PR TITLE
Rename ConvertExtensions to ColorExtensions and change access to public

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/ColorExtensions.cs
@@ -1,9 +1,8 @@
-﻿using System.Drawing;
-using Windows.UI.Xaml.Media;
+﻿using Windows.UI.Xaml.Media;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	internal static class ConvertExtensions
+	public static class ColorExtensions
 	{
 		public static Brush ToBrush(this Color color)
 		{

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -179,7 +179,7 @@
     <Compile Include="CellControl.cs" />
     <Compile Include="CollapseWhenEmptyConverter.cs" />
     <Compile Include="ColorConverter.cs" />
-    <Compile Include="ConvertExtensions.cs" />
+    <Compile Include="ColorExtensions.cs" />
     <Compile Include="DatePickerRenderer.cs" />
     <Compile Include="DefaultRenderer.cs" />
     <Compile Include="EditorRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###
Color extensions to convert a Forms Color to a UWP color / brush are not accessible since the class is marked as internal instead of public. I also renamed the class to ColorExtensions to be consistent with all other platforms.

### Bugs Fixed ###
Could not use ToWindowsColor or ToBrush in UWP Forms renderers.

### API Changes ###

List all API changes here (or just put None), example:

Changed:
 - internal static class ConvertExtensions => public static class ColorExtensions

### Behavioral Changes ###

### PR Checklist ###
I don't think this requires tests?

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
