### PR TITLE
[iOS] ViewDidLayoutSubviews after removing page fixes #1426

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1426.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1426.cs
@@ -15,16 +15,14 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			Children.Add(new NavigationPage(new HomePage()) { Title = "Home" });
-			Children.Add(new NavigationPage(new ContentPage { Title = "Fixes", Content = new Label() { Text = "coffee.png" } }) { Title = "Fixes" });
-			CurrentPage = Children.Where(x => x.Title == "Home").FirstOrDefault();
-
+			Children.Add(new NavigationPage(new HomePage()) { Title = "Home", BarBackgroundColor = Color.Red }) ;
 		}
 
 		class HomePage : ContentPage
 		{
 			public HomePage()
 			{
+				Title = "Home";
 				var grd = new Grid { BackgroundColor = Color.Brown };
 				grd.RowDefinitions.Add(new RowDefinition());
 				grd.RowDefinitions.Add(new RowDefinition());
@@ -46,8 +44,8 @@ namespace Xamarin.Forms.Controls.Issues
 							Content = btnPop,
 							BackgroundColor = Color.Yellow
 						};
-						NavigationPage.SetHasNavigationBar(page, false); //This breaks layout when you pop!
-
+						//This breaks layout when you pop!
+						NavigationPage.SetHasNavigationBar(page, false); 
 						await Navigation.PushAsync(page);
 					})
 				};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1426.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1426.cs
@@ -1,0 +1,79 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 99991426, "SetHasNavigationBar screen height wrong", PlatformAffected.iOS)]
+	public class Issue1426 : TestTabbedPage
+	{
+		protected override void Init()
+		{
+			Children.Add(new NavigationPage(new HomePage()) { Title = "Home" });
+			Children.Add(new NavigationPage(new ContentPage { Title = "Fixes", Content = new Label() { Text = "coffee.png" } }) { Title = "Fixes" });
+			CurrentPage = Children.Where(x => x.Title == "Home").FirstOrDefault();
+
+		}
+
+		class HomePage : ContentPage
+		{
+			public HomePage()
+			{
+				var grd = new Grid { BackgroundColor = Color.Brown };
+				grd.RowDefinitions.Add(new RowDefinition());
+				grd.RowDefinitions.Add(new RowDefinition());
+				grd.RowDefinitions.Add(new RowDefinition());
+
+				var boxView = new BoxView { BackgroundColor = Color.Blue };
+				grd.Children.Add(boxView, 0, 0);
+				var btn = new Button()
+				{
+					BackgroundColor = Color.Pink,
+					Text = "NextButtonID",
+					AutomationId ="NextButtonID",
+					Command = new Command(async () =>
+					{
+						var btnPop = new Button { Text = "PopButtonId",AutomationId ="PopButtonId", Command = new Command(async () => await Navigation.PopAsync()) };
+						var page = new ContentPage
+						{
+							Title = "Detail",
+							Content = btnPop,
+							BackgroundColor = Color.Yellow
+						};
+						NavigationPage.SetHasNavigationBar(page, false); //This breaks layout when you pop!
+
+						await Navigation.PushAsync(page);
+					})
+				};
+
+				grd.Children.Add(btn, 0, 1);
+				var image = new Image() { Source = "coffee.png",AutomationId ="CoffeeImageId", BackgroundColor = Color.Yellow };
+				image.VerticalOptions = LayoutOptions.End;
+				grd.Children.Add(image, 0, 2);
+				Content = grd;
+
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Github1426Test ()
+		{
+			RunningApp.Screenshot ("You can see the coffe mug");
+			RunningApp.WaitForElement (q => q.Marked ("CoffeeImageId"));
+			RunningApp.WaitForElement (q => q.Marked ("NextButtonID"));
+			RunningApp.Tap (q => q.Marked ("NextButtonID"));
+			RunningApp.WaitForElement (q => q.Marked ("PopButtonId"));
+			RunningApp.Tap (q => q.Marked ("PopButtonId"));
+			RunningApp.WaitForElement (q => q.Marked ("CoffeeImageId"));
+			RunningApp.Screenshot ("Coffe mug Image is still there on the bottom");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -635,6 +635,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58779.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51825.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31688.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1426.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -326,6 +326,7 @@ namespace Xamarin.Forms.Platform.iOS
 			poppedViewController.Dispose();
 
 			UpdateToolBarVisible();
+			ViewDidLayoutSubviews();
 			return actuallyRemoved;
 		}
 
@@ -713,7 +714,6 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				try
 				{
-
 					var source = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(masterDetailPage.Master.Icon);
 					var icon = await source.LoadImageAsync(masterDetailPage.Master.Icon);
 					containerController.NavigationItem.LeftBarButtonItem = new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, handler);


### PR DESCRIPTION
### Description of Change ###

The issue is related by ViewDidLayoutSubviews run before the CurrentPage is set. This method is normally called by the OS, but we update the stack asynchrony.  That means when for example we are checking if the CurrentPage has a NavigationPage is still checking the previous page, when CurrentPage is updated this code was not running. We not force to run when a page is removed. 

### Bugs Fixed ###

- fixes #1426 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
  