### PR TITLE
[UWP] Check LockApplicationHost/assigned access on IsInvokeRequired

### DIFF
--- a/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Core;
+using Windows.ApplicationModel.LockScreen;
 using Windows.Security.Cryptography;
 using Windows.Security.Cryptography.Core;
 using Windows.Storage;
@@ -112,7 +113,13 @@ namespace Xamarin.Forms.Platform.UWP
 			return new WindowsIsolatedStorage(ApplicationData.Current.LocalFolder);
 		}
 
-		public bool IsInvokeRequired => !CoreApplication.MainView.CoreWindow.Dispatcher.HasThreadAccess;
+		// Per https://docs.microsoft.com/en-us/windows-hardware/drivers/partnerapps/create-a-kiosk-app-for-assigned-access:
+		// "Each view or window has its own dispatcher. In assigned access mode, you should not use the MainView dispatcher, 
+		// instead you should use the CurrentView dispatcher." Checking to see if this isn't null (i.e. the current window is
+		// running above lock) calls through GetCurrentView(), and otherwise through MainView.
+		public bool IsInvokeRequired => LockApplicationHost.GetForCurrentView() != null
+			? !CoreApplication.GetCurrentView().Dispatcher.HasThreadAccess
+			: !CoreApplication.MainView.CoreWindow.Dispatcher.HasThreadAccess;
 
 		public string RuntimePlatform => Device.UWP;
 


### PR DESCRIPTION
### Description of Change ###

An issue exists where if a user is running an app in assigned access (kiosk) mode, calling DisplayAlert causes the application to crash. This is due to the current call on `IsInvokeRequired` checking `CoreApplication.MainView`; per the [MSDN docs](https://docs.microsoft.com/en-us/windows-hardware/drivers/partnerapps/create-a-kiosk-app-for-assigned-access), it is instructed that you use `CurrentView` instead:

> Each view or window has its own dispatcher. In assigned access mode, you should not use the MainView dispatcher, instead you should use the CurrentView dispatcher.

A check on `IsInvokeRequired` was made to see if `LockApplicationHost.GetForCurrentView()` is null. If it is, then the current window is not running above lock (i.e. in the assigned access/kiosk mode) and  `!CoreApplication.GetCurrentView().Dispatcher.HasThreadAccess` is used. Otherwise, we use the original value of `!CoreApplication.MainView.CoreWindow.Dispatcher.HasThreadAccess` as we have been.

Testing against the assigned access mode is a bit tricky as it requires setting up a separate user with the specific app set to run on login.

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60204

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
