### PR TITLE
[CSS] Apply StyleSheets through Cells

### DIFF
--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -394,6 +394,7 @@ namespace Xamarin.Forms
 		protected virtual void OnParentSet()
 		{
 			ParentSet?.Invoke(this, EventArgs.Empty);
+			ApplyStyleSheetsOnParentSet();
 		}
 
 		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
@@ -430,7 +431,10 @@ namespace Xamarin.Forms
 
 		internal virtual void OnParentResourcesChanged(object sender, ResourcesChangedEventArgs e)
 		{
-			OnParentResourcesChanged(e.Values);
+			if (e == ResourcesChangedEventArgs.StyleSheets)
+				ApplyStyleSheetsOnParentSet();
+			else
+				OnParentResourcesChanged(e.Values);
 		}
 
 		internal virtual void OnParentResourcesChanged(IEnumerable<KeyValuePair<string, object>> values)

--- a/Xamarin.Forms.Core/Element_StyleSheets.cs
+++ b/Xamarin.Forms.Core/Element_StyleSheets.cs
@@ -32,5 +32,23 @@ namespace Xamarin.Forms
 		}
 
 		IStyleSelectable IStyleSelectable.Parent => Parent;
+
+		//on parent set, or on parent stylesheet changed, reapply all
+		void ApplyStyleSheetsOnParentSet()
+		{
+			var parent = Parent;
+			if (parent == null)
+				return;
+			var sheets = new List<StyleSheet>();
+			while (parent != null) {
+				var visualParent = parent as VisualElement;
+				var vpSheets = visualParent?.GetStyleSheets();
+				if (vpSheets != null)
+					sheets.AddRange(vpSheets);
+				parent = parent.Parent;
+			}
+			for (var i = sheets.Count - 1; i >= 0; i--)
+				((IStyle)sheets[i]).Apply(this);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
+++ b/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
@@ -88,27 +88,30 @@ namespace Xamarin.Forms.StyleSheets
 
 		void IStyle.Apply(BindableObject bindable)
 		{
-			var styleable = bindable as VisualElement;
+			var styleable = bindable as Element;
 			if (styleable == null)
 				return;
 			Apply(styleable);
 		}
 
-		void Apply(VisualElement styleable)
+		void Apply(Element styleable)
 		{
 			ApplyCore(styleable);
 			foreach (var child in styleable.LogicalChildrenInternal)
 				((IStyle)this).Apply(child);
 		}
 
-		void ApplyCore(VisualElement styleable)
+		void ApplyCore(Element styleable)
 		{
+			var visualStylable = styleable as VisualElement;
+			if (visualStylable == null)
+				return;
 			foreach (var kvp in Styles) {
 				var selector = kvp.Key;
 				var style = kvp.Value;
 				if (!selector.Matches(styleable))
 					continue;
-				style.Apply(styleable);
+				style.Apply(visualStylable);
 			}
 		}
 

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -652,7 +652,6 @@ namespace Xamarin.Forms
 #pragma warning restore 0618
 
 			FlowController.NotifyFlowDirectionChanged();
-			ApplyStyleSheetsOnParentSet();
 		}
 
 		protected virtual void OnSizeAllocated(double width, double height)
@@ -728,14 +727,6 @@ namespace Xamarin.Forms
 		internal virtual void OnIsVisibleChanged(bool oldValue, bool newValue)
 		{
 			InvalidateMeasureInternal(InvalidationTrigger.Undefined);
-		}
-
-		internal override void OnParentResourcesChanged(object sender, ResourcesChangedEventArgs e)
-		{
-			if (e == ResourcesChangedEventArgs.StyleSheets)
-				ApplyStyleSheetsOnParentSet();
-			else
-				base.OnParentResourcesChanged(sender, e);
 		}
 
 		internal override void OnResourcesChanged(object sender, ResourcesChangedEventArgs e)

--- a/Xamarin.Forms.Core/VisualElement_StyleSheet.cs
+++ b/Xamarin.Forms.Core/VisualElement_StyleSheet.cs
@@ -40,23 +40,5 @@ namespace Xamarin.Forms
 			foreach (var styleSheet in this.GetStyleSheets())
 				((IStyle)styleSheet).Apply(this);
 		}
-
-		//on parent set, or on parent stylesheet changed, reapply all
-		void ApplyStyleSheetsOnParentSet()
-		{
-			var parent = Parent;
-			if (parent == null)
-				return;
-			var sheets = new List<StyleSheet>();
-			while (parent != null) {
-				var visualParent = parent as VisualElement;
-				var vpSheets = visualParent?.GetStyleSheets();
-				if (vpSheets != null)
-					sheets.AddRange(vpSheets);
-				parent = parent.Parent;
-			}
-			for (var i = sheets.Count - 1; i >= 0; i--)
-				((IStyle)sheets[i]).Apply(this);
-		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Cells, and other Elements, are now part of the hierarchy used for setting down stylesheets,

<img width="447" alt="2018-01-10_1257" src="https://user-images.githubusercontent.com/313003/34771937-9db19d82-f606-11e7-98b4-8e8cd4256df7.png">

### Bugs Fixed ###

- fixes #1472

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
