### PR TITLE
[Xaml[C]] avoid processing RD content multiple times

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Build.Tasks
 		public bool StopOnDataTemplate => true;
 		public bool StopOnResourceDictionary => false;
 		public bool VisitNodeOnDataTemplate => false;
-
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Build.Tasks/ExpandMarkupsVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/ExpandMarkupsVisitor.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Build.Tasks
 		public bool StopOnDataTemplate => false;
 		public bool StopOnResourceDictionary => false;
 		public bool VisitNodeOnDataTemplate => true;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Build.Tasks/SetFieldVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetFieldVisitor.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Build.Tasks
 		public bool StopOnDataTemplate => true;
 		public bool StopOnResourceDictionary => false;
 		public bool VisitNodeOnDataTemplate => false;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Build.Tasks
 		public bool StopOnDataTemplate => true;
 		public bool StopOnResourceDictionary => false;
 		public bool VisitNodeOnDataTemplate => false;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Forms.Build.Tasks
 		public TreeVisitingMode VisitingMode => TreeVisitingMode.BottomUp;
 		public bool StopOnDataTemplate => true;
 		public bool VisitNodeOnDataTemplate => true;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		ModuleDefinition Module { get; }
 

--- a/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
@@ -71,5 +71,21 @@ namespace Xamarin.Forms.Build.Tasks
 			return parentVar.VariableType.FullName == "Xamarin.Forms.ResourceDictionary"
 				|| parentVar.VariableType.Resolve().BaseType?.FullName == "Xamarin.Forms.ResourceDictionary";
 		}
+
+		public bool SkipChildren(INode node, INode parentNode)
+		{
+			var enode = node as ElementNode;
+			if (enode == null)
+				return false;
+			if (   parentNode is IElementNode
+			    && IsResourceDictionary((IElementNode)parentNode)
+			    && !((IElementNode)parentNode).Properties.ContainsKey(XmlName.xKey))
+				return true;
+			if (   parentNode is ListNode
+			    && IsResourceDictionary((IElementNode)parentNode.Parent)
+			    && !((IElementNode)parentNode.Parent).Properties.ContainsKey(XmlName.xKey))
+				return true;
+			return false;
+		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -801,7 +801,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)GitHub1331.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh1554.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh1554.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Gh1554">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary>
+                <Label x:Key="label0"/>
+            </ResourceDictionary>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh1554.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh1554.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh1554
+	{
+		public Gh1554()
+		{
+			InitializeComponent();
+		}
+
+		public Gh1554(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void NestedRDAreOnlyProcessedOnce(bool useCompiledXaml)
+			{
+				var layout = new Gh1554(useCompiledXaml);
+				Assert.That(layout.Resources.MergedDictionaries.First().First().Key, Is.EqualTo("label0"));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -567,6 +567,9 @@
     <Compile Include="Issues\Gh1497.xaml.cs">
       <DependentUpon>Gh1497.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh1554.xaml.cs">
+      <DependentUpon>Gh1554.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -1008,6 +1011,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh1497.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh1554.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Forms.Xaml
 		public bool StopOnDataTemplate => true;
 		public bool StopOnResourceDictionary { get; }
 		public bool VisitNodeOnDataTemplate => true;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -9,7 +9,7 @@ using Xamarin.Forms.Xaml.Internals;
 
 namespace Xamarin.Forms.Xaml
 {
-	internal class CreateValuesVisitor : IXamlNodeVisitor
+	class CreateValuesVisitor : IXamlNodeVisitor
 	{
 		public CreateValuesVisitor(HydrationContext context)
 		{
@@ -27,6 +27,7 @@ namespace Xamarin.Forms.Xaml
 		public bool StopOnDataTemplate => true;
 		public bool StopOnResourceDictionary => false;
 		public bool VisitNodeOnDataTemplate => false;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Xaml/ExpandMarkupsVisitor.cs
+++ b/Xamarin.Forms.Xaml/ExpandMarkupsVisitor.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms.Xaml.Internals;
 
 namespace Xamarin.Forms.Xaml
 {
-	internal class ExpandMarkupsVisitor : IXamlNodeVisitor
+	class ExpandMarkupsVisitor : IXamlNodeVisitor
 	{
 		public ExpandMarkupsVisitor(HydrationContext context)
 		{
@@ -32,6 +32,7 @@ namespace Xamarin.Forms.Xaml
 		public bool StopOnDataTemplate => false;
 		public bool StopOnResourceDictionary => false;
 		public bool VisitNodeOnDataTemplate => true;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
+++ b/Xamarin.Forms.Xaml/FillResourceDictionariesVisitor.cs
@@ -65,5 +65,22 @@ namespace Xamarin.Forms.Xaml
 		public void Visit(ListNode node, INode parentNode)
 		{
 		}
+
+		public bool SkipChildren(INode node, INode parentNode)
+		{
+			var enode = node as ElementNode;
+			if (enode is null)
+				return false;
+			if (   parentNode is IElementNode
+			    && typeof(ResourceDictionary).IsAssignableFrom(Context.Types[((IElementNode)parentNode)])
+			    && !((IElementNode)parentNode).Properties.ContainsKey(XmlName.xKey))
+				return true;
+			if (   parentNode is ListNode
+				&& typeof(ResourceDictionary).IsAssignableFrom(Context.Types[((IElementNode)parentNode.Parent)])
+				&& !((IElementNode)parentNode.Parent).Properties.ContainsKey(XmlName.xKey))
+				return true;
+			return false;
+		}
+
 	}
 }

--- a/Xamarin.Forms.Xaml/NamescopingVisitor.cs
+++ b/Xamarin.Forms.Xaml/NamescopingVisitor.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Xaml
 		public bool StopOnDataTemplate => false;
 		public bool StopOnResourceDictionary => false;
 		public bool VisitNodeOnDataTemplate => true;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Xaml/PruneIgnoredNodesVisitor.cs
+++ b/Xamarin.Forms.Xaml/PruneIgnoredNodesVisitor.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.Xaml
 		public bool StopOnDataTemplate => false;
 		public bool StopOnResourceDictionary => false;
 		public bool VisitNodeOnDataTemplate => true;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ElementNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
+++ b/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Xamarin.Forms.Xaml
 {
-	internal class RegisterXNamesVisitor : IXamlNodeVisitor
+	class RegisterXNamesVisitor : IXamlNodeVisitor
 	{
 		public RegisterXNamesVisitor(HydrationContext context)
 		{
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Xaml
 		public bool StopOnDataTemplate => true;
 		public bool StopOnResourceDictionary => false;
 		public bool VisitNodeOnDataTemplate => false;
+		public bool SkipChildren(INode node, INode parentNode) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
 		{

--- a/Xamarin.Forms.Xaml/XamlNode.cs
+++ b/Xamarin.Forms.Xaml/XamlNode.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Forms.Xaml
 			if (!SkipVisitNode(visitor, parentNode) && visitor.VisitingMode == TreeVisitingMode.TopDown)
 				visitor.Visit(this, parentNode);
 
-			if (!SkipChildren(visitor, parentNode)) {
+			if (!SkipChildren(visitor, this, parentNode)) {
 				foreach (var node in Properties.Values.ToList())
 					node.Accept(visitor, this);
 				foreach (var node in CollectionItems)
@@ -163,9 +163,10 @@ namespace Xamarin.Forms.Xaml
 
 		bool IsResourceDictionary() => XmlType.Name == "ResourceDictionary";
 
-		protected bool SkipChildren(IXamlNodeVisitor visitor, INode parentNode) =>
-			(visitor.StopOnDataTemplate && IsDataTemplate(parentNode)) ||
-			(visitor.StopOnResourceDictionary && IsResourceDictionary());
+		protected bool SkipChildren(IXamlNodeVisitor visitor, INode node, INode parentNode) =>
+			   (visitor.StopOnDataTemplate && IsDataTemplate(parentNode))
+			|| (visitor.StopOnResourceDictionary && IsResourceDictionary())
+			|| visitor.SkipChildren(node, parentNode);
 
 		protected bool SkipVisitNode(IXamlNodeVisitor visitor, INode parentNode) =>
 			!visitor.VisitNodeOnDataTemplate && IsDataTemplate(parentNode);
@@ -196,7 +197,7 @@ namespace Xamarin.Forms.Xaml
 			if (!SkipVisitNode(visitor, parentNode) && visitor.VisitingMode == TreeVisitingMode.TopDown)
 				visitor.Visit(this, parentNode);
 
-			if (!SkipChildren(visitor, parentNode)) {
+			if (!SkipChildren(visitor, this, parentNode)) {
 				foreach (var node in Properties.Values.ToList())
 					node.Accept(visitor, this);
 				foreach (var node in CollectionItems)

--- a/Xamarin.Forms.Xaml/XamlNodeVisitor.cs
+++ b/Xamarin.Forms.Xaml/XamlNodeVisitor.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Xaml
 		void Visit(ElementNode node, INode parentNode);
 		void Visit(RootNode node, INode parentNode);
 		void Visit(ListNode node, INode parentNode);
+		bool SkipChildren(INode node, INode parentNode);
 	}
 
 	enum TreeVisitingMode {
@@ -38,29 +39,11 @@ namespace Xamarin.Forms.Xaml
 		public bool StopOnResourceDictionary { get; }
 		public bool VisitNodeOnDataTemplate { get; }
 
-		public void Visit(ValueNode node, INode parentNode)
-		{
-			action(node, parentNode);
-		}
-
-		public void Visit(MarkupNode node, INode parentNode)
-		{
-			action(node, parentNode);
-		}
-
-		public void Visit(ElementNode node, INode parentNode)
-		{
-			action(node, parentNode);
-		}
-
-		public void Visit(RootNode node, INode parentNode)
-		{
-			action(node, parentNode);
-		}
-
-		public void Visit(ListNode node, INode parentNode)
-		{
-			action(node, parentNode);
-		}
+		public void Visit(ValueNode node, INode parentNode) => action(node, parentNode);
+		public void Visit(MarkupNode node, INode parentNode) => action(node, parentNode);
+		public void Visit(ElementNode node, INode parentNode) => action(node, parentNode);
+		public void Visit(RootNode node, INode parentNode) => action(node, parentNode);
+		public void Visit(ListNode node, INode parentNode) => action(node, parentNode);
+		public bool SkipChildren(INode node, INode parentNode) => false;
 	}
 }


### PR DESCRIPTION
### Description of Change ###

[Xaml[C]] avoid processing RD content multiple times

Stop the RD visitor on the RD node, as the SetPropVisitor is taking over

### Bugs Fixed ###

- fixes #1554

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense