### PR TITLE
[iOS] Clear prototype cell on UnevenRows

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1567.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1567.cs
@@ -1,0 +1,104 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Windows.Input;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1567, "NRE using TapGestureRecognizer on cell with HasUnevenRows", PlatformAffected.iOS)]
+	public class GitHub1567 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		ICommand SomeCommand;
+		ObservableCollection<LocalIem> LocalList { get; set; } = new ObservableCollection<LocalIem>();
+
+		protected override async void Init()
+		{
+			// Initialize ui here instead of ctor
+			var btn = new Button
+			{
+				AutomationId = "btnFillData",
+				Text = "FILL DATA",
+				Command = new Command(async () => { await FillData(); })
+			};
+			var lst = new ListView(ListViewCachingStrategy.RecycleElement)
+			{
+				Header = btn,
+				HasUnevenRows = true,
+				RowHeight = -1,
+				SeparatorVisibility = SeparatorVisibility.None,
+				ItemsSource = LocalList,
+				ItemTemplate = new DataTemplate(typeof(CustomCell))
+			};
+
+			Content = lst;
+			this.BindingContext = this;
+			SomeCommand = new Command(SomeCommandAction);
+			await FillData();
+		}
+
+		class CustomCell : ViewCell
+		{
+			public CustomCell()
+			{
+				var lbl = new Label { FontSize = 14 };
+				lbl.SetBinding(Label.TextProperty, "Value1");
+				var grd = new Grid();
+				var boxView = new BoxView
+				{
+					BackgroundColor = Color.Transparent,
+					HorizontalOptions = LayoutOptions.FillAndExpand,
+					VerticalOptions = LayoutOptions.FillAndExpand
+				};
+				var gesture = new TapGestureRecognizer();
+				gesture.SetBinding(TapGestureRecognizer.CommandProperty, "SomeCommand");
+				boxView.GestureRecognizers.Add(gesture);
+				grd.Children.Add(lbl);
+				grd.Children.Add(boxView);
+				View = grd;
+			}
+		}
+
+		void SomeCommandAction(object obj)
+		{		
+		}
+		
+		async Task FillData()
+		{
+			await Task.Factory.StartNew(async () =>
+			{
+				await Task.Delay(100);
+				LocalList.Clear();
+				for (int i = 0; i < 100; i++)
+				{
+					LocalList.Add(new LocalIem()
+					{
+						Value1 = DateTime.UtcNow.Ticks.ToString(),
+					});
+				}
+			}, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+		}
+
+		class LocalIem
+		{
+			public string Value1 { get; set; }
+		}
+
+#if UITEST
+		[Test]
+		public void GitHub1567Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("btnFillData"));
+			RunningApp.Tap(q => q.Marked("btnFillData"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1567.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1567.cs
@@ -45,6 +45,7 @@ namespace Xamarin.Forms.Controls.Issues
 			await FillData();
 		}
 
+        [Preserve(AllMembers = true)]
 		class CustomCell : ViewCell
 		{
 			public CustomCell()
@@ -87,6 +88,7 @@ namespace Xamarin.Forms.Controls.Issues
 			}, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 		}
 
+        [Preserve(AllMembers = true)]
 		class LocalIem
 		{
 			public string Value1 { get; set; }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1567.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1567.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 1567, "NRE using TapGestureRecognizer on cell with HasUnevenRows", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Github, 1567, "NRE using TapGestureRecognizer on cell with HasUnevenRows", PlatformAffected.iOS, issueTestNumber: 1)]
 	public class GitHub1567 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
 		ICommand SomeCommand;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -340,6 +340,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59925.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1436.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GitHub1567.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -552,7 +552,8 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.EndUpdates();
 
 					if (_estimatedRowHeight && TemplatedItemsView.TemplatedItems.Count == 0)
-						_estimatedRowHeight = false;
+						InvalidateCellCache();
+
 
 					break;
 
@@ -576,7 +577,7 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.EndUpdates();
 
 					if (_estimatedRowHeight && e.OldStartingIndex == 0)
-						_estimatedRowHeight = false;
+						InvalidateCellCache();
 
 					break;
 
@@ -588,15 +589,22 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.EndUpdates();
 
 					if (_estimatedRowHeight && e.OldStartingIndex == 0)
-						_estimatedRowHeight = false;
+						InvalidateCellCache();
+
 
 					break;
 
 				case NotifyCollectionChangedAction.Reset:
-					_estimatedRowHeight = false;
+					InvalidateCellCache();
 					Control.ReloadData();
 					return;
 			}
+		}
+
+		void InvalidateCellCache()
+		{
+			_estimatedRowHeight = false;
+			_dataSource.InvalidatePrototypicalCellCache();
 		}
 
 		void UpdatePullToRefreshEnabled()
@@ -703,6 +711,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			internal override void InvalidatePrototypicalCellCache()
 			{
+				ClearPrototype();
 				_prototypicalCellByTypeOrDataTemplate.Clear();
 			}
 
@@ -771,7 +780,6 @@ namespace Xamarin.Forms.Platform.iOS
 						renderer?.Dispose();
 						renderer = null;
 					}
-					_prototype = null;
 
 					// Let the EstimatedHeight method know to use this value.
 					// Much more efficient than checking the value each time.
@@ -793,14 +801,21 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (disposing)
 				{
-					if (_prototype != null)
-					{
-						_prototype.Dispose();
-						_prototype = null;
-					}
+					ClearPrototype();
 				}
 
 				base.Dispose(disposing);
+			}
+
+			void ClearPrototype()
+			{
+				if (_prototype != null)
+				{
+					var element = _prototype.Element;
+					element?.ClearValue(Platform.RendererProperty);
+					_prototype?.Dispose();
+					_prototype = null;
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -771,6 +771,7 @@ namespace Xamarin.Forms.Platform.iOS
 						renderer?.Dispose();
 						renderer = null;
 					}
+					_prototype = null;
 
 					// Let the EstimatedHeight method know to use this value.
 					// Much more efficient than checking the value each time.


### PR DESCRIPTION
### Description of Change ###

We were disposing our renderers of the prototype cell so we should also just clear our prototypecell 

### Bugs Fixed ###

- fixes #1567

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
