### PR TITLE
[Xaml] do not check PropertyName on Obsolete BPs

### DIFF
--- a/Xamarin.Forms.Core/BindablePropertyConverter.cs
+++ b/Xamarin.Forms.Core/BindablePropertyConverter.cs
@@ -103,7 +103,8 @@ namespace Xamarin.Forms
 			if (bpinfo == null)
 				throw new XamlParseException($"Can't resolve {name} on {type.Name}", lineinfo);
 			var bp = bpinfo.GetValue(null) as BindableProperty;
-			if (bp.PropertyName != propertyName)
+			var isObsolete = bpinfo.GetCustomAttribute<ObsoleteAttribute>() != null;
+			if (bp.PropertyName != propertyName && !isObsolete)
 				throw new XamlParseException($"The PropertyName of {type.Name}.{name} is not {propertyName}", lineinfo);
 			return bp;
 		}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh1566.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh1566.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Gh1566">
+    <Frame x:Name="frame">
+        <Frame.Style>
+            <Style TargetType="Frame">
+                <Setter Property="Frame.OutlineColor" Value="Red" />
+            </Style>
+        </Frame.Style>
+    </Frame>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh1566.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh1566.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh1566
+	{
+		public Gh1566()
+		{
+			InitializeComponent();
+		}
+
+		public Gh1566(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void ObsoletePropsDoNotThrow(bool useCompiledXaml)
+			{
+				var layout = new Gh1566(useCompiledXaml);
+				Assert.That(layout.frame.BorderColor, Is.EqualTo(Color.Red));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -570,6 +570,9 @@
     <Compile Include="Issues\Gh1554.xaml.cs">
       <DependentUpon>Gh1554.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh1566.xaml.cs">
+      <DependentUpon>Gh1566.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -1014,6 +1017,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh1554.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh1566.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

[Xaml] do not check PropertyName on Obsolete BPs


### Bugs Fixed ###

- fixes #1566

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense