### PR TITLE
Fix UWP button image rendering crash

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
@@ -171,7 +171,7 @@ namespace Xamarin.Forms.Platform.UWP
 			bmp.ImageOpened += (sender, args) => {
 				image.Width = bmp.PixelWidth;
 				image.Height = bmp.PixelHeight;
-				Element.InvalidateMeasureNonVirtual(InvalidationTrigger.RendererReady);
+				Element?.InvalidateMeasureNonVirtual(InvalidationTrigger.RendererReady);
 			};
 
 			// No text, just the image


### PR DESCRIPTION
On UWP, if you click around an app quickly, you can get it crash with this error:
> Xamarin.Forms.Platform.UAP.dll!Xamarin.Forms.Platform.UWP.ButtonRenderer.UpdateContent.AnonymousMethod__0(object sender, Windows.UI.Xaml.RoutedEventArgs args)

Since image loading is deferred, if you navigate quickly (or if you load the image from a slow source), the Xamarin.Forms element may no longer be present when `ImageOpened` is raised. The null check in this PR should fix that.

(I made the change in the GitHub web editor - since it's only one character. I haven't tested. The editor caused the newline change at the bottom of the file. No need to keep that change obviously.)