### PR TITLE
Construct Android Platform around Activity instead of Context

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PageExtensions.cs
@@ -8,7 +8,13 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public static class PageExtensions
 	{
+		[Obsolete("Please use CreateFragment(this ContentPage view, Activity activity) instead")]
 		public static Fragment CreateFragment(this ContentPage view, Context context)
+		{
+			return view.CreateFragment((Activity)context);
+		}
+
+		public static Fragment CreateFragment(this ContentPage view, Activity activity)
 		{
 			if (!Forms.IsInitialized)
 				throw new InvalidOperationException("call Forms.Init() before this");
@@ -19,7 +25,7 @@ namespace Xamarin.Forms.Platform.Android
 				app.MainPage = view;
 			}
 
-			var platform = new Platform(context, true);
+			var platform = new Platform(activity, true);
 			platform.SetPage(view);
 
 			var vg = platform.GetViewGroup();
@@ -27,7 +33,13 @@ namespace Xamarin.Forms.Platform.Android
 			return new EmbeddedFragment(vg, platform);
 		}
 
+		[Obsolete("Please use CreateSupportFragment(this ContentPage view, Activity activity) instead")]
 		public static global::Android.Support.V4.App.Fragment CreateSupportFragment(this ContentPage view, Context context)
+		{
+			return view.CreateSupportFragment((Activity)context);
+		}
+
+		public static global::Android.Support.V4.App.Fragment CreateSupportFragment(this ContentPage view, Activity activity)
 		{
 			if (!Forms.IsInitialized)
 				throw new InvalidOperationException("call Forms.Init() before this");
@@ -38,7 +50,7 @@ namespace Xamarin.Forms.Platform.Android
 				app.MainPage = view;
 			}
 
-			var platform = new Platform(context, true);
+			var platform = new Platform(activity, true);
 			platform.SetPage(view);
 
 			var vg = platform.GetViewGroup();


### PR DESCRIPTION
### Description of Change ###

`Platform` on Android has always implicitly relied on the `Context` passed to it being an `Activity`. Rather than having the internal constructor take a `Context` and then cast it to an `Activity`, we can simply have the constructor take an `Activity` in the first place. 

This is a more reasonable version of PR #1561.

### API Changes ###

In `Xamarin.Forms.Platform.Android.PageExtensions`:

Obsolete:
`public static Fragment CreateFragment(this ContentPage view, Context context)`
`public static Android.Support.V4.App.Fragment CreateSupportFragment(this ContentPage view, Context context)`

Add: 
`public static Fragment CreateFragment(this ContentPage view, Activity activity)`
`public static Android.Support.V4.App.Fragment CreateSupportFragment(this ContentPage view, Activity activity)`

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
