### PR TITLE
[Xaml] let the previewer know the asm

### DIFF
--- a/Xamarin.Forms.Core/Internals/ResourceLoader.cs
+++ b/Xamarin.Forms.Core/Internals/ResourceLoader.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Reflection;
+
 namespace Xamarin.Forms.Internals
 {
 	public static class ResourceLoader
 	{
 		//takes a resource path, returns string content
-		public static Func<string, string> ResourceProvider { get; internal set; }
+		public static Func<AssemblyName, string, string> ResourceProvider { get; internal set; }
 		internal static Action<Exception> ExceptionHandler { get; set; }
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceLoader.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceLoader.xaml.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				var layout = new ResourceLoader(useCompiledXaml);
 				Assert.That(layout.label.TextColor, Is.EqualTo(Color.FromHex("#368F95")));
 
-				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = path => {
+				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = (asmName, path) => {
 					if (path == "ResourceLoader.xaml")
 						return @"
 <ContentPage 
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				var layout = new ResourceLoader(useCompiledXaml);
 				Assert.That(layout.label.TextColor, Is.EqualTo(Color.FromHex("#368F95")));
 
-				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = path => {
+				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = (asmName, path) => {
 					if (path == "AppResources/Colors.xaml")
 						return @"
 <ResourceDictionary

--- a/Xamarin.Forms.Xaml/ResourcesLoader.cs
+++ b/Xamarin.Forms.Xaml/ResourcesLoader.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Xaml
 	{
 		public T CreateFromResource<T>(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo) where T: new()
 		{
-			var alternateResource = Xamarin.Forms.Internals.ResourceLoader.ResourceProvider?.Invoke(resourcePath);
+			var alternateResource = Xamarin.Forms.Internals.ResourceLoader.ResourceProvider?.Invoke(assembly.GetName(), resourcePath);
 			if (alternateResource != null) {
 				var rd = new T();
 				rd.LoadFromXaml(alternateResource);
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Xaml
 
 		public string GetResource(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo)
 		{
-			var alternateResource = Xamarin.Forms.Internals.ResourceLoader.ResourceProvider?.Invoke(resourcePath);
+			var alternateResource = Xamarin.Forms.Internals.ResourceLoader.ResourceProvider?.Invoke(assembly.GetName(), resourcePath);
 			if (alternateResource != null)
 				return alternateResource;
 

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -153,7 +153,6 @@ namespace Xamarin.Forms.Xaml
 				return xaml;
 #pragma warning restore 0618
 
-
 			var assembly = type.GetTypeInfo().Assembly;
 			var resourceId = XamlResourceIdAttribute.GetResourceIdForType(type);
 
@@ -168,7 +167,7 @@ namespace Xamarin.Forms.Xaml
 					xaml = null;
 			}
 
-			var alternateXaml = ResourceLoader.ResourceProvider?.Invoke(XamlResourceIdAttribute.GetPathForType(type));
+			var alternateXaml = ResourceLoader.ResourceProvider?.Invoke(assembly.GetName(), XamlResourceIdAttribute.GetPathForType(type));
 			return alternateXaml ?? xaml;
 		}
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ResourceLoader.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/ResourceLoader.xml
@@ -15,14 +15,14 @@
   </Docs>
   <Members>
     <Member MemberName="ResourceProvider">
-      <MemberSignature Language="C#" Value="public static Func&lt;string,string&gt; ResourceProvider { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property class System.Func`2&lt;string, string&gt; ResourceProvider" />
+      <MemberSignature Language="C#" Value="public static Func&lt;System.Reflection.AssemblyName,string,string&gt; ResourceProvider { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property class System.Func`3&lt;class System.Reflection.AssemblyName, string, string&gt; ResourceProvider" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.Func&lt;System.String,System.String&gt;</ReturnType>
+        <ReturnType>System.Func&lt;System.Reflection.AssemblyName,System.String,System.String&gt;</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Xamarin.Forms platform.</summary>


### PR DESCRIPTION
### Description of Change ###

in addition to the resourcePath, tell the previewer the assembly in
which we're looking for the resource.

it changes an API that's not supposed to be used (yet) but the previewer, but I'd like @alanmcgovern approval on this.

### Bugs Fixed ###

/

### API Changes ###

List all API changes here (or just put None), example:

Changed:
 - `public static Func<AssemblyName, string, string> Xamarin.Forms.Internals.ResourceLoader.ResourceProvider { get; internal set; }`

### Behavioral Changes ###


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense