### PR TITLE
[XamlC][Bindings] value types in compiled bindings

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
@@ -12,10 +12,11 @@
 			<Label Text="{Binding Path=Text}" x:Name="label1" />
 			<Label Text="{Binding Model.Text}" x:Name="label2" />
 			<Label Text="{Binding Model[3]}" x:Name="label3" />
-			<Label Text="{Binding}" x:Name="label4" x:DataType="sys:String"/>
+            <Label Text="{Binding}" x:Name="label4" x:DataType="sys:String"/>
+            <Label Text="{Binding I}" x:Name="label5" />
+            <Label Text="{Binding Model.Text}" x:Name="label6" x:DataType="local:MockStructViewModel" />
 			<Entry Text="{Binding Text, Mode=TwoWay}" x:Name="entry0"/>
 		</StackLayout>
-	
 		<Label Text="{Binding Text}" x:Name="labelWithUncompiledBinding" />
 	</StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -41,8 +41,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TestCase(true)]
 			public void Test(bool useCompiledXaml)
 			{
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(BindingsCompiler));
 				var vm = new MockViewModel {
 					Text = "Text0",
+					I = 42,
 					Model = new MockViewModel {
 						Text = "Text1"
 					},
@@ -51,11 +54,21 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 				var layout = new BindingsCompiler(useCompiledXaml);
 				layout.BindingContext = vm;
+				layout.label6.BindingContext = new MockStructViewModel {
+					Model = new MockViewModel { 
+						Text = "text6"
+					}
+				};
+
 				//testing paths
 				Assert.AreEqual("Text0", layout.label0.Text);
 				Assert.AreEqual("Text0", layout.label1.Text);
 				Assert.AreEqual("Text1", layout.label2.Text);
 				Assert.AreEqual("TextIndex", layout.label3.Text);
+
+				//value types
+				Assert.That(layout.label5.Text, Is.EqualTo("42"));
+				Assert.That(layout.label6.Text, Is.EqualTo("text6"));
 
 				//testing selfPath
 				layout.label4.BindingContext = "Self";
@@ -77,13 +90,21 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 	}
 
+	struct MockStructViewModel
+	{
+		public string Text { get; set; }
+		public int I { get; set; }
+		public MockViewModel Model { get; set; }
+	}
+
 	class MockViewModel : INotifyPropertyChanged
 	{
 		public event PropertyChangedEventHandler PropertyChanged;
 
-		public MockViewModel(string text = null)
+		public MockViewModel(string text = null, int i = -1)
 		{
 			_text = text;
+			_i = i;
 		}
 
 		string _text;
@@ -94,6 +115,17 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					return;
 
 				_text = value;
+				OnPropertyChanged();
+			}
+		}
+
+		int _i;
+		public int I {
+			get { return _i; }
+			set {
+				if (_i == value)
+					return;
+				_i = value;
 				OnPropertyChanged();
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

[XamlC][Bindings] value types in compiled bindings

support value types in path of bindings that will be compiled.

fixes #1558

### Bugs Fixed ###

- fixes #1558

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense