### PR TITLE
[iOS] Fix Picker InputAccessoryView visibility in landscape

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
@@ -1,0 +1,83 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1614, "iOS 11 prevents InputAccessoryView from showing in landscape mode", PlatformAffected.iOS)]
+	public class Issue1614 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var stackLayout = new StackLayout();
+			var picker = new Picker
+			{
+				AutomationId = "Picker"
+			};
+			var datePicker = new DatePicker
+			{
+				AutomationId = "DatePicker"
+			};
+			var timePicker = new TimePicker
+			{
+				AutomationId = "TimePicker"
+			};
+
+			stackLayout.Children.Add(picker);
+			stackLayout.Children.Add(datePicker);
+			stackLayout.Children.Add(timePicker);
+
+			Content = stackLayout;
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void Issue1614Test ()
+		{
+			RunningApp.Screenshot ("I am at Issue 1");
+			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
+			RunningApp.Screenshot ("I see the Label");
+
+            RunningApp.SetOrientationPortrait();
+
+            RunningApp.Tap(x => x.Marked("Picker"));
+            CheckPickerAccessory("UIPickerView");
+            RunningApp.SetOrientationLandscape();
+            CheckPickerAccessory("UIPickerView");
+            RunningApp.SetOrientationPortrait();
+            RunningApp.DismissKeyboard();
+
+            RunningApp.Tap(x => x.Marked("DatePicker"));
+            CheckPickerAccessory("UIDatePicker");
+            RunningApp.SetOrientationLandscape();
+            CheckPickerAccessory("UIDatePicker");
+            RunningApp.SetOrientationPortrait();
+            RunningApp.DismissKeyboard();
+
+            RunningApp.Tap(x => x.Marked("TimePicker"));
+            CheckPickerAccessory("UIDatePicker");
+            RunningApp.SetOrientationLandscape();
+            CheckPickerAccessory("UIDatePicker");
+            RunningApp.SetOrientationPortrait();
+            RunningApp.DismissKeyboard();
+        }
+
+        private void CheckPickerAccessory(string className)
+        {
+            RunningApp.WaitForElement(x => x.Class("UIButtonLabel"));
+            var buttonRect = RunningApp.Query(x => x.Class("UIButtonLabel"))[0].Rect;
+            var pickerRect = RunningApp.Query(x => x.Class(className))[0].Rect;
+
+            var buttonBottom = buttonRect.Y + buttonRect.Height;
+            var pickerTop = pickerRect.Y;
+
+            Assert.IsTrue(buttonBottom <= pickerTop);
+        }
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
@@ -41,21 +41,22 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.SetOrientationPortrait();
 
-			RunningApp.Tap(x => x.Marked("Picker"));
+			RunningApp.WaitForElement(x => x.Class("UITextField"));
+			RunningApp.Tap(x => x.Class("UITextField").Index(0));
 			CheckPickerAccessory("UIPickerView");
 			RunningApp.SetOrientationLandscape();
 			CheckPickerAccessory("UIPickerView");
 			RunningApp.SetOrientationPortrait();
 			RunningApp.DismissKeyboard();
 
-			RunningApp.Tap(x => x.Marked("DatePicker"));
+			RunningApp.Tap(x => x.Class("UITextField").Index(1));
 			CheckPickerAccessory("UIDatePicker");
 			RunningApp.SetOrientationLandscape();
 			CheckPickerAccessory("UIDatePicker");
 			RunningApp.SetOrientationPortrait();
 			RunningApp.DismissKeyboard();
 
-			RunningApp.Tap(x => x.Marked("TimePicker"));
+			RunningApp.Tap(x => x.Class("UITextField").Index(2));
 			CheckPickerAccessory("UIDatePicker");
 			RunningApp.SetOrientationLandscape();
 			CheckPickerAccessory("UIDatePicker");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = stackLayout;
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		protected override bool Isolate => true;
 
 		[Test]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
@@ -39,11 +39,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue1614Test ()
 		{
-			RunningApp.Screenshot ("I am at Issue 1");
-			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
-			RunningApp.Screenshot ("I see the Label");
-
-            RunningApp.SetOrientationPortrait();
+			RunningApp.SetOrientationPortrait();
 
             RunningApp.Tap(x => x.Marked("Picker"));
             CheckPickerAccessory("UIPickerView");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
@@ -41,39 +41,39 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.SetOrientationPortrait();
 
-            RunningApp.Tap(x => x.Marked("Picker"));
-            CheckPickerAccessory("UIPickerView");
-            RunningApp.SetOrientationLandscape();
-            CheckPickerAccessory("UIPickerView");
-            RunningApp.SetOrientationPortrait();
-            RunningApp.DismissKeyboard();
+			RunningApp.Tap(x => x.Marked("Picker"));
+			CheckPickerAccessory("UIPickerView");
+			RunningApp.SetOrientationLandscape();
+			CheckPickerAccessory("UIPickerView");
+			RunningApp.SetOrientationPortrait();
+			RunningApp.DismissKeyboard();
 
-            RunningApp.Tap(x => x.Marked("DatePicker"));
-            CheckPickerAccessory("UIDatePicker");
-            RunningApp.SetOrientationLandscape();
-            CheckPickerAccessory("UIDatePicker");
-            RunningApp.SetOrientationPortrait();
-            RunningApp.DismissKeyboard();
+			RunningApp.Tap(x => x.Marked("DatePicker"));
+			CheckPickerAccessory("UIDatePicker");
+			RunningApp.SetOrientationLandscape();
+			CheckPickerAccessory("UIDatePicker");
+			RunningApp.SetOrientationPortrait();
+			RunningApp.DismissKeyboard();
 
-            RunningApp.Tap(x => x.Marked("TimePicker"));
-            CheckPickerAccessory("UIDatePicker");
-            RunningApp.SetOrientationLandscape();
-            CheckPickerAccessory("UIDatePicker");
-            RunningApp.SetOrientationPortrait();
-            RunningApp.DismissKeyboard();
-        }
+			RunningApp.Tap(x => x.Marked("TimePicker"));
+			CheckPickerAccessory("UIDatePicker");
+			RunningApp.SetOrientationLandscape();
+			CheckPickerAccessory("UIDatePicker");
+			RunningApp.SetOrientationPortrait();
+			RunningApp.DismissKeyboard();
+		}
 
-        private void CheckPickerAccessory(string className)
-        {
-            RunningApp.WaitForElement(x => x.Class("UIButtonLabel"));
-            var buttonRect = RunningApp.Query(x => x.Class("UIButtonLabel"))[0].Rect;
-            var pickerRect = RunningApp.Query(x => x.Class(className))[0].Rect;
+		private void CheckPickerAccessory(string className)
+		{
+			RunningApp.WaitForElement(x => x.Class("UIButtonLabel"));
+			var buttonRect = RunningApp.Query(x => x.Class("UIButtonLabel"))[0].Rect;
+			var pickerRect = RunningApp.Query(x => x.Class(className))[0].Rect;
 
-            var buttonBottom = buttonRect.Y + buttonRect.Height;
-            var pickerTop = pickerRect.Y;
+			var buttonBottom = buttonRect.Y + buttonRect.Height;
+			var pickerTop = pickerRect.Y;
 
-            Assert.IsTrue(buttonBottom <= pickerTop);
-        }
+			Assert.IsTrue(buttonBottom <= pickerTop);
+		}
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1614.cs
@@ -35,7 +35,9 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = stackLayout;
 		}
 
-#if UITEST && __IOS__
+#if UITEST
+		protected override bool Isolate => true;
+
 		[Test]
 		public void Issue1614Test ()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -259,6 +259,7 @@
       <DependentUpon>GitHub1331.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)InputTransparentTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1614.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsInvokeRequiredRaceCondition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsPasswordToggleTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1023.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -56,6 +56,9 @@ namespace Xamarin.Forms.Platform.iOS
 				entry.InputView = _picker;
 				entry.InputAccessoryView = toolbar;
 
+				entry.InputView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
+				entry.InputAccessoryView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
+
 				_defaultTextColor = entry.TextColor;
 
 				_useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -50,6 +50,9 @@ namespace Xamarin.Forms.Platform.iOS
 					entry.InputView = _picker;
 					entry.InputAccessoryView = toolbar;
 
+					entry.InputView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
+					entry.InputAccessoryView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
+
 					_defaultTextColor = entry.TextColor;
 					
 					_useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -67,6 +67,9 @@ namespace Xamarin.Forms.Platform.iOS
 					entry.InputView = _picker;
 					entry.InputAccessoryView = toolbar;
 
+					entry.InputView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
+					entry.InputAccessoryView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
+
 					_defaultTextColor = entry.TextColor;
 
 					_useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();


### PR DESCRIPTION
### Description of Change ###

Address change in iOS 11 where InputAccessoryView is hidden by the InputView in landscape.

### Bugs Fixed ###

This fixes #1614 

### API Changes ###

None

### Behavioral Changes ###

The toolbar item (Done) will be visible while using a Picker, DatePicker or TimePicker on iOS 11 in landscape mode.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
