### PR TITLE
Allow Layouts to specify whether child controls inherit InputTransparent

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
@@ -13,9 +13,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-#if UITEST
+	#if UITEST
 	[Category(UITestCategories.InputTransparent)]
-#endif
+	#endif
 
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 5552368, "Transparency Inheritance", PlatformAffected.All)]
@@ -57,8 +57,8 @@ namespace Xamarin.Forms.Controls.Issues
 			var text = inherited
 				? transition ? InheritedChange : InheritedStatic
 				: transition
-					? NotInheritedChange
-					: NotInheritedStatic;
+				? NotInheritedChange
+				: NotInheritedStatic;
 
 			var button = new Button { Text = text, AutomationId = text };
 
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Text =
 					$"Wait 5 seconds. Tap the button labeled '{UnderButtonText}'. Then tap the button labeled '{OverButtonText}'."
 					+ $" If the label below's text changes to '{Success}' the test has passed."
-			};
+				};
 
 			grid.Children.Add(instructions);
 
@@ -212,12 +212,14 @@ namespace Xamarin.Forms.Controls.Issues
 
 		static IEnumerable<string> TestList => new List<string> { InheritedChange, InheritedStatic, NotInheritedChange, NotInheritedStatic };
 
-#if UITEST
+		#if UITEST
 		[Test, TestCaseSource(nameof(TestList))]
 		public void TransparencyNotInherited(string test)
 		{
 			RunningApp.WaitForElement(test);
 			RunningApp.Tap(test);
+
+			Task.Delay(2000).Wait();
 
 			RunningApp.WaitForElement(UnderButtonText);
 			RunningApp.Tap(UnderButtonText);
@@ -226,7 +228,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(Success);
 		}
 
-		
-#endif
+
+		#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
@@ -97,11 +98,12 @@ namespace Xamarin.Forms.Controls.Issues
 
 			bool overPressed = false;
 			bool underPressed = false;
+			bool layoutTapped = false;
 
 			underButton.Clicked += (sender, args) =>
 			{
 				underPressed = true;
-				UpdateResults(results, inherited, overPressed, underPressed);
+				EvaluateTest(results, inherited, overPressed, underPressed, layoutTapped);
 			};
 
 			var overButton = new Button
@@ -113,7 +115,7 @@ namespace Xamarin.Forms.Controls.Issues
 			overButton.Clicked += (sender, args) =>
 			{
 				overPressed = true;
-				UpdateResults(results, inherited, overPressed, underPressed);
+				EvaluateTest(results, inherited, overPressed, underPressed, layoutTapped);
 			};
 
 			var layout = new StackLayout
@@ -122,9 +124,19 @@ namespace Xamarin.Forms.Controls.Issues
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill,
 				InputTransparent = true,
+				InputTransparentInherited = inherited,
 				BackgroundColor = Color.Blue,
 				Opacity = 0.2
 			};
+
+			layout.GestureRecognizers.Add(new TapGestureRecognizer()
+			{
+				Command = new Command(() =>
+				{
+					layoutTapped = true;
+					EvaluateTest(results, inherited, overPressed, underPressed, layoutTapped);
+				})
+			});
 
 			layout.Children.Add(overButton);
 
@@ -140,8 +152,14 @@ namespace Xamarin.Forms.Controls.Issues
 			return new ContentPage { Content = grid, Title = inherited.ToString()};
 		}
 
-		static void UpdateResults(Label results, bool inherited, bool overPressed, bool underPressed)
+		static void EvaluateTest(Label results, bool inherited, bool overPressed, bool underPressed, bool layoutTapped)
 		{
+			if (layoutTapped)
+			{
+				results.Text = Failure;
+				return;
+			}
+
 			if (inherited)
 			{
 				if (overPressed)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration;
@@ -209,8 +210,10 @@ namespace Xamarin.Forms.Controls.Issues
 			results.Text = Running;
 		}
 
+		static IEnumerable<string> TestList => new List<string> { InheritedChange, InheritedStatic, NotInheritedChange, NotInheritedStatic };
+
 #if UITEST
-		[Test, TestCaseSource(nameof(GenerateTests))]
+		[Test, TestCaseSource(nameof(TestList))]
 		public void TransparencyNotInherited(string test)
 		{
 			RunningApp.WaitForElement(test);
@@ -223,7 +226,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(Success);
 		}
 
-		static IEnumerable<string> GenerateTests => new List<string> { InheritedChange, InheritedStatic, NotInheritedChange, NotInheritedStatic };
+		
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
@@ -17,7 +17,9 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[Category(UITestCategories.InputTransparent)]
 #endif
-	
+
+	// TODO hartez 2018/01/17 15:58:40 Somewhere we need tests for when InputTransparentInherited changes	
+
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 5552368, "Transparency Inheritance", PlatformAffected.All)]
     public class InputTransparentInheritance : TestNavigationPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.InputTransparent)]
+#endif
+	
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 5552368, "Transparency Inheritance", PlatformAffected.All)]
+    public class InputTransparentInheritance : TestNavigationPage
+    {
+		const string Running = "Running...";
+		const string Success = "Success";
+		const string Failure = "Failure";
+		const string UnderButtonText = "Button";
+		const string OverButtonText = "+";
+		const string Overlay = "overlay";
+
+		protected override void Init()
+		{
+			PushAsync(Menu());
+		}
+
+		ContentPage Menu()
+		{
+			var layout = new StackLayout();
+
+			layout.Children.Add(new Label {Text = "Select a test below"});
+
+			layout.Children.Add(MenuButton(true));
+			layout.Children.Add(MenuButton(false));
+
+			return new ContentPage { Content = layout };
+		}
+
+		Button MenuButton(bool inherited)
+		{
+			var text = inherited ? "Inherited" : "Not Inherited";
+			var button = new Button { Text = text, AutomationId = text };
+
+			button.Clicked += (sender, args) => PushAsync(CreateTestPage(inherited));
+
+			return button;
+		}
+
+		ContentPage CreateTestPage(bool inherited)
+		{
+            var grid = new Grid
+            {
+                AutomationId = "testgrid",
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill
+			};
+
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+
+			var instructions = new Label
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				HorizontalTextAlignment = TextAlignment.Center,
+				Text = $"Tap the button labeled '{UnderButtonText}'. Then tap the button labeled '{OverButtonText}'."
+				       + $" If the label below's text changes to '{Success}' the test has passed."
+			};
+
+			grid.Children.Add(instructions);
+
+            var results = new Label 
+            { 
+                HorizontalOptions = LayoutOptions.Fill,
+                HorizontalTextAlignment = TextAlignment.Center, 
+                Text = Running 
+            };
+
+            grid.Children.Add(results);
+            Grid.SetRow(results, 1);
+
+			var underButton = new Button
+			{
+				Text = UnderButtonText,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			bool overPressed = false;
+			bool underPressed = false;
+
+			underButton.Clicked += (sender, args) =>
+			{
+				underPressed = true;
+				UpdateResults(results, inherited, overPressed, underPressed);
+			};
+
+			var overButton = new Button
+			{
+				Text = OverButtonText,
+				HorizontalOptions = LayoutOptions.End
+			};
+
+			overButton.Clicked += (sender, args) =>
+			{
+				overPressed = true;
+				UpdateResults(results, inherited, overPressed, underPressed);
+			};
+
+			var layout = new StackLayout
+			{
+                AutomationId = Overlay,
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+				InputTransparent = true,
+				BackgroundColor = Color.Blue,
+				Opacity = 0.2
+			};
+
+			layout.Children.Add(overButton);
+
+			// Bump up the elevation to cover FastRenderer buttons
+			layout.On<Android>().SetElevation(10f);
+
+			grid.Children.Add(underButton);
+			Grid.SetRow(underButton, 2);
+
+			grid.Children.Add(layout);
+			Grid.SetRow(layout, 2);
+
+			return new ContentPage { Content = grid, Title = inherited.ToString()};
+		}
+
+		static void UpdateResults(Label results, bool inherited, bool overPressed, bool underPressed)
+		{
+			if (inherited)
+			{
+				if (overPressed)
+				{
+					results.Text = Failure;
+					return;
+				}
+
+				if (underPressed)
+				{
+					results.Text = Success;
+					return;
+				}
+			}
+			else
+			{
+				if (overPressed && underPressed)
+				{
+					results.Text = Success;
+					return;
+				}
+			}
+
+			results.Text = Running;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentInheritance.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+
 #if UITEST
 using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
@@ -21,15 +18,15 @@ namespace Xamarin.Forms.Controls.Issues
 
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 5552368, "Transparency Inheritance", PlatformAffected.All)]
-    public class InputTransparentInheritance : TestNavigationPage
-    {
+	public class InputTransparentInheritance : TestNavigationPage
+	{
 		const string Running = "Running...";
 		const string Success = "Success";
 		const string Failure = "Failure";
 		const string UnderButtonText = "Button";
 		const string OverButtonText = "+";
 		const string Overlay = "overlay";
-		
+
 		const string InheritedStatic = "Inherited";
 		const string InheritedChange = "Inherited (changes)";
 		const string NotInheritedStatic = "Not Inherited";
@@ -44,7 +41,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var layout = new StackLayout();
 
-			layout.Children.Add(new Label {Text = "Select a test below"});
+			layout.Children.Add(new Label { Text = "Select a test below" });
 
 			layout.Children.Add(MenuButton(true, false));
 			layout.Children.Add(MenuButton(false, false));
@@ -56,9 +53,11 @@ namespace Xamarin.Forms.Controls.Issues
 
 		Button MenuButton(bool inherited, bool transition)
 		{
-			var text = inherited 
-				? transition ? InheritedChange : InheritedStatic 
-				: transition ? NotInheritedChange : NotInheritedStatic;
+			var text = inherited
+				? transition ? InheritedChange : InheritedStatic
+				: transition
+					? NotInheritedChange
+					: NotInheritedStatic;
 
 			var button = new Button { Text = text, AutomationId = text };
 
@@ -69,36 +68,37 @@ namespace Xamarin.Forms.Controls.Issues
 
 		static ContentPage CreateTestPage(bool inherited, bool transition)
 		{
-            var grid = new Grid
-            {
-                AutomationId = "testgrid",
+			var grid = new Grid
+			{
+				AutomationId = "testgrid",
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill
 			};
 
 			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
 			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
 
 			var instructions = new Label
 			{
 				HorizontalOptions = LayoutOptions.Fill,
 				HorizontalTextAlignment = TextAlignment.Center,
-				Text = $"Wait 5 seconds. Tap the button labeled '{UnderButtonText}'. Then tap the button labeled '{OverButtonText}'."
-				       + $" If the label below's text changes to '{Success}' the test has passed."
+				Text =
+					$"Wait 5 seconds. Tap the button labeled '{UnderButtonText}'. Then tap the button labeled '{OverButtonText}'."
+					+ $" If the label below's text changes to '{Success}' the test has passed."
 			};
 
 			grid.Children.Add(instructions);
 
-            var results = new Label 
-            { 
-                HorizontalOptions = LayoutOptions.Fill,
-                HorizontalTextAlignment = TextAlignment.Center, 
-                Text = Running 
-            };
+			var results = new Label
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				HorizontalTextAlignment = TextAlignment.Center,
+				Text = Running
+			};
 
-            grid.Children.Add(results);
-            Grid.SetRow(results, 1);
+			grid.Children.Add(results);
+			Grid.SetRow(results, 1);
 
 			var underButton = new Button
 			{
@@ -131,7 +131,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var layout = new StackLayout
 			{
-                AutomationId = Overlay,
+				AutomationId = Overlay,
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill,
 				InputTransparent = true,
@@ -140,7 +140,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Opacity = 0.2
 			};
 
-			layout.GestureRecognizers.Add(new TapGestureRecognizer()
+			layout.GestureRecognizers.Add(new TapGestureRecognizer
 			{
 				Command = new Command(() =>
 				{
@@ -160,7 +160,7 @@ namespace Xamarin.Forms.Controls.Issues
 			grid.Children.Add(layout);
 			Grid.SetRow(layout, 2);
 
-			var page = new ContentPage { Content = grid, Title = inherited.ToString()};
+			var page = new ContentPage { Content = grid, Title = inherited.ToString() };
 
 			if (transition)
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -255,6 +255,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FailImageSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GestureBubblingTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)InputTransparentInheritance.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1331.xaml.cs">
       <DependentUpon>GitHub1331.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -54,6 +54,9 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty IsClippedToBoundsProperty = BindableProperty.Create("IsClippedToBounds", typeof(bool), typeof(Layout), false);
 
+		public static readonly BindableProperty InputTransparentInheritedProperty = BindableProperty.Create(
+			"InputTransparentInherited", typeof(bool), typeof(Layout), true);
+
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
 		static IList<KeyValuePair<Layout, int>> s_resolutionList = new List<KeyValuePair<Layout, int>>();
@@ -84,6 +87,12 @@ namespace Xamarin.Forms
 		{
 			get { return (Thickness)GetValue(PaddingElement.PaddingProperty); }
 			set { SetValue(PaddingElement.PaddingProperty, value); }
+		}
+
+		public bool InputTransparentInherited
+		{
+			get => (bool)GetValue(InputTransparentInheritedProperty);
+			set => SetValue(InputTransparentInheritedProperty, value);
 		}
 
 		Thickness IPaddingElement.PaddingDefaultValueCreator()

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -91,8 +91,8 @@ namespace Xamarin.Forms
 
 		public bool InputTransparentInherited
 		{
-			get => (bool)GetValue(InputTransparentInheritedProperty);
-			set => SetValue(InputTransparentInheritedProperty, value);
+			get { return (bool)GetValue(InputTransparentInheritedProperty); }
+			set { SetValue(InputTransparentInheritedProperty, value); }
 		}
 
 		Thickness IPaddingElement.PaddingDefaultValueCreator()

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -13,6 +13,9 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty InputTransparentProperty = BindableProperty.Create("InputTransparent", typeof(bool), typeof(VisualElement), default(bool));
 
+		public static readonly BindableProperty InputTransparentInheritedProperty = BindableProperty.Create(
+			"InputTransparentInherited", typeof(bool), typeof(VisualElement), true);
+
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool), 
 			typeof(VisualElement), true, propertyChanged: OnIsEnabledPropertyChanged);
 
@@ -204,6 +207,12 @@ namespace Xamarin.Forms
 		{
 			get { return (bool)GetValue(InputTransparentProperty); }
 			set { SetValue(InputTransparentProperty, value); }
+		}
+
+		public bool InputTransparentInherited
+		{
+			get => (bool)GetValue(InputTransparentInheritedProperty);
+			set => SetValue(InputTransparentInheritedProperty, value);
 		}
 
 		public bool IsEnabled

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -13,9 +13,6 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty InputTransparentProperty = BindableProperty.Create("InputTransparent", typeof(bool), typeof(VisualElement), default(bool));
 
-		public static readonly BindableProperty InputTransparentInheritedProperty = BindableProperty.Create(
-			"InputTransparentInherited", typeof(bool), typeof(VisualElement), true);
-
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool), 
 			typeof(VisualElement), true, propertyChanged: OnIsEnabledPropertyChanged);
 
@@ -207,12 +204,6 @@ namespace Xamarin.Forms
 		{
 			get { return (bool)GetValue(InputTransparentProperty); }
 			set { SetValue(InputTransparentProperty, value); }
-		}
-
-		public bool InputTransparentInherited
-		{
-			get => (bool)GetValue(InputTransparentInheritedProperty);
-			set => SetValue(InputTransparentInheritedProperty, value);
 		}
 
 		public bool IsEnabled

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Platform.Android
 		string _defaultContentDescription;
 		bool? _defaultFocusable;
 		string _defaultHint;
+		bool _inputTransparentInherited = true;
 
 		VisualElementPackager _packager;
 		PropertyChangedEventHandler _propertyChangeHandler;
@@ -51,11 +52,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override bool DispatchTouchEvent(MotionEvent e)
 		{
-			if (InputTransparent)
+			if (InputTransparent && _inputTransparentInherited)
 			{
 				// If the Element is InputTransparent, this ViewGroup will be marked InputTransparent
-				// If we're InputTransparent we should return false on all touch events without
-				// even bothering to send them to the child Views
+				// If we're InputTransparent and our transparency should be applied to our child controls,
+				// we return false on all touch events without even bothering to send them to the child Views
 
 				return false; // IOW, not handled
 			}
@@ -192,6 +193,7 @@ namespace Xamarin.Forms.Platform.Android
 			SetContentDescription();
 			SetFocusable();
 			UpdateInputTransparent();
+			UpdateInputTransparentInherited();
 
 			Performance.Stop();
 		}
@@ -279,7 +281,8 @@ namespace Xamarin.Forms.Platform.Android
 				SetFocusable();
 			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
 				UpdateInputTransparent();
-			
+			else if (e.PropertyName == VisualElement.InputTransparentInheritedProperty.PropertyName)
+				UpdateInputTransparentInherited();
 
 			ElementPropertyChanged?.Invoke(this, e);
 		}
@@ -325,6 +328,11 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateInputTransparent()
 		{
 			InputTransparent = Element.InputTransparent;
+		}
+
+		void UpdateInputTransparentInherited()
+		{
+			_inputTransparentInherited = Element.InputTransparentInherited;
 		}
 
 		protected void SetPackager(VisualElementPackager packager)

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -281,7 +281,7 @@ namespace Xamarin.Forms.Platform.Android
 				SetFocusable();
 			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
 				UpdateInputTransparent();
-			else if (e.PropertyName == VisualElement.InputTransparentInheritedProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.Layout.InputTransparentInheritedProperty.PropertyName)
 				UpdateInputTransparentInherited();
 
 			ElementPropertyChanged?.Invoke(this, e);
@@ -292,7 +292,6 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element == null)
 				return;
 
-			ReadOnlyCollection<Element> children = ((IElementController)Element).LogicalChildren;
 			UpdateLayout(((IElementController)Element).LogicalChildren);
 		}
 
@@ -332,7 +331,14 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateInputTransparentInherited()
 		{
-			_inputTransparentInherited = Element.InputTransparentInherited;
+			var layout = Element as Layout;
+
+			if (layout == null)
+			{
+				return;
+			}
+
+			_inputTransparentInherited = layout.InputTransparentInherited;
 		}
 
 		protected void SetPackager(VisualElementPackager packager)

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -438,11 +438,11 @@ namespace Xamarin.Forms.Platform.UWP
 			Color backgroundColor = Element.BackgroundColor;
 			var control = Control as Control;
 
-			var container = (Panel)this;
+			var backgroundLayer = (Panel)this;
 			if (_backgroundLayer != null)
 			{
-				container = _backgroundLayer;
-				Background = null;
+				backgroundLayer = _backgroundLayer;
+				Background = null; // Make the container effectively hit test invisible
 			}
 
 			if (control != null)
@@ -460,11 +460,11 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if (!backgroundColor.IsDefault)
 				{
-					container.Background = backgroundColor.ToBrush();
+					backgroundLayer.Background = backgroundColor.ToBrush();
 				}
 				else
 				{
-					container.ClearValue(BackgroundProperty);
+					backgroundLayer.ClearValue(BackgroundProperty);
 				}
 			}
 		}
@@ -581,6 +581,16 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				return;
 			}
+
+			// In UWP, once a control has hit testing disabled, all of its child controls
+			// also have hit testing disabled. The exception is a Panel with its 
+			// Background Brush set to `null`; the Panel will be invisible to hit testing, but its
+			// children will work just fine. 
+
+			// In order to handle the situation where we need the layout to be invisible to hit testing,
+			// the child controls to be visible to hit testing, *and* we need to support non-null
+			// background brushes, we insert another empty Panel which is invisible to hit testing; that
+			// Panel will be our Background color
 
 			_backgroundLayer = new Canvas { IsHitTestVisible = false };
 			Children.Insert(0, _backgroundLayer);

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -437,8 +437,13 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			Color backgroundColor = Element.BackgroundColor;
 			var control = Control as Control;
-			
-			var container = _backgroundLayer ?? (Panel)this;
+
+			var container = (Panel)this;
+			if (_backgroundLayer != null)
+			{
+				container = _backgroundLayer;
+				Background = null;
+			}
 
 			if (control != null)
 			{
@@ -579,6 +584,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_backgroundLayer = new Canvas { IsHitTestVisible = false };
 			Children.Insert(0, _backgroundLayer);
+			UpdateBackgroundColor();
 		}
 
 		void RemoveBackgroundLayer()
@@ -590,6 +596,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			Children.Remove(_backgroundLayer);
 			_backgroundLayer = null;
+			UpdateBackgroundColor();
 		}
 
 		internal static bool NeedsBackgroundLayer(VisualElement element)

--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -442,6 +442,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static void UpdateInputTransparent(VisualElement view, FrameworkElement frameworkElement)
 		{
+			if (view is Layout)
+			{
+				// Let VisualElementRenderer handle this
+			}
+
 			frameworkElement.IsHitTestVisible = view.IsEnabled && !view.InputTransparent;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -480,6 +480,12 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			public override UIView HitTest(CGPoint point, UIEvent uievent)
 			{
+				if (!UserInteractionEnabled) 
+				{
+					// This view can't interact, and neither can its children
+					return null;
+				}
+
 				// UIview hit testing ignores objects which have an alpha of less than 0.01 
 				// (see https://developer.apple.com/reference/uikit/uiview/1622469-hittest)
 				// To prevent layouts with low opacity from being implicitly input transparent, 
@@ -498,6 +504,14 @@ namespace Xamarin.Forms.Platform.iOS
 				if (UserInteractionEnabled && old <= 0.01)
 				{
 					Alpha = old;
+				}
+
+				if (UserInteractionEnabled && !Element.InputTransparentInherited)
+				{
+					if (result.Equals(this))
+					{
+						return null;
+					}
 				}
 
 				return result;

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -506,10 +506,12 @@ namespace Xamarin.Forms.Platform.iOS
 					Alpha = old;
 				}
 
-				if (UserInteractionEnabled && !Element.InputTransparentInherited)
+				if (UserInteractionEnabled && Element is Layout layout && !layout.InputTransparentInherited)
 				{
+					// This is a Layout with 'InputTransparent = true' and 'InputTransparentInherited = false'
 					if (result.Equals(this))
 					{
+						// If the hit is on the Layout (and not a child control), then ignore it
 						return null;
 					}
 				}

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -509,7 +509,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (UserInteractionEnabled && Element is Layout layout && !layout.InputTransparentInherited)
 				{
 					// This is a Layout with 'InputTransparent = true' and 'InputTransparentInherited = false'
-					if (result.Equals(this))
+					if (this.Equals(result))
 					{
 						// If the hit is on the Layout (and not a child control), then ignore it
 						return null;

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -82,7 +82,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				e.PropertyName == VisualElement.TranslationXProperty.PropertyName || e.PropertyName == VisualElement.TranslationYProperty.PropertyName || e.PropertyName == VisualElement.ScaleProperty.PropertyName ||
 				e.PropertyName == VisualElement.RotationProperty.PropertyName || e.PropertyName == VisualElement.RotationXProperty.PropertyName || e.PropertyName == VisualElement.RotationYProperty.PropertyName ||
 				e.PropertyName == VisualElement.IsVisibleProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName ||
-				e.PropertyName == VisualElement.InputTransparentProperty.PropertyName || e.PropertyName == VisualElement.OpacityProperty.PropertyName)
+				e.PropertyName == VisualElement.InputTransparentProperty.PropertyName || e.PropertyName == VisualElement.OpacityProperty.PropertyName || 
+				e.PropertyName == VisualElement.InputTransparentInheritedProperty.PropertyName)
 				UpdateNativeControl(); // poorly optimized
 		}
 
@@ -112,7 +113,24 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (view == null || view.Batched)
 				return;
 
-			var shouldInteract = !view.InputTransparent && view.IsEnabled;
+			bool shouldInteract;
+
+			if (view is Layout)
+			{
+				if (view.InputTransparent)
+				{
+					shouldInteract = !view.InputTransparentInherited;
+				}
+				else
+				{
+					shouldInteract = view.IsEnabled;
+				}
+			}
+			else
+			{
+				shouldInteract = !view.InputTransparent && view.IsEnabled;
+			}
+
 			if (_isInteractive != shouldInteract)
 			{
 #if __MOBILE__

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				e.PropertyName == VisualElement.RotationProperty.PropertyName || e.PropertyName == VisualElement.RotationXProperty.PropertyName || e.PropertyName == VisualElement.RotationYProperty.PropertyName ||
 				e.PropertyName == VisualElement.IsVisibleProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName ||
 				e.PropertyName == VisualElement.InputTransparentProperty.PropertyName || e.PropertyName == VisualElement.OpacityProperty.PropertyName || 
-				e.PropertyName == VisualElement.InputTransparentInheritedProperty.PropertyName)
+				e.PropertyName == Layout.InputTransparentInheritedProperty.PropertyName)
 				UpdateNativeControl(); // poorly optimized
 		}
 
@@ -115,15 +115,15 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			bool shouldInteract;
 
-			if (view is Layout)
+			if (view is Layout layout)
 			{
-				if (view.InputTransparent)
+				if (layout.InputTransparent)
 				{
-					shouldInteract = !view.InputTransparentInherited;
+					shouldInteract = !layout.InputTransparentInherited;
 				}
 				else
 				{
-					shouldInteract = view.IsEnabled;
+					shouldInteract = layout.IsEnabled;
 				}
 			}
 			else

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Layout.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Layout.xml
@@ -162,6 +162,37 @@
         <altmember cref="M:Xamarin.Forms.OnSizeRequest (double, double)" />
       </Docs>
     </Member>
+    <Member MemberName="InputTransparentInherited">
+      <MemberSignature Language="C#" Value="public bool InputTransparentInherited { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool InputTransparentInherited" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="InputTransparentInheritedProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty InputTransparentInheritedProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty InputTransparentInheritedProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="InvalidateLayout">
       <MemberSignature Language="C#" Value="protected virtual void InvalidateLayout ();" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig newslot virtual instance void InvalidateLayout() cil managed" />


### PR DESCRIPTION
### Description of Change ###

By default, if a `Layout` is marked `InputTransparent`, its child controls are also `InputTransparent`. However, in some scenarios this behavior may not be desirable (e.g., control overlays). This change adds a boolean `InputTransparentInherited`. When set to true (the default), a `Layout`'s child controls are `InputTransparent` when the `Layout` is `InputTransparent`. When set to false, the `Layout`'s child controls are `InputTransparent` only if that property is explicitly set.

### Bugs Fixed ###

- [40967 – Layouts intercept all input on iOS.](https://bugzilla.xamarin.com/show_bug.cgi?id=40967)
- [60766 – AbsoluteLayout without background captures input on Android](https://bugzilla.xamarin.com/show_bug.cgi?id=60766)

### API Changes ###

Added:
`Xamarin.Forms.Layout` 
- `bool InputTransparentInherited { get; set; }` 
- `BindableProperty InputTransparentInheritedProperty`

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
