### PR TITLE
Don't hook up Unloaded handler in UWP PageRenderer until Loaded fires. fixes #1602

### DIFF
--- a/Xamarin.Forms.Platform.UAP/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PageRenderer.cs
@@ -48,8 +48,6 @@ namespace Xamarin.Forms.Platform.UWP
 				if (e.OldElement == null)
 				{
 					Loaded += OnLoaded;
-					Unloaded += OnUnloaded;
-
 					Tracker = new BackgroundTracker<FrameworkElement>(BackgroundProperty);
 				}
 
@@ -71,11 +69,13 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 			}
 			_loaded = true;
+			Unloaded += OnUnloaded;
 			Element?.SendAppearing();
 		}
 
 		void OnUnloaded(object sender, RoutedEventArgs args)
 		{
+			Unloaded -= OnUnloaded;
 			_loaded = false;
 			Element?.SendDisappearing();
 		}


### PR DESCRIPTION
### Description of Change ###

If the `MainPage` of the application is set to a `NavigationPage`, the `Unloaded` event of the root `ContentPage`'s renderer fires incorrectly after the page loads. This only occurs on the first setting of `MainPage` - subsequent calls to set it work just fine.

This change adjusts the `PageRenderer` so that the `Unload` event is not tracked until the renderer has been `Loaded`, which prevents the renderer from incorrectly calling `SendDisappearing`.

Since this bug only occurs when an application sets `MainPage` for the first time, it's exceedingly awkward to UI test in ControlGallery.

### Bugs Fixed ###

- [60589 – Unexpected call to OnDisappearing on UWP when using NavigationPage](https://bugzilla.xamarin.com/show_bug.cgi?id=60589)
- [[UWP] Page.Disappearing is raised on the root page of a NavigationPage · Issue #1602 · xamarin/Xamarin.Forms](https://github.com/xamarin/Xamarin.Forms/issues/1602)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
