### PR TITLE
[XamlC] get the Assembly through the TypeInfo

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
@@ -51,9 +51,11 @@ namespace Xamarin.Forms.Core.XamlC
 			yield return Create(Ldstr, resourcePath); //resourcePath
 
 			var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
-			var getAssembly = module.ImportReference(typeof(Type).GetProperty("Assembly").GetGetMethod());
+			var getTypeInfo = module.ImportReference(typeof(System.Reflection.IntrospectionExtensions).GetMethod("GetTypeInfo", new Type[] { typeof(Type) }));
+			var getAssembly = module.ImportReference(typeof(System.Reflection.TypeInfo).GetProperty("Assembly").GetMethod);
 			yield return Create(Ldtoken, module.ImportReference(((ILRootNode)rootNode).TypeReference));
 			yield return Create(Call, module.ImportReference(getTypeFromHandle));
+			yield return Create(Call, module.ImportReference(getTypeInfo));
 			yield return Create(Callvirt, module.ImportReference(getAssembly)); //assembly
 
 			foreach (var instruction in node.PushXmlLineInfo(context))

--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -287,10 +287,12 @@ namespace Xamarin.Forms.Build.Tasks
 					il.Emit(Call, getResourceProvider);
 
 					var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
-					var getAssembly = module.ImportReference(typeof(Type).GetProperty("Assembly").GetGetMethod());
+					var getTypeInfo = module.ImportReference(typeof(System.Reflection.IntrospectionExtensions).GetMethod("GetTypeInfo", new Type[] { typeof(Type) }));
+					var getAssembly = module.ImportReference(typeof(Type).GetProperty("Assembly").GetMethod);
 					var getAssemblyName = module.ImportReference(typeof(System.Reflection.Assembly).GetMethod("GetName", new Type[] { }));
 					il.Emit(Ldtoken, module.ImportReference(initComp.DeclaringType));
 					il.Emit(Call, module.ImportReference(getTypeFromHandle));
+					il.Emit(Call, module.ImportReference(getTypeInfo));
 					il.Emit(Callvirt, module.ImportReference(getAssembly));
 					il.Emit(Callvirt, module.ImportReference(getAssemblyName)); //assemblyName
 


### PR DESCRIPTION
### Description of Change ###

[XamlC] get the Assembly through the TypeInfo

when an assembly object is required, XamlC was generating IL equivalent to the following c#
```
var asm = typeof(Foo).Assembly;
```

That API (the `Assembly` property) is not available in PCL profiles, but is always present at runtime. So there was no problem executing the code, but tools like CodeAnalysis were seriously confused.

The fix in this PR changes the generated code to the equivalent of
```
var asm = typeof(Foo).GetTypeInfo().Assembly;
```

Upgrading your projects from PCL to `netstandard2.0` would fix this as well.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=44130

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense