### PR TITLE
[Android] Redo: Hide Fragments before removing them to allow custom animations

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Resources/anim/enter_from_left.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/anim/enter_from_left.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+  <translate
+      android:fromXDelta="-100%" android:toXDelta="0%"
+      android:fromYDelta="0%" android:toYDelta="0%"
+      android:duration="500"/>
+</set>

--- a/Xamarin.Forms.ControlGallery.Android/Resources/anim/enter_from_right.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/anim/enter_from_right.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+  <translate
+     android:fromXDelta="100%" android:toXDelta="0%"
+     android:fromYDelta="0%" android:toYDelta="0%"
+     android:duration="500" />
+</set>

--- a/Xamarin.Forms.ControlGallery.Android/Resources/anim/exit_to_left.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/anim/exit_to_left.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+  <translate
+      android:fromXDelta="0%" android:toXDelta="-100%"
+      android:fromYDelta="0%" android:toYDelta="0%"
+      android:duration="500"/>
+</set>

--- a/Xamarin.Forms.ControlGallery.Android/Resources/anim/exit_to_right.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/anim/exit_to_right.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:shareInterpolator="false">
+  <translate
+     android:fromXDelta="0%" android:toXDelta="100%"
+     android:fromYDelta="0%" android:toYDelta="0%"
+     android:duration="500" />
+</set>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -184,6 +184,7 @@
     <Compile Include="TestCloudService.cs" />
     <Compile Include="_38989CustomRenderer.cs" />
     <Compile Include="BrokenImageSourceHandler.cs" />
+    <Compile Include="_50787CustomRenderer.cs" />
     <Compile Include="_57114CustomRenderer.cs" />
     <Compile Include="_58406EffectRenderer.cs" />
     <Compile Include="_59457CustomRenderer.cs" />
@@ -295,6 +296,26 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\synchronize_enabled.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\anim\enter_from_left.xml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\anim\enter_from_right.xml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\anim\exit_to_left.xml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\anim\exit_to_right.xml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Xamarin.Forms.ControlGallery.Android/_50787CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_50787CustomRenderer.cs
@@ -1,0 +1,27 @@
+﻿using Android.Content;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Platform.Android.AppCompat;
+using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
+
+[assembly: ExportRenderer(typeof(NavigationPage), typeof(_50787CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class _50787CustomRenderer : NavigationPageRenderer
+	{
+		public _50787CustomRenderer(Context context) : base(context)
+		{
+
+		}
+
+		protected override int TransitionDuration { get; set; } = 500;
+
+		protected override void SetupPageTransition(FragmentTransaction transaction, bool isPush)
+		{
+			if (isPush)
+				transaction.SetCustomAnimations(Resource.Animation.enter_from_right, Resource.Animation.exit_to_left);
+			else
+				transaction.SetCustomAnimations(Resource.Animation.enter_from_left, Resource.Animation.exit_to_right);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 50787, "Can\'t animate Fragment transition when it\'s being removed from the stack", PlatformAffected.Android)]
+	public class Bugzilla50787 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			PushAsync(new ContentPage50787());
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ContentPage50787 : ContentPage
+	{
+		public ContentPage50787()
+		{
+			BackgroundColor = Color.FromRgb(Guid.NewGuid().GetHashCode() % 255, Guid.NewGuid().GetHashCode() % 255, Guid.NewGuid().GetHashCode() % 255);
+
+			var button = new Button
+			{
+				Text = "Push",
+				Command = new Command(async () => { await Navigation.PushAsync(new ContentPage50787()); })
+			};
+
+			var button2 = new Button
+			{
+				Text = "Pop to root",
+				Command = new Command(async () => { await Navigation.PopToRootAsync(); })
+			};
+
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Label
+					{
+						Text = "As you push, a new page should slide in from the right. If you hit the back button or the navigation arrow, it should be the reverse. Popping to root should slide in only the root page.",
+						TextColor = Color.White
+					},
+					button,
+					button2
+				}
+			};
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			System.Diagnostics.Debug.WriteLine("appearing");
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+			System.Diagnostics.Debug.WriteLine("disappearing");
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla50787.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					new Label
 					{
-						Text = "As you push, a new page should slide in from the right. If you hit the back button or the navigation arrow, it should be the reverse. Popping to root should slide in only the root page.",
+						Text = "As you push, a new page should slide in from the right. If you hit the back button or the navigation arrow, the previous animation should be reversed. Popping to root should slide in only the root page.",
 						TextColor = Color.White
 					},
 					button,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -178,6 +178,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46363.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46363_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47548.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla50787.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52299.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla52419.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla49304.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -47,6 +47,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		bool _toolbarVisible;
 
 		// The following is based on https://android.googlesource.com/platform/frameworks/support.git/+/4a7e12af4ec095c3a53bb8481d8d92f63157c3b7/v4/java/android/support/v4/app/FragmentManager.java#677
+		// Must be overriden in a custom renderer to match durations in XML animation resource files
 		protected virtual int TransitionDuration { get; set; } = 220;
 
 		public NavigationPageRenderer(Context context) : base(context)

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -46,8 +46,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		MasterDetailPage _masterDetailPage;
 		bool _toolbarVisible;
 
-		// The following is based on https://android.googlesource.com/platform/frameworks/support/+/refs/heads/master/v4/java/android/support/v4/app/FragmentManager.java#849
-		const int TransitionDuration = 220;
+		// The following is based on https://android.googlesource.com/platform/frameworks/support.git/+/4a7e12af4ec095c3a53bb8481d8d92f63157c3b7/v4/java/android/support/v4/app/FragmentManager.java#677
+		protected virtual int TransitionDuration { get; set; } = 220;
 
 		public NavigationPageRenderer(Context context) : base(context)
 		{
@@ -604,7 +604,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			// Go ahead and take care of the fragment bookkeeping for the page being removed
 			FragmentTransaction transaction = FragmentManager.BeginTransaction();
-			transaction.DisallowAddToBackStack();
 			transaction.Remove(fragment);
 			transaction.CommitAllowingStateLoss();
 
@@ -676,6 +675,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (animated)
 				SetupPageTransition(transaction, !removed);
 
+			var fragmentsToRemove = new List<Fragment>();
+
 			if (_fragmentStack.Count == 0)
 			{
 				transaction.Add(Id, fragment);
@@ -691,7 +692,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					{
 						Fragment currentToRemove = _fragmentStack.Last();
 						_fragmentStack.RemoveAt(_fragmentStack.Count - 1);
-						transaction.Remove(currentToRemove);
+						transaction.Hide(currentToRemove);
+						fragmentsToRemove.Add(currentToRemove);
 						popPage = popToRoot;
 					}
 
@@ -731,29 +733,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else if (_drawerToggle != null && ((INavigationPageController)Element).StackDepth == 2)
 					AnimateArrowOut();
 
-				Device.StartTimer(TimeSpan.FromMilliseconds(TransitionDuration), () =>
-				{
-					tcs.TrySetResult(true);
-					fragment.UserVisibleHint = true;
-					if (removed)
-					{
-						UpdateToolbar();
-					}
-
-					return false;
-				});
+				AddTransitionTimer(tcs, fragment, FragmentManager, fragmentsToRemove, TransitionDuration, removed);
 			}
 			else
-			{
-				Device.StartTimer(TimeSpan.FromMilliseconds(1), () =>
-				{
-					tcs.TrySetResult(true);
-					fragment.UserVisibleHint = true;
-					UpdateToolbar();
-
-					return false;
-				});
-			}
+				AddTransitionTimer(tcs, fragment, FragmentManager, fragmentsToRemove, 1, true);
 
 			Context.HideKeyboard(this);
 			((Platform)Element.Platform).NavAnimationInProgress = false;
@@ -891,6 +874,26 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				bar.SetTitleTextColor(textColor.ToAndroid().ToArgb());
 
 			bar.Title = Element.CurrentPage.Title ?? "";
+		}
+
+		void AddTransitionTimer(TaskCompletionSource<bool> tcs, Fragment fragment, FragmentManager fragmentManager, IReadOnlyCollection<Fragment> fragmentsToRemove, int duration, bool shouldUpdateToolbar)
+		{
+			Device.StartTimer(TimeSpan.FromMilliseconds(duration), () =>
+			{
+				tcs.TrySetResult(true);
+				fragment.UserVisibleHint = true;
+				if (shouldUpdateToolbar)
+					UpdateToolbar();
+
+				FragmentTransaction fragmentTransaction = fragmentManager.BeginTransaction();
+
+				foreach (Fragment frag in fragmentsToRemove)
+					fragmentTransaction.Remove(frag);
+
+				fragmentTransaction.CommitAllowingStateLoss();
+
+				return false;
+			});
 		}
 
 		class ClickListener : Object, IOnClickListener


### PR DESCRIPTION
Redoing #661. 

Note that `TransitionDuration` must be overriden in a custom renderer to match durations in XML animation resource files so that pages disappear from the screen at the same time animations complete. I'm not sure if there is an API to extract durations from the resource files at runtime for us to sync `TransitionDuration` with those durations without having to set `TransitionDuration` manually. 

Also, another thing to note is it is possible for the page animation and the page removal timer to finish at different times even though they are expected to finish at about the same time since neither is probably guaranteed to finish in the given course of time. To guard for this, it might be a good idea to set `TransitionDuration` slightly higher than durations in resource files. I don't like this kind of coupling, but I can't think of another solution.

**Untested scenario:**

Though small, there is also the possibility that a developer wants different durations for different animations. Not sure if this PR provides support for that, but it might be possible to change `TransitionDuration` before pushes and pops to make this scenario work.