### PR TITLE
Use GetHandlerForObject instead of GetHandler

### DIFF
--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -81,6 +81,17 @@ namespace Xamarin.Forms.Internals
 			return (TOut)GetHandler(type);
 		}
 
+		public TOut GetHandlerForObject<TOut>(object obj, params object[] args) where TOut : TRegistrable
+		{
+			if (obj == null)
+				throw new ArgumentNullException(nameof(obj));
+
+			var reflectableType = obj as IReflectableType;
+			var type = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : obj.GetType();
+
+			return (TOut)GetHandler(type, args);
+		}
+
 		public Type GetHandlerType(Type viewType)
 		{
 			Type type;

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -307,7 +307,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
 		{
-			IVisualElementRenderer renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType(), context) 
+			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element, context)
 				?? new DefaultRenderer(context);
 			renderer.SetElement(element);
 
@@ -351,7 +351,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal static IVisualElementRenderer CreateRenderer(VisualElement element, FragmentManager fragmentManager, Context context)
 		{
-			IVisualElementRenderer renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType(), context) ?? new DefaultRenderer(context);
+			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element, context) ?? new DefaultRenderer(context);
 
 			var managesFragments = renderer as IManageFragments;
 			managesFragments?.SetFragmentManager(fragmentManager);

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Platform.Android
 				var bitmap = GetBitmap(context.Resources, file) ?? BitmapFactory.DecodeFile(file);
 				if (bitmap == null)
 				{
-					var source = Registrar.Registered.GetHandler<IImageSourceHandler>(fileImageSource.GetType());
+					var source = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(fileImageSource);
 					bitmap = source.LoadImageAsync(fileImageSource, context).GetAwaiter().GetResult();
 				}
 				if (bitmap != null)

--- a/Xamarin.Forms.Platform.GTK/Cells/ImageCellRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Cells/ImageCellRenderer.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
             Renderers.IImageSourceHandler handler;
 
             if (source != null && (handler =
-                Internals.Registrar.Registered.GetHandler<Renderers.IImageSourceHandler>(source.GetType())) != null)
+                Internals.Registrar.Registered.GetHandlerForObject<Renderers.IImageSourceHandler>(source)) != null)
             {
                 Gdk.Pixbuf image;
 

--- a/Xamarin.Forms.Platform.GTK/Controls/TableView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/TableView.cs
@@ -159,7 +159,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
                         var cell = tableSection[j];
 
                         var renderer =
-                            (Cells.CellRenderer)Internals.Registrar.Registered.GetHandler<IRegisterable>(cell.GetType());
+                            (Cells.CellRenderer)Internals.Registrar.Registered.GetHandlerForObject<IRegisterable>(cell);
                         var nativeCell = renderer.GetCell(cell, null, null);
 
                         if (nativeCell != null)

--- a/Xamarin.Forms.Platform.GTK/Platform.cs
+++ b/Xamarin.Forms.Platform.GTK/Platform.cs
@@ -89,8 +89,7 @@ namespace Xamarin.Forms.Platform.GTK
 
         public static IVisualElementRenderer CreateRenderer(VisualElement element)
         {
-            var elementType = element.GetType();
-            var renderer = Registrar.Registered.GetHandler<IVisualElementRenderer>(elementType) ?? new DefaultRenderer();
+            var renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultRenderer();
             renderer.SetElement(element);
 
             return renderer;

--- a/Xamarin.Forms.Platform.GTK/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ImageRenderer.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             ((IImageController)Element).SetIsLoading(true);
 
             if (source != null
-                && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+                && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
             {
                 Pixbuf image;
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
@@ -501,7 +501,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         private CellBase GetCell(Cell cell)
         {
             var renderer =
-                (Cells.CellRenderer)Registrar.Registered.GetHandler<IRegisterable>(cell.GetType());
+                (Cells.CellRenderer)Registrar.Registered.GetHandlerForObject<IRegisterable>(cell);
 
             var realCell = renderer.GetCell(cell, null, _listView);
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/MasterDetailPageRenderer.cs
@@ -192,7 +192,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             if (hamburguerIcon != null)
             {
                 IImageSourceHandler handler =
-                    Registrar.Registered.GetHandler<IImageSourceHandler>(hamburguerIcon.GetType());
+                    Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(hamburguerIcon);
 
                 var image = await handler.LoadImageAsync(hamburguerIcon);
                 Widget.UpdateHamburguerIcon(image);

--- a/Xamarin.Forms.Platform.WPF/CellControl.cs
+++ b/Xamarin.Forms.Platform.WPF/CellControl.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 		System.Windows.DataTemplate GetTemplate(Cell cell)
 		{
-			var renderer = Registrar.Registered.GetHandler<ICellRenderer>(cell.GetType());
+			var renderer = Registrar.Registered.GetHandlerForObject<ICellRenderer>(cell);
 			return renderer.GetTemplate(cell);
 		}
 

--- a/Xamarin.Forms.Platform.WPF/Converters/ImageConverter.cs
+++ b/Xamarin.Forms.Platform.WPF/Converters/ImageConverter.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.WPF
 			var source = (ImageSource)value;
 			IImageSourceHandler handler;
 			
-			if (source != null && (handler = Internals.Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				Task<System.Windows.Media.ImageSource> image = handler.LoadImageAsync(source);
 				image.Wait();

--- a/Xamarin.Forms.Platform.WPF/Platform.cs
+++ b/Xamarin.Forms.Platform.WPF/Platform.cs
@@ -139,7 +139,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 		public static IVisualElementRenderer CreateRenderer(VisualElement element)
 		{
-			IVisualElementRenderer result = Registrar.Registered.GetHandler<IVisualElementRenderer>(element.GetType()) ?? new DefaultViewRenderer();
+			IVisualElementRenderer result = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultViewRenderer();
 			result.SetElement(element);
 			return result;
 		}

--- a/Xamarin.Forms.Platform.WPF/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ImageRenderer.cs
@@ -82,7 +82,7 @@ namespace Xamarin.Forms.Platform.WPF
 			
 			ImageSource source = Element.Source;
 			IImageSourceHandler handler;
-			if (source != null && (handler = Registrar.Registered.GetHandler<IImageSourceHandler>(source.GetType())) != null)
+			if (source != null && (handler = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				System.Windows.Media.ImageSource imagesource;
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/Registrar`1.xml
@@ -132,6 +132,42 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="GetHandlerForObject&lt;TOut&gt;">
+      <MemberSignature Language="C#" Value="public TOut GetHandlerForObject&lt;TOut&gt; (object obj, object[] args) where TOut : TRegistrable;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance !!TOut GetHandlerForObject&lt;(!TRegistrable) TOut&gt;(object obj, object[] args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>TOut</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TOut">
+          <Constraints>
+            <BaseTypeName>TRegistrable</BaseTypeName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="obj" Type="System.Object" />
+        <Parameter Name="args" Type="System.Object[]">
+          <Attributes>
+            <Attribute>
+              <AttributeName>System.ParamArray</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+      </Parameters>
+      <Docs>
+        <typeparam name="TOut">To be added.</typeparam>
+        <param name="obj">To be added.</param>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="GetHandlerType">
       <MemberSignature Language="C#" Value="public Type GetHandlerType (Type viewType);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Type GetHandlerType(class System.Type viewType) cil managed" />


### PR DESCRIPTION
### Description of Change ###

Replace remaining uses of `GetHandler` with `GetHandlerForObject` so that IReflectableTypes can be used.

This is work that should have been done in #1006 but was missed.

### Bugs Fixed ###

- fixes #1712 

### API Changes ###

Added:
 - `public T Registrar.GetHandlerForObject<T>(obj, args)`

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
