### PR TITLE
Use GetMethod instead of GetRuntimeMethod in TypeConversionExtensions

### DIFF
--- a/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
+++ b/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
@@ -194,7 +194,12 @@ namespace Xamarin.Forms.Xaml
 
 		internal static MethodInfo GetImplicitConversionOperator(this Type onType, Type fromType, Type toType)
 		{
+#if PCL
 			var mi = onType.GetRuntimeMethod("op_Implicit", new[] { fromType });
+#else
+			var bindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy;
+			var mi = onType.GetMethod("op_Implicit", bindingFlags, null, new[] { fromType }, null);
+#endif
 			if (mi == null) return null;
 			if (!mi.IsSpecialName) return null;
 			if (!mi.IsPublic) return null;


### PR DESCRIPTION
### Description of Change ###

This allows the use of dynamic types (non runtime types) to be used in binding.

### Bugs Fixed ###

- #1703 

### API Changes ###

None

### Behavioral Changes ###

Dynamic types can now be bound to.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
