### PR TITLE
[Android] Ensure PanGestureRecognizer sends the Completed status (#1495)

### DIFF
--- a/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
+++ b/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
@@ -200,7 +200,7 @@ namespace Xamarin.Forms.Platform.Android
 			return _scrollDelegate(totalX, totalY, e2.PointerCount);
 		}
 
-		void EndScrolling()
+		internal void EndScrolling()
 		{
 			if (_isScrolling && _scrollCompleteDelegate != null)
 				_scrollCompleteDelegate();


### PR DESCRIPTION
### Description of Change ###

The ScaleGestureDetector in Android doesn't always fire an end gesture event. It seems we rely upon this to fire the EndScrolling method. 

If we also listen for the touch up event, we can call EndScrolling event if the ScaleGestureDetector fails to fire.

I'm not opposed to moving the TapAndPanGestureDetector to it's own file, if you prefer.

### Bugs Fixed ###

- fixes #1495

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
