### PR TITLE
[Android] Slider should show correct Value even though SeekBar's Progress is slightly off

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1625.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1625.cs
@@ -1,0 +1,45 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1625, "Slider value is not changed for the first position change", PlatformAffected.Android)]
+	public class Github1625 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var slider = new Slider();
+			slider.Maximum = 10;
+			slider.Minimum = 1;
+			slider.Value = 5;
+
+			var valueLabel = new Label();
+			var stack = new StackLayout { Orientation = StackOrientation.Vertical, Spacing = 15 };
+
+			valueLabel.SetBinding(Label.TextProperty, new Binding("Value", source: slider));
+			stack.Children.Add(valueLabel);
+			stack.Children.Add(slider);
+
+			var button = new Button
+			{
+				Text = "Set to 7",
+				Command = new Command(() => slider.Value = 7)
+			};
+			stack.Children.Add(button);
+
+			var label = new Label
+			{
+				Text = "On start, slider value should show 5 even though SeekBar is 4.996. Sliding back and forth should update the label and the tracker. Tapping on a slider position should do the same. Tapping on the button should show 7 even though SeekBar is 6.994."
+			};
+			stack.Children.Add(label);
+
+			Content = stack;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -259,6 +259,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1331.xaml.cs">
       <DependentUpon>GitHub1331.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Github1625.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InputTransparentTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsInvokeRequiredRaceCondition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsPasswordToggleTest.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.Android
 	public class SliderRenderer : ViewRenderer<Slider, SeekBar>, SeekBar.IOnSeekBarChangeListener
 	{
 		double _max, _min;
-		bool _progressChangedOnce;
+		bool _isTrackingChange;
 
 		public SliderRenderer(Context context) : base(context)
 		{
@@ -31,21 +31,18 @@ namespace Xamarin.Forms.Platform.Android
 
 		void SeekBar.IOnSeekBarChangeListener.OnProgressChanged(SeekBar seekBar, int progress, bool fromUser)
 		{
-			if (!_progressChangedOnce)
-			{
-				_progressChangedOnce = true;
-				return;
-			}
-
-			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, Value);
+			if (_isTrackingChange)
+				((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, Value);
 		}
 
 		void SeekBar.IOnSeekBarChangeListener.OnStartTrackingTouch(SeekBar seekBar)
 		{
+			_isTrackingChange = true;
 		}
 
 		void SeekBar.IOnSeekBarChangeListener.OnStopTrackingTouch(SeekBar seekBar)
 		{
+			_isTrackingChange = false;
 		}
 
 		protected override SeekBar CreateNativeControl()


### PR DESCRIPTION
### Description of Change ###

#378 fixed an issue but also introduced regression. This fixes both #378 and #1625. When the element itself or its properties are changing from the Core side, SeekBar's tracker isn't being manipulated by the user, so we can ignore native changes being propagated back to Core. Please see instructions in the test.

Note that this introduces the problem that Core and Native aren't always in sync as there is a small precision difference. However, not adding this fix is more problematic because users see values that they did not expect.

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=54887
- fixes #1625

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
