### PR TITLE
[Android] BackPressed preventing for an each event

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override void OnBackPressed()
 		{
-			if (BackPressed != null && BackPressed(this, EventArgs.Empty))
+			if (!CanGoBack())
 				return;
 			base.OnBackPressed();
 		}
@@ -274,6 +274,22 @@ namespace Xamarin.Forms.Platform.Android
 			_currentState = AndroidApplicationLifecycleState.OnStop;
 
 			await OnStateChanged();
+		}
+
+		bool CanGoBack()
+		{
+			var backPressed = BackPressed;
+
+			if (backPressed == null)
+				return true;
+
+			var invocationList = backPressed.GetInvocationList().ToList();
+
+			var canGoBack = !invocationList
+				.Select(@delegate => ((BackButtonPressedEventHandler) @delegate).Invoke(this, EventArgs.Empty))
+				.Any(b => b);
+
+			return canGoBack;
 		}
 
 		void AppOnPropertyChanged(object sender, PropertyChangedEventArgs args)

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override void OnBackPressed()
 		{
-			if (BackPressed != null && BackPressed(this, EventArgs.Empty))
+			if (!CanGoBack())
 				return;
 			base.OnBackPressed();
 		}
@@ -191,6 +191,22 @@ namespace Xamarin.Forms.Platform.Android
 			_currentState = AndroidApplicationLifecycleState.OnStop;
 
 			OnStateChanged();
+		}
+
+		bool CanGoBack()
+		{
+			var backPressed = BackPressed;
+
+			if (backPressed == null)
+				return true;
+
+			var invocationList = backPressed.GetInvocationList().ToList();
+
+			var canGoBack = !invocationList
+				.Select(@delegate => ((BackButtonPressedEventHandler) @delegate).Invoke(this, EventArgs.Empty))
+				.Any(b => b);
+
+			return canGoBack;
 		}
 
 		void AppOnPropertyChanged(object sender, PropertyChangedEventArgs args)


### PR DESCRIPTION
### Description of Change ###

I have [the library for xamarin forms](https://github.com/rotorgames/Rg.Plugins.Popup) and I should catch a back button event in my library and prevent it if it is needed. I have found the BackPressed events in FormsAppCompatActivity and FormsApplicationActivity and if I return `true` in these events the back button will not work. But it works only for the last delegate in the BackPressed event. I have fixed it. Each delegate will be invoked in the invocation list but if one in them returns true that the back button will not pop any pages.

I think that a lot of people would like to use this feature in their libraries.

I have not created any tests because it is simple changes.

I needed to created two CanGoBack methods in FormsAppCompatActivity and FormsApplicationActivity because there are two delegates for the BackPressed events. Maybe you will have better solution.

### Bugs Fixed ###

- 

### API Changes ###

-

Added:
 - private bool FormsAppCompatActivity.CanGoBack();
 - private bool FormsApplicationActivity.CanGoBack();

Changed:
 - void FormsAppCompatActivity.OnBackPressed();
 - void FormsApplicationActivity.OnBackPressed();

### Behavioral Changes ###

No changes

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
