### PR TITLE
[C] FlexLayout, with managed engine

### DIFF
--- a/Xamarin.Flex/Flex.cs
+++ b/Xamarin.Flex/Flex.cs
@@ -66,7 +66,14 @@ namespace Xamarin.Flex
 		public float MarginLeft { get; set; } = 0f;
 		public float MarginRight { get; set; } = 0f;
 		public float MarginTop { get; set; } = 0f;
-		public int Order { get; set; } = 0;
+		int order = 0;
+		public int Order {
+			get { return order; }
+			set {
+				if ((order = value) != 0 && Parent != null)
+					Parent.ShouldOrderChildren = true;
+			}
+		}
 		public float PaddingBottom { get; set; } = 0f;
 		public float PaddingLeft { get; set; } = 0f;
 		public float PaddingRight { get; set; } = 0f;
@@ -94,6 +101,8 @@ namespace Xamarin.Flex
 			ValidateNewChild(child);
 			(Children ?? (Children = new List<Item>())).Add(child);
 			child.Parent = this;
+			if (child.Order != 0)
+				ShouldOrderChildren = true;
 		}
 
 		public void InsertAt(uint index, Item child)
@@ -101,6 +110,8 @@ namespace Xamarin.Flex
 			ValidateNewChild(child);
 			(Children ?? (Children = new List<Item>())).Insert((int)index, child);
 			child.Parent = this;
+			if (child.Order != 0)
+				ShouldOrderChildren = true;
 		}
 
 		public Item RemoveAt(uint index)

--- a/Xamarin.Flex/Flex.cs
+++ b/Xamarin.Flex/Flex.cs
@@ -1,0 +1,678 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See the LICENSE.txt file in the project root
+// for the license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Xamarin.Flex
+{
+	enum Align
+	{
+		Auto = 0,
+		Stretch = 1,
+		Center = 2,
+		Start = 3,
+		End = 4,
+		SpaceBetween = 5,
+		SpaceAround = 6,
+		SpaceEvenly = 7,
+	}
+
+	enum Direction
+	{
+		Row = 0,
+		RowReverse = 1,
+		Column = 2,
+		ColumnReverse = 3,
+	}
+
+	enum Position
+	{
+		Relative = 0,
+		Absolute = 1,
+	}
+
+	enum Wrap
+	{
+		NoWrap = 0,
+		Wrap = 1,
+		WrapReverse = 2,
+	}
+
+	class Item : IEnumerable<Item>
+	{
+		public float[] Frame { get; } = new float[4];
+		public Item Parent { get; private set; }
+		IList<Item> Children { get; set; }
+		bool ShouldOrderChildren { get; set; }
+
+		public Align AlignContent { get; set; } = Align.Stretch;
+		public Align AlignItems { get; set; } = Align.Stretch;
+		public Align AlignSelf { get; set; } = Align.Auto;
+		public float Basis { get; set; } = float.NaN;
+		public float Bottom { get; set; } = float.NaN;
+		public Direction Direction { get; set; } = Direction.Column;
+		public float FrameHeight => Frame[3];
+		public float FrameWidth => Frame[2];
+		public float FrameX => Frame[0];
+		public float FrameY => Frame[1];
+		public float Grow { get; set; } = 0f;
+		public float Height { get; set; } = float.NaN;
+		public Align JustifyContent { get; set; } = Align.Start;
+		public float Left { get; set; } = float.NaN;
+		public float MarginBottom { get; set; } = 0f;
+		public float MarginLeft { get; set; } = 0f;
+		public float MarginRight { get; set; } = 0f;
+		public float MarginTop { get; set; } = 0f;
+		public int Order { get; set; } = 0;
+		public float PaddingBottom { get; set; } = 0f;
+		public float PaddingLeft { get; set; } = 0f;
+		public float PaddingRight { get; set; } = 0f;
+		public float PaddingTop { get; set; } = 0f;
+
+		public Position Position { get; set; } = Position.Relative;
+		public float Right { get; set; } = float.NaN;
+		public float Shrink { get; set; } = 1f;
+		public float Top { get; set; } = float.NaN;
+		public float Width { get; set; } = float.NaN;
+		public Wrap Wrap { get; set; } = Wrap.NoWrap;
+
+		public Item()
+		{
+		}
+
+		public Item(float width, float height)
+		{
+			Width = width;
+			Height = height;
+		}
+
+		public void Add(Item child)
+		{
+			ValidateNewChild(child);
+			(Children ?? (Children = new List<Item>())).Add(child);
+			child.Parent = this;
+		}
+
+		public void InsertAt(uint index, Item child)
+		{
+			ValidateNewChild(child);
+			(Children ?? (Children = new List<Item>())).Insert((int)index, child);
+			child.Parent = this;
+		}
+
+		public Item RemoveAt(uint index)
+		{
+			var child = Children[(int)index];
+			child.Parent = null;
+			Children.RemoveAt((int)index);
+			return child;
+		}
+
+		public uint Count =>
+			(uint)(Children?.Count ?? 0);
+
+		public Item ItemAt(uint index) =>
+			Children?[(int)index];
+
+		public Item this[uint index] {
+			get => ItemAt(index);
+		}
+
+		public Item Root {
+			get {
+				var root = this;
+				while (root.Parent != null)
+					root = root.Parent;
+				return root;
+			}
+		}
+
+		public void Layout()
+		{
+			if (Parent != null)
+				throw new InvalidOperationException("Layout() must be called on a root item (that hasn't been added to another item)");
+			if (Double.IsNaN(Width) || Double.IsNaN(Height))
+				throw new InvalidOperationException("Layout() must be called on an item that has proper values for the Width and Height properties");
+			if (SelfSizing != null)
+				throw new InvalidOperationException("Layout() cannot be called on an item that has the SelfSizing property set");
+			layout_item(this, Width, Height);
+		}
+
+		public float Padding {
+			set => PaddingTop = PaddingLeft = PaddingRight = PaddingBottom = value;
+		}
+
+		public float Margin {
+			set => MarginTop = MarginLeft = MarginRight = MarginBottom = value;
+		}
+
+		public void Flex(float grow = float.NaN, float shrink = float.NaN, float basis = float.NaN)
+		{
+			if (!Double.IsNaN(grow))
+				Grow = grow;
+			if (!Double.IsNaN(shrink))
+				Shrink = shrink;
+			if (!Double.IsNaN(basis))
+				Basis = basis;
+		}
+
+		public delegate void SelfSizingDelegate(Item item, ref float width, ref float height);
+
+		public SelfSizingDelegate SelfSizing { get; set; }
+
+		IEnumerator IEnumerable.GetEnumerator() =>
+			Children.GetEnumerator();
+
+		IEnumerator<Item> IEnumerable<Item>.GetEnumerator() =>
+			Children.GetEnumerator();
+
+		void ValidateNewChild(Item child)
+		{
+			if (this == child)
+				throw new ArgumentException("cannot add item into self");
+			if (child.Parent != null)
+				throw new ArgumentException("child already has a parent");
+		}
+
+		static void layout_item(Item item, float width, float height)
+		{
+			if (item.Children == null || item.Children.Count == 0)
+				return;
+
+			var layout = new flex_layout();
+			layout.init(item, width, height);
+			layout.reset();
+
+			uint last_layout_child = 0;
+			uint relative_children_count = 0;
+			for (uint i = 0; i < item.Count; i++) {
+				Item child = layout.child_at(item, i);
+				// Items with an absolute position have their frames determined
+				// directly and are skipped during layout.
+				if (child.Position == Position.Absolute) {
+					float child_width = absolute_size(child.Width, child.Left, child.Right, width);
+					float child_height = absolute_size(child.Height, child.Top, child.Bottom, height);
+					float child_x = absolute_pos(child.Left, child.Right, child_width, width);
+					float child_y = absolute_pos(child.Top, child.Bottom, child_height, height);
+
+					child.Frame[0] = child_x;
+					child.Frame[1] = child_y;
+					child.Frame[2] = child_width;
+					child.Frame[3] = child_height;
+
+					// Now that the item has a frame, we can layout its children.
+					layout_item(child, child.Frame[2], child.Frame[3]);
+					continue;
+				}
+
+				// Initialize frame.
+				child.Frame[0] = 0;
+				child.Frame[1] = 0;
+				child.Frame[2] = child.Width;
+				child.Frame[3] = child.Height;
+
+				// Main axis size defaults to 0.
+				if (float.IsNaN(child.Frame[layout.frame_size_i])) {
+					child.Frame[layout.frame_size_i] = 0;
+				}
+
+				// Cross axis size defaults to the parent's size (or line size in wrap
+				// mode, which is calculated later on).
+				if (float.IsNaN(child.Frame[layout.frame_size2_i])) {
+					if (layout.wrap) {
+						layout.need_lines = true;
+					}
+					else {
+						child.Frame[layout.frame_size2_i] = (layout.vertical ? width : height)
+							- (layout.vertical ? child.MarginLeft : child.MarginTop)
+							- (layout.vertical ? child.MarginRight : child.MarginBottom);
+
+					}
+				}
+
+				// Call the self_sizing callback if provided. Only non-NAN values
+				// are taken into account. If the item's cross-axis align property
+				// is set to stretch, ignore the value returned by the callback.
+				if (child.SelfSizing != null) {
+					float[] size = { child.Frame[2], child.Frame[3] };
+
+					child.SelfSizing(child, ref size[0], ref size[1]);
+
+					for (uint j = 0; j < 2; j++) {
+						uint size_off = j + 2;
+						if (size_off == layout.frame_size2_i && child_align(child, item) == Align.Stretch) {
+							continue;
+						}
+						float val = size[j];
+						if (!float.IsNaN(val)) {
+							child.Frame[size_off] = val;
+						}
+					}
+				}
+
+				// Honor the `basis' property which overrides the main-axis size.
+				if (!float.IsNaN(child.Basis)) {
+					//assert(child.Basis >= 0);
+					child.Frame[layout.frame_size_i] = child.Basis;
+				}
+
+				float child_size = child.Frame[layout.frame_size_i];
+				if (layout.wrap) {
+					if (layout.flex_dim < child_size) {
+						// Not enough space for this child on this line, layout the
+						// remaining items and move it to a new line.
+						layout_items(item, last_layout_child, i, relative_children_count, ref layout);
+
+						layout.reset();
+						last_layout_child = i;
+						relative_children_count = 0;
+					}
+
+					float child_size2 = child.Frame[layout.frame_size2_i];
+					if (!float.IsNaN(child_size2) && child_size2 > layout.line_dim) {
+						layout.line_dim = child_size2;
+					}
+				}
+
+				layout.flex_grows += child.Grow;
+				layout.flex_shrinks += child.Shrink;
+
+				layout.flex_dim -= child_size
+					+ (layout.vertical ? child.MarginTop : child.MarginLeft)
+					+ (layout.vertical ? child.MarginBottom : child.MarginRight);
+
+				relative_children_count++;
+
+				if (child_size > 0 && child.Grow > 0) {
+					layout.extra_flex_dim += child_size;
+				}
+			}
+
+			// Layout remaining items in wrap mode, or everything otherwise.
+			layout_items(item, last_layout_child, item.Count, relative_children_count, ref layout);
+
+			// In wrap mode we may need to tweak the position of each line according to
+			// the align_content property as well as the cross-axis size of items that
+			// haven't been set yet.
+			if (layout.need_lines && (layout.lines?.Length ?? 0) > 0) {
+				float pos = 0;
+				float spacing = 0;
+				float flex_dim = layout.align_dim - layout.lines_sizes;
+				if (flex_dim > 0) {
+					layout_align(item.AlignContent, flex_dim, (uint)(layout.lines?.Length ?? 0), ref pos, ref spacing, true);
+				}
+
+				float old_pos = 0;
+				if (layout.reverse2) {
+					pos = layout.align_dim - pos;
+					old_pos = layout.align_dim;
+				}
+
+				for (uint i = 0; i < (layout.lines?.Length ?? 0); i++) {
+
+					flex_layout.flex_layout_line line = layout.lines[i];
+
+					if (layout.reverse2) {
+						pos -= line.size;
+						pos -= spacing;
+						old_pos -= line.size;
+					}
+
+					// Re-position the children of this line, honoring any child
+					// alignment previously set within the line.
+					for (uint j = line.child_begin; j < line.child_end; j++) {
+						Item child = layout.child_at(item, j);
+						if (child.Position == Position.Absolute) {
+							// Should not be re-positioned.
+							continue;
+						}
+						if (float.IsNaN(child.Frame[layout.frame_size2_i])) {
+							// If the child's cross axis size hasn't been set it, it
+							// defaults to the line size.
+							child.Frame[layout.frame_size2_i] = line.size
+								+ (item.AlignContent == Align.Stretch
+								   ? spacing : 0);
+						}
+						child.Frame[layout.frame_pos2_i] = pos + (child.Frame[layout.frame_pos2_i] - old_pos);
+					}
+
+					if (!layout.reverse2) {
+						pos += line.size;
+						pos += spacing;
+						old_pos += line.size;
+					}
+				}
+			}
+
+			layout.cleanup();
+		}
+
+		static bool layout_align(Align align, float flex_dim, uint children_count, ref float pos_p, ref float spacing_p, bool stretch_allowed)
+		{
+			if (flex_dim < 0)
+				throw new ArgumentException();
+			float pos = 0;
+			float spacing = 0;
+
+			switch (align) {
+			case Align.Start:
+				break;
+			case Align.End:
+				pos = flex_dim;
+				break;
+			case Align.Center:
+				pos = flex_dim / 2;
+				break;
+			case Align.SpaceBetween:
+				if (children_count > 0)
+					spacing = flex_dim / (children_count - 1);
+				break;
+			case Align.SpaceAround:
+				if (children_count > 0) {
+					spacing = flex_dim / children_count;
+					pos = spacing / 2;
+				}
+				break;
+			case Align.SpaceEvenly:
+				if (children_count > 0) {
+					spacing = flex_dim / (children_count + 1);
+					pos = spacing;
+				}
+				break;
+			case Align.Stretch:
+				if (stretch_allowed) {
+					spacing = flex_dim / children_count;
+					break;
+				}
+				return false;
+			default:
+				return false;
+			}
+
+			pos_p = pos;
+			spacing_p = spacing;
+			return true;
+		}
+
+		static void layout_items(Item item, uint child_begin, uint child_end, uint children_count, ref flex_layout layout)
+		{
+			if (children_count > (child_end - child_begin))
+				throw new ArgumentException();
+			if (children_count <= 0)
+				return;
+			if (layout.flex_dim > 0 && layout.extra_flex_dim > 0) {
+				// If the container has a positive flexible space, let's add to it
+				// the sizes of all flexible children.
+				layout.flex_dim += layout.extra_flex_dim;
+			}
+
+			// Determine the main axis initial position and optional spacing.
+			float pos = 0;
+			float spacing = 0;
+			if (layout.flex_grows == 0 && layout.flex_dim > 0) {
+				layout_align(item.JustifyContent, layout.flex_dim, children_count, ref pos, ref spacing, false);
+
+				if (layout.reverse) {
+					pos = layout.size_dim - pos;
+				}
+			}
+
+			if (layout.reverse) {
+				pos -= layout.vertical ? item.PaddingBottom : item.PaddingRight;
+			}
+			else {
+				pos += layout.vertical ? item.PaddingTop : item.PaddingLeft;
+			}
+			if (layout.wrap && layout.reverse2) {
+				layout.pos2 -= layout.line_dim;
+			}
+
+			for (uint i = child_begin; i < child_end; i++) {
+
+				Item child = layout.child_at(item, i);
+				if (child.Position == Position.Absolute) {
+					// Already positioned.
+					continue;
+				}
+
+				// Grow or shrink the main axis item size if needed.
+				float flex_size = 0;
+				if (layout.flex_dim > 0) {
+					if (child.Grow != 0) {
+						child.Frame[layout.frame_size_i] = 0; // Ignore previous size when growing.
+						flex_size = (layout.flex_dim / layout.flex_grows) * child.Grow;
+					}
+				}
+				else if (layout.flex_dim < 0) {
+					if (child.Shrink != 0) {
+						flex_size = (layout.flex_dim / layout.flex_shrinks) * child.Shrink;
+					}
+				}
+				child.Frame[layout.frame_size_i] += flex_size;
+
+				// Set the cross axis position (and stretch the cross axis size if
+				// needed).
+				float align_size = child.Frame[layout.frame_size2_i];
+				float align_pos = layout.pos2 + 0;
+				switch (child_align(child, item)) {
+				case Align.End:
+					align_pos += layout.line_dim - align_size - (layout.vertical ? child.MarginRight : child.MarginBottom);
+					break;
+
+				case Align.Center:
+					align_pos += (layout.line_dim / 2) - (align_size / 2)
+						+ ((layout.vertical ? child.MarginLeft : child.MarginTop)
+						   - (layout.vertical ? child.MarginRight : child.MarginBottom));
+					break;
+
+				case Align.Stretch:
+					if (align_size == 0) {
+						child.Frame[layout.frame_size2_i] = layout.line_dim
+							- ((layout.vertical ? child.MarginLeft : child.MarginTop)
+							   + (layout.vertical ? child.MarginRight : child.MarginBottom));
+					}
+					align_pos += (layout.vertical ? child.MarginLeft : child.MarginTop);
+					break;
+				case Align.Start:
+					align_pos += (layout.vertical ? child.MarginLeft : child.MarginTop);
+					break;
+
+				default:
+					throw new Exception("incorrect align_self");
+				}
+				child.Frame[layout.frame_pos2_i] = align_pos;
+
+				// Set the main axis position.
+				if (layout.reverse) {
+					pos -= (layout.vertical ? child.MarginBottom : child.MarginRight);
+					pos -= child.Frame[layout.frame_size_i];
+					child.Frame[layout.frame_pos_i] = pos;
+					pos -= spacing;
+					pos -= (layout.vertical ? child.MarginTop : child.MarginLeft);
+				}
+				else {
+					pos += (layout.vertical ? child.MarginTop : child.MarginLeft);
+					child.Frame[layout.frame_pos_i] = pos;
+					pos += child.Frame[layout.frame_size_i];
+					pos += spacing;
+					pos += (layout.vertical ? child.MarginBottom : child.MarginRight);
+				}
+
+				// Now that the item has a frame, we can layout its children.
+				layout_item(child, child.Frame[2], child.Frame[3]);
+			}
+
+			if (layout.wrap && !layout.reverse2) {
+				layout.pos2 += layout.line_dim;
+			}
+
+			if (layout.need_lines) {
+				Array.Resize(ref layout.lines, (layout.lines?.Length ?? 0) + 1);
+
+				ref flex_layout.flex_layout_line line = ref layout.lines[layout.lines.Length - 1];
+
+				line.child_begin = child_begin;
+				line.child_end = child_end;
+				line.size = layout.line_dim;
+
+				layout.lines_sizes += line.size;
+			}
+		}
+
+		static float absolute_size(float val, float pos1, float pos2, float dim) =>
+			!float.IsNaN(val) ? val : (!float.IsNaN(pos1) && !float.IsNaN(pos2) ? dim-pos2-pos1: 0);
+
+		static float absolute_pos(float pos1, float pos2, float size, float dim) =>
+			!float.IsNaN(pos1) ? pos1 : (!float.IsNaN(pos2) ? dim - size - pos2 : 0);
+
+		static Align child_align(Item child, Item parent) =>
+			child.AlignSelf == Align.Auto ? parent.AlignItems : child.AlignSelf;
+
+		struct flex_layout {
+			// Set during init.
+			public bool wrap;
+			public bool reverse;				// whether main axis is reversed
+			public bool reverse2;				// whether cross axis is reversed (wrap only)
+			public bool vertical;
+			public float size_dim;				// main axis parent size
+			public float align_dim;				// cross axis parent size
+			public uint frame_pos_i;			// main axis position
+			public uint frame_pos2_i;			// cross axis position
+			public uint frame_size_i;			// main axis size
+			public uint frame_size2_i;			// cross axis size
+			uint[] ordered_indices;
+
+			// Set for each line layout.
+			public float line_dim;				// the cross axis size
+			public float flex_dim;				// the flexible part of the main axis size
+			public float extra_flex_dim;		// sizes of flexible items
+			public float flex_grows;
+			public float flex_shrinks;
+			public float pos2;					// cross axis position
+
+			// Calculated layout lines - only tracked when needed:
+			//   - if the root's align_content property isn't set to FLEX_ALIGN_START
+			//   - or if any child item doesn't have a cross-axis size set
+			public bool need_lines;
+			public struct flex_layout_line
+			{
+				public uint child_begin;
+				public uint child_end;
+				public float size;
+			};
+
+			public flex_layout_line[] lines;
+			public float lines_sizes;
+
+			//LAYOUT_RESET
+			public void reset()
+			{
+				line_dim = wrap ? 0 : align_dim;
+				flex_dim = size_dim;
+				extra_flex_dim = 0;
+				flex_grows = 0;
+				flex_shrinks = 0;
+			}
+
+			//layout_init
+			public void init(Item item, float width, float height)
+			{
+				if (item.PaddingLeft < 0)
+					throw new ArgumentException();
+				if (item.PaddingRight < 0)
+					throw new ArgumentException();
+				if (item.PaddingTop < 0)
+					throw new ArgumentException();
+				if (item.PaddingBottom < 0)
+					throw new ArgumentException();
+
+				width -= item.PaddingLeft + item.PaddingRight;
+				height -= item.PaddingTop + item.PaddingBottom;
+
+				if (width < 0)
+					throw new ArgumentException();
+				if (height < 0)
+					throw new ArgumentException();
+
+				reverse = item.Direction == Direction.RowReverse || item.Direction == Direction.ColumnReverse;
+				vertical = true;
+				switch (item.Direction) {
+				case Direction.Row:
+				case Direction.RowReverse:
+					vertical = false;
+					size_dim = width;
+					align_dim = height;
+					frame_pos_i = 0;
+					frame_pos2_i = 1;
+					frame_size_i = 2;
+					frame_size2_i = 3;
+					break;
+				case Direction.Column:
+				case Direction.ColumnReverse:
+					size_dim = height;
+					align_dim = width;
+					frame_pos_i = 1;
+					frame_pos2_i = 0;
+					frame_size_i = 3;
+					frame_size2_i = 2;
+					break;
+				}
+
+				ordered_indices = null;
+				if (item.ShouldOrderChildren && item.Count > 0) {
+					var indices = new uint[item.Count];
+					// Creating a list of item indices sorted using the children's `order'
+					// attribute values. We are using a simple insertion sort as we need
+					// stability (insertion order must be preserved) and cross-platform
+					// support. We should eventually switch to merge sort (or something
+					// else) if the number of items becomes significant enough.
+					for (uint i = 0; i < item.Count; i++) {
+						indices[i] = i;
+						for (uint j = i; j > 0; j--) {
+							uint prev = indices[j - 1];
+							uint curr = indices[j];
+							if (item.Children[(int)prev].Order <= item.Children[(int)curr].Order) {
+								break;
+							}
+							indices[j - 1] = curr;
+							indices[j] = prev;
+						}
+					}
+					ordered_indices = indices;
+				}
+
+				flex_dim = 0;
+				flex_grows = 0;
+				flex_shrinks = 0;
+
+				reverse2 = false;
+				wrap = item.Wrap != Wrap.NoWrap;
+				if (wrap) {
+					if (item.Wrap == Wrap.WrapReverse) {
+						reverse2 = true;
+						pos2 = align_dim;
+					}
+				}
+				else {
+					pos2 = vertical ? item.PaddingLeft : item.PaddingTop;
+				}
+
+				need_lines = wrap && item.AlignContent != Align.Start;
+				lines = null;
+				lines_sizes = 0;
+			}
+
+			public Item child_at(Item item, uint i) =>
+				item.Children[(int)(ordered_indices?[i] ?? i)];
+
+			public void cleanup()
+			{
+				ordered_indices = null;
+				lines = null;
+			}
+		}
+	}
+}

--- a/Xamarin.Flex/Flex.cs
+++ b/Xamarin.Flex/Flex.cs
@@ -205,10 +205,10 @@ namespace Xamarin.Flex
 		public SelfSizingDelegate SelfSizing { get; set; }
 
 		IEnumerator IEnumerable.GetEnumerator() =>
-			Children.GetEnumerator();
+			((IEnumerable<Item>)this).GetEnumerator();
 
 		IEnumerator<Item> IEnumerable<Item>.GetEnumerator() =>
-			Children.GetEnumerator();
+			(Children ?? System.Linq.Enumerable.Empty<Item>()).GetEnumerator();
 
 		void ValidateChild(Item child)
 		{

--- a/Xamarin.Flex/Xamarin.Flex.projitems
+++ b/Xamarin.Flex/Xamarin.Flex.projitems
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>{A6703C7D-D362-452A-A7A5-73771194D38C}</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Xamarin.Flex</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Flex.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
+  </ItemGroup>
+</Project>

--- a/Xamarin.Flex/Xamarin.Flex.shproj
+++ b/Xamarin.Flex/Xamarin.Flex.shproj
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{A6703C7D-D362-452A-A7A5-73771194D38C}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <Import Project="Xamarin.Flex.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignContentTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignContentTests.cs
@@ -1,0 +1,753 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class FlexLayoutAlignContentTests : BaseTestFixture
+	{
+		[Test]
+		public void TestAlignContentFlexStart()
+		{
+			var platform = new UnitPlatform((visual, width, height) => new SizeRequest(new Size(50, 10)));
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				WidthRequest = 130,
+				HeightRequest = 100,
+
+				AlignContent = FlexAlignContent.FlexStart,
+				AlignItems = FlexAlignItems.FlexStart,
+				Direction = FlexDirection.Row,
+				Wrap = FlexWrap.Wrap,
+			};
+
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 130, 100));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 130, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 50, 10)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(50, 0, 50, 10)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(0, 10, 50, 10)));
+			Assert.That(view3.Bounds, Is.EqualTo(new Rectangle(50, 10, 50, 10)));
+			Assert.That(view4.Bounds, Is.EqualTo(new Rectangle(0, 20, 50, 10)));
+		}
+
+		[Test]
+		public void TestAlignContentFlexStartWithoutHeightOnChildren()
+		{
+			var platform = new UnitPlatform((visual, width, height) => new SizeRequest(new Size(50, 10)));
+			var layout = new FlexLayout {
+				WidthRequest = 100,
+				HeightRequest = 100,
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				AlignItems = FlexAlignItems.FlexStart,
+				Direction = FlexDirection.Column,
+				Wrap = FlexWrap.Wrap,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 50, };
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true, WidthRequest = 50, };
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 50, 10)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(0, 10, 50, 10)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(0, 20, 50, 10)));
+			Assert.That(view3.Bounds, Is.EqualTo(new Rectangle(0, 30, 50, 10)));
+			Assert.That(view4.Bounds, Is.EqualTo(new Rectangle(0, 40, 50, 10)));
+		}
+
+		[Test]
+		public void TestAlignContentFlexStartWithFlex()
+		{
+			var platform = new UnitPlatform((visual, width, height) => new SizeRequest(new Size(0, 0)));
+
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				WidthRequest = 100,
+				HeightRequest = 120,
+
+				Direction = FlexDirection.Column,
+				Wrap = FlexWrap.Wrap,
+				AlignItems = FlexAlignItems.FlexStart,
+			};
+
+			var view0 = new View { IsPlatformEnabled = true };
+			FlexLayout.SetGrow(view0, 1);
+			FlexLayout.SetBasis(view0, 0);
+			view0.WidthRequest = 50;
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true };
+			FlexLayout.SetGrow(view1, 1);
+			FlexLayout.SetBasis(view1, 0);
+			view1.WidthRequest = 50;
+			view1.HeightRequest = 10;
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true };
+			view2.WidthRequest = 50;
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true };
+			FlexLayout.SetGrow(view3, 1);
+			FlexLayout.SetShrink(view3, 1);
+			FlexLayout.SetBasis(view3, 0);
+			view3.WidthRequest = 50;
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true };
+			view4.WidthRequest = 50;
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 100, 120));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 120)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 50, 40)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(0, 40, 50, 40)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(0, 80, 50, 0)));
+			Assert.That(view3.Bounds, Is.EqualTo(new Rectangle(0, 80, 50, 40)));
+			Assert.That(view4.Bounds, Is.EqualTo(new Rectangle(0, 120, 50, 0)));
+		}
+
+		[Test]
+		public void TestAlignContentFlexEnd()
+		{
+			var platform = new UnitPlatform((visual, width, height) => new SizeRequest(new Size(50, 10)));
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				WidthRequest = 100,
+				HeightRequest = 100,
+
+				Direction = FlexDirection.Column,
+				AlignContent = FlexAlignContent.FlexEnd,
+				AlignItems = FlexAlignItems.FlexStart,
+				Wrap = FlexWrap.Wrap,
+			};
+
+			Func<View> createView = () => new View {
+				IsPlatformEnabled = true,
+				Platform = platform,
+				WidthRequest = 50,
+				HeightRequest = 10,
+			};
+			var view0 = createView();
+			layout.Children.Add(view0);
+
+			var view1 = createView();
+			layout.Children.Add(view1);
+
+			var view2 = createView();
+			layout.Children.Add(view2);
+
+			var view3 = createView();
+			layout.Children.Add(view3);
+
+			var view4 = createView();
+			layout.Children.Add(view4);
+
+			var measure = layout.Measure(100, 100);
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0,0,100,100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(50, 0, 50, 10)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(50, 10, 50, 10)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(50, 20, 50, 10)));
+			Assert.That(view3.Bounds, Is.EqualTo(new Rectangle(50, 30, 50, 10)));
+			Assert.That(view4.Bounds, Is.EqualTo(new Rectangle(50, 40, 50, 10)));
+
+		}
+
+		[Test]
+		public void TestAlignContentStretch()
+		{
+			var platform = new UnitPlatform((visual, width, height) => new SizeRequest(new Size(0, 0)));
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Column,
+				AlignContent = FlexAlignContent.Stretch,
+				AlignItems = FlexAlignItems.FlexStart,
+				Wrap = FlexWrap.Wrap,
+				WidthRequest = 150,
+				HeightRequest = 100
+			};
+			var view0 = new View { IsPlatformEnabled = true };
+			view0.WidthRequest = 50;
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true };
+			view1.WidthRequest = 50;
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true };
+			view2.WidthRequest = 50;
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true };
+			view3.WidthRequest = 50;
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true };
+			view4.WidthRequest = 50;
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 150, 100));
+
+			Assert.AreEqual(0f, layout.X);
+			Assert.AreEqual(0f, layout.Y);
+			Assert.AreEqual(150f, layout.Width);
+			Assert.AreEqual(100f, layout.Height);
+
+			Assert.AreEqual(0f, view0.X);
+			Assert.AreEqual(0f, view0.Y);
+			Assert.AreEqual(50f, view0.Width);
+			Assert.AreEqual(0f, view0.Height);
+
+			Assert.AreEqual(0f, view1.X);
+			Assert.AreEqual(0f, view1.Y);
+			Assert.AreEqual(50f, view1.Width);
+			Assert.AreEqual(0f, view1.Height);
+
+			Assert.AreEqual(0f, view2.X);
+			Assert.AreEqual(0f, view2.Y);
+			Assert.AreEqual(50f, view2.Width);
+			Assert.AreEqual(0f, view2.Height);
+
+			Assert.AreEqual(0f, view3.X);
+			Assert.AreEqual(0f, view3.Y);
+			Assert.AreEqual(50f, view3.Width);
+			Assert.AreEqual(0f, view3.Height);
+
+			Assert.AreEqual(0f, view4.X);
+			Assert.AreEqual(0f, view4.Y);
+			Assert.AreEqual(50f, view4.Width);
+			Assert.AreEqual(0f, view4.Height);
+		}
+
+		[Test]
+		public void TestAlignContentSpaceBetween()
+		{
+			var platform = new UnitPlatform((visual, width, height) => new SizeRequest(new Size(50, 10)));
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				WidthRequest = 130,
+				HeightRequest = 100,
+
+				Direction = FlexDirection.Row,
+				AlignContent = FlexAlignContent.SpaceBetween,
+				Wrap = FlexWrap.Wrap,
+			};
+
+			var view0 = new View { IsPlatformEnabled = true, Platform = platform, WidthRequest=50, HeightRequest=10  };
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true, Platform = platform, WidthRequest = 50, HeightRequest = 10 };
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true, Platform = platform, WidthRequest = 50, HeightRequest = 10 };
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true, Platform = platform, WidthRequest = 50, HeightRequest = 10 };
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true, Platform = platform, WidthRequest = 50, HeightRequest = 10 };
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 130, 100));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 130, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 50, 10)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(50, 0, 50, 10)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(0, 45, 50, 10)));
+			Assert.That(view3.Bounds, Is.EqualTo(new Rectangle(50, 45, 50, 10)));
+			Assert.That(view4.Bounds, Is.EqualTo(new Rectangle(0, 90, 50, 10)));
+		}
+
+		[Test]
+		public void TestAlignContentSpaceAround()
+		{
+			var platform = new UnitPlatform((visual, width, height) => new SizeRequest(new Size(50, 10)));
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				WidthRequest = 140,
+				HeightRequest = 120,
+
+				Direction = FlexDirection.Row,
+				AlignContent = FlexAlignContent.SpaceAround,
+				Wrap = FlexWrap.Wrap,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true, WidthRequest = 50, HeightRequest = 10, };
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 140, 120));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 140, 120)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 15, 50, 10)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(50, 15, 50, 10)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(0, 55, 50, 10)));
+			Assert.That(view3.Bounds, Is.EqualTo(new Rectangle(50, 55, 50, 10)));
+			Assert.That(view4.Bounds, Is.EqualTo(new Rectangle(0, 95, 50, 10)));
+		}
+
+		[Test]
+		public void TestAlignContentStretchRow()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Row,
+				AlignContent = FlexAlignContent.Stretch,
+				AlignItems = FlexAlignItems.FlexStart,
+				Wrap = FlexWrap.Wrap,
+				WidthRequest = 150,
+				HeightRequest = 100
+			};
+			var view0 = new View { IsPlatformEnabled = true };
+			view0.WidthRequest = 50;
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true };
+			view1.WidthRequest = 50;
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true };
+			view2.WidthRequest = 50;
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true };
+			view3.WidthRequest = 50;
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true };
+			view4.WidthRequest = 50;
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 150, 100));
+
+			Assert.AreEqual(0f, layout.X);
+			Assert.AreEqual(0f, layout.Y);
+			Assert.AreEqual(150f, layout.Width);
+			Assert.AreEqual(100f, layout.Height);
+
+			Assert.AreEqual(0f, view0.X);
+			Assert.AreEqual(0f, view0.Y);
+			Assert.AreEqual(50f, view0.Width);
+			Assert.AreEqual(20f, view0.Height);
+
+			Assert.AreEqual(50f, view1.X);
+			Assert.AreEqual(0f, view1.Y);
+			Assert.AreEqual(50f, view1.Width);
+			Assert.AreEqual(20f, view1.Height);
+
+			Assert.AreEqual(100f, view2.X);
+			Assert.AreEqual(0f, view2.Y);
+			Assert.AreEqual(50f, view2.Width);
+			Assert.AreEqual(20f, view2.Height);
+
+			Assert.AreEqual(0f, view3.X);
+			Assert.AreEqual(50f, view3.Y);
+			Assert.AreEqual(50f, view3.Width);
+			Assert.AreEqual(20f, view3.Height);
+
+			Assert.AreEqual(50f, view4.X);
+			Assert.AreEqual(50f, view4.Y);
+			Assert.AreEqual(50f, view4.Width);
+			Assert.AreEqual(20f, view4.Height);
+		}
+
+		[Test]
+		public void TestAlignContentStretchRowWithChildren()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				WidthRequest = 150,
+				HeightRequest = 100,
+
+				Direction = FlexDirection.Row,
+				AlignContent = FlexAlignContent.Stretch,
+				Wrap = FlexWrap.Wrap,
+			};
+			var view0 = new FlexLayout { IsPlatformEnabled = true, WidthRequest = 50, };
+			layout.Children.Add(view0);
+
+			//var view0_child0 = new View { IsPlatformEnabled = true };
+			//FlexLayout.SetGrow(view0_child0, 1);
+			//FlexLayout.SetShrink(view0_child0, 1);
+			//FlexLayout.SetBasis(view0_child0, 0);
+			//view0.Children.Add(view0_child0);
+
+			var view1 = new View { IsPlatformEnabled = true, WidthRequest = 50, };
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true, WidthRequest = 50, };
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true, WidthRequest = 50, };
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true, WidthRequest = 50, };
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 150, 100));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 150, 100)));
+
+			Assert.AreEqual(0f, view0.X);
+			Assert.AreEqual(0f, view0.Y);
+			Assert.AreEqual(50f, view0.Width);
+			Assert.AreEqual(50f, view0.Height);
+
+			//Assert.AreEqual(0f, view0_child0.X);
+			//Assert.AreEqual(0f, view0_child0.Y);
+			//Assert.AreEqual(50f, view0_child0.Width);
+			//Assert.AreEqual(50f, view0_child0.Height);
+
+			Assert.AreEqual(50f, view1.X);
+			Assert.AreEqual(0f, view1.Y);
+			Assert.AreEqual(50f, view1.Width);
+			Assert.AreEqual(50f, view1.Height);
+
+			Assert.AreEqual(100f, view2.X);
+			Assert.AreEqual(0f, view2.Y);
+			Assert.AreEqual(50f, view2.Width);
+			Assert.AreEqual(50f, view2.Height);
+
+			Assert.AreEqual(0f, view3.X);
+			Assert.AreEqual(50f, view3.Y);
+			Assert.AreEqual(50f, view3.Width);
+			Assert.AreEqual(50f, view3.Height);
+
+			Assert.AreEqual(50f, view4.X);
+			Assert.AreEqual(50f, view4.Y);
+			Assert.AreEqual(50f, view4.Width);
+			Assert.AreEqual(50f, view4.Height);
+		}
+
+		[Test]
+		public void TestAlignContentStretchRowWithFlex()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				AlignContent = FlexAlignContent.Stretch,
+				Direction = FlexDirection.Row,
+				Wrap = FlexWrap.Wrap,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			FlexLayout.SetGrow(view1, 1);
+			FlexLayout.SetShrink(view1, 1);
+			FlexLayout.SetBasis(view1, 0);
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			FlexLayout.SetGrow(view3, 1);
+			FlexLayout.SetShrink(view3, 1);
+			FlexLayout.SetBasis(view3, 0);
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 150, 100));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 150, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 50, 100)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(50, 0, 0, 100)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(50, 0, 50, 100)));
+			Assert.That(view3.Bounds, Is.EqualTo(new Rectangle(100, 0, 0, 100)));
+			Assert.That(view4.Bounds, Is.EqualTo(new Rectangle(100, 0, 50, 100)));
+		}
+
+		[Test]
+		public void TestAlignContentStretchRowWithFlexNoShrink()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Row,
+				AlignContent = FlexAlignContent.Stretch,
+				Wrap = FlexWrap.Wrap,
+				WidthRequest = 150,
+				HeightRequest = 100
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			FlexLayout.SetGrow(view1, 1);
+			FlexLayout.SetShrink(view1, 1);
+			FlexLayout.SetBasis(view1, 0);
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			FlexLayout.SetGrow(view3, 1);
+			FlexLayout.SetBasis(view3, 0);
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true, WidthRequest = 50 };
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 150, 100));
+
+			Assert.AreEqual(0f, layout.X);
+			Assert.AreEqual(0f, layout.Y);
+			Assert.AreEqual(150f, layout.Width);
+			Assert.AreEqual(100f, layout.Height);
+
+			Assert.AreEqual(0f, view0.X);
+			Assert.AreEqual(0f, view0.Y);
+			Assert.AreEqual(50f, view0.Width);
+			Assert.AreEqual(100f, view0.Height);
+
+			Assert.AreEqual(50f, view1.X);
+			Assert.AreEqual(0f, view1.Y);
+			Assert.AreEqual(0f, view1.Width);
+			Assert.AreEqual(100f, view1.Height);
+
+			Assert.AreEqual(50f, view2.X);
+			Assert.AreEqual(0f, view2.Y);
+			Assert.AreEqual(50f, view2.Width);
+			Assert.AreEqual(100f, view2.Height);
+
+			Assert.AreEqual(100f, view3.X);
+			Assert.AreEqual(0f, view3.Y);
+			Assert.AreEqual(0f, view3.Width);
+			Assert.AreEqual(100f, view3.Height);
+
+			Assert.AreEqual(100f, view4.X);
+			Assert.AreEqual(0f, view4.Y);
+			Assert.AreEqual(50f, view4.Width);
+			Assert.AreEqual(100f, view4.Height);
+		}
+
+		[Test]
+		[Ignore("")]
+		public void TestAlignContentStretchRowWithMargin()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				WidthRequest = 150,
+				HeightRequest = 100,
+
+				Direction = FlexDirection.Row,
+				AlignContent = FlexAlignContent.Stretch,
+				Wrap = FlexWrap.Wrap,
+			};
+			var view0 = new View {
+				IsPlatformEnabled = true,
+				WidthRequest = 50,
+				HeightRequest = 20,
+			};
+
+			layout.Children.Add(view0);
+
+			var view1 = new View {
+				IsPlatformEnabled = true,
+				Margin = 10,
+				WidthRequest = 50,
+				HeightRequest = 20,
+			};
+			layout.Children.Add(view1);
+
+			var view2 = new View {
+				IsPlatformEnabled = true,
+				WidthRequest = 50,
+				HeightRequest = 20,
+			};
+			layout.Children.Add(view2);
+
+			var view3 = new View {
+				IsPlatformEnabled = true,
+				Margin = new Thickness(10),
+				WidthRequest = 50,
+				HeightRequest = 20,
+			};
+			layout.Children.Add(view3);
+
+			var view4 = new View {
+				IsPlatformEnabled = true,
+				WidthRequest = 50,
+				HeightRequest = 20,
+			};
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 150, 100));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 150, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 50, 20)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(60, 10, 50, 20)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(0, 40, 50, 20)));
+			Assert.That(view3.Bounds, Is.EqualTo(new Rectangle(60, 50, 50, 20)));
+			Assert.That(view4.Bounds, Is.EqualTo(new Rectangle(0, 80, 50, 20)));
+		}
+
+		[Test]
+		public void TestAlignContentStretchRowWithSingleRow()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Row,
+				AlignContent = FlexAlignContent.Stretch,
+				Wrap = FlexWrap.Wrap,
+				WidthRequest = 150,
+				HeightRequest = 100
+			};
+			var view0 = new View { IsPlatformEnabled = true };
+			view0.WidthRequest = 50;
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true };
+			view1.WidthRequest = 50;
+			layout.Children.Add(view1);
+
+			layout.Layout(new Rectangle(0, 0, 150, 100));
+
+			Assert.AreEqual(0f, layout.X);
+			Assert.AreEqual(0f, layout.Y);
+			Assert.AreEqual(150f, layout.Width);
+			Assert.AreEqual(100f, layout.Height);
+
+			Assert.AreEqual(0f, view0.X);
+			Assert.AreEqual(0f, view0.Y);
+			Assert.AreEqual(50f, view0.Width);
+			Assert.AreEqual(100f, view0.Height);
+
+			Assert.AreEqual(50f, view1.X);
+			Assert.AreEqual(0f, view1.Y);
+			Assert.AreEqual(50f, view1.Width);
+			Assert.AreEqual(100f, view1.Height);
+		}
+
+		[Test]
+		public void TestAlignContentStretchRowWithFixedHeight()
+		{
+			var platform = new UnitPlatform((visual, width, height) => new SizeRequest(new Size(0, 0)));
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Row,
+				AlignContent = FlexAlignContent.Stretch,
+				AlignItems = FlexAlignItems.FlexStart,
+				Wrap = FlexWrap.Wrap,
+				WidthRequest = 150,
+				HeightRequest = 100
+			};
+			var view0 = new View { IsPlatformEnabled = true };
+			view0.WidthRequest = 50;
+			layout.Children.Add(view0);
+
+			var view1 = new View { IsPlatformEnabled = true };
+			view1.WidthRequest = 50;
+			view1.HeightRequest = 60;
+			layout.Children.Add(view1);
+
+			var view2 = new View { IsPlatformEnabled = true };
+			view2.WidthRequest = 50;
+			layout.Children.Add(view2);
+
+			var view3 = new View { IsPlatformEnabled = true };
+			view3.WidthRequest = 50;
+			layout.Children.Add(view3);
+
+			var view4 = new View { IsPlatformEnabled = true };
+			view4.WidthRequest = 50;
+			layout.Children.Add(view4);
+
+			layout.Layout(new Rectangle(0, 0, 150, 100));
+
+			Assert.AreEqual(0f, layout.X);
+			Assert.AreEqual(0f, layout.Y);
+			Assert.AreEqual(150f, layout.Width);
+			Assert.AreEqual(100f, layout.Height);
+
+			Assert.AreEqual(0f, view0.X);
+			Assert.AreEqual(0f, view0.Y);
+			Assert.AreEqual(50f, view0.Width);
+			Assert.AreEqual(0f, view0.Height);
+
+			Assert.AreEqual(50f, view1.X);
+			Assert.AreEqual(0f, view1.Y);
+			Assert.AreEqual(50f, view1.Width);
+			Assert.AreEqual(60f, view1.Height);
+
+			Assert.AreEqual(100f, view2.X);
+			Assert.AreEqual(0f, view2.Y);
+			Assert.AreEqual(50f, view2.Width);
+			Assert.AreEqual(0f, view2.Height);
+
+			Assert.AreEqual(0f, view3.X);
+			Assert.AreEqual(80f, view3.Y);
+			Assert.AreEqual(50f, view3.Width);
+			Assert.AreEqual(0f, view3.Height);
+
+			Assert.AreEqual(50f, view4.X);
+			Assert.AreEqual(80f, view4.Y);
+			Assert.AreEqual(50f, view4.Width);
+			Assert.AreEqual(0f, view4.Height);
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignContentTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignContentTests.cs
@@ -16,8 +16,8 @@ namespace Xamarin.Forms.Core.UnitTests
 				WidthRequest = 130,
 				HeightRequest = 100,
 
-				AlignContent = FlexAlignContent.FlexStart,
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignContent = FlexAlignContent.Start,
+				AlignItems = FlexAlignItems.Start,
 				Direction = FlexDirection.Row,
 				Wrap = FlexWrap.Wrap,
 			};
@@ -57,7 +57,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				Platform = platform,
 				IsPlatformEnabled = true,
 
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignItems = FlexAlignItems.Start,
 				Direction = FlexDirection.Column,
 				Wrap = FlexWrap.Wrap,
 			};
@@ -98,7 +98,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 				Direction = FlexDirection.Column,
 				Wrap = FlexWrap.Wrap,
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignItems = FlexAlignItems.Start,
 			};
 
 			var view0 = new View { IsPlatformEnabled = true };
@@ -150,8 +150,8 @@ namespace Xamarin.Forms.Core.UnitTests
 				HeightRequest = 100,
 
 				Direction = FlexDirection.Column,
-				AlignContent = FlexAlignContent.FlexEnd,
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignContent = FlexAlignContent.End,
+				AlignItems = FlexAlignItems.Start,
 				Wrap = FlexWrap.Wrap,
 			};
 
@@ -197,7 +197,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				IsPlatformEnabled = true,
 				Direction = FlexDirection.Column,
 				AlignContent = FlexAlignContent.Stretch,
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignItems = FlexAlignItems.Start,
 				Wrap = FlexWrap.Wrap,
 				WidthRequest = 150,
 				HeightRequest = 100
@@ -343,7 +343,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				IsPlatformEnabled = true,
 				Direction = FlexDirection.Row,
 				AlignContent = FlexAlignContent.Stretch,
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignItems = FlexAlignItems.Start,
 				Wrap = FlexWrap.Wrap,
 				WidthRequest = 150,
 				HeightRequest = 100
@@ -691,7 +691,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				IsPlatformEnabled = true,
 				Direction = FlexDirection.Row,
 				AlignContent = FlexAlignContent.Stretch,
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignItems = FlexAlignItems.Start,
 				Wrap = FlexWrap.Wrap,
 				WidthRequest = 150,
 				HeightRequest = 100

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignItemsTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignItemsTests.cs
@@ -1,0 +1,89 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class FlexLayoutAlignItemsTests : BaseTestFixture
+	{
+		[Test]
+		public void TestAlignItemsStretch()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				Direction = FlexDirection.Column,
+			};
+			var view0 = new View { IsPlatformEnabled = true, HeightRequest = 10, };
+			layout.Children.Add(view0);
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 10)));
+		}
+
+		[Test]
+		public void TestAlignItemsCenter()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				AlignItems = FlexAlignItems.Center,
+				Direction = FlexDirection.Column,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
+			layout.Children.Add(view0);
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(45, 0, 10, 10)));
+		}
+
+		[Test]
+		public void TestAlignItemsFlexStart()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				AlignItems = FlexAlignItems.FlexStart,
+				Direction = FlexDirection.Column,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
+			layout.Children.Add(view0);
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 10, 10)));
+		}
+
+		[Test]
+		public void TestAlignItemsFlexEnd()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				AlignItems = FlexAlignItems.FlexEnd,
+				Direction = FlexDirection.Column,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
+			layout.Children.Add(view0);
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(90, 0, 10, 10)));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignItemsTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignItemsTests.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				Platform = platform,
 				IsPlatformEnabled = true,
 
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignItems = FlexAlignItems.Start,
 				Direction = FlexDirection.Column,
 			};
 			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
@@ -75,7 +75,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				Platform = platform,
 				IsPlatformEnabled = true,
 
-				AlignItems = FlexAlignItems.FlexEnd,
+				AlignItems = FlexAlignItems.End,
 				Direction = FlexDirection.Column,
 			};
 			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignSelfTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignSelfTests.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				Direction = FlexDirection.Column,
 			};
 			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
-			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.FlexEnd);
+			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.End);
 			layout.Children.Add(view0);
 
 			layout.Layout(new Rectangle(0, 0, 100, 100));
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				Direction = FlexDirection.Column,
 			};
 			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
-			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.FlexStart);
+			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.Start);
 			layout.Children.Add(view0);
 
 			layout.Layout(new Rectangle(0, 0, 100, 100));
@@ -70,11 +70,11 @@ namespace Xamarin.Forms.Core.UnitTests
 				Platform = platform,
 				IsPlatformEnabled = true,
 
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignItems = FlexAlignItems.Start,
 				Direction = FlexDirection.Column,
 			};
 			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
-			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.FlexEnd);
+			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.End);
 			layout.Children.Add(view0);
 
 			layout.Layout(new Rectangle(0, 0, 100, 100));

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignSelfTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutAlignSelfTests.cs
@@ -1,0 +1,85 @@
+﻿using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class FlexLayoutAlignSelfTest : BaseTestFixture
+	{
+		[Test]
+		public void TestAlignSelfCenter()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				Direction = FlexDirection.Column,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
+			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.Center);
+			layout.Children.Add(view0);
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(45, 0, 10, 10)));
+		}
+
+		[Test]
+		public void TestAlignSelfFlexEnd()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				Direction = FlexDirection.Column,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
+			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.FlexEnd);
+			layout.Children.Add(view0);
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(90, 0, 10, 10)));
+		}
+
+		[Test]
+		public void TestAlignSelfFlexStart()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				Direction = FlexDirection.Column,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
+			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.FlexStart);
+			layout.Children.Add(view0);
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 10, 10)));
+		}
+
+		[Test]
+		public void TestAlignSelfFlexEndOverrideFlexStart()
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+
+				AlignItems = FlexAlignItems.FlexStart,
+				Direction = FlexDirection.Column,
+			};
+			var view0 = new View { IsPlatformEnabled = true, WidthRequest = 10, HeightRequest = 10 };
+			FlexLayout.SetAlignSelf(view0, FlexAlignSelf.FlexEnd);
+			layout.Children.Add(view0);
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(90, 0, 10, 10)));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutFlexDirectionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutFlexDirectionTests.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class FlexLayoutFlexDirectionTests : BaseTestFixture
+	{
+		[Test]
+		public void TestFlexDirectionColumnWithoutHeight()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10 };
+			var view1 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10 };
+			var view2 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10 };
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+					view1,
+					view2,
+				},
+
+				Direction = FlexDirection.Column,
+			};
+
+			var sizeRequest = layout.Measure(100, double.PositiveInfinity);
+			layout.Layout(new Rectangle(0, 0, sizeRequest.Request.Width, sizeRequest.Request.Height));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 30)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 10)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(0, 10, 100, 10)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(0, 20, 100, 10)));
+		}
+
+		[Test]
+		public void TestFlexDirectionRowNoWidth()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, };
+			var view1 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, };
+			var view2 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, };
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+					view1,
+					view2,
+				},
+
+				Direction = FlexDirection.Row,
+			};
+
+
+			var measure = layout.Measure(double.PositiveInfinity, 100);
+			layout.Layout(new Rectangle(0, 0, measure.Request.Width, measure.Request.Height));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 30, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 10, 100)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(10, 0, 10, 100)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(20, 0, 10, 100)));
+		}
+
+		[Test]
+		public void TestFlexDirectionColumn()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10 };
+			var view1 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10 };
+			var view2 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10 };
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+					view1,
+					view2,
+				},
+
+				Direction = FlexDirection.Column,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 10)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(0, 10, 100, 10)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(0, 20, 100, 10)));
+		}
+
+		[Test]
+		public void TestFlexDirectionRow()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, };
+			var view1 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, };
+			var view2 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, };
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+					view1,
+					view2,
+				},
+
+				Direction = FlexDirection.Row,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 10, 100)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(10, 0, 10, 100)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(20, 0, 10, 100)));
+		}
+
+		[Test]
+		public void TestFlexDirectionColumnReverse()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10 };
+			var view1 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10 };
+			var view2 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10 };
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+					view1,
+					view2,
+				},
+
+				Direction = FlexDirection.ColumnReverse,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 90, 100, 10)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(0, 80, 100, 10)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(0, 70, 100, 10)));
+		}
+
+		[Test]
+		public void TestFlexDirectionRowReverse()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, };
+			var view1 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, };
+			var view2 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, };
+
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+					view1,
+					view2,
+				},
+
+				Direction = FlexDirection.RowReverse,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(90, 0, 10, 100)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(80, 0, 10, 100)));
+			Assert.That(view2.Bounds, Is.EqualTo(new Rectangle(70, 0, 10, 100)));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutMarginTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutMarginTests.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				},
 
 				Direction = FlexDirection.Row,
-				JustifyContent = FlexJustify.FlexEnd,
+				JustifyContent = FlexJustify.End,
 			};
 
 			layout.Layout(new Rectangle(0, 0, 100, 100));
@@ -82,7 +82,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				},
 
 				Direction = FlexDirection.Column,
-				JustifyContent = FlexJustify.FlexEnd,
+				JustifyContent = FlexJustify.End,
 			};
 
 			layout.Layout(new Rectangle(0, 0, 100, 100));

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutMarginTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutMarginTests.cs
@@ -1,0 +1,226 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	public class FlexLayoutMarginTests : BaseTestFixture
+	{
+		[Test]
+		public void TestMarginLeft()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, Margin = new Thickness(10, 0, 0, 0), };
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+				},
+				Direction = FlexDirection.Row,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(10, 0, 10, 100)));
+		}
+
+		[Test]
+		public void TestMarginTop()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10, Margin = new Thickness(0, 10, 0, 0), };
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+				},
+
+				Direction = FlexDirection.Column,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 10, 100, 10)));
+		}
+
+		[Test]
+		public void TestMarginRight()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, WidthRequest = 10, Margin = new Thickness(0, 0, 10, 0), };
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+				},
+
+				Direction = FlexDirection.Row,
+				JustifyContent = FlexJustify.FlexEnd,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(80, 0, 10, 100)));
+		}
+
+		[Test]
+		public void TestMarginBottom()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, HeightRequest = 10, Margin = new Thickness(0, 0, 0, 10), };
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+				},
+
+				Direction = FlexDirection.Column,
+				JustifyContent = FlexJustify.FlexEnd,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 80, 100, 10)));
+		}
+
+		[Test]
+		public void TestMarginAndFlexRow()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, Margin = new Thickness(10, 0, 10, 0), };
+			FlexLayout.SetGrow(view0, 1);
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+				},
+
+				Direction = FlexDirection.Row,
+			};
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(10, 0, 80, 100)));
+		}
+
+		[Test]
+		public void TestMarginAndFlexColumn()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, Margin = new Thickness(0, 10, 0, 10), };
+			FlexLayout.SetGrow(view0, 1);
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+				},
+
+				Direction = FlexDirection.Column,
+			};
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 10, 100, 80)));
+		}
+
+		[Test]
+		public void TestMarginAndStretchRow()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, Margin = new Thickness(0, 10, 0, 10), };
+			FlexLayout.SetGrow(view0, 1);
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+				},
+
+				Direction = FlexDirection.Row,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 10, 100, 80)));
+		}
+
+		[Test]
+		public void TestMarginAndStretchColumn()
+		{
+
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true,Margin = new Thickness(10, 0, 10, 0) };
+			FlexLayout.SetGrow(view0, 1);
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+				},
+				Direction = FlexDirection.Column,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(10, 0, 80, 100)));
+		}
+
+		[Test]
+		public void TestMarginWithSiblingRow()
+		{
+			var platform = new UnitPlatform((visual, width, height) => new SizeRequest(new Size(0, 0)));
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, Margin = new Thickness(0, 0, 10, 0) };
+			FlexLayout.SetGrow(view0, 1);
+			var view1 = new View { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(view1, 1);
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+					view1,
+				},
+
+				Direction = FlexDirection.Row,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 45, 100)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(55, 0, 45, 100)));
+		}
+
+		[Test]
+		public void TestMarginWithSiblingColumn()
+		{
+			var platform = new UnitPlatform();
+			var view0 = new View { Platform = platform, IsPlatformEnabled = true, Margin = new Thickness(0, 0, 0, 10) };
+			FlexLayout.SetGrow(view0, 1);
+			var view1 = new View { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(view1, 1);
+
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					view0,
+					view1,
+				},
+
+				Direction = FlexDirection.Column,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(view0.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 45)));
+			Assert.That(view1.Bounds, Is.EqualTo(new Rectangle(0, 55, 100, 45)));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
@@ -88,7 +88,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var layout = new FlexLayout {
 				Direction = FlexDirection.Row,
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignItems = FlexAlignItems.Start,
 				Platform = platform,
 				IsPlatformEnabled = true
 			};
@@ -244,7 +244,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var layout = new FlexLayout {
 				Direction = FlexDirection.Row,
-				AlignItems = FlexAlignItems.FlexStart,
+				AlignItems = FlexAlignItems.Start,
 				Platform = platform,
 				IsPlatformEnabled = true
 			};

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
@@ -326,5 +326,37 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.That(footer.Bounds, Is.EqualTo(new Rectangle(0, 550, 300, 50)));
 		}
+
+		[Test]
+		public void TestMeasuring()
+		{
+			var platform = new UnitPlatform();
+			var label = new Label {
+				Platform = platform,
+				IsPlatformEnabled = true,
+			};
+			var Layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Row,
+				Wrap = FlexWrap.Wrap,
+				Children = { 
+					label,
+				}
+			};
+
+			//measure sith +inf as main-axis
+			var measure = Layout.Measure(double.PositiveInfinity, 40);
+			Assert.That(measure.Request, Is.EqualTo(new Size(100, 40)));
+
+			//measure sith +inf as cross-axis
+			measure = Layout.Measure(200, double.PositiveInfinity);
+			Assert.That(measure.Request, Is.EqualTo(new Size(200, 20)));
+
+			//measure with +inf as both axis
+			measure = Layout.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			Assert.That(measure.Request, Is.EqualTo(new Size(100, 20)));
+
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
@@ -1,0 +1,330 @@
+﻿using NUnit.Framework;
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class FlexLayoutTests : BaseTestFixture
+	{
+		[Test]
+		public void TestBasicLayout()
+		{
+			var platform = new UnitPlatform();
+			var label1 = new Label { Platform = platform, IsPlatformEnabled = true };
+			var label2 = new Label { Platform = platform, IsPlatformEnabled = true };
+
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					label1,
+					label2,
+				}
+			};
+
+			layout.Layout(new Rectangle(0, 0, 912, 912));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 912, 912)));
+			Assert.That(label1.Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 912)));
+			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(100, 0, 100, 912)));
+		}
+
+		[Test]
+		public void TestBasicLayoutWithElementsWidth()
+		{
+			var platform = new UnitPlatform();
+			var label1 = new Label { Platform = platform, IsPlatformEnabled = true, WidthRequest = 120 };
+			var label2 = new Label { Platform = platform, IsPlatformEnabled = true, WidthRequest = 120 };
+
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					label1,
+					label2,
+				}
+			};
+
+			layout.Layout(new Rectangle(0, 0, 912, 912));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 912, 912)));
+			Assert.That(label1.Bounds, Is.EqualTo(new Rectangle(0, 0, 120, 912)));
+			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(120, 0, 120, 912)));
+
+		}
+
+		[Test]
+		public void TestBasicLayoutWithElementsWidthAndMargin()
+		{
+			var platform = new UnitPlatform();
+			var label1 = new Label { Platform = platform, IsPlatformEnabled = true, WidthRequest = 100, Margin = new Thickness(5, 0, 0, 0) };
+			var label2 = new Label { Platform = platform, IsPlatformEnabled = true, WidthRequest = 100, Margin = new Thickness(5, 0, 0, 0) };
+
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					label1,
+					label2,
+				}
+			};
+
+			layout.Layout(new Rectangle(0, 0, 912, 912));
+
+			Assert.AreEqual(912, layout.Width);
+			Assert.AreEqual(912, layout.Height);
+
+			Assert.AreEqual(new Rectangle(5, 0, 100, 912), label1.Bounds);
+			Assert.AreEqual(new Rectangle(110, 0, 100, 912), label2.Bounds);
+		}
+
+		[Test]
+		public void TestSetBounds()
+		{
+			var layoutSize = new Size(320, 50);
+			var platform = new UnitPlatform();
+
+			var layout = new FlexLayout {
+				Direction = FlexDirection.Row,
+				AlignItems = FlexAlignItems.FlexStart,
+				Platform = platform,
+				IsPlatformEnabled = true
+			};
+
+			var label1 = new Label { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(label1, 1);
+			layout.Children.Add(label1);
+
+			var label2 = new Label { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(label2, 1);
+			layout.Children.Add(label2);
+
+			var label3 = new Label { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(label3, 1);
+			layout.Children.Add(label3);
+
+			layout.Layout(new Rectangle(0, 0, layoutSize.Width, layoutSize.Height));
+
+			Assert.AreEqual(label2.Bounds.Left, Math.Max(label1.Bounds.Left, label1.Bounds.Right), 1);
+			Assert.AreEqual(label3.Bounds.Left, Math.Max(label2.Bounds.Left, label2.Bounds.Right), 1);
+
+			double totalWidth = 0;
+			foreach (var view in layout.Children)
+			{
+				totalWidth += view.Bounds.Width;
+			}
+
+			Assert.AreEqual(layoutSize.Width, totalWidth, 2);
+		}
+
+		[Test]
+		public void TestRelayoutOnChildrenRemoved()
+		{
+			var layoutSize = new Size(300, 50);
+
+			var platform = new UnitPlatform();
+
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Row
+			};
+
+			var label1 = new Label { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(label1, 1);
+			layout.Children.Add(label1);
+
+			var label2 = new Label { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(label2, 1);
+			layout.Children.Add(label2);
+
+			var label3 = new Label { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(label3, 1);
+			layout.Children.Add(label3);
+
+			layout.Layout(new Rectangle(0, 0, layoutSize.Width, layoutSize.Height));
+
+			foreach (var view in layout.Children)
+				Assert.That(view.Bounds.Width, Is.EqualTo(100));
+
+			layout.Children.Remove(label3);
+
+			Assert.That(label1.Bounds.Width, Is.EqualTo(150));
+			Assert.That(label2.Bounds.Width, Is.EqualTo(150));
+			Assert.That(label3.Bounds.Width, Is.EqualTo(100));
+		}
+
+		[Test]
+		public void TestFlexLayoutIsIncludeChangeWorksOnSecondPass()
+		{
+			var layoutSize = new Size(300, 50);
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Direction = FlexDirection.Row,
+				Platform = platform,
+				IsPlatformEnabled = true,
+			};
+
+			var label1 = new Label { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(label1, 1);
+			layout.Children.Add(label1);
+
+			var label2 = new Label { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(label2, 1);
+			layout.Children.Add(label2);
+
+			var label3 = new Label { Platform = platform, IsPlatformEnabled = true };
+			FlexLayout.SetGrow(label3, 1);
+
+			layout.Layout(new Rectangle(0, 0, layoutSize.Width, layoutSize.Height));
+
+			Assert.AreEqual(150, label1.Bounds.Width);
+			Assert.AreEqual(150, label2.Bounds.Width);
+			Assert.AreEqual(-1, label3.Bounds.Width);
+
+			layout.Children.Add(label3);
+
+			layout.Layout(new Rectangle(0, 0, layoutSize.Width, layoutSize.Height));
+			Assert.AreEqual(100, label1.Bounds.Width);
+			Assert.AreEqual(100, label2.Bounds.Width);
+			Assert.AreEqual(100, label3.Bounds.Width);
+		}
+
+		[Test]
+		// fixed at https://github.com/xamarin/flex/commit/0ccb9f1625abdc5400def29651373937bf6610cd
+		public void TestSwapChildrenOrder()
+		{
+			var layoutSize = new Size(300, 50);
+
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout { 
+				Direction = FlexDirection.Row,
+				Platform = platform,
+				IsPlatformEnabled = true,
+			};
+
+			var label0 = new Label { Platform = platform, IsPlatformEnabled = true, Text="Label0" };
+			FlexLayout.SetGrow(label0, 1);
+			layout.Children.Add(label0);
+
+			var label1 = new Label { Platform = platform, IsPlatformEnabled = true, Text = "Label1" };
+			FlexLayout.SetGrow(label1, 1);
+			layout.Children.Add(label1);
+
+			var label2 = new Label { Platform = platform, IsPlatformEnabled = true, Text = "Label2" };
+			FlexLayout.SetGrow(label2, 1);
+			layout.Children.Add(label2);
+
+			layout.Layout(new Rectangle(0, 0, layoutSize.Width, layoutSize.Height));
+
+			Assert.AreEqual(new Rectangle(0, 0, 100, 50), label0.Bounds);
+			Assert.AreEqual(new Rectangle(100, 0, 100, 50), label1.Bounds);
+			Assert.AreEqual(new Rectangle(200, 0, 100, 50), label2.Bounds);
+
+			var lastItem = layout.Children[2];
+			Assert.That(lastItem, Is.SameAs(label2));
+
+			layout.Children.Remove(lastItem);
+			Assert.AreEqual(new Rectangle(0, 0, 150, 50), label0.Bounds);
+			Assert.AreEqual(new Rectangle(150, 0, 150, 50), label1.Bounds);
+
+			layout.Children.Insert(0, lastItem);
+
+			Assert.AreEqual(new Rectangle(0, 0, 100, 50), label2.Bounds);
+			Assert.AreEqual(new Rectangle(100, 0, 100, 50), label0.Bounds);
+			Assert.AreEqual(new Rectangle(200, 0, 100, 50), label1.Bounds);
+		}
+
+		[Test]
+		public void TestSizeThatFits()
+		{
+			var platform = new UnitPlatform(useRealisticLabelMeasure: true);
+
+			var layout = new FlexLayout {
+				Direction = FlexDirection.Row,
+				AlignItems = FlexAlignItems.FlexStart,
+				Platform = platform,
+				IsPlatformEnabled = true
+			};
+
+			var label1 = new Label {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				LineBreakMode = LineBreakMode.TailTruncation,
+				Text = @"This is a very very very very very very very very long piece of text."
+			};
+			FlexLayout.SetShrink(label1, 1);
+			layout.Children.Add(label1);
+
+			var label2 = new Label {
+				Text = "",
+				Platform = platform,
+				IsPlatformEnabled = true,
+				WidthRequest = 10,
+				HeightRequest = 10
+			};
+			layout.Children.Add(label2);
+			layout.Layout(new Rectangle(0, 0, 320, 50));
+
+			var label2Size = label2.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			Assert.AreEqual(10, label2Size.Request.Height);
+			Assert.AreEqual(10, label2Size.Request.Width);
+
+			var label1Size = label1.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			//	var layoutSize = layout.Measure(-1, -1);
+		}
+
+		[Test]
+		public void TestNesting()
+		{
+			var platform = new UnitPlatform();
+
+			var header = new View { HeightRequest = 50, IsPlatformEnabled = true, };
+			var footer = new View { HeightRequest = 50, IsPlatformEnabled = true, };
+			Func<View> createItem = () => {
+				var v = new View { WidthRequest = 50, Margin = 5, IsPlatformEnabled = true, };
+				FlexLayout.SetGrow(v, 1);
+				return v;
+			};
+
+			var layout = new FlexLayout
+			{
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Children = {
+					header,
+					new FlexLayout{
+						Direction = FlexDirection.Row,
+						IsPlatformEnabled = true,
+						Children = {
+							createItem(),
+							createItem(),
+							createItem(),
+							createItem(),
+							createItem(),
+						}
+					},
+					footer,
+				},
+				Direction = FlexDirection.Column,
+			};
+
+			var inner = layout.Children[1] as FlexLayout;
+			FlexLayout.SetGrow(inner, 1);
+
+			layout.Layout(new Rectangle(0, 0, 300, 600));
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 600)));
+			Assert.That(header.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 50)));
+			Assert.That(inner.Bounds, Is.EqualTo(new Rectangle(0, 50, 300, 500)));
+			Assert.That(inner.Children[0].Bounds, Is.EqualTo(new Rectangle(5, 5, 50, 490)));
+			Assert.That(inner.Children[1].Bounds, Is.EqualTo(new Rectangle(65, 5, 50, 490)));
+			Assert.That(inner.Children[2].Bounds, Is.EqualTo(new Rectangle(125, 5, 50, 490)));
+			Assert.That(inner.Children[3].Bounds, Is.EqualTo(new Rectangle(185, 5, 50, 490)));
+			Assert.That(inner.Children[4].Bounds, Is.EqualTo(new Rectangle(245, 5, 50, 490)));
+
+			Assert.That(footer.Bounds, Is.EqualTo(new Rectangle(0, 550, 300, 50)));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/FlexOrderTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexOrderTests.cs
@@ -1,0 +1,46 @@
+﻿using NUnit.Framework;
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class FlexOrderTests : BaseTestFixture
+	{
+		[Test]
+		public void TestOrderingElements()
+		{
+			var platform = new UnitPlatform();
+			var label0 = new Label { Platform = platform, IsPlatformEnabled = true };
+			var label1 = new Label { Platform = platform, IsPlatformEnabled = true };
+			var label2 = new Label { Platform = platform, IsPlatformEnabled = true };
+			var label3 = new Label { Platform = platform, IsPlatformEnabled = true };
+
+			FlexLayout.SetOrder(label3, 0);
+			FlexLayout.SetOrder(label2, 1);
+			FlexLayout.SetOrder(label1, 2);
+			FlexLayout.SetOrder(label0, 3);
+
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Column,
+				Children = {
+					label0,
+					label1,
+					label2,
+					label3
+				}
+			};
+
+			layout.Layout(new Rectangle(0, 0, 912, 912));
+
+			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 912, 912)));
+			Assert.That(label3.Bounds, Is.EqualTo(new Rectangle(0, 0, 912, 20)));
+			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(0, 20, 912, 20)));
+			Assert.That(label1.Bounds, Is.EqualTo(new Rectangle(0, 40, 912, 20)));
+			Assert.That(label0.Bounds, Is.EqualTo(new Rectangle(0, 60, 912, 20)));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -192,6 +192,7 @@
     <Compile Include="FlexLayoutMarginTests.cs" />
     <Compile Include="FlexLayoutAlignContentTests.cs" />
     <Compile Include="FlexLayoutAlignSelfTests.cs" />
+    <Compile Include="FlexOrderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -186,6 +186,12 @@
     <Compile Include="StyleSheets\SelectorTests.cs" />
     <Compile Include="StyleSheets\IStylableTest.cs" />
     <Compile Include="StyleSheets\StyleTests.cs" />
+    <Compile Include="FlexLayoutTests.cs" />
+    <Compile Include="FlexLayoutAlignItemsTests.cs" />
+    <Compile Include="FlexLayoutFlexDirectionTests.cs" />
+    <Compile Include="FlexLayoutMarginTests.cs" />
+    <Compile Include="FlexLayoutAlignContentTests.cs" />
+    <Compile Include="FlexLayoutAlignSelfTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -257,6 +257,25 @@ namespace Xamarin.Forms
 			return values;
 		}
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		internal object[] GetValues(params BindableProperty[] properties)
+		{
+			var values = new object[properties.Length];
+			for (var i = 0; i < _properties.Count; i++) {
+				var context = _properties[i];
+				var index = properties.IndexOf(context.Property);
+				if (index < 0)
+					continue;
+				values[index] = context.Value;
+			}
+			for (var i = 0; i < values.Length; i++) {
+				if (!ReferenceEquals(values[i], null))
+					continue;
+				values[i] = properties[i].DefaultValueCreator == null ? properties[i].DefaultValue : CreateAndAddContext(properties[i]).Value;
+			}
+			return values;
+		}
+
 		internal virtual void OnRemoveDynamicResource(BindableProperty property)
 		{
 		}

--- a/Xamarin.Forms.Core/FlexEnums.cs
+++ b/Xamarin.Forms.Core/FlexEnums.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Globalization;
+            
 namespace Xamarin.Forms
 {
-	//TODO require a typeConverter for css values
+	[TypeConverter(typeof(FlexJustifyTypeConverter))]
 	public enum FlexJustify
 	{
 		FlexStart = Flex.Align.Start,
@@ -9,7 +11,28 @@ namespace Xamarin.Forms
 		FlexEnd = Flex.Align.End,
 		SpaceBetween = Flex.Align.SpaceBetween,
 		SpaceAround = Flex.Align.SpaceAround,
-		SpaceEvenly = Flex.Align.SpaceEvenly,
+		//SpaceEvenly = Flex.Align.SpaceEvenly,
+	}
+
+	[Xaml.TypeConversion(typeof(FlexJustify))]
+	public class FlexJustifyTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null) {
+				if (Enum.TryParse(value, true, out FlexJustify justify))
+					return justify;
+				if (value.Equals("flex-start", StringComparison.OrdinalIgnoreCase))
+					return FlexJustify.FlexStart;
+				if (value.Equals("flex-end", StringComparison.OrdinalIgnoreCase))
+					return FlexJustify.FlexEnd;
+				if (value.Equals("space-between", StringComparison.OrdinalIgnoreCase))
+					return FlexJustify.SpaceBetween;
+				if (value.Equals("space-around", StringComparison.OrdinalIgnoreCase))
+					return FlexJustify.SpaceAround;
+			}
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexJustify)));
+		}
 	}
 
 	public enum FlexPosition
@@ -18,7 +41,7 @@ namespace Xamarin.Forms
 		Absolute = Flex.Position.Absolute,
 	}
 
-	//TODO require a typeConverter for css values
+	[TypeConverter(typeof(FlexDirectionTypeConverter))]
 	public enum FlexDirection
 	{
 		Column = Flex.Direction.Column,
@@ -27,7 +50,24 @@ namespace Xamarin.Forms
 		RowReverse = Flex.Direction.RowReverse,
 	}
 
-	//TODO require a typeConverter for css values
+	[Xaml.TypeConversion(typeof(FlexDirection))]
+	public class FlexDirectionTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null) {
+				if (Enum.TryParse(value, true, out FlexDirection aligncontent))
+					return aligncontent;
+				if (value.Equals("row-reverse", StringComparison.OrdinalIgnoreCase))
+					return FlexDirection.RowReverse;
+				if (value.Equals("column-reverse", StringComparison.OrdinalIgnoreCase))
+					return FlexDirection.ColumnReverse;
+			}
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexDirection)));
+		}
+	}
+
+	[TypeConverter(typeof(FlexAlignContentTypeConverter))]
 	public enum FlexAlignContent
 	{
 		Stretch = Flex.Align.Stretch,
@@ -38,7 +78,28 @@ namespace Xamarin.Forms
 		SpaceAround = Flex.Align.SpaceAround,
 	}
 
-	//TODO require a typeConverter for css values
+	[Xaml.TypeConversion(typeof(FlexAlignContent))]
+	public class FlexAlignContentTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null) {
+				if (Enum.TryParse(value, true, out FlexAlignContent aligncontent))
+					return aligncontent;
+				if (value.Equals("flex-start", StringComparison.OrdinalIgnoreCase))
+					return FlexAlignContent.FlexStart;
+				if (value.Equals("flex-end", StringComparison.OrdinalIgnoreCase))
+					return FlexAlignContent.FlexEnd;
+				if (value.Equals("space-between", StringComparison.OrdinalIgnoreCase))
+					return FlexAlignContent.SpaceBetween;
+				if (value.Equals("space-around", StringComparison.OrdinalIgnoreCase))
+					return FlexAlignContent.SpaceAround;
+			}
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexAlignContent)));
+		}
+	}
+
+	[TypeConverter(typeof(FlexAlignItemsTypeConverter))]
 	public enum FlexAlignItems
 	{
 		Stretch = Flex.Align.Stretch,
@@ -48,7 +109,24 @@ namespace Xamarin.Forms
 		//Baseline = Flex.Align.Baseline,
 	}
 
-	//TODO require a typeConverter for css values
+	[Xaml.TypeConversion(typeof(FlexAlignItems))]
+	public class FlexAlignItemsTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null) {
+				if (Enum.TryParse(value, true, out FlexAlignItems alignitems))
+					return alignitems;
+				if (value.Equals("flex-start", StringComparison.OrdinalIgnoreCase))
+					return FlexAlignItems.FlexStart;
+				if (value.Equals("flex-end", StringComparison.OrdinalIgnoreCase))
+					return FlexAlignItems.FlexEnd;
+			}
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexAlignItems)));
+		}
+	}
+
+	[TypeConverter(typeof(FlexAlignSelfTypeConverter))]
 	public enum FlexAlignSelf
 	{
 		Auto = Flex.Align.Auto,
@@ -59,7 +137,24 @@ namespace Xamarin.Forms
 		//Baseline = Flex.Align.Baseline,
 	}
 
-	//TODO require a typeConverter for css values
+	[Xaml.TypeConversion(typeof(FlexAlignSelf))]
+	public class FlexAlignSelfTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null) {
+				if (Enum.TryParse(value, true, out FlexAlignSelf alignself))
+					return alignself;
+				if (value.Equals("flex-start", StringComparison.OrdinalIgnoreCase))
+					return FlexAlignSelf.FlexStart;
+				if (value.Equals("flex-end", StringComparison.OrdinalIgnoreCase))
+					return FlexAlignSelf.FlexEnd;
+			}
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexAlignSelf)));
+		}
+	}
+
+	[TypeConverter(typeof(FlexWrapTypeConverter))]
 	public enum FlexWrap
 	{
 		NoWrap = Flex.Wrap.NoWrap,
@@ -67,7 +162,22 @@ namespace Xamarin.Forms
 		Reverse = Flex.Wrap.WrapReverse,
 	}
 
-	//TODO require a typeConverter
+	[Xaml.TypeConversion(typeof(FlexWrap))]
+	public class FlexWrapTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null) {
+				if (Enum.TryParse(value, true, out FlexWrap wrap))
+					return wrap;
+				if (value.Equals("wrap-reverse", StringComparison.OrdinalIgnoreCase))
+					return FlexWrap.Reverse;
+			}
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexWrap)));
+		}
+	}
+
+	[TypeConverter(typeof(FlexBasisTypeConverter))]
 	public struct FlexBasis
 	{
 		bool _isLength;
@@ -86,6 +196,21 @@ namespace Xamarin.Forms
 		public static implicit operator FlexBasis(float length)
 		{
 			return new FlexBasis(length);
+		}
+
+		[Xaml.TypeConversion(typeof(FlexBasis))]
+		public class FlexBasisTypeConverter : TypeConverter
+		{
+			public override object ConvertFromInvariantString(string value)
+			{
+				if (value != null) {
+					if (value.Equals("auto", StringComparison.OrdinalIgnoreCase))
+						return Auto;
+					if (float.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out float flex))
+						return new FlexBasis(flex);
+				}
+				throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexBasis)));
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Core/FlexEnums.cs
+++ b/Xamarin.Forms.Core/FlexEnums.cs
@@ -1,0 +1,91 @@
+﻿using System;
+namespace Xamarin.Forms
+{
+	//TODO require a typeConverter for css values
+	public enum FlexJustify
+	{
+		FlexStart = Flex.Align.Start,
+		Center = Flex.Align.Center,
+		FlexEnd = Flex.Align.End,
+		SpaceBetween = Flex.Align.SpaceBetween,
+		SpaceAround = Flex.Align.SpaceAround,
+		SpaceEvenly = Flex.Align.SpaceEvenly,
+	}
+
+	public enum FlexPosition
+	{
+		Relative = Flex.Position.Relative,
+		Absolute = Flex.Position.Absolute,
+	}
+
+	//TODO require a typeConverter for css values
+	public enum FlexDirection
+	{
+		Column = Flex.Direction.Column,
+		ColumnReverse = Flex.Direction.ColumnReverse,
+		Row = Flex.Direction.Row,
+		RowReverse = Flex.Direction.RowReverse,
+	}
+
+	//TODO require a typeConverter for css values
+	public enum FlexAlignContent
+	{
+		Stretch = Flex.Align.Stretch,
+		Center = Flex.Align.Center,
+		FlexStart = Flex.Align.Start,
+		FlexEnd = Flex.Align.End,
+		SpaceBetween = Flex.Align.SpaceBetween,
+		SpaceAround = Flex.Align.SpaceAround,
+	}
+
+	//TODO require a typeConverter for css values
+	public enum FlexAlignItems
+	{
+		Stretch = Flex.Align.Stretch,
+		Center = Flex.Align.Center,
+		FlexStart = Flex.Align.Start,
+		FlexEnd = Flex.Align.End,
+		//Baseline = Flex.Align.Baseline,
+	}
+
+	//TODO require a typeConverter for css values
+	public enum FlexAlignSelf
+	{
+		Auto = Flex.Align.Auto,
+		Stretch = Flex.Align.Stretch,
+		Center = Flex.Align.Center,
+		FlexStart = Flex.Align.Start,
+		FlexEnd = Flex.Align.End,
+		//Baseline = Flex.Align.Baseline,
+	}
+
+	//TODO require a typeConverter for css values
+	public enum FlexWrap
+	{
+		NoWrap = Flex.Wrap.NoWrap,
+		Wrap = Flex.Wrap.Wrap,
+		Reverse = Flex.Wrap.WrapReverse,
+	}
+
+	//TODO require a typeConverter
+	public struct FlexBasis
+	{
+		bool _isLength;
+		public static FlexBasis Auto = new FlexBasis();
+		public float Length { get; }
+		internal bool IsAuto => !_isLength;
+
+		public FlexBasis(float length)
+		{
+			if (length < 0)
+				throw new ArgumentException("should be a positive value", nameof(length));
+			_isLength = true;
+			Length = length;
+		}
+
+		public static implicit operator FlexBasis(float length)
+		{
+			return new FlexBasis(length);
+		}
+	}
+}

--- a/Xamarin.Forms.Core/FlexEnums.cs
+++ b/Xamarin.Forms.Core/FlexEnums.cs
@@ -6,12 +6,12 @@ namespace Xamarin.Forms
 	[TypeConverter(typeof(FlexJustifyTypeConverter))]
 	public enum FlexJustify
 	{
-		FlexStart = Flex.Align.Start,
-		Center = Flex.Align.Center,
-		FlexEnd = Flex.Align.End,
-		SpaceBetween = Flex.Align.SpaceBetween,
-		SpaceAround = Flex.Align.SpaceAround,
-		//SpaceEvenly = Flex.Align.SpaceEvenly,
+		Start = Flex.Justify.Start,
+		Center = Flex.Justify.Center,
+		End = Flex.Justify.End,
+		SpaceBetween = Flex.Justify.SpaceBetween,
+		SpaceAround = Flex.Justify.SpaceAround,
+		SpaceEvenly = Flex.Justify.SpaceEvenly,
 	}
 
 	[Xaml.TypeConversion(typeof(FlexJustify))]
@@ -23,9 +23,9 @@ namespace Xamarin.Forms
 				if (Enum.TryParse(value, true, out FlexJustify justify))
 					return justify;
 				if (value.Equals("flex-start", StringComparison.OrdinalIgnoreCase))
-					return FlexJustify.FlexStart;
+					return FlexJustify.Start;
 				if (value.Equals("flex-end", StringComparison.OrdinalIgnoreCase))
-					return FlexJustify.FlexEnd;
+					return FlexJustify.End;
 				if (value.Equals("space-between", StringComparison.OrdinalIgnoreCase))
 					return FlexJustify.SpaceBetween;
 				if (value.Equals("space-around", StringComparison.OrdinalIgnoreCase))
@@ -70,12 +70,13 @@ namespace Xamarin.Forms
 	[TypeConverter(typeof(FlexAlignContentTypeConverter))]
 	public enum FlexAlignContent
 	{
-		Stretch = Flex.Align.Stretch,
-		Center = Flex.Align.Center,
-		FlexStart = Flex.Align.Start,
-		FlexEnd = Flex.Align.End,
-		SpaceBetween = Flex.Align.SpaceBetween,
-		SpaceAround = Flex.Align.SpaceAround,
+		Stretch = Flex.AlignContent.Stretch,
+		Center = Flex.AlignContent.Center,
+		Start = Flex.AlignContent.Start,
+		End = Flex.AlignContent.End,
+		SpaceBetween = Flex.AlignContent.SpaceBetween,
+		SpaceAround = Flex.AlignContent.SpaceAround,
+		SpaceEvenly = Flex.AlignContent.SpaceEvenly,
 	}
 
 	[Xaml.TypeConversion(typeof(FlexAlignContent))]
@@ -87,9 +88,9 @@ namespace Xamarin.Forms
 				if (Enum.TryParse(value, true, out FlexAlignContent aligncontent))
 					return aligncontent;
 				if (value.Equals("flex-start", StringComparison.OrdinalIgnoreCase))
-					return FlexAlignContent.FlexStart;
+					return FlexAlignContent.Start;
 				if (value.Equals("flex-end", StringComparison.OrdinalIgnoreCase))
-					return FlexAlignContent.FlexEnd;
+					return FlexAlignContent.End;
 				if (value.Equals("space-between", StringComparison.OrdinalIgnoreCase))
 					return FlexAlignContent.SpaceBetween;
 				if (value.Equals("space-around", StringComparison.OrdinalIgnoreCase))
@@ -102,11 +103,11 @@ namespace Xamarin.Forms
 	[TypeConverter(typeof(FlexAlignItemsTypeConverter))]
 	public enum FlexAlignItems
 	{
-		Stretch = Flex.Align.Stretch,
-		Center = Flex.Align.Center,
-		FlexStart = Flex.Align.Start,
-		FlexEnd = Flex.Align.End,
-		//Baseline = Flex.Align.Baseline,
+		Stretch = Flex.AlignItems.Stretch,
+		Center = Flex.AlignItems.Center,
+		Start = Flex.AlignItems.Start,
+		End = Flex.AlignItems.End,
+		//Baseline = Flex.AlignItems.Baseline,
 	}
 
 	[Xaml.TypeConversion(typeof(FlexAlignItems))]
@@ -118,9 +119,9 @@ namespace Xamarin.Forms
 				if (Enum.TryParse(value, true, out FlexAlignItems alignitems))
 					return alignitems;
 				if (value.Equals("flex-start", StringComparison.OrdinalIgnoreCase))
-					return FlexAlignItems.FlexStart;
+					return FlexAlignItems.Start;
 				if (value.Equals("flex-end", StringComparison.OrdinalIgnoreCase))
-					return FlexAlignItems.FlexEnd;
+					return FlexAlignItems.End;
 			}
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexAlignItems)));
 		}
@@ -129,12 +130,12 @@ namespace Xamarin.Forms
 	[TypeConverter(typeof(FlexAlignSelfTypeConverter))]
 	public enum FlexAlignSelf
 	{
-		Auto = Flex.Align.Auto,
-		Stretch = Flex.Align.Stretch,
-		Center = Flex.Align.Center,
-		FlexStart = Flex.Align.Start,
-		FlexEnd = Flex.Align.End,
-		//Baseline = Flex.Align.Baseline,
+		Auto = Flex.AlignSelf.Auto,
+		Stretch = Flex.AlignSelf.Stretch,
+		Center = Flex.AlignSelf.Center,
+		Start = Flex.AlignSelf.Start,
+		End = Flex.AlignSelf.End,
+		//Baseline = Flex.AlignSelf.Baseline,
 	}
 
 	[Xaml.TypeConversion(typeof(FlexAlignSelf))]
@@ -146,9 +147,9 @@ namespace Xamarin.Forms
 				if (Enum.TryParse(value, true, out FlexAlignSelf alignself))
 					return alignself;
 				if (value.Equals("flex-start", StringComparison.OrdinalIgnoreCase))
-					return FlexAlignSelf.FlexStart;
+					return FlexAlignSelf.Start;
 				if (value.Equals("flex-end", StringComparison.OrdinalIgnoreCase))
-					return FlexAlignSelf.FlexEnd;
+					return FlexAlignSelf.End;
 			}
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexAlignSelf)));
 		}
@@ -181,15 +182,19 @@ namespace Xamarin.Forms
 	public struct FlexBasis
 	{
 		bool _isLength;
+		bool _isRelative;
 		public static FlexBasis Auto = new FlexBasis();
 		public float Length { get; }
-		internal bool IsAuto => !_isLength;
-
-		public FlexBasis(float length)
+		internal bool IsAuto => !_isLength && !_isRelative;
+		internal bool IsRelative => _isRelative;
+		public FlexBasis(float length, bool isRelative = false)
 		{
 			if (length < 0)
 				throw new ArgumentException("should be a positive value", nameof(length));
-			_isLength = true;
+			if (isRelative && length > 1)
+				throw new ArgumentException("relative length should be in [0, 1]", nameof(length));
+			_isLength = !isRelative;
+			_isRelative = isRelative;
 			Length = length;
 		}
 
@@ -206,6 +211,9 @@ namespace Xamarin.Forms
 				if (value != null) {
 					if (value.Equals("auto", StringComparison.OrdinalIgnoreCase))
 						return Auto;
+					value = value.Trim();
+					if (value.EndsWith("%", StringComparison.InvariantCulture) && float.TryParse(value.Substring(0, value.Length - 1), NumberStyles.Number, CultureInfo.InvariantCulture, out float relflex))
+						return new FlexBasis(relflex/100, isRelative: true);
 					if (float.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out float flex))
 						return new FlexBasis(flex);
 				}

--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -397,10 +397,11 @@ namespace Xamarin.Forms
 			if (!double.IsPositiveInfinity(widthConstraint) && !double.IsPositiveInfinity(heightConstraint))
 				return new SizeRequest(new Size(widthConstraint, heightConstraint));
 
-			//1. Set Shrink to 0;
-			foreach (var item in _root)
+			//1. Set Shrink to 0, set align-self to start (to avoid stretching)
+			foreach (var item in _root) {
 				item.Shrink = 0;
-
+				item.AlignSelf = Flex.AlignSelf.Start;
+			}
 			Layout(0, 0, widthConstraint, heightConstraint);
 
 			//2. look at the children location
@@ -415,9 +416,11 @@ namespace Xamarin.Forms
 					heightConstraint = Math.Max(heightConstraint, item.Frame[1] + item.Frame[3]);
 			}
 
-			//3. reset Shrink
-			foreach (var child in Children)
+			//3. reset Shrink and algin-self
+			foreach (var child in Children) {
 				GetFlexItem(child).Shrink = (float)child.GetValue(ShrinkProperty);
+				GetFlexItem(child).AlignSelf = (Flex.AlignSelf)(FlexAlignSelf)child.GetValue(AlignSelfProperty);
+			}
 
 			return new SizeRequest(new Size(widthConstraint, heightConstraint));
 		}

--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -255,7 +255,6 @@ namespace Xamarin.Forms
 		{
 			foreach (var child in Children)
 				RemoveChild(child);
-			//_root.Dispose();
 			_root = null;
 		}
 
@@ -321,7 +320,6 @@ namespace Xamarin.Forms
 				return;
 			var item = GetFlexItem(view);
 			_root.Remove(item);
-			//item.Dispose();
 			view.ClearValue(FlexItemProperty);
 		}
 
@@ -334,16 +332,29 @@ namespace Xamarin.Forms
 				item.Height = ((View)sender).HeightRequest < 0 ? float.NaN : (float)((View)sender).HeightRequest;
 				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 				UpdateChildrenLayout();
+				return;
+			}
+
+			if (e.PropertyName == MarginProperty.PropertyName) {
+				var item = (sender as FlexLayout)?._root ?? GetFlexItem((BindableObject)sender);
+				var margin = (Thickness)((View)sender).GetValue(MarginProperty);
+				item.MarginLeft = (float)margin.Left;
+				item.MarginTop = (float)margin.Top;
+				item.MarginRight = (float)margin.Right;
+				item.MarginBottom = (float)margin.Bottom;
+				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+				UpdateChildrenLayout();
+				return;
 			}
 
 			if (   e.PropertyName == OrderProperty.PropertyName
 				|| e.PropertyName == GrowProperty.PropertyName
 				|| e.PropertyName == ShrinkProperty.PropertyName
 				|| e.PropertyName == BasisProperty.PropertyName
-				|| e.PropertyName == AlignSelfProperty.PropertyName
-			    || e.PropertyName == MarginProperty.PropertyName) {
+				|| e.PropertyName == AlignSelfProperty.PropertyName) {
 				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 				UpdateChildrenLayout();
+				return;
 			}
 		}
 

--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -1,0 +1,451 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms
+{
+	public class FlexLayout : Layout<View>
+	{
+		public static readonly BindableProperty DirectionProperty =
+			BindableProperty.Create(nameof(Direction), typeof(FlexDirection), typeof(FlexLayout), FlexDirection.Row,
+									propertyChanged: OnDirectionPropertyChanged);
+
+		public static readonly BindableProperty JustifyContentProperty =
+			BindableProperty.Create(nameof(JustifyContent), typeof(FlexJustify), typeof(FlexLayout), FlexJustify.FlexStart,
+									propertyChanged: OnJustifyContentPropertyChanged);
+
+		public static readonly BindableProperty AlignContentProperty =
+			BindableProperty.Create(nameof(AlignContent), typeof(FlexAlignContent), typeof(FlexLayout), FlexAlignContent.Stretch,
+									propertyChanged: OnAlignContentPropertyChanged);
+
+		public static readonly BindableProperty AlignItemsProperty =
+			BindableProperty.Create(nameof(AlignItems), typeof(FlexAlignItems), typeof(FlexLayout), FlexAlignItems.Stretch,
+									propertyChanged: OnAlignItemsPropertyChanged);
+
+		public static readonly BindableProperty PositionProperty =
+			BindableProperty.Create(nameof(Position), typeof(FlexPosition), typeof(FlexLayout), FlexPosition.Relative,
+									propertyChanged: OnPositionPropertyChanged);
+
+		public static readonly BindableProperty WrapProperty =
+			BindableProperty.Create(nameof(Wrap), typeof(FlexWrap), typeof(FlexLayout), FlexWrap.NoWrap,
+									propertyChanged: OnWrapPropertyChanged);
+
+		static readonly BindableProperty FlexItemProperty =
+			BindableProperty.CreateAttached("FlexItem", typeof(Flex.Item), typeof(FlexLayout), null);
+
+		public static readonly BindableProperty OrderProperty =
+			BindableProperty.CreateAttached("Order", typeof(int), typeof(FlexLayout), default(int),
+											propertyChanged: OnOrderPropertyChanged);
+
+		public static readonly BindableProperty GrowProperty =
+			BindableProperty.CreateAttached("Grow", typeof(float), typeof(FlexLayout), default(float),
+											propertyChanged: OnGrowPropertyChanged);
+
+		public static readonly BindableProperty ShrinkProperty =
+			BindableProperty.CreateAttached("Shrink", typeof(float), typeof(FlexLayout), 1f,
+											propertyChanged: OnShrinkPropertyChanged);
+
+		public static readonly BindableProperty AlignSelfProperty =
+			BindableProperty.CreateAttached("AlignSelf", typeof(FlexAlignSelf), typeof(FlexLayout), FlexAlignSelf.Auto,
+											propertyChanged: OnAlignSelfPropertyChanged);
+
+		public static readonly BindableProperty BasisProperty =
+			BindableProperty.CreateAttached("Basis", typeof(FlexBasis), typeof(FlexLayout), FlexBasis.Auto,
+											propertyChanged: OnBasisPropertyChanged);
+
+		public FlexDirection Direction {
+			get => (FlexDirection)GetValue(DirectionProperty);
+			set => SetValue(DirectionProperty, value);
+		}
+
+		public FlexJustify JustifyContent {
+			get => (FlexJustify)GetValue(JustifyContentProperty);
+			set => SetValue(JustifyContentProperty, value);
+		}
+
+		public FlexAlignContent AlignContent {
+			get => (FlexAlignContent)GetValue(AlignContentProperty);
+			set => SetValue(AlignContentProperty, value);
+		}
+
+		public FlexAlignItems AlignItems {
+			get => (FlexAlignItems)GetValue(AlignItemsProperty);
+			set => SetValue(AlignItemsProperty, value);
+		}
+
+		public FlexPosition Position {
+			get => (FlexPosition)GetValue(PositionProperty);
+			set => SetValue(PositionProperty, value);
+		}
+
+		public FlexWrap Wrap {
+			get => (FlexWrap)GetValue(WrapProperty);
+			set => SetValue(WrapProperty, value);
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		static Flex.Item GetFlexItem(BindableObject bindable)
+			=> (Flex.Item)bindable.GetValue(FlexItemProperty);
+
+		static void SetFlexItem(BindableObject bindable, Flex.Item node)
+			=> bindable.SetValue(FlexItemProperty, node);
+
+		public static int GetOrder(BindableObject bindable)
+			=> (int)bindable.GetValue(OrderProperty);
+
+		public static void SetOrder(BindableObject bindable, int value)
+			=> bindable.SetValue(OrderProperty, value);
+
+		public static float GetGrow(BindableObject bindable)
+			=> (float)bindable.GetValue(GrowProperty);
+
+		public static void SetGrow(BindableObject bindable, float value)
+			=> bindable.SetValue(GrowProperty, value);
+
+		public static float GetShrink(BindableObject bindable)
+			=> (float)bindable.GetValue(ShrinkProperty);
+
+		public static void SetShrink(BindableObject bindable, float value)
+			=> bindable.SetValue(ShrinkProperty, value);
+
+		public static FlexAlignSelf GetAlignSelf(BindableObject bindable)
+			=> (FlexAlignSelf)bindable.GetValue(AlignSelfProperty);
+
+		public static void SetAlignSelf(BindableObject bindable, FlexAlignSelf value)
+			=> bindable.SetValue(AlignSelfProperty, value);
+
+		public static FlexBasis GetBasis(BindableObject bindable)
+			=> (FlexBasis)bindable.GetValue(BasisProperty);
+
+		public static void SetBasis(BindableObject bindable, FlexBasis value)
+			=> bindable.SetValue(BasisProperty, value);
+
+		static void OnOrderPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable.GetIsDefault(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).Order = (int)newValue;
+		}
+
+		static void OnGrowPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable.GetIsDefault(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).Grow = (float)newValue;
+		}
+
+		static void OnShrinkPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable.GetIsDefault(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).Shrink = (float)newValue;
+		}
+
+		static void OnAlignSelfPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable.GetIsDefault(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).AlignSelf = (Flex.Align)(FlexAlignSelf)newValue;
+		}
+
+		static void OnBasisPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable.GetIsDefault(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).Basis = ((FlexBasis)newValue).ToFlexFloat();
+		}
+
+		static void OnDirectionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = bindable as FlexLayout;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.Direction = (Flex.Direction)(FlexDirection)newValue;
+			flexLayout.InvalidateLayout();
+		}
+
+		static void OnJustifyContentPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = bindable as FlexLayout;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.JustifyContent = (Flex.Align)(FlexJustify)newValue;
+			flexLayout.InvalidateLayout();
+		}
+
+		static void OnAlignContentPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = bindable as FlexLayout;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.AlignContent = (Flex.Align)(FlexAlignContent)newValue;
+			flexLayout.InvalidateLayout();
+		}
+
+		static void OnAlignItemsPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = (FlexLayout)bindable;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.AlignItems = (Flex.Align)(FlexAlignItems)newValue;
+			flexLayout.InvalidateLayout();
+		}
+
+		static void OnPositionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = (FlexLayout)bindable;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.Position = (Flex.Position)(FlexPosition)newValue;
+			flexLayout.InvalidateLayout();
+		}
+
+		static void OnWrapPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = bindable as FlexLayout;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.Wrap = (Flex.Wrap)(FlexWrap)newValue;
+			flexLayout.InvalidateLayout();
+		}
+
+		Flex.Item _root;
+		//this should only be used in unitTests. layout creation will normally happen on OnParentSet
+		internal override void OnIsPlatformEnabledChanged()
+		{
+			base.OnIsPlatformEnabledChanged();
+			if (IsPlatformEnabled && _root == null)
+				PopulateLayout();
+			else if(!IsPlatformEnabled && _root != null)
+				ClearLayout();
+		}
+
+		protected override void OnParentSet()
+		{
+			base.OnParentSet();
+			if (Parent != null && _root == null)
+				PopulateLayout();
+			else if (Parent == null && _root != null)
+				ClearLayout();
+		}
+
+		void PopulateLayout()
+		{
+			InitLayoutProperties(_root = new Flex.Item());
+			foreach (var child in Children)
+				AddChild(child);
+		}
+
+		void InitLayoutProperties(Flex.Item item)
+		{
+			var values = GetValues(AlignContentProperty,
+								   AlignItemsProperty,
+								   DirectionProperty,
+								   JustifyContentProperty,
+								   WrapProperty);
+			item.AlignContent = (Flex.Align)(FlexAlignContent)values[0];
+			item.AlignItems = (Flex.Align)(FlexAlignItems)values[1];
+			item.Direction = (Flex.Direction)(FlexDirection)values[2];
+			item.JustifyContent = (Flex.Align)(FlexJustify)values[3];
+			item.Wrap = (Flex.Wrap)(FlexWrap)values[4];
+		}
+
+		void ClearLayout()
+		{
+			foreach (var child in Children)
+				RemoveChild(child);
+			//_root.Dispose();
+			_root = null;
+		}
+
+		protected override void OnAdded(View view)
+		{
+			AddChild(view);
+			view.PropertyChanged += OnChildPropertyChanged;
+			base.OnAdded(view);
+		}
+
+		protected override void OnRemoved(View view)
+		{
+			view.PropertyChanged -= OnChildPropertyChanged;
+			RemoveChild(view);
+			base.OnRemoved(view);
+		}
+
+		void AddChild(View view)
+		{
+			if (_root == null)
+				return;
+			var item = (view as FlexLayout)?._root ?? new Flex.Item();
+			InitItemProperties(view, item);
+			if (!(view is FlexLayout)) { //inner layouts don't get measured
+				item.SelfSizing = (Flex.Item it, ref float w, ref float h) => {
+					(var widthConstraint, var heightConstraint) = item.GetConstraints();
+					var request = view.Measure(widthConstraint, heightConstraint).Request;
+					w = (float)request.Width;
+					h = (float)request.Height;
+				};
+			}
+
+			_root.InsertAt((uint)Children.IndexOf(view), item);
+			SetFlexItem(view, item);
+		}
+
+		void InitItemProperties(View view, Flex.Item item)
+		{
+			var values = view.GetValues(OrderProperty,
+										GrowProperty,
+										ShrinkProperty,
+										BasisProperty,
+										AlignSelfProperty,
+										MarginProperty,
+										WidthRequestProperty,
+										HeightRequestProperty);
+			item.Order = (int)values[0];
+			item.Grow = (float)values[1];
+			item.Shrink = (float)values[2];
+			item.Basis = ((FlexBasis)values[3]).ToFlexFloat();
+			item.AlignSelf = (Flex.Align)(FlexAlignSelf)values[4];
+			item.MarginLeft = (float)((Thickness)values[5]).Left;
+			item.MarginTop = (float)((Thickness)values[5]).Top;
+			item.MarginRight = (float)((Thickness)values[5]).Right;
+			item.MarginBottom = (float)((Thickness)values[5]).Bottom;
+			item.Width = (double)values[6] < 0 ? float.NaN : (float)(double)values[6];
+			item.Height = (double)values[7] < 0 ? float.NaN : (float)(double)values[7];
+		}
+
+		void RemoveChild(View view)
+		{
+			if (_root == null)
+				return;
+			var item = GetFlexItem(view);
+			_root.Remove(item);
+			//item.Dispose();
+			view.ClearValue(FlexItemProperty);
+		}
+
+		void OnChildPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (   e.PropertyName == WidthRequestProperty.PropertyName
+				|| e.PropertyName == HeightRequestProperty.PropertyName) {
+				var item = (sender as FlexLayout)?._root ?? GetFlexItem((BindableObject)sender);
+				item.Width = ((View)sender).WidthRequest < 0 ? float.NaN : (float)((View)sender).WidthRequest;
+				item.Height = ((View)sender).HeightRequest < 0 ? float.NaN : (float)((View)sender).HeightRequest;
+				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+				UpdateChildrenLayout();
+			}
+
+			if (   e.PropertyName == OrderProperty.PropertyName
+				|| e.PropertyName == GrowProperty.PropertyName
+				|| e.PropertyName == ShrinkProperty.PropertyName
+				|| e.PropertyName == BasisProperty.PropertyName
+				|| e.PropertyName == AlignSelfProperty.PropertyName
+			    || e.PropertyName == MarginProperty.PropertyName) {
+				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+				UpdateChildrenLayout();
+			}
+		}
+
+		protected override void LayoutChildren(double x, double y, double width, double height)
+		{
+			Layout(x, y, width, height);
+			foreach (var child in Children)
+				child.Layout(GetFlexItem(child).GetFrame());
+		}
+
+		protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
+		{
+			//All of this is a HACK as X.Flex doesn't supports measuring
+			if (!double.IsPositiveInfinity(widthConstraint) && !double.IsPositiveInfinity(heightConstraint))
+				return new SizeRequest(new Size(widthConstraint, heightConstraint));
+
+			//1. Set Shrink to 0;
+			foreach (var item in _root)
+				item.Shrink = 0;
+
+			Layout(0, 0, widthConstraint, heightConstraint);
+
+			//2. look at the children location
+			if (double.IsPositiveInfinity(widthConstraint)) {
+				widthConstraint = 0;
+				foreach (var item in _root)
+					widthConstraint = Math.Max(widthConstraint, item.FrameX + item.FrameWidth);
+			}
+			if (double.IsPositiveInfinity(heightConstraint)) {
+				heightConstraint = 0;
+				foreach (var item in _root)
+					heightConstraint = Math.Max(heightConstraint, item.FrameY + item.FrameHeight);
+			}
+
+			//3. reset Shrink
+			foreach (var child in Children)
+				GetFlexItem(child).Shrink = (float)child.GetValue(ShrinkProperty);
+
+			return new SizeRequest(new Size(widthConstraint, heightConstraint));
+		}
+
+		void Layout(double x, double y, double width, double height)
+		{
+			if (_root.Parent != null)	//Layout is only computed at root level
+				return;
+			_root.Left = (float)x;
+			_root.Top = (float)y;
+			_root.Width = !double.IsPositiveInfinity((width)) ? (float)width : 0;
+			_root.Height = !double.IsPositiveInfinity((height)) ? (float)height : 0;
+			_root.Layout();
+		}
+	}
+
+	static class FlexExtensions
+	{
+		public static int IndexOf(this Flex.Item parent, Flex.Item child)
+		{
+			var index = -1;
+			foreach (var it in parent) {
+				index++;
+				if (it == child)
+					return index;
+			}
+			return -1;
+		}
+
+		public static void Remove(this Flex.Item parent, Flex.Item child)
+		{
+			var index = parent.IndexOf(child);
+			if (index < 0)
+				return;
+			parent.RemoveAt((uint)index);
+		}
+
+		public static Rectangle GetFrame(this Flex.Item item)
+		{
+			return new Rectangle(item.FrameX, item.FrameY, item.FrameWidth, item.FrameHeight);
+		}
+
+		public static (double widthConstraint, double heightConstraint) GetConstraints(this Flex.Item item)
+		{
+			var widthConstraint = -1d;
+			var heightConstraint = -1d;
+
+			var parent = item.Parent;
+			do {
+				if (parent == null)
+					break;
+				if (widthConstraint < 0 && !float.IsNaN(parent.Width))
+					widthConstraint = (double)parent.Width;
+				if (heightConstraint < 0 && !float.IsNaN(parent.Height))
+					heightConstraint = (double)parent.Height;
+				parent = parent.Parent;
+			} while (widthConstraint < 0 || heightConstraint < 0);
+			return (widthConstraint, heightConstraint);
+		}
+
+		public static float ToFlexFloat(this FlexBasis basis)
+		{
+			if (basis.IsAuto)
+				return float.NaN;
+			return basis.Length;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -60,3 +60,16 @@ using Xamarin.Forms.StyleSheets;
 [assembly: StyleProperty("text-align", typeof(ITextAlignmentElement), nameof(TextAlignmentElement.HorizontalTextAlignmentProperty), Inherited = true)]
 [assembly: StyleProperty("visibility", typeof(VisualElement), nameof(VisualElement.IsVisibleProperty), Inherited = true)]
 [assembly: StyleProperty("width", typeof(VisualElement), nameof(VisualElement.WidthRequestProperty))]
+
+//flex
+[assembly: StyleProperty("align-content", typeof(FlexLayout), nameof(FlexLayout.AlignContentProperty))]
+[assembly: StyleProperty("align-items", typeof(FlexLayout), nameof(FlexLayout.AlignSelfProperty))]
+[assembly: StyleProperty("align-self", typeof(VisualElement), nameof(FlexLayout.AlignSelfProperty), PropertyOwnerType = typeof(FlexLayout))]
+[assembly: StyleProperty("flex-direction", typeof(FlexLayout), nameof(FlexLayout.DirectionProperty))]
+[assembly: StyleProperty("flex-basis", typeof(VisualElement), nameof(FlexLayout.BasisProperty), PropertyOwnerType = typeof(FlexLayout))]
+[assembly: StyleProperty("flex-grow", typeof(VisualElement), nameof(FlexLayout.GrowProperty), PropertyOwnerType = typeof(FlexLayout))]
+[assembly: StyleProperty("flex-shrink", typeof(VisualElement), nameof(FlexLayout.ShrinkProperty), PropertyOwnerType = typeof(FlexLayout))]
+[assembly: StyleProperty("flex-wrap", typeof(VisualElement), nameof(FlexLayout.WrapProperty), PropertyOwnerType = typeof(FlexLayout))]
+[assembly: StyleProperty("justify-content", typeof(FlexLayout), nameof(FlexLayout.JustifyContentProperty))]
+[assembly: StyleProperty("order", typeof(VisualElement), nameof(FlexLayout.OrderProperty), PropertyOwnerType = typeof(FlexLayout))]
+[assembly: StyleProperty("position", typeof(FlexLayout), nameof(FlexLayout.PositionProperty))]

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -63,7 +63,7 @@ using Xamarin.Forms.StyleSheets;
 
 //flex
 [assembly: StyleProperty("align-content", typeof(FlexLayout), nameof(FlexLayout.AlignContentProperty))]
-[assembly: StyleProperty("align-items", typeof(FlexLayout), nameof(FlexLayout.AlignSelfProperty))]
+[assembly: StyleProperty("align-items", typeof(FlexLayout), nameof(FlexLayout.AlignItemsProperty))]
 [assembly: StyleProperty("align-self", typeof(VisualElement), nameof(FlexLayout.AlignSelfProperty), PropertyOwnerType = typeof(FlexLayout))]
 [assembly: StyleProperty("flex-direction", typeof(FlexLayout), nameof(FlexLayout.DirectionProperty))]
 [assembly: StyleProperty("flex-basis", typeof(VisualElement), nameof(FlexLayout.BasisProperty), PropertyOwnerType = typeof(FlexLayout))]

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -9,4 +9,5 @@
     <ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj" />
   </ItemGroup>
 
+  <Import Project="..\Xamarin.Flex\Xamarin.Flex.projitems" Label="Shared" Condition="Exists('..\Xamarin.Flex\Xamarin.Flex.projitems')" />
 </Project>

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -166,6 +166,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.ControlGaller
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Embedding.Tizen", "EmbeddingTestBeds\Embedding.Tizen\Embedding.Tizen.csproj", "{C5C1D2BE-DB01-4B2E-BCA5-2C9A9691E3F1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Xamarin.Flex", "Xamarin.Flex", "{CA1DF598-3650-4A7B-A065-492C26009295}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Xamarin.Flex", "Xamarin.Flex\Xamarin.Flex.shproj", "{A6703C7D-D362-452A-A7A5-73771194D38C}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{0a39a74b-6f7a-4d41-84f2-b0ccdce899df}*SharedItemsImports = 4
@@ -2988,6 +2992,7 @@ Global
 		{AFF3AD0D-7181-4551-A29C-8701FE3E6753} = {80BAC3FB-357A-4D05-A050-9F234DF49C97}
 		{8C7F0087-4031-4297-A651-6ED55F7B88BA} = {4F5E2D21-17F6-4A42-B8FB-D03D82E24EC8}
 		{C5C1D2BE-DB01-4B2E-BCA5-2C9A9691E3F1} = {406DE4B0-F541-4092-B0EE-F0A20E9A89F5}
+		{A6703C7D-D362-452A-A7A5-73771194D38C} = {CA1DF598-3650-4A7B-A065-492C26009295}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {650AE971-2F29-46A8-822C-FB4FCDC6A9A0}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignContent.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignContent.xml
@@ -8,6 +8,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FlexAlignContentTypeConverter))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignContent.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignContent.xml
@@ -32,23 +32,9 @@
         <summary>To be added.</summary>
       </Docs>
     </Member>
-    <Member MemberName="FlexEnd">
-      <MemberSignature Language="C#" Value="FlexEnd" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent FlexEnd = int32(4)" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-      </Docs>
-    </Member>
-    <Member MemberName="FlexStart">
-      <MemberSignature Language="C#" Value="FlexStart" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent FlexStart = int32(3)" />
+    <Member MemberName="End">
+      <MemberSignature Language="C#" Value="End" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent End = int32(4)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -77,6 +63,34 @@
     <Member MemberName="SpaceBetween">
       <MemberSignature Language="C#" Value="SpaceBetween" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent SpaceBetween = int32(5)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SpaceEvenly">
+      <MemberSignature Language="C#" Value="SpaceEvenly" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent SpaceEvenly = int32(7)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Start">
+      <MemberSignature Language="C#" Value="Start" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent Start = int32(3)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignContent.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignContent.xml
@@ -1,0 +1,101 @@
+<Type Name="FlexAlignContent" FullName="Xamarin.Forms.FlexAlignContent">
+  <TypeSignature Language="C#" Value="public enum FlexAlignContent" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed FlexAlignContent extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Center">
+      <MemberSignature Language="C#" Value="Center" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent Center = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="FlexEnd">
+      <MemberSignature Language="C#" Value="FlexEnd" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent FlexEnd = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="FlexStart">
+      <MemberSignature Language="C#" Value="FlexStart" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent FlexStart = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SpaceAround">
+      <MemberSignature Language="C#" Value="SpaceAround" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent SpaceAround = int32(6)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SpaceBetween">
+      <MemberSignature Language="C#" Value="SpaceBetween" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent SpaceBetween = int32(5)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Stretch">
+      <MemberSignature Language="C#" Value="Stretch" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignContent Stretch = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignContentTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignContentTypeConverter.xml
@@ -1,0 +1,56 @@
+<Type Name="FlexAlignContentTypeConverter" FullName="Xamarin.Forms.FlexAlignContentTypeConverter">
+  <TypeSignature Language="C#" Value="public class FlexAlignContentTypeConverter : Xamarin.Forms.TypeConverter" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FlexAlignContentTypeConverter extends Xamarin.Forms.TypeConverter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.FlexAlignContent))</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FlexAlignContentTypeConverter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="public override object ConvertFromInvariantString (string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance object ConvertFromInvariantString(string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignItems.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignItems.xml
@@ -32,9 +32,9 @@
         <summary>To be added.</summary>
       </Docs>
     </Member>
-    <Member MemberName="FlexEnd">
-      <MemberSignature Language="C#" Value="FlexEnd" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignItems FlexEnd = int32(4)" />
+    <Member MemberName="End">
+      <MemberSignature Language="C#" Value="End" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignItems End = int32(4)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -46,9 +46,9 @@
         <summary>To be added.</summary>
       </Docs>
     </Member>
-    <Member MemberName="FlexStart">
-      <MemberSignature Language="C#" Value="FlexStart" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignItems FlexStart = int32(3)" />
+    <Member MemberName="Start">
+      <MemberSignature Language="C#" Value="Start" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignItems Start = int32(3)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignItems.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignItems.xml
@@ -8,6 +8,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FlexAlignItemsTypeConverter))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignItems.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignItems.xml
@@ -1,0 +1,73 @@
+<Type Name="FlexAlignItems" FullName="Xamarin.Forms.FlexAlignItems">
+  <TypeSignature Language="C#" Value="public enum FlexAlignItems" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed FlexAlignItems extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Center">
+      <MemberSignature Language="C#" Value="Center" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignItems Center = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignItems</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="FlexEnd">
+      <MemberSignature Language="C#" Value="FlexEnd" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignItems FlexEnd = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignItems</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="FlexStart">
+      <MemberSignature Language="C#" Value="FlexStart" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignItems FlexStart = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignItems</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Stretch">
+      <MemberSignature Language="C#" Value="Stretch" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignItems Stretch = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignItems</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignItemsTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignItemsTypeConverter.xml
@@ -1,0 +1,56 @@
+<Type Name="FlexAlignItemsTypeConverter" FullName="Xamarin.Forms.FlexAlignItemsTypeConverter">
+  <TypeSignature Language="C#" Value="public class FlexAlignItemsTypeConverter : Xamarin.Forms.TypeConverter" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FlexAlignItemsTypeConverter extends Xamarin.Forms.TypeConverter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.FlexAlignItems))</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FlexAlignItemsTypeConverter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="public override object ConvertFromInvariantString (string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance object ConvertFromInvariantString(string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignSelf.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignSelf.xml
@@ -8,6 +8,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FlexAlignSelfTypeConverter))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignSelf.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignSelf.xml
@@ -46,9 +46,9 @@
         <summary>To be added.</summary>
       </Docs>
     </Member>
-    <Member MemberName="FlexEnd">
-      <MemberSignature Language="C#" Value="FlexEnd" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignSelf FlexEnd = int32(4)" />
+    <Member MemberName="End">
+      <MemberSignature Language="C#" Value="End" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignSelf End = int32(4)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -60,9 +60,9 @@
         <summary>To be added.</summary>
       </Docs>
     </Member>
-    <Member MemberName="FlexStart">
-      <MemberSignature Language="C#" Value="FlexStart" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignSelf FlexStart = int32(3)" />
+    <Member MemberName="Start">
+      <MemberSignature Language="C#" Value="Start" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignSelf Start = int32(3)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignSelf.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignSelf.xml
@@ -1,0 +1,87 @@
+<Type Name="FlexAlignSelf" FullName="Xamarin.Forms.FlexAlignSelf">
+  <TypeSignature Language="C#" Value="public enum FlexAlignSelf" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed FlexAlignSelf extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Auto">
+      <MemberSignature Language="C#" Value="Auto" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignSelf Auto = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignSelf</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Center">
+      <MemberSignature Language="C#" Value="Center" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignSelf Center = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignSelf</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="FlexEnd">
+      <MemberSignature Language="C#" Value="FlexEnd" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignSelf FlexEnd = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignSelf</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="FlexStart">
+      <MemberSignature Language="C#" Value="FlexStart" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignSelf FlexStart = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignSelf</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Stretch">
+      <MemberSignature Language="C#" Value="Stretch" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexAlignSelf Stretch = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignSelf</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignSelfTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexAlignSelfTypeConverter.xml
@@ -1,0 +1,56 @@
+<Type Name="FlexAlignSelfTypeConverter" FullName="Xamarin.Forms.FlexAlignSelfTypeConverter">
+  <TypeSignature Language="C#" Value="public class FlexAlignSelfTypeConverter : Xamarin.Forms.TypeConverter" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FlexAlignSelfTypeConverter extends Xamarin.Forms.TypeConverter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.FlexAlignSelf))</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FlexAlignSelfTypeConverter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="public override object ConvertFromInvariantString (string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance object ConvertFromInvariantString(string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexBasis+FlexBasisTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexBasis+FlexBasisTypeConverter.xml
@@ -1,0 +1,56 @@
+<Type Name="FlexBasis+FlexBasisTypeConverter" FullName="Xamarin.Forms.FlexBasis+FlexBasisTypeConverter">
+  <TypeSignature Language="C#" Value="public class FlexBasis.FlexBasisTypeConverter : Xamarin.Forms.TypeConverter" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit FlexBasis/FlexBasisTypeConverter extends Xamarin.Forms.TypeConverter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.FlexBasis))</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FlexBasisTypeConverter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="public override object ConvertFromInvariantString (string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance object ConvertFromInvariantString(string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexBasis.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexBasis.xml
@@ -20,17 +20,19 @@
   </Docs>
   <Members>
     <Member MemberName=".ctor">
-      <MemberSignature Language="C#" Value="public FlexBasis (float length);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(float32 length) cil managed" />
+      <MemberSignature Language="C#" Value="public FlexBasis (float length, bool isRelative = false);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(float32 length, bool isRelative) cil managed" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Parameters>
         <Parameter Name="length" Type="System.Single" />
+        <Parameter Name="isRelative" Type="System.Boolean" />
       </Parameters>
       <Docs>
         <param name="length">To be added.</param>
+        <param name="isRelative">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexBasis.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexBasis.xml
@@ -1,0 +1,85 @@
+<Type Name="FlexBasis" FullName="Xamarin.Forms.FlexBasis">
+  <TypeSignature Language="C#" Value="public struct FlexBasis" />
+  <TypeSignature Language="ILAsm" Value=".class public sequential ansi sealed beforefieldinit FlexBasis extends System.ValueType" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.ValueType</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FlexBasis (float length);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(float32 length) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="length" Type="System.Single" />
+      </Parameters>
+      <Docs>
+        <param name="length">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Auto">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.FlexBasis Auto;" />
+      <MemberSignature Language="ILAsm" Value=".field public static valuetype Xamarin.Forms.FlexBasis Auto" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexBasis</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Length">
+      <MemberSignature Language="C#" Value="public float Length { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float32 Length" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Implicit">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.FlexBasis op_Implicit (float length);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname valuetype Xamarin.Forms.FlexBasis op_Implicit(float32 length) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexBasis</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="length" Type="System.Single" />
+      </Parameters>
+      <Docs>
+        <param name="length">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexBasis.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexBasis.xml
@@ -9,6 +9,11 @@
     <BaseTypeName>System.ValueType</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FlexBasis/FlexBasisTypeConverter))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexDirection.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexDirection.xml
@@ -1,0 +1,73 @@
+<Type Name="FlexDirection" FullName="Xamarin.Forms.FlexDirection">
+  <TypeSignature Language="C#" Value="public enum FlexDirection" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed FlexDirection extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Column">
+      <MemberSignature Language="C#" Value="Column" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexDirection Column = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexDirection</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="ColumnReverse">
+      <MemberSignature Language="C#" Value="ColumnReverse" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexDirection ColumnReverse = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexDirection</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Row">
+      <MemberSignature Language="C#" Value="Row" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexDirection Row = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexDirection</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="RowReverse">
+      <MemberSignature Language="C#" Value="RowReverse" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexDirection RowReverse = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexDirection</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexDirection.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexDirection.xml
@@ -8,6 +8,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FlexDirectionTypeConverter))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexDirectionTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexDirectionTypeConverter.xml
@@ -1,0 +1,56 @@
+<Type Name="FlexDirectionTypeConverter" FullName="Xamarin.Forms.FlexDirectionTypeConverter">
+  <TypeSignature Language="C#" Value="public class FlexDirectionTypeConverter : Xamarin.Forms.TypeConverter" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FlexDirectionTypeConverter extends Xamarin.Forms.TypeConverter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.FlexDirection))</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FlexDirectionTypeConverter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="public override object ConvertFromInvariantString (string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance object ConvertFromInvariantString(string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexJustify.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexJustify.xml
@@ -8,6 +8,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FlexJustifyTypeConverter))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
@@ -72,20 +77,6 @@
     <Member MemberName="SpaceBetween">
       <MemberSignature Language="C#" Value="SpaceBetween" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify SpaceBetween = int32(5)" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-      </Docs>
-    </Member>
-    <Member MemberName="SpaceEvenly">
-      <MemberSignature Language="C#" Value="SpaceEvenly" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify SpaceEvenly = int32(7)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexJustify.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexJustify.xml
@@ -32,23 +32,9 @@
         <summary>To be added.</summary>
       </Docs>
     </Member>
-    <Member MemberName="FlexEnd">
-      <MemberSignature Language="C#" Value="FlexEnd" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify FlexEnd = int32(4)" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-      </Docs>
-    </Member>
-    <Member MemberName="FlexStart">
-      <MemberSignature Language="C#" Value="FlexStart" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify FlexStart = int32(3)" />
+    <Member MemberName="End">
+      <MemberSignature Language="C#" Value="End" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify End = int32(4)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -77,6 +63,34 @@
     <Member MemberName="SpaceBetween">
       <MemberSignature Language="C#" Value="SpaceBetween" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify SpaceBetween = int32(5)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SpaceEvenly">
+      <MemberSignature Language="C#" Value="SpaceEvenly" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify SpaceEvenly = int32(7)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Start">
+      <MemberSignature Language="C#" Value="Start" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify Start = int32(3)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexJustify.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexJustify.xml
@@ -1,0 +1,101 @@
+<Type Name="FlexJustify" FullName="Xamarin.Forms.FlexJustify">
+  <TypeSignature Language="C#" Value="public enum FlexJustify" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed FlexJustify extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Center">
+      <MemberSignature Language="C#" Value="Center" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify Center = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="FlexEnd">
+      <MemberSignature Language="C#" Value="FlexEnd" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify FlexEnd = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="FlexStart">
+      <MemberSignature Language="C#" Value="FlexStart" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify FlexStart = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SpaceAround">
+      <MemberSignature Language="C#" Value="SpaceAround" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify SpaceAround = int32(6)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SpaceBetween">
+      <MemberSignature Language="C#" Value="SpaceBetween" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify SpaceBetween = int32(5)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="SpaceEvenly">
+      <MemberSignature Language="C#" Value="SpaceEvenly" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexJustify SpaceEvenly = int32(7)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexJustifyTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexJustifyTypeConverter.xml
@@ -1,0 +1,56 @@
+<Type Name="FlexJustifyTypeConverter" FullName="Xamarin.Forms.FlexJustifyTypeConverter">
+  <TypeSignature Language="C#" Value="public class FlexJustifyTypeConverter : Xamarin.Forms.TypeConverter" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FlexJustifyTypeConverter extends Xamarin.Forms.TypeConverter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.FlexJustify))</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FlexJustifyTypeConverter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="public override object ConvertFromInvariantString (string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance object ConvertFromInvariantString(string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexLayout.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexLayout.xml
@@ -1,0 +1,601 @@
+<Type Name="FlexLayout" FullName="Xamarin.Forms.FlexLayout">
+  <TypeSignature Language="C#" Value="public class FlexLayout : Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FlexLayout extends Xamarin.Forms.Layout`1&lt;class Xamarin.Forms.View&gt;" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.Layout&lt;Xamarin.Forms.View&gt;</BaseTypeName>
+    <BaseTypeArguments>
+      <BaseTypeArgument TypeParamName="T">Xamarin.Forms.View</BaseTypeArgument>
+    </BaseTypeArguments>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FlexLayout ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AlignContent">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.FlexAlignContent AlignContent { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.FlexAlignContent AlignContent" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignContent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AlignContentProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty AlignContentProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty AlignContentProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AlignItems">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.FlexAlignItems AlignItems { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.FlexAlignItems AlignItems" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignItems</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AlignItemsProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty AlignItemsProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty AlignItemsProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AlignSelfProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty AlignSelfProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty AlignSelfProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="BasisProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty BasisProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty BasisProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Direction">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.FlexDirection Direction { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.FlexDirection Direction" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexDirection</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DirectionProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty DirectionProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty DirectionProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetAlignSelf">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.FlexAlignSelf GetAlignSelf (Xamarin.Forms.BindableObject bindable);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.FlexAlignSelf GetAlignSelf(class Xamarin.Forms.BindableObject bindable) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexAlignSelf</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetBasis">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.FlexBasis GetBasis (Xamarin.Forms.BindableObject bindable);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.FlexBasis GetBasis(class Xamarin.Forms.BindableObject bindable) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexBasis</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetGrow">
+      <MemberSignature Language="C#" Value="public static float GetGrow (Xamarin.Forms.BindableObject bindable);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig float32 GetGrow(class Xamarin.Forms.BindableObject bindable) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetOrder">
+      <MemberSignature Language="C#" Value="public static int GetOrder (Xamarin.Forms.BindableObject bindable);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig int32 GetOrder(class Xamarin.Forms.BindableObject bindable) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetShrink">
+      <MemberSignature Language="C#" Value="public static float GetShrink (Xamarin.Forms.BindableObject bindable);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig float32 GetShrink(class Xamarin.Forms.BindableObject bindable) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GrowProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty GrowProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty GrowProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="JustifyContent">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.FlexJustify JustifyContent { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.FlexJustify JustifyContent" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexJustify</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="JustifyContentProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty JustifyContentProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty JustifyContentProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="LayoutChildren">
+      <MemberSignature Language="C#" Value="protected override void LayoutChildren (double x, double y, double width, double height);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void LayoutChildren(float64 x, float64 y, float64 width, float64 height) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="System.Double" />
+        <Parameter Name="y" Type="System.Double" />
+        <Parameter Name="width" Type="System.Double" />
+        <Parameter Name="height" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="x">To be added.</param>
+        <param name="y">To be added.</param>
+        <param name="width">To be added.</param>
+        <param name="height">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="OnAdded">
+      <MemberSignature Language="C#" Value="protected override void OnAdded (Xamarin.Forms.View view);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void OnAdded(class Xamarin.Forms.View view) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="view" Type="Xamarin.Forms.View" />
+      </Parameters>
+      <Docs>
+        <param name="view">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="OnMeasure">
+      <MemberSignature Language="C#" Value="protected override Xamarin.Forms.SizeRequest OnMeasure (double widthConstraint, double heightConstraint);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance valuetype Xamarin.Forms.SizeRequest OnMeasure(float64 widthConstraint, float64 heightConstraint) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.SizeRequest</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="widthConstraint" Type="System.Double" />
+        <Parameter Name="heightConstraint" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="widthConstraint">To be added.</param>
+        <param name="heightConstraint">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="OnParentSet">
+      <MemberSignature Language="C#" Value="protected override void OnParentSet ();" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void OnParentSet() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="OnRemoved">
+      <MemberSignature Language="C#" Value="protected override void OnRemoved (Xamarin.Forms.View view);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void OnRemoved(class Xamarin.Forms.View view) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="view" Type="Xamarin.Forms.View" />
+      </Parameters>
+      <Docs>
+        <param name="view">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="OrderProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty OrderProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty OrderProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Position">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.FlexPosition Position { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.FlexPosition Position" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexPosition</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PositionProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty PositionProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty PositionProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetAlignSelf">
+      <MemberSignature Language="C#" Value="public static void SetAlignSelf (Xamarin.Forms.BindableObject bindable, Xamarin.Forms.FlexAlignSelf value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetAlignSelf(class Xamarin.Forms.BindableObject bindable, valuetype Xamarin.Forms.FlexAlignSelf value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="Xamarin.Forms.FlexAlignSelf" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetBasis">
+      <MemberSignature Language="C#" Value="public static void SetBasis (Xamarin.Forms.BindableObject bindable, Xamarin.Forms.FlexBasis value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetBasis(class Xamarin.Forms.BindableObject bindable, valuetype Xamarin.Forms.FlexBasis value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="Xamarin.Forms.FlexBasis" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetGrow">
+      <MemberSignature Language="C#" Value="public static void SetGrow (Xamarin.Forms.BindableObject bindable, float value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetGrow(class Xamarin.Forms.BindableObject bindable, float32 value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Single" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetOrder">
+      <MemberSignature Language="C#" Value="public static void SetOrder (Xamarin.Forms.BindableObject bindable, int value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetOrder(class Xamarin.Forms.BindableObject bindable, int32 value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetShrink">
+      <MemberSignature Language="C#" Value="public static void SetShrink (Xamarin.Forms.BindableObject bindable, float value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetShrink(class Xamarin.Forms.BindableObject bindable, float32 value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="bindable" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Single" />
+      </Parameters>
+      <Docs>
+        <param name="bindable">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ShrinkProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ShrinkProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ShrinkProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Wrap">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.FlexWrap Wrap { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.FlexWrap Wrap" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexWrap</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="WrapProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty WrapProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty WrapProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexPosition.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexPosition.xml
@@ -1,0 +1,45 @@
+<Type Name="FlexPosition" FullName="Xamarin.Forms.FlexPosition">
+  <TypeSignature Language="C#" Value="public enum FlexPosition" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed FlexPosition extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Absolute">
+      <MemberSignature Language="C#" Value="Absolute" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexPosition Absolute = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexPosition</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Relative">
+      <MemberSignature Language="C#" Value="Relative" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexPosition Relative = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexPosition</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexWrap.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexWrap.xml
@@ -8,6 +8,11 @@
   <Base>
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.FlexWrapTypeConverter))</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexWrap.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexWrap.xml
@@ -1,0 +1,59 @@
+<Type Name="FlexWrap" FullName="Xamarin.Forms.FlexWrap">
+  <TypeSignature Language="C#" Value="public enum FlexWrap" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed FlexWrap extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="NoWrap">
+      <MemberSignature Language="C#" Value="NoWrap" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexWrap NoWrap = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexWrap</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Reverse">
+      <MemberSignature Language="C#" Value="Reverse" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexWrap Reverse = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexWrap</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Wrap">
+      <MemberSignature Language="C#" Value="Wrap" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.FlexWrap Wrap = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.FlexWrap</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexWrapTypeConverter.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/FlexWrapTypeConverter.xml
@@ -1,0 +1,56 @@
+<Type Name="FlexWrapTypeConverter" FullName="Xamarin.Forms.FlexWrapTypeConverter">
+  <TypeSignature Language="C#" Value="public class FlexWrapTypeConverter : Xamarin.Forms.TypeConverter" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FlexWrapTypeConverter extends Xamarin.Forms.TypeConverter" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>Xamarin.Forms.TypeConverter</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Xamarin.Forms.Xaml.TypeConversion(typeof(Xamarin.Forms.FlexWrap))</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FlexWrapTypeConverter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertFromInvariantString">
+      <MemberSignature Language="C#" Value="public override object ConvertFromInvariantString (string value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance object ConvertFromInvariantString(string value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -213,14 +213,21 @@
       <Type Name="FileImageSource" Kind="Class" />
       <Type Name="FileImageSourceConverter" Kind="Class" />
       <Type Name="FlexAlignContent" Kind="Enumeration" />
+      <Type Name="FlexAlignContentTypeConverter" Kind="Class" />
       <Type Name="FlexAlignItems" Kind="Enumeration" />
+      <Type Name="FlexAlignItemsTypeConverter" Kind="Class" />
       <Type Name="FlexAlignSelf" Kind="Enumeration" />
+      <Type Name="FlexAlignSelfTypeConverter" Kind="Class" />
       <Type Name="FlexBasis" Kind="Structure" />
+      <Type Name="FlexBasis+FlexBasisTypeConverter" Kind="Class" />
       <Type Name="FlexDirection" Kind="Enumeration" />
+      <Type Name="FlexDirectionTypeConverter" Kind="Class" />
       <Type Name="FlexJustify" Kind="Enumeration" />
+      <Type Name="FlexJustifyTypeConverter" Kind="Class" />
       <Type Name="FlexLayout" Kind="Class" />
       <Type Name="FlexPosition" Kind="Enumeration" />
       <Type Name="FlexWrap" Kind="Enumeration" />
+      <Type Name="FlexWrapTypeConverter" Kind="Class" />
       <Type Name="FlowDirection" Kind="Enumeration" />
       <Type Name="FlowDirectionConverter" Kind="Class" />
       <Type Name="FocusEventArgs" Kind="Class" />

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -212,6 +212,15 @@
       <Type Name="ExportEffectAttribute" Kind="Class" />
       <Type Name="FileImageSource" Kind="Class" />
       <Type Name="FileImageSourceConverter" Kind="Class" />
+      <Type Name="FlexAlignContent" Kind="Enumeration" />
+      <Type Name="FlexAlignItems" Kind="Enumeration" />
+      <Type Name="FlexAlignSelf" Kind="Enumeration" />
+      <Type Name="FlexBasis" Kind="Structure" />
+      <Type Name="FlexDirection" Kind="Enumeration" />
+      <Type Name="FlexJustify" Kind="Enumeration" />
+      <Type Name="FlexLayout" Kind="Class" />
+      <Type Name="FlexPosition" Kind="Enumeration" />
+      <Type Name="FlexWrap" Kind="Enumeration" />
       <Type Name="FlowDirection" Kind="Enumeration" />
       <Type Name="FlowDirectionConverter" Kind="Class" />
       <Type Name="FocusEventArgs" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###

Add a new FlexLayout to Xamarin.Forms.

#### Credits

The Xamarin.Flex engine is a port of @lrz's native https://github.com/xamarin/flex.

Thanks to @rmarinho for the initial proof of concept and the almost-extensive test suite.

#### Complexity

Measure and Layout are O(n) and doesn't get more complex if you nest FlexLayout into each other. Layout and Measure are single-pass, top-down.

### Bugs Fixed ###

/

### API Changes ###

Added:
```csharp
public class Xamarin.Forms.FlexLayout : Layout<View>
{
	//BP, applies to the layout
	public static readonly BindableProperty DirectionProperty;
	public static readonly BindableProperty JustifyContentProperty;
	public static readonly BindableProperty AlignContentProperty;
	public static readonly BindableProperty AlignItemsProperty;
	public static readonly BindableProperty PositionProperty;
	public static readonly BindableProperty WrapProperty;

	//Attached ones, applies to children
	public static readonly BindableProperty OrderProperty;
	public static readonly BindableProperty GrowProperty;
	public static readonly BindableProperty ShrinkProperty;
	public static readonly BindableProperty AlignSelfProperty;
	public static readonly BindableProperty BasisProperty;

	//property accessors
	public FlexDirection Direction { get; set; }
	public FlexJustify JustifyContent { get; set; }
	public FlexAlignContent AlignContent { get; set; }
	public FlexAlignItems AlignItems { get; set; }
	public FlexPosition Position { get; set; }
	public FlexWrap Wrap { get; set; }

	public static int GetOrder(BindableObject bindable);
	public static void SetOrder(BindableObject bindable, int value);
	public static float GetGrow(BindableObject bindable);
	public static void SetGrow(BindableObject bindable, float value);
	public static float GetShrink(BindableObject bindable);
	public static void SetShrink(BindableObject bindable, float value);
	public static FlexAlignSelf GetAlignSelf(BindableObject bindable);
	public static void SetAlignSelf(BindableObject bindable, FlexAlignSelf value);
	public static FlexBasis GetBasis(BindableObject bindable);
	public static void SetBasis(BindableObject bindable, FlexBasis value);
}

public enum Xamarin.Forms.FlexJustify
{
	Center,
	Start,
	End,
	SpaceBetween,
	SpaceAround,
	SpaceEvenly,
}

public enum Xamarin.Forms.FlexPosition
{
	Relative,
	Absolute,
}

public enum Xamarin.Forms.FlexDirection
{
	Row,
	RowReverse,
	Column,
	ColumnReverse,
}

public enum Xamarin.Forms.FlexAlignContent
{
	Stretch,
	Center,
	Start,
	End,
	SpaceBetween,
	SpaceAround,
	SpaceEvenly,
}

public enum Xamarin.Forms.FlexAlignItems
{
	Stretch,
	Center,
	Start,
	End,
}

public enum Xamarin.Forms.FlexAlignSelf
{
	Auto,
	Stretch,
	Center,
	Start,
	End,
}

public enum Xamarin.Forms.FlexWrap
{
	NoWrap,
	Wrap,
	Reverse,
}

public struct Xamarin.Forms.FlexBasis
{
	public static FlexBasis Auto;
	public float Length { get; }
	public FlexBasis (float length, bool isRelative = false);
	public static implicit operator FlexBasis(float length);
}
```

### Behavioral Changes ###

/

### Screenshot

<img width="1428" alt="2018-02-02_1330" src="https://user-images.githubusercontent.com/313003/35733984-d0713d24-081f-11e8-8c51-a1b173402fc3.png">

### Working samples

https://gist.github.com/StephaneDelcroix/da29dcbb1a1f7501bab387e76ad0be17

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense