### PR TITLE
[Core] AbsoluteLayout content now fills all available space on Android devices

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40092.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40092.cs
@@ -1,0 +1,42 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Bugzilla, 40092, "Ensure android devices with fractional scale factors (3.5) don't have a white line around the border", PlatformAffected.Android)]
+    public class Bugzilla40092 : TestContentPage
+    {
+        protected override void Init()
+        {
+            AbsoluteLayout mainLayout = new AbsoluteLayout()
+            {
+                BackgroundColor = Color.White
+            };
+
+
+            // The root page of your application
+            var thePage = new ContentView
+            {
+                BackgroundColor = Color.Red,
+                Content = mainLayout
+            };
+
+            BoxView view = new BoxView()
+            {
+                Color = Color.Black
+            };
+
+            mainLayout.Children.Add(view, new Rectangle(0, 0, 1, 1), AbsoluteLayoutFlags.All);
+            Content = thePage;
+
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -672,6 +672,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla58779.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla51825.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31688.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40092.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core.UnitTests/AbsoluteLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AbsoluteLayoutTests.cs
@@ -7,6 +7,14 @@ namespace Xamarin.Forms.Core.UnitTests
 	[TestFixture]
 	public class AbsoluteLayoutTests : BaseTestFixture
 	{
+		[SetUp]
+		public override void Setup()
+		{
+			base.Setup();
+			var mockDeviceInfo = new TestDeviceInfo();
+			Device.Info = mockDeviceInfo;
+		}
+
 
 		[Test]
 		public void Constructor ()

--- a/Xamarin.Forms.Core/AbsoluteLayout.cs
+++ b/Xamarin.Forms.Core/AbsoluteLayout.cs
@@ -232,7 +232,7 @@ namespace Xamarin.Forms
 
 			if (widthIsProportional)
 			{
-				result.Width = Math.Round(region.Width * bounds.Width);
+				result.Width = Device.Info.DisplayRound(region.Width * bounds.Width);
 			}
 			else if (bounds.Width != AutoSize)
 			{
@@ -241,7 +241,7 @@ namespace Xamarin.Forms
 
 			if (heightIsProportional)
 			{
-				result.Height = Math.Round(region.Height * bounds.Height);
+				result.Height = Device.Info.DisplayRound(region.Height * bounds.Height);
 			}
 			else if (bounds.Height != AutoSize)
 			{
@@ -273,7 +273,7 @@ namespace Xamarin.Forms
 
 			if (xIsProportional)
 			{
-				result.X = Math.Round((region.Width - result.Width) * bounds.X);
+				result.X = Device.Info.DisplayRound((region.Width - result.Width) * bounds.X);
 			}
 			else
 			{
@@ -282,7 +282,7 @@ namespace Xamarin.Forms
 
 			if (yIsProportional)
 			{
-				result.Y = Math.Round((region.Height - result.Height) * bounds.Y);
+				result.Y = Device.Info.DisplayRound((region.Height - result.Height) * bounds.Y);
 			}
 			else
 			{

--- a/Xamarin.Forms.Core/DeviceInfo.cs
+++ b/Xamarin.Forms.Core/DeviceInfo.cs
@@ -22,6 +22,9 @@ namespace Xamarin.Forms.Internals
 			}
 		}
 
+		public virtual double DisplayRound(double value) =>
+			Math.Round(value);
+
 		public abstract Size PixelScreenSize { get; }
 
 		public abstract Size ScaledScreenSize { get; }

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -272,6 +272,10 @@ namespace Xamarin.Forms
 				get { return _scalingFactor; }
 			}
 
+
+			public override double DisplayRound(double value) =>
+				Math.Round(ScalingFactor * value) / ScalingFactor;
+
 			protected override void Dispose(bool disposing)
 			{
 				if (_disposed)

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DeviceInfo.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/DeviceInfo.xml
@@ -55,6 +55,26 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="DisplayRound">
+      <MemberSignature Language="C#" Value="public virtual double DisplayRound (double value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance float64 DisplayRound(float64 value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Dispose">
       <MemberSignature Language="C#" Value="public void Dispose ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Dispose() cil managed" />


### PR DESCRIPTION
### Description of Change ###

Changed AbsoluteLayout.cs to use a platform specific DisplayRound method to allow for cases where a straight Math.Round won't correctly round to the pixel density of the device.  Currently this is only overridden in Android and all the other platforms still just use Math.Round

### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=40092
fixes #1128

### API Changes ###

Added:
 - public override double DisplayRound(double value)

Platforms can now customize how rounding works for calculations that pertain to pixels.

### Behavioral Changes ###

None

### PR Checklist ###

- [X ] Has tests (if omitted, state reason in description)
- [ X] Rebased on top of master at time of PR
- [ X] Changes adhere to coding standard
- [ X] Consolidate commits as makes sense
