### PR TITLE
[Internal] Enable iOS test for AutomationId on ToolbarItems

### DIFF
--- a/Xamarin.Forms.Core.UITests.Shared/Tests/AutomationIDUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/AutomationIDUITests.cs
@@ -59,9 +59,8 @@ namespace Xamarin.Forms.Core.UITests
 			//App.WaitForElement (c => c.Marked ("webviewHello"));
 			App.Tap (c => c.Marked ("popModal"));
 		}
-
+#if __IOS__
 		[Test]
-		[Ignore("only works on ios")] 
 		public void TestToolbarItem ()
 		{
 			App.Tap (c => c.Marked ("tbItemHello"));
@@ -71,6 +70,7 @@ namespace Xamarin.Forms.Core.UITests
 			App.WaitForElement (x => x.Marked ("Hello2"));
 			App.Tap (c => c.Marked ("ok"));
 		}
+#endif
 	}
 }
 


### PR DESCRIPTION
### Description of Change ###

Making sure we test `AutomationId` on `ToolbarItems`. `AutomationId` is not supported on `ToolbarItems` on Android at this time, so this test is only for iOS.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###
 
None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
