### PR TITLE
[Enhancement] Android PlatformSpecific for WebView mixed content

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
@@ -1,4 +1,6 @@
 using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Controls
 {
@@ -54,9 +56,39 @@ namespace Xamarin.Forms.Controls
 				}
 			);
 
+			// NOTE: Currently the ability to programmatically enable/disable mixed content only exists on Android
+			if (Device.RuntimePlatform == Device.Android)
+			{
+				var mixedContentTestPage = "https://mixed-content-test.appspot.com/";
+
+				var mixedContentDisallowedWebView = new WebView() { HeightRequest = 1000 };
+				mixedContentDisallowedWebView.On<Android>().SetMixedContentMode(MixedContentHandling.NeverAllow);
+				mixedContentDisallowedWebView.Source = new UrlWebViewSource
+				{
+					Url = mixedContentTestPage
+				};
+
+				var mixedContentAllowedWebView = new WebView() { HeightRequest = 1000 };
+				mixedContentAllowedWebView.On<Android>().SetMixedContentMode(MixedContentHandling.AlwaysAllow);
+				mixedContentAllowedWebView.Source = new UrlWebViewSource
+				{
+					Url = mixedContentTestPage
+				};
+
+				var mixedContentDisallowedContainer = new ViewContainer<WebView>(Test.WebView.MixedContentDisallowed,
+					mixedContentDisallowedWebView);
+				var mixedContentAllowedContainer = new ViewContainer<WebView>(Test.WebView.MixedContentAllowed,
+					mixedContentAllowedWebView);
+
+				Add(mixedContentDisallowedContainer);
+				Add(mixedContentAllowedContainer);
+			}
+
+
 			Add (urlWebViewSourceContainer);
 			Add (htmlWebViewSourceContainer);
 			Add (htmlFileWebSourceContainer);
+
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 
 using NUnit.Framework;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -88,6 +90,18 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual ("<html><body><p>This is a WebView!</p></body></html>", htmlSource.Html);
 			Assert.AreEqual ("http://xamarin.com", urlSource.Url);
+		}
+
+		[Test]
+		public void TestAndroidMixedContent()
+		{
+			var defaultWebView = new WebView();
+
+			var mixedContentWebView = new WebView();
+			mixedContentWebView.On<Android>().SetMixedContentMode(MixedContentHandling.AlwaysAllow);
+
+			Assert.AreEqual(defaultWebView.On<Android>().MixedContentMode(), MixedContentHandling.NeverAllow);
+			Assert.AreEqual(mixedContentWebView.On<Android>().MixedContentMode(), MixedContentHandling.AlwaysAllow);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/WebView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/WebView.cs
@@ -1,0 +1,38 @@
+﻿
+namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using FormsElement = Forms.WebView;
+
+	public enum MixedContentHandling
+	{
+		AlwaysAllow = 0,
+		NeverAllow = 1,
+		CompatibilityMode = 2
+	}
+
+	public static class WebView
+    {
+		public static readonly BindableProperty MixedContentModeProperty = BindableProperty.Create("MixedContentMode", typeof(MixedContentHandling), typeof(WebView), MixedContentHandling.NeverAllow);
+
+		public static MixedContentHandling GetMixedContentMode(BindableObject element)
+		{
+			return (MixedContentHandling)element.GetValue(MixedContentModeProperty);
+		}
+
+		public static void SetMixedContentMode(BindableObject element, MixedContentHandling value)
+		{
+			element.SetValue(MixedContentModeProperty, value);
+		}
+
+		public static MixedContentHandling MixedContentMode(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetMixedContentMode(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetMixedContentMode(this IPlatformElementConfiguration<Android, FormsElement> config, MixedContentHandling value)
+		{
+			SetMixedContentMode(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -679,7 +679,9 @@ namespace Xamarin.Forms.CustomAttributes
 		public enum WebView {
 			UrlWebViewSource,
 			HtmlWebViewSource,
-			LoadHtml
+			LoadHtml,
+			MixedContentDisallowed,
+			MixedContentAllowed
 		}
 
 		public enum UrlWebViewSource {

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -4,7 +4,10 @@ using Android.App;
 using Android.Content;
 using Android.Webkit;
 using Android.Widget;
+using Android.OS;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Xamarin.Forms.Internals;
+using MixedContentHandling = Android.Webkit.MixedContentHandling;
 using AWebView = Android.Webkit.WebView;
 
 namespace Xamarin.Forms.Platform.Android
@@ -106,6 +109,8 @@ namespace Xamarin.Forms.Platform.Android
 				newElementController.EvalRequested += OnEvalRequested;
 				newElementController.GoBackRequested += OnGoBackRequested;
 				newElementController.GoForwardRequested += OnGoForwardRequested;
+
+				UpdateMixedContentMode();
 			}
 
 			Load();
@@ -119,6 +124,9 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				case "Source":
 					Load();
+					break;
+				case "MixedContentMode":
+					UpdateMixedContentMode();
 					break;
 			}
 		}
@@ -161,6 +169,14 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			ElementController.CanGoBack = Control.CanGoBack();
 			ElementController.CanGoForward = Control.CanGoForward();
+		}
+
+		void UpdateMixedContentMode()
+		{
+			if (Control != null && ((int)Build.VERSION.SdkInt >= 21))
+			{
+				Control.Settings.MixedContentMode = (MixedContentHandling)Element.OnThisPlatform().MixedContentMode();
+			}
 		}
 
 		class WebClient : WebViewClient


### PR DESCRIPTION
Closes #1679.

### Description of Change ###

Add a PlatformSpecific property for `WebView` on Android to set the value of `WebSettings.MixedContentMode`. This setting is ignored for API levels < 21 (5.0 / Lollipop), where `WebSettings.MixedContentMode` is not implemented

`webView.On<Android>().SetMixedContentMode(MixedContentHandling.AlwaysAllow)` allows for insecure HTTP requests to be made in an HTTPS frame.

### API Changes ###

Added (Android Only):
 - enum MixedContentHandling
 - MixedContentHandling WebView.MixedContentMode() //Bindable Property
 - void WebView.SetMixedContentMode(MixedContentHandling value)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
