### PR TITLE
[UWP] Update ListView header and footer fixes to #1493

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -90,11 +90,11 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateGrouping();
 			}
-			else if (e.PropertyName == ListView.HeaderProperty.PropertyName)
+			else if (e.PropertyName == ListView.HeaderProperty.PropertyName || e.PropertyName == "HeaderElement")
 			{
 				UpdateHeader();
 			}
-			else if (e.PropertyName == ListView.FooterProperty.PropertyName)
+			else if (e.PropertyName == ListView.FooterProperty.PropertyName || e.PropertyName == "FooterElement")
 			{
 				UpdateFooter();
 			}


### PR DESCRIPTION
### Description of Change ###

Bug Fix. Now working file.

### Bugs Fixed ###

fixes #1493

### API Changes ###

No change in API

Changed:

change in OnElementPropertyChanged() for Header change
From:
else if (e.PropertyName == ListView.HeaderProperty.PropertyName)
To:
else if (e.PropertyName == ListView.HeaderProperty.PropertyName || e.PropertyName == "HeaderElement")
{
	UpdateHeader();
}

From:
else if (e.PropertyName == ListView.FooterProperty.PropertyName)
To:
else if (e.PropertyName == ListView.FooterProperty.PropertyName || e.PropertyName == "FooterElement")
{
      UpdateFooter();
}

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
