### PR TITLE
Rename InputTransparentInherited to CascadeInputTransparent

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CascadeInputTransparent.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CascadeInputTransparent.cs
@@ -18,8 +18,8 @@ namespace Xamarin.Forms.Controls.Issues
 	#endif
 
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.None, 5552368, "Transparency Inheritance", PlatformAffected.All)]
-	public class InputTransparentInheritance : TestNavigationPage
+	[Issue(IssueTracker.None, 5552368, "Transparency Cascading", PlatformAffected.All)]
+	public class CascadeInputTransparent : TestNavigationPage
 	{
 		const string Running = "Running...";
 		const string Success = "Success";
@@ -28,10 +28,10 @@ namespace Xamarin.Forms.Controls.Issues
 		const string OverButtonText = "+";
 		const string Overlay = "overlay";
 
-		const string InheritedStatic = "Inherited";
-		const string InheritedChange = "Inherited (changes)";
-		const string NotInheritedStatic = "Not Inherited";
-		const string NotInheritedChange = "Not Inherited (changes)";
+		const string CascadesStatic = "Cascades";
+		const string CascadesChange = "Cascades (changes)";
+		const string NotCascadingStatic = "Not Cascading";
+		const string NotCascadingChange = "Not Cascading (changes)";
 
 		protected override void Init()
 		{
@@ -52,22 +52,22 @@ namespace Xamarin.Forms.Controls.Issues
 			return new ContentPage { Content = layout };
 		}
 
-		Button MenuButton(bool inherited, bool transition)
+		Button MenuButton(bool cascades, bool transition)
 		{
-			var text = inherited
-				? transition ? InheritedChange : InheritedStatic
+			var text = cascades
+				? transition ? CascadesChange : CascadesStatic
 				: transition
-				? NotInheritedChange
-				: NotInheritedStatic;
+				? NotCascadingChange
+				: NotCascadingStatic;
 
 			var button = new Button { Text = text, AutomationId = text };
 
-			button.Clicked += (sender, args) => PushAsync(CreateTestPage(inherited, transition));
+			button.Clicked += (sender, args) => PushAsync(CreateTestPage(cascades, transition));
 
 			return button;
 		}
 
-		static ContentPage CreateTestPage(bool inherited, bool transition)
+		static ContentPage CreateTestPage(bool cascades, bool transition)
 		{
 			var grid = new Grid
 			{
@@ -115,7 +115,7 @@ namespace Xamarin.Forms.Controls.Issues
 			underButton.Clicked += (sender, args) =>
 			{
 				underPressed = true;
-				EvaluateTest(results, inherited, overPressed, underPressed, layoutTapped);
+				EvaluateTest(results, cascades, overPressed, underPressed, layoutTapped);
 			};
 
 			var overButton = new Button
@@ -127,7 +127,7 @@ namespace Xamarin.Forms.Controls.Issues
 			overButton.Clicked += (sender, args) =>
 			{
 				overPressed = true;
-				EvaluateTest(results, inherited, overPressed, underPressed, layoutTapped);
+				EvaluateTest(results, cascades, overPressed, underPressed, layoutTapped);
 			};
 
 			var layout = new StackLayout
@@ -136,7 +136,7 @@ namespace Xamarin.Forms.Controls.Issues
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill,
 				InputTransparent = true,
-				InputTransparentInherited = inherited,
+				CascadeInputTransparent = cascades,
 				BackgroundColor = Color.Blue,
 				Opacity = 0.2
 			};
@@ -146,7 +146,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Command = new Command(() =>
 				{
 					layoutTapped = true;
-					EvaluateTest(results, inherited, overPressed, underPressed, layoutTapped);
+					EvaluateTest(results, cascades, overPressed, underPressed, layoutTapped);
 				})
 			});
 
@@ -161,22 +161,22 @@ namespace Xamarin.Forms.Controls.Issues
 			grid.Children.Add(layout);
 			Grid.SetRow(layout, 2);
 
-			var page = new ContentPage { Content = grid, Title = inherited.ToString() };
+			var page = new ContentPage { Content = grid, Title = cascades.ToString() };
 
 			if (transition)
 			{
 				page.Appearing += async (sender, args) =>
 				{
 					await Task.Delay(1000);
-					inherited = !inherited;
-					layout.InputTransparentInherited = inherited;
+					cascades = !cascades;
+					layout.CascadeInputTransparent = cascades;
 				};
 			}
 
 			return page;
 		}
 
-		static void EvaluateTest(Label results, bool inherited, bool overPressed, bool underPressed, bool layoutTapped)
+		static void EvaluateTest(Label results, bool cascades, bool overPressed, bool underPressed, bool layoutTapped)
 		{
 			if (layoutTapped)
 			{
@@ -184,7 +184,7 @@ namespace Xamarin.Forms.Controls.Issues
 				return;
 			}
 
-			if (inherited)
+			if (cascades)
 			{
 				if (overPressed)
 				{
@@ -210,11 +210,11 @@ namespace Xamarin.Forms.Controls.Issues
 			results.Text = Running;
 		}
 
-		static IEnumerable<string> TestList => new List<string> { InheritedChange, InheritedStatic, NotInheritedChange, NotInheritedStatic };
+		static IEnumerable<string> TestList => new List<string> { CascadesChange, CascadesStatic, NotCascadingChange, NotCascadingStatic };
 
 		#if UITEST
 		[Test, TestCaseSource(nameof(TestList))]
-		public void TransparencyNotInherited(string test)
+		public void TransparencyCascading(string test)
 		{
 			RunningApp.WaitForElement(test);
 			RunningApp.Tap(test);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -257,7 +257,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FailImageSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GestureBubblingTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)InputTransparentInheritance.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CascadeInputTransparent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1331.xaml.cs">
       <DependentUpon>GitHub1331.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -54,8 +54,8 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty IsClippedToBoundsProperty = BindableProperty.Create("IsClippedToBounds", typeof(bool), typeof(Layout), false);
 
-		public static readonly BindableProperty InputTransparentInheritedProperty = BindableProperty.Create(
-			"InputTransparentInherited", typeof(bool), typeof(Layout), true);
+		public static readonly BindableProperty CascadeInputTransparentProperty = BindableProperty.Create(
+			nameof(CascadeInputTransparent), typeof(bool), typeof(Layout), true);
 
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
@@ -89,10 +89,10 @@ namespace Xamarin.Forms
 			set { SetValue(PaddingElement.PaddingProperty, value); }
 		}
 
-		public bool InputTransparentInherited
+		public bool CascadeInputTransparent
 		{
-			get { return (bool)GetValue(InputTransparentInheritedProperty); }
-			set { SetValue(InputTransparentInheritedProperty, value); }
+			get { return (bool)GetValue(CascadeInputTransparentProperty); }
+			set { SetValue(CascadeInputTransparentProperty, value); }
 		}
 
 		Thickness IPaddingElement.PaddingDefaultValueCreator()

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -340,7 +340,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			_inputTransparentInherited = layout.InputTransparentInherited;
+			_inputTransparentInherited = layout.CascadeInputTransparent;
 		}
 
 		protected void SetPackager(VisualElementPackager packager)

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -283,7 +283,7 @@ namespace Xamarin.Forms.Platform.Android
 				SetFocusable();
 			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
 				UpdateInputTransparent();
-			else if (e.PropertyName == Xamarin.Forms.Layout.InputTransparentInheritedProperty.PropertyName)
+			else if (e.PropertyName == Xamarin.Forms.Layout.CascadeInputTransparentProperty.PropertyName)
 				UpdateInputTransparentInherited();
 
 			ElementPropertyChanged?.Invoke(this, e);

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -310,7 +310,7 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (e.PropertyName == AutomationProperties.LabeledByProperty.PropertyName)
 				SetAutomationPropertiesLabeledBy();
 			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName || 
-					e.PropertyName == Layout.InputTransparentInheritedProperty.PropertyName)
+					e.PropertyName == Layout.CascadeInputTransparentProperty.PropertyName)
 				UpdateInputTransparent();
 		}
 
@@ -616,7 +616,7 @@ namespace Xamarin.Forms.Platform.UWP
 				return false;
 			}
 
-			if (layout.IsEnabled && layout.InputTransparent && !layout.InputTransparentInherited)
+			if (layout.IsEnabled && layout.InputTransparent && !layout.CascadeInputTransparent)
 			{
 				return true;
 			}

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -510,7 +510,7 @@ namespace Xamarin.Forms.Platform.iOS
 					Alpha = old;
 				}
 
-				if (UserInteractionEnabled && Element is Layout layout && !layout.InputTransparentInherited)
+				if (UserInteractionEnabled && Element is Layout layout && !layout.CascadeInputTransparent)
 				{
 					// This is a Layout with 'InputTransparent = true' and 'InputTransparentInherited = false'
 					if (this.Equals(result))

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				if (layout.InputTransparent)
 				{
-					shouldInteract = !layout.InputTransparentInherited;
+					shouldInteract = !layout.CascadeInputTransparent;
 				}
 				else
 				{

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				e.PropertyName == VisualElement.RotationProperty.PropertyName || e.PropertyName == VisualElement.RotationXProperty.PropertyName || e.PropertyName == VisualElement.RotationYProperty.PropertyName ||
 				e.PropertyName == VisualElement.IsVisibleProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName ||
 				e.PropertyName == VisualElement.InputTransparentProperty.PropertyName || e.PropertyName == VisualElement.OpacityProperty.PropertyName || 
-				e.PropertyName == Layout.InputTransparentInheritedProperty.PropertyName)
+				e.PropertyName == Layout.CascadeInputTransparentProperty.PropertyName)
 				UpdateNativeControl(); // poorly optimized
 		}
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Layout.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Layout.xml
@@ -79,6 +79,37 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="CascadeInputTransparent">
+      <MemberSignature Language="C#" Value="public bool CascadeInputTransparent { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool CascadeInputTransparent" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CascadeInputTransparentProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty CascadeInputTransparentProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty CascadeInputTransparentProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Children">
       <MemberSignature Language="C#" Value="public System.Collections.Generic.IReadOnlyList&lt;Xamarin.Forms.Element&gt; Children { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.IReadOnlyList`1&lt;class Xamarin.Forms.Element&gt; Children" />
@@ -160,37 +191,6 @@
             </para>
         </remarks>
         <altmember cref="M:Xamarin.Forms.OnSizeRequest (double, double)" />
-      </Docs>
-    </Member>
-    <Member MemberName="InputTransparentInherited">
-      <MemberSignature Language="C#" Value="public bool InputTransparentInherited { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance bool InputTransparentInherited" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Boolean</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="InputTransparentInheritedProperty">
-      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty InputTransparentInheritedProperty;" />
-      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty InputTransparentInheritedProperty" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvalidateLayout">


### PR DESCRIPTION
### Description of Change ###

This is the property renaming I wanted to do in [1621](https://github.com/xamarin/Xamarin.Forms/pull/1621#issuecomment-362105404). 

`InputTransparentInherited` is confusing and doesn't really communicate what the property does. Changing it to the more descriptive `CascadeInputTransparent`.






