### PR TITLE
[Enhancement] UWP PlatformSpecific to display JavaScript alerts in WebView

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
@@ -1,4 +1,6 @@
 using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
 namespace Xamarin.Forms.Controls
 {
@@ -54,9 +56,32 @@ namespace Xamarin.Forms.Controls
 				}
 			);
 
+			var jsAlertWebView = new WebView
+			{
+				Source = new HtmlWebViewSource
+				{
+					Html = @"<html>
+<head>
+<link rel=""stylesheet"" href=""default.css"">
+</head>
+<body>
+<button onclick=""window.alert('foo');"">Click</button>
+</body>
+</html>"
+				},
+				HeightRequest = 200
+			};
+
+			jsAlertWebView.On<Windows>().SetIsJavaScriptAlertEnabled(true);
+			
+			var javascriptAlertWebSourceContainer = new ViewContainer<WebView>(Test.WebView.JavaScriptAlert,
+				jsAlertWebView
+			);
+
 			Add (urlWebViewSourceContainer);
 			Add (htmlWebViewSourceContainer);
 			Add (htmlFileWebSourceContainer);
+			Add (javascriptAlertWebSourceContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 
 using NUnit.Framework;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -88,6 +90,18 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual ("<html><body><p>This is a WebView!</p></body></html>", htmlSource.Html);
 			Assert.AreEqual ("http://xamarin.com", urlSource.Url);
+		}
+
+		[Test]
+		public void TestWindowsSetAllowJavaScriptAlertsFlag()
+		{
+			var defaultWebView = new WebView();
+
+			var jsAlertsAllowedWebView = new WebView();
+			jsAlertsAllowedWebView.On<Windows>().SetIsJavaScriptAlertEnabled(true);
+
+			Assert.AreEqual(defaultWebView.On<Windows>().IsJavaScriptAlertEnabled(), false);
+			Assert.AreEqual(jsAlertsAllowedWebView.On<Windows>().IsJavaScriptAlertEnabled(), true);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/WebView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/WebView.cs
@@ -1,0 +1,31 @@
+﻿
+namespace Xamarin.Forms.PlatformConfiguration.WindowsSpecific
+{
+	using FormsElement = Forms.WebView;
+
+    public static class WebView
+    {
+		public static readonly BindableProperty IsJavaScriptAlertEnabledProperty = BindableProperty.Create("IsJavaScriptAlertEnabled", typeof(bool), typeof(WebView), false);
+
+		public static bool GetIsJavaScriptAlertEnabled(BindableObject element)
+		{
+			return (bool)element.GetValue(IsJavaScriptAlertEnabledProperty);
+		}
+
+		public static void SetIsJavaScriptAlertEnabled(BindableObject element, bool value)
+		{
+			element.SetValue(IsJavaScriptAlertEnabledProperty, value);
+		}
+
+		public static bool IsJavaScriptAlertEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			return GetIsJavaScriptAlertEnabled(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Windows, FormsElement> SetIsJavaScriptAlertEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
+		{
+			SetIsJavaScriptAlertEnabled(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -679,7 +679,8 @@ namespace Xamarin.Forms.CustomAttributes
 		public enum WebView {
 			UrlWebViewSource,
 			HtmlWebViewSource,
-			LoadHtml
+			LoadHtml,
+			JavaScriptAlert
 		}
 
 		public enum UrlWebViewSource {

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.WindowsSpecific/WebView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.WindowsSpecific/WebView.xml
@@ -1,0 +1,116 @@
+<Type Name="WebView" FullName="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.WebView">
+  <TypeSignature Language="C#" Value="public static class WebView" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit WebView extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetIsJavaScriptAlertEnabled">
+      <MemberSignature Language="C#" Value="public static bool GetIsJavaScriptAlertEnabled (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetIsJavaScriptAlertEnabled(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsJavaScriptAlertEnabled">
+      <MemberSignature Language="C#" Value="public static bool IsJavaScriptAlertEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsJavaScriptAlertEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.WebView&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsJavaScriptAlertEnabledProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty IsJavaScriptAlertEnabledProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty IsJavaScriptAlertEnabledProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetIsJavaScriptAlertEnabled">
+      <MemberSignature Language="C#" Value="public static void SetIsJavaScriptAlertEnabled (Xamarin.Forms.BindableObject element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetIsJavaScriptAlertEnabled(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetIsJavaScriptAlertEnabled">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt; SetIsJavaScriptAlertEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.WebView&gt; SetIsJavaScriptAlertEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.WebView&gt; config, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -563,6 +563,7 @@
       <Type Name="Page" Kind="Class" />
       <Type Name="ToolbarPlacement" Kind="Enumeration" />
       <Type Name="VisualElement" Kind="Class" />
+      <Type Name="WebView" Kind="Class" />
     </Namespace>
     <Namespace Name="Xamarin.Forms.StyleSheets">
       <Type Name="StyleSheet" Kind="Class" />
@@ -4231,6 +4232,50 @@
           <summary>To be added.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.VisualElement" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.VisualElement.SetIsLegacyColorModeEnabled(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.VisualElement},System.Boolean)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="IsJavaScriptAlertEnabled">
+        <MemberSignature Language="C#" Value="public static bool IsJavaScriptAlertEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsJavaScriptAlertEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.WebView&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.WebView" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.WebView.IsJavaScriptAlertEnabled(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetIsJavaScriptAlertEnabled">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt; SetIsJavaScriptAlertEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt; config, bool value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.WebView&gt; SetIsJavaScriptAlertEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.WebView&gt; config, bool value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView&gt;" RefType="this" />
+          <Parameter Name="value" Type="System.Boolean" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.WebView" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.WebView.SetIsJavaScriptAlertEnabled(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.WebView},System.Boolean)" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>


### PR DESCRIPTION
Implements and fixes #1682.

### Description of Change ###

Add a PlatformSpecific property for `WebView` on UWP to allow WebViews to display alert boxes via JavaScript.

`webView.On<Windows>().SetIsJavaScriptAlertEnabled(true)` causes js calls to `window.alert` to display the intended message in a native UWP message box.

### API Changes ###

Added (UWP Only):
 - bool WebView.IsJavaScriptAlertEnabled() //Bindable Property
 - void WebView.SetIsJavaScriptAlertEnabled(bool value)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
