### PR TITLE
Feature/1663 entry maxlength

### DIFF
--- a/Xamarin.Forms.Core/InputView.cs
+++ b/Xamarin.Forms.Core/InputView.cs
@@ -5,6 +5,14 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create("Keyboard", typeof(Keyboard), typeof(InputView), Keyboard.Default,
 			coerceValue: (o, v) => (Keyboard)v ?? Keyboard.Default);
 
+        public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create("MaxLength", typeof(int), typeof(int), int.MaxValue);
+
+        public int MaxLength
+        {
+            get { return (int)GetValue(MaxLengthProperty); }
+            set { SetValue(MaxLengthProperty, value); }
+        }
+
 		internal InputView()
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -186,6 +186,11 @@ namespace Xamarin.Forms.Platform.Android
         void UpdateMaxLength()
         {
             var currentFilters = Control?.GetFilters()?.ToList() ?? new List<IInputFilter>();
+            var currentMaxLengthFilter = currentFilters.SingleOrDefault(f => f is InputFilterLengthFilter);
+
+            if (currentMaxLengthFilter != null)
+                currentFilters.Remove(currentMaxLengthFilter);
+            
             currentFilters.Add(new InputFilterLengthFilter(Element.MaxLength));
 
             Control?.SetFilters(currentFilters.ToArray());

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using Android.Content;
 using Android.Content.Res;
 using Android.OS;
@@ -82,22 +84,25 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateInputType();
 			UpdateTextColor();
 			UpdateFont();
+            UpdateMaxLength();
 		}
 
-		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == Editor.TextProperty.PropertyName)
-				UpdateText();
-			else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
-				UpdateInputType();
-			else if (e.PropertyName == Editor.TextColorProperty.PropertyName)
-				UpdateTextColor();
-			else if (e.PropertyName == Editor.FontAttributesProperty.PropertyName)
-				UpdateFont();
-			else if (e.PropertyName == Editor.FontFamilyProperty.PropertyName)
-				UpdateFont();
-			else if (e.PropertyName == Editor.FontSizeProperty.PropertyName)
-				UpdateFont();
+            if (e.PropertyName == Editor.TextProperty.PropertyName)
+                UpdateText();
+            else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
+                UpdateInputType();
+            else if (e.PropertyName == Editor.TextColorProperty.PropertyName)
+                UpdateTextColor();
+            else if (e.PropertyName == Editor.FontAttributesProperty.PropertyName)
+                UpdateFont();
+            else if (e.PropertyName == Editor.FontFamilyProperty.PropertyName)
+                UpdateFont();
+            else if (e.PropertyName == Editor.FontSizeProperty.PropertyName)
+                UpdateFont();
+            else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+                UpdateMaxLength();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -177,5 +182,13 @@ namespace Xamarin.Forms.Platform.Android
 			ElementController?.SendCompleted();
 			Control?.ClearFocus();
 		}
+
+        void UpdateMaxLength()
+        {
+            var currentFilters = Control?.GetFilters()?.ToList() ?? new List<IInputFilter>();
+            currentFilters.Add(new InputFilterLengthFilter(Element.MaxLength));
+
+            Control?.SetFilters(currentFilters.ToArray());
+        }
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using Android.Content;
 using Android.Content.Res;
 using Android.Text;
@@ -96,6 +98,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateAlignment();
 			UpdateFont();
 			UpdatePlaceholderColor();
+            UpdateMaxLength();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -152,6 +155,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdatePlaceholderColor();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateAlignment();
+            else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+                UpdateMaxLength();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -207,5 +212,13 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Control?.ClearFocus();
 		}
+
+        void UpdateMaxLength()
+        {
+            var currentFilters = Control?.GetFilters()?.ToList() ?? new List<IInputFilter>();
+            currentFilters.Add(new InputFilterLengthFilter(Element.MaxLength));
+
+            Control?.SetFilters(currentFilters.ToArray());
+        }
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -85,8 +85,6 @@ namespace Xamarin.Forms.Platform.Android
 				_textColorSwitcher = new TextColorSwitcher(textView.TextColors, useLegacyColorManagement);
 				_hintColorSwitcher = new TextColorSwitcher(textView.HintTextColors, useLegacyColorManagement);
 
-				
-
 				SetNativeControl(textView);
 			}
 
@@ -216,6 +214,11 @@ namespace Xamarin.Forms.Platform.Android
         void UpdateMaxLength()
         {
             var currentFilters = Control?.GetFilters()?.ToList() ?? new List<IInputFilter>();
+            var currentMaxLengthFilter = currentFilters.SingleOrDefault(f => f is InputFilterLengthFilter);
+
+            if (currentMaxLengthFilter != null)
+                currentFilters.Remove(currentMaxLengthFilter);
+
             currentFilters.Add(new InputFilterLengthFilter(Element.MaxLength));
 
             Control?.SetFilters(currentFilters.ToArray());

--- a/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
@@ -76,6 +76,11 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             _placeholder.ModifyFont(fontDescription);
         }
 
+        public void SetMaxLength(int maxLength)
+        {
+            _entry.MaxLength = maxLength;
+        }
+
         protected override void OnSizeAllocated(Gdk.Rectangle allocation)
         {
             base.OnSizeAllocated(allocation);

--- a/Xamarin.Forms.Platform.GTK/Controls/ScrolledTextView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/ScrolledTextView.cs
@@ -5,6 +5,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
     public class ScrolledTextView : ScrolledWindow
     {
         private TextView _textView;
+        private int _maxLength;
 
         public ScrolledTextView()
         {
@@ -18,14 +19,25 @@ namespace Xamarin.Forms.Platform.GTK.Controls
                 WrapMode = WrapMode.WordChar
             };
 
+            _textView.Buffer.InsertText += InsertText;
             Add(_textView);
         }
 
         public TextView TextView => _textView;
 
+        public void SetMaxLength(int maxLength)
+        {
+            
+        }
+
         protected override void OnFocusGrabbed()
         {
             _textView?.GrabFocus();
+        }
+
+        void InsertText(object o, InsertTextArgs args)
+        {
+            args.RetVal = args.Length <= _maxLength;
         }
     }
 }

--- a/Xamarin.Forms.Platform.GTK/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/EditorRenderer.cs
@@ -47,6 +47,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 UpdateText();
                 UpdateFont();
                 UpdateTextColor();
+                UpdateMaxLength();
             }
 
             base.OnElementChanged(e);
@@ -66,6 +67,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 UpdateFont();
             else if (e.PropertyName == Editor.FontSizeProperty.PropertyName)
                 UpdateFont();
+            else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+                UpdateMaxLength();
         }
 
         protected override void Dispose(bool disposing)
@@ -152,6 +155,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             {
                 textView.HeightRequest = minHeight;
             }
+        }
+
+        private void UpdateMaxLength()
+        {
+            Control.SetMaxLength(Element.MaxLength);
         }
     }
 }

--- a/Xamarin.Forms.Platform.GTK/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/EntryRenderer.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using Xamarin.Forms.Platform.GTK.Controls;
 using Xamarin.Forms.Platform.GTK.Extensions;
 using Xamarin.Forms.Platform.GTK.Helpers;
+using System;
 
 namespace Xamarin.Forms.Platform.GTK.Renderers
 {
@@ -35,6 +36,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 UpdateFont();
                 UpdateTextVisibility();
                 UpdatePlaceholder();
+                UpdateMaxLength();
             }
 
             base.OnElementChanged(e);
@@ -60,6 +62,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 UpdatePlaceholder();
             else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
                 UpdatePlaceholder();
+            else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+                UpdateMaxLength();
 
             base.OnElementPropertyChanged(sender, e);
         }
@@ -147,6 +151,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             {
                 EntryController.SendCompleted();
             }
+        }
+
+        private void UpdateMaxLength()
+        {
+            Control.SetMaxLength(Element.MaxLength);
         }
     }
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
@@ -27,6 +27,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				};
 				entry.TextChanged += OnTextChanged;
 				entry.Unfocused += OnCompleted;
+				entry.PrependMarkUpFilter(MaxLengthFilter);
 
 				SetNativeControl(entry);
 			}
@@ -91,6 +92,14 @@ namespace Xamarin.Forms.Platform.Tizen
 				return;
 
 			Control.Keyboard = Element.Keyboard.ToNative();
+		}
+
+		string MaxLengthFilter(Entry entry, string s)
+		{
+			if (s.Length <= Element.MaxLength)
+				return s;
+
+			return null;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using ElmSharp;
 using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.Entry;
 
 namespace Xamarin.Forms.Platform.Tizen
@@ -36,6 +37,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				entry.SetVerticalTextAlignment("elm.guide", 0.5);
 				entry.TextChanged += OnTextChanged;
 				entry.Activated += OnCompleted;
+				entry.PrependMarkUpFilter(MaxLengthFilter);
 				SetNativeControl(entry);
 			}
 			base.OnElementChanged(e);
@@ -128,6 +130,14 @@ namespace Xamarin.Forms.Platform.Tizen
 		void UpdateFontWeight()
 		{
 			Control.FontWeight = Specific.GetFontWeight(Element);
+		}
+
+		string MaxLengthFilter(Entry entry, string s)
+		{
+			if (s.Length <= Element.MaxLength)
+				return s;
+
+			return null;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.UWP
 					// If the Forms VisualStateManager is in play or the user wants to disable the Forms legacy
 					// color stuff, then the underlying textbox should just use the Forms VSM states
 					textBox.UseFormsVsm = e.NewElement.HasVisualStateGroups()
-										|| !e.NewElement.OnThisPlatform().GetIsLegacyColorModeEnabled();
+					                      || !e.NewElement.OnThisPlatform().GetIsLegacyColorModeEnabled();
 				}
 
 				UpdateText();
@@ -46,6 +46,7 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateFont();
 				UpdateTextAlignment();
 				UpdateFlowDirection();
+				UpdateMaxLength();
 			}
 
 			base.OnElementChanged(e);
@@ -91,6 +92,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTextAlignment();
 				UpdateFlowDirection();
 			}
+			else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+				UpdateMaxLength();
 		}
 
 		void OnLostFocus(object sender, RoutedEventArgs e)
@@ -127,7 +130,9 @@ namespace Xamarin.Forms.Platform.UWP
 			if (editor == null)
 				return;
 
-			bool editorIsDefault = editor.FontFamily == null && editor.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Editor), true) && editor.FontAttributes == FontAttributes.None;
+			bool editorIsDefault = editor.FontFamily == null &&
+			                       editor.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Editor), true) &&
+			                       editor.FontAttributes == FontAttributes.None;
 
 			if (editorIsDefault && !_fontApplied)
 				return;
@@ -200,6 +205,11 @@ namespace Xamarin.Forms.Platform.UWP
 		void UpdateFlowDirection()
 		{
 			Control.UpdateFlowDirection(Element);
+		}
+
+		void UpdateMaxLength()
+		{
+			Control.MaxLength = Element.MaxLength;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -44,6 +44,7 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateInputScope();
 				UpdateAlignment();
 				UpdatePlaceholderColor();
+				UpdateMaxLength();
 			}
 		}
 
@@ -84,6 +85,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdatePlaceholderColor();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateAlignment();
+			else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+				UpdateMaxLength();
 		}
 
 		protected override void UpdateBackgroundColor()
@@ -203,6 +206,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 			BrushHelpers.UpdateColor(textColor, ref _defaultTextColorFocusBrush,
 				() => Control.ForegroundFocusBrush, brush => Control.ForegroundFocusBrush = brush);
+		}
+
+		void UpdateMaxLength()
+		{
+			Control.MaxLength = Element.MaxLength;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/EditorRenderer.cs
@@ -25,6 +25,7 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateInputScope();
 				UpdateTextColor();
 				UpdateFont();
+				UpdateMaxLength();
 			}
 
 			base.OnElementChanged(e);
@@ -47,6 +48,8 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateFont();
 			else if (e.PropertyName == Editor.FontSizeProperty.PropertyName)
 				UpdateFont();
+			else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+				UpdateMaxLength();
 		}
 		
 		void NativeOnTextChanged(object sender, System.Windows.Controls.TextChangedEventArgs textChangedEventArgs)
@@ -103,6 +106,11 @@ namespace Xamarin.Forms.Platform.WPF
 		void UpdateTextColor()
 		{
 			Control.UpdateDependencyColor(System.Windows.Controls.Control.ForegroundProperty, Element.TextColor);
+		}
+
+		void UpdateMaxLength()
+		{
+			Control.MaxLength = Element.MaxLength;
 		}
 
 		bool _isDisposed;

--- a/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateFont();
 				UpdateAlignment();
 				UpdatePlaceholderColor();
+				UpdateMaxLength();
 			}
 
 			base.OnElementChanged(e);
@@ -67,6 +68,8 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateAlignment();
 			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
 				UpdatePlaceholderColor();
+			else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+				UpdateMaxLength();
 		}
 		
 		internal override void OnModelFocusChangeRequested(object sender, VisualElement.FocusRequestArgs args)
@@ -226,6 +229,11 @@ namespace Xamarin.Forms.Platform.WPF
 
 			Control.Text = Element.Text ?? "";
 			Control.Select(Control.Text == null ? 0 : Control.Text.Length, 0);
+		}
+
+		void UpdateMaxLength()
+		{
+			Control.MaxLength = Element.MaxLength;
 		}
 
 		bool _isDisposed;

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using Foundation;
 using UIKit;
 using RectangleF = CoreGraphics.CGRect;
 
@@ -24,6 +25,7 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.Changed -= HandleChanged;
 					Control.Started -= OnStarted;
 					Control.Ended -= OnEnded;
+                    Control.ShouldChangeText -= ShouldChangeText;
 				}
 			}
 
@@ -60,6 +62,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.Changed += HandleChanged;
 				Control.Started += OnStarted;
 				Control.Ended += OnEnded;
+                Control.ShouldChangeText += ShouldChangeText;
 			}
 
 			UpdateText();
@@ -152,5 +155,11 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				Control.TextColor = textColor.ToUIColor();
 		}
-	}
+
+        bool ShouldChangeText(UITextView textView, NSRange range, string text)
+        {
+            var newLength = textView.Text.Length + text.Length - range.Length;
+            return newLength <= Element.MaxLength;
+        }
+    }
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -62,6 +62,7 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.EditingDidBegin -= OnEditingBegan;
 					Control.EditingChanged -= OnEditingChanged;
 					Control.EditingDidEnd -= OnEditingEnded;
+                    Control.ShouldChangeCharacters -= Control_ShouldChangeCharacters;
 				}
 			}
 
@@ -94,6 +95,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 				textField.EditingDidBegin += OnEditingBegan;
 				textField.EditingDidEnd += OnEditingEnded;
+
+                textField.ShouldChangeCharacters += Control_ShouldChangeCharacters;
 			}
 
 			UpdatePlaceholder();
@@ -106,35 +109,35 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateAdjustsFontSizeToFitWidth();
 		}
 
-		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == Entry.PlaceholderProperty.PropertyName || e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
-				UpdatePlaceholder();
-			else if (e.PropertyName == Entry.IsPasswordProperty.PropertyName)
-				UpdatePassword();
-			else if (e.PropertyName == Entry.TextProperty.PropertyName)
-				UpdateText();
-			else if (e.PropertyName == Entry.TextColorProperty.PropertyName)
-				UpdateColor();
-			else if (e.PropertyName == Xamarin.Forms.InputView.KeyboardProperty.PropertyName)
-				UpdateKeyboard();
-			else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
-				UpdateAlignment();
-			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
-				UpdateFont();
-			else if (e.PropertyName == Entry.FontFamilyProperty.PropertyName)
-				UpdateFont();
-			else if (e.PropertyName == Entry.FontSizeProperty.PropertyName)
-				UpdateFont();
-			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
-			{
-				UpdateColor();
-				UpdatePlaceholder();
-			}
-			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Entry.AdjustsFontSizeToFitWidthProperty.PropertyName)
-				UpdateAdjustsFontSizeToFitWidth();
-			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
-				UpdateAlignment();
+            if (e.PropertyName == Entry.PlaceholderProperty.PropertyName || e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
+                UpdatePlaceholder();
+            else if (e.PropertyName == Entry.IsPasswordProperty.PropertyName)
+                UpdatePassword();
+            else if (e.PropertyName == Entry.TextProperty.PropertyName)
+                UpdateText();
+            else if (e.PropertyName == Entry.TextColorProperty.PropertyName)
+                UpdateColor();
+            else if (e.PropertyName == Xamarin.Forms.InputView.KeyboardProperty.PropertyName)
+                UpdateKeyboard();
+            else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
+                UpdateAlignment();
+            else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
+                UpdateFont();
+            else if (e.PropertyName == Entry.FontFamilyProperty.PropertyName)
+                UpdateFont();
+            else if (e.PropertyName == Entry.FontSizeProperty.PropertyName)
+                UpdateFont();
+            else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+            {
+                UpdateColor();
+                UpdatePlaceholder();
+            }
+            else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Entry.AdjustsFontSizeToFitWidthProperty.PropertyName)
+                UpdateAdjustsFontSizeToFitWidth();
+            else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
+                UpdateAlignment();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -249,5 +252,11 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Control.Text != Element.Text)
 				Control.Text = Element.Text;
 		}
-	}
+
+        bool Control_ShouldChangeCharacters(UITextField textField, NSRange range, string replacementString)
+        {
+            var newLength = textField.Text.Length + replacementString.Length - range.Length;
+            return newLength <= Element.MaxLength;
+        }
+    }
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.EditingDidBegin -= OnEditingBegan;
 					Control.EditingChanged -= OnEditingChanged;
 					Control.EditingDidEnd -= OnEditingEnded;
-                    Control.ShouldChangeCharacters -= Control_ShouldChangeCharacters;
+                    Control.ShouldChangeCharacters -= ShouldChangeCharacters;
 				}
 			}
 
@@ -96,7 +96,7 @@ namespace Xamarin.Forms.Platform.iOS
 				textField.EditingDidBegin += OnEditingBegan;
 				textField.EditingDidEnd += OnEditingEnded;
 
-                textField.ShouldChangeCharacters += Control_ShouldChangeCharacters;
+                textField.ShouldChangeCharacters += ShouldChangeCharacters;
 			}
 
 			UpdatePlaceholder();
@@ -253,7 +253,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.Text = Element.Text;
 		}
 
-        bool Control_ShouldChangeCharacters(UITextField textField, NSRange range, string replacementString)
+        bool ShouldChangeCharacters(UITextField textField, NSRange range, string replacementString)
         {
             var newLength = textField.Text.Length + replacementString.Length - range.Length;
             return newLength <= Element.MaxLength;


### PR DESCRIPTION
### Description of Change ###

Implementation of MaxLength on both the Entry as well as the Editor (by implementing it on the InputView) for all platforms supported today.

### Bugs Fixed ###

- N/A

### API Changes ###
Added:
 - int InputView.MaxLength { get; set; } //Bindable Property, default value int.MaxValue

### Behavioral Changes ###

There shouldn't be any behavioral changes by just upgrading. But they now have the ability to limit the input length of the Editor and Entry controls.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
