### PR TITLE
[C/XamlC] BindingMode.OneTime

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2175,7 +2175,41 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("FOO", label.Text);
 			label.SetBinding(Label.TextProperty, "Tuple[1]");
 			Assert.AreEqual("BAR", label.Text);
+		}
 
+		[Test]
+		public void OneTimeBindingDoesntUpdateOnPropertyChanged()
+		{
+			var view = new VisualElement();
+			var bp1t = BindableProperty.Create("Foo", typeof(string), typeof(VisualElement));
+			var bp1w = BindableProperty.Create("Foo", typeof(string), typeof(VisualElement));
+			var vm = new MockViewModel("foobar");
+			view.BindingContext = vm;
+			view.SetBinding(bp1t, "Text", mode: BindingMode.OneTime);
+			view.SetBinding(bp1w, "Text", mode: BindingMode.OneWay);
+			Assert.That(view.GetValue(bp1w), Is.EqualTo("foobar"));
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("foobar"));
+
+			vm.Text = "qux";
+			Assert.That(view.GetValue(bp1w), Is.EqualTo("qux"));
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("foobar"));
+		}
+
+		[Test]
+		public void OneTimeBindingUpdatesOnBindingContextChanged()
+		{
+			var view = new VisualElement();
+			var bp1t = BindableProperty.Create("Foo", typeof(string), typeof(VisualElement));
+			var bp1w = BindableProperty.Create("Foo", typeof(string), typeof(VisualElement));
+			view.BindingContext = new MockViewModel("foobar");
+			view.SetBinding(bp1t, "Text", mode: BindingMode.OneTime);
+			view.SetBinding(bp1w, "Text", mode: BindingMode.OneWay);
+			Assert.That(view.GetValue(bp1w), Is.EqualTo("foobar"));
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("foobar"));
+
+			view.BindingContext = new MockViewModel("qux");
+			Assert.That(view.GetValue(bp1w), Is.EqualTo("qux"));
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("qux"));
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
@@ -1387,6 +1387,65 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void OneTimeBindingDoesntUpdateOnPropertyChanged()
+		{
+			var view = new VisualElement();
+			var bp1t = BindableProperty.Create("Foo", typeof(string), typeof(VisualElement));
+			var bp1w = BindableProperty.Create("Foo", typeof(string), typeof(VisualElement));
+			var vm = new MockViewModel("foobar");
+			view.BindingContext = vm;
+			var b1t = CreateBinding(mode: BindingMode.OneTime);
+			var b1w = CreateBinding(mode: BindingMode.OneWay);
+
+			view.SetBinding(bp1t, b1t);
+			view.SetBinding(bp1w, b1w);
+			Assert.That(view.GetValue(bp1w), Is.EqualTo("foobar"));
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("foobar"));
+
+			vm.Text = "qux";
+			Assert.That(view.GetValue(bp1w), Is.EqualTo("qux"));
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("foobar"));
+		}
+
+		[Test]
+		public void OneTimeBindingUpdatesOnBindingContextChanged()
+		{
+			var view = new VisualElement();
+			var bp1t = BindableProperty.Create("Foo", typeof(string), typeof(VisualElement));
+			var bp1w = BindableProperty.Create("Foo", typeof(string), typeof(VisualElement));
+			view.BindingContext = new MockViewModel("foobar");
+			var b1t = CreateBinding(mode: BindingMode.OneTime);
+			var b1w = CreateBinding(mode: BindingMode.OneWay);
+
+			view.SetBinding(bp1t, b1t);
+			view.SetBinding(bp1w, b1w);
+			Assert.That(view.GetValue(bp1w), Is.EqualTo("foobar"));
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("foobar"));
+
+			view.BindingContext = new MockViewModel("qux");
+			Assert.That(view.GetValue(bp1w), Is.EqualTo("qux"));
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("qux"));
+		}
+
+		[Test]
+		public void OneTimeBindingDoesntUpdateNeedSettersOrHandlers()
+		{
+			var view = new VisualElement();
+			var bp1t = BindableProperty.Create("Foo", typeof(string), typeof(VisualElement));
+			var vm = new MockViewModel("foobar");
+			view.BindingContext = vm;
+
+			var b1t = new TypedBinding<MockViewModel, string>(v => v.Text, null, null);
+
+			view.SetBinding(bp1t, b1t);
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("foobar"));
+
+			vm.Text = "qux";
+			Assert.That(view.GetValue(bp1t), Is.EqualTo("foobar"));
+			Assert.Pass(); //doesn't throw
+		}
+
+		[Test]
 		[Ignore]
 		public void SpeedTestApply()
 		{

--- a/Xamarin.Forms.Core/BindingBase.cs
+++ b/Xamarin.Forms.Core/BindingBase.cs
@@ -20,7 +20,11 @@ namespace Xamarin.Forms
 			get { return _mode; }
 			set
 			{
-				if (value != BindingMode.Default && value != BindingMode.OneWay && value != BindingMode.OneWayToSource && value != BindingMode.TwoWay)
+				if (   value != BindingMode.Default
+				    && value != BindingMode.OneWay
+				    && value != BindingMode.OneWayToSource
+				    && value != BindingMode.TwoWay
+				    && value != BindingMode.OneTime)
 					throw new ArgumentException("mode is not a valid BindingMode", "mode");
 
 				ThrowIfApplied();

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -106,10 +106,10 @@ namespace Xamarin.Forms
 		void ApplyCore(object sourceObject, BindableObject target, BindableProperty property, bool fromTarget = false)
 		{
 			BindingMode mode = Binding.GetRealizedMode(_targetProperty);
-			if (mode == BindingMode.OneWay && fromTarget)
+			if ((mode == BindingMode.OneWay || mode == BindingMode.OneTime) && fromTarget)
 				return;
 
-			bool needsGetter = (mode == BindingMode.TwoWay && !fromTarget) || mode == BindingMode.OneWay;
+			bool needsGetter = (mode == BindingMode.TwoWay && !fromTarget) || mode == BindingMode.OneWay || mode == BindingMode.OneTime;
 			bool needsSetter = !needsGetter && ((mode == BindingMode.TwoWay && fromTarget) || mode == BindingMode.OneWayToSource);
 
 			object current = sourceObject;

--- a/Xamarin.Forms.Core/BindingMode.cs
+++ b/Xamarin.Forms.Core/BindingMode.cs
@@ -5,6 +5,7 @@ namespace Xamarin.Forms
 		Default,
 		TwoWay,
 		OneWay,
-		OneWayToSource
+		OneWayToSource,
+		OneTime,
 	}
 }

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -190,10 +190,10 @@ namespace Xamarin.Forms.Internals
 		{
 			var isTSource = sourceObject != null && sourceObject is TSource;
 			var mode = this.GetRealizedMode(property);
-			if (mode == BindingMode.OneWay && fromTarget)
+			if ((mode == BindingMode.OneWay || mode == BindingMode.OneTime) && fromTarget)
 				return;
 
-			var needsGetter = (mode == BindingMode.TwoWay && !fromTarget) || mode == BindingMode.OneWay;
+			var needsGetter = (mode == BindingMode.TwoWay && !fromTarget) || mode == BindingMode.OneWay || mode == BindingMode.OneTime;
 
 			if (isTSource && (mode == BindingMode.OneWay || mode == BindingMode.TwoWay) && _handlers != null)
 				Subscribe((TSource)sourceObject);

--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
@@ -17,6 +17,7 @@
             <Label Text="{Binding Model.Text}" x:Name="label6" x:DataType="local:MockStructViewModel" />
 			<Entry Text="{Binding Text, Mode=TwoWay}" x:Name="entry0"/>
             <Label Text="{Binding .}" x:Name="label7" x:DataType="sys:Int32"/>
+            <Label Text="{Binding Text, Mode=OneTime}" x:Name="label8" />
 		</StackLayout>
 		<Label Text="{Binding Text}" x:Name="labelWithUncompiledBinding" />
 	</StackLayout>

--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -65,6 +65,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.AreEqual("Text0", layout.label1.Text);
 				Assert.AreEqual("Text1", layout.label2.Text);
 				Assert.AreEqual("TextIndex", layout.label3.Text);
+				Assert.AreEqual("Text0", layout.label8.Text);
 
 				//value types
 				Assert.That(layout.label5.Text, Is.EqualTo("42"));

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/BindingMode.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/BindingMode.xml
@@ -85,6 +85,20 @@ Debug.WriteLine (viewmodel.Name); //prints "Foo"
         <summary>When used in Bindings, indicates that the Binding should use the <see cref="P:Xamarin.Forms.BindableProperty.DefaultBindingMode" />. When used in BindableProperty declaration, defaults to BindingMode.OneWay.</summary>
       </Docs>
     </Member>
+    <Member MemberName="OneTime">
+      <MemberSignature Language="C#" Value="OneTime" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.BindingMode OneTime = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindingMode</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
     <Member MemberName="OneWay">
       <MemberSignature Language="C#" Value="OneWay" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.BindingMode OneWay = int32(2)" />


### PR DESCRIPTION
### Description of Change ###

[C/XamlC] BindingMode.OneTime

Bindings with mode == OneTime:
 - are only applied when the BindingContext changes
 - do not subscribe to INPC

if the Binding is compiled and the mode explicitely set in the
`{Binding}` Markup extension, the setters and handlers aren't even
created.

### Bugs Fixed

 - fixes #1686

### API Changes ###



Added:
 - `BindingMode.OneTime`

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense