### PR TITLE
[macOS] ScrollView doesnt support Horizontal Orientation and doesnt d…

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.ComponentModel;
 using AppKit;
 using RectangleF = CoreGraphics.CGRect;
@@ -21,9 +21,10 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			ContentView = new FlippedClipView();
 			DrawsBackground = false;
+			AutohidesScrollers = true;
 			ContentView.PostsBoundsChangedNotifications = false;
 			NSNotificationCenter.DefaultCenter.AddObserver(this, new Selector(nameof(UpdateScrollPosition)), BoundsChangedNotification, ContentView);
-			HasVerticalScroller = true;
+			UpdateOrientation();
 		}
 
 		ScrollView ScrollView => Element as ScrollView;
@@ -68,9 +69,11 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				UpdateContentSize();
 				UpdateBackgroundColor();
-
+				UpdateOrientation();
 				RaiseElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 			}
+
+			ResetNativeNonScroll();
 		}
 
 		public void SetElementSize(Size size)
@@ -113,12 +116,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void RaiseElementChanged(VisualElementChangedEventArgs e)
 		{
-			OnElementChanged(e);
 			ElementChanged?.Invoke(this, e);
-		}
-
-		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
-		{
 		}
 
 		void PackContent()
@@ -155,6 +153,36 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateContentSize();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
+			else if (e.PropertyName == ScrollView.OrientationProperty.PropertyName)
+				UpdateOrientation();
+		}
+
+		private void UpdateOrientation()
+		{
+			if (ScrollView == null)
+				return;
+
+			switch (ScrollView.Orientation)
+			{
+				case ScrollOrientation.Both:
+					{
+						HasHorizontalScroller = true;
+						HasVerticalScroller = true;
+						break;
+					}
+				case ScrollOrientation.Horizontal:
+					{
+						HasVerticalScroller = false;
+						HasHorizontalScroller = true;
+						break;
+					}
+				case ScrollOrientation.Vertical:
+					{
+						HasHorizontalScroller = false;
+						HasVerticalScroller = true;
+						break;
+					}
+			}
 		}
 
 		void OnNativeControlUpdated(object sender, EventArgs eventArgs)
@@ -200,14 +228,15 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 
 			ContentView.Frame = new RectangleF(ContentView.Frame.X, ContentView.Frame.Y, Frame.Width, Frame.Height);
+			ResetNativeNonScroll();
 		}
 
-		private bool ResetNativeNonScroll( )
+		private bool ResetNativeNonScroll()
 		{
 			if (ScrollView == null || ContentView == null)
 				return false;
 
-			if (ScrollView.ScrollY <= 0.0f && ContentView.DocumentVisibleRect().Location.Y > 0.0f)
+			if (Math.Abs(ScrollView.ScrollY) < 0.001 && Math.Abs(ScrollView.ScrollX) < 0.001 && ScrollView.Content.Height > ScrollView.Height)
 			{
 				ContentView.ScrollToPoint(new CoreGraphics.CGPoint(0, 0));
 				return true;
@@ -226,8 +255,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				CoreGraphics.CGPoint location = ContentView.DocumentVisibleRect().Location;
 
-				if (location.Y > -1)
-					ScrollView.SetScrolledPosition(Math.Max(0, location.X), Math.Max(0, ContentView.Frame.Height - location.Y));
+				if (location.Y > -1 && ScrollView.Height >= 0)
+					ScrollView.SetScrolledPosition(Math.Max(0, location.X), Math.Max(0, ScrollView.ContentSize.Height - ScrollView.Height - location.Y));
 			}
 			else
 				ResetNativeNonScroll();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -233,7 +233,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		private bool ResetNativeNonScroll()
 		{
-			if (ScrollView == null || ContentView == null)
+			if (ContentView == null || ScrollView == null || ScrollView.Content == null)
 				return false;
 
 			if (Math.Abs(ScrollView.ScrollY) < 0.001 && Math.Abs(ScrollView.ScrollX) < 0.001 && ScrollView.Content.Height > ScrollView.Height)


### PR DESCRIPTION
…efault to Start.

### Description of Change ###

ScrollView on macOS does not currently support Horizontal scrolling and the scrolling currently sits at the end when the Content is over drawn.

### Bugs Fixed ###

fixes #1816

### API Changes ###

None.

### Behavioral Changes ###

Actual Behavior
-End Scroll
Scroll will start at the begging.

-Horizontal Scroll
No scroll available.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
