### PR TITLE
[Core] Fixed leaking reference to popped Page in PopAsync()

### DIFF
--- a/Xamarin.Flex/Flex.cs
+++ b/Xamarin.Flex/Flex.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE.txt file in the project root
+// Licensed under the MIT License. See the LICENSE file in the project root
 // for the license information.
-
+// 
+// Author(s):
+//  - Laurent Sansonetti (native Xamarin flex https://github.com/xamarin/flex)
+//  - Stephane Delcroix (.NET port)
+//
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -132,21 +132,19 @@ namespace Xamarin.Forms
 
 		public async Task<Page> PopAsync(bool animated)
 		{
+			var tcs = new TaskCompletionSource<bool>();
 			if (CurrentNavigationTask != null && !CurrentNavigationTask.IsCompleted)
 			{
-				var tcs = new TaskCompletionSource<bool>();
-				Task oldTask = CurrentNavigationTask;
+				var oldTask = CurrentNavigationTask;
 				CurrentNavigationTask = tcs.Task;
 				await oldTask;
-
-				Page page = await PopAsyncInner(animated, false);
-				tcs.SetResult(true);
-				return page;
 			}
+			else
+				CurrentNavigationTask = tcs.Task;
 
-			Task<Page> result = PopAsyncInner(animated, false);
-			CurrentNavigationTask = result;
-			return await result;
+			var result = await PopAsyncInner(animated, false);
+			tcs.SetResult(true);
+			return result;
 		}
 
 		public event EventHandler<NavigationEventArgs> Popped;


### PR DESCRIPTION
### Description of Change ###

fixed by using a private wait handle the same way as when there is a pending task

### Bugs Fixed ###

- [https://bugzilla.xamarin.com/show_bug.cgi?id=31171](https://bugzilla.xamarin.com/show_bug.cgi?id=31171)
- fixes #1429

### API Changes ###

-

### Behavioral Changes ###

-

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

