### PR TITLE
[macOS] DatePicker & TimePicker dont report IsFocused and use old Dat…

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Controls/FormsNSDatePicker.cs
+++ b/Xamarin.Forms.Platform.MacOS/Controls/FormsNSDatePicker.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using AppKit;
+
+namespace Xamarin.Forms.Platform.MacOS
+{
+	internal class BoolEventArgs : EventArgs
+	{
+		public BoolEventArgs(bool value)
+		{
+			Value = value;
+		}
+		public bool Value
+		{
+			get;
+			private set;
+		}
+	}
+
+	internal class FormsNSDatePicker : NSDatePicker
+	{
+		public EventHandler<BoolEventArgs> FocusChanged;
+
+		public override bool ResignFirstResponder()
+		{
+			FocusChanged?.Invoke(this, new BoolEventArgs(false));
+			return base.ResignFirstResponder();
+		}
+		public override bool BecomeFirstResponder()
+		{
+			FocusChanged?.Invoke(this, new BoolEventArgs(true));
+			return base.BecomeFirstResponder();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using AppKit;
 using Foundation;
 
@@ -22,7 +21,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				if (Control == null)
 				{
-					_picker = new NSDatePicker
+					_picker = new FormsNSDatePicker
 					{
 						DatePickerMode = NSDatePickerMode.Single,
 						TimeZone = new NSTimeZone("UTC"),
@@ -30,6 +29,7 @@ namespace Xamarin.Forms.Platform.MacOS
 						DatePickerElements = NSDatePickerElementFlags.YearMonthDateDay
 					};
 					_picker.ValidateProposedDateValue += HandleValueChanged;
+					(_picker as FormsNSDatePicker).FocusChanged += ControlFocusChanged;
 					_defaultTextColor = _picker.TextColor;
 					_defaultBackgroundColor = _picker.BackgroundColor;
 
@@ -69,7 +69,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (disposing && !_disposed)
 			{
 				if (_picker != null)
+				{
 					_picker.ValidateProposedDateValue -= HandleValueChanged;
+					(_picker as FormsNSDatePicker).FocusChanged -= ControlFocusChanged;
+				}
 
 				_disposed = true;
 			}
@@ -89,21 +92,17 @@ namespace Xamarin.Forms.Platform.MacOS
 				Control.BackgroundColor = color.ToNSColor();
 		}
 
+		void ControlFocusChanged(object sender, BoolEventArgs e)
+		{
+			ElementController?.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, e.Value);
+		}
+
 		void HandleValueChanged(object sender, NSDatePickerValidatorEventArgs e)
 		{
 			if (Control == null || Element == null)
 				return;
-			ElementController?.SetValueFromRenderer(DatePicker.DateProperty, _picker.DateValue.ToDateTime().Date);
-		}
 
-		void OnEnded(object sender, EventArgs eventArgs)
-		{
-			ElementController?.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
-		}
-
-		void OnStarted(object sender, EventArgs eventArgs)
-		{
-			ElementController?.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
+			ElementController?.SetValueFromRenderer(DatePicker.DateProperty, e.ProposedDateValue.ToDateTime().Date);
 		}
 
 		void UpdateDateFromModel()
@@ -118,7 +117,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (Control == null || Element == null)
 				return;
-			
+
 			Control.Font = Element.ToNSFont();
 		}
 

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -6,18 +6,6 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	public class EntryRenderer : ViewRenderer<Entry, NSTextField>
 	{
-		class BoolEventArgs : EventArgs
-		{
-			public BoolEventArgs(bool value)
-			{
-				Value = value;
-			}
-			public bool Value
-			{
-				get;
-				private set;
-			}
-		}
 		class FormsNSTextField : NSTextField
 		{
 			public EventHandler<BoolEventArgs> FocusChanged;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				if (Control == null)
 				{
-					SetNativeControl(new NSDatePicker
+					SetNativeControl(new FormsNSDatePicker
 					{
 						DatePickerMode = NSDatePickerMode.Single,
 						TimeZone = new NSTimeZone("UTC"),
@@ -29,6 +29,7 @@ namespace Xamarin.Forms.Platform.MacOS
 						DatePickerElements = NSDatePickerElementFlags.HourMinuteSecond
 					});
 
+					(Control as FormsNSDatePicker).FocusChanged += ControlFocusChanged;
 					Control.ValidateProposedDateValue += HandleValueChanged;
 					_defaultTextColor = Control.TextColor;
 					_defaultBackgroundColor = Control.BackgroundColor;
@@ -55,7 +56,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (e.PropertyName == Picker.FontSizeProperty.PropertyName ||
 				e.PropertyName == Picker.FontFamilyProperty.PropertyName ||
 				e.PropertyName == Picker.FontAttributesProperty.PropertyName)
-					UpdateFont();
+				UpdateFont();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -63,7 +64,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (disposing && !_disposed)
 			{
 				if (Control != null)
+				{
 					Control.ValidateProposedDateValue -= HandleValueChanged;
+					(Control as FormsNSDatePicker).FocusChanged -= ControlFocusChanged;
+				}
 
 				_disposed = true;
 			}
@@ -79,10 +83,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			Control.BackgroundColor = color == Color.Default ? _defaultBackgroundColor : color.ToNSColor();
 		}
 
+		void ControlFocusChanged(object sender, BoolEventArgs e)
+		{
+			ElementController?.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, e.Value);
+		}
+
 		void HandleValueChanged(object sender, NSDatePickerValidatorEventArgs e)
 		{
-			ElementController?.SetValueFromRenderer(TimePicker.TimeProperty,
-				Control.DateValue.ToDateTime() - new DateTime(2001, 1, 1));
+			ElementController?.SetValueFromRenderer(TimePicker.TimeProperty, e.ProposedDateValue.ToDateTime() - new DateTime(2001, 1, 1));
 		}
 
 		void UpdateFont()
@@ -90,7 +98,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (Control == null || Element == null)
 				return;
 
-			Control.Font = Element.ToNSFont();	
+			Control.Font = Element.ToNSFont();
 		}
 
 		void UpdateTime()

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -71,6 +71,7 @@
     <Compile Include="..\Xamarin.Forms.Platform.iOS\Flags.cs">
       <Link>Flags.cs</Link>
     </Compile>
+    <Compile Include="Controls\FormsNSDatePicker.cs" />
     <Compile Include="Extensions\FlowDirectionExtensions.cs" />
     <Compile Include="FormsApplicationDelegate.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
…eTime.

### Description of Change ###

DatePicker & TimePicker are not reporting IsFocused to the Forms controls.
The DateTime being reported back is the old value. The macOS control doesnt update until after the event completes.

### Bugs Fixed ###

fixes #1819

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
