### PR TITLE
[iOS] Fix: disable touch input when user interaction is disabled

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -659,7 +659,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					var cell = table.CellAt(_lastPath) as ContextActionsCell;
 
-					return cell != null;
+					return cell != null && cell.ContentCell.UserInteractionEnabled;
 				};
 			}
 


### PR DESCRIPTION
### Description of Change ###

The fix will not generate touch event for TextCell if UserInteractionEnabled is false (due to TextCell.Command.CanExecute returing false) and caching strategy is set RecycleElement / RecycleElementAndDataTemplate.

### Bugs Fixed ###

[https://bugzilla.xamarin.com/show_bug.cgi?id=60045](https://bugzilla.xamarin.com/show_bug.cgi?id=60045)

### API Changes ###

no

### Behavioral Changes ###

Will not generate touch event if UserInteractionEnabled is false.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
