### PR TITLE
[C] BO.IsSet() returns false after ClearValue()

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindableObjectUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindableObjectUnitTests.cs
@@ -891,7 +891,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void IsSetIsTrueWhenPropCleared()
+		public void IsSetIsFalseWhenPropCleared()
 		{
 			string defaultValue = "default";
 			string newValue = "new value";
@@ -900,11 +900,9 @@ namespace Xamarin.Forms.Core.UnitTests
 			var bindable = new MockBindable();
 
 			bindable.SetValue(bindableProperty, newValue);
-
 			bindable.ClearValue(bindableProperty);
 
-			var isSet = bindable.IsSet(bindableProperty);
-			Assert.IsTrue(isSet);
+			Assert.That(bindable.IsSet(bindableProperty), Is.False);
 		}
 
 		[Test]
@@ -924,7 +922,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void IsSetIsTrueWhenPropSetByDefaultValueCreator()
+		public void IsSetIsFalseWhenPropSetByDefaultValueCreator()
 		{
 			string defaultValue = "default";
 			string defaultValueC = "defaultVC";
@@ -941,7 +939,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(defaultValueC, created);
 
 			var isSet = bindable.IsSet(bindableProperty);
-			Assert.IsTrue(isSet);
+			Assert.IsFalse(isSet);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -57,7 +57,9 @@ namespace Xamarin.Forms
 			if (targetProperty == null)
 				throw new ArgumentNullException(nameof(targetProperty));
 
-			return GetContext(targetProperty) != null;
+			var bpcontext = GetContext(targetProperty);
+			return bpcontext != null
+				&& (bpcontext.Attributes & BindableContextAttributes.IsDefaultValue) == 0;
 		}
 
 		public object GetValue(BindableProperty property)
@@ -176,14 +178,6 @@ namespace Xamarin.Forms
 
 			BindablePropertyContext bpcontext = GetContext(targetProperty);
 			return bpcontext != null && bpcontext.Binding != null;
-		}
-
-		internal bool GetIsDefault(BindableProperty targetProperty)
-		{
-			if (targetProperty == null)
-				throw new ArgumentNullException(nameof(targetProperty));
-
-			return GetContext(targetProperty) == null;
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -123,35 +123,35 @@ namespace Xamarin.Forms
 
 		static void OnOrderPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (bindable.GetIsDefault(FlexItemProperty))
+			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).Order = (int)newValue;
 		}
 
 		static void OnGrowPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (bindable.GetIsDefault(FlexItemProperty))
+			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).Grow = (float)newValue;
 		}
 
 		static void OnShrinkPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (bindable.GetIsDefault(FlexItemProperty))
+			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).Shrink = (float)newValue;
 		}
 
 		static void OnAlignSelfPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (bindable.GetIsDefault(FlexItemProperty))
+			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).AlignSelf = (Flex.AlignSelf)(FlexAlignSelf)newValue;
 		}
 
 		static void OnBasisPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (bindable.GetIsDefault(FlexItemProperty))
+			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).Basis = ((FlexBasis)newValue).ToFlexBasis();
 		}

--- a/Xamarin.Forms.Core/VisualStateManager.cs
+++ b/Xamarin.Forms.Core/VisualStateManager.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms
 
 		public static bool GoToState(VisualElement visualElement, string name)
 		{
-			if (visualElement.GetIsDefault(VisualStateGroupsProperty))
+			if (!visualElement.IsSet(VisualStateGroupsProperty))
 			{
 				return false;
 			}
@@ -86,7 +86,7 @@ namespace Xamarin.Forms
 
 		public static bool HasVisualStateGroups(this VisualElement element)
 		{
-			return !element.GetIsDefault(VisualStateGroupsProperty);
+			return element.IsSet(VisualStateGroupsProperty);
 		}
 	}
 


### PR DESCRIPTION
### Description of Change ###

[C] BO.IsSet() returns false after ClearValue()

### Bugs Fixed ###

 - fixes #1813

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense