### PR TITLE
[Android,Core] Entry platform specific to set ImeOptions and flags

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/EntryPageAndroid.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/EntryPageAndroid.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+
+namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
+{
+	public class EntryPageAndroid : ContentPage
+	{
+		Label _lbl;
+		Entry _entry;
+		Picker _picker;
+		public EntryPageAndroid()
+		{
+			_entry = new Entry
+			{
+				FontSize = 22,
+				Placeholder = "Type and use the picker to set your ImeFlags"
+			};
+
+			_entry.On<Android>().SetImeOptions(ImeFlags.Default);
+
+			_lbl = new Label
+			{
+				FontSize = 20
+			};
+
+			_picker = new Picker();
+			_picker.Items.Add(ImeFlags.Default.ToString());
+			_picker.Items.Add(ImeFlags.Go.ToString());
+			_picker.Items.Add(ImeFlags.Next.ToString());
+			_picker.Items.Add(ImeFlags.Previous.ToString());
+			_picker.Items.Add(ImeFlags.Search.ToString());
+			_picker.Items.Add(ImeFlags.Send.ToString());
+			_picker.Items.Add(ImeFlags.Done.ToString());
+			_picker.Items.Add(ImeFlags.NoAccessoryAction.ToString());
+			_picker.Items.Add(ImeFlags.None.ToString());
+			_picker.Items.Add(ImeFlags.NoExtractUi.ToString());
+			_picker.Items.Add(ImeFlags.NoPersonalizedLearning.ToString());
+			_picker.Items.Add(ImeFlags.NoFullscreen.ToString());
+			_picker.SelectedIndexChanged += _picker_SelectedIndexChanged;
+			_picker.SelectedIndex = 0;
+			Content = new StackLayout
+			{
+				Children =
+				{
+					_lbl,
+					_entry,
+					_picker
+				}
+			};
+		}
+
+		void _picker_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			ImeFlags flag = (ImeFlags)Enum.Parse(typeof(ImeFlags), _picker.SelectedItem.ToString());
+			_entry.On<Android>().SetImeOptions(flag);
+			UpdateLabelText();
+		}
+
+		private void UpdateLabelText()
+		{
+			_lbl.Text = $"Default ImeOptions {_entry.On<Android>().ImeOptions()}";
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Controls
 			var appAndroidButton = new Button() { Text = "Application (Android)" };
 			var tbAndroidButton = new Button { Text = "TabbedPage (Android)" };
 			var entryiOSButton = new Button() { Text = "Entry (iOS)" };
+			var entryAndroidButton = new Button() { Text = "Entry (Android)" };
 			var largeTitlesiOSButton = new Button() { Text = "Large Title (iOS)" };
 			var safeareaiOSButton = new Button() { Text = "SafeArea (iOS)" };
 
@@ -32,6 +33,7 @@ namespace Xamarin.Forms.Controls
 			appAndroidButton.Clicked += (sender, args) => { SetRoot(new ApplicationAndroid(new Command(RestoreOriginal))); };
 			tbAndroidButton.Clicked += (sender, args) => { SetRoot(new TabbedPageAndroid(new Command(RestoreOriginal))); };
 			entryiOSButton.Clicked += (sender, args) => { Navigation.PushAsync(new EntryPageiOS()); };
+			entryAndroidButton.Clicked += (sender, args) => { Navigation.PushAsync(new EntryPageAndroid()); };
 			largeTitlesiOSButton.Clicked += (sender, args) => { Navigation.PushAsync(new LargeTitlesPageiOS(new Command(RestoreOriginal))); };
 			safeareaiOSButton.Clicked += (sender, args) => { SetRoot(new SafeAreaPageiOS(new Command(RestoreOriginal), new Command<Page>( p => SetRoot(p)))); };
 
@@ -41,7 +43,7 @@ namespace Xamarin.Forms.Controls
 				Content = new StackLayout
 				{
 					Children = { mdpiOSButton, mdpWindowsButton, npWindowsButton, tbiOSButton, tbWindowsButton, viselemiOSButton,
-							 appAndroidButton, tbAndroidButton, entryiOSButton, largeTitlesiOSButton, safeareaiOSButton }
+							 appAndroidButton, tbAndroidButton, entryiOSButton, entryAndroidButton, largeTitlesiOSButton, safeareaiOSButton }
 				}
 			};
 		}

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Entry.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Entry.cs
@@ -1,0 +1,47 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using FormsElement = Forms.Entry;
+
+	public static class Entry
+	{
+		public static readonly BindableProperty ImeOptionsProperty = BindableProperty.Create(nameof(ImeOptions), typeof(ImeFlags), typeof(Entry), ImeFlags.Default);
+
+		public static ImeFlags GetImeOptions(BindableObject element)
+		{
+			return (ImeFlags)element.GetValue(ImeOptionsProperty);
+		}
+
+		public static void SetImeOptions(BindableObject element, ImeFlags value)
+		{
+			element.SetValue(ImeOptionsProperty, value);
+		}
+
+		public static ImeFlags ImeOptions(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetImeOptions(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetImeOptions(this IPlatformElementConfiguration<Xamarin.Forms.PlatformConfiguration.Android, FormsElement> config, ImeFlags value)
+		{
+			SetImeOptions(config.Element, value);
+			return config;
+		}
+	}
+
+	public enum ImeFlags
+	{
+		Default = 0,
+		None = 1,
+		Go = 2,
+		Search = 3,
+		Send = 4,
+		Next = 5,
+		Done = 6,
+		Previous = 7,
+		ImeMaskAction = 255,
+		NoPersonalizedLearning = 16777216,
+		NoFullscreen = 33554432,
+		NoExtractUi = 268435456,
+		NoAccessoryAction = 536870912,
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Extensions/EntryRendererExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/EntryRendererExtensions.cs
@@ -1,0 +1,40 @@
+﻿using Android.Views.InputMethods;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal static class EntryRendererExtensions
+	{
+		public static ImeAction ToAndroidImeOptions(this PlatformConfiguration.AndroidSpecific.ImeFlags flags)
+		{
+			switch (flags)
+			{
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.Previous:
+					return ImeAction.Previous;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.Next:
+					return ImeAction.Next;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.Search:
+					return ImeAction.Search;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.Send:
+					return ImeAction.Send;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.Go:
+					return ImeAction.Go;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.None:
+					return ImeAction.None;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.ImeMaskAction:
+					return ImeAction.ImeMaskAction;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.NoPersonalizedLearning:
+					return (ImeAction)ImeFlags.NoPersonalizedLearning;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.NoExtractUi:
+					return (ImeAction)ImeFlags.NoExtractUi;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.NoAccessoryAction:
+					return (ImeAction)ImeFlags.NoAccessoryAction;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.NoFullscreen:
+					return (ImeAction)ImeFlags.NoFullscreen;
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.Default:
+				case PlatformConfiguration.AndroidSpecific.ImeFlags.Done:
+				default:
+					return ImeAction.Done;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -105,6 +105,7 @@
     <Compile Include="AndroidTitleBarVisibility.cs" />
     <Compile Include="AppCompat\FrameRenderer.cs" />
     <Compile Include="Elevation.cs" />
+    <Compile Include="Extensions\EntryRendererExtensions.cs" />
     <Compile Include="FastRenderers\AutomationPropertiesProvider.cs" />
     <Compile Include="AppCompat\PageExtensions.cs" />
     <Compile Include="Extensions\JavaObjectExtensions.cs" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/Entry.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/Entry.xml
@@ -1,0 +1,116 @@
+<Type Name="Entry" FullName="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Entry">
+  <TypeSignature Language="C#" Value="public static class Entry" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Entry extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetImeOptions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags GetImeOptions (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags GetImeOptions(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ImeOptions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags ImeOptions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags ImeOptions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Entry&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ImeOptionsProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ImeOptionsProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ImeOptionsProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetImeOptions">
+      <MemberSignature Language="C#" Value="public static void SetImeOptions (Xamarin.Forms.BindableObject element, Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetImeOptions(class Xamarin.Forms.BindableObject element, valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetImeOptions">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt; SetImeOptions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt; config, Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Entry&gt; SetImeOptions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Entry&gt; config, valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt;" RefType="this" />
+        <Parameter Name="value" Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/ImeFlags.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/ImeFlags.xml
@@ -1,0 +1,199 @@
+<Type Name="ImeFlags" FullName="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags">
+  <TypeSignature Language="C#" Value="public enum ImeFlags" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed ImeFlags extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Default">
+      <MemberSignature Language="C#" Value="Default" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags Default = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Done">
+      <MemberSignature Language="C#" Value="Done" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags Done = int32(6)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Go">
+      <MemberSignature Language="C#" Value="Go" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags Go = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="ImeMaskAction">
+      <MemberSignature Language="C#" Value="ImeMaskAction" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags ImeMaskAction = int32(255)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Next">
+      <MemberSignature Language="C#" Value="Next" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags Next = int32(5)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="NoAccessoryAction">
+      <MemberSignature Language="C#" Value="NoAccessoryAction" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags NoAccessoryAction = int32(536870912)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="NoExtractUi">
+      <MemberSignature Language="C#" Value="NoExtractUi" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags NoExtractUi = int32(268435456)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="NoFullscreen">
+      <MemberSignature Language="C#" Value="NoFullscreen" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags NoFullscreen = int32(33554432)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="None">
+      <MemberSignature Language="C#" Value="None" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags None = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="NoPersonalizedLearning">
+      <MemberSignature Language="C#" Value="NoPersonalizedLearning" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags NoPersonalizedLearning = int32(16777216)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Previous">
+      <MemberSignature Language="C#" Value="Previous" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags Previous = int32(7)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Search">
+      <MemberSignature Language="C#" Value="Search" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags Search = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Send">
+      <MemberSignature Language="C#" Value="Send" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags Send = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -522,6 +522,8 @@
     </Namespace>
     <Namespace Name="Xamarin.Forms.PlatformConfiguration.AndroidSpecific">
       <Type Name="Application" Kind="Class" />
+      <Type Name="Entry" Kind="Class" />
+      <Type Name="ImeFlags" Kind="Enumeration" />
       <Type Name="ListView" Kind="Class" />
       <Type Name="TabbedPage" Kind="Class" />
       <Type Name="VisualElement" Kind="Class" />
@@ -1903,6 +1905,50 @@
           <summary>Sets a value that controls whether the soft input mode of the provided platform configuration pans or resizes its content to allow the display of the on-screen input UI.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Application" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Application.UseWindowSoftInputModeAdjust(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application},Xamarin.Forms.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="ImeOptions">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags ImeOptions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags ImeOptions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Entry&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Entry" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Entry.ImeOptions(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetImeOptions">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt; SetImeOptions (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt; config, Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Entry&gt; SetImeOptions(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Entry&gt; config, valuetype Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry&gt;" RefType="this" />
+          <Parameter Name="value" Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Entry" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Entry.SetImeOptions(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Entry},Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ImeFlags)" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>


### PR DESCRIPTION
### Description of Change ###

Add a platform specific for entries on Android that allows to control the options for keyboard and interactions with TextView

### Bugs Fixed ###

- Fixes #1696

### API Changes ###
``` 
public static readonly BindableProperty ImeOptionsProperty = BindableProperty.Create(nameof(ImeOptions), typeof(ImeFlags), typeof(Entry), ImeFlags.Default);

public static ImeFlags GetImeOptions(BindableObject element)

public static void SetImeOptions(BindableObject element, ImeFlags value)

public static ImeFlags ImeOptions(this IPlatformElementConfiguration<Android, FormsElement> config)

public static IPlatformElementConfiguration<Android, FormsElement> SetImeOptions(this IPlatformElementConfiguration<Xamarin.Forms.PlatformConfiguration.Android, FormsElement> config, ImeFlags value)

public enum ImeFlags
{
	Default = 0,
	None = 1,
	Go = 2,
	Search = 3,
	Send = 4,
	Next = 5,
	Done = 6,
	Previous = 7,
	ImeMaskAction = 255,
	NoPersonalizedLearning = 16777216,
	NoFullscreen = 33554432,
	NoExtractUi = 268435456,
	NoAccessoryAction = 536870912,
}

``` 
### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
