### PR TITLE
[macOS] Alternate picker.  Changed native control to NSPopupButton.

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PickerRenderer.cs
@@ -83,10 +83,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					_disposed = true;
 					if (Element != null)
-					{
-						//TODO: Implement ObservableList picker source change 
-						//((ObservableList<string>)Element.Items).CollectionChanged -= RowsCollectionChanged;
-					}
+						((INotifyCollectionChanged)Element.Items).CollectionChanged -= RowsCollectionChanged;
 
 					if (Control != null)
 						Control.Activated -= ComboBoxSelectionChanged;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PickerRenderer.cs
@@ -2,38 +2,50 @@
 using AppKit;
 using System.ComponentModel;
 using Foundation;
+using System.Collections.Specialized;
+using System.Linq;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
-	public class PickerRenderer : ViewRenderer<Picker, NSComboBox>
+	public class PickerRenderer : ViewRenderer<Picker, NSPopUpButton>
 	{
 		bool _disposed;
-		NSColor _defaultTextColor;
 		NSColor _defaultBackgroundColor;
 
 		IElementController ElementController => Element;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
 		{
+			if (e.OldElement != null)
+				((INotifyCollectionChanged)e.OldElement.Items).CollectionChanged -= RowsCollectionChanged;
+
 			if (e.NewElement != null)
 			{
 				if (Control == null)
-					SetNativeControl(new NSComboBox { Editable = false });
+					SetNativeControl(new NSPopUpButton());
 
-				_defaultTextColor = Control.TextColor;
-				_defaultBackgroundColor = Control.BackgroundColor;
+				_defaultBackgroundColor = Control.Cell.BackgroundColor;
 
-				Control.UsesDataSource = true;
-				Control.DataSource = new ComboDataSource(this);
-
-				Control.SelectionChanged += ComboBoxSelectionChanged;
-
+				Control.Activated -= ComboBoxSelectionChanged;
+				Control.Activated += ComboBoxSelectionChanged;
 				UpdatePicker();
 				UpdateFont();
 				UpdateTextColor();
+
+				((INotifyCollectionChanged)e.NewElement.Items).CollectionChanged -= RowsCollectionChanged;
+				((INotifyCollectionChanged)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
 			}
 
 			base.OnElementChanged(e);
+		}
+
+		private void UpdateItems()
+		{
+			if (Control == null || Element == null)
+				return;
+
+			Control.RemoveAllItems();
+			Control.AddItems(Element.Items.ToArray());
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -44,13 +56,13 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 				UpdatePicker();
 			if (e.PropertyName == Picker.TextColorProperty.PropertyName ||
-			    e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+				e.PropertyName == VisualElement.IsEnabledProperty.PropertyName ||
+				e.PropertyName == Picker.SelectedItemProperty.PropertyName)
 				UpdateTextColor();
 			if (e.PropertyName == Picker.FontSizeProperty.PropertyName ||
 				e.PropertyName == Picker.FontFamilyProperty.PropertyName ||
 				e.PropertyName == Picker.FontAttributesProperty.PropertyName)
 				UpdateFont();
-				
 		}
 
 		protected override void SetBackgroundColor(Color color)
@@ -60,7 +72,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (Control == null)
 				return;
 
-			Control.BackgroundColor = color == Color.Default ? _defaultBackgroundColor : color.ToNSColor();
+			Control.Cell.BackgroundColor = color == Color.Default ? _defaultBackgroundColor : color.ToNSColor();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -77,7 +89,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					}
 
 					if (Control != null)
-						Control.SelectionChanged -= ComboBoxSelectionChanged;
+						Control.Activated -= ComboBoxSelectionChanged;
 				}
 			}
 			base.Dispose(disposing);
@@ -85,7 +97,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void ComboBoxSelectionChanged(object sender, EventArgs e)
 		{
-			ElementController?.SetValueFromRenderer(Picker.SelectedIndexProperty, (int)Control.SelectedIndex);
+			ElementController?.SetValueFromRenderer(Picker.SelectedIndexProperty, (int)Control.IndexOfSelectedItem);
 		}
 
 		void OnEnded(object sender, EventArgs eventArgs)
@@ -108,7 +120,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (Control == null || Element == null)
 				return;
 
-			Control.Font = Element.ToNSFont();
+			//Control.Menu.Font = Element.ToNSFont();
 		}
 
 		void UpdatePicker()
@@ -118,8 +130,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			var selectedIndex = Element.SelectedIndex;
 			var items = Element.Items;
-			Control.PlaceholderString = Element.Title ?? string.Empty;
-			Control.ReloadData();
+			UpdateItems();
+
 			if (items == null || items.Count == 0 || selectedIndex < 0)
 				return;
 
@@ -131,37 +143,16 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (Control == null || Element == null)
 				return;
 
-			var textColor = Element.TextColor;
-
-			if (textColor.IsDefault || !Element.IsEnabled)
-				Control.TextColor = _defaultTextColor;
-			else
-				Control.TextColor = textColor.ToNSColor();
-		}
-
-		class ComboDataSource : NSComboBoxDataSource
-		{
-			readonly PickerRenderer _renderer;
-
-			public ComboDataSource(PickerRenderer model)
+			foreach (NSMenuItem it in Control.Items())
 			{
-				_renderer = model;
+				it.AttributedTitle = new NSAttributedString();
 			}
 
-			public override nint ItemCount(NSComboBox comboBox)
+			var color = Element.TextColor;
+			if (color != Color.Default && Control.SelectedItem != null)
 			{
-				return _renderer.Element.Items?.Count ?? 0;
-			}
-
-			public override NSObject ObjectValueForItem(NSComboBox comboBox, nint index)
-			{
-				return new NSString(_renderer.Element.Items[(int)index]);
-			}
-
-			public override nint IndexOfItem(NSComboBox comboBox, string value)
-			{
-				var index = _renderer.Element.Items?.IndexOf(value) ?? -1;
-				return index;
+				NSAttributedString textWithColor = new NSAttributedString(Control.SelectedItem.Title, foregroundColor: color.ToNSColor(), paragraphStyle: new NSMutableParagraphStyle() { Alignment = NSTextAlignment.Left });
+				Control.SelectedItem.AttributedTitle = textWithColor;
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Changed the native control in macOS's Picker to the NSPopUpButton from the NSComboBox.

### Bugs Fixed ###

fixes #1610

### API Changes ###

None.

### Behavioral Changes ###

The popup on the control will now size to the elements in the list no longer ellipsising the items.  It also allows for the control to be clicked over the entirety of the control rather than just the drop down button.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

### Screenshots ###
OLD:

![screen shot 2018-02-07 at 2 52 19 pm](https://user-images.githubusercontent.com/13279060/35938578-89e02da6-0c17-11e8-8bf8-d411a5e8192b.png)

NEW:
![screen shot 2018-02-07 at 2 58 29 pm](https://user-images.githubusercontent.com/13279060/35938563-7dcea13c-0c17-11e8-9415-7d35db04bda1.png)

