### PR TITLE
Retain row-as-header behavior when recycling

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -448,7 +448,7 @@ namespace Xamarin.Forms.Platform.Android
 				var layout = cellOwner as ConditionalFocusLayout;
 				if (layout != null)
 					cellOwner = layout.GetChildAt(0);
-				cell = (Cell)((INativeElementView)cellOwner).Element;
+				cell = (Cell)(cellOwner as INativeElementView)?.Element;
 			}
 
 			// All our ListView's have called AddHeaderView. This effectively becomes index 0, so our index 0 is index 1 to the listView.


### PR DESCRIPTION
### Description of Change ###

Expect tapping on header of ListView to do nothing. Actually crashed as logic didn't account for implementation reserving a row for header use.

### Bugs Fixed ###

https://github.com/xamarin/Xamarin.Forms/issues/1598

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
