### PR TITLE
AutoCapitalization support for Entry/Editor

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -30,6 +30,8 @@ using Xamarin.Forms.Controls.Issues;
 
 [assembly: ExportRenderer(typeof(Bugzilla42000._42000NumericEntryNoDecimal), typeof(EntryRendererNoDecimal))]
 [assembly: ExportRenderer(typeof(Bugzilla42000._42000NumericEntryNoNegative), typeof(EntryRendererNoNegative))]
+[assembly: ExportRenderer(typeof(Issue1683.EntryKeyboardFlags), typeof(EntryRendererKeyboardFlags))]
+[assembly: ExportRenderer(typeof(Issue1683.EditorKeyboardFlags), typeof(EditorRendererKeyboardFlags))]
 //[assembly: ExportRenderer(typeof(AndroidHelpText.HintLabel), typeof(HintLabel))]
 [assembly: ExportRenderer(typeof(QuickCollectNavigationPage), typeof(QuickCollectNavigationPageRenderer))]
 
@@ -122,7 +124,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 	public class NativeListViewRenderer : ViewRenderer<NativeListView, global::Android.Widget.ListView>
 	{
-#pragma warning disable 618 
+#pragma warning disable 618
 		public NativeListViewRenderer()
 #pragma warning restore 618
 		{
@@ -514,10 +516,12 @@ namespace Xamarin.Forms.ControlGallery.Android
 		}
 	}
 
-#pragma warning disable 618
 	public class CustomButtonRenderer : ButtonRenderer
-#pragma warning restore 618
 	{
+		public CustomButtonRenderer(Context context) : base(context)
+		{
+		}
+
 		protected override AButton CreateNativeControl()
 		{
 			return new CustomNativeButton(Context);
@@ -536,11 +540,12 @@ namespace Xamarin.Forms.ControlGallery.Android
 	}
 
 	// Custom renderers for Bugzilla42000 demonstration purposes
-
-#pragma warning disable 618
 	public class EntryRendererNoNegative : EntryRenderer
-#pragma warning restore 618
 	{
+		public EntryRendererNoNegative(Context context) : base(context)
+		{
+		}
+
 		protected override NumberKeyListener GetDigitsKeyListener(InputTypes inputTypes)
 		{
 			// Disable the NumberFlagSigned bit
@@ -550,16 +555,108 @@ namespace Xamarin.Forms.ControlGallery.Android
 		}
 	}
 
-#pragma warning disable 618
 	public class EntryRendererNoDecimal : EntryRenderer
-#pragma warning restore 618
 	{
+		public EntryRendererNoDecimal(Context context) : base(context)
+		{
+		}
+
 		protected override NumberKeyListener GetDigitsKeyListener(InputTypes inputTypes)
 		{
 			// Disable the NumberFlagDecimal bit
 			inputTypes &= ~InputTypes.NumberFlagDecimal;
 
 			return base.GetDigitsKeyListener(inputTypes);
+		}
+	}
+
+	public class EntryRendererKeyboardFlags : EntryRenderer
+	{
+		public EntryRendererKeyboardFlags(Context context) : base(context)
+		{
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			var FlagsToSet = ((Issue1683.EntryKeyboardFlags)Element).FlagsToSet;
+			var FlagsToTestFor = ((Issue1683.EntryKeyboardFlags)Element).FlagsToTestFor;
+
+			base.OnElementPropertyChanged(sender, e);
+
+			Control.SetKeyboardFlags(FlagsToSet);
+			Control.TestKeyboardFlags(FlagsToTestFor);
+		}
+	}
+
+	public class EditorRendererKeyboardFlags : EditorRenderer
+	{
+		public EditorRendererKeyboardFlags(Context context) : base(context)
+		{
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			var FlagsToSet = ((Issue1683.EditorKeyboardFlags)Element).FlagsToSet;
+			var FlagsToTestFor = ((Issue1683.EditorKeyboardFlags)Element).FlagsToTestFor;
+			base.OnElementPropertyChanged(sender, e);
+
+			Control.SetKeyboardFlags(FlagsToSet);
+			Control.TestKeyboardFlags(FlagsToTestFor);
+		}
+	}
+
+	public static class KeyboardFlagExtensions
+	{
+		public static void TestKeyboardFlags(this FormsEditText Control, KeyboardFlags? flags)
+		{
+			if (flags == null)
+			{
+				return;
+			}
+			if (flags.Value.HasFlag(KeyboardFlags.CapitalizeSentence))
+			{
+				if (!Control.InputType.HasFlag(InputTypes.TextFlagCapSentences))
+				{
+					throw new Exception("TextFlagCapSentences not correctly set");
+				}
+			}
+			else if (flags.Value.HasFlag(KeyboardFlags.CapitalizeCharacter))
+			{
+				if (!Control.InputType.HasFlag(InputTypes.TextFlagCapCharacters))
+				{
+					throw new Exception("TextFlagCapCharacters not correctly set");
+				}
+			}
+			else if (flags.Value.HasFlag(KeyboardFlags.CapitalizeWord))
+			{
+				if (!Control.InputType.HasFlag(InputTypes.TextFlagCapWords))
+				{
+					throw new Exception("TextFlagCapWords not correctly set");
+				}
+			}
+		}
+
+		public static void SetKeyboardFlags(this FormsEditText Control, KeyboardFlags? flags)
+		{
+			if (flags == null)
+			{
+				return;
+			}
+
+			if (flags.Value.HasFlag(KeyboardFlags.CapitalizeCharacter))
+			{
+				Control.InputType = Control.InputType | InputTypes.TextFlagCapCharacters;
+			}
+
+			if (flags.Value.HasFlag(KeyboardFlags.CapitalizeSentence))
+			{
+				Control.InputType = Control.InputType | InputTypes.TextFlagCapSentences;
+			}
+
+			if (flags.Value.HasFlag(KeyboardFlags.CapitalizeWord))
+			{
+				Control.InputType = Control.InputType | InputTypes.TextFlagCapWords;
+			}
 		}
 	}
 
@@ -573,7 +670,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 	// }
 
 #pragma warning disable CS0618 // Leaving in old constructor so we can verify it works
-	public class NoFlashTestNavigationPage 
+	public class NoFlashTestNavigationPage
 #if FORMS_APPLICATION_ACTIVITY
 		: Xamarin.Forms.Platform.Android.NavigationRenderer
 #else

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomRenderers.cs
@@ -1,11 +1,101 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using System.ComponentModel;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.UWP;
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Bugzilla42602.TextBoxView), typeof(Xamarin.Forms.ControlGallery.WindowsUniversal.TextBoxViewRenderer))]
+[assembly: ExportRenderer(typeof(Issue1683.EntryKeyboardFlags), typeof(EntryRendererKeyboardFlags))]
+[assembly: ExportRenderer(typeof(Issue1683.EditorKeyboardFlags), typeof(EditorRendererKeyboardFlags))]
 namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 {
+	public class EntryRendererKeyboardFlags : EntryRenderer
+	{
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+			Control.SetKeyboardFlags(((Issue1683.EntryKeyboardFlags)Element).FlagsToSet);
+			Control.TestKeyboardFlags(((Issue1683.EntryKeyboardFlags)Element).FlagsToSet);
+
+
+		}
+	}
+	public class EditorRendererKeyboardFlags : EditorRenderer
+	{
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+			Control.SetKeyboardFlags(((Issue1683.EditorKeyboardFlags)Element).FlagsToSet);
+			Control.TestKeyboardFlags(((Issue1683.EditorKeyboardFlags)Element).FlagsToSet);
+
+
+		}
+	}
+
+	public static class KeyboardFlagExtensions
+	{
+		public static void TestKeyboardFlags(this FormsTextBox Control, KeyboardFlags? flags)
+		{
+			if (flags == null) { return; }
+			if (flags.Value.HasFlag(KeyboardFlags.CapitalizeSentence))
+			{
+				if (!Control.IsSpellCheckEnabled)
+				{
+					throw new System.Exception("IsSpellCheckEnabled not enabled");
+				}
+			}
+			else if (flags.Value.HasFlag(KeyboardFlags.CapitalizeWord))
+			{
+				if (!Control.InputScope.Names.Select(x => x.NameValue).Contains(InputScopeNameValue.NameOrPhoneNumber))
+				{
+					throw new System.Exception("Input Scope Not Set to NameOrPhoneNumber");
+				}
+
+				if (!Control.IsSpellCheckEnabled)
+				{
+					throw new System.Exception("IsSpellCheckEnabled not enabled");
+				}
+
+			}
+			else
+			{
+				return;
+			}
+		}
+
+		public static void SetKeyboardFlags(this FormsTextBox Control, KeyboardFlags? flags)
+		{
+			if (flags == null) { return; }
+			var result = new InputScope();
+			var value = InputScopeNameValue.Default;
+
+			if (flags.Value.HasFlag(KeyboardFlags.CapitalizeSentence))
+			{
+				Control.IsSpellCheckEnabled = true;
+			}
+			else if (flags.Value.HasFlag(KeyboardFlags.CapitalizeWord))
+			{
+				value = InputScopeNameValue.NameOrPhoneNumber;
+				Control.IsSpellCheckEnabled = true;
+			}
+			else
+			{
+				return;
+			}
+
+
+			InputScopeName nameValue = new InputScopeName();
+			nameValue.NameValue = value;
+			result.Names.Add(nameValue);
+			Control.InputScope = result;
+		}
+	}
+
+
 	public class TextBoxViewRenderer : BoxViewRenderer
 	{
 		Canvas m_Canvas;

--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using CoreLocation;
 using Foundation;
 using MapKit;
@@ -21,8 +22,11 @@ using RectangleF = CoreGraphics.CGRect;
 [assembly: ExportRenderer(typeof(Bugzilla43161.AccessoryViewCell), typeof(AccessoryViewCellRenderer))]
 [assembly: ExportRenderer(typeof(Bugzilla36802.AccessoryViewCell), typeof(AccessoryViewCellRenderer))]
 [assembly: ExportRenderer(typeof(Bugzilla52700.NoSelectionViewCell), typeof(NoSelectionViewCellRenderer))]
+[assembly: ExportRenderer(typeof(Issue1683.EntryKeyboardFlags), typeof(EntryRendererKeyboardFlags))]
+[assembly: ExportRenderer(typeof(Issue1683.EditorKeyboardFlags), typeof(EditorRendererKeyboardFlags))]
 namespace Xamarin.Forms.ControlGallery.iOS
 {
+
 	public class CustomIOSMapRenderer : ViewRenderer<CustomMapView, MKMapView>
 	{
 		private MKMapView _mapView;
@@ -391,7 +395,9 @@ namespace Xamarin.Forms.ControlGallery.iOS
 
 		public IEnumerable<string> Items
 		{
-			set { _tableItems = new List<string>(value); 
+			set
+			{
+				_tableItems = new List<string>(value);
 			}
 		}
 
@@ -504,7 +510,8 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		public CollectionViewController(UICollectionViewLayout layout, OnItemSelected onItemSelected) : base(layout)
 		{
 			items = new List<string>();
-			for (int i = 0; i < 20; i++) {
+			for (int i = 0; i < 20; i++)
+			{
 				items.Add($"#{i}");
 			}
 			_onItemSelected = onItemSelected;
@@ -597,5 +604,92 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			return cell;
 		}
 	}
+
+	public class EditorRendererKeyboardFlags : EditorRenderer
+	{
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+			KeyboardFlagExtensions.SetFlags(
+				(value) => Control.AutocapitalizationType = value,
+				(((Issue1683.EditorKeyboardFlags)Element).FlagsToTestFor)
+			);
+
+			Control.AutocapitalizationType.TestKeyboardFlags(((Issue1683.EditorKeyboardFlags)Element).FlagsToTestFor);
+		}
+	}
+
+	public class EntryRendererKeyboardFlags : EntryRenderer
+	{
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+			KeyboardFlagExtensions.SetFlags(
+				(value) => Control.AutocapitalizationType = value,
+				(((Issue1683.EntryKeyboardFlags)Element).FlagsToTestFor)
+			);
+
+			Control.AutocapitalizationType.TestKeyboardFlags(((Issue1683.EntryKeyboardFlags)Element).FlagsToTestFor);
+		}
+	}
+
+
+	public static class KeyboardFlagExtensions
+	{
+		public static void SetFlags(Action<UITextAutocapitalizationType> setField, KeyboardFlags? flags)
+		{
+			if (flags == null)
+			{
+				return;
+			}
+
+
+			if (flags.Value.HasFlag(KeyboardFlags.CapitalizeSentence))
+			{
+				setField(UITextAutocapitalizationType.Sentences);
+			}
+			else if (flags.Value.HasFlag(KeyboardFlags.CapitalizeCharacter))
+			{
+				setField(UITextAutocapitalizationType.AllCharacters);
+			}
+			else if (flags.Value.HasFlag(KeyboardFlags.CapitalizeWord))
+			{
+				setField(UITextAutocapitalizationType.Words);
+			}
+		}
+
+		public static void TestKeyboardFlags(this UITextAutocapitalizationType currentValue, KeyboardFlags? flags)
+		{
+			if (flags == null)
+			{
+				return;
+			}
+
+			if (flags.Value.HasFlag(KeyboardFlags.CapitalizeSentence))
+			{
+				if (currentValue != UITextAutocapitalizationType.Sentences)
+				{
+					throw new Exception("TextFlagCapSentences not correctly set");
+				}
+			}
+
+			else if (flags.Value.HasFlag(KeyboardFlags.CapitalizeCharacter))
+			{
+				if (currentValue != UITextAutocapitalizationType.AllCharacters)
+				{
+					throw new Exception("CapitalizeCharacter not correctly set");
+				}
+			}
+			else if (flags.Value.HasFlag(KeyboardFlags.CapitalizeWord))
+			{
+
+				if (currentValue != UITextAutocapitalizationType.Words)
+				{
+					throw new Exception("CapitalizeWord not correctly set");
+				}
+			}
+		}
+	}
+
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1683.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1683.cs
@@ -1,0 +1,202 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using System.Diagnostics;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1683, "Auto Capitalization Implementation")]
+	public class Issue1683 : TestContentPage
+	{
+		const string kContainerId = "Container";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout() { ClassId = kContainerId };
+
+			KeyboardFlags[] flags = new[]
+			{
+				KeyboardFlags.None,
+				KeyboardFlags.CapitalizeWord,
+				KeyboardFlags.CapitalizeSentence,
+				KeyboardFlags.CapitalizeCharacter,
+				KeyboardFlags.CapitalizeNone,
+				KeyboardFlags.All
+			};
+
+			List<Entry> entryViews = new List<Entry>();
+			List<Editor> editorViews = new List<Editor>();
+			List<InputView> inputViews = new List<InputView>();
+
+			KeyboardFlags spellCheckForUwp = KeyboardFlags.None;
+
+			if (Device.RuntimePlatform == Device.UWP)
+			{
+				spellCheckForUwp = KeyboardFlags.Spellcheck;
+			}
+
+			foreach (var flag in flags)
+			{
+				entryViews.Add(new EntryKeyboardFlags() { FlagsToTestFor = flag, Keyboard = Keyboard.Create(flag | spellCheckForUwp), ClassId = $"Entry{flag}" });
+				editorViews.Add(new EditorKeyboardFlags() { Keyboard = Keyboard.Create(flag | spellCheckForUwp), ClassId = $"Editor{flag}" });
+			}
+
+			entryViews.Add(new EntryKeyboardFlags() { ClassId = "EntryNoKeyboard" });
+			editorViews.Add(new EditorKeyboardFlags() { ClassId = "EditorNoKeyboard" });
+
+			inputViews.AddRange(entryViews);
+			inputViews.AddRange(editorViews);
+
+			inputViews.Add(new EntryKeyboardFlags() { ClassId = "CustomRenderer" });
+			inputViews.Add(new EntryKeyboardFlags() { ClassId = "CustomRendererCapitalizeSentence", FlagsToSet = KeyboardFlags.CapitalizeSentence, FlagsToTestFor = KeyboardFlags.CapitalizeSentence });
+			inputViews.Add(new EntryKeyboardFlags() { ClassId = "CustomRendererCapitalizeWord", FlagsToSet = KeyboardFlags.CapitalizeWord, FlagsToTestFor = KeyboardFlags.CapitalizeWord });
+
+			if (Device.RuntimePlatform != Device.UWP)
+			{
+				inputViews.Add(new EntryKeyboardFlags() { ClassId = "CustomRendererCapitalizeCharacter", FlagsToSet = KeyboardFlags.CapitalizeCharacter });
+			}
+
+			if (Device.RuntimePlatform == Device.UWP)
+			{
+				layout.Children.Add(new Label() { Text = "Capitalization settings only work when using touch keyboard" });
+				layout.Children.Add(new Label() { Text = "Character doesn't do anything on UWP" });
+			}
+			else if (Device.RuntimePlatform == Device.iOS)
+			{
+				layout.Children.Add(new Label() { Text = "All will use Sentence" });
+				layout.Children.Add(new Label() { Text = "No Keyboard will use Sentence" });
+			}
+			else if (Device.RuntimePlatform == Device.Android)
+			{
+				layout.Children.Add(new Label() { Text = "All will use Sentence" });
+				layout.Children.Add(new Label() { Text = "No Keyboard will use None" });
+			}
+
+			foreach (InputView child in inputViews)
+			{
+				var inputs = new StackLayout()
+				{
+					Orientation = StackOrientation.Horizontal
+				};
+
+				if (child is Entry)
+					(child as Entry).Text = "All the Same.";
+
+				if (child is Editor)
+					(child as Editor).Text = "All the Same.";
+
+
+				child.HorizontalOptions = LayoutOptions.FillAndExpand;
+				var theLabel = new Label();
+
+				theLabel.SetBinding(Label.TextProperty, new Binding("ClassId", source: child));
+				inputs.Children.Add(theLabel);
+				inputs.Children.Add(child);
+
+				layout.Children.Add(inputs);
+			}
+
+
+
+			Button rotate = new Button()
+			{
+				Text = "Change Capitalization Settings. Ensure they update correctly",
+				AutomationId = "Rotation"
+			};
+
+
+			// This shifts everyones capitalization by one in order
+			// to test that updating the field works as expected
+			rotate.Clicked += (_, __) =>
+			{
+				var item1 = entryViews[0];
+				entryViews.Remove(item1);
+				entryViews.Add(item1);
+
+				var item2 = editorViews[0];
+				editorViews.Remove(item2);
+				editorViews.Add(item2);
+
+				for (int i = 0; i <= flags.Length; i++)
+				{
+					var editorView = editorViews[i] as EditorKeyboardFlags;
+					var entryView = entryViews[i] as EntryKeyboardFlags;
+
+					if (i == flags.Length)
+					{
+						entryView.FlagsToTestFor = null;
+						entryView.Keyboard = null;
+						entryView.ClassId = "EntryNoKeyboard";
+
+
+						editorView.FlagsToTestFor = null;
+						editorView.ClassId = "EntryNoKeyboard";
+						editorView.Keyboard = null;
+					}
+					else
+					{
+						entryView.FlagsToTestFor = flags[i];
+						entryView.Keyboard = Keyboard.Create(flags[i] | spellCheckForUwp);
+						entryView.ClassId = $"Entry{flags[i]}";
+
+						editorView.FlagsToTestFor = flags[i];
+						editorView.Keyboard = Keyboard.Create(flags[i] | spellCheckForUwp);
+						editorView.ClassId = $"Editor{flags[i]}";
+					}
+				}
+			};
+
+			StackLayout content = new StackLayout();
+			content.Children.Add(new ScrollView()
+			{
+				Content = layout
+			});
+
+			content.Children.Add(rotate);
+
+			Content = content;
+		}
+
+
+
+		public class EditorKeyboardFlags : Editor
+		{
+			public KeyboardFlags? FlagsToSet { get; set; }
+
+
+			public KeyboardFlags? FlagsToTestFor { get; set; }
+		}
+
+
+		public class EntryKeyboardFlags : Entry
+		{
+			public KeyboardFlags? FlagsToSet { get; set; }
+
+
+			public KeyboardFlags? FlagsToTestFor { get; set; }
+		}
+
+
+#if UITEST
+		[Test]
+		public void Issue1683Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Rotation"));
+			for (int i = 0; i < 6; i++)
+			{
+				RunningApp.Tap(q => q.Marked("Rotation"));
+			}
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -238,6 +238,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59457.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1683.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1717.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60001.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60056.cs" />

--- a/Xamarin.Forms.Core/KeyboardFlags.cs
+++ b/Xamarin.Forms.Core/KeyboardFlags.cs
@@ -9,6 +9,9 @@ namespace Xamarin.Forms
 		CapitalizeSentence = 1,
 		Spellcheck = 1 << 1,
 		Suggestions = 1 << 2,
+		CapitalizeWord = 1 << 3,
+		CapitalizeCharacter = 1 << 4,
+		CapitalizeNone = 1 << 5,
 		All = ~0
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/KeyboardExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/KeyboardExtensions.cs
@@ -31,9 +31,12 @@ namespace Xamarin.Forms.Platform.Android
 			else if (self is CustomKeyboard)
 			{
 				var custom = (CustomKeyboard)self;
-				bool capitalizedSentenceEnabled = (custom.Flags & KeyboardFlags.CapitalizeSentence) == KeyboardFlags.CapitalizeSentence;
-				bool spellcheckEnabled = (custom.Flags & KeyboardFlags.Spellcheck) == KeyboardFlags.Spellcheck;
-				bool suggestionsEnabled = (custom.Flags & KeyboardFlags.Suggestions) == KeyboardFlags.Suggestions;
+				var capitalizedSentenceEnabled = (custom.Flags & KeyboardFlags.CapitalizeSentence) == KeyboardFlags.CapitalizeSentence;
+				var capitalizedWordsEnabled = (custom.Flags & KeyboardFlags.CapitalizeWord) == KeyboardFlags.CapitalizeWord;
+				var capitalizedCharacterEnabled = (custom.Flags & KeyboardFlags.CapitalizeCharacter) == KeyboardFlags.CapitalizeCharacter;
+
+				var spellcheckEnabled = (custom.Flags & KeyboardFlags.Spellcheck) == KeyboardFlags.Spellcheck;
+				var suggestionsEnabled = (custom.Flags & KeyboardFlags.Suggestions) == KeyboardFlags.Suggestions;
 
 				if (!capitalizedSentenceEnabled && !spellcheckEnabled && !suggestionsEnabled)
 					result = InputTypes.ClassText | InputTypes.TextFlagNoSuggestions;
@@ -66,6 +69,17 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (capitalizedSentenceEnabled && spellcheckEnabled && suggestionsEnabled)
 					result = InputTypes.ClassText | InputTypes.TextFlagCapSentences | InputTypes.TextFlagAutoCorrect;
+
+				// All existed before these settings. This ensures these changes are backwards compatible
+				// without this check TextFlagCapCharacters would win
+				if (custom.Flags != KeyboardFlags.All)
+				{
+					if (capitalizedWordsEnabled)
+						result = result | InputTypes.TextFlagCapWords;
+
+					if (capitalizedCharacterEnabled)
+						result = result | InputTypes.TextFlagCapCharacters;
+				}
 			}
 			else
 			{

--- a/Xamarin.Forms.Platform.UAP/KeyboardExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/KeyboardExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Windows.UI.Xaml.Input;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -42,8 +43,41 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 			else
 			{
-				name.NameValue = InputScopeNameValue.Default;
+				var custom = (CustomKeyboard)self;
+				var capitalizedSentenceEnabled = (custom.Flags & KeyboardFlags.CapitalizeSentence) == KeyboardFlags.CapitalizeSentence;
+				var capitalizedWordsEnabled = (custom.Flags & KeyboardFlags.CapitalizeWord) == KeyboardFlags.CapitalizeWord;
+				var capitalizedCharacterEnabled = (custom.Flags & KeyboardFlags.CapitalizeCharacter) == KeyboardFlags.CapitalizeCharacter;
+
+				var spellcheckEnabled = (custom.Flags & KeyboardFlags.Spellcheck) == KeyboardFlags.Spellcheck;
+				var suggestionsEnabled = (custom.Flags & KeyboardFlags.Suggestions) == KeyboardFlags.Suggestions;
+
+				InputScopeNameValue nameValue = InputScopeNameValue.Default;
+
+				if (capitalizedSentenceEnabled)
+				{
+					if (!spellcheckEnabled)
+					{
+						Log.Warning(null, "CapitalizeSentence only works when spell check is enabled");
+					}
+				}
+				else if (capitalizedWordsEnabled)
+				{
+					if (!spellcheckEnabled)
+					{
+						Log.Warning(null, "CapitalizeWord only works when spell check is enabled");
+					}
+
+					nameValue = InputScopeNameValue.NameOrPhoneNumber;
+				}
+
+				if (capitalizedCharacterEnabled)
+				{
+					Log.Warning(null, "UWP does not support CapitalizeCharacter");
+				}
+
+				name.NameValue = nameValue;
 			}
+
 			result.Names.Add(name);
 			return result;
 		}

--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -40,11 +40,29 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (keyboard is CustomKeyboard)
 			{
 				var custom = (CustomKeyboard)keyboard;
+
 				var capitalizedSentenceEnabled = (custom.Flags & KeyboardFlags.CapitalizeSentence) == KeyboardFlags.CapitalizeSentence;
+				var capitalizedWordsEnabled = (custom.Flags & KeyboardFlags.CapitalizeWord) == KeyboardFlags.CapitalizeWord;
+				var capitalizedCharacterEnabled = (custom.Flags & KeyboardFlags.CapitalizeCharacter) == KeyboardFlags.CapitalizeCharacter;
+				var capitalizedNone = (custom.Flags & KeyboardFlags.None) == KeyboardFlags.None;
+
 				var spellcheckEnabled = (custom.Flags & KeyboardFlags.Spellcheck) == KeyboardFlags.Spellcheck;
 				var suggestionsEnabled = (custom.Flags & KeyboardFlags.Suggestions) == KeyboardFlags.Suggestions;
 
-				textInput.AutocapitalizationType = capitalizedSentenceEnabled ? UITextAutocapitalizationType.Sentences : UITextAutocapitalizationType.None;
+
+				UITextAutocapitalizationType capSettings = UITextAutocapitalizationType.None;
+
+				// Sentence being first ensures that the behavior of ALL is backwards compatible
+				if (capitalizedSentenceEnabled)
+					capSettings = UITextAutocapitalizationType.Sentences;
+				else if (capitalizedWordsEnabled)
+					capSettings = UITextAutocapitalizationType.Words;
+				else if (capitalizedCharacterEnabled)
+					capSettings = UITextAutocapitalizationType.AllCharacters;
+				else if (capitalizedNone)
+					capSettings = UITextAutocapitalizationType.None;
+
+				textInput.AutocapitalizationType = capSettings;
 				textInput.AutocorrectionType = suggestionsEnabled ? UITextAutocorrectionType.Yes : UITextAutocorrectionType.No;
 				textInput.SpellCheckingType = spellcheckEnabled ? UITextSpellCheckingType.Yes : UITextSpellCheckingType.No;
 			}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/KeyboardFlags.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/KeyboardFlags.xml
@@ -44,6 +44,34 @@
         <summary>Capitalize the first words of sentences, and perform spellcheck and offer suggested word completions on text that the user enters.</summary>
       </Docs>
     </Member>
+    <Member MemberName="CapitalizeCharacter">
+      <MemberSignature Language="C#" Value="CapitalizeCharacter" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.KeyboardFlags CapitalizeCharacter = int32(16)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.KeyboardFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="CapitalizeNone">
+      <MemberSignature Language="C#" Value="CapitalizeNone" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.KeyboardFlags CapitalizeNone = int32(32)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.KeyboardFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
     <Member MemberName="CapitalizeSentence">
       <MemberSignature Language="C#" Value="CapitalizeSentence" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.KeyboardFlags CapitalizeSentence = int32(1)" />
@@ -62,6 +90,20 @@
       </ReturnValue>
       <Docs>
         <summary>Capitalize the first words of sentences.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="CapitalizeWord">
+      <MemberSignature Language="C#" Value="CapitalizeWord" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.KeyboardFlags CapitalizeWord = int32(8)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.KeyboardFlags</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="None">


### PR DESCRIPTION
### Description of Change ###

The Entry and Editor controls do not have a simple mechanism for controlling the native automatic capitalization features.

Expand Keyboard flags to include Word, Character, and No Capitalized. The keyboard already supports CapitalizeSentence so it just needs to have Words and Characters added to it

Currently
```
[Flags]
	public enum KeyboardFlags
	{
		None = 0,
		CapitalizeSentence = 1,
		Spellcheck = 1 << 1,
		Suggestions = 1 << 2,
		All = ~0
	}
```
Expand To

```
[Flags]
	public enum KeyboardFlags
	{
		None = 0,
		CapitalizeSentence = 1,
		Spellcheck = 1 << 1,
		Suggestions = 1 << 2,
		CapitalizeWords = 1 << 3,
		CapitalizeCharacters = 1 << 4,
		CapitalizeNone = 1 << 5,
		All = ~0
	}
```

Currently None only really has in meaning for iOS

### iOS
Add checks for additional flags to
```
public static void ApplyKeyboard(this IUITextInput textInput, Keyboard keyboard)
```
To set the keyboard settings for iOS

These settings are mutually exclusive so if the user specifies multiple they'll just get one and warning

### Android
Add checks for additional flags to
```
public static InputTypes ToInputType(this Keyboard self)
```
There are currently checks inside this method that verifies valid permutations and warns the user if the settings don't make sense together. The new flags should be figured into these warnings

### UWP
Currently UWP completely lacks any custom keyboard implementation 
```
public static InputScope ToInputScope(this Keyboard self)
```
The WPF implementation has CustomKeyboard settings that mostly all just end up as setting the InputScopeName to Default but it comes with a set of warnings based on non compatible settings which I feel has value
https://msdn.microsoft.com/en-us/library/windows/apps/mt280229.aspx?f=255&MSPPError=-2147217396

Default behavior won't change but user will now get a warning.
You have to use a touch screen keyboard to see any changes. 

### Bugs Fixed ###

fixes #1683

### API Changes ###

Currently
```
[Flags]
	public enum KeyboardFlags
	{
		None = 0,
		CapitalizeSentence = 1,
		Spellcheck = 1 << 1,
		Suggestions = 1 << 2,
		All = ~0
	}
```
Expand To

```
[Flags]
	public enum KeyboardFlags
	{
		None = 0,
		CapitalizeSentence = 1,
		Spellcheck = 1 << 1,
		Suggestions = 1 << 2,
		CapitalizeWords = 1 << 3,
		CapitalizeCharacters = 1 << 4,
		CapitalizeNone = 1 << 5,
		All = ~0
	}
```

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
