### PR TITLE
[All] IsSpellCheckEnabled on Entry/Editor

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1660.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1660.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 1660, "[Enhancement] IsSpellCheckEnabled on Entry/Editor", PlatformAffected.All)]
+	public class Issue1660
+		: TestContentPage
+	{
+		protected override void Init()
+		{
+			var text = "The quck bron fx jumps ovr the lazyy doog";
+
+			var entryDefaults = new Entry { Text = text };
+			var editorDefaults = new Editor { Text = text };
+			var entryNoSpellCheck = new Entry { Text = text, IsSpellCheckEnabled = false };
+			var editorNoSpellCheck = new Editor { Text = text, IsSpellCheckEnabled = false };
+			var entryToggleable = new Entry { Text = text };
+			var editorToggleable = new Editor { Text = text };
+			var toggle = new Switch { IsToggled = true };
+
+			var stackLayout = new StackLayout();
+			stackLayout.Children.Add(new Label { Text = "Defaults" });
+			stackLayout.Children.Add(entryDefaults);
+			stackLayout.Children.Add(editorDefaults);
+			stackLayout.Children.Add(new Label { Text = "Spell checking disabled" });
+			stackLayout.Children.Add(entryNoSpellCheck);
+			stackLayout.Children.Add(editorNoSpellCheck);
+			stackLayout.Children.Add(new Label { Text = "Toggleable spell checking" });
+			stackLayout.Children.Add(entryToggleable);
+			stackLayout.Children.Add(editorToggleable);
+			stackLayout.Children.Add(toggle);
+
+			toggle.Toggled += (_, b) =>
+			{
+				entryToggleable.IsSpellCheckEnabled = b.Value;
+				editorToggleable.IsSpellCheckEnabled = b.Value;
+			};
+
+			stackLayout.Padding = new Thickness(0, 20, 0, 0);
+			Content = stackLayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -274,6 +274,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1347.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1356.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1439.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1660.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />

--- a/Xamarin.Forms.Core/InputView.cs
+++ b/Xamarin.Forms.Core/InputView.cs
@@ -4,6 +4,7 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create("Keyboard", typeof(Keyboard), typeof(InputView), Keyboard.Default,
 			coerceValue: (o, v) => (Keyboard)v ?? Keyboard.Default);
+		public static readonly BindableProperty IsSpellCheckEnabledProperty = BindableProperty.Create("IsSpellCheckEnabled", typeof(bool), typeof(InputView), true);
 
 		internal InputView()
 		{
@@ -13,6 +14,12 @@ namespace Xamarin.Forms
 		{
 			get { return (Keyboard)GetValue(KeyboardProperty); }
 			set { SetValue(KeyboardProperty, value); }
+		}
+
+		public bool IsSpellCheckEnabled
+		{
+			get { return (bool)GetValue(IsSpellCheckEnabledProperty); }
+			set { SetValue(IsSpellCheckEnabledProperty, value); }
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -90,6 +90,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateText();
 			else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
 				UpdateInputType();
+			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
+				UpdateInputType();
 			else if (e.PropertyName == Editor.TextColorProperty.PropertyName)
 				UpdateTextColor();
 			else if (e.PropertyName == Editor.FontAttributesProperty.PropertyName)
@@ -149,6 +151,14 @@ namespace Xamarin.Forms.Platform.Android
 			var keyboard = model.Keyboard;
 
 			edit.InputType = keyboard.ToInputType() | InputTypes.TextFlagMultiLine;
+			if (!(keyboard is Internals.CustomKeyboard) && model.IsSet(InputView.IsSpellCheckEnabledProperty))
+			{
+				if ((edit.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+				{
+					if (!model.IsSpellCheckEnabled)
+						edit.InputType = edit.InputType | InputTypes.TextFlagNoSuggestions;
+				}
+			}
 
 			if (keyboard == Keyboard.Numeric)
 			{

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -140,6 +140,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateColor();
 			else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
 				UpdateInputType();
+			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
+				UpdateInputType();
 			else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
 				UpdateAlignment();
 			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
@@ -186,6 +188,14 @@ namespace Xamarin.Forms.Platform.Android
 			var keyboard = model.Keyboard;
 
 			Control.InputType = keyboard.ToInputType();
+			if (!(keyboard is Internals.CustomKeyboard) && model.IsSet(InputView.IsSpellCheckEnabledProperty))
+			{
+				if ((Control.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+				{
+					if (!model.IsSpellCheckEnabled)
+						Control.InputType = Control.InputType | InputTypes.TextFlagNoSuggestions;
+				}
+			}
 
 			if (keyboard == Keyboard.Numeric)
 			{

--- a/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
@@ -72,6 +72,14 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateTextColor();
 			}
+			else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
+			{
+				UpdateInputScope();
+			}
+			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
+			{
+				UpdateInputScope();
+			}
 			else if (e.PropertyName == Editor.FontAttributesProperty.PropertyName)
 			{
 				UpdateFont();
@@ -157,7 +165,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateInputScope()
 		{
-			var custom = Element.Keyboard as CustomKeyboard;
+			Editor editor = Element;
+			var custom = editor.Keyboard as CustomKeyboard;
 			if (custom != null)
 			{
 				Control.IsTextPredictionEnabled = (custom.Flags & KeyboardFlags.Suggestions) != 0;
@@ -166,10 +175,13 @@ namespace Xamarin.Forms.Platform.UWP
 			else
 			{
 				Control.ClearValue(TextBox.IsTextPredictionEnabledProperty);
-				Control.ClearValue(TextBox.IsSpellCheckEnabledProperty);
+				if (editor.IsSet(InputView.IsSpellCheckEnabledProperty))
+					Control.IsSpellCheckEnabled = editor.IsSpellCheckEnabled;
+				else
+					Control.ClearValue(TextBox.IsSpellCheckEnabledProperty);
 			}
 
-			Control.InputScope = Element.Keyboard.ToInputScope();
+			Control.InputScope = editor.Keyboard.ToInputScope();
 		}
 
 		void UpdateText()

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using Windows.System;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
@@ -74,6 +75,8 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (e.PropertyName == Entry.TextColorProperty.PropertyName)
 				UpdateTextColor();
 			else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
+				UpdateInputScope();
+			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
 				UpdateInputScope();
 			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
 				UpdateFont();
@@ -163,14 +166,23 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateInputScope()
 		{
-			var custom = Element.Keyboard as CustomKeyboard;
+			Entry entry = Element;
+			var custom = entry.Keyboard as CustomKeyboard;
 			if (custom != null)
 			{
 				Control.IsTextPredictionEnabled = (custom.Flags & KeyboardFlags.Suggestions) != 0;
 				Control.IsSpellCheckEnabled = (custom.Flags & KeyboardFlags.Spellcheck) != 0;
 			}
+			else
+			{
+				Control.ClearValue(TextBox.IsTextPredictionEnabledProperty);
+				if (entry.IsSet(InputView.IsSpellCheckEnabledProperty))
+					Control.IsSpellCheckEnabled = entry.IsSpellCheckEnabled;
+				else
+					Control.ClearValue(TextBox.IsSpellCheckEnabledProperty);
+			}
 
-			Control.InputScope = Element.Keyboard.ToInputScope();
+			Control.InputScope = entry.Keyboard.ToInputScope();
 		}
 
 		void UpdateIsPassword()

--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -18,6 +18,7 @@
 		<Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderThemeThickness}" />
 		<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
 		<Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+		<Setter Property="IsSpellCheckEnabled" Value="True" />
 		<Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
 		<Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
 		<Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -78,6 +78,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateText();
 			else if (e.PropertyName == Xamarin.Forms.InputView.KeyboardProperty.PropertyName)
 				UpdateKeyboard();
+			else if (e.PropertyName == Xamarin.Forms.InputView.IsSpellCheckEnabledProperty.PropertyName)
+				UpdateKeyboard();
 			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateEditable();
 			else if (e.PropertyName == Editor.TextColorProperty.PropertyName)
@@ -128,6 +130,13 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateKeyboard()
 		{
 			Control.ApplyKeyboard(Element.Keyboard);
+			if (!(Element.Keyboard is Internals.CustomKeyboard) && Element.IsSet(Xamarin.Forms.InputView.IsSpellCheckEnabledProperty))
+			{
+				if (!Element.IsSpellCheckEnabled)
+				{
+					Control.SpellCheckingType = UITextSpellCheckingType.No;
+				}
+			}
 			Control.ReloadInputViews();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -118,6 +118,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateColor();
 			else if (e.PropertyName == Xamarin.Forms.InputView.KeyboardProperty.PropertyName)
 				UpdateKeyboard();
+			else if (e.PropertyName == Xamarin.Forms.InputView.IsSpellCheckEnabledProperty.PropertyName)
+				UpdateKeyboard();
 			else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
 				UpdateAlignment();
 			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
@@ -205,6 +207,13 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateKeyboard()
 		{
 			Control.ApplyKeyboard(Element.Keyboard);
+			if (!(Element.Keyboard is Internals.CustomKeyboard) && Element.IsSet(Xamarin.Forms.InputView.IsSpellCheckEnabledProperty))
+			{
+				if (!Element.IsSpellCheckEnabled)
+				{
+					Control.SpellCheckingType = UITextSpellCheckingType.No;
+				}
+			}
 			Control.ReloadInputViews();
 		}
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/InputView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/InputView.xml
@@ -20,6 +20,37 @@
     <remarks>The constructor of this class is internal. Forms does not provide any renderer for InputView base class.</remarks>
   </Docs>
   <Members>
+    <Member MemberName="IsSpellCheckEnabled">
+      <MemberSignature Language="C#" Value="public bool IsSpellCheckEnabled { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool IsSpellCheckEnabled" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsSpellCheckEnabledProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty IsSpellCheckEnabledProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty IsSpellCheckEnabledProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Keyboard">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.Keyboard Keyboard { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class Xamarin.Forms.Keyboard Keyboard" />


### PR DESCRIPTION
Adds the InputView.IsSpellCheckEnabled property which makes it easier to
disable the native spell checking features. Fixes #1660.

### Description of Change ###

Added `IsSpellCheckEnabledProperty` to `InputView`, which is the base class of both `Entry` and `Editor`. Modified `EditorRenderer.OnElementPropertyChanged()` and `EntryRenderer.OnElementPropertyChanged()` for Android, iOS and UWP to react to changes to the new `IsSpellCheckEnabled` property.

While implementing this for UWP I discovered what seemed to be a bug in that the UWP `EditorRenderer.UpdateInputScope()` method had calls to `ClearValue()` for the native control's `IsTextPredictionEnabledProperty` and `IsSpellCheckEnabledProperty`  while `EntryRenderer.UpdateInputScope()` hadn't. The effect was that for UWP `Editor`s text prediction and spell checking were disabled by default while they were enabled for UWP `Entry`s (the default on Windows 10). My change adds `ClearValue()` calls to the UWP `EntryRenderer.UpdateInputScope()` and sets the native `IsSpellCheckEnabled` to `true` by default in  `FormsTextBoxStyle.xaml`. This makes the behavior more consistent for these two components and also enforces the default of `true` on Windows 10.

On Android there's no way to control spell checking directly. Instead the `IsSpellCheckedEnabled` property when set to `false` disables suggestions.

**NOTE**: According to #1660 the name of the new property should be `IsSpellCheckedEnabled`, i.e. *spell check* as two words. However, the term *spellcheck* as one word is already used in the Xamarin.Forms APIs, e.g. the enum field `KeyboardFlags.Spellcheck`.

### Bugs Fixed ###

* Fixes #1660 [Enhancement] IsSpellCheckEnabled on Entry/Editor.

### API Changes ###

Added:
* `bool InputView.IsSpellCheckEnabled { get; set; } //Bindable Property`

### Behavioral Changes ###

When `IsSpellCheckEnabled` is set to `false` (default is `true`) and no `CustomKeyboard` is in use the native spell checker feature will be disabled. This means that `CustomKeyboard` always has precedence. If a `Keyboard` has been set which disables spell checking, e.g. `Keyboard.Chat`, the `IsSpellCheckEnabled` property is ignored. The property cannot be used to enable spell checking for a `Keyboard` which explicitly disables it. Let me know if this conservative behavior is undesired.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
