### PR TITLE
[Core] Add DesignMode.DesignModeEnabled

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/DesignModeTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DesignModeTests.cs
@@ -1,0 +1,22 @@
+﻿using NUnit;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	public class DesignModeTests : BaseTestFixture
+	{
+		[Test]
+		public void DesignModeEnabledIsFalseByDefault()
+		{
+			Assert.IsFalse(DesignMode.DesignModeEnabled);
+		}
+
+		[Test]
+		public void DesignModeEnabledIsTrueWhenSet()
+		{
+			DesignMode.DesignModeEnabled = true;
+
+			Assert.IsTrue(DesignMode.DesignModeEnabled);
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="ColorUnitTests.cs" />
     <Compile Include="CommandSourceTests.cs" />
     <Compile Include="CommandTests.cs" />
+    <Compile Include="DesignModeTests.cs" />
     <Compile Include="EffectiveFlowDirectionExtensions.cs" />
     <Compile Include="FlowDirectionTests.cs" />
     <Compile Include="LayoutChildIntoBoundingRegionTests.cs" />
@@ -225,7 +226,5 @@
       <LogicalName>Images/crimson.jpg</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="StyleSheets\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/Xamarin.Forms.Core/DesignMode.cs
+++ b/Xamarin.Forms.Core/DesignMode.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms
+{
+    public static class DesignMode
+    {
+		public static bool DesignModeEnabled { get; internal set; }
+	}
+}

--- a/Xamarin.Forms.Core/Internals/ResourceLoader.cs
+++ b/Xamarin.Forms.Core/Internals/ResourceLoader.cs
@@ -5,8 +5,17 @@ namespace Xamarin.Forms.Internals
 {
 	public static class ResourceLoader
 	{
+		static Func<string, string> resourceProvider;
+
 		//takes a resource path, returns string content
-		public static Func<AssemblyName, string, string> ResourceProvider { get; internal set; }
+		public static Func<string, string> ResourceProvider {
+			get { return resourceProvider; }
+			internal set {
+				DesignMode.DesignModeEnabled = true;
+				resourceProvider = value;
+			}
+		}
+
 		internal static Action<Exception> ExceptionHandler { get; set; }
 	}
 }

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -47,6 +47,7 @@ namespace Xamarin.Forms.Xaml.Internals
 				xamlFileProvider = value;
 				//¯\_(ツ)_/¯ the previewer forgot to set that bool
 				DoNotThrowOnExceptions = value != null;
+				DesignMode.DesignModeEnabled = true;
 			}
 		}
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/DesignMode.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/DesignMode.xml
@@ -1,0 +1,34 @@
+<Type Name="DesignMode" FullName="Xamarin.Forms.DesignMode">
+  <TypeSignature Language="C#" Value="public static class DesignMode" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit DesignMode extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>Enables you to detect whether your app is running in a visual designer or previewer.</summary>
+    <remarks></remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="DesignModeEnabled">
+      <MemberSignature Language="C#" Value="public static bool DesignModeEnabled { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property bool DesignModeEnabled" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets a value that indicates whether the application is running in design or preview mode.</summary>
+        <value></value>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -196,6 +196,7 @@
       <Type Name="DependencyAttribute" Kind="Class" />
       <Type Name="DependencyFetchTarget" Kind="Enumeration" />
       <Type Name="DependencyService" Kind="Class" />
+      <Type Name="DesignMode" Kind="Class" />
       <Type Name="Device" Kind="Class" />
       <Type Name="Device+Styles" Kind="Class" />
       <Type Name="Easing" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###

Adds a static class and static bool for `DesignModeEnabled` to `Xamarin.Forms.Core`. This is to address the F100 Issue (fixes #1731). This is only intended to address programmatic checks by a developer. It does not cover things like `d:DesignHeight` or other designer aware XAML elements and attributes. 

Tooling would need to toggle the `DesignModeEnabled` property whenever appropriate so that developers can rely on it. 

### Bugs Fixed ###

N/A

### API Changes ###

Added:
 - `public static class DesignMode`
 - `public static bool DesignModeEnabled`

### Behavioral Changes ###

None.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
