### PR TITLE
Add ProgressColor on ProgressBar

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/ProgressBarCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/ProgressBarCoreGalleryPage.cs
@@ -20,8 +20,11 @@ namespace Xamarin.Forms.Controls
 		{
 			base.Build (stackLayout);
 
-			var progressContainer = new ViewContainer<ProgressBar> (Test.ProgressBar.Progress, new ProgressBar { Progress = 0.5 });
+			var progressContainer = new ViewContainer<ProgressBar>(Test.ProgressBar.Progress, new ProgressBar { Progress = 0.5 });
+			var colorContainer = new ViewContainer<ProgressBar>(Test.ProgressBar.ProgressColor, new ProgressBar { ProgressColor = Color.Lime, Progress = 0.5 });
+
 			Add (progressContainer);
+			Add(colorContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/NotifiedPropertiesTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/NotifiedPropertiesTests.cs
@@ -124,6 +124,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			new PropertyTestCase<Picker, string> ("Title", v=>v.Title, (v, o) =>v.Title = o, () => null, "FooBar"),
 			new PropertyTestCase<Picker, int> ("SelectedIndex", v=>v.SelectedIndex, (v, o) =>v.SelectedIndex = o, () => -1, 2, ()=>new Picker{Items= {"Foo", "Bar", "Baz", "Qux"}}),
 			new PropertyTestCase<ProgressBar, double> ("Progress", v => v.Progress, (v, o) => v.Progress = o, () => 0, .5),
+			new PropertyTestCase<ProgressBar, Color> ("ProgressColor", v => v.ProgressColor, (v, o) => v.ProgressColor = o, () => Color.Default, new Color (0, 1, 0)),
 			new PropertyTestCase<SearchBar, string> ("Placeholder", v => v.Placeholder, (v, o) => v.Placeholder = o, () => null, "Foo"),
 			new PropertyTestCase<SearchBar, string> ("Text", v => v.Text, (v, o) => v.Text = o, () => null, "Foo"),
 			new PropertyTestCase<Slider, double> ("Minimum", v => v.Minimum, (v, o) => v.Minimum = o, () => 0, .5),

--- a/Xamarin.Forms.Core/ProgressBar.cs
+++ b/Xamarin.Forms.Core/ProgressBar.cs
@@ -8,13 +8,21 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_ProgressBarRenderer))]
 	public class ProgressBar : View, IElementConfiguration<ProgressBar>
 	{
-		public static readonly BindableProperty ProgressProperty = BindableProperty.Create("Progress", typeof(double), typeof(ProgressBar), 0d, coerceValue: (bo, v) => ((double)v).Clamp(0, 1));
+		public static readonly BindableProperty ProgressColorProperty = BindableProperty.Create(nameof(ProgressColor), typeof(Color), typeof(ProgressBar), Color.Default);
+
+		public static readonly BindableProperty ProgressProperty = BindableProperty.Create(nameof(Progress), typeof(double), typeof(ProgressBar), 0d, coerceValue: (bo, v) => ((double)v).Clamp(0, 1));
 
 		readonly Lazy<PlatformConfigurationRegistry<ProgressBar>> _platformConfigurationRegistry;
 
 		public ProgressBar()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<ProgressBar>>(() => new PlatformConfigurationRegistry<ProgressBar>(this));
+		}
+
+		public Color ProgressColor
+		{
+			get { return (Color)GetValue(ProgressColorProperty); }
+			set { SetValue(ProgressColorProperty, value); }
 		}
 
 		public double Progress

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -609,7 +609,8 @@ namespace Xamarin.Forms.CustomAttributes
 		}
 
 		public enum ProgressBar {
-			Progress
+			Progress,
+			ProgressColor
 		}
 
 		public enum RelativeLayout {

--- a/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
@@ -1,6 +1,9 @@
 using System;
 using System.ComponentModel;
 using Android.Content;
+using Android.Content.Res;
+using Android.Graphics;
+using Android.OS;
 using AProgressBar = Android.Widget.ProgressBar;
 
 namespace Xamarin.Forms.Platform.Android
@@ -35,6 +38,8 @@ namespace Xamarin.Forms.Platform.Android
 
 					SetNativeControl(progressBar);
 				}
+
+				UpdateProgressColor();
 				UpdateProgress();
 			}
 		}
@@ -45,6 +50,38 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (e.PropertyName == ProgressBar.ProgressProperty.PropertyName)
 				UpdateProgress();
+			else if (e.PropertyName == ProgressBar.ProgressColorProperty.PropertyName)
+				UpdateProgressColor();
+		}
+
+		void UpdateProgressColor()
+		{
+			if (Element == null || Control == null)
+				return;
+
+			Color color = Element.ProgressColor;
+
+			if (color.IsDefault)
+			{
+				(Control.Indeterminate ? Control.IndeterminateDrawable : 
+					Control.ProgressDrawable).ClearColorFilter();
+			}
+			else
+			{
+				if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
+				{
+					(Control.Indeterminate ? Control.IndeterminateDrawable :
+						Control.ProgressDrawable).SetColorFilter(color.ToAndroid(), PorterDuff.Mode.SrcIn);
+				}
+				else
+				{
+					var tintList = ColorStateList.ValueOf(color.ToAndroid());
+					if (Control.Indeterminate)
+						Control.IndeterminateTintList = tintList;
+					else
+						Control.ProgressTintList = tintList;
+				}
+			}
 		}
 
 		void UpdateProgress()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ProgressBarRenderer.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					MinValue = 0,
 					MaxValue = 1
 				});
+			UpdateProgressColor();
 			UpdateProgress();
 		}
 
@@ -28,8 +29,15 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == ProgressBar.ProgressProperty.PropertyName)
+			if (e.PropertyName == ProgressBar.ProgressColorProperty.PropertyName)
+				UpdateProgressColor();
+			else if (e.PropertyName == ProgressBar.ProgressProperty.PropertyName)
 				UpdateProgress();
+		}
+
+		void UpdateProgressColor()
+		{
+			SetBackgroundColor(Element.ProgressColor);
 		}
 
 		protected override void SetBackgroundColor(Color color)
@@ -37,13 +45,18 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (Control == null)
 				return;
 
-			if (s_currentColorFilter == null && color.IsDefault)
-				return;
-
 			if (color.IsDefault)
-				Control.ContentFilters = new CIFilter[0];
+			{
+				if (s_currentColorFilter != null && Element.BackgroundColor.IsDefault && Element.ProgressColor.IsDefault)
+				{
+					Control.ContentFilters = new CIFilter[0];
+					s_currentColor = null;
+				}
 
-			var newColor = Element.BackgroundColor.ToNSColor();
+				return;
+			}
+
+			var newColor = color.ToNSColor();
 			if (Equals(s_currentColor, newColor))
 				return;
 

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ProgressBarRenderer.cs
@@ -3,11 +3,19 @@ using System.ComponentModel;
 using SpecificVE = Xamarin.Forms.PlatformConfiguration.TizenSpecific.VisualElement;
 using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.ProgressBar;
 using EProgressBar = ElmSharp.ProgressBar;
+using EColor = ElmSharp.Color;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
 	public class ProgressBarRenderer : ViewRenderer<ProgressBar, EProgressBar>
 	{
+		static readonly EColor s_defaultColor = new EColor(129, 198, 255);
+
+		public ProgressBarRenderer()
+		{
+			RegisterPropertyHandler(ProgressBar.ProgressColorProperty, UpdateProgressColor);
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<ProgressBar> e)
 		{
 			if (Control == null)
@@ -58,6 +66,14 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				UpdatePulsingStatus();
 			}
+		}
+
+		void UpdateProgressColor(bool initialize)
+		{
+			if (initialize && Element.ProgressColor.IsDefault)
+				return;
+
+			Control.Color = Element.ProgressColor == Color.Default ? s_defaultColor : Element.ProgressColor.ToNative();
 		}
 
 		void UpdateProgress()

--- a/Xamarin.Forms.Platform.UAP/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ProgressBarRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Primitives;
 using Xamarin.Forms.Internals;
 
@@ -6,6 +7,8 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public class ProgressBarRenderer : ViewRenderer<ProgressBar, Windows.UI.Xaml.Controls.ProgressBar>
 	{
+		object _foregroundDefault;
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
@@ -13,6 +16,7 @@ namespace Xamarin.Forms.Platform.UWP
 				if (Control != null)
 				{
 					Control.ValueChanged -= ProgressBarOnValueChanged;
+					Control.Loaded -= OnControlLoaded;
 				}
 			}
 
@@ -23,6 +27,14 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			base.OnElementChanged(e);
 
+			if (e.OldElement != null)
+			{
+				if (Control != null)
+				{
+					Control.Loaded -= OnControlLoaded;
+				}
+			}
+
 			if (e.NewElement != null)
 			{
 				if (Control == null)
@@ -32,6 +44,8 @@ namespace Xamarin.Forms.Platform.UWP
 					progressBar.ValueChanged += ProgressBarOnValueChanged;
 
 					SetNativeControl(progressBar);
+
+					Control.Loaded += OnControlLoaded;
 				}
 
 				Control.Value = e.NewElement.Progress;
@@ -47,6 +61,28 @@ namespace Xamarin.Forms.Platform.UWP
 				Control.Value = Element.Progress;
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
+			else if (e.PropertyName == ProgressBar.ProgressColorProperty.PropertyName)
+				UpdateProgressColor();
+		}
+
+		void OnControlLoaded(object sender, RoutedEventArgs routedEventArgs)
+		{
+			_foregroundDefault = Control.GetForegroundCache();
+			UpdateProgressColor();
+		}
+
+		void UpdateProgressColor()
+		{
+			Color color = Element.ProgressColor;
+
+			if (color.IsDefault)
+			{
+				Control.RestoreForegroundCache(_foregroundDefault);
+			}
+			else
+			{
+				Control.Foreground = color.ToBrush();
+			}
 		}
 
 		void ProgressBarOnValueChanged(object sender, RangeBaseValueChangedEventArgs rangeBaseValueChangedEventArgs)

--- a/Xamarin.Forms.Platform.WPF/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ProgressBarRenderer.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
 using System.Windows;
-using System.Windows.Media;
 using Xamarin.Forms.Internals;
 using WProgressBar = System.Windows.Controls.ProgressBar;
 
@@ -19,12 +13,13 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				if (Control == null) // construct and SetNativeControl and suscribe control event
 				{
-					SetNativeControl(new WProgressBar { Minimum = 0, Maximum = 1, Foreground = Brushes.DeepSkyBlue });
+					SetNativeControl(new WProgressBar { Minimum = 0, Maximum = 1 });
 					Control.ValueChanged += HandleValueChanged;
 				}
 
 				// Update control property 
 				UpdateProgress();
+				UpdateProgressColor();
 			}
 
 			base.OnElementChanged(e);
@@ -36,8 +31,15 @@ namespace Xamarin.Forms.Platform.WPF
 
 			if (e.PropertyName == ProgressBar.ProgressProperty.PropertyName)
 				UpdateProgress();
+			else if (e.PropertyName == ProgressBar.ProgressColorProperty.PropertyName)
+				UpdateProgressColor();
 		}
-		
+
+		void UpdateProgressColor()
+		{
+			Control.UpdateDependencyColor(WProgressBar.ForegroundProperty, Element.ProgressColor.IsDefault ? Color.DeepSkyBlue : Element.ProgressColor);
+		}
+
 		void UpdateProgress()
 		{
 			Control.Value = Element.Progress;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ProgressBarRenderer.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (Control == null)
 					SetNativeControl(new UIProgressView(UIProgressViewStyle.Default));
 
+				UpdateProgressColor();
 				UpdateProgress();
 			}
 
@@ -31,7 +32,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == ProgressBar.ProgressProperty.PropertyName)
+			if (e.PropertyName == ProgressBar.ProgressColorProperty.PropertyName)
+				UpdateProgressColor();
+			else if (e.PropertyName == ProgressBar.ProgressProperty.PropertyName)
 				UpdateProgress();
 		}
 
@@ -43,6 +46,11 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			Control.TrackTintColor = color != Color.Default ? color.ToUIColor() : null;
+		}
+
+		void UpdateProgressColor()
+		{
+			Control.ProgressTintColor = Element.ProgressColor == Color.Default ? null : Element.ProgressColor.ToUIColor();
 		}
 
 		void UpdateProgress()

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ProgressBar.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ProgressBar.xml
@@ -52,6 +52,12 @@ Debug.WriteLine ("Animation completed");
           <description>Value</description>
         </listheader>
         <item>
+          <term>Color</term>
+          <description>
+            <para>A color specification, with or without the prefix, "Color". For example, "Color.Red" and "Red" both specify the color red.</para>
+          </description>
+        </item>
+        <item>
           <term>Progress</term>
           <description>
             <para>A decimal value between 0 and 1, inclusive, that specifies the fraction of the bar that is colored.</para>
@@ -126,6 +132,39 @@ Debug.WriteLine ("Animation completed");
         <summary>Gets or sets the progress value. This is s bindable property.</summary>
         <value>Gets or sets a value that specifies the fraction of the bar that is colored.</value>
         <remarks>Values less than 0 or larger than 1 will be clamped to the range [0-1].</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ProgressColor">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.Color ProgressColor { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.Color ProgressColor" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets the <see cref="T:Xamarin.Forms.Color" /> of the ProgressBar line. This is a bindable property.</summary>
+        <value>A <see cref="T:Xamarin.Forms.Color" /> used to display the ProgressBar line. Default is <see cref="P:Xamarin.Forms.Color.Default" />.</value>
+        <remarks>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ProgressColorProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ProgressColorProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ProgressColorProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Identifies the ProgressColor bindable property.</summary>
+        <remarks>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ProgressProperty">


### PR DESCRIPTION
# Description of Change #

This PR adds the `ProgressColor` bindable property to the `ProgressBar` control.

### Bugs Fixed ###

 - fixes #1690

### API Changes ###

Added:
 - `BindableProperty ProgressBar.ProgressColorProperty;`
 - `Color ProgressBar.ProgressColor { get; set; } //Bindable Property`

Changed:
 - None

### Behavioral Changes ###

 - None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

### Supported Platforms ###

- [x] Android
- [x] iOS
- [x] UWP
- [x] WPF
- [x] macOS
- [x] Tizen
- [ ] GTK

### Remarks ###

 - On Android API 21+ `ColorStateList` is used instead of `SetColorFilter` in order to apply the color tinting to the progress line only
 - The Android Renderer manages both the `Determinate` and `Intederminate` state
 - NOP on GTK due to some constraints when overriding the default GtkWidget style
 - Not every platform exposes APIs to change the track appearance. Shouldn't the TrackColor feature be implemented in a platform-specific fashion?