### PR TITLE
[Android] Allow customizing Android MenuItem

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -468,7 +468,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				ResetToolbar();
 		}
 
-		void HandleToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void HandleToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == MenuItem.IsEnabledProperty.PropertyName || e.PropertyName == MenuItem.TextProperty.PropertyName || e.PropertyName == MenuItem.IconProperty.PropertyName)
 				UpdateMenu();
@@ -792,17 +792,35 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else
 				{
 					IMenuItem menuItem = menu.Add(item.Text);
-					FileImageSource icon = item.Icon;
-					if (!string.IsNullOrEmpty(icon))
-					{
-						Drawable iconDrawable = context.GetFormsDrawable(icon);
-						if (iconDrawable != null)
-							menuItem.SetIcon(iconDrawable);
-					}
+					UpdateDrawableMenuItem(context, menuItem, item);
 					menuItem.SetEnabled(controller.IsEnabled);
 					menuItem.SetShowAsAction(ShowAsAction.Always);
 					menuItem.SetOnMenuItemClickListener(new GenericMenuClickListener(controller.Activate));
 				}
+			}
+		}
+
+		/// <summary>
+		/// For override specify tint color menu or specify drawable menu
+		/// Sample:
+		/// base.UpdateMenuItem(...)
+		/// menuItem.Icon.Mutate();
+		/// menuItem.Icon.SetColorFilter(this.Resources.GetColor([ResourceColor]), Android.Graphics.PorterDuff.Mode.SrcIn);
+		/// 
+		/// Sample with drawable badge count:
+		/// menuItem.SetIcon(SetDrawableIcon(menuItem.Icon)));
+		/// 
+		/// In this fact, toolBarItem is necessary for access to custom property like badge count
+		/// </summary>
+		/// <param name="menuItem"></param>
+		protected virtual void UpdateDrawableMenuItem(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)
+		{
+			FileImageSource icon = toolBarItem.Icon;
+			if (!string.IsNullOrEmpty(icon))
+			{
+				Drawable iconDrawable = context.GetFormsDrawable(icon);
+				if (iconDrawable != null)
+					menuItem.SetIcon(iconDrawable);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -807,7 +807,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				Drawable iconDrawable = context.GetFormsDrawable(icon);
 				if (iconDrawable != null)
+				{
 					menuItem.SetIcon(iconDrawable);
+					iconDrawable.Dispose();
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -468,7 +468,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				ResetToolbar();
 		}
 
-		protected virtual void HandleToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == MenuItem.IsEnabledProperty.PropertyName || e.PropertyName == MenuItem.TextProperty.PropertyName || e.PropertyName == MenuItem.IconProperty.PropertyName)
 				UpdateMenu();
@@ -776,13 +776,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			IMenu menu = bar.Menu;
 
 			foreach (ToolbarItem item in _toolbarTracker.ToolbarItems)
-				item.PropertyChanged -= HandleToolbarItemPropertyChanged;
+				item.PropertyChanged -= OnToolbarItemPropertyChanged;
 			menu.Clear();
 
 			foreach (ToolbarItem item in _toolbarTracker.ToolbarItems)
 			{
 				IMenuItemController controller = item;
-				item.PropertyChanged += HandleToolbarItemPropertyChanged;
+				item.PropertyChanged += OnToolbarItemPropertyChanged;
 				if (item.Order == ToolbarItemOrder.Secondary)
 				{
 					IMenuItem menuItem = menu.Add(item.Text);
@@ -792,7 +792,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else
 				{
 					IMenuItem menuItem = menu.Add(item.Text);
-					UpdateDrawableMenuItem(context, menuItem, item);
+					UpdateMenuItemIcon(context, menuItem, item);
 					menuItem.SetEnabled(controller.IsEnabled);
 					menuItem.SetShowAsAction(ShowAsAction.Always);
 					menuItem.SetOnMenuItemClickListener(new GenericMenuClickListener(controller.Activate));
@@ -800,20 +800,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 
-		/// <summary>
-		/// For override specify tint color menu or specify drawable menu
-		/// Sample:
-		/// base.UpdateMenuItem(...)
-		/// menuItem.Icon.Mutate();
-		/// menuItem.Icon.SetColorFilter(this.Resources.GetColor([ResourceColor]), Android.Graphics.PorterDuff.Mode.SrcIn);
-		/// 
-		/// Sample with drawable badge count:
-		/// menuItem.SetIcon(SetDrawableIcon(menuItem.Icon)));
-		/// 
-		/// In this fact, toolBarItem is necessary for access to custom property like badge count
-		/// </summary>
-		/// <param name="menuItem"></param>
-		protected virtual void UpdateDrawableMenuItem(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)
+		protected virtual void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)
 		{
 			FileImageSource icon = toolBarItem.Icon;
 			if (!string.IsNullOrEmpty(icon))


### PR DESCRIPTION
### Description of Change ###

Allow customizing Android MenuItem with tintcolor and custom drawable.

### API Changes ###
Added:
 - protected virtual void UpdateDrawableMenuItem(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)

Changed:
- void HandleToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e) -> protected virtual void HandleToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
