### PR TITLE
[XamlC] Cache Resolve and ImportReference

### DIFF
--- a/Xamarin.Forms.Build.Tasks/BindablePropertyReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/BindablePropertyReferenceExtensions.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Build.Tasks
 												md.IsStatic &&
 												md.IsPublic &&
 												md.Parameters.Count == 1 &&
-												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.ImportReference(typeof(BindableObject))), module).SingleOrDefault()?.Item1;
+												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.ImportReferenceCached(typeof(BindableObject))), module).SingleOrDefault()?.Item1;
 			if (getter == null)
 				throw new XamlParseException($"Missing a public static Get{bpName} or a public instance property getter for the attached property \"{bpRef.DeclaringType}.{bpRef.Name}\"", iXmlLineInfo);
 			return getter.ResolveGenericReturnType(declaringTypeRef, module);
@@ -43,17 +43,17 @@ namespace Xamarin.Forms.Build.Tasks
 												md.IsStatic &&
 												md.IsPublic &&
 												md.Parameters.Count == 1 &&
-												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.ImportReference(typeof(BindableObject))), module).SingleOrDefault()?.Item1;
+												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.ImportReferenceCached(typeof(BindableObject))), module).SingleOrDefault()?.Item1;
 
 			var attributes = new List<CustomAttribute>();
 			if (property != null && property.HasCustomAttributes)
 				attributes.AddRange(property.CustomAttributes);
-			if (propertyType != null && propertyType.Resolve().HasCustomAttributes)
-				attributes.AddRange(propertyType.Resolve().CustomAttributes);
+			if (propertyType != null && propertyType.ResolveCached().HasCustomAttributes)
+				attributes.AddRange(propertyType.ResolveCached().CustomAttributes);
 			if (staticGetter != null && staticGetter.HasCustomAttributes)
 				attributes.AddRange(staticGetter.CustomAttributes);
-			if (staticGetter != null && staticGetter.ReturnType.Resolve().HasCustomAttributes)
-				attributes.AddRange(staticGetter.ReturnType.Resolve().CustomAttributes);
+			if (staticGetter != null && staticGetter.ReturnType.ResolveCached().HasCustomAttributes)
+				attributes.AddRange(staticGetter.ReturnType.ResolveCached().CustomAttributes);
 
 			return attributes.FirstOrDefault(cad => TypeConverterAttribute.TypeConvertersType.Contains(cad.AttributeType.FullName))?.ConstructorArguments [0].Value as TypeReference;
 		}

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BindingTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BindingTypeConverter.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Core.XamlC
 			if (IsNullOrEmpty(value))
 				throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(Binding)}", node);
 
-			var bindingCtor = module.ImportReference(typeof(Binding)).Resolve().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 6);
+			var bindingCtor = module.ImportReferenceCached(typeof(Binding)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 6);
 			var bindingCtorRef = module.ImportReference(bindingCtor);
 
 			yield return Instruction.Create(OpCodes.Ldstr, value);

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Forms.Core.XamlC
 			yield return Instruction.Create(OpCodes.Ldc_R8, w);
 			yield return Instruction.Create(OpCodes.Ldc_R8, h);
 
-			var rectangleCtor = module.ImportReference(typeof(Rectangle)).Resolve().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 4);
+			var rectangleCtor = module.ImportReferenceCached(typeof(Rectangle)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 4);
 			var rectangleCtorRef = module.ImportReference(rectangleCtor);
 			yield return Instruction.Create(OpCodes.Newobj, rectangleCtorRef);
 		}

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ColorTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ColorTypeConverter.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Core.XamlC
 					yield return Instruction.Create(OpCodes.Ldc_R8, color.G);
 					yield return Instruction.Create(OpCodes.Ldc_R8, color.B);
 					yield return Instruction.Create(OpCodes.Ldc_R8, color.A);
-					var colorCtor = module.ImportReference(typeof(Color)).Resolve().Methods.FirstOrDefault(
+					var colorCtor = module.ImportReferenceCached(typeof(Color)).ResolveCached().Methods.FirstOrDefault(
 						md => md.IsConstructor && md.Parameters.Count == 4 &&
 						md.Parameters.All(p => p.ParameterType.FullName == "System.Double"));
 					var colorCtorRef = module.ImportReference(colorCtor);
@@ -39,12 +39,12 @@ namespace Xamarin.Forms.Core.XamlC
 				if (parts.Length == 1 || (parts.Length == 2 && parts [0] == "Color")) {
 					var color = parts [parts.Length - 1];
 
-					var field = module.ImportReference(typeof(Color)).Resolve().Fields.SingleOrDefault(fd => fd.Name == color && fd.IsStatic);
+					var field = module.ImportReferenceCached(typeof(Color)).ResolveCached().Fields.SingleOrDefault(fd => fd.Name == color && fd.IsStatic);
 					if (field != null) {
 						yield return Instruction.Create(OpCodes.Ldsfld, module.ImportReference(field));
 						yield break;
 					}
-					var propertyGetter = module.ImportReference(typeof(Color)).Resolve().Properties.SingleOrDefault(pd => pd.Name == color && pd.GetMethod.IsStatic)?.GetMethod;
+					var propertyGetter = module.ImportReferenceCached(typeof(Color)).ResolveCached().Properties.SingleOrDefault(pd => pd.Name == color && pd.GetMethod.IsStatic)?.GetMethod;
 					if (propertyGetter != null) {
 						yield return Instruction.Create(OpCodes.Call, module.ImportReference(propertyGetter));
 						yield break;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Core.XamlC
 
 			yield return Instruction.Create(OpCodes.Ldc_R8, size);
 
-			var constantDef = module.ImportReference(typeof(Constraint)).Resolve().Methods.FirstOrDefault(md => md.IsStatic && md.Name == "Constant");
+			var constantDef = module.ImportReferenceCached(typeof(Constraint)).ResolveCached().Methods.FirstOrDefault(md => md.IsStatic && md.Name == "Constant");
 			var constantRef = module.ImportReference(constantDef);
 			yield return Instruction.Create(OpCodes.Call, constantRef);
 		}

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/LayoutOptionsConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/LayoutOptionsConverter.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Core.XamlC
 				if (parts.Length == 1 || (parts.Length == 2 && parts [0] == "LayoutOptions")) {
 					var options = parts [parts.Length - 1];
 
-					var field = module.ImportReference(typeof(LayoutOptions)).Resolve().Fields.SingleOrDefault(fd => fd.Name == options && fd.IsStatic);
+					var field = module.ImportReferenceCached(typeof(LayoutOptions)).ResolveCached().Fields.SingleOrDefault(fd => fd.Name == options && fd.IsStatic);
 					if (field != null) {
 						yield return Instruction.Create(OpCodes.Ldsfld, module.ImportReference(field));
 						yield break;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ListStringTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ListStringTypeConverter.cs
@@ -22,13 +22,13 @@ namespace Xamarin.Forms.Core.XamlC
 			}
 			var parts = value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToList();
 
-			var listCtor = module.ImportReference(typeof(List<>)).Resolve().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 1 && md.Parameters[0].ParameterType.FullName == "System.Int32");
+			var listCtor = module.ImportReferenceCached(typeof(List<>)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 1 && md.Parameters[0].ParameterType.FullName == "System.Int32");
 			var listCtorRef = module.ImportReference(listCtor);
-			listCtorRef = module.ImportReference(listCtorRef.ResolveGenericParameters(module.ImportReference(typeof(List<string>)), module));
+			listCtorRef = module.ImportReference(listCtorRef.ResolveGenericParameters(module.ImportReferenceCached(typeof(List<string>)), module));
 
-			var adder = module.ImportReference(typeof(ICollection<>)).Resolve().Methods.FirstOrDefault(md => md.Name == "Add" && md.Parameters.Count == 1);
+			var adder = module.ImportReferenceCached(typeof(ICollection<>)).ResolveCached().Methods.FirstOrDefault(md => md.Name == "Add" && md.Parameters.Count == 1);
 			var adderRef = module.ImportReference(adder);
-			adderRef = module.ImportReference(adderRef.ResolveGenericParameters(module.ImportReference(typeof(ICollection<string>)), module));
+			adderRef = module.ImportReference(adderRef.ResolveGenericParameters(module.ImportReferenceCached(typeof(ICollection<string>)), module));
 
 			yield return Instruction.Create(OpCodes.Ldc_I4, parts.Count);
 			yield return Instruction.Create(OpCodes.Newobj, listCtorRef);

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
@@ -44,15 +44,15 @@ namespace Xamarin.Forms.Core.XamlC
 
 			//keep the Uri for later
 			yield return Create(Dup);
-			var uriVarDef = new VariableDefinition(module.ImportReference(typeof(Uri)));
+			var uriVarDef = new VariableDefinition(module.ImportReferenceCached(typeof(Uri)));
 			body.Variables.Add(uriVarDef);
 			yield return Create(Stloc, uriVarDef);
 
 			yield return Create(Ldstr, resourcePath); //resourcePath
 
-			var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
-			var getTypeInfo = module.ImportReference(typeof(System.Reflection.IntrospectionExtensions).GetMethod("GetTypeInfo", new Type[] { typeof(Type) }));
-			var getAssembly = module.ImportReference(typeof(System.Reflection.TypeInfo).GetProperty("Assembly").GetMethod);
+			var getTypeFromHandle = module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
+			var getTypeInfo = module.ImportReferenceCached(typeof(System.Reflection.IntrospectionExtensions).GetMethod("GetTypeInfo", new Type[] { typeof(Type) }));
+			var getAssembly = module.ImportReferenceCached(typeof(System.Reflection.TypeInfo).GetProperty("Assembly").GetMethod);
 			yield return Create(Ldtoken, module.ImportReference(((ILRootNode)rootNode).TypeReference));
 			yield return Create(Call, module.ImportReference(getTypeFromHandle));
 			yield return Create(Call, module.ImportReference(getTypeInfo));
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Core.XamlC
 			foreach (var instruction in node.PushXmlLineInfo(context))
 				yield return instruction; //lineinfo
 
-			var setAndLoadSource = module.ImportReference(typeof(ResourceDictionary).GetMethod("SetAndLoadSource"));
+			var setAndLoadSource = module.ImportReferenceCached(typeof(ResourceDictionary).GetMethod("SetAndLoadSource"));
 			yield return Create(Callvirt, module.ImportReference(setAndLoadSource));
 
 			//ldloc the stored uri as return value
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Core.XamlC
 		internal static string GetPathForType(ModuleDefinition module, TypeReference type)
 		{
 			foreach (var ca in type.Module.GetCustomAttributes()) {
-				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReference(typeof(XamlResourceIdAttribute))))
+				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReferenceCached(typeof(XamlResourceIdAttribute))))
 					continue;
 				if (!TypeRefComparer.Default.Equals(ca.ConstructorArguments[2].Value as TypeReference, type))
 					continue;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RectangleTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RectangleTypeConverter.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Core.XamlC
 			yield return Instruction.Create(OpCodes.Ldc_R8, w);
 			yield return Instruction.Create(OpCodes.Ldc_R8, h);
 
-			var rectangleCtor = module.ImportReference(typeof(Rectangle)).Resolve().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 4);
+			var rectangleCtor = module.ImportReferenceCached(typeof(Rectangle)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 4);
 			var rectangleCtorRef = module.ImportReference(rectangleCtor);
 			yield return Instruction.Create(OpCodes.Newobj, rectangleCtorRef);
 		}

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ThicknessTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ThicknessTypeConverter.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Core.XamlC
 		{
 			foreach (var d in args)
 				yield return Instruction.Create(OpCodes.Ldc_R8, d);
-			var thicknessCtor = module.ImportReference(typeof(Thickness)).Resolve().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == args.Length);
+			var thicknessCtor = module.ImportReferenceCached(typeof(Thickness)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == args.Length);
 			var thicknessCtorRef = module.ImportReference(thicknessCtor);
 			yield return Instruction.Create(OpCodes.Newobj, thicknessCtorRef);
 		}

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/TypeTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/TypeTypeConverter.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Core.XamlC
 			if (typeRef == null)
 				goto error;
 
-			var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
+			var getTypeFromHandle = module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
 			yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReference(typeRef));
 			yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
 			yield break;

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/UriTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/UriTypeConverter.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Core.XamlC
 				yield break;
 			}
 
-			var uriCtor = module.ImportReference(typeof(Uri)).Resolve().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 2 && md.Parameters[1].ParameterType.FullName == "System.UriKind");
+			var uriCtor = module.ImportReferenceCached(typeof(Uri)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 2 && md.Parameters[1].ParameterType.FullName == "System.UriKind");
 			var uriCtorRef = module.ImportReference(uriCtor);
 
 			yield return Create(Ldstr, value);

--- a/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Build.Tasks
 					return new [] { Instruction.Create(OpCodes.Ldc_I8, (ulong)fieldDef.Constant) };
 
 				//enum values
-				if (memberRef.Resolve().IsEnum) {
+				if (memberRef.ResolveCached().IsEnum) {
 					if (fieldDef.Constant is long)
 						return new [] { Instruction.Create(OpCodes.Ldc_I8, (long)fieldDef.Constant) };
 					if (fieldDef.Constant is ulong)

--- a/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/TypeExtension.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/TypeExtension.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Build.Tasks
 	{
 		public IEnumerable<Instruction> ProvideValue(IElementNode node, ModuleDefinition module, ILContext context, out TypeReference memberRef)
 		{
-			memberRef = module.ImportReference(typeof(Type));
+			memberRef = module.ImportReferenceCached(typeof(Type));
 			INode typeNameNode;
 
 			var name = new XmlName("", "TypeName");
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 			context.TypeExtensions[node] = typeref;
 
-			var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
+			var getTypeFromHandle = module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
 			return new List<Instruction> {
 				Instruction.Create(OpCodes.Ldtoken, module.ImportReference(typeref)),
 				Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle))

--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Core.XamlC
 			var value = ((string)((ValueNode)valueNode).Value);
 
 			TypeReference _;
-			var setValueRef = module.ImportReference(module.ImportReference(typeof(Setter)).GetProperty(p => p.Name == "Value", out _).SetMethod);
+			var setValueRef = module.ImportReference(module.ImportReferenceCached(typeof(Setter)).GetProperty(p => p.Name == "Value", out _).SetMethod);
 
 			//push the setter
 			yield return Instruction.Create(OpCodes.Ldloc, vardefref.VariableDefinition);

--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/StyleSheetProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/StyleSheetProvider.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Core.XamlC
 				var style = (styleNode as ValueNode).Value as string;
 				yield return Create(Ldstr, style);
 
-				var fromString = module.ImportReference(typeof(StyleSheets.StyleSheet).GetMethods().FirstOrDefault(mi => mi.Name == nameof(StyleSheets.StyleSheet.FromString) && mi.GetParameters().Length == 1));
+				var fromString = module.ImportReferenceCached(typeof(StyleSheets.StyleSheet).GetMethods().FirstOrDefault(mi => mi.Name == nameof(StyleSheets.StyleSheet.FromString) && mi.GetParameters().Length == 1));
 				yield return Create(Call, module.ImportReference(fromString));
 			}
 			else {
@@ -65,8 +65,8 @@ namespace Xamarin.Forms.Core.XamlC
 				if (resourceId == null)
 					throw new XamlParseException($"Resource '{source}' not found.", node);
 
-				var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle), new[] { typeof(RuntimeTypeHandle) }));
-				var getAssembly = module.ImportReference(typeof(Type).GetProperty(nameof(Type.Assembly)).GetGetMethod());
+				var getTypeFromHandle = module.ImportReferenceCached(typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle), new[] { typeof(RuntimeTypeHandle) }));
+				var getAssembly = module.ImportReferenceCached(typeof(Type).GetProperty(nameof(Type.Assembly)).GetGetMethod());
 				yield return Create(Ldtoken, module.ImportReference(((ILRootNode)rootNode).TypeReference));
 				yield return Create(Call, module.ImportReference(getTypeFromHandle));
 				yield return Create(Callvirt, module.ImportReference(getAssembly)); //assembly
@@ -76,12 +76,12 @@ namespace Xamarin.Forms.Core.XamlC
 				foreach (var instruction in node.PushXmlLineInfo(context))
 					yield return instruction; //lineinfo
 
-				var fromAssemblyResource = module.ImportReference(typeof(StyleSheets.StyleSheet).GetMethods().FirstOrDefault(mi => mi.Name == nameof(StyleSheets.StyleSheet.FromAssemblyResource) && mi.GetParameters().Length == 3));
+				var fromAssemblyResource = module.ImportReferenceCached(typeof(StyleSheets.StyleSheet).GetMethods().FirstOrDefault(mi => mi.Name == nameof(StyleSheets.StyleSheet.FromAssemblyResource) && mi.GetParameters().Length == 3));
 				yield return Create(Call, module.ImportReference(fromAssemblyResource));
 			}
 
 			//the variable is of type `object`. fix that
-			var vardef = new VariableDefinition(module.ImportReference(typeof(StyleSheets.StyleSheet)));
+			var vardef = new VariableDefinition(module.ImportReferenceCached(typeof(StyleSheets.StyleSheet)));
 			yield return Create(Stloc, vardef);
 			vardefref.VariableDefinition = vardef;
 		}

--- a/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/DebugXamlCTask.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Forms.Build.Tasks
 						var ret = Instruction.Create(OpCodes.Ret);
 						il.Emit(OpCodes.Ldarg_0);
 						il.Emit(OpCodes.Callvirt,
-							module.ImportReference(typeDef.BaseType.Resolve().GetConstructors().First(c => c.HasParameters == false)));
+						        module.ImportReference(typeDef.BaseType.Resolve().GetConstructors().First(c => c.HasParameters == false)));
 
 						il.Emit(OpCodes.Nop);
 						il.Emit(OpCodes.Ldarg_1);

--- a/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Mono.Cecil;
+
+namespace Xamarin.Forms.Build.Tasks
+{
+	static class ModuleDefinitionExtensions
+	{
+		static readonly Dictionary<Tuple<ModuleDefinition, System.Reflection.MethodBase>, MethodReference> MbMr =
+			new Dictionary<Tuple<ModuleDefinition, System.Reflection.MethodBase>, MethodReference>();
+
+		static readonly Dictionary<Tuple<ModuleDefinition, Type>, TypeReference> TTr =
+			new Dictionary<Tuple<ModuleDefinition, Type>, TypeReference>();
+
+		public static MethodReference ImportReferenceCached(this ModuleDefinition module, System.Reflection.MethodBase method)
+		{
+			var key = new Tuple<ModuleDefinition, System.Reflection.MethodBase>(module, method);
+			if (MbMr.TryGetValue(key, out var result))
+				return result;
+			return MbMr[key] = module.ImportReference(method);
+		}
+
+		public static TypeReference ImportReferenceCached(this ModuleDefinition module, Type type)
+		{
+			var key = new Tuple<ModuleDefinition, Type>(module, type);
+			if (TTr.TryGetValue(key, out var result))
+				return result;
+			return TTr[key] = module.ImportReference(type);
+		}
+	}
+}

--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 			//If there's a [TypeConverter], use it
 			if (typeConverter != null && str != null) {
-				var typeConvAttribute = typeConverter.GetCustomAttribute(module.ImportReference(typeof(TypeConversionAttribute)));
+				var typeConvAttribute = typeConverter.GetCustomAttribute(module.ImportReferenceCached(typeof(TypeConversionAttribute)));
 				if (typeConvAttribute == null) //trust the unattributed TypeConverter
 					return true;
 				var toType = typeConvAttribute.ConstructorArguments.First().Value as TypeReference;
@@ -98,7 +98,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var str = (string)node.Value;
 
 			//If the TypeConverter has a ProvideCompiledAttribute that can be resolved, shortcut this
-			var compiledConverterName = typeConverter?.GetCustomAttribute (module.ImportReference(typeof(ProvideCompiledAttribute)))?.ConstructorArguments?.First().Value as string;
+			var compiledConverterName = typeConverter?.GetCustomAttribute (module.ImportReferenceCached(typeof(ProvideCompiledAttribute)))?.ConstructorArguments?.First().Value as string;
 			Type compiledConverterType;
 			if (compiledConverterName != null && (compiledConverterType = Type.GetType (compiledConverterName)) != null) {
 				var compiledConverter = Activator.CreateInstance (compiledConverterType);
@@ -115,14 +115,14 @@ namespace Xamarin.Forms.Build.Tasks
 			//If there's a [TypeConverter], use it
 			if (typeConverter != null)
 			{
-				var isExtendedConverter = typeConverter.ImplementsInterface(module.ImportReference(typeof (IExtendedTypeConverter)));
-				var typeConverterCtor = typeConverter.Resolve().Methods.Single(md => md.IsConstructor && md.Parameters.Count == 0 && !md.IsStatic);
+				var isExtendedConverter = typeConverter.ImplementsInterface(module.ImportReferenceCached(typeof (IExtendedTypeConverter)));
+				var typeConverterCtor = typeConverter.ResolveCached().Methods.Single(md => md.IsConstructor && md.Parameters.Count == 0 && !md.IsStatic);
 				var typeConverterCtorRef = module.ImportReference(typeConverterCtor);
 				var convertFromInvariantStringDefinition = isExtendedConverter
-					? module.ImportReference(typeof (IExtendedTypeConverter))
-						.Resolve()
+					? module.ImportReferenceCached(typeof (IExtendedTypeConverter))
+						.ResolveCached()
 						.Methods.FirstOrDefault(md => md.Name == "ConvertFromInvariantString" && md.Parameters.Count == 2)
-					: typeConverter.Resolve()
+					: typeConverter.ResolveCached()
 						.AllMethods()
 						.FirstOrDefault(md => md.Name == "ConvertFromInvariantString" && md.Parameters.Count == 1);
 				var convertFromInvariantStringReference = module.ImportReference(convertFromInvariantStringDefinition);
@@ -147,7 +147,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var originalTypeRef = targetTypeRef;
 			var isNullable = false;
 			MethodReference nullableCtor = null;
-			if (targetTypeRef.Resolve().FullName == "System.Nullable`1")
+			if (targetTypeRef.ResolveCached().FullName == "System.Nullable`1")
 			{
 				var nullableTypeRef = targetTypeRef;
 				targetTypeRef = ((GenericInstanceType)targetTypeRef).GenericArguments[0];
@@ -159,7 +159,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var implicitOperator = module.TypeSystem.String.GetImplicitOperatorTo(targetTypeRef, module);
 
 			//Obvious Built-in conversions
-			if (targetTypeRef.Resolve().BaseType != null && targetTypeRef.Resolve().BaseType.FullName == "System.Enum")
+			if (targetTypeRef.ResolveCached().BaseType != null && targetTypeRef.ResolveCached().BaseType.FullName == "System.Enum")
 				yield return PushParsedEnum(targetTypeRef, str, node);
 			else if (targetTypeRef.FullName == "System.Char")
 				yield return Instruction.Create(OpCodes.Ldc_I4, Char.Parse(str));
@@ -192,8 +192,8 @@ namespace Xamarin.Forms.Build.Tasks
 				var ts = TimeSpan.Parse(str, CultureInfo.InvariantCulture);
 				var ticks = ts.Ticks;
 				var timeSpanCtor =
-					module.ImportReference(typeof(TimeSpan))
-						.Resolve()
+					module.ImportReferenceCached(typeof(TimeSpan))
+						.ResolveCached()
 						.Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 1);
 				var timeSpanCtorRef = module.ImportReference(timeSpanCtor);
 
@@ -203,8 +203,8 @@ namespace Xamarin.Forms.Build.Tasks
 				var dt = DateTime.Parse(str, CultureInfo.InvariantCulture);
 				var ticks = dt.Ticks;
 				var dateTimeCtor =
-					module.ImportReference(typeof(DateTime))
-						.Resolve()
+					module.ImportReferenceCached(typeof(DateTime))
+						.ResolveCached()
 						.Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 1);
 				var dateTimeCtorRef = module.ImportReference(dateTimeCtor);
 
@@ -219,7 +219,7 @@ namespace Xamarin.Forms.Build.Tasks
 			else if (targetTypeRef.FullName == "System.Decimal") {
 				decimal outdecimal;
 				if (decimal.TryParse(str, NumberStyles.Number, CultureInfo.InvariantCulture, out outdecimal)) {
-					var vardef = new VariableDefinition(context.Body.Method.Module.ImportReference(typeof(decimal)));
+					var vardef = new VariableDefinition(context.Body.Method.Module.ImportReferenceCached(typeof(decimal)));
 					context.Body.Variables.Add(vardef);
 					//Use an extra temp var so we can push the value to the stack, just like other cases
 					//					IL_0003:  ldstr "adecimal"
@@ -231,16 +231,16 @@ namespace Xamarin.Forms.Build.Tasks
 					yield return Instruction.Create(OpCodes.Ldstr, str);
 					yield return Instruction.Create(OpCodes.Ldc_I4, 0x6f); //NumberStyles.Number
 					var getInvariantInfo =
-						context.Body.Method.Module.ImportReference(typeof(CultureInfo))
-							.Resolve()
+						context.Body.Method.Module.ImportReferenceCached(typeof(CultureInfo))
+							.ResolveCached()
 							.Properties.FirstOrDefault(pd => pd.Name == "InvariantCulture")
 							.GetMethod;
 					var getInvariant = context.Body.Method.Module.ImportReference(getInvariantInfo);
 					yield return Instruction.Create(OpCodes.Call, getInvariant);
 					yield return Instruction.Create(OpCodes.Ldloca, vardef);
 					var tryParseInfo =
-						context.Body.Method.Module.ImportReference(typeof(decimal))
-							.Resolve()
+						context.Body.Method.Module.ImportReferenceCached(typeof(decimal))
+							.ResolveCached()
 							.Methods.FirstOrDefault(md => md.Name == "TryParse" && md.Parameters.Count == 4);
 					var tryParse = context.Body.Method.Module.ImportReference(tryParseInfo);
 					yield return Instruction.Create(OpCodes.Call, tryParse);
@@ -249,8 +249,8 @@ namespace Xamarin.Forms.Build.Tasks
 				} else {
 					yield return Instruction.Create(OpCodes.Ldc_I4_0);
 					var decimalctorinfo =
-						context.Body.Method.Module.ImportReference(typeof(decimal))
-							.Resolve()
+						context.Body.Method.Module.ImportReferenceCached(typeof(decimal))
+							.ResolveCached()
 							.Methods.FirstOrDefault(
 								md => md.IsConstructor && md.Parameters.Count == 1 && md.Parameters[0].ParameterType.FullName == "System.Int32");
 					var decimalctor = context.Body.Method.Module.ImportReference(decimalctorinfo);
@@ -270,7 +270,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 		static Instruction PushParsedEnum(TypeReference enumRef, string value, IXmlLineInfo lineInfo)
 		{
-			var enumDef = enumRef.Resolve();
+			var enumDef = enumRef.ResolveCached();
 			if (!enumDef.IsEnum)
 				throw new InvalidOperationException();
 
@@ -364,10 +364,10 @@ namespace Xamarin.Forms.Build.Tasks
 			if (xmlLineInfo.HasLineInfo()) {
 				yield return Instruction.Create(OpCodes.Ldc_I4, xmlLineInfo.LineNumber);
 				yield return Instruction.Create(OpCodes.Ldc_I4, xmlLineInfo.LinePosition);
-				ctor = module.ImportReference(typeof(XmlLineInfo).GetConstructor(new[] { typeof(int), typeof(int) }));
+				ctor = module.ImportReferenceCached(typeof(XmlLineInfo).GetConstructor(new[] { typeof(int), typeof(int) }));
 			}
 			else
-				ctor = module.ImportReference(typeof(XmlLineInfo).GetConstructor(new Type[] { }));
+				ctor = module.ImportReferenceCached(typeof(XmlLineInfo).GetConstructor(new Type[] { }));
 			yield return Instruction.Create(OpCodes.Newobj, ctor);
 		}
 
@@ -417,7 +417,7 @@ namespace Xamarin.Forms.Build.Tasks
 			yield return Instruction.Create(OpCodes.Ldc_I4, nodes.Count);
 			yield return Instruction.Create(OpCodes.Add);
 			yield return Instruction.Create(OpCodes.Newarr, module.TypeSystem.Object);
-			var finalArray = new VariableDefinition(module.ImportReference(typeof (object[])));
+			var finalArray = new VariableDefinition(module.ImportReferenceCached(typeof (object[])));
 			context.Body.Variables.Add(finalArray);
 			yield return Instruction.Create(OpCodes.Stloc, finalArray);
 
@@ -431,8 +431,8 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Instruction.Create(OpCodes.Ldc_I4, nodes.Count); //destinationIndex
 				yield return Instruction.Create(OpCodes.Ldloc, parentObjectLength); //length
 				var arrayCopy =
-					module.ImportReference(typeof (Array))
-						.Resolve()
+					module.ImportReferenceCached(typeof (Array))
+						.ResolveCached()
 						.Methods.First(
 							md =>
 								md.Name == "Copy" && md.Parameters.Count == 5 &&
@@ -468,8 +468,8 @@ namespace Xamarin.Forms.Build.Tasks
 //				IL_0005:  call class [mscorlib]System.Type class [mscorlib] System.Type::GetTypeFromHandle(valuetype [mscorlib] System.RuntimeTypeHandle)
 //				IL_000a:  ldstr "Foo"
 //				IL_000f:  callvirt instance class [mscorlib] System.Reflection.PropertyInfo class [mscorlib] System.Type::GetProperty(string)
-				var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new [] { typeof(RuntimeTypeHandle) }));
-				var getPropertyInfo = module.ImportReference(typeof(Type).GetMethod("GetProperty", new [] { typeof(string) }));
+				var getTypeFromHandle = module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new [] { typeof(RuntimeTypeHandle) }));
+				var getPropertyInfo = module.ImportReferenceCached(typeof(Type).GetMethod("GetProperty", new [] { typeof(string) }));
 				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReference(declaringTypeReference ?? propertyRef.DeclaringType));
 				yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
 				yield return Instruction.Create(OpCodes.Ldstr, propertyRef.Name);
@@ -490,15 +490,15 @@ namespace Xamarin.Forms.Build.Tasks
 #endif
 
 			var ctorinfo = typeof (XamlServiceProvider).GetConstructor(new Type[] { });
-			var ctor = module.ImportReference(ctorinfo);
+			var ctor = module.ImportReferenceCached(ctorinfo);
 
 			var addServiceInfo = typeof (XamlServiceProvider).GetMethod("Add", new[] { typeof (Type), typeof (object) });
-			var addService = module.ImportReference(addServiceInfo);
+			var addService = module.ImportReferenceCached(addServiceInfo);
 
 			var getTypeFromHandle =
-				module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
-			var getTypeInfo = module.ImportReference(typeof(System.Reflection.IntrospectionExtensions).GetMethod("GetTypeInfo", new Type[] { typeof(Type)}));
-			var getAssembly = module.ImportReference(typeof(System.Reflection.TypeInfo).GetProperty("Assembly").GetMethod);
+				module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
+			var getTypeInfo = module.ImportReferenceCached(typeof(System.Reflection.IntrospectionExtensions).GetMethod("GetTypeInfo", new Type[] { typeof(Type)}));
+			var getAssembly = module.ImportReferenceCached(typeof(System.Reflection.TypeInfo).GetProperty("Assembly").GetMethod);
 
 			yield return Instruction.Create(OpCodes.Newobj, ctor);
 
@@ -507,7 +507,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (pushParentIl[pushParentIl.Count - 1].OpCode != OpCodes.Ldnull)
 			{
 				yield return Instruction.Create(OpCodes.Dup); //Keep the serviceProvider on the stack
-				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReference(typeof (IProvideValueTarget)));
+				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReferenceCached(typeof (IProvideValueTarget)));
 				yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
 
 				foreach (var instruction in pushParentIl)
@@ -517,7 +517,7 @@ namespace Xamarin.Forms.Build.Tasks
 					yield return instruction;
 
 				var targetProviderCtor =
-					module.ImportReference(typeof (SimpleValueTargetProvider).GetConstructor(new[] { typeof (object[]), typeof(object) }));
+					module.ImportReferenceCached(typeof (SimpleValueTargetProvider).GetConstructor(new[] { typeof (object[]), typeof(object) }));
 				yield return Instruction.Create(OpCodes.Newobj, targetProviderCtor);
 				yield return Instruction.Create(OpCodes.Callvirt, addService);
 			}
@@ -526,12 +526,12 @@ namespace Xamarin.Forms.Build.Tasks
 			if (context.Scopes.ContainsKey(node))
 			{
 				yield return Instruction.Create(OpCodes.Dup); //Dupicate the serviceProvider
-				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReference(typeof (INameScopeProvider)));
+				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReferenceCached(typeof (INameScopeProvider)));
 				yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
-				var namescopeProviderCtor = module.ImportReference(typeof (NameScopeProvider).GetConstructor(new Type[] { }));
+				var namescopeProviderCtor = module.ImportReferenceCached(typeof (NameScopeProvider).GetConstructor(new Type[] { }));
 				yield return Instruction.Create(OpCodes.Newobj, namescopeProviderCtor);
 				yield return Instruction.Create(OpCodes.Dup); //Duplicate the namescopeProvider
-				var setNamescope = module.ImportReference(typeof (NameScopeProvider).GetProperty("NameScope").GetSetMethod());
+				var setNamescope = module.ImportReferenceCached(typeof (NameScopeProvider).GetProperty("NameScope").GetSetMethod());
 
 				yield return Instruction.Create(OpCodes.Ldloc, context.Scopes[node].Item1);
 				yield return Instruction.Create(OpCodes.Callvirt, setNamescope);
@@ -542,10 +542,10 @@ namespace Xamarin.Forms.Build.Tasks
 			if (node.NamespaceResolver != null)
 			{
 				yield return Create(Dup); //Dupicate the serviceProvider
-				yield return Create(Ldtoken, module.ImportReference(typeof (IXamlTypeResolver)));
+				yield return Create(Ldtoken, module.ImportReferenceCached(typeof (IXamlTypeResolver)));
 				yield return Create(Call, module.ImportReference(getTypeFromHandle));
-				var xmlNamespaceResolverCtor = module.ImportReference(typeof (XmlNamespaceResolver).GetConstructor(new Type[] { }));
-				var addNamespace = module.ImportReference(typeof (XmlNamespaceResolver).GetMethod("Add"));
+				var xmlNamespaceResolverCtor = module.ImportReferenceCached(typeof (XmlNamespaceResolver).GetConstructor(new Type[] { }));
+				var addNamespace = module.ImportReferenceCached(typeof (XmlNamespaceResolver).GetMethod("Add"));
 				yield return Create(Newobj, xmlNamespaceResolverCtor);
 				foreach (var kvp in node.NamespaceResolver.GetNamespacesInScope(XmlNamespaceScope.ExcludeXml))
 				{
@@ -558,7 +558,7 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Create(Call, module.ImportReference(getTypeFromHandle));
 				yield return Create(Call, module.ImportReference(getTypeInfo));
 				yield return Create(Callvirt, getAssembly);
-				var xtr = module.ImportReference(typeof (XamlTypeResolver)).Resolve();
+				var xtr = module.ImportReferenceCached(typeof (XamlTypeResolver)).ResolveCached();
 				var xamlTypeResolverCtor = module.ImportReference(xtr.Methods.First(md => md.IsConstructor && md.Parameters.Count == 2));
 				yield return Create(Newobj, xamlTypeResolverCtor);
 				yield return Create(Callvirt, addService);
@@ -567,13 +567,13 @@ namespace Xamarin.Forms.Build.Tasks
 			if (node is IXmlLineInfo)
 			{
 				yield return Instruction.Create(OpCodes.Dup); //Dupicate the serviceProvider
-				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReference(typeof (IXmlLineInfoProvider)));
+				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReferenceCached(typeof (IXmlLineInfoProvider)));
 				yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
 
 				foreach (var instruction in node.PushXmlLineInfo(context))
 					yield return instruction;
 
-				var lip = module.ImportReference(typeof (XmlLineInfoProvider)).Resolve();
+				var lip = module.ImportReferenceCached(typeof (XmlLineInfoProvider)).ResolveCached();
 				var lineInfoProviderCtor = module.ImportReference(lip.Methods.First(md => md.IsConstructor && md.Parameters.Count == 1));
 				yield return Instruction.Create(OpCodes.Newobj, lineInfoProviderCtor);
 				yield return Instruction.Create(OpCodes.Callvirt, addService);

--- a/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Build.Tasks
 				namescopeVarDef = Context.Scopes[parentNode].Item1;
 				namesInNamescope = Context.Scopes[parentNode].Item2;
 			}
-			if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference(typeof (BindableObject))))
+			if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReferenceCached(typeof (BindableObject))))
 				SetNameScope(node, namescopeVarDef);
 			Context.Scopes[node] = new System.Tuple<VariableDefinition, IList<string>>(namescopeVarDef, namesInNamescope);
 		}
@@ -57,7 +57,7 @@ namespace Xamarin.Forms.Build.Tasks
 		{
 			var namescopeVarDef = CreateNamescope();
 			IList<string> namesInNamescope = new List<string>();
-			if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference(typeof (BindableObject))))
+			if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReferenceCached(typeof (BindableObject))))
 				SetNameScope(node, namescopeVarDef);
 			Context.Scopes[node] = new System.Tuple<VariableDefinition, IList<string>>(namescopeVarDef, namesInNamescope);
 		}
@@ -100,10 +100,10 @@ namespace Xamarin.Forms.Build.Tasks
 		VariableDefinition CreateNamescope()
 		{
 			var module = Context.Body.Method.Module;
-			var nsRef = module.ImportReference(typeof (NameScope));
+			var nsRef = module.ImportReferenceCached(typeof (NameScope));
 			var vardef = new VariableDefinition(nsRef);
 			Context.Body.Variables.Add(vardef);
-			var nsDef = nsRef.Resolve();
+			var nsDef = nsRef.ResolveCached();
 			var ctorinfo = nsDef.Methods.First(md => md.IsConstructor && !md.HasParameters);
 			var ctor = module.ImportReference(ctorinfo);
 			Context.IL.Emit(OpCodes.Newobj, ctor);
@@ -114,8 +114,8 @@ namespace Xamarin.Forms.Build.Tasks
 		void SetNameScope(ElementNode node, VariableDefinition ns)
 		{
 			var module = Context.Body.Method.Module;
-			var nsRef = module.ImportReference(typeof (NameScope));
-			var nsDef = nsRef.Resolve();
+			var nsRef = module.ImportReferenceCached(typeof (NameScope));
+			var nsDef = nsRef.ResolveCached();
 			var setNSInfo = nsDef.Methods.First(md => md.Name == "SetNameScope" && md.IsStatic);
 			var setNS = module.ImportReference(setNSInfo);
 			Context.IL.Emit(OpCodes.Ldloc, Context.Variables[node]);
@@ -130,8 +130,8 @@ namespace Xamarin.Forms.Build.Tasks
 			namesInNamescope.Add(str);
 
 			var module = Context.Body.Method.Module;
-			var nsRef = module.ImportReference(typeof (INameScope));
-			var nsDef = nsRef.Resolve();
+			var nsRef = module.ImportReferenceCached(typeof (INameScope));
+			var nsDef = nsRef.ResolveCached();
 			var registerInfo = nsDef.Methods.First(md => md.Name == nameof(INameScope.RegisterName) && md.Parameters.Count == 2);
 			var register = module.ImportReference(registerInfo);
 
@@ -143,11 +143,11 @@ namespace Xamarin.Forms.Build.Tasks
 
 		void SetStyleId(string str, VariableDefinition element)
 		{
-			if (!element.VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference(typeof(Element))))
+			if (!element.VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReferenceCached(typeof(Element))))
 				return;
 
 			var module = Context.Body.Method.Module;
-			var eltDef = module.ImportReference(typeof(Element)).Resolve();
+			var eltDef = module.ImportReferenceCached(typeof(Element)).ResolveCached();
 			var styleIdInfo = eltDef.Properties.First(pd => pd.Name == nameof(Element.StyleId));
 			var getStyleId = module.ImportReference(styleIdInfo.GetMethod);
 			var setStyleId = module.ImportReference(styleIdInfo.SetMethod);

--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -136,7 +136,7 @@ namespace Xamarin.Forms.Build.Tasks
 					Context.IL.Append(AddToResourceDictionary(node, node, Context));
 				}
 				// Collection element, implicit content, or implicit collection element.
-				else if (parentVar.VariableType.ImplementsInterface(Module.ImportReference(typeof (IEnumerable))) && parentVar.VariableType.GetMethods(md => md.Name == "Add" && md.Parameters.Count == 1, Module).Any()) {
+				else if (parentVar.VariableType.ImplementsInterface(Module.ImportReferenceCached(typeof (IEnumerable))) && parentVar.VariableType.GetMethods(md => md.Name == "Add" && md.Parameters.Count == 1, Module).Any()) {
 					var elementType = parentVar.VariableType;
 					var adderTuple = elementType.GetMethods(md => md.Name == "Add" && md.Parameters.Count == 1, Module).First();
 					var adderRef = Module.ImportReference(adderTuple.Item1);
@@ -228,7 +228,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 		internal static string GetContentProperty(TypeReference typeRef)
 		{
-			var typeDef = typeRef.Resolve();
+			var typeDef = typeRef.ResolveCached();
 			var attributes = typeDef.CustomAttributes;
 			var attr =
 				attributes.FirstOrDefault(cad => ContentPropertyAttribute.ContentPropertyTypes.Contains(cad.AttributeType.FullName));
@@ -249,7 +249,7 @@ namespace Xamarin.Forms.Build.Tasks
 			    vardefref.VariableDefinition.VariableType.ImplementsGenericInterface("Xamarin.Forms.Xaml.IMarkupExtension`1",
 				    out markupExtension, out genericArguments))
 			{
-				var markExt = markupExtension.Resolve();
+				var markExt = markupExtension.ResolveCached();
 				var provideValueInfo = markExt.Methods.First(md => md.Name == "ProvideValue");
 				var provideValue = module.ImportReference(provideValueInfo);
 				provideValue =
@@ -273,12 +273,12 @@ namespace Xamarin.Forms.Build.Tasks
 			else if (vardefref.VariableDefinition.VariableType.ImplementsGenericInterface("Xamarin.Forms.Xaml.IMarkupExtension`1",
 				out markupExtension, out genericArguments))
 			{
-				var acceptEmptyServiceProvider = vardefref.VariableDefinition.VariableType.GetCustomAttribute(module.ImportReference(typeof(AcceptEmptyServiceProviderAttribute))) != null;
+				var acceptEmptyServiceProvider = vardefref.VariableDefinition.VariableType.GetCustomAttribute(module.ImportReferenceCached(typeof(AcceptEmptyServiceProviderAttribute))) != null;
 				if (vardefref.VariableDefinition.VariableType.FullName == "Xamarin.Forms.Xaml.BindingExtension")
 					foreach (var instruction in CompileBindingPath(node, context, vardefref.VariableDefinition))
 						yield return instruction;
 
-				var markExt = markupExtension.Resolve();
+				var markExt = markupExtension.ResolveCached();
 				var provideValueInfo = markExt.Methods.First(md => md.Name == "ProvideValue");
 				var provideValue = module.ImportReference(provideValueInfo);
 				provideValue =
@@ -294,10 +294,10 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Instruction.Create(OpCodes.Callvirt, provideValue);
 				yield return Instruction.Create(OpCodes.Stloc, vardefref.VariableDefinition);
 			}
-			else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReference(typeof (IMarkupExtension))))
+			else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReferenceCached(typeof (IMarkupExtension))))
 			{
-				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module.ImportReference(typeof(AcceptEmptyServiceProviderAttribute))) != null;
-				var markExt = module.ImportReference(typeof (IMarkupExtension)).Resolve();
+				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module.ImportReferenceCached(typeof(AcceptEmptyServiceProviderAttribute))) != null;
+				var markExt = module.ImportReferenceCached(typeof (IMarkupExtension)).ResolveCached();
 				var provideValueInfo = markExt.Methods.First(md => md.Name == "ProvideValue");
 				var provideValue = module.ImportReference(provideValueInfo);
 
@@ -311,12 +311,12 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Instruction.Create(OpCodes.Callvirt, provideValue);
 				yield return Instruction.Create(OpCodes.Stloc, vardefref.VariableDefinition);
 			}
-			else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReference(typeof (IValueProvider))))
+			else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReferenceCached(typeof (IValueProvider))))
 			{
-				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module.ImportReference(typeof(AcceptEmptyServiceProviderAttribute))) != null;
+				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module.ImportReferenceCached(typeof(AcceptEmptyServiceProviderAttribute))) != null;
 				var valueProviderType = context.Variables[node].VariableType;
 				//If the IValueProvider has a ProvideCompiledAttribute that can be resolved, shortcut this
-				var compiledValueProviderName = valueProviderType?.GetCustomAttribute(module.ImportReference(typeof(ProvideCompiledAttribute)))?.ConstructorArguments?[0].Value as string;
+				var compiledValueProviderName = valueProviderType?.GetCustomAttribute(module.ImportReferenceCached(typeof(ProvideCompiledAttribute)))?.ConstructorArguments?[0].Value as string;
 				Type compiledValueProviderType;
 				if (compiledValueProviderName != null && (compiledValueProviderType = Type.GetType(compiledValueProviderName)) != null) {
 					var compiledValueProvider = Activator.CreateInstance(compiledValueProviderType);
@@ -331,7 +331,7 @@ namespace Xamarin.Forms.Build.Tasks
 					yield break;
 				}
 
-				var valueProviderDef = module.ImportReference(typeof (IValueProvider)).Resolve();
+				var valueProviderDef = module.ImportReferenceCached(typeof (IValueProvider)).ResolveCached();
 				var provideValueInfo = valueProviderDef.Methods.First(md => md.Name == "ProvideValue");
 				var provideValue = module.ImportReference(provideValueInfo);
 
@@ -382,16 +382,16 @@ namespace Xamarin.Forms.Build.Tasks
 			var properties = ParsePath(path, tSourceRef, node as IXmlLineInfo, context.Module);
 			var tPropertyRef = properties != null && properties.Any() ? properties.Last().Item1.PropertyType : tSourceRef;
 
-			var funcRef = context.Module.ImportReference(context.Module.ImportReference(typeof(Func<,>)).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
-			var actionRef = context.Module.ImportReference(context.Module.ImportReference(typeof(Action<,>)).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
-			var funcObjRef = context.Module.ImportReference(context.Module.ImportReference(typeof(Func<,>)).MakeGenericInstanceType(new [] { tSourceRef, context.Module.TypeSystem.Object }));
-			var tupleRef = context.Module.ImportReference(context.Module.ImportReference(typeof(Tuple<,>)).MakeGenericInstanceType(new [] { funcObjRef, context.Module.TypeSystem.String}));
-			var typedBindingRef = context.Module.ImportReference(context.Module.ImportReference(typeof(TypedBinding<,>)).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef}));
+			var funcRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(Func<,>)).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
+			var actionRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(Action<,>)).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
+			var funcObjRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(Func<,>)).MakeGenericInstanceType(new [] { tSourceRef, context.Module.TypeSystem.Object }));
+			var tupleRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(Tuple<,>)).MakeGenericInstanceType(new [] { funcObjRef, context.Module.TypeSystem.String}));
+			var typedBindingRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(TypedBinding<,>)).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef}));
 
 			TypeReference _;
-			var ctorInfo =  context.Module.ImportReference(typedBindingRef.Resolve().Methods.FirstOrDefault(md => md.IsConstructor && !md.IsStatic && md.Parameters.Count == 3 ));
+			var ctorInfo =  context.Module.ImportReference(typedBindingRef.ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && !md.IsStatic && md.Parameters.Count == 3 ));
 			var ctorinforef = ctorInfo.MakeGeneric(typedBindingRef, funcRef, actionRef, tupleRef);
-			var setTypedBinding = context.Module.ImportReference(typeof(BindingExtension)).GetProperty(pd => pd.Name == "TypedBinding", out _).SetMethod;
+			var setTypedBinding = context.Module.ImportReferenceCached(typeof(BindingExtension)).GetProperty(pd => pd.Name == "TypedBinding", out _).SetMethod;
 
 			yield return Instruction.Create(OpCodes.Ldloc, bindingExt);
 			foreach (var instruction in CompiledBindingGetGetter(tSourceRef, tPropertyRef, properties, node, context))
@@ -447,7 +447,7 @@ namespace Xamarin.Forms.Build.Tasks
 					previousPartTypeRef = property.PropertyType;
 				}
 				if (indexArg != null) {
-					var defaultMemberAttribute = previousPartTypeRef.GetCustomAttribute(module.ImportReference(typeof(System.Reflection.DefaultMemberAttribute)));
+					var defaultMemberAttribute = previousPartTypeRef.GetCustomAttribute(module.ImportReferenceCached(typeof(System.Reflection.DefaultMemberAttribute)));
 					var indexerName = defaultMemberAttribute?.ConstructorArguments?.FirstOrDefault().Value as string ?? "Item";
 					var indexer = previousPartTypeRef.GetProperty(pd => pd.Name == indexerName && pd.GetMethod != null && pd.GetMethod.IsPublic, out _);
 					properties.Add(new Tuple<PropertyDefinition, string>(indexer, indexArg));
@@ -472,7 +472,7 @@ namespace Xamarin.Forms.Build.Tasks
 //			}
 
 			var module = context.Module;
-			var compilerGeneratedCtor = module.ImportReference(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
+			var compilerGeneratedCtor = module.ImportReferenceCached(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
 			var getter = new MethodDefinition($"<{context.Body.Method.Name}>typedBindingsM__{typedBindingCount++}",
 											  MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
 											  tPropertyRef) {
@@ -519,9 +519,9 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 			context.Body.Method.DeclaringType.Methods.Add(getter);
 
-			var funcRef = module.ImportReference(typeof(Func<,>));
+			var funcRef = module.ImportReferenceCached(typeof(Func<,>));
 			funcRef = module.ImportReference(funcRef.MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
-			var funcCtor = module.ImportReference(funcRef.Resolve().GetConstructors().First());
+			var funcCtor = module.ImportReference(funcRef.ResolveCached().GetConstructors().First());
 			funcCtor = funcCtor.MakeGeneric(funcRef, new [] { tSourceRef, tPropertyRef });
 
 //			IL_0007:  ldnull
@@ -552,7 +552,7 @@ namespace Xamarin.Forms.Build.Tasks
 			//			}
 
 			var module = context.Module;
-			var compilerGeneratedCtor = module.ImportReference(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
+			var compilerGeneratedCtor = module.ImportReferenceCached(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
 			var setter = new MethodDefinition($"<{context.Body.Method.Name}>typedBindingsM__{typedBindingCount++}",
 											  MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
 			                                  module.TypeSystem.Void) {
@@ -622,9 +622,9 @@ namespace Xamarin.Forms.Build.Tasks
 
 			context.Body.Method.DeclaringType.Methods.Add(setter);
 
-			var actionRef = module.ImportReference(typeof(Action<,>));
+			var actionRef = module.ImportReferenceCached(typeof(Action<,>));
 			actionRef = module.ImportReference(actionRef.MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
-			var actionCtor = module.ImportReference(actionRef.Resolve().GetConstructors().First());
+			var actionCtor = module.ImportReference(actionRef.ResolveCached().GetConstructors().First());
 			actionCtor = actionCtor.MakeGeneric(actionRef, new [] { tSourceRef, tPropertyRef });
 
 //			IL_0024: ldnull
@@ -651,7 +651,7 @@ namespace Xamarin.Forms.Build.Tasks
 //			}
 
 			var module = context.Module;
-			var compilerGeneratedCtor = module.ImportReference(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
+			var compilerGeneratedCtor = module.ImportReferenceCached(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
 
 			var partGetters = new List<MethodDefinition>();
 			if (properties == null || properties.Count == 0) {
@@ -716,11 +716,11 @@ namespace Xamarin.Forms.Build.Tasks
 				partGetters.Add(partGetter);
 			}
 
-			var funcObjRef = context.Module.ImportReference(module.ImportReference(typeof(Func<,>)).MakeGenericInstanceType(new [] { tSourceRef, module.TypeSystem.Object }));
-			var tupleRef = context.Module.ImportReference(module.ImportReference(typeof(Tuple<,>)).MakeGenericInstanceType(new [] { funcObjRef, module.TypeSystem.String }));
-			var funcCtor = module.ImportReference(funcObjRef.Resolve().GetConstructors().First());
+			var funcObjRef = context.Module.ImportReference(module.ImportReferenceCached(typeof(Func<,>)).MakeGenericInstanceType(new [] { tSourceRef, module.TypeSystem.Object }));
+			var tupleRef = context.Module.ImportReference(module.ImportReferenceCached(typeof(Tuple<,>)).MakeGenericInstanceType(new [] { funcObjRef, module.TypeSystem.String }));
+			var funcCtor = module.ImportReference(funcObjRef.ResolveCached().GetConstructors().First());
 			funcCtor = funcCtor.MakeGeneric(funcObjRef, new [] { tSourceRef, module.TypeSystem.Object });
-			var tupleCtor = module.ImportReference(tupleRef.Resolve().GetConstructors().First());
+			var tupleCtor = module.ImportReference(tupleRef.ResolveCached().GetConstructors().First());
 			tupleCtor = tupleCtor.MakeGeneric(tupleRef, new [] { funcObjRef, module.TypeSystem.String});
 
 //			IL_003a:  ldc.i4.2 
@@ -878,7 +878,7 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Instruction.Create(OpCodes.Ldftn, handler);
 
 			//FIXME: eventually get the right ctor instead fo the First() one, just in case another one could exists (not even sure it's possible).
-			var ctor = module.ImportReference(eventinfo.EventType.Resolve().GetConstructors().First());
+			var ctor = module.ImportReference(eventinfo.EventType.ResolveCached().GetConstructors().First());
 			ctor = ctor.ResolveGenericParameters(eventinfo.EventType, module);
 			yield return Instruction.Create(OpCodes.Newobj, module.ImportReference(ctor));
 			var adder = module.ImportReference(eventinfo.AddMethod);
@@ -904,13 +904,13 @@ namespace Xamarin.Forms.Build.Tasks
 		{
 			var module = context.Body.Method.Module;
 			var varValue = context.Variables [elementNode];
-			var setDynamicResource = module.ImportReference(typeof(IDynamicResourceHandler)).Resolve().Methods.First(m => m.Name == "SetDynamicResource");
+			var setDynamicResource = module.ImportReferenceCached(typeof(IDynamicResourceHandler)).ResolveCached().Methods.First(m => m.Name == "SetDynamicResource");
 			var getKey = typeof(DynamicResource).GetProperty("Key").GetMethod;
 
 			yield return Instruction.Create(OpCodes.Ldloc, parent);
 			yield return Instruction.Create(OpCodes.Ldsfld, bpRef);
 			yield return Instruction.Create(OpCodes.Ldloc, varValue);
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(getKey));
+			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReferenceCached(getKey));
 			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(setDynamicResource));
 		}
 
@@ -927,18 +927,18 @@ namespace Xamarin.Forms.Build.Tasks
 			VariableDefinition varValue;
 			if (!context.Variables.TryGetValue(valueNode as IElementNode, out varValue))
 				return false;
-			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference(typeof(BindingBase)), module);
+			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReferenceCached(typeof(BindingBase)), module);
 			if (implicitOperator != null)
 				return true;
 
-			return varValue.VariableType.InheritsFromOrImplements(module.ImportReference(typeof(BindingBase)));
+			return varValue.VariableType.InheritsFromOrImplements(module.ImportReferenceCached(typeof(BindingBase)));
 		}
 
 		static IEnumerable<Instruction> SetBinding(VariableDefinition parent, FieldReference bpRef, IElementNode elementNode, IXmlLineInfo iXmlLineInfo, ILContext context)
 		{
 			var module = context.Body.Method.Module;
 			var varValue = context.Variables [elementNode];
-			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference(typeof(BindingBase)), module);
+			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReferenceCached(typeof(BindingBase)), module);
 
 			//TODO: check if parent is a BP
 			var setBinding = typeof(BindableObject).GetMethod("SetBinding", new [] { typeof(BindableProperty), typeof(BindingBase) });
@@ -949,7 +949,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (implicitOperator != null) 
 //				IL_000f:  call !0 class [Xamarin.Forms.Core]Xamarin.Forms.OnPlatform`1<BindingBase>::op_Implicit(class [Xamarin.Forms.Core]Xamarin.Forms.OnPlatform`1<!0>)
 				yield return Instruction.Create(OpCodes.Call, module.ImportReference(implicitOperator));
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(setBinding));
+			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReferenceCached(setBinding));
 		}
 
 		static bool CanSetValue(FieldReference bpRef, bool attached, INode node, IXmlLineInfo iXmlLineInfo, ILContext context)
@@ -995,7 +995,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (bpRef == null)
 				return false;
 
-			if (!parent.VariableType.InheritsFromOrImplements(module.ImportReference(typeof(BindableObject))))
+			if (!parent.VariableType.InheritsFromOrImplements(module.ImportReferenceCached(typeof(BindableObject))))
 				return false;
 
 			propertyType = bpRef.GetBindablePropertyType(iXmlLineInfo, module);
@@ -1034,7 +1034,7 @@ namespace Xamarin.Forms.Build.Tasks
 					yield return Instruction.Create(OpCodes.Box, varType);
 			}
 
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(setValue));
+			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReferenceCached(setValue));
 		}
 
 		static IEnumerable<Instruction> GetValue(VariableDefinition parent, FieldReference bpRef, IXmlLineInfo iXmlLineInfo, ILContext context, out TypeReference propertyType)
@@ -1046,7 +1046,7 @@ namespace Xamarin.Forms.Build.Tasks
 			return new[] {
 				Instruction.Create(OpCodes.Ldloc, parent),
 				Instruction.Create(OpCodes.Ldsfld, bpRef),
-				Instruction.Create(OpCodes.Callvirt, module.ImportReference(getValue)),
+				Instruction.Create(OpCodes.Callvirt, module.ImportReferenceCached(getValue)),
 			};
 		}
 
@@ -1063,7 +1063,7 @@ namespace Xamarin.Forms.Build.Tasks
 				return false;
 
 			var valueNode = node as ValueNode;
-			if (valueNode != null && valueNode.CanConvertValue(context, propertyType, new ICustomAttributeProvider[] { property, propertyType.Resolve()}))
+			if (valueNode != null && valueNode.CanConvertValue(context, propertyType, new ICustomAttributeProvider[] { property, propertyType.ResolveCached()}))
 				return true;
 
 			var elementNode = node as IElementNode;
@@ -1099,7 +1099,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (propertyGetter == null || !propertyGetter.IsPublic || propertyGetter.IsStatic)
 				return false;
 
-			module.ImportReference(parent.VariableType.Resolve());
+			module.ImportReference(parent.VariableType.ResolveCached());
 			var propertyGetterRef = module.ImportReference(module.ImportReference(propertyGetter).ResolveGenericParameters(declaringTypeReference, module));
 			propertyGetterRef.ImportTypes(module);
 			propertyType = propertyGetterRef.ReturnType.ResolveGenericParameters(declaringTypeReference);
@@ -1118,7 +1118,7 @@ namespace Xamarin.Forms.Build.Tasks
 //			IL_0008:  ldstr "foo"
 //			IL_000d:  callvirt instance void class [Xamarin.Forms.Core]Xamarin.Forms.Label::set_Text(string)
 
-			module.ImportReference(parent.VariableType.Resolve());
+			module.ImportReference(parent.VariableType.ResolveCached());
 			var propertySetterRef = module.ImportReference(module.ImportReference(propertySetter).ResolveGenericParameters(declaringTypeReference, module));
 			propertySetterRef.ImportTypes(module);
 			var propertyType = property.ResolveGenericPropertyType(declaringTypeReference, module);
@@ -1132,7 +1132,7 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Instruction.Create(OpCodes.Ldloc, parent);
 
 			if (valueNode != null) {
-				foreach (var instruction in valueNode.PushConvertedValue(context, propertyType, new ICustomAttributeProvider [] { property, propertyType.Resolve() }, valueNode.PushServiceProvider(context, propertyRef:property), false, true))
+				foreach (var instruction in valueNode.PushConvertedValue(context, propertyType, new ICustomAttributeProvider [] { property, propertyType.ResolveCached() }, valueNode.PushServiceProvider(context, propertyRef:property), false, true))
 					yield return instruction;
 				if (parent.VariableType.IsValueType)
 					yield return Instruction.Create(OpCodes.Call, propertySetterRef);
@@ -1163,7 +1163,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var property = parent.VariableType.GetProperty(pd => pd.Name == localName, out declaringTypeReference);
 			var propertyGetter = property.GetMethod;
 
-			module.ImportReference(parent.VariableType.Resolve());
+			module.ImportReference(parent.VariableType.ResolveCached());
 			var propertyGetterRef = module.ImportReference(module.ImportReference(propertyGetter).ResolveGenericParameters(declaringTypeReference, module));
 			propertyGetterRef.ImportTypes(module);
 			propertyType = propertyGetterRef.ReturnType.ResolveGenericParameters(declaringTypeReference);
@@ -1203,7 +1203,7 @@ namespace Xamarin.Forms.Build.Tasks
 		static bool CanAddToResourceDictionary(TypeReference collectionType, IElementNode node, IXmlLineInfo lineInfo, ILContext context)
 		{
 			if (   collectionType.FullName != "Xamarin.Forms.ResourceDictionary"
-				&& collectionType.Resolve().BaseType?.FullName != "Xamarin.Forms.ResourceDictionary")
+				&& collectionType.ResolveCached().BaseType?.FullName != "Xamarin.Forms.ResourceDictionary")
 				return false;
 
 
@@ -1213,7 +1213,7 @@ namespace Xamarin.Forms.Build.Tasks
 			//is there a RD.Add() overrides that accepts this ?
 			var nodeTypeRef = context.Variables[node].VariableType;
 			var module = context.Body.Method.Module;
-			if (module.ImportReference(typeof(ResourceDictionary)).Resolve().Methods.Any(md =>
+			if (module.ImportReferenceCached(typeof(ResourceDictionary)).ResolveCached().Methods.Any(md =>
 						   md.Name == "Add"
 						&& md.Parameters.Count == 1
 						&& TypeRefComparer.Default.Equals(md.Parameters[0].ParameterType, nodeTypeRef)))
@@ -1269,8 +1269,8 @@ namespace Xamarin.Forms.Build.Tasks
 					yield return Create(Box, module.ImportReference(varDef.VariableType));
 				yield return Create(Callvirt,
 					module.ImportReference(
-						module.ImportReference(typeof(ResourceDictionary))
-							.Resolve()
+						module.ImportReferenceCached(typeof(ResourceDictionary))
+							.ResolveCached()
 							.Methods.Single(md => md.Name == "Add" && md.Parameters.Count == 2)));
 				yield break;
 			}
@@ -1279,8 +1279,8 @@ namespace Xamarin.Forms.Build.Tasks
 			yield return Create(Ldloc, context.Variables[node]);
 			yield return Create(Callvirt,
 				module.ImportReference(
-					module.ImportReference(typeof(ResourceDictionary))
-						.Resolve()
+					module.ImportReferenceCached(typeof(ResourceDictionary))
+						.ResolveCached()
 						.Methods.Single(md => md.Name == "Add"
 									 && md.Parameters.Count == 1
 									 && TypeRefComparer.Default.Equals(md.Parameters[0].ParameterType, nodeTypeRef))));
@@ -1322,7 +1322,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 
 			var module = parentContext.Module;
-			var compilerGeneratedCtor = module.ImportReference(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
+			var compilerGeneratedCtor = module.ImportReferenceCached(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
 			var anonType = new TypeDefinition(
 				null,
 				"<" + parentContext.Body.Method.Name + ">_anonXamlCDataTemplate_" + dtcount++,
@@ -1345,7 +1345,7 @@ namespace Xamarin.Forms.Build.Tasks
 			loadTemplate.Body.InitLocals = true;
 			anonType.Methods.Add(loadTemplate);
 
-			var parentValues = new FieldDefinition("parentValues", FieldAttributes.Assembly, module.ImportReference(typeof (object[])));
+			var parentValues = new FieldDefinition("parentValues", FieldAttributes.Assembly, module.ImportReferenceCached(typeof (object[])));
 			anonType.Fields.Add(parentValues);
 
 			TypeReference rootType = null;
@@ -1397,17 +1397,17 @@ namespace Xamarin.Forms.Build.Tasks
 
 			//SetDataTemplate
 			parentIl.Emit(OpCodes.Ldftn, loadTemplate);
-			var funcObjRef = module.ImportReference(typeof(Func<object>));
+			var funcObjRef = module.ImportReferenceCached(typeof(Func<object>));
 			var funcCtor =
 				funcObjRef
-					.Resolve()
+					.ResolveCached()
 					.Methods.First(md => md.IsConstructor && md.Parameters.Count == 2)
 					.ResolveGenericParameters(funcObjRef, module);
 			parentIl.Emit(OpCodes.Newobj, module.ImportReference(funcCtor));
 
 #pragma warning disable 0612
 			var propertySetter =
-				module.ImportReference(typeof (IDataTemplate)).Resolve().Properties.First(p => p.Name == "LoadTemplate").SetMethod;
+				module.ImportReferenceCached(typeof (IDataTemplate)).ResolveCached().Properties.First(p => p.Name == "LoadTemplate").SetMethod;
 #pragma warning restore 0612
 			parentContext.IL.Emit(OpCodes.Callvirt, module.ImportReference(propertySetter));
 
@@ -1419,7 +1419,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (propertyName != XmlName.xName)
 				return false;
 
-			var attributes = variableDefinition.VariableType.Resolve()
+			var attributes = variableDefinition.VariableType.ResolveCached()
 				.CustomAttributes.Where(attribute => attribute.AttributeType.FullName == "Xamarin.Forms.Xaml.RuntimeNamePropertyAttribute").ToList();
 
 			if (!attributes.Any())

--- a/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetResourcesVisitor.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Build.Tasks
 		{
 			var parentVar = Context.Variables[(IElementNode)node];
 			return parentVar.VariableType.FullName == "Xamarin.Forms.ResourceDictionary"
-				|| parentVar.VariableType.Resolve().BaseType?.FullName == "Xamarin.Forms.ResourceDictionary";
+				|| parentVar.VariableType.ResolveCached().BaseType?.FullName == "Xamarin.Forms.ResourceDictionary";
 		}
 
 		public bool SkipChildren(INode node, INode parentNode)

--- a/Xamarin.Forms.Build.Tasks/TypeDefinitionExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeDefinitionExtensions.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Build.Tasks
 		public static MethodDefinition AddDefaultConstructor(this TypeDefinition targetType, Type parentType)
 		{
 			var module = targetType.Module;
-			var voidType = module.ImportReference(typeof (void));
+			var voidType = module.ImportReferenceCached(typeof (void));
 			var methodAttributes = MethodAttributes.Public |
 			                       MethodAttributes.HideBySig |
 			                       MethodAttributes.SpecialName |
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (objectConstructor == null)
 				objectConstructor = typeof (object).GetConstructor(new Type[0]);
 
-			var baseConstructor = module.ImportReference(objectConstructor);
+			var baseConstructor = module.ImportReferenceCached(objectConstructor);
 
 			var ctor = new MethodDefinition(".ctor", methodAttributes, voidType)
 			{
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Build.Tasks
 			{
 				foreach (var md in self.Methods)
 					yield return md;
-				self = self.BaseType == null ? null : self.BaseType.Resolve();
+				self = self.BaseType == null ? null : self.BaseType.ResolveCached();
 			}
 		}
 	}

--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Build.Tasks
 			out TypeReference declaringTypeRef)
 		{
 			declaringTypeRef = typeRef;
-			var typeDef = typeRef.Resolve();
+			var typeDef = typeRef.ResolveCached();
 			var properties = typeDef.Properties.Where(predicate);
 			if (properties.Any())
 				return properties.Single();
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Build.Tasks
 			out TypeReference declaringTypeRef)
 		{
 			declaringTypeRef = typeRef;
-			var typeDef = typeRef.Resolve();
+			var typeDef = typeRef.ResolveCached();
 			var events = typeDef.Events.Where(predicate);
 			if (events.Any()) {
 				var ev = events.Single();
@@ -89,7 +89,7 @@ namespace Xamarin.Forms.Build.Tasks
 				throw new ArgumentNullException(nameof(declaringTypeRef));
 			if (!eventDef.EventType.IsGenericInstance)
 				return eventDef;
-			if (eventDef.EventType.Resolve().FullName != "System.EventHandler`1")
+			if (eventDef.EventType.ResolveCached().FullName != "System.EventHandler`1")
 				return eventDef;
 
 			var git = eventDef.EventType as GenericInstanceType;
@@ -105,7 +105,7 @@ namespace Xamarin.Forms.Build.Tasks
 			out TypeReference declaringTypeRef)
 		{
 			declaringTypeRef = typeRef;
-			var typeDef = typeRef.Resolve();
+			var typeDef = typeRef.ResolveCached();
 			var bp = typeDef.Fields.Where
 				(predicate);
 			if (bp.Any())
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 		public static bool ImplementsInterface(this TypeReference typeRef, TypeReference @interface)
 		{
-			var typeDef = typeRef.Resolve();
+			var typeDef = typeRef.ResolveCached();
 			if (typeDef.Interfaces.Any(tr => tr.InterfaceType.FullName == @interface.FullName))
 				return true;
 			var baseTypeRef = typeDef.BaseType;
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Build.Tasks
 		{
 			interfaceReference = null;
 			genericArguments = null;
-			var typeDef = typeRef.Resolve();
+			var typeDef = typeRef.ResolveCached();
 			InterfaceImplementation iface;
 			if ((iface = typeDef.Interfaces.FirstOrDefault(tr =>
 							tr.InterfaceType.FullName.StartsWith(@interface, StringComparison.Ordinal) &&
@@ -175,11 +175,11 @@ namespace Xamarin.Forms.Build.Tasks
 
 			if (typeRef.IsArray) {
 				var array = (ArrayType)typeRef;
-				var arrayType = typeRef.Resolve();
+				var arrayType = typeRef.ResolveCached();
 				if (arrayInterfaces.Contains(baseClass.FullName))
 					return true;
 				if (array.IsVector &&  //generic interfaces are not implemented on multidimensional arrays
-					arrayGenericInterfaces.Contains(baseClass.Resolve().FullName) &&
+				    arrayGenericInterfaces.Contains(baseClass.ResolveCached().FullName) &&
 					baseClass.IsGenericInstance &&
 					TypeRefComparer.Default.Equals((baseClass as GenericInstanceType).GenericArguments[0], arrayType))
 					return true;
@@ -188,8 +188,8 @@ namespace Xamarin.Forms.Build.Tasks
 
 			if (typeRef.FullName == "System.Object")
 				return false;
-			var typeDef = typeRef.Resolve();
-			if (TypeRefComparer.Default.Equals(typeDef, baseClass.Resolve()))
+			var typeDef = typeRef.ResolveCached();
+			if (TypeRefComparer.Default.Equals(typeDef, baseClass.ResolveCached()))
 				return true;
 			if (typeDef.Interfaces.Any(ir => TypeRefComparer.Default.Equals(ir.InterfaceType.ResolveGenericParameters(typeRef), baseClass)))
 				return true;
@@ -202,7 +202,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 		public static CustomAttribute GetCustomAttribute(this TypeReference typeRef, TypeReference attribute)
 		{
-			var typeDef = typeRef.Resolve();
+			var typeDef = typeRef.ResolveCached();
 			//FIXME: avoid string comparison. make sure the attribute TypeRef is the same one
 			var attr = typeDef.CustomAttributes.SingleOrDefault(ca => ca.AttributeType.FullName == attribute.FullName);
 			if (attr != null)
@@ -225,7 +225,7 @@ namespace Xamarin.Forms.Build.Tasks
 			out TypeReference declaringTypeRef)
 		{
 			declaringTypeRef = typeRef;
-			var typeDef = typeRef.Resolve();
+			var typeDef = typeRef.ResolveCached();
 			var methods = typeDef.Methods.Where(predicate);
 			if (methods.Any())
 				return methods.Single();
@@ -253,7 +253,7 @@ namespace Xamarin.Forms.Build.Tasks
 		public static IEnumerable<Tuple<MethodDefinition, TypeReference>> GetMethods(this TypeReference typeRef,
 			Func<MethodDefinition, TypeReference, bool> predicate, ModuleDefinition module)
 		{
-			var typeDef = typeRef.Resolve();
+			var typeDef = typeRef.ResolveCached();
 			foreach (var method in typeDef.Methods.Where(md => predicate(md, typeRef)))
 				yield return new Tuple<MethodDefinition, TypeReference>(method, typeRef);
 			if (typeDef.IsInterface)
@@ -333,6 +333,14 @@ namespace Xamarin.Forms.Build.Tasks
 					args.Add(genericdeclType.GenericArguments[(genericself.GenericArguments[i] as GenericParameter).Position]);
 			}
 			return self.GetElementType().MakeGenericInstanceType(args.ToArray());
+		}
+
+		static Dictionary<TypeReference, TypeDefinition> resolves = new Dictionary<TypeReference, TypeDefinition>();
+		public static TypeDefinition ResolveCached(this TypeReference typeReference)
+		{
+			if (resolves.TryGetValue(typeReference, out var typeDefinition))
+				return typeDefinition;
+			return (resolves[typeReference] = typeReference.Resolve());
 		}
 	}
 }

--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -278,18 +278,18 @@ namespace Xamarin.Forms.Build.Tasks
 
 					//First using the ResourceLoader
 					var nop = Instruction.Create(Nop);
-					var getResourceProvider = module.ImportReference(module.ImportReference(typeof(Internals.ResourceLoader))
-							 .Resolve()
+					var getResourceProvider = module.ImportReference(module.ImportReferenceCached(typeof(Internals.ResourceLoader))
+							 .ResolveCached()
 							 .Properties.FirstOrDefault(pd => pd.Name == "ResourceProvider")
 							 .GetMethod);
 					il.Emit(Call, getResourceProvider);
 					il.Emit(Brfalse, nop);
 					il.Emit(Call, getResourceProvider);
 
-					var getTypeFromHandle = module.ImportReference(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
-					var getTypeInfo = module.ImportReference(typeof(System.Reflection.IntrospectionExtensions).GetMethod("GetTypeInfo", new Type[] { typeof(Type) }));
-					var getAssembly = module.ImportReference(typeof(Type).GetProperty("Assembly").GetMethod);
-					var getAssemblyName = module.ImportReference(typeof(System.Reflection.Assembly).GetMethod("GetName", new Type[] { }));
+					var getTypeFromHandle = module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
+					var getTypeInfo = module.ImportReferenceCached(typeof(System.Reflection.IntrospectionExtensions).GetMethod("GetTypeInfo", new Type[] { typeof(Type) }));
+					var getAssembly = module.ImportReferenceCached(typeof(Type).GetProperty("Assembly").GetMethod);
+					var getAssemblyName = module.ImportReferenceCached(typeof(System.Reflection.Assembly).GetMethod("GetName", new Type[] { }));
 					il.Emit(Ldtoken, module.ImportReference(initComp.DeclaringType));
 					il.Emit(Call, module.ImportReference(getTypeFromHandle));
 					il.Emit(Call, module.ImportReference(getTypeInfo));
@@ -297,10 +297,10 @@ namespace Xamarin.Forms.Build.Tasks
 					il.Emit(Callvirt, module.ImportReference(getAssemblyName)); //assemblyName
 
 					il.Emit(Ldstr, resourcePath);	//resourcePath
-					var func = module.ImportReference(module.ImportReference(typeof(Func<System.Reflection.AssemblyName, string, string>))
-							 .Resolve()
+					var func = module.ImportReference(module.ImportReferenceCached(typeof(Func<System.Reflection.AssemblyName, string, string>))
+							 .ResolveCached()
 							 .Methods.FirstOrDefault(md => md.Name == "Invoke"));
-					func = func.ResolveGenericParameters(module.ImportReference(typeof(Func<System.Reflection.AssemblyName, string, string>)), module);
+					func = func.ResolveGenericParameters(module.ImportReferenceCached(typeof(Func<System.Reflection.AssemblyName, string, string>)), module);
 					il.Emit(Callvirt, func);
 					il.Emit(Brfalse, nop);
 					il.Emit(Ldarg_0);
@@ -311,8 +311,8 @@ namespace Xamarin.Forms.Build.Tasks
 					//Or using the deprecated XamlLoader
 					nop = Instruction.Create(Nop);
 #pragma warning disable 0618
-					var getXamlFileProvider = module.ImportReference(module.ImportReference(typeof(Xaml.Internals.XamlLoader))
-							.Resolve()
+					var getXamlFileProvider = module.ImportReference(module.ImportReferenceCached(typeof(Xaml.Internals.XamlLoader))
+							.ResolveCached()
 							.Properties.FirstOrDefault(pd => pd.Name == "XamlFileProvider")
 							.GetMethod);
 #pragma warning restore 0618
@@ -321,14 +321,14 @@ namespace Xamarin.Forms.Build.Tasks
 					il.Emit(Brfalse, nop);
 					il.Emit(Call, getXamlFileProvider);
 					il.Emit(Ldarg_0);
-					var getType = module.ImportReference(module.ImportReference(typeof(object))
-									  .Resolve()
+					var getType = module.ImportReference(module.ImportReferenceCached(typeof(object))
+									  .ResolveCached()
 									  .Methods.FirstOrDefault(md => md.Name == "GetType"));
 					il.Emit(Call, getType);
-					func = module.ImportReference(module.ImportReference(typeof(Func<Type, string>))
-							 .Resolve()
+					func = module.ImportReference(module.ImportReferenceCached(typeof(Func<Type, string>))
+							 .ResolveCached()
 							 .Methods.FirstOrDefault(md => md.Name == "Invoke"));
-					func = func.ResolveGenericParameters(module.ImportReference(typeof(Func<Type, string>)), module);
+					func = func.ResolveGenericParameters(module.ImportReferenceCached(typeof(Func<Type, string>)), module);
 					il.Emit(Callvirt, func);
 					il.Emit(Brfalse, nop);
 					il.Emit(Ldarg_0);
@@ -360,8 +360,9 @@ namespace Xamarin.Forms.Build.Tasks
 
 		internal static string GetPathForType(ModuleDefinition module, TypeReference type)
 		{
-			foreach (var ca in type.Module.GetCustomAttributes()) {
-				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReference(typeof(XamlResourceIdAttribute))))
+			foreach (var ca in type.Module.GetCustomAttributes())
+			{
+				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReferenceCached(typeof(XamlResourceIdAttribute))))
 					continue;
 				if (!TypeRefComparer.Default.Equals(ca.ConstructorArguments[2].Value as TypeReference, type))
 					continue;
@@ -372,8 +373,9 @@ namespace Xamarin.Forms.Build.Tasks
 
 		internal static string GetResourceIdForPath(ModuleDefinition module, string path)
 		{
-			foreach (var ca in module.GetCustomAttributes()) {
-				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReference(typeof(XamlResourceIdAttribute))))
+			foreach (var ca in module.GetCustomAttributes())
+			{
+				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReferenceCached(typeof(XamlResourceIdAttribute))))
 					continue;
 				if (ca.ConstructorArguments[1].Value as string != path)
 					continue;

--- a/Xamarin.Forms.Build.Tasks/XamlTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlTask.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Build.Tasks
 		static TypeReference GetTypeForResourceId(ModuleDefinition module, string resourceId)
 		{
 			foreach (var ca in module.GetCustomAttributes()) {
-				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReference(typeof(XamlResourceIdAttribute))))
+				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReferenceCached(typeof(XamlResourceIdAttribute))))
 					continue;
 				if (ca.ConstructorArguments[0].Value as string != resourceId)
 					continue;


### PR DESCRIPTION
### Description of Change ###

[XamlC] Cache Resolve and ImportReference

ImportReference with System.Reflection based argument is notoriously
slow on .NET. So we cache the results for those.

We do not cache the results for TypeReference, MethodReference or
FieldReference calls, as those are already fast (passthrough if the
reference was already imported), and they aren't valid as dictionary
keys (no concept of equatability).

While we're at it, we shave another few ms from Resolve(TypeReference)
calls as well.

As, on good days, it shaves up to 40% of XamlC time, we can say that it fixes #1848

### Bugs Fixed ###

 - fixes #1848

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense