### PR TITLE
[Internal] Remove $IdAppend$ from our .nuspec

### DIFF
--- a/.nuspec/Xamarin.Forms.AppLinks.nuspec
+++ b/.nuspec/Xamarin.Forms.AppLinks.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Xamarin.Forms.AppLinks$IdAppend$</id>
+    <id>Xamarin.Forms.AppLinks</id>
     <version>$version$</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>

--- a/.nuspec/Xamarin.Forms.Maps.GTK.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.GTK.nuspec
@@ -14,8 +14,8 @@
     <copyright>Copyright 2013-2018</copyright>
     <dependencies>
       <group>
-        <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
-        <dependency id="Xamarin.Forms.Maps$IdAppend$" version="$version$" />
+        <dependency id="Xamarin.Forms" version="$version$"/>
+        <dependency id="Xamarin.Forms.Maps" version="$version$" />
       </group>
     </dependencies>
   </metadata>

--- a/.nuspec/Xamarin.Forms.Maps.WPF.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.WPF.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Xamarin.Forms.Maps.WPF$IdAppend$</id>
+    <id>Xamarin.Forms.Maps.WPF</id>
     <version>$version$</version>
     <authors>Xamarin, Inc.</authors>
     <owners>Xamarin, Inc.</owners>
@@ -14,8 +14,8 @@
     <copyright>Copyright 2013-2017</copyright>
     <dependencies>
       <group>
-        <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
-        <dependency id="Xamarin.Forms.Maps$IdAppend$" version="$version$"/>
+        <dependency id="Xamarin.Forms" version="$version$"/>
+        <dependency id="Xamarin.Forms.Maps" version="$version$"/>
       </group>
       <group targetFramework="net45">
         <dependency id="Microsoft.Maps.MapControl.WPF" version="1.0.0.3"/>

--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Xamarin.Forms.Maps$IdAppend$</id>
+    <id>Xamarin.Forms.Maps</id>
     <version>$version$</version>
     <authors>Xamarin, Inc.</authors>
     <owners>Xamarin, Inc.</owners>
@@ -14,25 +14,25 @@
     <copyright>Copyright 2013-2017</copyright>
     <dependencies>
       <group>
-        <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
+        <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
       <group targetFramework="MonoAndroid10">
         <dependency id="Xamarin.GooglePlayServices.Maps" version="[29.0.0.1]"/>
         <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="[23.3.0]"/>
         <dependency id="Xamarin.Android.Support.v7.AppCompat" version="[23.3.0]"/>
-        <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
+        <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
       <group targetFramework="MonoAndroid70">
         <dependency id="Xamarin.GooglePlayServices.Maps" version="29.0.0.1"/>
         <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0"/>
         <dependency id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0"/>
-        <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
+        <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
       <group targetFramework="MonoAndroid71">
         <dependency id="Xamarin.GooglePlayServices.Maps" version="42.1021.1"/>
         <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="25.4.0.2"/>
         <dependency id="Xamarin.Android.Support.v7.AppCompat" version="25.4.0.2"/>
-        <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
+        <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
       <group targetFramework="tizen40">
         <dependency id="Tizen.NET" version="4.0.0"/>

--- a/.nuspec/Xamarin.Forms.Pages.nuspec
+++ b/.nuspec/Xamarin.Forms.Pages.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Xamarin.Forms.Pages$IdAppend$</id>
+    <id>Xamarin.Forms.Pages</id>
     <version>$version$</version>
     <authors>Xamarin, Inc.</authors>
     <owners>Xamarin, Inc.</owners>
@@ -13,7 +13,7 @@
     <copyright>Copyright 2013-2017</copyright>
     <dependencies>
       <group>
-        <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
+        <dependency id="Xamarin.Forms" version="$version$"/>
         <dependency id="Newtonsoft.Json" version="10.0.3"/>
         <dependency id="modernhttpclient" version="2.4.2"/>
       </group>

--- a/.nuspec/Xamarin.Forms.Platform.GTK.nuspec
+++ b/.nuspec/Xamarin.Forms.Platform.GTK.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2013-2018</copyright>
     <dependencies>
       <group>
-        <dependency id="Xamarin.Forms$IdAppend$" version="$version$" />
+        <dependency id="Xamarin.Forms" version="$version$" />
       </group>
     </dependencies>
   </metadata>

--- a/.nuspec/Xamarin.Forms.Platform.WPF.nuspec
+++ b/.nuspec/Xamarin.Forms.Platform.WPF.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Xamarin.Forms.Platform.WPF$IdAppend$</id>
+    <id>Xamarin.Forms.Platform.WPF</id>
     <version>$version$</version>
     <authors>Xamarin, Inc.</authors>
     <owners>Xamarin, Inc.</owners>
@@ -14,7 +14,7 @@
     <copyright>Copyright 2013-2017</copyright>
     <dependencies>
       <group>
-        <dependency id="Xamarin.Forms$IdAppend$" version="$version$"/>
+        <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
       <group targetFramework="net45">
         <dependency id="WpfLightToolkit" version="1.0.1"/>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Xamarin.Forms$IdAppend$</id>
+    <id>Xamarin.Forms</id>
     <version>$version$</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
@@ -59,8 +59,8 @@
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.*pdb" target="lib\netstandard1.0" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.*mdb" target="lib\netstandard1.0" />
 
-    <file src="Xamarin.Forms.targets" target="build\netstandard1.0\Xamarin.Forms$IdAppend$.targets" />
-    <file src="Xamarin.Forms.props" target="build\netstandard1.0\Xamarin.Forms$IdAppend$.props" />
+    <file src="Xamarin.Forms.targets" target="build\netstandard1.0\Xamarin.Forms.targets" />
+    <file src="Xamarin.Forms.props" target="build\netstandard1.0\Xamarin.Forms.props" />
     <file src="Xamarin.Forms.DefaultItems.targets" target="build\netstandard1.0" />
     <file src="Xamarin.Forms.DefaultItems.props" target="build\netstandard1.0" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Build.Tasks.dll" target="build\netstandard1.0" />
@@ -86,8 +86,8 @@
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Platform.*mdb" target="lib\netstandard2.0" />
 
     <!--Xamlc stuff-->
-    <file src="Xamarin.Forms.targets" target="build\netstandard2.0\Xamarin.Forms$IdAppend$.targets" />
-    <file src="Xamarin.Forms.props" target="build\netstandard2.0\Xamarin.Forms$IdAppend$.props" />
+    <file src="Xamarin.Forms.targets" target="build\netstandard2.0\Xamarin.Forms.targets" />
+    <file src="Xamarin.Forms.props" target="build\netstandard2.0\Xamarin.Forms.props" />
     <file src="Xamarin.Forms.DefaultItems.targets" target="build\netstandard2.0" />
     <file src="Xamarin.Forms.DefaultItems.props" target="build\netstandard2.0" />
     <file src="..\Xamarin.Forms.Build.Tasks\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Build.Tasks.dll" target="build\netstandard2.0" />


### PR DESCRIPTION
### Description of Change ###

remove $IdAppend$ from our .nuspec

those nuget variables aren't used anymore, I think, in any of our release script (but I might be wrong)