### PR TITLE
[UWP] Allow SearchBar cancel button colors to be set individually 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1878.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1878.cs
@@ -1,0 +1,33 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1878, "[UWP] Setting SearchBar.CancelButtonColor affects all SearchBars on page", PlatformAffected.UWP)]
+	public class GitHub1878 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label 
+			{ 
+				Text = "The SearchBars below should have different cancel button colors. " 
+						+ "If they each have the same cancel button color, this test has failed."
+			};
+
+			var sb1 = new SearchBar { Text = "This should have a red cancel button." };
+			var sb2 = new SearchBar { Text = "This should have a blue cancel button." };
+
+			sb1.CancelButtonColor = Color.Red;
+			sb2.CancelButtonColor = Color.Blue;
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(sb1);
+			layout.Children.Add(sb2);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -234,6 +234,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59248.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59457.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1717.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60001.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60056.cs" />

--- a/Xamarin.Forms.Platform.UAP/AutoSuggestStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/AutoSuggestStyle.xaml
@@ -81,7 +81,7 @@
 				<ControlTemplate TargetType="uwp:FormsTextBox">
 					<Grid>
 						<Grid.Resources>
-							<Style x:Name="DeleteButtonStyle" TargetType="Button">
+							<Style x:Name="DeleteButtonStyle" TargetType="uwp:FormsCancelButton">
 								<Setter Property="Template">
 									<Setter.Value>
 										<ControlTemplate TargetType="Button">
@@ -97,7 +97,7 @@
 																</ObjectAnimationUsingKeyFrames>
 																<ObjectAnimationUsingKeyFrames Storyboard.TargetName="GlyphElement"
                                                              Storyboard.TargetProperty="Foreground">
-																	<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FormsCancelBackgroundBrush}" />
+																	<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltAccentBrush}" />
 																</ObjectAnimationUsingKeyFrames>
 															</Storyboard>
 														</VisualState>
@@ -126,9 +126,9 @@
 												<Border x:Name="BorderElement"
                               BorderBrush="{ThemeResource TextBoxButtonBorderThemeBrush}"
                               BorderThickness="{TemplateBinding BorderThickness}"
-                              Background="{ThemeResource FormsCancelBackgroundBrush}">
+                              Background="{ThemeResource TextBoxButtonBackgroundThemeBrush}">
 													<TextBlock x:Name="GlyphElement"
-                                   Foreground="{ThemeResource FormsCancelForegroundBrush}"
+                                   Foreground="{ThemeResource SystemControlBackgroundChromeBlackMediumBrush}"
                                    VerticalAlignment="Center"
                                    HorizontalAlignment="Center"
                                    FontStyle="Normal"
@@ -391,7 +391,8 @@
                         HorizontalAlignment="{Binding TextAlignment, 
                                             RelativeSource={RelativeSource Mode=TemplatedParent}, 
                                             Converter={StaticResource AlignmentConverter}}" />
-						<Button x:Name="DeleteButton"
+						<!-- We use a custom version of the cancel button so we can control the colors from Forms -->
+						<uwp:FormsCancelButton x:Name="DeleteButton"
                   Grid.Row="1"
                   Style="{StaticResource DeleteButtonStyle}"
                   BorderThickness="{TemplateBinding BorderThickness}"

--- a/Xamarin.Forms.Platform.UAP/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/ColorExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Windows.UI;
+using Windows.UI.Xaml.Media;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	internal static class ColorExtensions
+	{
+		public static Windows.UI.Color GetContrastingColor(this Windows.UI.Color color)
+		{
+			var nThreshold = 105;
+			int bgLuminance = Convert.ToInt32(color.R * 0.2 + color.G * 0.7 + color.B * 0.1);
+
+			Windows.UI.Color contrastingColor = 255 - bgLuminance < nThreshold ? Colors.Black : Colors.White;
+			return contrastingColor;
+		}
+
+		public static Color ToFormsColor(this Windows.UI.Color color)
+		{
+			return Color.FromRgba(color.R, color.G, color.B, color.A);
+		}
+
+		public static Color ToFormsColor(this SolidColorBrush solidColorBrush)
+		{
+			return solidColorBrush.Color.ToFormsColor();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/Extensions.cs
+++ b/Xamarin.Forms.Platform.UAP/Extensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Windows.Foundation;
-using Windows.UI;
 using Windows.UI.Xaml;
 
 namespace Xamarin.Forms.Platform.UWP
@@ -16,15 +15,6 @@ namespace Xamarin.Forms.Platform.UWP
 		public static ConfiguredTaskAwaitable DontSync(this IAsyncAction self)
 		{
 			return self.AsTask().ConfigureAwait(false);
-		}
-
-		public static Windows.UI.Color GetIdealForegroundForBackgroundColor(this Windows.UI.Color backgroundColor)
-		{
-			var nThreshold = 105;
-			int bgLuminance = Convert.ToInt32(backgroundColor.R * 0.2 + backgroundColor.G * 0.7 + backgroundColor.B * 0.1);
-
-			Windows.UI.Color foregroundColor = 255 - bgLuminance < nThreshold ? Colors.Black : Colors.White;
-			return foregroundColor;
 		}
 
 		public static void SetBinding(this FrameworkElement self, DependencyProperty property, string path)

--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms
 				return;
 
 			var accent = (SolidColorBrush)Windows.UI.Xaml.Application.Current.Resources["SystemColorControlAccentBrush"];
-			Color.SetAccent(Color.FromRgba(accent.Color.R, accent.Color.G, accent.Color.B, accent.Color.A));
+			Color.SetAccent(accent.ToFormsColor());
 
 			Log.Listeners.Add(new DelegateLogListener((c, m) => Debug.WriteLine(LogFormat, c, m)));
 

--- a/Xamarin.Forms.Platform.UAP/FormsCancelButton.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsCancelButton.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	internal class FormsCancelButton : Windows.UI.Xaml.Controls.Button
+	{
+		TextBlock _cancelButtonGlyph;
+		Border _cancelButtonBackground;
+
+		public Brush ForegroundBrush 
+		{
+			get => _cancelButtonGlyph.Foreground;
+			set => _cancelButtonGlyph.Foreground = value;
+		}
+
+		public Brush BackgroundBrush
+		{
+			get => _cancelButtonBackground.Background;
+			set => _cancelButtonBackground.Background = value;
+		}
+
+		public bool IsReady { get; private set; }
+
+		public event EventHandler ReadyChanged;
+
+		protected override void OnApplyTemplate()
+		{
+			base.OnApplyTemplate();
+
+			_cancelButtonGlyph = (TextBlock)GetTemplateChild("GlyphElement");
+			_cancelButtonBackground = (Border)GetTemplateChild("BorderElement");
+
+			if (_cancelButtonGlyph != null && _cancelButtonBackground != null)
+			{
+				// The SearchBarRenderer needs to be able to check whether we're ready to have the colors set
+				// (we won't be until the first time the button actually appears, which requires the search bar
+				// to be focused and have text in it)
+				IsReady = true;
+
+				// And we need to inform the SearchBarRenderer of this so it can run the button color update method
+				OnReadyChanged();
+			}
+		}
+
+		protected virtual void OnReadyChanged()
+		{
+			ReadyChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/MasterBackgroundConverter.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterBackgroundConverter.cs
@@ -36,8 +36,7 @@ namespace Xamarin.Forms.Platform.UWP
 			brush = value as SolidColorBrush;
 			if (brush != null)
 			{
-				Windows.UI.Color wcolor = brush.Color;
-				Color color = Color.FromRgba(wcolor.R, wcolor.G, wcolor.B, wcolor.A);
+				Color color = brush.ToFormsColor();
 
 				double delta = Shift;
 				if (color.Luminosity > .6)

--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -359,8 +359,5 @@
 	<Style TargetType="ToggleSwitch">
 		<Setter Property="MinWidth" Value="0"/>
 	</Style>
-	
-	<SolidColorBrush x:Key="FormsCancelForegroundBrush" />
-    <SolidColorBrush x:Key="FormsCancelBackgroundBrush" />
     
 </ResourceDictionary>

--- a/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
-using WVisualStateManager = Windows.UI.Xaml.VisualStateManager;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -18,6 +16,9 @@ namespace Xamarin.Forms.Platform.UWP
 		bool _fontApplied;
 
 		FormsTextBox _queryTextBox;
+		FormsCancelButton _cancelButton;
+		Brush _defaultDeleteButtonForegroundColorBrush;
+		Brush _defaultDeleteButtonBackgroundColorBrush;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<SearchBar> e)
 		{
@@ -43,7 +44,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			base.OnElementChanged(e);
 		}
-
+		
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
@@ -73,6 +74,14 @@ namespace Xamarin.Forms.Platform.UWP
 		void OnControlLoaded(object sender, RoutedEventArgs routedEventArgs)
 		{
 			_queryTextBox = Control.GetFirstDescendant<FormsTextBox>();
+			_cancelButton = _queryTextBox?.GetFirstDescendant<FormsCancelButton>();
+
+			if (_cancelButton != null)
+			{
+				// The Cancel button's content won't be loaded right away (because the default Visibility is Collapsed)
+				// So we need to wait until it's ready, then force an update of the button color
+				_cancelButton.ReadyChanged += (o, args) => UpdateCancelButtonColor();
+			}
 
 			UpdateAlignment();
 			UpdateTextColor();
@@ -108,21 +117,25 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateCancelButtonColor()
 		{
-			var foregroundBrush = Windows.UI.Xaml.Application.Current.Resources["FormsCancelForegroundBrush"] as SolidColorBrush;
-			var backgroundBrush = Windows.UI.Xaml.Application.Current.Resources["FormsCancelBackgroundBrush"] as SolidColorBrush;
+			if (_cancelButton == null || !_cancelButton.IsReady)
+				return;
 
 			Color cancelColor = Element.CancelButtonColor;
 
+			BrushHelpers.UpdateColor(cancelColor, ref _defaultDeleteButtonForegroundColorBrush,
+				() => _cancelButton.ForegroundBrush, brush => _cancelButton.ForegroundBrush = brush);
+
 			if (cancelColor.IsDefault)
 			{
-				backgroundBrush.Color = (Windows.UI.Xaml.Application.Current.Resources["TextBoxButtonBackgroundThemeBrush"] as SolidColorBrush).Color;
-				foregroundBrush.Color = (Windows.UI.Xaml.Application.Current.Resources["SystemControlBackgroundChromeBlackMediumBrush"] as SolidColorBrush).Color;
+				BrushHelpers.UpdateColor(Color.Default, ref _defaultDeleteButtonBackgroundColorBrush,
+					() => _cancelButton.BackgroundBrush, brush => _cancelButton.BackgroundBrush = brush);
 			}
 			else
 			{
-				Windows.UI.Color newColor = cancelColor.ToWindowsColor();
-				backgroundBrush.Color = newColor;
-				foregroundBrush.Color = newColor.GetIdealForegroundForBackgroundColor();
+				// Determine whether the background should be black or white (in order to make the foreground color visible) 
+				var bcolor = cancelColor.ToWindowsColor().GetContrastingColor().ToFormsColor();
+				BrushHelpers.UpdateColor(bcolor, ref _defaultDeleteButtonBackgroundColorBrush,
+					() => _cancelButton.BackgroundBrush, brush => _cancelButton.BackgroundBrush = brush);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -43,6 +43,8 @@
     </NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ColorExtensions.cs" />
+    <Compile Include="FormsCancelButton.cs" />
     <Compile Include="FormsPivot.cs" />
     <Compile Include="AlignmentExtensions.cs" />
     <Compile Include="BrushHelpers.cs" />


### PR DESCRIPTION
### Description of Change ###

When setting the `CancelButtonColor` of multiple SearchBars on UWP, every SearchBar's cancel button will have the color of the last one set. 

This PR changes the way the colors are set in the renderer, and allows each SearchBar to have its own CancelButtonColor.

### Bugs Fixed ###

- fixes #1878 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
