### PR TITLE
Check IsEnabled on TextCell before executing command

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60045.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60045.xaml
@@ -1,0 +1,22 @@
+﻿<local:TestContentPage 
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Xamarin.Forms.Controls"
+	x:Class=" Xamarin.Forms.Controls.Issues.Bugzilla60045"
+	x:Name="This"
+	BindingContext="{x:Reference This}">
+
+	<StackLayout>
+
+		<Label Text="The command on the list item below has CanExecute == false; clicking on it should not display an alert. If it does, this test has failed."></Label>
+
+		<ListView CachingStrategy="RecycleElement" ItemsSource="{Binding Items}" >
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<TextCell Text="Click This" Command="{Binding Action}"/>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+
+	</StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60045.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60045.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ListView)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60045, 
+		"ListView with RecycleElement strategy doesn't handle CanExecute of TextCell Command properly",
+		PlatformAffected.iOS)]
+    public partial class Bugzilla60045 : TestContentPage
+	{
+		public const string ClickThis = "Click This";
+		public const string Fail = "Fail";
+
+		public object Items { get; set; }
+
+		public Bugzilla60045()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+			Items = new[]
+			{
+				new { 
+					Action = new Command(async () =>
+					{
+						await DisplayAlert(Fail, "Well, this is embarrassing.", "Ok");
+					}, 
+					() => false) }
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void CommandDoesNotFire()
+		{
+			RunningApp.WaitForElement(ClickThis);
+			RunningApp.Tap(ClickThis);
+			RunningApp.WaitForNoElement(Fail);
+		}
+#endif
+	}
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,9 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60045.xaml.cs">
+      <DependentUpon>Bugzilla60045.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)AddingMultipleItemsListView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AndroidStatusBarColor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AppBarIconColors.cs" />
@@ -839,6 +842,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)GitHub1331.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla60045.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core.UnitTests/TextCellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TextCellTests.cs
@@ -18,6 +18,19 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True (tapped);
 		}
 
+		[TestCase(true)]
+		[TestCase(false)]
+		public void TappedHonorsCanExecute(bool canExecute)
+		{
+			bool executed = false;
+
+			var cmd = new Command (() => executed = true, () => canExecute);
+			var cell = new TextCell { Command = cmd };
+			cell.OnTapped();
+
+			Assert.That (executed, Is.EqualTo(canExecute));
+		}
+
 		[Test]
 		public void TestCommand()
 		{

--- a/Xamarin.Forms.Core/Cells/TextCell.cs
+++ b/Xamarin.Forms.Core/Cells/TextCell.cs
@@ -81,9 +81,12 @@ namespace Xamarin.Forms
 		{
 			base.OnTapped();
 
-			ICommand cmd = Command;
-			if (cmd != null)
-				cmd.Execute(CommandParameter);
+			if (!IsEnabled)
+			{
+				return;
+			}
+
+			Command?.Execute(CommandParameter);
 		}
 
 		void OnCommandCanExecuteChanged(object sender, EventArgs eventArgs)


### PR DESCRIPTION
### Description of Change ###

Adds a check for `IsEnabled` before executing a Command from a TextCell.

### Bugs Fixed ###

* [60045 – ListView with RecycleElement strategy doesn't handle CanExecute of TextCell Command properly (Forms->iOS)](https://bugzilla.xamarin.com/show_bug.cgi?id=60045)

### API Changes ###

None

### Behavioral Changes ###

None 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
