### PR TITLE
[XamlC] no longer use any reflection-base ImportReference

### DIFF
--- a/Xamarin.Forms.Build.Tasks/BindablePropertyReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/BindablePropertyReferenceExtensions.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Build.Tasks
 												md.IsStatic &&
 												md.IsPublic &&
 												md.Parameters.Count == 1 &&
-												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.ImportReferenceCached(typeof(BindableObject))), module).SingleOrDefault()?.Item1;
+												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"))), module).SingleOrDefault()?.Item1;
 			if (getter == null)
 				throw new XamlParseException($"Missing a public static Get{bpName} or a public instance property getter for the attached property \"{bpRef.DeclaringType}.{bpRef.Name}\"", iXmlLineInfo);
 			return getter.ResolveGenericReturnType(declaringTypeRef, module);
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Build.Tasks
 												md.IsStatic &&
 												md.IsPublic &&
 												md.Parameters.Count == 1 &&
-												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.ImportReferenceCached(typeof(BindableObject))), module).SingleOrDefault()?.Item1;
+												md.Parameters[0].ParameterType.InheritsFromOrImplements(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"))), module).SingleOrDefault()?.Item1;
 
 			var attributes = new List<CustomAttribute>();
 			if (property != null && property.HasCustomAttributes)

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BindingTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BindingTypeConverter.cs
@@ -20,9 +20,7 @@ namespace Xamarin.Forms.Core.XamlC
 			if (IsNullOrEmpty(value))
 				throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(Binding)}", node);
 
-			var bindingCtor = module.ImportReferenceCached(typeof(Binding)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 6);
-			var bindingCtorRef = module.ImportReference(bindingCtor);
-
+			var bindingCtorRef = module.ImportCtorReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Binding"), paramCount: 6);
 			yield return Instruction.Create(OpCodes.Ldstr, value);
 			yield return Instruction.Create(OpCodes.Ldc_I4, (int)BindingMode.Default);
 			yield return Instruction.Create(OpCodes.Ldnull);

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
@@ -68,8 +68,7 @@ namespace Xamarin.Forms.Core.XamlC
 			yield return Instruction.Create(OpCodes.Ldc_R8, w);
 			yield return Instruction.Create(OpCodes.Ldc_R8, h);
 
-			var rectangleCtor = module.ImportReferenceCached(typeof(Rectangle)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 4);
-			var rectangleCtorRef = module.ImportReference(rectangleCtor);
+			var rectangleCtorRef = module.ImportCtorReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Rectangle"), paramCount: 4);
 			yield return Instruction.Create(OpCodes.Newobj, rectangleCtorRef);
 		}
 	}

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
@@ -22,10 +22,11 @@ namespace Xamarin.Forms.Core.XamlC
 				throw new XamlParseException($"Cannot convert \"{value}\" into {typeof(Constraint)}", node);
 
 			yield return Instruction.Create(OpCodes.Ldc_R8, size);
-
-			var constantDef = module.ImportReferenceCached(typeof(Constraint)).ResolveCached().Methods.FirstOrDefault(md => md.IsStatic && md.Name == "Constant");
-			var constantRef = module.ImportReference(constantDef);
-			yield return Instruction.Create(OpCodes.Call, constantRef);
+			var constantReference = module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Constraint"),
+																 methodName: "Constant",
+																 paramCount: 1,
+																 predicate: md => md.IsStatic);
+			yield return Instruction.Create(OpCodes.Call, constantReference);
 		}
 	}
 }

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/LayoutOptionsConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/LayoutOptionsConverter.cs
@@ -26,9 +26,11 @@ namespace Xamarin.Forms.Core.XamlC
 				if (parts.Length == 1 || (parts.Length == 2 && parts [0] == "LayoutOptions")) {
 					var options = parts [parts.Length - 1];
 
-					var field = module.ImportReferenceCached(typeof(LayoutOptions)).ResolveCached().Fields.SingleOrDefault(fd => fd.Name == options && fd.IsStatic);
-					if (field != null) {
-						yield return Instruction.Create(OpCodes.Ldsfld, module.ImportReference(field));
+					var fieldReference = module.ImportFieldReference(("Xamarin.Forms.Core", "Xamarin.Forms", "LayoutOptions"),
+																	 fieldName: options,
+																	 predicate: fd => fd.IsStatic);
+					if (fieldReference != null) {
+						yield return Instruction.Create(OpCodes.Ldsfld, fieldReference);
 						yield break;
 					}
 				}

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ListStringTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ListStringTypeConverter.cs
@@ -22,21 +22,20 @@ namespace Xamarin.Forms.Core.XamlC
 			}
 			var parts = value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToList();
 
-			var listCtor = module.ImportReferenceCached(typeof(List<>)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 1 && md.Parameters[0].ParameterType.FullName == "System.Int32");
-			var listCtorRef = module.ImportReference(listCtor);
-			listCtorRef = module.ImportReference(listCtorRef.ResolveGenericParameters(module.ImportReferenceCached(typeof(List<string>)), module));
-
-			var adder = module.ImportReferenceCached(typeof(ICollection<>)).ResolveCached().Methods.FirstOrDefault(md => md.Name == "Add" && md.Parameters.Count == 1);
-			var adderRef = module.ImportReference(adder);
-			adderRef = module.ImportReference(adderRef.ResolveGenericParameters(module.ImportReferenceCached(typeof(ICollection<string>)), module));
+			var add = module.ImportMethodReference(("mscorlib", "System.Collections.Generic", "ICollection`1"),
+												   methodName: "Add",
+												   paramCount: 1,
+												   classArguments: new[] { ("mscorlib", "System", "String") });
 
 			yield return Instruction.Create(OpCodes.Ldc_I4, parts.Count);
-			yield return Instruction.Create(OpCodes.Newobj, listCtorRef);
-
+			yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("mscorlib", "System.Collections.Generic", "List`1"),
+																					   paramCount: 1,
+																					   predicate: md => md.Parameters[0].ParameterType.FullName == "System.Int32",
+																					   classArguments: new[] { ("mscorlib", "System", "String") }));
 			foreach (var part in parts) {
 				yield return Instruction.Create(OpCodes.Dup);
 				yield return Instruction.Create(OpCodes.Ldstr, part);
-				yield return Instruction.Create(OpCodes.Callvirt, adderRef);
+				yield return Instruction.Create(OpCodes.Callvirt, add);
 			}
 		}
 	}

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ListStringTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ListStringTypeConverter.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Core.XamlC
 												   classArguments: new[] { ("mscorlib", "System", "String") });
 
 			yield return Instruction.Create(OpCodes.Ldc_I4, parts.Count);
-			yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("mscorlib", "System.Collections.Generic", "List`1"),
+			yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("System.Collections", "System.Collections.Generic", "List`1"),
 																					   paramCount: 1,
 																					   predicate: md => md.Parameters[0].ParameterType.FullName == "System.Int32",
 																					   classArguments: new[] { ("mscorlib", "System", "String") }));

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RectangleTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RectangleTypeConverter.cs
@@ -43,9 +43,7 @@ namespace Xamarin.Forms.Core.XamlC
 			yield return Instruction.Create(OpCodes.Ldc_R8, w);
 			yield return Instruction.Create(OpCodes.Ldc_R8, h);
 
-			var rectangleCtor = module.ImportReferenceCached(typeof(Rectangle)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 4);
-			var rectangleCtorRef = module.ImportReference(rectangleCtor);
-			yield return Instruction.Create(OpCodes.Newobj, rectangleCtorRef);
+			yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Rectangle"), paramCount: 4));
 		}
 	}
 }

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ThicknessTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ThicknessTypeConverter.cs
@@ -45,9 +45,8 @@ namespace Xamarin.Forms.Core.XamlC
 		{
 			foreach (var d in args)
 				yield return Instruction.Create(OpCodes.Ldc_R8, d);
-			var thicknessCtor = module.ImportReferenceCached(typeof(Thickness)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == args.Length);
-			var thicknessCtorRef = module.ImportReference(thicknessCtor);
-			yield return Instruction.Create(OpCodes.Newobj, thicknessCtorRef);
+			yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Thickness"),
+																					   paramCount: args.Length));
 		}
 	}
 	

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/TypeTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/TypeTypeConverter.cs
@@ -33,9 +33,9 @@ namespace Xamarin.Forms.Core.XamlC
 			if (typeRef == null)
 				goto error;
 
-			var getTypeFromHandle = module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
 			yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReference(typeRef));
-			yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
+			yield return Instruction.Create(OpCodes.Call, module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", paramCount: 1, predicate: md => md.IsStatic));
+
 			yield break;
 
 		error:

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/UriTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/UriTypeConverter.cs
@@ -24,9 +24,9 @@ namespace Xamarin.Forms.Core.XamlC
 				yield break;
 			}
 
-			var uriCtor = module.ImportReferenceCached(typeof(Uri)).ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 2 && md.Parameters[1].ParameterType.FullName == "System.UriKind");
-			var uriCtorRef = module.ImportReference(uriCtor);
-
+			var uriCtorRef = module.ImportCtorReference(("System", "System", "Uri"),
+														paramCount: 2,
+														predicate: md => md.Parameters[1].ParameterType.FullName == "System.UriKind");
 			yield return Create(Ldstr, value);
 			yield return Create(Ldc_I4_0); //UriKind.RelativeOrAbsolute
 			yield return Create(Newobj, uriCtorRef);

--- a/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/TypeExtension.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledMarkupExtensions/TypeExtension.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Build.Tasks
 	{
 		public IEnumerable<Instruction> ProvideValue(IElementNode node, ModuleDefinition module, ILContext context, out TypeReference memberRef)
 		{
-			memberRef = module.ImportReferenceCached(typeof(Type));
+			memberRef = module.ImportReference(("mscorlib", "System", "Type"));
 			INode typeNameNode;
 
 			var name = new XmlName("", "TypeName");
@@ -34,10 +34,10 @@ namespace Xamarin.Forms.Build.Tasks
 
 			context.TypeExtensions[node] = typeref;
 
-			var getTypeFromHandle = module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
 			return new List<Instruction> {
 				Instruction.Create(OpCodes.Ldtoken, module.ImportReference(typeref)),
-				Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle))
+				Instruction.Create(OpCodes.Call, module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", paramCount: 1, predicate: md => md.IsStatic)),
+
 			};
 		}
 	}

--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
@@ -34,9 +34,6 @@ namespace Xamarin.Forms.Core.XamlC
 
 			var value = ((string)((ValueNode)valueNode).Value);
 
-			TypeReference _;
-			var setValueRef = module.ImportReference(module.ImportReferenceCached(typeof(Setter)).GetProperty(p => p.Name == "Value", out _).SetMethod);
-
 			//push the setter
 			yield return Instruction.Create(OpCodes.Ldloc, vardefref.VariableDefinition);
 
@@ -45,7 +42,7 @@ namespace Xamarin.Forms.Core.XamlC
 				yield return instruction;
 
 			//set the value
-			yield return Instruction.Create(OpCodes.Callvirt, setValueRef);
+			yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Setter"), propertyName: "Value"));
 		}
 
 		static bool SetterValueIsCollection(FieldReference bindablePropertyReference, ModuleDefinition module, BaseNode node, ILContext context)

--- a/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
@@ -7,6 +7,9 @@ using Mono.Cecil.Cil;
 using Xamarin.Forms.Xaml;
 using System.Xml;
 
+using static Mono.Cecil.Cil.Instruction;
+using static Mono.Cecil.Cil.OpCodes;
+
 namespace Xamarin.Forms.Build.Tasks
 {
 	class CreateObjectVisitor : IXamlNodeVisitor
@@ -53,7 +56,9 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 
 			//if this is a MarkupExtension that can be compiled directly, compile and returns the value
-			var compiledMarkupExtensionName = typeref.GetCustomAttribute(Module.ImportReferenceCached(typeof(ProvideCompiledAttribute)))?.ConstructorArguments?[0].Value as string;
+			var compiledMarkupExtensionName = typeref
+				.GetCustomAttribute(Module, ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "ProvideCompiledAttribute"))
+				?.ConstructorArguments?[0].Value as string;
 			Type compiledMarkupExtensionType;
 			ICompiledMarkupExtension markupProvider;
 			if (compiledMarkupExtensionName != null &&
@@ -337,207 +342,174 @@ namespace Xamarin.Forms.Build.Tasks
 
 		IEnumerable<Instruction> PushValueFromLanguagePrimitive(TypeDefinition typedef, ElementNode node)
 		{
+			var module = Context.Body.Method.Module;
 			var hasValue = node.CollectionItems.Count == 1 && node.CollectionItems[0] is ValueNode &&
 			               ((ValueNode)node.CollectionItems[0]).Value is string;
 			var valueString = hasValue ? ((ValueNode)node.CollectionItems[0]).Value as string : string.Empty;
 			switch (typedef.FullName) {
 			case "System.SByte":
-				sbyte outsbyte;
-				if (hasValue && sbyte.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outsbyte))
-					yield return Instruction.Create(OpCodes.Ldc_I4, (int)outsbyte);
+				if (hasValue && sbyte.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out sbyte outsbyte))
+					yield return Create(Ldc_I4, (int)outsbyte);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I4, 0x00);
+					yield return Create(Ldc_I4, 0x00);
 				break;
 			case "System.Int16":
-				short outshort;
-				if (hasValue && short.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outshort))
-					yield return Instruction.Create(OpCodes.Ldc_I4, outshort);
+				if (hasValue && short.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out short outshort))
+					yield return Create(Ldc_I4, outshort);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I4, 0x00);
+					yield return Create(Ldc_I4, 0x00);
 				break;
 			case "System.Int32":
-				int outint;
-				if (hasValue && int.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outint))
-					yield return Instruction.Create(OpCodes.Ldc_I4, outint);
+				if (hasValue && int.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out int outint))
+					yield return Create(Ldc_I4, outint);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I4, 0x00);
+					yield return Create(Ldc_I4, 0x00);
 				break;
 			case "System.Int64":
-				long outlong;
-				if (hasValue && long.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outlong))
-					yield return Instruction.Create(OpCodes.Ldc_I8, outlong);
+				if (hasValue && long.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out long outlong))
+					yield return Create(Ldc_I8, outlong);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I8, 0L);
+					yield return Create(Ldc_I8, 0L);
 				break;
 			case "System.Byte":
-				byte outbyte;
-				if (hasValue && byte.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outbyte))
-					yield return Instruction.Create(OpCodes.Ldc_I4, (int)outbyte);
+				if (hasValue && byte.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out byte outbyte))
+					yield return Create(Ldc_I4, (int)outbyte);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I4, 0x00);
+					yield return Create(Ldc_I4, 0x00);
 				break;
 			case "System.UInt16":
-				short outushort;
-				if (hasValue && short.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outushort))
-					yield return Instruction.Create(OpCodes.Ldc_I4, outushort);
+				if (hasValue && short.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out short outushort))
+					yield return Create(Ldc_I4, outushort);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I4, 0x00);
+					yield return Create(Ldc_I4, 0x00);
 				break;
 			case "System.UInt32":
-				int outuint;
-				if (hasValue && int.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outuint))
-					yield return Instruction.Create(OpCodes.Ldc_I4, outuint);
+				if (hasValue && int.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out int outuint))
+					yield return Create(Ldc_I4, outuint);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I4, 0x00);
+					yield return Create(Ldc_I4, 0x00);
 				break;
 			case "System.UInt64":
-				long outulong;
-				if (hasValue && long.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outulong))
-					yield return Instruction.Create(OpCodes.Ldc_I8, outulong);
+				if (hasValue && long.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out long outulong))
+					yield return Create(Ldc_I8, outulong);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I8, 0L);
+					yield return Create(Ldc_I8, 0L);
 				break;
 			case "System.Boolean":
-				bool outbool;
-				if (hasValue && bool.TryParse(valueString, out outbool))
-					yield return Instruction.Create(outbool ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
+				if (hasValue && bool.TryParse(valueString, out bool outbool))
+					yield return Create(outbool ? Ldc_I4_1 : Ldc_I4_0);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I4_0);
+					yield return Create(Ldc_I4_0);
 				break;
 			case "System.String":
-				yield return Instruction.Create(OpCodes.Ldstr, valueString);
+				yield return Create(Ldstr, valueString);
 				break;
 			case "System.Object":
 				var ctorinfo =
-					Context.Body.Method.Module.TypeSystem.Object.ResolveCached()
+					module.TypeSystem.Object.ResolveCached()
 						.Methods.FirstOrDefault(md => md.IsConstructor && !md.HasParameters);
-				var ctor = Context.Body.Method.Module.ImportReference(ctorinfo);
-				yield return Instruction.Create(OpCodes.Newobj, ctor);
+				var ctor = module.ImportReference(ctorinfo);
+				yield return Create(Newobj, ctor);
 				break;
 			case "System.Char":
-				char outchar;
-				if (hasValue && char.TryParse(valueString, out outchar))
-					yield return Instruction.Create(OpCodes.Ldc_I4, outchar);
+				if (hasValue && char.TryParse(valueString, out char outchar))
+					yield return Create(Ldc_I4, outchar);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_I4, 0x00);
+					yield return Create(Ldc_I4, 0x00);
 				break;
 			case "System.Decimal":
 				decimal outdecimal;
 				if (hasValue && decimal.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outdecimal)) {
-					var vardef = new VariableDefinition(Context.Body.Method.Module.ImportReferenceCached(typeof(decimal)));
+					var vardef = new VariableDefinition(module.ImportReference(("mscorlib", "System", "Decimal")));
 					Context.Body.Variables.Add(vardef);
 					//Use an extra temp var so we can push the value to the stack, just like other cases
-					//					IL_0003:  ldstr "adecimal"
-					//					IL_0008:  ldc.i4.s 0x6f
-					//					IL_000a:  call class [mscorlib]System.Globalization.CultureInfo class [mscorlib]System.Globalization.CultureInfo::get_InvariantCulture()
-					//					IL_000f:  ldloca.s 0
-					//					IL_0011:  call bool valuetype [mscorlib]System.Decimal::TryParse(string, valuetype [mscorlib]System.Globalization.NumberStyles, class [mscorlib]System.IFormatProvider, [out] valuetype [mscorlib]System.Decimal&)
-					//					IL_0016:  pop
-					yield return Instruction.Create(OpCodes.Ldstr, valueString);
-					yield return Instruction.Create(OpCodes.Ldc_I4, 0x6f); //NumberStyles.Number
-					var getInvariantInfo =
-						Context.Body.Method.Module.ImportReferenceCached(typeof(CultureInfo))
-							.ResolveCached()
-							.Properties.FirstOrDefault(pd => pd.Name == "InvariantCulture")
-							.GetMethod;
-					var getInvariant = Context.Body.Method.Module.ImportReference(getInvariantInfo);
-					yield return Instruction.Create(OpCodes.Call, getInvariant);
-					yield return Instruction.Create(OpCodes.Ldloca, vardef);
-					var tryParseInfo =
-						Context.Body.Method.Module.ImportReferenceCached(typeof(decimal))
-							.ResolveCached()
-							.Methods.FirstOrDefault(md => md.Name == "TryParse" && md.Parameters.Count == 4);
-					var tryParse = Context.Body.Method.Module.ImportReference(tryParseInfo);
-					yield return Instruction.Create(OpCodes.Call, tryParse);
-					yield return Instruction.Create(OpCodes.Pop);
-					yield return Instruction.Create(OpCodes.Ldloc, vardef);
+//					IL_0003:  ldstr "adecimal"
+//					IL_0008:  ldc.i4.s 0x6f
+//					IL_000a:  call class [mscorlib]System.Globalization.CultureInfo class [mscorlib]System.Globalization.CultureInfo::get_InvariantCulture()
+//					IL_000f:  ldloca.s 0
+//					IL_0011:  call bool valuetype [mscorlib]System.Decimal::TryParse(string, valuetype [mscorlib]System.Globalization.NumberStyles, class [mscorlib]System.IFormatProvider, [out] valuetype [mscorlib]System.Decimal&)
+//					IL_0016:  pop
+					yield return Create(Ldstr, valueString);
+					yield return Create(Ldc_I4, 0x6f); //NumberStyles.Number
+					var getInvariant = module.ImportPropertyGetterReference(("mscorlib", "System.Globalization", "CultureInfo"),
+																			propertyName: "InvariantCulture");
+					yield return Create(Call, getInvariant);
+					yield return Create(Ldloca, vardef);
+					var tryParse = module.ImportMethodReference(("mscorlib", "System", "Decimal"),
+																methodName: "TryParse",
+																paramCount: 4);
+					yield return Create(Call, tryParse);
+					yield return Create(Pop);
+					yield return Create(Ldloc, vardef);
 				} else {
-					yield return Instruction.Create(OpCodes.Ldc_I4_0);
-					var decimalctorinfo =
-						Context.Body.Method.Module.ImportReferenceCached(typeof(decimal))
-							.ResolveCached()
-							.Methods.FirstOrDefault(
-								md => md.IsConstructor && md.Parameters.Count == 1 && md.Parameters [0].ParameterType.FullName == "System.Int32");
-					var decimalctor = Context.Body.Method.Module.ImportReference(decimalctorinfo);
-					yield return Instruction.Create(OpCodes.Newobj, decimalctor);
+					yield return Create(Ldc_I4_0);
+					var decimalctor = module.ImportCtorReference(("mscorlib", "System", "Decimal"),
+																 paramCount: 1,
+																 predicate: md => md.Parameters[0].ParameterType.FullName == "System.Int32");
+					yield return Create(Newobj, decimalctor);
 				}
 				break;
 			case "System.Single":
-				float outfloat;
-				if (hasValue && float.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outfloat))
-					yield return Instruction.Create(OpCodes.Ldc_R4, outfloat);
+				if (hasValue && float.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out float outfloat))
+					yield return Create(Ldc_R4, outfloat);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_R4, 0f);
+					yield return Create(Ldc_R4, 0f);
 				break;
 			case "System.Double":
-				double outdouble;
-				if (hasValue && double.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out outdouble))
-					yield return Instruction.Create(OpCodes.Ldc_R8, outdouble);
+				if (hasValue && double.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out double outdouble))
+					yield return Create(Ldc_R8, outdouble);
 				else
-					yield return Instruction.Create(OpCodes.Ldc_R8, 0d);
+					yield return Create(Ldc_R8, 0d);
 				break;
 			case "System.TimeSpan":
-				TimeSpan outspan;
-				if (hasValue && TimeSpan.TryParse(valueString, CultureInfo.InvariantCulture, out outspan)) {
-					var vardef = new VariableDefinition(Context.Body.Method.Module.ImportReferenceCached(typeof(TimeSpan)));
+				if (hasValue && TimeSpan.TryParse(valueString, CultureInfo.InvariantCulture, out TimeSpan outspan)) {
+					var vardef = new VariableDefinition(module.ImportReference(("mscorlib", "System", "TimeSpan")));
 					Context.Body.Variables.Add(vardef);
 					//Use an extra temp var so we can push the value to the stack, just like other cases
-					yield return Instruction.Create(OpCodes.Ldstr, valueString);
-					var getInvariantInfo =
-						Context.Body.Method.Module.ImportReferenceCached(typeof(CultureInfo))
-							.ResolveCached()
-							.Properties.FirstOrDefault(pd => pd.Name == "InvariantCulture")
-							.GetMethod;
-					var getInvariant = Context.Body.Method.Module.ImportReference(getInvariantInfo);
-					yield return Instruction.Create(OpCodes.Call, getInvariant);
-					yield return Instruction.Create(OpCodes.Ldloca, vardef);
-					var tryParseInfo =
-						Context.Body.Method.Module.ImportReferenceCached(typeof(TimeSpan))
-							.ResolveCached()
-							.Methods.FirstOrDefault(md => md.Name == "TryParse" && md.Parameters.Count == 3);
-					var tryParse = Context.Body.Method.Module.ImportReference(tryParseInfo);
-					yield return Instruction.Create(OpCodes.Call, tryParse);
-					yield return Instruction.Create(OpCodes.Pop);
-					yield return Instruction.Create(OpCodes.Ldloc, vardef);
+					yield return Create(Ldstr, valueString);
+					var getInvariant = module.ImportPropertyGetterReference(("mscorlib", "System.Globalization", "CultureInfo"),
+																			propertyName: "InvariantCulture");
+					yield return Create(Call, getInvariant);
+					yield return Create(Ldloca, vardef);
+					var tryParse = module.ImportMethodReference(("mscorlib", "System", "TimeSpan"),
+																methodName: "TryParse",
+																paramCount: 3);
+
+					yield return Create(Call, tryParse);
+					yield return Create(Pop);
+					yield return Create(Ldloc, vardef);
 				} else {
-					yield return Instruction.Create(OpCodes.Ldc_I8, 0L);
-					var timespanctorinfo =
-						Context.Body.Method.Module.ImportReferenceCached(typeof(TimeSpan))
-							.ResolveCached()
-							.Methods.FirstOrDefault(
-								md => md.IsConstructor && md.Parameters.Count == 1 && md.Parameters [0].ParameterType.FullName == "System.Int64");
-					var timespanctor = Context.Body.Method.Module.ImportReference(timespanctorinfo);
-					yield return Instruction.Create(OpCodes.Newobj, timespanctor);
+					yield return Create(Ldc_I8, 0L);
+					var timespanctor = module.ImportCtorReference(("mscorlib", "System", "TimeSpan"),
+																  paramCount: 1,
+																  predicate: md => md.Parameters[0].ParameterType.FullName == "System.Int64");
+					yield return Create(Newobj, timespanctor);
 				}
 				break;
 			case "System.Uri":
-				Uri outuri;
-				if (hasValue && Uri.TryCreate(valueString, UriKind.RelativeOrAbsolute, out outuri)) {
-					var vardef = new VariableDefinition(Context.Body.Method.Module.ImportReferenceCached(typeof(Uri)));
+				if (hasValue && Uri.TryCreate(valueString, UriKind.RelativeOrAbsolute, out Uri outuri)) {
+					var vardef = new VariableDefinition(module.ImportReference(("System", "System", "Uri")));
 					Context.Body.Variables.Add(vardef);
 					//Use an extra temp var so we can push the value to the stack, just like other cases
-					yield return Instruction.Create(OpCodes.Ldstr, valueString);
-					yield return Instruction.Create(OpCodes.Ldc_I4, (int)UriKind.RelativeOrAbsolute);
-					yield return Instruction.Create(OpCodes.Ldloca, vardef);
-					var tryCreateInfo =
-						Context.Body.Method.Module.ImportReferenceCached(typeof(Uri))
-							.ResolveCached()
-							.Methods.FirstOrDefault(md => md.Name == "TryCreate" && md.Parameters.Count == 3);
-					var tryCreate = Context.Body.Method.Module.ImportReference(tryCreateInfo);
-					yield return Instruction.Create(OpCodes.Call, tryCreate);
-					yield return Instruction.Create(OpCodes.Pop);
-					yield return Instruction.Create(OpCodes.Ldloc, vardef);
+					yield return Create(Ldstr, valueString);
+					yield return Create(Ldc_I4, (int)UriKind.RelativeOrAbsolute);
+					yield return Create(Ldloca, vardef);
+					var tryCreate = module.ImportMethodReference(("System", "System", "Uri"),
+																 methodName: "TryCreate",
+																 paramCount: 3);
+					yield return Create(Call, tryCreate);
+					yield return Create(Pop);
+					yield return Create(Ldloc, vardef);
 				} else
-					yield return Instruction.Create(OpCodes.Ldnull);
+					yield return Create(Ldnull);
 				break;
 			default:
-				var defaultctorinfo = typedef.Methods.FirstOrDefault(md => md.IsConstructor && !md.HasParameters);
-				if (defaultctorinfo != null) {
-					var defaultctor = Context.Body.Method.Module.ImportReference(defaultctorinfo);
-					yield return Instruction.Create(OpCodes.Newobj, defaultctor);
-				} else {
+				var defaultCtor = module.ImportCtorReference(typedef, paramCount: 0);
+				if (defaultCtor != null)
+					yield return Create(Newobj, defaultCtor);
+				else {
 					//should never happen. but if it does, this prevents corrupting the IL stack
-					yield return Instruction.Create(OpCodes.Ldnull);
+					yield return Create(Ldnull);
 				}
 				break;
 			}

--- a/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
@@ -1,32 +1,167 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using Mono.Cecil;
+using Mono.Cecil.Rocks;
 
 namespace Xamarin.Forms.Build.Tasks
 {
 	static class ModuleDefinitionExtensions
 	{
-		static readonly Dictionary<Tuple<ModuleDefinition, System.Reflection.MethodBase>, MethodReference> MbMr =
-			new Dictionary<Tuple<ModuleDefinition, System.Reflection.MethodBase>, MethodReference>();
-
-		static readonly Dictionary<Tuple<ModuleDefinition, Type>, TypeReference> TTr =
-			new Dictionary<Tuple<ModuleDefinition, Type>, TypeReference>();
-
-		public static MethodReference ImportReferenceCached(this ModuleDefinition module, System.Reflection.MethodBase method)
+		public static TypeReference ImportReference(this ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) type, (string assemblyName, string clrNamespace, string typeName)[] classArguments = null)
 		{
-			var key = new Tuple<ModuleDefinition, System.Reflection.MethodBase>(module, method);
-			if (MbMr.TryGetValue(key, out var result))
-				return result;
-			return MbMr[key] = module.ImportReference(method);
+			var typeRef = module.ImportReference(module.GetTypeDefinition(type));
+			if (classArguments is null)
+				return typeRef;
+			return module.ImportReference(typeRef.MakeGenericInstanceType(classArguments.Select(gp => module.GetTypeDefinition((gp.assemblyName, gp.clrNamespace, gp.typeName))).ToArray()));
 		}
 
-		public static TypeReference ImportReferenceCached(this ModuleDefinition module, Type type)
+		public static TypeReference ImportArrayReference(this ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) type)
 		{
-			var key = new Tuple<ModuleDefinition, Type>(module, type);
-			if (TTr.TryGetValue(key, out var result))
-				return result;
-			return TTr[key] = module.ImportReference(type);
+			var typeRef = module.ImportReference(type);
+			if (typeRef is null)
+				return null;
+			return module.ImportReference(typeRef.MakeArrayType());
+		}
+
+		public static MethodReference ImportCtorReference(this ModuleDefinition module, TypeReference type, int paramCount, TypeReference[] classArguments = null, Func<MethodDefinition, bool> predicate = null)
+		{
+			var ctor = module
+				.ImportReference(type)
+				.ResolveCached()
+				.Methods
+				.FirstOrDefault(md =>
+								   md.IsConstructor
+								&& md.Parameters.Count == paramCount
+								&& (predicate?.Invoke(md) ?? true));
+			if (ctor is null)
+				return null;
+			var ctorRef = module.ImportReference(ctor);
+			if (classArguments == null)
+				return ctorRef;
+			return module.ImportReference(ctorRef.ResolveGenericParameters(type.MakeGenericInstanceType(classArguments), module));
+		}
+
+		public static MethodReference ImportCtorReference(this ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) type, int paramCount, (string assemblyName, string clrNamespace, string typeName)[] classArguments, Func<MethodDefinition, bool> predicate = null)
+		{
+			return module.ImportCtorReference(module.GetTypeDefinition(type), paramCount, classArguments?.Select(gp => module.GetTypeDefinition((gp.assemblyName, gp.clrNamespace, gp.typeName))).ToArray(), predicate);
+		}
+
+		public static MethodReference ImportCtorReference(this ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) type, int paramCount, TypeReference[] classArguments, Func<MethodDefinition, bool> predicate = null)
+		{
+			return module.ImportCtorReference(module.GetTypeDefinition(type), paramCount, classArguments, predicate);
+		}
+
+		public static MethodReference ImportCtorReference(this ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) type, int paramCount, Func<MethodDefinition, bool> predicate = null)
+		{
+			return module.ImportCtorReference(module.GetTypeDefinition(type), paramCount, null, predicate);
+		}
+
+		public static MethodReference ImportPropertyGetterReference(this ModuleDefinition module, TypeReference type, string propertyName, Func<PropertyDefinition, bool> predicate = null, bool flatten = false)
+		{
+			var properties = module.ImportReference(type).Resolve().Properties;
+			var getter = module
+				.ImportReference(type)
+				.ResolveCached()
+				.Properties(flatten)
+				.FirstOrDefault(pd =>
+								   pd.Name == propertyName
+								&& (predicate?.Invoke(pd) ?? true))
+				?.GetMethod;
+			return getter == null ? null : module.ImportReference(getter);
+		}
+
+		public static MethodReference ImportPropertyGetterReference(this ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) type, string propertyName, Func<PropertyDefinition, bool> predicate = null, bool flatten = false)
+		{
+			return module.ImportPropertyGetterReference(module.GetTypeDefinition(type), propertyName, predicate, flatten);
+		}
+
+		public static MethodReference ImportPropertySetterReference(this ModuleDefinition module, TypeReference type, string propertyName, Func<PropertyDefinition, bool> predicate = null)
+		{
+			var setter = module
+				.ImportReference(type)
+				.ResolveCached()
+				.Properties
+				.FirstOrDefault(pd =>
+								   pd.Name == propertyName
+								&& (predicate?.Invoke(pd) ?? true))
+				?.SetMethod;
+			return setter == null ? null : module.ImportReference(setter);
+		}
+
+		public static MethodReference ImportPropertySetterReference(this ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) type, string propertyName, Func<PropertyDefinition, bool> predicate = null)
+		{
+			return module.ImportPropertySetterReference(module.GetTypeDefinition(type), propertyName, predicate);
+		}
+
+		public static FieldReference ImportFieldReference(this ModuleDefinition module, TypeReference type, string fieldName, Func<FieldDefinition, bool> predicate = null)
+		{
+			var field = module
+				.ImportReference(type)
+				.ResolveCached()
+				.Fields
+				.FirstOrDefault(fd =>
+								   fd.Name == fieldName
+								&& (predicate?.Invoke(fd) ?? true));
+			return field == null ? null : module.ImportReference(field);
+		}
+
+		public static FieldReference ImportFieldReference(this ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) type, string fieldName, Func<FieldDefinition, bool> predicate = null)
+		{
+			return module.ImportFieldReference(module.GetTypeDefinition(type), fieldName: fieldName, predicate: predicate);
+		}
+
+		public static MethodReference ImportMethodReference(this ModuleDefinition module, TypeReference type, string methodName, int paramCount, Func<MethodDefinition, bool> predicate = null, TypeReference[] classArguments = null)
+		{
+			var method = module
+				.ImportReference(type)
+				.ResolveCached()
+				.Methods
+				.FirstOrDefault(md =>
+								   !md.IsConstructor
+								&& md.Name == methodName
+								&& md.Parameters.Count == paramCount
+								&& (predicate?.Invoke(md) ?? true));
+			if (method is null)
+				return null;
+			var methodRef = module.ImportReference(method);
+			if (classArguments == null)
+				return methodRef;
+			return module.ImportReference(methodRef.ResolveGenericParameters(type.MakeGenericInstanceType(classArguments), module));
+		}
+
+		public static MethodReference ImportMethodReference(this ModuleDefinition module,
+															(string assemblyName, string clrNamespace, string typeName) type,
+															string methodName, int paramCount, Func<MethodDefinition, bool> predicate = null,
+															(string assemblyName, string clrNamespace, string typeName)[] classArguments = null)
+		{
+			return module.ImportMethodReference(module.GetTypeDefinition(type), methodName, paramCount, predicate,
+												classArguments?.Select(gp => module.GetTypeDefinition((gp.assemblyName, gp.clrNamespace, gp.typeName))).ToArray());
+		}
+
+		public static TypeDefinition GetTypeDefinition(this ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) type)
+		{
+			var asm = module.Assembly.Name.Name == type.assemblyName
+							? module.Assembly
+							: module.AssemblyResolver.Resolve(AssemblyNameReference.Parse(type.assemblyName));
+			var typeDef = asm.MainModule.GetType($"{type.clrNamespace}.{type.typeName}");
+			if (typeDef != null)
+				return typeDef;
+			var exportedType = asm.MainModule.ExportedTypes.FirstOrDefault(
+				(ExportedType arg) => arg.IsForwarder && arg.Namespace == type.clrNamespace && arg.Name == type.typeName);
+			if (exportedType != null)
+				return exportedType.Resolve();
+			return null;
+		}
+
+		static IEnumerable<PropertyDefinition> Properties(this TypeDefinition typedef, bool flatten)
+		{
+			foreach (var property in typedef.Properties)
+				yield return property;
+			if (!flatten || typedef.BaseType == null)
+				yield break;
+			foreach (var property in typedef.BaseType.ResolveCached().Properties(true))
+				yield return property;
 		}
 	}
 }

--- a/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
@@ -166,7 +166,7 @@ namespace Xamarin.Forms.Build.Tasks
 			//I hate you, netstandard
 			if (type.assemblyName == "mscorlib" && type.clrNamespace == "System.Reflection")
 				return module.GetTypeDefinition(("System.Reflection", type.clrNamespace, type.typeName));
-				throw new Exception($"Failed to get typedef for {type}");
+			return null;
 		}
 
 		static IEnumerable<PropertyDefinition> Properties(this TypeDefinition typedef, bool flatten)

--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 			//If there's a [TypeConverter], use it
 			if (typeConverter != null && str != null) {
-				var typeConvAttribute = typeConverter.GetCustomAttribute(module.ImportReferenceCached(typeof(TypeConversionAttribute)));
+				var typeConvAttribute = typeConverter.GetCustomAttribute(module, ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "TypeConversionAttribute"));
 				if (typeConvAttribute == null) //trust the unattributed TypeConverter
 					return true;
 				var toType = typeConvAttribute.ConstructorArguments.First().Value as TypeReference;
@@ -98,7 +98,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var str = (string)node.Value;
 
 			//If the TypeConverter has a ProvideCompiledAttribute that can be resolved, shortcut this
-			var compiledConverterName = typeConverter?.GetCustomAttribute (module.ImportReferenceCached(typeof(ProvideCompiledAttribute)))?.ConstructorArguments?.First().Value as string;
+			var compiledConverterName = typeConverter?.GetCustomAttribute(module, ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "ProvideCompiledAttribute"))?.ConstructorArguments?.First().Value as string;
 			Type compiledConverterType;
 			if (compiledConverterName != null && (compiledConverterType = Type.GetType (compiledConverterName)) != null) {
 				var compiledConverter = Activator.CreateInstance (compiledConverterType);
@@ -115,11 +115,10 @@ namespace Xamarin.Forms.Build.Tasks
 			//If there's a [TypeConverter], use it
 			if (typeConverter != null)
 			{
-				var isExtendedConverter = typeConverter.ImplementsInterface(module.ImportReferenceCached(typeof (IExtendedTypeConverter)));
-				var typeConverterCtor = typeConverter.ResolveCached().Methods.Single(md => md.IsConstructor && md.Parameters.Count == 0 && !md.IsStatic);
-				var typeConverterCtorRef = module.ImportReference(typeConverterCtor);
+				var isExtendedConverter = typeConverter.ImplementsInterface(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "IExtendedTypeConverter")));
+				var typeConverterCtorRef = module.ImportCtorReference(typeConverter, paramCount: 0, predicate: md => !md.IsStatic);
 				var convertFromInvariantStringDefinition = isExtendedConverter
-					? module.ImportReferenceCached(typeof (IExtendedTypeConverter))
+					? module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "IExtendedTypeConverter"))
 						.ResolveCached()
 						.Methods.FirstOrDefault(md => md.Name == "ConvertFromInvariantString" && md.Parameters.Count == 2)
 					: typeConverter.ResolveCached()
@@ -191,22 +190,14 @@ namespace Xamarin.Forms.Build.Tasks
 			} else if (targetTypeRef.FullName == "System.TimeSpan") {
 				var ts = TimeSpan.Parse(str, CultureInfo.InvariantCulture);
 				var ticks = ts.Ticks;
-				var timeSpanCtor =
-					module.ImportReferenceCached(typeof(TimeSpan))
-						.ResolveCached()
-						.Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 1);
-				var timeSpanCtorRef = module.ImportReference(timeSpanCtor);
+				var timeSpanCtorRef = module.ImportCtorReference(("mscorlib", "System", "TimeSpan"), paramCount: 1);
 
 				yield return Instruction.Create(OpCodes.Ldc_I8, ticks);
 				yield return Instruction.Create(OpCodes.Newobj, timeSpanCtorRef);
 			} else if (targetTypeRef.FullName == "System.DateTime") {
 				var dt = DateTime.Parse(str, CultureInfo.InvariantCulture);
 				var ticks = dt.Ticks;
-				var dateTimeCtor =
-					module.ImportReferenceCached(typeof(DateTime))
-						.ResolveCached()
-						.Methods.FirstOrDefault(md => md.IsConstructor && md.Parameters.Count == 1);
-				var dateTimeCtorRef = module.ImportReference(dateTimeCtor);
+				var dateTimeCtorRef = module.ImportCtorReference(("mscorlib", "System", "DateTime"), paramCount: 1);
 
 				yield return Instruction.Create(OpCodes.Ldc_I8, ticks);
 				yield return Instruction.Create(OpCodes.Newobj, dateTimeCtorRef);
@@ -219,41 +210,32 @@ namespace Xamarin.Forms.Build.Tasks
 			else if (targetTypeRef.FullName == "System.Decimal") {
 				decimal outdecimal;
 				if (decimal.TryParse(str, NumberStyles.Number, CultureInfo.InvariantCulture, out outdecimal)) {
-					var vardef = new VariableDefinition(context.Body.Method.Module.ImportReferenceCached(typeof(decimal)));
+					var vardef = new VariableDefinition(module.ImportReference(("mscorlib", "System", "Decimal")));
 					context.Body.Variables.Add(vardef);
 					//Use an extra temp var so we can push the value to the stack, just like other cases
-					//					IL_0003:  ldstr "adecimal"
-					//					IL_0008:  ldc.i4.s 0x6f
-					//					IL_000a:  call class [mscorlib]System.Globalization.CultureInfo class [mscorlib]System.Globalization.CultureInfo::get_InvariantCulture()
-					//					IL_000f:  ldloca.s 0
-					//					IL_0011:  call bool valuetype [mscorlib]System.Decimal::TryParse(string, valuetype [mscorlib]System.Globalization.NumberStyles, class [mscorlib]System.IFormatProvider, [out] valuetype [mscorlib]System.Decimal&)
-					//					IL_0016:  pop
+//					IL_0003:  ldstr "adecimal"
+//					IL_0008:  ldc.i4.s 0x6f
+//					IL_000a:  call class [mscorlib]System.Globalization.CultureInfo class [mscorlib]System.Globalization.CultureInfo::get_InvariantCulture()
+//					IL_000f:  ldloca.s 0
+//					IL_0011:  call bool valuetype [mscorlib]System.Decimal::TryParse(string, valuetype [mscorlib]System.Globalization.NumberStyles, class [mscorlib]System.IFormatProvider, [out] valuetype [mscorlib]System.Decimal&)
+//					IL_0016:  pop
 					yield return Instruction.Create(OpCodes.Ldstr, str);
 					yield return Instruction.Create(OpCodes.Ldc_I4, 0x6f); //NumberStyles.Number
-					var getInvariantInfo =
-						context.Body.Method.Module.ImportReferenceCached(typeof(CultureInfo))
-							.ResolveCached()
-							.Properties.FirstOrDefault(pd => pd.Name == "InvariantCulture")
-							.GetMethod;
-					var getInvariant = context.Body.Method.Module.ImportReference(getInvariantInfo);
+					var getInvariant = module.ImportPropertyGetterReference(("mscorlib", "System.Globalization", "CultureInfo"),
+																			propertyName: "InvariantCulture");
 					yield return Instruction.Create(OpCodes.Call, getInvariant);
 					yield return Instruction.Create(OpCodes.Ldloca, vardef);
-					var tryParseInfo =
-						context.Body.Method.Module.ImportReferenceCached(typeof(decimal))
-							.ResolveCached()
-							.Methods.FirstOrDefault(md => md.Name == "TryParse" && md.Parameters.Count == 4);
-					var tryParse = context.Body.Method.Module.ImportReference(tryParseInfo);
+					var tryParse = module.ImportMethodReference(("mscorlib", "System", "Decimal"),
+																methodName: "TryParse",
+																paramCount: 4);
 					yield return Instruction.Create(OpCodes.Call, tryParse);
 					yield return Instruction.Create(OpCodes.Pop);
 					yield return Instruction.Create(OpCodes.Ldloc, vardef);
 				} else {
 					yield return Instruction.Create(OpCodes.Ldc_I4_0);
-					var decimalctorinfo =
-						context.Body.Method.Module.ImportReferenceCached(typeof(decimal))
-							.ResolveCached()
-							.Methods.FirstOrDefault(
-								md => md.IsConstructor && md.Parameters.Count == 1 && md.Parameters[0].ParameterType.FullName == "System.Int32");
-					var decimalctor = context.Body.Method.Module.ImportReference(decimalctorinfo);
+					var decimalctor = module.ImportCtorReference(("mscorlib", "System", "Decimal"),
+																 paramCount: 1,
+																 predicate: md => md.Parameters[0].ParameterType.FullName == "System.Int32");
 					yield return Instruction.Create(OpCodes.Newobj, decimalctor);
 				}
 			} else if (implicitOperator != null) {
@@ -357,18 +339,18 @@ namespace Xamarin.Forms.Build.Tasks
 
 			var xmlLineInfo = node as IXmlLineInfo;
 			if (xmlLineInfo == null) {
-				yield return Instruction.Create(OpCodes.Ldnull);
+				yield return Create(Ldnull);
 				yield break;
 			}
 			MethodReference ctor;
 			if (xmlLineInfo.HasLineInfo()) {
-				yield return Instruction.Create(OpCodes.Ldc_I4, xmlLineInfo.LineNumber);
-				yield return Instruction.Create(OpCodes.Ldc_I4, xmlLineInfo.LinePosition);
-				ctor = module.ImportReferenceCached(typeof(XmlLineInfo).GetConstructor(new[] { typeof(int), typeof(int) }));
+				yield return Create(Ldc_I4, xmlLineInfo.LineNumber);
+				yield return Create(Ldc_I4, xmlLineInfo.LinePosition);
+				ctor = module.ImportCtorReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "XmlLineInfo"), paramCount: 2);
 			}
 			else
-				ctor = module.ImportReferenceCached(typeof(XmlLineInfo).GetConstructor(new Type[] { }));
-			yield return Instruction.Create(OpCodes.Newobj, ctor);
+				ctor = module.ImportCtorReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "XmlLineInfo"), paramCount: 0);
+			yield return Create(Newobj, ctor);
 		}
 
 		public static IEnumerable<Instruction> PushParentObjectsArray(this INode node, ILContext context)
@@ -417,7 +399,7 @@ namespace Xamarin.Forms.Build.Tasks
 			yield return Instruction.Create(OpCodes.Ldc_I4, nodes.Count);
 			yield return Instruction.Create(OpCodes.Add);
 			yield return Instruction.Create(OpCodes.Newarr, module.TypeSystem.Object);
-			var finalArray = new VariableDefinition(module.ImportReferenceCached(typeof (object[])));
+			var finalArray = new VariableDefinition(module.ImportArrayReference(("mscorlib", "System", "Object")));
 			context.Body.Variables.Add(finalArray);
 			yield return Instruction.Create(OpCodes.Stloc, finalArray);
 
@@ -430,14 +412,11 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Instruction.Create(OpCodes.Ldloc, finalArray); //destinationArray
 				yield return Instruction.Create(OpCodes.Ldc_I4, nodes.Count); //destinationIndex
 				yield return Instruction.Create(OpCodes.Ldloc, parentObjectLength); //length
-				var arrayCopy =
-					module.ImportReferenceCached(typeof (Array))
-						.ResolveCached()
-						.Methods.First(
-							md =>
-								md.Name == "Copy" && md.Parameters.Count == 5 &&
-								md.Parameters[1].ParameterType.FullName == module.TypeSystem.Int32.FullName);
-				yield return Instruction.Create(OpCodes.Call, module.ImportReference(arrayCopy));
+				var arrayCopy = module.ImportMethodReference(("mscorlib", "System", "Array"),
+															 methodName: "Copy",
+															 paramCount: 5,
+															 predicate: md => md.Parameters[1].ParameterType.FullName == "System.Int32");
+				yield return Instruction.Create(OpCodes.Call, arrayCopy);
 			}
 
 			//Add nodes to array
@@ -460,7 +439,7 @@ namespace Xamarin.Forms.Build.Tasks
 		static IEnumerable<Instruction> PushTargetProperty(FieldReference bpRef, PropertyReference propertyRef, TypeReference declaringTypeReference, ModuleDefinition module)
 		{
 			if (bpRef != null) {
-				yield return Instruction.Create(OpCodes.Ldsfld, bpRef);
+				yield return Create(Ldsfld, bpRef);
 				yield break;
 			}
 			if (propertyRef != null) {
@@ -468,15 +447,15 @@ namespace Xamarin.Forms.Build.Tasks
 //				IL_0005:  call class [mscorlib]System.Type class [mscorlib] System.Type::GetTypeFromHandle(valuetype [mscorlib] System.RuntimeTypeHandle)
 //				IL_000a:  ldstr "Foo"
 //				IL_000f:  callvirt instance class [mscorlib] System.Reflection.PropertyInfo class [mscorlib] System.Type::GetProperty(string)
-				var getTypeFromHandle = module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new [] { typeof(RuntimeTypeHandle) }));
-				var getPropertyInfo = module.ImportReferenceCached(typeof(Type).GetMethod("GetProperty", new [] { typeof(string) }));
-				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReference(declaringTypeReference ?? propertyRef.DeclaringType));
-				yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
-				yield return Instruction.Create(OpCodes.Ldstr, propertyRef.Name);
-				yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(getPropertyInfo));
+				var getTypeFromHandle = module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", paramCount: 1, predicate: md => md.IsStatic);
+				var getPropertyInfo = module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetProperty", paramCount: 1);
+				yield return Create(Ldtoken, module.ImportReference(declaringTypeReference ?? propertyRef.DeclaringType));
+				yield return Create(Call, module.ImportReference(getTypeFromHandle));
+				yield return Create(Ldstr, propertyRef.Name);
+				yield return Create(Callvirt, module.ImportReference(getPropertyInfo));
 				yield break;
 			}
-			yield return Instruction.Create(OpCodes.Ldnull);
+			yield return Create(Ldnull);
 			yield break;
 		}
 
@@ -489,26 +468,17 @@ namespace Xamarin.Forms.Build.Tasks
 			yield break;
 #endif
 
-			var ctorinfo = typeof (XamlServiceProvider).GetConstructor(new Type[] { });
-			var ctor = module.ImportReferenceCached(ctorinfo);
+			var addService = module.ImportMethodReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml.Internals", "XamlServiceProvider"), methodName: "Add", paramCount: 2);
+			var getTypeFromHandle = module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", paramCount: 1, predicate: md => md.IsStatic);
 
-			var addServiceInfo = typeof (XamlServiceProvider).GetMethod("Add", new[] { typeof (Type), typeof (object) });
-			var addService = module.ImportReferenceCached(addServiceInfo);
-
-			var getTypeFromHandle =
-				module.ImportReferenceCached(typeof(Type).GetMethod("GetTypeFromHandle", new[] { typeof(RuntimeTypeHandle) }));
-			var getTypeInfo = module.ImportReferenceCached(typeof(System.Reflection.IntrospectionExtensions).GetMethod("GetTypeInfo", new Type[] { typeof(Type)}));
-			var getAssembly = module.ImportReferenceCached(typeof(System.Reflection.TypeInfo).GetProperty("Assembly").GetMethod);
-
-			yield return Instruction.Create(OpCodes.Newobj, ctor);
+			yield return Create(Newobj, module.ImportCtorReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml.Internals", "XamlServiceProvider"), paramCount: 0));
 
 			//Add a SimpleValueTargetProvider
 			var pushParentIl = node.PushParentObjectsArray(context).ToList();
-			if (pushParentIl[pushParentIl.Count - 1].OpCode != OpCodes.Ldnull)
-			{
-				yield return Instruction.Create(OpCodes.Dup); //Keep the serviceProvider on the stack
-				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReferenceCached(typeof (IProvideValueTarget)));
-				yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
+			if (pushParentIl[pushParentIl.Count - 1].OpCode != Ldnull) {
+				yield return Create(Dup); //Keep the serviceProvider on the stack
+				yield return Create(Ldtoken, module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IProvideValueTarget")));
+				yield return Create(Call, getTypeFromHandle);
 
 				foreach (var instruction in pushParentIl)
 					yield return instruction;
@@ -516,67 +486,50 @@ namespace Xamarin.Forms.Build.Tasks
 				foreach (var instruction in PushTargetProperty(bpRef, propertyRef, declaringTypeReference, module))
 					yield return instruction;
 
-				var targetProviderCtor =
-					module.ImportReferenceCached(typeof (SimpleValueTargetProvider).GetConstructor(new[] { typeof (object[]), typeof(object) }));
-				yield return Instruction.Create(OpCodes.Newobj, targetProviderCtor);
-				yield return Instruction.Create(OpCodes.Callvirt, addService);
-			}
-
-			//Add a NamescopeProvider
-			if (context.Scopes.ContainsKey(node))
-			{
-				yield return Instruction.Create(OpCodes.Dup); //Dupicate the serviceProvider
-				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReferenceCached(typeof (INameScopeProvider)));
-				yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
-				var namescopeProviderCtor = module.ImportReferenceCached(typeof (NameScopeProvider).GetConstructor(new Type[] { }));
-				yield return Instruction.Create(OpCodes.Newobj, namescopeProviderCtor);
-				yield return Instruction.Create(OpCodes.Dup); //Duplicate the namescopeProvider
-				var setNamescope = module.ImportReferenceCached(typeof (NameScopeProvider).GetProperty("NameScope").GetSetMethod());
-
-				yield return Instruction.Create(OpCodes.Ldloc, context.Scopes[node].Item1);
-				yield return Instruction.Create(OpCodes.Callvirt, setNamescope);
-				yield return Instruction.Create(OpCodes.Callvirt, addService);
-			}
-
-			//Add a XamlTypeResolver
-			if (node.NamespaceResolver != null)
-			{
-				yield return Create(Dup); //Dupicate the serviceProvider
-				yield return Create(Ldtoken, module.ImportReferenceCached(typeof (IXamlTypeResolver)));
-				yield return Create(Call, module.ImportReference(getTypeFromHandle));
-				var xmlNamespaceResolverCtor = module.ImportReferenceCached(typeof (XmlNamespaceResolver).GetConstructor(new Type[] { }));
-				var addNamespace = module.ImportReferenceCached(typeof (XmlNamespaceResolver).GetMethod("Add"));
-				yield return Create(Newobj, xmlNamespaceResolverCtor);
-				foreach (var kvp in node.NamespaceResolver.GetNamespacesInScope(XmlNamespaceScope.ExcludeXml))
-				{
-					yield return Create(Dup); //dup the resolver
-					yield return Create(Ldstr, kvp.Key);
-					yield return Create(Ldstr, kvp.Value);
-					yield return Create(Callvirt, addNamespace);
-				}
-				yield return Create(Ldtoken, context.Body.Method.DeclaringType);
-				yield return Create(Call, module.ImportReference(getTypeFromHandle));
-				yield return Create(Call, module.ImportReference(getTypeInfo));
-				yield return Create(Callvirt, getAssembly);
-				var xtr = module.ImportReferenceCached(typeof (XamlTypeResolver)).ResolveCached();
-				var xamlTypeResolverCtor = module.ImportReference(xtr.Methods.First(md => md.IsConstructor && md.Parameters.Count == 2));
-				yield return Create(Newobj, xamlTypeResolverCtor);
+				yield return Create(Newobj, module.ImportCtorReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml.Internals", "SimpleValueTargetProvider"), paramCount: 2));
 				yield return Create(Callvirt, addService);
 			}
 
-			if (node is IXmlLineInfo)
-			{
-				yield return Instruction.Create(OpCodes.Dup); //Dupicate the serviceProvider
-				yield return Instruction.Create(OpCodes.Ldtoken, module.ImportReferenceCached(typeof (IXmlLineInfoProvider)));
-				yield return Instruction.Create(OpCodes.Call, module.ImportReference(getTypeFromHandle));
+			//Add a NamescopeProvider
+			if (context.Scopes.ContainsKey(node)) {
+				yield return Create(Dup); //Dupicate the serviceProvider
+				yield return Create(Ldtoken, module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml.Internals", "INameScopeProvider")));
+				yield return Create(Call, getTypeFromHandle);
+				yield return Create(Newobj, module.ImportCtorReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml.Internals", "NameScopeProvider"), paramCount: 0));
+				yield return Create(Dup); //Duplicate the namescopeProvider
+				yield return Create(Ldloc, context.Scopes[node].Item1);
+				yield return Create(Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml.Internals", "NameScopeProvider"), propertyName: "NameScope"));
+				yield return Create(Callvirt, addService);
+			}
 
+			//Add a XamlTypeResolver
+			if (node.NamespaceResolver != null) {
+				yield return Create(Dup); //Dupicate the serviceProvider
+				yield return Create(Ldtoken, module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IXamlTypeResolver")));
+				yield return Create(Call, getTypeFromHandle);
+				yield return Create(Newobj, module.ImportCtorReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml.Internals", "XmlNamespaceResolver"), paramCount: 0));
+				foreach (var kvp in node.NamespaceResolver.GetNamespacesInScope(XmlNamespaceScope.ExcludeXml)) {
+					yield return Create(Dup); //dup the resolver
+					yield return Create(Ldstr, kvp.Key);
+					yield return Create(Ldstr, kvp.Value);
+					yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml.Internals", "XmlNamespaceResolver"), methodName: "Add", paramCount: 2));
+				}
+				yield return Create(Ldtoken, context.Body.Method.DeclaringType);
+				yield return Create(Call, getTypeFromHandle);
+				yield return Create(Call, module.ImportMethodReference(("mscorlib", "System.Reflection", "IntrospectionExtensions"), methodName: "GetTypeInfo", paramCount: 1, predicate: md => md.IsStatic));
+				yield return Create(Callvirt, module.ImportPropertyGetterReference(("mscorlib", "System.Reflection", "TypeInfo"), propertyName: "Assembly", flatten: true));
+				yield return Create(Newobj, module.ImportCtorReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml.Internals", "XamlTypeResolver"), paramCount: 2));
+				yield return Create(Callvirt, addService);
+			}
+
+			if (node is IXmlLineInfo) {
+				yield return Create(Dup); //Dupicate the serviceProvider
+				yield return Create(Ldtoken, module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IXmlLineInfoProvider")));
+				yield return Create(Call, getTypeFromHandle);
 				foreach (var instruction in node.PushXmlLineInfo(context))
 					yield return instruction;
-
-				var lip = module.ImportReferenceCached(typeof (XmlLineInfoProvider)).ResolveCached();
-				var lineInfoProviderCtor = module.ImportReference(lip.Methods.First(md => md.IsConstructor && md.Parameters.Count == 1));
-				yield return Instruction.Create(OpCodes.Newobj, lineInfoProviderCtor);
-				yield return Instruction.Create(OpCodes.Callvirt, addService);
+				yield return Create(Newobj, module.ImportCtorReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml.Internals", "XmlLineInfoProvider"), paramCount: 1));
+				yield return Create(Callvirt, addService);
 			}
 		}
 	}

--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -443,16 +443,10 @@ namespace Xamarin.Forms.Build.Tasks
 				yield break;
 			}
 			if (propertyRef != null) {
-//				IL_0000:  ldtoken [mscorlib]System.String
-//				IL_0005:  call class [mscorlib]System.Type class [mscorlib] System.Type::GetTypeFromHandle(valuetype [mscorlib] System.RuntimeTypeHandle)
-//				IL_000a:  ldstr "Foo"
-//				IL_000f:  callvirt instance class [mscorlib] System.Reflection.PropertyInfo class [mscorlib] System.Type::GetProperty(string)
-				var getTypeFromHandle = module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", paramCount: 1, predicate: md => md.IsStatic);
-				var getPropertyInfo = module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetProperty", paramCount: 1);
 				yield return Create(Ldtoken, module.ImportReference(declaringTypeReference ?? propertyRef.DeclaringType));
-				yield return Create(Call, module.ImportReference(getTypeFromHandle));
+				yield return Create(Call, module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", paramCount: 1, predicate: md => md.IsStatic));
 				yield return Create(Ldstr, propertyRef.Name);
-				yield return Create(Callvirt, module.ImportReference(getPropertyInfo));
+				yield return Create(Call, module.ImportMethodReference(("System.Reflection.Extensions", "System.Reflection", "RuntimeReflectionExtensions"), methodName: "GetRuntimeProperty", paramCount: 2));
 				yield break;
 			}
 			yield return Create(Ldnull);

--- a/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Build.Tasks
 				namescopeVarDef = Context.Scopes[parentNode].Item1;
 				namesInNamescope = Context.Scopes[parentNode].Item2;
 			}
-			if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReferenceCached(typeof (BindableObject))))
+			if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference(("Xamarin.Forms.Core","Xamarin.Forms","BindableObject"))))
 				SetNameScope(node, namescopeVarDef);
 			Context.Scopes[node] = new System.Tuple<VariableDefinition, IList<string>>(namescopeVarDef, namesInNamescope);
 		}
@@ -57,7 +57,7 @@ namespace Xamarin.Forms.Build.Tasks
 		{
 			var namescopeVarDef = CreateNamescope();
 			IList<string> namesInNamescope = new List<string>();
-			if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReferenceCached(typeof (BindableObject))))
+			if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"))))
 				SetNameScope(node, namescopeVarDef);
 			Context.Scopes[node] = new System.Tuple<VariableDefinition, IList<string>>(namescopeVarDef, namesInNamescope);
 		}
@@ -100,13 +100,9 @@ namespace Xamarin.Forms.Build.Tasks
 		VariableDefinition CreateNamescope()
 		{
 			var module = Context.Body.Method.Module;
-			var nsRef = module.ImportReferenceCached(typeof (NameScope));
-			var vardef = new VariableDefinition(nsRef);
+			var vardef = new VariableDefinition(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "NameScope")));
 			Context.Body.Variables.Add(vardef);
-			var nsDef = nsRef.ResolveCached();
-			var ctorinfo = nsDef.Methods.First(md => md.IsConstructor && !md.HasParameters);
-			var ctor = module.ImportReference(ctorinfo);
-			Context.IL.Emit(OpCodes.Newobj, ctor);
+			Context.IL.Emit(OpCodes.Newobj, module.ImportCtorReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "NameScope"), paramCount: 0));
 			Context.IL.Emit(OpCodes.Stloc, vardef);
 			return vardef;
 		}
@@ -114,13 +110,12 @@ namespace Xamarin.Forms.Build.Tasks
 		void SetNameScope(ElementNode node, VariableDefinition ns)
 		{
 			var module = Context.Body.Method.Module;
-			var nsRef = module.ImportReferenceCached(typeof (NameScope));
-			var nsDef = nsRef.ResolveCached();
-			var setNSInfo = nsDef.Methods.First(md => md.Name == "SetNameScope" && md.IsStatic);
-			var setNS = module.ImportReference(setNSInfo);
 			Context.IL.Emit(OpCodes.Ldloc, Context.Variables[node]);
 			Context.IL.Emit(OpCodes.Ldloc, ns);
-			Context.IL.Emit(OpCodes.Call, setNS);
+			Context.IL.Emit(OpCodes.Call, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "NameScope"),
+																	   methodName: "SetNameScope",
+																	   paramCount: 2,
+																	   predicate: md => md.IsStatic));
 		}
 
 		void RegisterName(string str, VariableDefinition namescopeVarDef, IList<string> namesInNamescope, VariableDefinition element, INode node)
@@ -130,35 +125,28 @@ namespace Xamarin.Forms.Build.Tasks
 			namesInNamescope.Add(str);
 
 			var module = Context.Body.Method.Module;
-			var nsRef = module.ImportReferenceCached(typeof (INameScope));
-			var nsDef = nsRef.ResolveCached();
-			var registerInfo = nsDef.Methods.First(md => md.Name == nameof(INameScope.RegisterName) && md.Parameters.Count == 2);
-			var register = module.ImportReference(registerInfo);
-
 			Context.IL.Emit(OpCodes.Ldloc, namescopeVarDef);
 			Context.IL.Emit(OpCodes.Ldstr, str);
 			Context.IL.Emit(OpCodes.Ldloc, element);
-			Context.IL.Emit(OpCodes.Callvirt, register);
+			Context.IL.Emit(OpCodes.Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "INameScope"),
+																		   methodName: "RegisterName",
+																		   paramCount: 2));
 		}
 
 		void SetStyleId(string str, VariableDefinition element)
 		{
-			if (!element.VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReferenceCached(typeof(Element))))
+			if (!element.VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Element"))))
 				return;
 
 			var module = Context.Body.Method.Module;
-			var eltDef = module.ImportReferenceCached(typeof(Element)).ResolveCached();
-			var styleIdInfo = eltDef.Properties.First(pd => pd.Name == nameof(Element.StyleId));
-			var getStyleId = module.ImportReference(styleIdInfo.GetMethod);
-			var setStyleId = module.ImportReference(styleIdInfo.SetMethod);
 
 			var nop = Instruction.Create(OpCodes.Nop);
 			Context.IL.Emit(OpCodes.Ldloc, element);
-			Context.IL.Emit(OpCodes.Callvirt, getStyleId);
+			Context.IL.Emit(OpCodes.Callvirt, module.ImportPropertyGetterReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Element"), propertyName: "StyleId"));
 			Context.IL.Emit(OpCodes.Brtrue, nop);
 			Context.IL.Emit(OpCodes.Ldloc, element);
 			Context.IL.Emit(OpCodes.Ldstr, str);
-			Context.IL.Emit(OpCodes.Callvirt, setStyleId);
+			Context.IL.Emit(OpCodes.Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Element"), propertyName: "StyleId"));
 			Context.IL.Append(nop);
 		}
 	}

--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -136,17 +136,18 @@ namespace Xamarin.Forms.Build.Tasks
 					Context.IL.Append(AddToResourceDictionary(node, node, Context));
 				}
 				// Collection element, implicit content, or implicit collection element.
-				else if (parentVar.VariableType.ImplementsInterface(Module.ImportReferenceCached(typeof (IEnumerable))) && parentVar.VariableType.GetMethods(md => md.Name == "Add" && md.Parameters.Count == 1, Module).Any()) {
+				else if (   parentVar.VariableType.ImplementsInterface(Module.ImportReference(("mscorlib", "System.Collections", "IEnumerable")))
+						 && parentVar.VariableType.GetMethods(md => md.Name == "Add" && md.Parameters.Count == 1, Module).Any()) {
 					var elementType = parentVar.VariableType;
 					var adderTuple = elementType.GetMethods(md => md.Name == "Add" && md.Parameters.Count == 1, Module).First();
 					var adderRef = Module.ImportReference(adderTuple.Item1);
 					adderRef = Module.ImportReference(adderRef.ResolveGenericParameters(adderTuple.Item2, Module));
 
-					Context.IL.Emit(OpCodes.Ldloc, parentVar);
-					Context.IL.Emit(OpCodes.Ldloc, vardef);
-					Context.IL.Emit(OpCodes.Callvirt, adderRef);
+					Context.IL.Emit(Ldloc, parentVar);
+					Context.IL.Emit(Ldloc, vardef);
+					Context.IL.Emit(Callvirt, adderRef);
 					if (adderRef.ReturnType.FullName != "System.Void")
-						Context.IL.Emit(OpCodes.Pop);
+						Context.IL.Emit(Pop);
 				}
 				else if ((contentProperty = GetContentProperty(parentVar.VariableType)) != null) {
 					var name = new XmlName(node.NamespaceURI, contentProperty);
@@ -273,7 +274,7 @@ namespace Xamarin.Forms.Build.Tasks
 			else if (vardefref.VariableDefinition.VariableType.ImplementsGenericInterface("Xamarin.Forms.Xaml.IMarkupExtension`1",
 				out markupExtension, out genericArguments))
 			{
-				var acceptEmptyServiceProvider = vardefref.VariableDefinition.VariableType.GetCustomAttribute(module.ImportReferenceCached(typeof(AcceptEmptyServiceProviderAttribute))) != null;
+				var acceptEmptyServiceProvider = vardefref.VariableDefinition.VariableType.GetCustomAttribute(module, ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "AcceptEmptyServiceProviderAttribute")) != null;
 				if (vardefref.VariableDefinition.VariableType.FullName == "Xamarin.Forms.Xaml.BindingExtension")
 					foreach (var instruction in CompileBindingPath(node, context, vardefref.VariableDefinition))
 						yield return instruction;
@@ -294,13 +295,9 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Instruction.Create(OpCodes.Callvirt, provideValue);
 				yield return Instruction.Create(OpCodes.Stloc, vardefref.VariableDefinition);
 			}
-			else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReferenceCached(typeof (IMarkupExtension))))
+			else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IMarkupExtension"))))
 			{
-				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module.ImportReferenceCached(typeof(AcceptEmptyServiceProviderAttribute))) != null;
-				var markExt = module.ImportReferenceCached(typeof (IMarkupExtension)).ResolveCached();
-				var provideValueInfo = markExt.Methods.First(md => md.Name == "ProvideValue");
-				var provideValue = module.ImportReference(provideValueInfo);
-
+				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module, ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "AcceptEmptyServiceProviderAttribute")) != null;
 				vardefref.VariableDefinition = new VariableDefinition(module.TypeSystem.Object);
 				yield return Instruction.Create(OpCodes.Ldloc, context.Variables[node]);
 				if (acceptEmptyServiceProvider)
@@ -308,15 +305,15 @@ namespace Xamarin.Forms.Build.Tasks
 				else
 					foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
 						yield return instruction;
-				yield return Instruction.Create(OpCodes.Callvirt, provideValue);
+				yield return Instruction.Create(OpCodes.Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IMarkupExtension"), methodName: "ProvideValue", paramCount: 1));
 				yield return Instruction.Create(OpCodes.Stloc, vardefref.VariableDefinition);
 			}
-			else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReferenceCached(typeof (IValueProvider))))
+			else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IValueProvider"))))
 			{
-				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module.ImportReferenceCached(typeof(AcceptEmptyServiceProviderAttribute))) != null;
+				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module, ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "AcceptEmptyServiceProviderAttribute")) != null;
 				var valueProviderType = context.Variables[node].VariableType;
 				//If the IValueProvider has a ProvideCompiledAttribute that can be resolved, shortcut this
-				var compiledValueProviderName = valueProviderType?.GetCustomAttribute(module.ImportReferenceCached(typeof(ProvideCompiledAttribute)))?.ConstructorArguments?[0].Value as string;
+				var compiledValueProviderName = valueProviderType?.GetCustomAttribute(module, ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "ProvideCompiledAttribute"))?.ConstructorArguments?[0].Value as string;
 				Type compiledValueProviderType;
 				if (compiledValueProviderName != null && (compiledValueProviderType = Type.GetType(compiledValueProviderName)) != null) {
 					var compiledValueProvider = Activator.CreateInstance(compiledValueProviderType);
@@ -331,10 +328,6 @@ namespace Xamarin.Forms.Build.Tasks
 					yield break;
 				}
 
-				var valueProviderDef = module.ImportReferenceCached(typeof (IValueProvider)).ResolveCached();
-				var provideValueInfo = valueProviderDef.Methods.First(md => md.Name == "ProvideValue");
-				var provideValue = module.ImportReference(provideValueInfo);
-
 				vardefref.VariableDefinition = new VariableDefinition(module.TypeSystem.Object);
 				yield return Instruction.Create(OpCodes.Ldloc, context.Variables[node]);
 				if (acceptEmptyServiceProvider)
@@ -342,7 +335,9 @@ namespace Xamarin.Forms.Build.Tasks
 				else
 					foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
 						yield return instruction;
-				yield return Instruction.Create(OpCodes.Callvirt, provideValue);
+				yield return Instruction.Create(OpCodes.Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IValueProvider"),
+																							   methodName: "ProvideValue",
+																							   paramCount: 1));
 				yield return Instruction.Create(OpCodes.Stloc, vardefref.VariableDefinition);
 			}
 		}
@@ -351,6 +346,7 @@ namespace Xamarin.Forms.Build.Tasks
 		static IEnumerable<Instruction> CompileBindingPath(ElementNode node, ILContext context, VariableDefinition bindingExt)
 		{
 			//TODO support casting operators
+			var module = context.Module;
 
 			INode pathNode;
 			if (!node.Properties.TryGetValue(new XmlName("", "Path"), out pathNode) && node.CollectionItems.Any())
@@ -375,23 +371,21 @@ namespace Xamarin.Forms.Build.Tasks
 			var namespaceuri = dataType.Contains(":") ? node.NamespaceResolver.LookupNamespace(dataType.Split(':') [0].Trim()) : "";
 			var dtXType = new XmlType(namespaceuri, dataType, null);
 
-			var tSourceRef = dtXType.GetTypeReference(context.Module, (IXmlLineInfo)node);
+			var tSourceRef = dtXType.GetTypeReference(module, (IXmlLineInfo)node);
 			if (tSourceRef == null)
 				yield break; //throw
 
-			var properties = ParsePath(path, tSourceRef, node as IXmlLineInfo, context.Module);
+			var properties = ParsePath(path, tSourceRef, node as IXmlLineInfo, module);
 			var tPropertyRef = properties != null && properties.Any() ? properties.Last().Item1.PropertyType : tSourceRef;
 
-			var funcRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(Func<,>)).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
-			var actionRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(Action<,>)).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
-			var funcObjRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(Func<,>)).MakeGenericInstanceType(new [] { tSourceRef, context.Module.TypeSystem.Object }));
-			var tupleRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(Tuple<,>)).MakeGenericInstanceType(new [] { funcObjRef, context.Module.TypeSystem.String}));
-			var typedBindingRef = context.Module.ImportReference(context.Module.ImportReferenceCached(typeof(TypedBinding<,>)).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef}));
+			var funcRef = module.ImportReference(module.ImportReference(("mscorlib", "System", "Func`2")).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
+			var actionRef = module.ImportReference(module.ImportReference(("mscorlib", "System", "Action`2")).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
+			var funcObjRef = module.ImportReference(module.ImportReference(("mscorlib", "System", "Func`2")).MakeGenericInstanceType(new [] { tSourceRef, module.TypeSystem.Object }));
+			var tupleRef = module.ImportReference(module.ImportReference(("mscorlib", "System", "Tuple`2")).MakeGenericInstanceType(new [] { funcObjRef, module.TypeSystem.String}));
+			var typedBindingRef = module.ImportReference(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "TypedBinding`2")).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef}));
 
-			TypeReference _;
-			var ctorInfo =  context.Module.ImportReference(typedBindingRef.ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && !md.IsStatic && md.Parameters.Count == 3 ));
+			var ctorInfo =  module.ImportReference(typedBindingRef.ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && !md.IsStatic && md.Parameters.Count == 3 ));
 			var ctorinforef = ctorInfo.MakeGeneric(typedBindingRef, funcRef, actionRef, tupleRef);
-			var setTypedBinding = context.Module.ImportReferenceCached(typeof(BindingExtension)).GetProperty(pd => pd.Name == "TypedBinding", out _).SetMethod;
 
 			yield return Instruction.Create(OpCodes.Ldloc, bindingExt);
 			foreach (var instruction in CompiledBindingGetGetter(tSourceRef, tPropertyRef, properties, node, context))
@@ -406,8 +400,8 @@ namespace Xamarin.Forms.Build.Tasks
 					yield return instruction;
 			} else
 				yield return Create(Ldnull);
-			yield return Instruction.Create(OpCodes.Newobj, context.Module.ImportReference(ctorinforef));
-			yield return Instruction.Create(OpCodes.Callvirt, context.Module.ImportReference(setTypedBinding));
+			yield return Instruction.Create(OpCodes.Newobj, module.ImportReference(ctorinforef));
+			yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml", "BindingExtension"), propertyName: "TypedBinding"));
 		}
 
 		static IList<Tuple<PropertyDefinition, string>> ParsePath(string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module)
@@ -447,7 +441,7 @@ namespace Xamarin.Forms.Build.Tasks
 					previousPartTypeRef = property.PropertyType;
 				}
 				if (indexArg != null) {
-					var defaultMemberAttribute = previousPartTypeRef.GetCustomAttribute(module.ImportReferenceCached(typeof(System.Reflection.DefaultMemberAttribute)));
+					var defaultMemberAttribute = previousPartTypeRef.GetCustomAttribute(module, ("mscorlib", "System.Reflection", "DefaultMemberAttribute"));
 					var indexerName = defaultMemberAttribute?.ConstructorArguments?.FirstOrDefault().Value as string ?? "Item";
 					var indexer = previousPartTypeRef.GetProperty(pd => pd.Name == indexerName && pd.GetMethod != null && pd.GetMethod.IsPublic, out _);
 					properties.Add(new Tuple<PropertyDefinition, string>(indexer, indexArg));
@@ -472,7 +466,6 @@ namespace Xamarin.Forms.Build.Tasks
 //			}
 
 			var module = context.Module;
-			var compilerGeneratedCtor = module.ImportReferenceCached(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
 			var getter = new MethodDefinition($"<{context.Body.Method.Name}>typedBindingsM__{typedBindingCount++}",
 											  MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
 											  tPropertyRef) {
@@ -480,7 +473,7 @@ namespace Xamarin.Forms.Build.Tasks
 					new ParameterDefinition(tSourceRef)
 				},
 				CustomAttributes = {
-					new CustomAttribute (context.Module.ImportReference(compilerGeneratedCtor))
+					new CustomAttribute (module.ImportCtorReference(("mscorlib", "System.Runtime.CompilerServices", "CompilerGeneratedAttribute"), paramCount: 0))
 				}
 			};
 			getter.Body.InitLocals = true;
@@ -519,18 +512,13 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 			context.Body.Method.DeclaringType.Methods.Add(getter);
 
-			var funcRef = module.ImportReferenceCached(typeof(Func<,>));
-			funcRef = module.ImportReference(funcRef.MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
-			var funcCtor = module.ImportReference(funcRef.ResolveCached().GetConstructors().First());
-			funcCtor = funcCtor.MakeGeneric(funcRef, new [] { tSourceRef, tPropertyRef });
-
 //			IL_0007:  ldnull
 //			IL_0008:  ldftn string class Test::'<Main>m__0'(class ViewModel)
 //			IL_000e:  newobj instance void class [mscorlib]System.Func`2<class ViewModel, string>::'.ctor'(object, native int)
 
 			yield return Create(Ldnull);
 			yield return Create(Ldftn, getter);
-			yield return Create(Newobj, module.ImportReference(funcCtor));
+			yield return Create(Newobj, module.ImportCtorReference(("mscorlib", "System", "Func`2"), paramCount: 2, classArguments: new[] { tSourceRef, tPropertyRef }));
 		}
 
 		static IEnumerable<Instruction> CompiledBindingGetSetter(TypeReference tSourceRef, TypeReference tPropertyRef, IList<Tuple<PropertyDefinition, string>> properties, ElementNode node, ILContext context)
@@ -552,7 +540,6 @@ namespace Xamarin.Forms.Build.Tasks
 			//			}
 
 			var module = context.Module;
-			var compilerGeneratedCtor = module.ImportReferenceCached(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
 			var setter = new MethodDefinition($"<{context.Body.Method.Name}>typedBindingsM__{typedBindingCount++}",
 											  MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
 			                                  module.TypeSystem.Void) {
@@ -561,7 +548,7 @@ namespace Xamarin.Forms.Build.Tasks
 					new ParameterDefinition(tPropertyRef)
 				},
 				CustomAttributes = {
-					new CustomAttribute (module.ImportReference(compilerGeneratedCtor))
+					new CustomAttribute (module.ImportCtorReference(("mscorlib", "System.Runtime.CompilerServices", "CompilerGeneratedAttribute"), paramCount: 0))
 				}
 			};
 			setter.Body.InitLocals = true;
@@ -622,17 +609,15 @@ namespace Xamarin.Forms.Build.Tasks
 
 			context.Body.Method.DeclaringType.Methods.Add(setter);
 
-			var actionRef = module.ImportReferenceCached(typeof(Action<,>));
-			actionRef = module.ImportReference(actionRef.MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
-			var actionCtor = module.ImportReference(actionRef.ResolveCached().GetConstructors().First());
-			actionCtor = actionCtor.MakeGeneric(actionRef, new [] { tSourceRef, tPropertyRef });
-
 //			IL_0024: ldnull
 //			IL_0025: ldftn void class Test::'<Main>m__1'(class ViewModel, string)
 //			IL_002b: newobj instance void class [mscorlib]System.Action`2<class ViewModel, string>::'.ctor'(object, native int)
-			yield return Instruction.Create(OpCodes.Ldnull);
-			yield return Instruction.Create(OpCodes.Ldftn, setter);
-			yield return Instruction.Create(OpCodes.Newobj, module.ImportReference(actionCtor));
+			yield return Create(Ldnull);
+			yield return Create(Ldftn, setter);
+			yield return Create(Newobj, module.ImportCtorReference(("mscorlib", "System", "Action`2"),
+																   paramCount: 2,
+																   classArguments:
+																   new[] { tSourceRef, tPropertyRef }));
 		}
 
 		static IEnumerable<Instruction> CompiledBindingGetHandlers(TypeReference tSourceRef, TypeReference tPropertyRef, IList<Tuple<PropertyDefinition, string>> properties, ElementNode node, ILContext context)
@@ -651,7 +636,6 @@ namespace Xamarin.Forms.Build.Tasks
 //			}
 
 			var module = context.Module;
-			var compilerGeneratedCtor = module.ImportReferenceCached(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
 
 			var partGetters = new List<MethodDefinition>();
 			if (properties == null || properties.Count == 0) {
@@ -666,7 +650,7 @@ namespace Xamarin.Forms.Build.Tasks
 						new ParameterDefinition(tSourceRef)
 					},
 					CustomAttributes = {
-						new CustomAttribute (context.Module.ImportReference(compilerGeneratedCtor))
+						new CustomAttribute (module.ImportCtorReference(("mscorlib", "System.Runtime.CompilerServices", "CompilerGeneratedAttribute"), paramCount: 0))
 					}
 				};
 				partGetter.Body.InitLocals = true;
@@ -716,8 +700,8 @@ namespace Xamarin.Forms.Build.Tasks
 				partGetters.Add(partGetter);
 			}
 
-			var funcObjRef = context.Module.ImportReference(module.ImportReferenceCached(typeof(Func<,>)).MakeGenericInstanceType(new [] { tSourceRef, module.TypeSystem.Object }));
-			var tupleRef = context.Module.ImportReference(module.ImportReferenceCached(typeof(Tuple<,>)).MakeGenericInstanceType(new [] { funcObjRef, module.TypeSystem.String }));
+			var funcObjRef = context.Module.ImportReference(module.ImportReference(("mscorlib", "System", "Func`2")).MakeGenericInstanceType(new [] { tSourceRef, module.TypeSystem.Object }));
+			var tupleRef = context.Module.ImportReference(module.ImportReference(("mscorlib", "System", "Tuple`2")).MakeGenericInstanceType(new [] { funcObjRef, module.TypeSystem.String }));
 			var funcCtor = module.ImportReference(funcObjRef.ResolveCached().GetConstructors().First());
 			funcCtor = funcCtor.MakeGeneric(funcObjRef, new [] { tSourceRef, module.TypeSystem.Object });
 			var tupleCtor = module.ImportReference(tupleRef.ResolveCached().GetConstructors().First());
@@ -903,15 +887,12 @@ namespace Xamarin.Forms.Build.Tasks
 		static IEnumerable<Instruction> SetDynamicResource(VariableDefinition parent, FieldReference bpRef, IElementNode elementNode, IXmlLineInfo iXmlLineInfo, ILContext context)
 		{
 			var module = context.Body.Method.Module;
-			var varValue = context.Variables [elementNode];
-			var setDynamicResource = module.ImportReferenceCached(typeof(IDynamicResourceHandler)).ResolveCached().Methods.First(m => m.Name == "SetDynamicResource");
-			var getKey = typeof(DynamicResource).GetProperty("Key").GetMethod;
 
-			yield return Instruction.Create(OpCodes.Ldloc, parent);
-			yield return Instruction.Create(OpCodes.Ldsfld, bpRef);
-			yield return Instruction.Create(OpCodes.Ldloc, varValue);
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReferenceCached(getKey));
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReference(setDynamicResource));
+			yield return Create(Ldloc, parent);
+			yield return Create(Ldsfld, bpRef);
+			yield return Create(Ldloc, context.Variables[elementNode]);
+			yield return Create(Callvirt, module.ImportPropertyGetterReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "DynamicResource"), propertyName: "Key"));
+			yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "IDynamicResourceHandler"), methodName: "SetDynamicResource", paramCount: 2));
 		}
 
 		static bool CanSetBinding(FieldReference bpRef, INode valueNode, ILContext context)
@@ -927,29 +908,27 @@ namespace Xamarin.Forms.Build.Tasks
 			VariableDefinition varValue;
 			if (!context.Variables.TryGetValue(valueNode as IElementNode, out varValue))
 				return false;
-			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReferenceCached(typeof(BindingBase)), module);
+			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference(("Xamarin.Forms.Core","Xamarin.Forms","BindingBase")), module);
 			if (implicitOperator != null)
 				return true;
 
-			return varValue.VariableType.InheritsFromOrImplements(module.ImportReferenceCached(typeof(BindingBase)));
+			return varValue.VariableType.InheritsFromOrImplements(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindingBase")));
 		}
 
 		static IEnumerable<Instruction> SetBinding(VariableDefinition parent, FieldReference bpRef, IElementNode elementNode, IXmlLineInfo iXmlLineInfo, ILContext context)
 		{
 			var module = context.Body.Method.Module;
 			var varValue = context.Variables [elementNode];
-			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReferenceCached(typeof(BindingBase)), module);
+			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindingBase")), module);
 
 			//TODO: check if parent is a BP
-			var setBinding = typeof(BindableObject).GetMethod("SetBinding", new [] { typeof(BindableProperty), typeof(BindingBase) });
-
-			yield return Instruction.Create(OpCodes.Ldloc, parent);
-			yield return Instruction.Create(OpCodes.Ldsfld, bpRef);
-			yield return Instruction.Create(OpCodes.Ldloc, varValue);
+			yield return Create(Ldloc, parent);
+			yield return Create(Ldsfld, bpRef);
+			yield return Create(Ldloc, varValue);
 			if (implicitOperator != null) 
 //				IL_000f:  call !0 class [Xamarin.Forms.Core]Xamarin.Forms.OnPlatform`1<BindingBase>::op_Implicit(class [Xamarin.Forms.Core]Xamarin.Forms.OnPlatform`1<!0>)
-				yield return Instruction.Create(OpCodes.Call, module.ImportReference(implicitOperator));
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReferenceCached(setBinding));
+				yield return Create(Call, module.ImportReference(implicitOperator));
+			yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"), methodName: "SetBinding", paramCount: 2));
 		}
 
 		static bool CanSetValue(FieldReference bpRef, bool attached, INode node, IXmlLineInfo iXmlLineInfo, ILContext context)
@@ -995,7 +974,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (bpRef == null)
 				return false;
 
-			if (!parent.VariableType.InheritsFromOrImplements(module.ImportReferenceCached(typeof(BindableObject))))
+			if (!parent.VariableType.InheritsFromOrImplements(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"))))
 				return false;
 
 			propertyType = bpRef.GetBindablePropertyType(iXmlLineInfo, module);
@@ -1004,7 +983,6 @@ namespace Xamarin.Forms.Build.Tasks
 
 		static IEnumerable<Instruction> SetValue(VariableDefinition parent, FieldReference bpRef, INode node, IXmlLineInfo iXmlLineInfo, ILContext context)
 		{
-			var setValue = typeof(BindableObject).GetMethod("SetValue", new [] { typeof(BindableProperty), typeof(object) });
 			var valueNode = node as ValueNode;
 			var elementNode = node as IElementNode;
 			var module = context.Body.Method.Module;
@@ -1014,8 +992,8 @@ namespace Xamarin.Forms.Build.Tasks
 //			IL_000d:  ldstr "foo"
 //			IL_0012:  callvirt instance void class [Xamarin.Forms.Core]Xamarin.Forms.BindableObject::SetValue(class [Xamarin.Forms.Core]Xamarin.Forms.BindableProperty, object)
 
-			yield return Instruction.Create(OpCodes.Ldloc, parent);
-			yield return Instruction.Create(OpCodes.Ldsfld, bpRef);
+			yield return Create(Ldloc, parent);
+			yield return Create(Ldsfld, bpRef);
 
 			if (valueNode != null) {
 				foreach (var instruction in valueNode.PushConvertedValue(context, bpRef, valueNode.PushServiceProvider(context, bpRef:bpRef), true, false))
@@ -1025,28 +1003,26 @@ namespace Xamarin.Forms.Build.Tasks
 				var varDef = context.Variables[elementNode];
 				var varType = varDef.VariableType;
 				var implicitOperator = varDef.VariableType.GetImplicitOperatorTo(bpTypeRef, module);
-				yield return Instruction.Create(OpCodes.Ldloc, varDef);
+				yield return Create(Ldloc, varDef);
 				if (implicitOperator != null) {
-					yield return Instruction.Create(OpCodes.Call, module.ImportReference(implicitOperator));
+					yield return Create(Call, module.ImportReference(implicitOperator));
 					varType = module.ImportReference(bpTypeRef);
 				}
 				if (varType.IsValueType)
-					yield return Instruction.Create(OpCodes.Box, varType);
+					yield return Create(Box, varType);
 			}
-
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportReferenceCached(setValue));
+			yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"), methodName: "SetValue", paramCount: 2));
 		}
 
 		static IEnumerable<Instruction> GetValue(VariableDefinition parent, FieldReference bpRef, IXmlLineInfo iXmlLineInfo, ILContext context, out TypeReference propertyType)
 		{
-			var getValue = typeof(BindableObject).GetMethod("GetValue", new[] { typeof(BindableProperty) });
 			var module = context.Body.Method.Module;
 			propertyType = bpRef.GetBindablePropertyType(iXmlLineInfo, module);
 
 			return new[] {
-				Instruction.Create(OpCodes.Ldloc, parent),
-				Instruction.Create(OpCodes.Ldsfld, bpRef),
-				Instruction.Create(OpCodes.Callvirt, module.ImportReferenceCached(getValue)),
+				Create(Ldloc, parent),
+				Create(Ldsfld, bpRef),
+				Create(Callvirt,  module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"), methodName: "GetValue", paramCount: 1)),
 			};
 		}
 
@@ -1213,10 +1189,10 @@ namespace Xamarin.Forms.Build.Tasks
 			//is there a RD.Add() overrides that accepts this ?
 			var nodeTypeRef = context.Variables[node].VariableType;
 			var module = context.Body.Method.Module;
-			if (module.ImportReferenceCached(typeof(ResourceDictionary)).ResolveCached().Methods.Any(md =>
-						   md.Name == "Add"
-						&& md.Parameters.Count == 1
-						&& TypeRefComparer.Default.Equals(md.Parameters[0].ParameterType, nodeTypeRef)))
+			if (module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "ResourceDictionary"),
+											 methodName: "Add",
+											 paramCount: 1,
+											 predicate: md => TypeRefComparer.Default.Equals(md.Parameters[0].ParameterType, nodeTypeRef)) != null)
 				return true;
 
 			throw new XamlParseException("resources in ResourceDictionary require a x:Key attribute", lineInfo);
@@ -1267,23 +1243,16 @@ namespace Xamarin.Forms.Build.Tasks
 				yield return Create(Ldloc, varDef);
 				if (varDef.VariableType.IsValueType)
 					yield return Create(Box, module.ImportReference(varDef.VariableType));
-				yield return Create(Callvirt,
-					module.ImportReference(
-						module.ImportReferenceCached(typeof(ResourceDictionary))
-							.ResolveCached()
-							.Methods.Single(md => md.Name == "Add" && md.Parameters.Count == 2)));
+				yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "ResourceDictionary"),
+																		   methodName: "Add", paramCount: 2));
 				yield break;
 			}
 
 			var nodeTypeRef = context.Variables[node].VariableType;
 			yield return Create(Ldloc, context.Variables[node]);
-			yield return Create(Callvirt,
-				module.ImportReference(
-					module.ImportReferenceCached(typeof(ResourceDictionary))
-						.ResolveCached()
-						.Methods.Single(md => md.Name == "Add"
-									 && md.Parameters.Count == 1
-									 && TypeRefComparer.Default.Equals(md.Parameters[0].ParameterType, nodeTypeRef))));
+			yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "ResourceDictionary"),
+																	   methodName: "Add", paramCount: 1,
+																	   predicate: md => TypeRefComparer.Default.Equals(md.Parameters[0].ParameterType, nodeTypeRef)));
 			yield break;
 		}
 
@@ -1322,17 +1291,15 @@ namespace Xamarin.Forms.Build.Tasks
 
 
 			var module = parentContext.Module;
-			var compilerGeneratedCtor = module.ImportReferenceCached(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)).GetMethods(md => md.IsConstructor, module).First().Item1;
 			var anonType = new TypeDefinition(
 				null,
 				"<" + parentContext.Body.Method.Name + ">_anonXamlCDataTemplate_" + dtcount++,
 				TypeAttributes.BeforeFieldInit |
 				TypeAttributes.Sealed |
-				TypeAttributes.NestedPrivate)
-			{
+				TypeAttributes.NestedPrivate) {
 				BaseType = module.TypeSystem.Object,
 				CustomAttributes = {
-					new CustomAttribute (module.ImportReference(compilerGeneratedCtor))
+					new CustomAttribute (module.ImportCtorReference(("mscorlib", "System.Runtime.CompilerServices", "CompilerGeneratedAttribute"), paramCount: 0)),
 				}
 			};
 
@@ -1345,7 +1312,7 @@ namespace Xamarin.Forms.Build.Tasks
 			loadTemplate.Body.InitLocals = true;
 			anonType.Methods.Add(loadTemplate);
 
-			var parentValues = new FieldDefinition("parentValues", FieldAttributes.Assembly, module.ImportReferenceCached(typeof (object[])));
+			var parentValues = new FieldDefinition("parentValues", FieldAttributes.Assembly, module.ImportArrayReference(("mscorlib", "System", "Object")));
 			anonType.Fields.Add(parentValues);
 
 			TypeReference rootType = null;
@@ -1396,20 +1363,12 @@ namespace Xamarin.Forms.Build.Tasks
 			parentIl.Emit(OpCodes.Stfld, root);
 
 			//SetDataTemplate
-			parentIl.Emit(OpCodes.Ldftn, loadTemplate);
-			var funcObjRef = module.ImportReferenceCached(typeof(Func<object>));
-			var funcCtor =
-				funcObjRef
-					.ResolveCached()
-					.Methods.First(md => md.IsConstructor && md.Parameters.Count == 2)
-					.ResolveGenericParameters(funcObjRef, module);
-			parentIl.Emit(OpCodes.Newobj, module.ImportReference(funcCtor));
+			parentIl.Emit(Ldftn, loadTemplate);
+			parentIl.Emit(Newobj, module.ImportCtorReference(("mscorlib", "System", "Func`1"),
+															 paramCount: 2,
+															 classArguments: new[] { ("mscorlib", "System", "Object") }));
 
-#pragma warning disable 0612
-			var propertySetter =
-				module.ImportReferenceCached(typeof (IDataTemplate)).ResolveCached().Properties.First(p => p.Name == "LoadTemplate").SetMethod;
-#pragma warning restore 0612
-			parentContext.IL.Emit(OpCodes.Callvirt, module.ImportReference(propertySetter));
+			parentContext.IL.Emit(OpCodes.Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "IDataTemplate"), propertyName: "LoadTemplate"));
 
 			loadTemplate.Body.Optimize();
 		}

--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -200,7 +200,7 @@ namespace Xamarin.Forms.Build.Tasks
 			return typeRef.InheritsFromOrImplements(baseClass);
 		}
 
-		public static CustomAttribute GetCustomAttribute(this TypeReference typeRef, TypeReference attribute)
+		static CustomAttribute GetCustomAttribute(this TypeReference typeRef, TypeReference attribute)
 		{
 			var typeDef = typeRef.ResolveCached();
 			//FIXME: avoid string comparison. make sure the attribute TypeRef is the same one
@@ -211,6 +211,11 @@ namespace Xamarin.Forms.Build.Tasks
 			if (baseTypeRef != null && baseTypeRef.FullName != "System.Object")
 				return baseTypeRef.GetCustomAttribute(attribute);
 			return null;
+		}
+
+		public static CustomAttribute GetCustomAttribute(this TypeReference typeRef, ModuleDefinition module, (string assemblyName, string clrNamespace, string typeName) attributeType)
+		{
+			return typeRef.GetCustomAttribute(module.ImportReference(module.GetTypeDefinition(attributeType)));
 		}
 
 		[Obsolete]

--- a/Xamarin.Forms.Build.Tasks/XamlCAssemblyResolver.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCAssemblyResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using Mono.Cecil;
 
 namespace Xamarin.Forms.Build.Tasks
@@ -10,6 +11,37 @@ namespace Xamarin.Forms.Build.Tasks
 			{
 				AssemblyResolver = this
 			}));
+		}
+
+		public override AssemblyDefinition Resolve(AssemblyNameReference name)
+		{
+			if (TryResolve(name, out AssemblyDefinition assembly))
+				return assembly;
+			if (   IsMscorlib(name)
+			    && (  TryResolve(AssemblyNameReference.Parse("mscorlib"), out assembly)
+			       || TryResolve(AssemblyNameReference.Parse("netstandard"), out assembly)
+			       || TryResolve(AssemblyNameReference.Parse("System.Runtime"), out assembly)))
+				return assembly;
+			throw new AssemblyResolutionException(name);
+		}
+
+		bool TryResolve(AssemblyNameReference assemblyNameReference, out AssemblyDefinition assembly)
+		{
+			try {
+				assembly = base.Resolve(assemblyNameReference);
+				return true;
+			}
+			catch (AssemblyResolutionException) {
+				assembly = null;
+				return false;
+			}
+		}
+
+		static bool IsMscorlib(AssemblyNameReference name)
+		{
+			return    name.Name == "mscorlib"
+				   || name.Name == "System.Runtime"
+				   || name.Name == "netstandard";
 		}
 	}
 }

--- a/Xamarin.Forms.Build.Tasks/XamlTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlTask.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Build.Tasks
 		static TypeReference GetTypeForResourceId(ModuleDefinition module, string resourceId)
 		{
 			foreach (var ca in module.GetCustomAttributes()) {
-				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReferenceCached(typeof(XamlResourceIdAttribute))))
+				if (!TypeRefComparer.Default.Equals(ca.AttributeType, module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "XamlResourceIdAttribute"))))
 					continue;
 				if (ca.ConstructorArguments[0].Value as string != resourceId)
 					continue;

--- a/Xamarin.Forms.Build.Tasks/XmlTypeExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/XmlTypeExtensions.cs
@@ -114,19 +114,7 @@ namespace Xamarin.Forms.Build.Tasks
 						clrNamespace += '.' + typeName.Substring(0, typeName.LastIndexOf('.'));
 						typeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
 					}
-					var assemblydefinition = module.Assembly.Name.Name == asm.AssemblyName ?
-												module.Assembly :
-												module.AssemblyResolver.Resolve(AssemblyNameReference.Parse(asm.AssemblyName));
-
-					type = assemblydefinition.MainModule.GetType(clrNamespace + "." + typeName);
-					if (type == null)
-					{
-						var exportedtype =
-							assemblydefinition.MainModule.ExportedTypes.FirstOrDefault(
-								(ExportedType arg) => arg.IsForwarder && arg.Namespace == clrNamespace && arg.Name == typeName);
-						if (exportedtype != null)
-							type = exportedtype.Resolve();
-					}
+					type = module.GetTypeDefinition((asm.AssemblyName, clrNamespace, typeName));
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

[XamlC] no longer use any reflection-base ImportReference

reflection-base ImportReference -- we were using MethodBase and Type --
are importing the types present in the reflection context, at the time
of compilation. As the compilation happens on netstandard2.0, and our
assembly can now be netstandard1.0 again, those imported types are
failing to be resolved.

this changes always import references based on the assembly, or the
assembly references.

it might, or might not, give us another speed bump.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense