### PR TITLE
Remove error XF001 since MSBuild already checks for double imports

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -27,11 +27,6 @@
 	</PropertyGroup>
 
 	<Target Name="_ValidateXFTasks" BeforeTargets="_CheckForInvalidConfigurationAndPlatform" Condition="'$(XFDisableTargetsValidation)' != 'True'">
-		<Error
-			Text="Xamarin.Forms targets have been imported multiple times. Please check your project file and remove the duplicate import(s)."
-			Code="XF001"
-			Condition="'$(_XFTargetsImportedAgain)' == 'True'" />
-
 		<GetTasksAbi>
 			<Output TaskParameter="AbiVersion" PropertyName="_XFTasksAbi" />
 		</GetTasksAbi >


### PR DESCRIPTION
Importing twice the same targets might be a user authoring error, but it should 
hardly fail the build, unless it causes a real issue when the imported targets are 
actually from different versions, which is checked a few lines below in XF002.

MSBuild will already issue a warning for double imports, so there is already a 
non-silent way for users to fail the build on that case if they want to.