### PR TITLE
[Core, iOS, Android, UWP, WPF] Hide scroll view scroll bars

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ScrollGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ScrollGallery.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Forms.Controls
 			var btn1 = new Button { Text = "Start" };
 			var btn2 = new Button { Text = "Center" };
 			var btn3 = new Button { Text = "End" };
+			var btn7 = new Button { Text = "Toggle Scroll Bar Visibility" };
 			var btn6 = new Button { Text = "MakeVisible", HorizontalOptions= LayoutOptions.CenterAndExpand, BackgroundColor = Color.Accent };
 			
 			var label = new Label { Text = string.Format ("X: {0}, Y: {1}", 0, 0) };
@@ -40,6 +41,7 @@ namespace Xamarin.Forms.Controls
 			btnStack.Children.Add (btn1);
 			btnStack.Children.Add (btn2);
 			btnStack.Children.Add (btn3);
+			btnStack.Children.Add(btn7);
 
 			btnStack1.Children.Add (btn);
 			btnStack1.Children.Add (btn4);
@@ -104,6 +106,20 @@ namespace Xamarin.Forms.Controls
 			};
 			btn6.Clicked += async (object sender, EventArgs e) => {
 				await _scrollview.ScrollToAsync (_toNavigateTo, ScrollToPosition.MakeVisible, true);
+			};
+			btn7.Clicked += (object sender, EventArgs e) =>
+			{
+				if (_scrollview.VerticalScrollBarVisibility == ScrollBarVisibility.Always ||
+				_scrollview.VerticalScrollBarVisibility == ScrollBarVisibility.Default)
+				{
+					_scrollview.VerticalScrollBarVisibility = ScrollBarVisibility.Never;
+					_scrollview.HorizontalScrollBarVisibility = ScrollBarVisibility.Never;
+				}
+				else
+				{
+					_scrollview.VerticalScrollBarVisibility = ScrollBarVisibility.Always;
+					_scrollview.HorizontalScrollBarVisibility = ScrollBarVisibility.Always;
+				}
 			};
 
 			_stack.Padding = new Size (20, 60);

--- a/Xamarin.Forms.Core/ScrollBarVisibility.cs
+++ b/Xamarin.Forms.Core/ScrollBarVisibility.cs
@@ -1,0 +1,9 @@
+﻿namespace Xamarin.Forms
+{
+    public enum ScrollBarVisibility
+    {
+		Default,
+		Always,
+		Never,
+	}
+}

--- a/Xamarin.Forms.Core/ScrollView.cs
+++ b/Xamarin.Forms.Core/ScrollView.cs
@@ -26,6 +26,10 @@ namespace Xamarin.Forms
 
 		readonly Lazy<PlatformConfigurationRegistry<ScrollView>> _platformConfigurationRegistry;
 
+		public static readonly BindableProperty HorizontalScrollBarVisibilityProperty = BindableProperty.Create("HorizontalScrollBarVisibility", typeof(ScrollBarVisibility), typeof(ScrollView), ScrollBarVisibility.Default);
+
+		public static readonly BindableProperty VerticalScrollBarVisibilityProperty = BindableProperty.Create("VerticalScrollBarVisibility", typeof(ScrollBarVisibility), typeof(ScrollView), ScrollBarVisibility.Default);
+
 		View _content;
 
 		TaskCompletionSource<bool> _scrollCompletionSource;
@@ -70,6 +74,18 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(ScrollYProperty); }
 			private set { SetValue(ScrollYPropertyKey, value); }
+		}
+
+		public ScrollBarVisibility HorizontalScrollBarVisibility
+		{
+			get { return (ScrollBarVisibility)GetValue(HorizontalScrollBarVisibilityProperty); }
+			set { SetValue(HorizontalScrollBarVisibilityProperty, value); }
+		}
+
+		public ScrollBarVisibility VerticalScrollBarVisibility
+		{
+			get { return (ScrollBarVisibility)GetValue(VerticalScrollBarVisibilityProperty); }
+			set { SetValue(VerticalScrollBarVisibilityProperty, value); }
 		}
 
 		public ScrollView()

--- a/Xamarin.Forms.Core/ScrollView.cs
+++ b/Xamarin.Forms.Core/ScrollView.cs
@@ -26,9 +26,9 @@ namespace Xamarin.Forms
 
 		readonly Lazy<PlatformConfigurationRegistry<ScrollView>> _platformConfigurationRegistry;
 
-		public static readonly BindableProperty HorizontalScrollBarVisibilityProperty = BindableProperty.Create("HorizontalScrollBarVisibility", typeof(ScrollBarVisibility), typeof(ScrollView), ScrollBarVisibility.Default);
+		public static readonly BindableProperty HorizontalScrollBarVisibilityProperty = BindableProperty.Create(nameof(HorizontalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ScrollView), ScrollBarVisibility.Default);
 
-		public static readonly BindableProperty VerticalScrollBarVisibilityProperty = BindableProperty.Create("VerticalScrollBarVisibility", typeof(ScrollBarVisibility), typeof(ScrollView), ScrollBarVisibility.Default);
+		public static readonly BindableProperty VerticalScrollBarVisibilityProperty = BindableProperty.Create(nameof(VerticalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ScrollView), ScrollBarVisibility.Default);
 
 		View _content;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -88,6 +88,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateBackgroundColor();
 				UpdateOrientation();
 				UpdateIsEnabled();
+				UpdateHorizontalScrollBarVisibility();
+				UpdateVerticalScrollBarVisibility();
 
 				element.SendViewInitialized(this);
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -278,6 +278,10 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateOrientation();
 			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled();
+			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
+				UpdateHorizontalScrollBarVisibility();
+			else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
+				UpdateVerticalScrollBarVisibility();
 		}
 
 		void UpdateIsEnabled()
@@ -423,6 +427,18 @@ namespace Xamarin.Forms.Platform.Android
 					AddView(_container);
 				}
 			}
+		}
+
+		void UpdateHorizontalScrollBarVisibility()
+		{
+			if (_hScrollView != null)
+				_hScrollView.HorizontalScrollBarEnabled = _view.HorizontalScrollBarVisibility == ScrollBarVisibility.Always;
+		}
+
+		void UpdateVerticalScrollBarVisibility()
+		{
+			VerticalScrollBarEnabled = _view.VerticalScrollBarVisibility == ScrollBarVisibility.Always ||
+				_view.VerticalScrollBarVisibility == ScrollBarVisibility.Default;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		ScrollViewContainer _container;
 		HorizontalScrollView _hScrollView;
+		ScrollBarVisibility _defaultHorizontalScrollVisibility = 0;
+		ScrollBarVisibility _defaultVerticalScrollVisibility = 0;
 		bool _isAttached;
 		internal bool ShouldSkipOnTouch;
 		bool _isBidirectional;
@@ -434,13 +436,34 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateHorizontalScrollBarVisibility()
 		{
 			if (_hScrollView != null)
-				_hScrollView.HorizontalScrollBarEnabled = _view.HorizontalScrollBarVisibility == ScrollBarVisibility.Always;
+			{
+				if (_defaultHorizontalScrollVisibility == 0)
+				{
+					_defaultHorizontalScrollVisibility = _hScrollView.HorizontalScrollBarEnabled ? ScrollBarVisibility.Always : ScrollBarVisibility.Never;
+				}
+
+				var newHorizontalScrollVisiblility = _view.HorizontalScrollBarVisibility;
+
+				if (newHorizontalScrollVisiblility == ScrollBarVisibility.Default)
+				{
+					newHorizontalScrollVisiblility = _defaultHorizontalScrollVisibility;
+				}
+
+				_hScrollView.HorizontalScrollBarEnabled = newHorizontalScrollVisiblility == ScrollBarVisibility.Always;
+			}
 		}
 
 		void UpdateVerticalScrollBarVisibility()
 		{
-			VerticalScrollBarEnabled = _view.VerticalScrollBarVisibility == ScrollBarVisibility.Always ||
-				_view.VerticalScrollBarVisibility == ScrollBarVisibility.Default;
+			if (_defaultVerticalScrollVisibility == 0)
+				_defaultVerticalScrollVisibility = VerticalScrollBarEnabled ? ScrollBarVisibility.Always : ScrollBarVisibility.Never;
+
+			var newVerticalScrollVisibility = _view.VerticalScrollBarVisibility;
+
+			if (newVerticalScrollVisibility == ScrollBarVisibility.Default)
+				newVerticalScrollVisibility = _defaultVerticalScrollVisibility;
+
+			VerticalScrollBarEnabled = newVerticalScrollVisibility == ScrollBarVisibility.Always;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
@@ -34,8 +34,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                         CanFocus = true,
                         ShadowType = ShadowType.None,
                         BorderWidth = 0,
-                        HscrollbarPolicy = PolicyType.Automatic,
-                        VscrollbarPolicy = PolicyType.Automatic
+                        HscrollbarPolicy = ScrollBarVisibilityToGtk(Element.HorizontalScrollBarVisibility),
+                        VscrollbarPolicy = ScrollBarVisibilityToGtk(Element.VerticalScrollBarVisibility)
                     };
 
                     _viewPort = new Viewport();
@@ -54,6 +54,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 UpdateOrientation();
                 LoadContent();
                 UpdateContentSize();
+                UpdateVerticalScrollBarVisibility();
+                UpdateHorizontalScrollBarVisibility();
             }
         }
 
@@ -67,6 +69,10 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 LoadContent();
             else if (e.PropertyName == ScrollView.OrientationProperty.PropertyName)
                 UpdateOrientation();
+            else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
+                UpdateVerticalScrollBarVisibility();
+            else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
+                UpdateHorizontalScrollBarVisibility();
         }
 
         protected override void Dispose(bool disposing)
@@ -146,15 +152,15 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             {
                 case ScrollOrientation.Vertical:
                     Control.HscrollbarPolicy = PolicyType.Never;
-                    Control.VscrollbarPolicy = PolicyType.Automatic;
+                    Control.VscrollbarPolicy = ScrollBarVisibilityToGtk(Element.VerticalScrollBarVisibility);
                     break;
                 case ScrollOrientation.Horizontal:
-                    Control.HscrollbarPolicy = PolicyType.Automatic;
+                    Control.HscrollbarPolicy = ScrollBarVisibilityToGtk(Element.HorizontalScrollBarVisibility);
                     Control.VscrollbarPolicy = PolicyType.Never;
                     break;
                 case ScrollOrientation.Both:
-                    Control.HscrollbarPolicy = PolicyType.Automatic;
-                    Control.VscrollbarPolicy = PolicyType.Automatic;
+                    Control.HscrollbarPolicy = ScrollBarVisibilityToGtk(Element.HorizontalScrollBarVisibility);
+                    Control.VscrollbarPolicy = ScrollBarVisibilityToGtk(Element.VerticalScrollBarVisibility);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(Element.Orientation));
@@ -195,6 +201,28 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             var width = Convert.ToInt32(contentSize.Width);
 
             Control.SetSizeRequest(width, height);
+        }
+
+        void UpdateVerticalScrollBarVisibility()
+        {
+            Control.VscrollbarPolicy = ScrollBarVisibilityToGtk(Element.VerticalScrollBarVisibility);
+        }
+
+        void UpdateHorizontalScrollBarVisibility()
+        {
+            if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+                Control.HscrollbarPolicy = ScrollBarVisibilityToGtk(Element.HorizontalScrollBarVisibility);
+        }
+
+        PolicyType ScrollBarVisibilityToGtk(ScrollBarVisibility visibility)
+        {
+            switch(visibility)
+            {
+                case ScrollBarVisibility.Default: return PolicyType.Automatic;
+                case ScrollBarVisibility.Always: return PolicyType.Always;
+                case ScrollBarVisibility.Never: return PolicyType.Never;
+                default: return PolicyType.Automatic;
+            }
         }
     }
 }

--- a/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
@@ -210,7 +210,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         void UpdateHorizontalScrollBarVisibility()
         {
-            if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+	        var orientation = Element.Orientation;
+            if (orientation == ScrollOrientation.Horizontal || orientation == ScrollOrientation.Both)
                 Control.HscrollbarPolicy = ScrollBarVisibilityToGtk(Element.HorizontalScrollBarVisibility);
         }
 
@@ -218,10 +219,14 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         {
             switch(visibility)
             {
-                case ScrollBarVisibility.Default: return PolicyType.Automatic;
-                case ScrollBarVisibility.Always: return PolicyType.Always;
-                case ScrollBarVisibility.Never: return PolicyType.Never;
-                default: return PolicyType.Automatic;
+                case ScrollBarVisibility.Default:
+	                return PolicyType.Automatic;
+                case ScrollBarVisibility.Always:
+	                return PolicyType.Always;
+                case ScrollBarVisibility.Never:
+	                return PolicyType.Never;
+                default:
+	                return PolicyType.Automatic;
             }
         }
     }

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -69,8 +69,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				UpdateContentSize();
 				UpdateBackgroundColor();
-                UpdateVerticalScrollBarVisibility();
-                UpdateHorizontalScrollBarVisibility();
+				UpdateVerticalScrollBarVisibility();
+				UpdateHorizontalScrollBarVisibility();
 
 				UpdateOrientation();
 				RaiseElementChanged(new VisualElementChangedEventArgs(oldElement, element));
@@ -238,15 +238,17 @@ namespace Xamarin.Forms.Platform.MacOS
 			ResetNativeNonScroll();
 		}
 
-        void UpdateVerticalScrollBarVisibility()
+		void UpdateVerticalScrollBarVisibility()
         {
-            if (ScrollView.VerticalScrollBarVisibility == ScrollBarVisibility.Always || ScrollView.VerticalScrollBarVisibility == ScrollBarVisibility.Default)
-                HasVerticalScroller = true;
-            else
-                HasVerticalScroller = false;
+	        var verticalScrollBarVisibility = ScrollView.VerticalScrollBarVisibility;
+
+			if (verticalScrollBarVisibility == ScrollBarVisibility.Always || verticalScrollBarVisibility == ScrollBarVisibility.Default)
+				HasVerticalScroller = true;
+			else
+				HasVerticalScroller = false;
         }
 
-        void UpdateHorizontalScrollBarVisibility()
+		void UpdateHorizontalScrollBarVisibility()
         {
             if (ScrollView.HorizontalScrollBarVisibility == ScrollBarVisibility.Always)
                 HasHorizontalScroller = true;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -69,6 +69,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				UpdateContentSize();
 				UpdateBackgroundColor();
+                UpdateVerticalScrollBarVisibility();
+                UpdateHorizontalScrollBarVisibility();
+
 				UpdateOrientation();
 				RaiseElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 			}
@@ -153,6 +156,10 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateContentSize();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
+            else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
+                UpdateVerticalScrollBarVisibility();
+            else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
+                UpdateHorizontalScrollBarVisibility();
 			else if (e.PropertyName == ScrollView.OrientationProperty.PropertyName)
 				UpdateOrientation();
 		}
@@ -231,7 +238,23 @@ namespace Xamarin.Forms.Platform.MacOS
 			ResetNativeNonScroll();
 		}
 
-		private bool ResetNativeNonScroll()
+        void UpdateVerticalScrollBarVisibility()
+        {
+            if (ScrollView.VerticalScrollBarVisibility == ScrollBarVisibility.Always || ScrollView.VerticalScrollBarVisibility == ScrollBarVisibility.Default)
+                HasVerticalScroller = true;
+            else
+                HasVerticalScroller = false;
+        }
+
+        void UpdateHorizontalScrollBarVisibility()
+        {
+            if (ScrollView.HorizontalScrollBarVisibility == ScrollBarVisibility.Always)
+                HasHorizontalScroller = true;
+            else
+                HasHorizontalScroller = false;
+        }
+
+		private bool ResetNativeNonScroll( )
 		{
 			if (ContentView == null || ScrollView == null || ScrollView.Content == null)
 				return false;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -239,22 +239,16 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 		void UpdateVerticalScrollBarVisibility()
-        	{
-	        	var verticalScrollBarVisibility = ScrollView.VerticalScrollBarVisibility;
+        {
+			var verticalScrollBarVisibility = ScrollView.VerticalScrollBarVisibility;
 
-			if (verticalScrollBarVisibility == ScrollBarVisibility.Always || verticalScrollBarVisibility == ScrollBarVisibility.Default)
-				HasVerticalScroller = true;
-			else
-				HasVerticalScroller = false;
-        	}
+			HasVerticalScroller = (verticalScrollBarVisibility == ScrollBarVisibility.Always || verticalScrollBarVisibility == ScrollBarVisibility.Default);
+		}
 
 		void UpdateHorizontalScrollBarVisibility()
-        	{
-            		if (ScrollView.HorizontalScrollBarVisibility == ScrollBarVisibility.Always)
-                		HasHorizontalScroller = true;
-            		else
-                		HasHorizontalScroller = false;
-        	}
+        {
+			HasHorizontalScroller = (ScrollView.HorizontalScrollBarVisibility == ScrollBarVisibility.Always);
+        }
 
 		private bool ResetNativeNonScroll( )
 		{

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -239,22 +239,22 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 		void UpdateVerticalScrollBarVisibility()
-        {
-	        var verticalScrollBarVisibility = ScrollView.VerticalScrollBarVisibility;
+        	{
+	        	var verticalScrollBarVisibility = ScrollView.VerticalScrollBarVisibility;
 
 			if (verticalScrollBarVisibility == ScrollBarVisibility.Always || verticalScrollBarVisibility == ScrollBarVisibility.Default)
 				HasVerticalScroller = true;
 			else
 				HasVerticalScroller = false;
-        }
+        	}
 
 		void UpdateHorizontalScrollBarVisibility()
-        {
-            if (ScrollView.HorizontalScrollBarVisibility == ScrollBarVisibility.Always)
-                HasHorizontalScroller = true;
-            else
-                HasHorizontalScroller = false;
-        }
+        	{
+            		if (ScrollView.HorizontalScrollBarVisibility == ScrollBarVisibility.Always)
+                		HasHorizontalScroller = true;
+            		else
+                		HasHorizontalScroller = false;
+        	}
 
 		private bool ResetNativeNonScroll( )
 		{

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -239,16 +239,16 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 		void UpdateVerticalScrollBarVisibility()
-        {
+		{
 			var verticalScrollBarVisibility = ScrollView.VerticalScrollBarVisibility;
 
 			HasVerticalScroller = (verticalScrollBarVisibility == ScrollBarVisibility.Always || verticalScrollBarVisibility == ScrollBarVisibility.Default);
 		}
 
 		void UpdateHorizontalScrollBarVisibility()
-        {
+		{
 			HasHorizontalScroller = (ScrollView.HorizontalScrollBarVisibility == ScrollBarVisibility.Always);
-        }
+		}
 
 		private bool ResetNativeNonScroll( )
 		{

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -156,10 +156,10 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateContentSize();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
-            else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
-                UpdateVerticalScrollBarVisibility();
-            else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
-                UpdateHorizontalScrollBarVisibility();
+			else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
+				UpdateVerticalScrollBarVisibility();
+			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
+				UpdateHorizontalScrollBarVisibility();
 			else if (e.PropertyName == ScrollView.OrientationProperty.PropertyName)
 				UpdateOrientation();
 		}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
@@ -195,28 +195,6 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateHorizontalScrollBarVisibility()
 		{
-			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
-				Control.HorizontalScrollBarVisiblePolicy = ScrollBarVisibilityToTizen(Element.HorizontalScrollBarVisibility);
-		}
-
-		ScrollBarVisiblePolicy ScrollBarVisibilityToTizen(ScrollBarVisibility visibility)
-		{
-			switch (visibility)
-			{
-				case ScrollBarVisibility.Default: return ScrollBarVisiblePolicy.Auto;
-				case ScrollBarVisibility.Always: return ScrollBarVisiblePolicy.Visible;
-				case ScrollBarVisibility.Never: return ScrollBarVisiblePolicy.Invisible;
-				default: return ScrollBarVisiblePolicy.Auto;
-			}
-		}
-
-		void UpdateVerticalScrollBarVisibility()
-		{
-			Control.VerticalScrollBarVisiblePolicy = ScrollBarVisibilityToTizen(Element.VerticalScrollBarVisibility);
-		}
-
-		void UpdateHorizontalScrollBarVisibility()
-		{
 			var orientation = Element.Orientation;
 			if (orientation == ScrollOrientation.Horizontal || orientation == ScrollOrientation.Both)
 				Control.HorizontalScrollBarVisiblePolicy = ScrollBarVisibilityToTizen(Element.HorizontalScrollBarVisibility);

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
@@ -209,5 +209,27 @@ namespace Xamarin.Forms.Platform.Tizen
 				default: return ScrollBarVisiblePolicy.Auto;
 			}
 		}
+
+		void UpdateVerticalScrollBarVisibility()
+		{
+			Control.VerticalScrollBarVisiblePolicy = ScrollBarVisibilityToTizen(Element.VerticalScrollBarVisibility);
+		}
+
+		void UpdateHorizontalScrollBarVisibility()
+		{
+			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+				Control.HorizontalScrollBarVisiblePolicy = ScrollBarVisibilityToTizen(Element.HorizontalScrollBarVisibility);
+		}
+
+		ScrollBarVisiblePolicy ScrollBarVisibilityToTizen(ScrollBarVisibility visibility)
+		{
+			switch (visibility)
+			{
+				case ScrollBarVisibility.Default: return ScrollBarVisiblePolicy.Auto;
+				case ScrollBarVisibility.Always: return ScrollBarVisiblePolicy.Visible;
+				case ScrollBarVisibility.Never: return ScrollBarVisiblePolicy.Invisible;
+				default: return ScrollBarVisiblePolicy.Auto;
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
@@ -99,6 +99,8 @@ namespace Xamarin.Forms.Platform.Tizen
 		void UpdateAll()
 		{
 			UpdateOrientation();
+			UpdateVerticalScrollBarVisibility();
+			UpdateHorizontalScrollBarVisibility();
 		}
 
 		void UpdateOrientation()
@@ -156,6 +158,10 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				UpdateContentSize();
 			}
+			else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
+				UpdateVerticalScrollBarVisibility();
+			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
+				UpdateHorizontalScrollBarVisibility();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -180,6 +186,28 @@ namespace Xamarin.Forms.Platform.Tizen
 			Rect region = new Rectangle(x, y, Element.Width, Element.Height).ToPixel();
 			await Control.ScrollToAsync(region, e.ShouldAnimate);
 			Element.SendScrollFinished();
+		}
+
+		void UpdateVerticalScrollBarVisibility()
+		{
+			Control.VerticalScrollBarVisiblePolicy = ScrollBarVisibilityToTizen(Element.VerticalScrollBarVisibility);
+		}
+
+		void UpdateHorizontalScrollBarVisibility()
+		{
+			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+				Control.HorizontalScrollBarVisiblePolicy = ScrollBarVisibilityToTizen(Element.HorizontalScrollBarVisibility);
+		}
+
+		ScrollBarVisiblePolicy ScrollBarVisibilityToTizen(ScrollBarVisibility visibility)
+		{
+			switch (visibility)
+			{
+				case ScrollBarVisibility.Default: return ScrollBarVisiblePolicy.Auto;
+				case ScrollBarVisibility.Always: return ScrollBarVisiblePolicy.Visible;
+				case ScrollBarVisibility.Never: return ScrollBarVisiblePolicy.Invisible;
+				default: return ScrollBarVisiblePolicy.Auto;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
@@ -217,7 +217,8 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateHorizontalScrollBarVisibility()
 		{
-			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+			var orientation = Element.Orientation;
+			if (orientation == ScrollOrientation.Horizontal || orientation == ScrollOrientation.Both)
 				Control.HorizontalScrollBarVisiblePolicy = ScrollBarVisibilityToTizen(Element.HorizontalScrollBarVisibility);
 		}
 
@@ -225,10 +226,14 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			switch (visibility)
 			{
-				case ScrollBarVisibility.Default: return ScrollBarVisiblePolicy.Auto;
-				case ScrollBarVisibility.Always: return ScrollBarVisiblePolicy.Visible;
-				case ScrollBarVisibility.Never: return ScrollBarVisiblePolicy.Invisible;
-				default: return ScrollBarVisiblePolicy.Auto;
+				case ScrollBarVisibility.Default:
+					return ScrollBarVisiblePolicy.Auto;
+				case ScrollBarVisibility.Always:
+					return ScrollBarVisiblePolicy.Visible;
+				case ScrollBarVisibility.Never:
+					return ScrollBarVisiblePolicy.Invisible;
+				default:
+					return ScrollBarVisiblePolicy.Auto;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using UwpScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -74,7 +75,11 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if (Control == null)
 				{
-					SetNativeControl(new ScrollViewer { HorizontalScrollBarVisibility = ScrollBarVisibility.Auto, VerticalScrollBarVisibility = ScrollBarVisibility.Auto });
+					SetNativeControl(new ScrollViewer
+					{
+						HorizontalScrollBarVisibility = ScrollBarVisibilityToUwp(e.NewElement.HorizontalScrollBarVisibility),
+						VerticalScrollBarVisibility = ScrollBarVisibilityToUwp(e.NewElement.VerticalScrollBarVisibility)
+					});
 
 					Control.ViewChanged += OnViewChanged;
 				}
@@ -97,6 +102,10 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateMargins();
 			else if (e.PropertyName == ScrollView.OrientationProperty.PropertyName)
 				UpdateOrientation();
+			else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
+				UpdateVerticalScrollBarVisibiilty();
+			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
+				UpdateHorizontalScrollBarVisibility();
 		}
 
 		void LoadContent()
@@ -188,12 +197,34 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
 			{
-				Control.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
+				Control.HorizontalScrollBarVisibility = UwpScrollBarVisibility.Auto;
 			}
 			else
 			{
-				Control.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+				Control.HorizontalScrollBarVisibility = UwpScrollBarVisibility.Disabled;
 			}
+		}
+
+		UwpScrollBarVisibility ScrollBarVisibilityToUwp(ScrollBarVisibility visibility)
+		{
+			switch(visibility)
+			{
+				case ScrollBarVisibility.Always: return UwpScrollBarVisibility.Visible;
+				case ScrollBarVisibility.Default: return UwpScrollBarVisibility.Auto;
+				case ScrollBarVisibility.Never: return UwpScrollBarVisibility.Hidden;
+				default: return UwpScrollBarVisibility.Auto;
+			}
+		}
+
+		void UpdateVerticalScrollBarVisibiilty()
+		{
+			Control.VerticalScrollBarVisibility = ScrollBarVisibilityToUwp(Element.VerticalScrollBarVisibility);
+		}
+
+		void UpdateHorizontalScrollBarVisibility()
+		{
+			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+				Control.HorizontalScrollBarVisibility = ScrollBarVisibilityToUwp(Element.HorizontalScrollBarVisibility);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
@@ -209,10 +209,14 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			switch(visibility)
 			{
-				case ScrollBarVisibility.Always: return UwpScrollBarVisibility.Visible;
-				case ScrollBarVisibility.Default: return UwpScrollBarVisibility.Auto;
-				case ScrollBarVisibility.Never: return UwpScrollBarVisibility.Hidden;
-				default: return UwpScrollBarVisibility.Auto;
+				case ScrollBarVisibility.Always:
+					return UwpScrollBarVisibility.Visible;
+				case ScrollBarVisibility.Default:
+					return UwpScrollBarVisibility.Auto;
+				case ScrollBarVisibility.Never:
+					return UwpScrollBarVisibility.Hidden;
+				default:
+					return UwpScrollBarVisibility.Auto;
 			}
 		}
 
@@ -223,7 +227,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateHorizontalScrollBarVisibility()
 		{
-			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+			var orientation = Element.Orientation;
+			if (orientation == ScrollOrientation.Horizontal || orientation == ScrollOrientation.Both)
 				Control.HorizontalScrollBarVisibility = ScrollBarVisibilityToUwp(Element.HorizontalScrollBarVisibility);
 		}
 	}

--- a/Xamarin.Forms.Platform.WPF/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/EditorRenderer.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using WpfScrollBarVisibility = System.Windows.Controls.ScrollBarVisibility;
 
 namespace Xamarin.Forms.Platform.WPF
 {
@@ -15,7 +16,7 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				if (Control == null) // construct and SetNativeControl and suscribe control event
 				{
-					SetNativeControl(new TextBox { VerticalScrollBarVisibility = ScrollBarVisibility.Visible, TextWrapping = TextWrapping.Wrap, AcceptsReturn = true });
+					SetNativeControl(new TextBox { VerticalScrollBarVisibility = WpfScrollBarVisibility.Visible, TextWrapping = TextWrapping.Wrap, AcceptsReturn = true });
 					Control.LostFocus += NativeOnLostFocus; 
 					Control.TextChanged += NativeOnTextChanged;
 				}

--- a/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using WpfScrollBarVisibility = System.Windows.Controls.ScrollBarVisibility;
 
 namespace Xamarin.Forms.Platform.WPF
 {
@@ -156,14 +157,14 @@ namespace Xamarin.Forms.Platform.WPF
 		void UpdateOrientation()
 		{
 			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
-				Control.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
+				Control.HorizontalScrollBarVisibility = WpfScrollBarVisibility.Auto;
 			else
-				Control.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+				Control.HorizontalScrollBarVisibility = WpfScrollBarVisibility.Disabled;
 
 			if (Element.Orientation == ScrollOrientation.Vertical || Element.Orientation == ScrollOrientation.Both)
-				Control.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
+				Control.VerticalScrollBarVisibility = WpfScrollBarVisibility.Auto;
 			else
-				Control.VerticalScrollBarVisibility = ScrollBarVisibility.Disabled;
+				Control.VerticalScrollBarVisibility = WpfScrollBarVisibility.Disabled;
 		}
 
 		void UpdateScrollOffset(double x, double y)

--- a/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
@@ -211,7 +211,8 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void UpdateHorizontalScrollBarVisibility()
 		{
-			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+			var orientation = Element.Orientation;
+			if (orientation == ScrollOrientation.Horizontal || orientation == ScrollOrientation.Both)
 				Control.HorizontalScrollBarVisibility = ScrollBarVisibilityToWpf(Element.HorizontalScrollBarVisibility);
 		}
 

--- a/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
@@ -32,7 +32,10 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				if (Control == null) // construct and SetNativeControl and suscribe control event
 				{
-					SetNativeControl(new ScrollViewer() { IsManipulationEnabled = true, PanningMode = PanningMode.Both });
+					SetNativeControl(new ScrollViewer() { IsManipulationEnabled = true, PanningMode = PanningMode.Both,
+						HorizontalScrollBarVisibility = ScrollBarVisibilityToUwp(e.NewElement.HorizontalScrollBarVisibility),
+						VerticalScrollBarVisibility = ScrollBarVisibilityToUwp(e.NewElement.VerticalScrollBarVisibility)
+					});
 					Control.LayoutUpdated += NativeLayoutUpdated;
 				}
 
@@ -58,6 +61,10 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateMargins();
 			else if (e.PropertyName == ScrollView.OrientationProperty.PropertyName)
 				UpdateOrientation();
+			else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
+				UpdateVerticalScrollBarVisibiilty();
+			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
+				UpdateHorizontalScrollBarVisibility();
 		}
 
 		void NativeLayoutUpdated(object sender, EventArgs e)
@@ -179,6 +186,28 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			if (Element != null)
 				Controller.SetScrolledPosition(Control.HorizontalOffset, Control.VerticalOffset);
+		}
+
+		WpfScrollBarVisibility ScrollBarVisibilityToUwp(ScrollBarVisibility visibility)
+		{
+			switch (visibility)
+			{
+				case ScrollBarVisibility.Always: return WpfScrollBarVisibility.Visible;
+				case ScrollBarVisibility.Default: return WpfScrollBarVisibility.Auto;
+				case ScrollBarVisibility.Never: return WpfScrollBarVisibility.Hidden;
+				default: return WpfScrollBarVisibility.Auto;
+			}
+		}
+
+		void UpdateVerticalScrollBarVisibiilty()
+		{
+			Control.VerticalScrollBarVisibility = ScrollBarVisibilityToUwp(Element.VerticalScrollBarVisibility);
+		}
+
+		void UpdateHorizontalScrollBarVisibility()
+		{
+			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+				Control.HorizontalScrollBarVisibility = ScrollBarVisibilityToUwp(Element.HorizontalScrollBarVisibility);
 		}
 
 		bool _isDisposed;

--- a/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
@@ -163,12 +163,13 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void UpdateOrientation()
 		{
-			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
+			var orientation = Element.Orientation;
+			if (orientation == ScrollOrientation.Horizontal || orientation == ScrollOrientation.Both)
 				Control.HorizontalScrollBarVisibility = WpfScrollBarVisibility.Auto;
 			else
 				Control.HorizontalScrollBarVisibility = WpfScrollBarVisibility.Disabled;
 
-			if (Element.Orientation == ScrollOrientation.Vertical || Element.Orientation == ScrollOrientation.Both)
+			if (orientation == ScrollOrientation.Vertical || orientation == ScrollOrientation.Both)
 				Control.VerticalScrollBarVisibility = WpfScrollBarVisibility.Auto;
 			else
 				Control.VerticalScrollBarVisibility = WpfScrollBarVisibility.Disabled;
@@ -192,10 +193,14 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			switch (visibility)
 			{
-				case ScrollBarVisibility.Always: return WpfScrollBarVisibility.Visible;
-				case ScrollBarVisibility.Default: return WpfScrollBarVisibility.Auto;
-				case ScrollBarVisibility.Never: return WpfScrollBarVisibility.Hidden;
-				default: return WpfScrollBarVisibility.Auto;
+				case ScrollBarVisibility.Always:
+					return WpfScrollBarVisibility.Visible;
+				case ScrollBarVisibility.Default:
+					return WpfScrollBarVisibility.Auto;
+				case ScrollBarVisibility.Never:
+					return WpfScrollBarVisibility.Hidden;
+				default:
+					return WpfScrollBarVisibility.Auto;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ScrollViewRenderer.cs
@@ -33,8 +33,8 @@ namespace Xamarin.Forms.Platform.WPF
 				if (Control == null) // construct and SetNativeControl and suscribe control event
 				{
 					SetNativeControl(new ScrollViewer() { IsManipulationEnabled = true, PanningMode = PanningMode.Both,
-						HorizontalScrollBarVisibility = ScrollBarVisibilityToUwp(e.NewElement.HorizontalScrollBarVisibility),
-						VerticalScrollBarVisibility = ScrollBarVisibilityToUwp(e.NewElement.VerticalScrollBarVisibility)
+						HorizontalScrollBarVisibility = ScrollBarVisibilityToWpf(e.NewElement.HorizontalScrollBarVisibility),
+						VerticalScrollBarVisibility = ScrollBarVisibilityToWpf(e.NewElement.VerticalScrollBarVisibility)
 					});
 					Control.LayoutUpdated += NativeLayoutUpdated;
 				}
@@ -188,7 +188,7 @@ namespace Xamarin.Forms.Platform.WPF
 				Controller.SetScrolledPosition(Control.HorizontalOffset, Control.VerticalOffset);
 		}
 
-		WpfScrollBarVisibility ScrollBarVisibilityToUwp(ScrollBarVisibility visibility)
+		WpfScrollBarVisibility ScrollBarVisibilityToWpf(ScrollBarVisibility visibility)
 		{
 			switch (visibility)
 			{
@@ -201,13 +201,13 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void UpdateVerticalScrollBarVisibiilty()
 		{
-			Control.VerticalScrollBarVisibility = ScrollBarVisibilityToUwp(Element.VerticalScrollBarVisibility);
+			Control.VerticalScrollBarVisibility = ScrollBarVisibilityToWpf(Element.VerticalScrollBarVisibility);
 		}
 
 		void UpdateHorizontalScrollBarVisibility()
 		{
 			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
-				Control.HorizontalScrollBarVisibility = ScrollBarVisibilityToUwp(Element.HorizontalScrollBarVisibility);
+				Control.HorizontalScrollBarVisibility = ScrollBarVisibilityToWpf(Element.HorizontalScrollBarVisibility);
 		}
 
 		bool _isDisposed;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -196,7 +196,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateHorizontalScrollBarVisibility()
 		{
-			var horizontalScrollBarVisibility;
+			var horizontalScrollBarVisibility = ScrollView.HorizontalScrollBarVisibility;
 			ShowsHorizontalScrollIndicator = horizontalScrollBarVisibility == ScrollBarVisibility.Always
 			                               || horizontalScrollBarVisibility == ScrollBarVisibility.Default;
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -82,6 +82,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateContentSize();
 				UpdateBackgroundColor();
 				UpdateIsEnabled();
+                UpdateVerticalScrollBarVisibility();
+                UpdateHorizontalScrollBarVisibility();
 
 				OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -169,6 +169,10 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateBackgroundColor();
 			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled();
+			else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
+				UpdateVerticalScrollBarVisibility();
+			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
+				UpdateHorizontalScrollBarVisibility();
 		}
 
 		void UpdateIsEnabled()
@@ -179,6 +183,22 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			ScrollEnabled = Element.IsEnabled;
+		}
+
+		void UpdateVerticalScrollBarVisibility()
+		{
+			if (ScrollView.VerticalScrollBarVisibility == ScrollBarVisibility.Always || ScrollView.VerticalScrollBarVisibility == ScrollBarVisibility.Default)
+				ShowsVerticalScrollIndicator = true;
+			else
+				ShowsVerticalScrollIndicator = false;
+		}
+
+		void UpdateHorizontalScrollBarVisibility()
+		{
+			if (ScrollView.HorizontalScrollBarVisibility == ScrollBarVisibility.Always)
+				ShowsHorizontalScrollIndicator = true;
+			else
+				ShowsHorizontalScrollIndicator = false;
 		}
 
 		void HandleScrollAnimationEnded(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -82,8 +82,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateContentSize();
 				UpdateBackgroundColor();
 				UpdateIsEnabled();
-                UpdateVerticalScrollBarVisibility();
-                UpdateHorizontalScrollBarVisibility();
+				UpdateVerticalScrollBarVisibility();
+				UpdateHorizontalScrollBarVisibility();
 
 				OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
@@ -189,18 +189,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateVerticalScrollBarVisibility()
 		{
-			if (ScrollView.VerticalScrollBarVisibility == ScrollBarVisibility.Always || ScrollView.VerticalScrollBarVisibility == ScrollBarVisibility.Default)
-				ShowsVerticalScrollIndicator = true;
-			else
-				ShowsVerticalScrollIndicator = false;
+			var verticalScrollBarVisibility = ScrollView.VerticalScrollBarVisibility;
+			ShowsVerticalScrollIndicator = verticalScrollBarVisibility == ScrollBarVisibility.Always 
+			                               || verticalScrollBarVisibility == ScrollBarVisibility.Default;
 		}
 
 		void UpdateHorizontalScrollBarVisibility()
 		{
-			if (ScrollView.HorizontalScrollBarVisibility == ScrollBarVisibility.Always)
-				ShowsHorizontalScrollIndicator = true;
-			else
-				ShowsHorizontalScrollIndicator = false;
+			var horizontalScrollBarVisibility;
+			ShowsHorizontalScrollIndicator = horizontalScrollBarVisibility == ScrollBarVisibility.Always
+			                               || horizontalScrollBarVisibility == ScrollBarVisibility.Default;
 		}
 
 		void HandleScrollAnimationEnded(object sender, EventArgs e)

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ScrollBarVisibility.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ScrollBarVisibility.xml
@@ -1,0 +1,59 @@
+<Type Name="ScrollBarVisibility" FullName="Xamarin.Forms.ScrollBarVisibility">
+  <TypeSignature Language="C#" Value="public enum ScrollBarVisibility" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed ScrollBarVisibility extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Always">
+      <MemberSignature Language="C#" Value="Always" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ScrollBarVisibility Always = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ScrollBarVisibility</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Default">
+      <MemberSignature Language="C#" Value="Default" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ScrollBarVisibility Default = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ScrollBarVisibility</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Never">
+      <MemberSignature Language="C#" Value="Never" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ScrollBarVisibility Never = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ScrollBarVisibility</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ScrollView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ScrollView.xml
@@ -194,6 +194,37 @@ MainPage = new ContentPage
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="HorizontalScrollBarVisibility">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.ScrollBarVisibility HorizontalScrollBarVisibility { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.ScrollBarVisibility HorizontalScrollBarVisibility" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ScrollBarVisibility</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="HorizontalScrollBarVisibilityProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty HorizontalScrollBarVisibilityProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty HorizontalScrollBarVisibilityProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="LayoutChildren">
       <MemberSignature Language="C#" Value="protected override void LayoutChildren (double x, double y, double width, double height);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void LayoutChildren(float64 x, float64 y, float64 width, float64 height) cil managed" />
@@ -536,6 +567,37 @@ MainPage = new ContentPage
         <param name="x">For internal use by the Xamarin.Forms platform.</param>
         <param name="y">For internal use by the Xamarin.Forms platform.</param>
         <summary>For internal use by the Xamarin.Forms platform.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="VerticalScrollBarVisibility">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.ScrollBarVisibility VerticalScrollBarVisibility { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.ScrollBarVisibility VerticalScrollBarVisibility" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ScrollBarVisibility</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="VerticalScrollBarVisibilityProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty VerticalScrollBarVisibilityProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty VerticalScrollBarVisibilityProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -374,6 +374,7 @@
       <Type Name="RoutingEffect" Kind="Class" />
       <Type Name="RowDefinition" Kind="Class" />
       <Type Name="RowDefinitionCollection" Kind="Class" />
+      <Type Name="ScrollBarVisibility" Kind="Enumeration" />
       <Type Name="ScrolledEventArgs" Kind="Class" />
       <Type Name="ScrollOrientation" Kind="Enumeration" />
       <Type Name="ScrollToMode" Kind="Enumeration" />


### PR DESCRIPTION
### Description of Change ###

Added vertical and horizontal scroll bar visibility properties to ScrollView and updated UWP, WPF, iOS and Android renderers

I noticed on Android when the ScrollView.Orientation = ScrollOrientation.Both that a horizontal scroll bar is never shown, only the vertical.  I did not try to change this to avoid making a default behavior change.

Unit Tests are not included as I'm not sure what to test right now besides that basic properties were set.

fixes #1670 

### Bugs Fixed ###

- N/A

### API Changes ###

Added:

```
 public enum ScrollBarVisibility
 {
	Default,
	Always,
	Never,
} 
```
 - ScrollBarVisibility ScrollView.HorizontalScrollBarVisibility {get; set;};
 - ScrollBarVisibility ScrollView.VerticalScrollBarVisibility {get;set;};

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense