### PR TITLE
[Tizen] Support CascadeInputTransparent to Tizen

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Renderers/LayoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/LayoutRenderer.cs
@@ -1,5 +1,6 @@
 using ElmSharp;
 using System;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -29,6 +30,15 @@ namespace Xamarin.Forms.Platform.Tizen
 			base.OnElementChanged(e);
 		}
 
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+			if (e.PropertyName == Layout.CascadeInputTransparentProperty.PropertyName)
+			{
+				UpdateInputTransparent(false);
+			}
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
@@ -41,6 +51,39 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 
 			base.Dispose(disposing);
+		}
+
+		protected override void UpdateInputTransparent(bool initialize)
+		{
+			if (initialize && Element.InputTransparent == default(bool))
+			{
+				NativeView.RepeatEvents = Element.CascadeInputTransparent;
+				return;
+			}
+
+			if (Element.InputTransparent)
+			{
+				if (Element.CascadeInputTransparent)
+				{
+					//Ignore all events of both layout and it's chidren
+					NativeView.PassEvents = true;
+					GestureDetector.IsEnabled = Element.IsEnabled;
+				}
+				else
+				{
+					//Ignore Layout's event only. Children's events should be allowded.
+					NativeView.PassEvents = false;
+					NativeView.RepeatEvents = true;
+					GestureDetector.IsEnabled = false;
+				}
+			}
+			else
+			{
+				//Allow layout's events and children's events would be determined by CascadeInputParent.
+				NativeView.PassEvents = false;
+				NativeView.RepeatEvents = Element.CascadeInputTransparent;
+				GestureDetector.IsEnabled = Element.IsEnabled;
+			}
 		}
 
 		void OnLayoutUpdated(object sender, Native.LayoutEventArgs e)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ViewRenderer.cs
@@ -1,6 +1,7 @@
+using System;
 using System.ComponentModel;
-using ElmSharp;
 using System.Diagnostics;
+using ElmSharp;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -11,28 +12,24 @@ namespace Xamarin.Forms.Platform.Tizen
 		where TView : View
 		where TNativeView : EvasObject
 	{
-		GestureDetector _gestureDetector;
+		readonly Lazy<GestureDetector> _gestureDetector;
+
+		internal GestureDetector GestureDetector => _gestureDetector.Value;
 
 		/// <summary>
 		/// Default constructor.
 		/// </summary>
 		protected ViewRenderer()
 		{
+			_gestureDetector = new Lazy<GestureDetector>(() => new GestureDetector(this));
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<TView> e)
 		{
 			base.OnElementChanged(e);
-
-			if (e.OldElement != null)
+			if (e.OldElement != null && _gestureDetector.IsValueCreated)
 			{
-				_gestureDetector.Clear();
-				_gestureDetector = null;
-			}
-
-			if (e.NewElement != null)
-			{
-				_gestureDetector = new GestureDetector(this);
+				_gestureDetector.Value.Clear();
 			}
 		}
 
@@ -65,7 +62,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateIsEnabled()
 		{
-			_gestureDetector.IsEnabled = Element.IsEnabled;
+			_gestureDetector.Value.IsEnabled = Element.IsEnabled;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/VisualElementRenderer.cs
@@ -781,7 +781,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		/// <summary>
 		/// Updates the InputTransparent property.
 		/// </summary>
-		void UpdateInputTransparent(bool initialize)
+		protected virtual void UpdateInputTransparent(bool initialize)
 		{
 			if (initialize && Element.InputTransparent == default(bool))
 				return;


### PR DESCRIPTION
### Description of Change ###

This PR is extension of #1771 and #1621 for tizen backend. 

- On Tizen Mobile Emulator
<img src="https://user-images.githubusercontent.com/1029134/36370456-42173444-15a2-11e8-98b8-85ab3c2de2ed.gif" alt="On Tizen Mobile Emulator" width="240" >

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

From now, tizen also support to allow `Layout` to specify whether child controls cascade `InputTrandparent`.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
