### PR TITLE
Use relative URL to support recursive checkout in VSTS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Xamarin.Forms.Build"]
 	path = Xamarin.Forms.Build
-	url = https://github.com/xamarin/Xamarin.Forms.Build
+	url = ../../xamarin/Xamarin.Forms.Build


### PR DESCRIPTION
This is the norm in all other repos building in VSTS and
makes upstream build definitions and scripts much simpler.