### PR TITLE
[Android] Buttons can be round; remove Padding & Shadow by default

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Resources/drawable/red_button.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/drawable/red_button.xml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+	<item android:state_pressed="true" >
+		<shape>
+			<solid
+          android:color="#ef4444" />
+			<stroke
+          android:width="1dp"
+          android:color="#992f2f" />
+			<corners
+          android:radius="6dp" />
+			<padding
+          android:left="10dp"
+          android:top="10dp"
+          android:right="10dp"
+          android:bottom="10dp" />
+		</shape>
+	</item>
+	<item>
+		<shape>
+			<gradient
+          android:startColor="#ef4444"
+          android:endColor="#992f2f"
+          android:angle="270" />
+			<stroke
+          android:width="1dp"
+          android:color="#992f2f" />
+			<corners
+          android:radius="6dp" />
+			<padding
+          android:left="10dp"
+          android:top="10dp"
+          android:right="10dp"
+          android:bottom="10dp" />
+		</shape>
+	</item>
+</selector>

--- a/Xamarin.Forms.ControlGallery.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/values/styles.xml
@@ -27,6 +27,9 @@
     <item name="windowActionModeOverlay">true</item>
 
     <item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
+		
+		<!--Uncomment to test exceptionally red button-->
+		<!--<item name="android:buttonStyle">@style/red_button_style</item>-->
   </style>
 
   <style name="AppCompatDialogStyle" parent="Theme.AppCompat.Light.Dialog">
@@ -35,4 +38,19 @@
 
   <style name="TestStyle" parent="@android:style/Theme.Holo.Light.DarkActionBar">    
   </style>
+
+	<style name="red_button_style" >
+		<item name="android:layout_width" >fill_parent</item>
+		<item name="android:layout_height" >wrap_content</item>
+		<item name="android:textColor" >#ffffff</item>
+		<item name="android:gravity" >center</item>
+		<item name="android:layout_margin" >3dp</item>
+		<item name="android:textSize" >30dp</item>
+		<item name="android:textStyle" >bold</item>
+		<item name="android:shadowColor" >#ffffff</item>
+		<item name="android:shadowDx" >1</item>
+		<item name="android:shadowDy" >4</item>
+		<item name="android:shadowRadius" >2</item>
+		<item name="android:background" >@drawable/red_button</item>
+	</style>
 </resources>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -322,6 +322,9 @@
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\synchronize_enabled.png" />
   </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\drawable\red_button.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Import Project="..\packages\Xamarin.Insights.1.11.4\build\MonoAndroid10\Xamarin.Insights.targets" Condition="Exists('..\packages\Xamarin.Insights.1.11.4\build\MonoAndroid10\Xamarin.Insights.targets')" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -208,6 +208,7 @@
     <Compile Include="ColorPicker.cs" />
     <Compile Include="StringProvider.cs" />
     <Compile Include="TestCloudService.cs" />
+    <Compile Include="_1909CustomRenderer.cs" />
     <Compile Include="_38989CustomRenderer.cs" />
     <Compile Include="BrokenImageSourceHandler.cs" />
     <Compile Include="_57114CustomRenderer.cs" />

--- a/Xamarin.Forms.ControlGallery.Android/_1909CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_1909CustomRenderer.cs
@@ -1,0 +1,31 @@
+﻿using Android.Content;
+using System;
+using System.Linq;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Platform.Android.AppCompat;
+using Xamarin.Forms.Controls.Issues;
+
+[assembly: ExportRenderer(typeof(Issue1909.FlatButton), typeof(FlatButtonRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+		public class FlatButtonRenderer : ButtonRenderer
+		{
+			public FlatButtonRenderer(Context context) : base(context)
+			{
+			}
+
+			protected override void OnElementChanged(Platform.Android.ElementChangedEventArgs<Button> e)
+			{
+				base.OnElementChanged(e);
+
+				if (this.Control != null && this.Element != null)
+				{
+					var nativeButton = (global::Android.Widget.Button)Control;
+					nativeButton.SetShadowLayer(0, 0, 0, global::Android.Graphics.Color.Transparent);
+
+					nativeButton.Elevation = 0;
+				}
+			}
+		}
+	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1436.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1436.cs
@@ -1,6 +1,8 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using System.Reflection;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
@@ -83,6 +85,14 @@ namespace Xamarin.Forms.Controls.Issues
 					}
 				},
 			};
+
+			foreach (var element in stackLayout.Descendants())
+			{
+				//TODO: if (element is Button button)
+				var button = element as Button;
+				if (button != null)
+					button.On<Android>().SetUseDefaultPadding(true).SetUseDefaultShadow(true);
+			}
 
 			Content = stackLayout;
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
@@ -3,6 +3,12 @@ using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
@@ -25,8 +31,6 @@ namespace Xamarin.Forms.Controls.Issues
 				WidthRequest = 64
 			};
 
-			button.On<Android>().SetUseNativePadding(false);
-
 			Content = new StackLayout
 					{
 				Children = {
@@ -47,5 +51,13 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 		}
+#if UITEST
+		[Test]
+		[Category(UITestCategories.ManualReview)]
+		public void Issue1909Test()
+		{
+			RunningApp.Screenshot("I am at Issue 1909");
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
@@ -1,10 +1,7 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-
-#if UITEST
-using Xamarin.UITest;
-using NUnit.Framework;
-#endif
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Controls.Issues
 {
@@ -15,22 +12,26 @@ namespace Xamarin.Forms.Controls.Issues
 		public class FlatButton : Button { }
 		protected override void Init()
 		{
-			Content = new StackLayout
+			Button button = new Button
 			{
-				Children = {
-					new Label{ Text = "The following buttons should be perfectly round. If they are not, this test has failed." },
-					new Button
+				BackgroundColor = Color.Red,
+				CornerRadius = 32,
+				BorderWidth = 0,
+				FontSize = 36,
+				HeightRequest = 64,
+				HorizontalOptions = LayoutOptions.Center,
+				TextColor = Color.White,
+				VerticalOptions = LayoutOptions.Center,
+				WidthRequest = 64
+			};
+
+			button.On<Android>().SetUseNativePadding(false);
+
+			Content = new StackLayout
 					{
-						BackgroundColor = Color.Red,
-						CornerRadius = 32,
-						BorderWidth = 0,
-						FontSize = 36,
-						HeightRequest = 64,
-						HorizontalOptions = LayoutOptions.Center,
-						TextColor = Color.White,
-						VerticalOptions = LayoutOptions.Center,
-						WidthRequest = 64
-					},
+				Children = {
+					new Label{ Text = "The following buttons should be perfectly round. The top button should be larger." },
+					button,
 					new FlatButton
 					{
 						BackgroundColor = Color.Red,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
@@ -31,23 +31,27 @@ namespace Xamarin.Forms.Controls.Issues
 				WidthRequest = 64
 			};
 
+			button.On<Android>().SetUseDefaultPadding(true).SetUseDefaultShadow(true);
+
+			FlatButton flatButton = new FlatButton
+			{
+				BackgroundColor = Color.Red,
+				CornerRadius = 32,
+				BorderWidth = 0,
+				FontSize = 36,
+				HeightRequest = 64,
+				HorizontalOptions = LayoutOptions.Center,
+				TextColor = Color.White,
+				VerticalOptions = LayoutOptions.Center,
+				WidthRequest = 64
+			};
+
 			Content = new StackLayout
 					{
 				Children = {
-					new Label{ Text = "The following buttons should be perfectly round. The top button should be larger." },
+					new Label{ Text = "The following buttons should be perfectly round. The bottom button should be larger and should not have a shadow." },
 					button,
-					new FlatButton
-					{
-						BackgroundColor = Color.Red,
-						CornerRadius = 32,
-						BorderWidth = 0,
-						FontSize = 36,
-						HeightRequest = 64,
-						HorizontalOptions = LayoutOptions.Center,
-						TextColor = Color.White,
-						VerticalOptions = LayoutOptions.Center,
-						WidthRequest = 64
-					}
+					flatButton
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
@@ -1,0 +1,50 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1909, "Xamarin.forms 2.5.0.280555 and android circle button issue", PlatformAffected.Android)]
+	public class Issue1909 : TestContentPage 
+	{
+		public class FlatButton : Button { }
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children = {
+					new Label{ Text = "The following buttons should be perfectly round. If they are not, this test has failed." },
+					new Button
+					{
+						BackgroundColor = Color.Red,
+						CornerRadius = 32,
+						BorderWidth = 0,
+						FontSize = 36,
+						HeightRequest = 64,
+						HorizontalOptions = LayoutOptions.Center,
+						TextColor = Color.White,
+						VerticalOptions = LayoutOptions.Center,
+						WidthRequest = 64
+					},
+					new FlatButton
+					{
+						BackgroundColor = Color.Red,
+						CornerRadius = 32,
+						BorderWidth = 0,
+						FontSize = 36,
+						HeightRequest = 64,
+						HorizontalOptions = LayoutOptions.Center,
+						TextColor = Color.White,
+						VerticalOptions = LayoutOptions.Center,
+						WidthRequest = 64
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -340,6 +340,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59925.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1436.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Button.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Button.cs
@@ -4,27 +4,54 @@
 
 	public static class Button
 	{
-		public static readonly BindableProperty UseNativePaddingProperty = BindableProperty.Create("UseNativePadding", typeof(bool), typeof(Button), true);
+		#region UseDefaultPadding
+		public static readonly BindableProperty UseDefaultPaddingProperty = BindableProperty.Create("UseDefaultPadding", typeof(bool), typeof(Button), false);
 
-		public static bool GetUseNativePadding(BindableObject element)
+		public static bool GetUseDefaultPadding(BindableObject element)
 		{
-			return (bool)element.GetValue(UseNativePaddingProperty);
+			return (bool)element.GetValue(UseDefaultPaddingProperty);
 		}
 
-		public static void SetUseNativePadding(BindableObject element, bool value)
+		public static void SetUseDefaultPadding(BindableObject element, bool value)
 		{
-			element.SetValue(UseNativePaddingProperty, value);
+			element.SetValue(UseDefaultPaddingProperty, value);
 		}
 
-		public static bool UseNativePadding(this IPlatformElementConfiguration<Android, FormsElement> config)
+		public static bool UseDefaultPadding(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
-			return GetUseNativePadding(config.Element);
+			return GetUseDefaultPadding(config.Element);
 		}
 
-		public static IPlatformElementConfiguration<Android, FormsElement> SetUseNativePadding(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
+		public static IPlatformElementConfiguration<Android, FormsElement> SetUseDefaultPadding(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
-			SetUseNativePadding(config.Element, value);
+			SetUseDefaultPadding(config.Element, value);
 			return config;
 		}
+		#endregion
+
+		#region UseDefaultShadow
+		public static readonly BindableProperty UseDefaultShadowProperty = BindableProperty.Create("UseDefaultShadow", typeof(bool), typeof(Button), false);
+
+		public static bool GetUseDefaultShadow(BindableObject element)
+		{
+			return (bool)element.GetValue(UseDefaultShadowProperty);
+		}
+
+		public static void SetUseDefaultShadow(BindableObject element, bool value)
+		{
+			element.SetValue(UseDefaultShadowProperty, value);
+		}
+
+		public static bool UseDefaultShadow(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetUseDefaultShadow(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetUseDefaultShadow(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
+		{
+			SetUseDefaultShadow(config.Element, value);
+			return config;
+		}
+		#endregion
 	}
 }

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Button.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Button.cs
@@ -1,0 +1,30 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using FormsElement = Forms.Button;
+
+	public static class Button
+	{
+		public static readonly BindableProperty UseNativePaddingProperty = BindableProperty.Create("UseNativePadding", typeof(bool), typeof(Button), true);
+
+		public static bool GetUseNativePadding(BindableObject element)
+		{
+			return (bool)element.GetValue(UseNativePaddingProperty);
+		}
+
+		public static void SetUseNativePadding(BindableObject element, bool value)
+		{
+			element.SetValue(UseNativePaddingProperty, value);
+		}
+
+		public static bool UseNativePadding(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetUseNativePadding(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetUseNativePadding(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
+		{
+			SetUseNativePadding(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -100,6 +100,7 @@
     <Compile Include="PlatformConfiguration\AndroidSpecific\AppCompat\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\Application.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\Elevation.cs" />
+    <Compile Include="PlatformConfiguration\AndroidSpecific\Button.cs" />
     <Compile Include="PlatformConfiguration\AndroidSpecific\TabbedPage.cs" />
     <Compile Include="PlatformConfiguration\ExtensionPoints.cs" />
     <Compile Include="PlatformConfiguration\iOSSpecific\BlurEffectStyle.cs" />

--- a/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
@@ -6,6 +6,7 @@ using Android.OS;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Specifics = Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AButton = Android.Widget.Button;
+using AColor = Android.Graphics.Color;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -69,11 +70,20 @@ namespace Xamarin.Forms.Platform.Android
 
 				_backgroundDrawable.Button = _button;
 
-				var useNativePadding = _button.OnThisPlatform().UseNativePadding();
-				if (useNativePadding)
-					_backgroundDrawable.SetPadding(_nativeButton.PaddingTop, _nativeButton.PaddingLeft);
-				else
-					_backgroundDrawable.SetPadding(0, 0);
+				var useDefaultPadding = _button.OnThisPlatform().UseDefaultPadding();
+
+				int paddingTop = useDefaultPadding ? _nativeButton.PaddingTop : 0;
+				int paddingLeft = useDefaultPadding ? _nativeButton.PaddingLeft : 0;
+
+				var useDefaultShadow = _button.OnThisPlatform().UseDefaultShadow();
+
+				float shadowRadius = useDefaultShadow ? 2 : _nativeButton.ShadowRadius;
+				float shadowDx = useDefaultShadow ? 0 : _nativeButton.ShadowDx;
+				float shadowDy = useDefaultShadow ? 4 : _nativeButton.ShadowDy;
+				AColor shadowColor = useDefaultShadow ? _backgroundDrawable.PressedBackgroundColor.ToAndroid() : _nativeButton.ShadowColor;
+
+				_backgroundDrawable.SetPadding(paddingTop, paddingLeft)
+								   .SetShadow(shadowDy, shadowDx, shadowColor, shadowRadius);
 
 				if (_drawableEnabled)
 					return;
@@ -149,7 +159,8 @@ namespace Xamarin.Forms.Platform.Android
 				e.PropertyName.Equals(Button.BorderWidthProperty.PropertyName) ||
 				e.PropertyName.Equals(Button.CornerRadiusProperty.PropertyName) ||
 				e.PropertyName.Equals(VisualElement.BackgroundColorProperty.PropertyName) ||
-				e.PropertyName.Equals(Specifics.Button.UseNativePaddingProperty.PropertyName))
+				e.PropertyName.Equals(Specifics.Button.UseDefaultPaddingProperty.PropertyName) ||
+				e.PropertyName.Equals(Specifics.Button.UseDefaultShadowProperty.PropertyName))
 			{
 				Reset();
 				UpdateDrawable();

--- a/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.Android
 					_backgroundDrawable = new ButtonDrawable(_nativeButton.Context.ToPixels, Forms.GetColorButtonNormal(_nativeButton.Context));
 
 				_backgroundDrawable.Button = _button;
-				_backgroundDrawable.SetPaddingTop(_nativeButton.PaddingTop);
+				_backgroundDrawable.SetPadding(_nativeButton.PaddingTop, _nativeButton.PaddingLeft);
 
 				if (_drawableEnabled)
 					return;

--- a/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
@@ -3,6 +3,8 @@ using System.ComponentModel;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
 using Android.OS;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+using Specifics = Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AButton = Android.Widget.Button;
 
 namespace Xamarin.Forms.Platform.Android
@@ -66,7 +68,12 @@ namespace Xamarin.Forms.Platform.Android
 					_backgroundDrawable = new ButtonDrawable(_nativeButton.Context.ToPixels, Forms.GetColorButtonNormal(_nativeButton.Context));
 
 				_backgroundDrawable.Button = _button;
-				_backgroundDrawable.SetPadding(_nativeButton.PaddingTop, _nativeButton.PaddingLeft);
+
+				var useNativePadding = _button.OnThisPlatform().UseNativePadding();
+				if (useNativePadding)
+					_backgroundDrawable.SetPadding(_nativeButton.PaddingTop, _nativeButton.PaddingLeft);
+				else
+					_backgroundDrawable.SetPadding(0, 0);
 
 				if (_drawableEnabled)
 					return;
@@ -141,7 +148,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (e.PropertyName.Equals(Button.BorderColorProperty.PropertyName) ||
 				e.PropertyName.Equals(Button.BorderWidthProperty.PropertyName) ||
 				e.PropertyName.Equals(Button.CornerRadiusProperty.PropertyName) ||
-				e.PropertyName.Equals(VisualElement.BackgroundColorProperty.PropertyName))
+				e.PropertyName.Equals(VisualElement.BackgroundColorProperty.PropertyName) ||
+				e.PropertyName.Equals(Specifics.Button.UseNativePaddingProperty.PropertyName))
 			{
 				Reset();
 				UpdateDrawable();

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonDrawable.cs
@@ -15,15 +15,21 @@ namespace Xamarin.Forms.Platform.Android
 		Bitmap _normalBitmap;
 		bool _pressed;
 		Bitmap _pressedBitmap;
+		float _paddingLeft;
 		float _paddingTop;
 		Color _defaultColor;
 
-		float PaddingLeft => _convertToPixels(8) / 2f; //<dimen name="button_padding_horizontal_material">8dp</dimen>
-		float PaddingTop //can change based on font, so this is not a constant
+		float PaddingLeft
+		{
+			get { return (_paddingLeft / 2f); }
+			set { _paddingLeft = value; }
+		}
+
+		float PaddingTop
 		{
 			get { return (_paddingTop / 2f) + ShadowDy; }
 			set { _paddingTop = value; }
-		} 
+		}
 
 		public ButtonDrawable(Func<double, float> convertToPixels, Color defaultColor)
 		{
@@ -64,9 +70,10 @@ namespace Xamarin.Forms.Platform.Android
 			canvas.DrawBitmap(bitmap, 0, 0, new Paint());
 		}
 
-		public void SetPaddingTop(float value)
+		public void SetPadding(float top, float left)
 		{
-			_paddingTop = value;
+			_paddingTop = top;
+			_paddingLeft = left;
 		}
 
 		public void Reset()

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonDrawable.cs
@@ -2,13 +2,13 @@ using System;
 using System.Linq;
 using Android.Graphics;
 using Android.Graphics.Drawables;
+using AColor = Android.Graphics.Color;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	internal class ButtonDrawable : Drawable
 	{
 		public const int DefaultCornerRadius = 2; // Default value for Android material button.
-		const int ShadowDy = 4;
 
 		readonly Func<double, float> _convertToPixels;
 		bool _isDisposed;
@@ -19,6 +19,11 @@ namespace Xamarin.Forms.Platform.Android
 		float _paddingTop;
 		Color _defaultColor;
 
+		AColor _shadowColor;
+		float _shadowDx;
+		float _shadowDy;
+		float _shadowRadius;
+
 		float PaddingLeft
 		{
 			get { return (_paddingLeft / 2f); }
@@ -27,7 +32,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		float PaddingTop
 		{
-			get { return (_paddingTop / 2f) + ShadowDy; }
+			get { return (_paddingTop / 2f) + _shadowDy; }
 			set { _paddingTop = value; }
 		}
 
@@ -70,10 +75,20 @@ namespace Xamarin.Forms.Platform.Android
 			canvas.DrawBitmap(bitmap, 0, 0, new Paint());
 		}
 
-		public void SetPadding(float top, float left)
+		public ButtonDrawable SetShadow(float dy, float dx, AColor color, float radius)
+		{
+			_shadowDx = dx;
+			_shadowDy = dy;
+			_shadowColor = color;
+			_shadowRadius = radius;
+			return this;
+		}
+
+		public ButtonDrawable SetPadding(float top, float left)
 		{
 			_paddingTop = top;
 			_paddingLeft = left;
+			return this;
 		}
 
 		public void Reset()
@@ -143,15 +158,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		void DrawBackground(Canvas canvas, int width, int height, bool pressed)
 		{
-			const int shadowDx = 0;
-			const int shadowRadius = 2;
-
 			var paint = new Paint { AntiAlias = true };
 			var path = new Path();
 
 			float borderRadius = ConvertCornerRadiusToPixels();
 
-			RectF rect = new RectF(0, 0, width, height - 0);
+			RectF rect = new RectF(0, 0, width, height);
 
 			rect.Inset(PaddingLeft, PaddingTop);
 
@@ -159,7 +171,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			paint.Color = pressed ? PressedBackgroundColor.ToAndroid() : BackgroundColor.ToAndroid();
 			paint.SetStyle(Paint.Style.Fill);
-			paint.SetShadowLayer(shadowRadius, shadowDx, ShadowDy, PressedBackgroundColor.ToAndroid());
+			paint.SetShadowLayer(_shadowRadius, _shadowDx, _shadowDy, _shadowColor);
+
 			canvas.DrawPath(path, paint);
 		}
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/Button.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/Button.xml
@@ -14,9 +14,9 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
-    <Member MemberName="GetUseNativePadding">
-      <MemberSignature Language="C#" Value="public static bool GetUseNativePadding (Xamarin.Forms.BindableObject element);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetUseNativePadding(class Xamarin.Forms.BindableObject element) cil managed" />
+    <Member MemberName="GetUseDefaultPadding">
+      <MemberSignature Language="C#" Value="public static bool GetUseDefaultPadding (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetUseDefaultPadding(class Xamarin.Forms.BindableObject element) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -34,9 +34,29 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="SetUseNativePadding">
-      <MemberSignature Language="C#" Value="public static void SetUseNativePadding (Xamarin.Forms.BindableObject element, bool value);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetUseNativePadding(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
+    <Member MemberName="GetUseDefaultShadow">
+      <MemberSignature Language="C#" Value="public static bool GetUseDefaultShadow (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetUseDefaultShadow(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetUseDefaultPadding">
+      <MemberSignature Language="C#" Value="public static void SetUseDefaultPadding (Xamarin.Forms.BindableObject element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetUseDefaultPadding(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -55,9 +75,9 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="SetUseNativePadding">
-      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; SetUseNativePadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config, bool value);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; SetUseNativePadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config, bool value) cil managed" />
+    <Member MemberName="SetUseDefaultPadding">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; SetUseDefaultPadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; SetUseDefaultPadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config, bool value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -77,9 +97,52 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="UseNativePadding">
-      <MemberSignature Language="C#" Value="public static bool UseNativePadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool UseNativePadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config) cil managed" />
+    <Member MemberName="SetUseDefaultShadow">
+      <MemberSignature Language="C#" Value="public static void SetUseDefaultShadow (Xamarin.Forms.BindableObject element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetUseDefaultShadow(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetUseDefaultShadow">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; SetUseDefaultShadow (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; SetUseDefaultShadow(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseDefaultPadding">
+      <MemberSignature Language="C#" Value="public static bool UseDefaultPadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool UseDefaultPadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
@@ -97,9 +160,44 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="UseNativePaddingProperty">
-      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty UseNativePaddingProperty;" />
-      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty UseNativePaddingProperty" />
+    <Member MemberName="UseDefaultPaddingProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty UseDefaultPaddingProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty UseDefaultPaddingProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseDefaultShadow">
+      <MemberSignature Language="C#" Value="public static bool UseDefaultShadow (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool UseDefaultShadow(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseDefaultShadowProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty UseDefaultShadowProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty UseDefaultShadowProperty" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/Button.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.AndroidSpecific/Button.xml
@@ -1,0 +1,116 @@
+<Type Name="Button" FullName="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button">
+  <TypeSignature Language="C#" Value="public static class Button" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Button extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetUseNativePadding">
+      <MemberSignature Language="C#" Value="public static bool GetUseNativePadding (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetUseNativePadding(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetUseNativePadding">
+      <MemberSignature Language="C#" Value="public static void SetUseNativePadding (Xamarin.Forms.BindableObject element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetUseNativePadding(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetUseNativePadding">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; SetUseNativePadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; SetUseNativePadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseNativePadding">
+      <MemberSignature Language="C#" Value="public static bool UseNativePadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool UseNativePadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseNativePaddingProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty UseNativePaddingProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty UseNativePaddingProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Button.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Button.xml
@@ -181,6 +181,11 @@ namespace FormsGallery
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("BorderRadius is obsolete as of 2.5.0. Please use CornerRadius instead.")</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -204,6 +209,11 @@ namespace FormsGallery
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("BorderRadiusProperty is obsolete as of 2.5.0. Please use CornerRadius instead.")</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
       </ReturnValue>
@@ -395,6 +405,37 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="T:Xamarin.Forms.Button.ContentLayout" /> property.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CornerRadius">
+      <MemberSignature Language="C#" Value="public int CornerRadius { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 CornerRadius" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CornerRadiusProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty CornerRadiusProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty CornerRadiusProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Button.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Button.xml
@@ -181,11 +181,6 @@ namespace FormsGallery
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.Obsolete("BorderRadius is obsolete as of 2.5.0. Please use CornerRadius instead.")</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -209,11 +204,6 @@ namespace FormsGallery
         <AssemblyVersion>1.5.0.0</AssemblyVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.Obsolete("BorderRadiusProperty is obsolete as of 2.5.0. Please use CornerRadius instead.")</AttributeName>
-        </Attribute>
-      </Attributes>
       <ReturnValue>
         <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
       </ReturnValue>
@@ -405,37 +395,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="T:Xamarin.Forms.Button.ContentLayout" /> property.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="CornerRadius">
-      <MemberSignature Language="C#" Value="public int CornerRadius { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance int32 CornerRadius" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Int32</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="CornerRadiusProperty">
-      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty CornerRadiusProperty;" />
-      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty CornerRadiusProperty" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -507,6 +507,7 @@
     </Namespace>
     <Namespace Name="Xamarin.Forms.PlatformConfiguration.AndroidSpecific">
       <Type Name="Application" Kind="Class" />
+      <Type Name="Button" Kind="Class" />
       <Type Name="Elevation" Kind="Class" />
       <Type Name="ListView" Kind="Class" />
       <Type Name="TabbedPage" Kind="Class" />
@@ -1776,6 +1777,50 @@
           <summary>Sets a value that controls whether the soft input mode of the provided platform configuration pans or resizes its content to allow the display of the on-screen input UI.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Application" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Application.UseWindowSoftInputModeAdjust(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Application},Xamarin.Forms.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetUseNativePadding">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; SetUseNativePadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config, bool value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; SetUseNativePadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config, bool value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;" RefType="this" />
+          <Parameter Name="value" Type="System.Boolean" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button.SetUseNativePadding(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button},System.Boolean)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="UseNativePadding">
+        <MemberSignature Language="C#" Value="public static bool UseNativePadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool UseNativePadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button.UseNativePadding(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button})" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -1783,9 +1783,9 @@
       <Targets>
         <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
       </Targets>
-      <Member MemberName="SetUseNativePadding">
-        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; SetUseNativePadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config, bool value);" />
-        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; SetUseNativePadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config, bool value) cil managed" />
+      <Member MemberName="SetUseDefaultPadding">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; SetUseDefaultPadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config, bool value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; SetUseDefaultPadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config, bool value) cil managed" />
         <MemberType>ExtensionMethod</MemberType>
         <ReturnValue>
           <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;</ReturnType>
@@ -1799,16 +1799,39 @@
           <param name="value">To be added.</param>
           <summary>To be added.</summary>
         </Docs>
-        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button.SetUseNativePadding(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button},System.Boolean)" />
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button.SetUseDefaultPadding(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button},System.Boolean)" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>
       <Targets>
         <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
       </Targets>
-      <Member MemberName="UseNativePadding">
-        <MemberSignature Language="C#" Value="public static bool UseNativePadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config);" />
-        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool UseNativePadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config) cil managed" />
+      <Member MemberName="SetUseDefaultShadow">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; SetUseDefaultShadow (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config, bool value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; SetUseDefaultShadow(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config, bool value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;" RefType="this" />
+          <Parameter Name="value" Type="System.Boolean" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button.SetUseDefaultShadow(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button},System.Boolean)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="UseDefaultPadding">
+        <MemberSignature Language="C#" Value="public static bool UseDefaultPadding (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool UseDefaultPadding(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config) cil managed" />
         <MemberType>ExtensionMethod</MemberType>
         <ReturnValue>
           <ReturnType>System.Boolean</ReturnType>
@@ -1820,7 +1843,28 @@
           <param name="config">To be added.</param>
           <summary>To be added.</summary>
         </Docs>
-        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button.UseNativePadding(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button})" />
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button.UseDefaultPadding(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="UseDefaultShadow">
+        <MemberSignature Language="C#" Value="public static bool UseDefaultShadow (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool UseDefaultShadow(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Android, class Xamarin.Forms.Button&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button" Member="M:Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Button.UseDefaultShadow(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Android,Xamarin.Forms.Button})" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>


### PR DESCRIPTION
### Description of Change ###

Removing the Padding and Shadow that were added in #1570 to make the X.F. Buttons mimic the style of a default Android `Button`. These can be added back to Buttons using new Platform Specifics.

Also adjusting the padding mismatch that made circle Buttons appear to be slightly rectangular.

Before #1570:
![before-1570](https://user-images.githubusercontent.com/7827070/36458576-5d0c1bbc-1664-11e8-8af0-3b5a96bd01ad.png)


After #1570:
![before](https://user-images.githubusercontent.com/7827070/36458583-6a95ba54-1664-11e8-9730-3b218fdbcb51.png)


After this change (note, changed the test case for an additional parameter):
![screenshot_20180227-124138](https://user-images.githubusercontent.com/7827070/36753667-b3689344-1bbb-11e8-8737-86eb31502d8a.png)



### Bugs Fixed ###

- fixes #1909
- fixes #1954 

### API Changes ###

Added:
- `bool Button.On<Android>().UseDefaultPadding()`
- `void Button.On<Android>().SetUseDefaultPadding(true/false)`
- `bool Button.On<Android>().UseDefaultShadow()`
- `void Button.On<Android>().SetUseDefaultShadow(true/false)`

### Behavioral Changes ###

#### ⚠️ Setting the `CornerRadius`, `BackgroundColor`, `BorderColor`, or `BorderWidth` properties _will_ replace the Background drawable of an Android Button. If you need to use a custom drawable, please incorporate all of these properties into your custom drawable instead of attempting to use the Xamarin.Forms properties to adjust some or all of those values. 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
