### PR TITLE
[UWP] Icon on TabbedPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1705_2.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1705_2.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 		PlatformAffected.UWP, issueTestNumber: 2)]
 
 	class Issue1705_2 : TabbedPage
-    {
+	{
 		ContentPage _page1;
 		ContentPage _page2;
 		ContentPage _page3;
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue1705_2()
 		{
 			_page1 = new ContentPage { Title = "TabPage1", Icon = "bank.png" };
-			_page1.Content = new StackLayout { Padding = new Thickness(0,16), Children = { new Label { Text = "This is TabPage1 using bank.png icon.", FontAttributes = FontAttributes.Bold } } };
+			_page1.Content = new StackLayout { Padding = new Thickness(0, 16), Children = { new Label { Text = "This is TabPage1 using bank.png icon.", FontAttributes = FontAttributes.Bold } } };
 			_page2 = new ContentPage { Title = "TabPage2", Icon = "coffee.png" };
 			_page2.Content = new StackLayout { Padding = new Thickness(0, 16), Children = { new Label { Text = "This is TabPage2 using coffee.png icon.", FontAttributes = FontAttributes.Bold } } };
 			_page3 = new ContentPage { Title = "TabPage3" };
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Controls.Issues
 			if (Device.RuntimePlatform == Device.UWP)
 				Children.Add(new HeaderIconsControlPage(this) { Title = "UWPSpecifics" });
 		}
-    }
+	}
 
 	class HeaderIconsControlPage : ContentPage
 	{
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 
-			var iconWidthLabel = new Label { Text = "Head Icons Width:"};
+			var iconWidthLabel = new Label { Text = "Head Icons Width:" };
 			var iconHeightLabel = new Label { Text = "Head Icons Height:" };
 
 			_iconWidthEntry = new Entry { Text = "16" };
@@ -101,7 +101,6 @@ namespace Xamarin.Forms.Controls.Issues
 				_iconWidthEntry.Text = currentSize.Width.ToString();
 				_iconHeightEntry.Text = currentSize.Height.ToString();
 			};
-
 
 			Content = new StackLayout { Padding = new Thickness(0, 16), Children = {
 					new Label { Text = "Control page for header icons on UWP.", FontAttributes = FontAttributes.Bold },

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1705_2.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1705_2.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1705, "[Enhancement] Icon on TabbedPage UWP",
+		PlatformAffected.UWP, issueTestNumber: 2)]
+
+	class Issue1705_2 : TabbedPage
+    {
+		ContentPage _page1;
+		ContentPage _page2;
+		ContentPage _page3;
+
+		public Issue1705_2()
+		{
+			_page1 = new ContentPage { Title = "TabPage1", Icon = "bank.png" };
+			_page1.Content = new StackLayout { Padding = new Thickness(0,16), Children = { new Label { Text = "This is TabPage1 using bank.png icon.", FontAttributes = FontAttributes.Bold } } };
+			_page2 = new ContentPage { Title = "TabPage2", Icon = "coffee.png" };
+			_page2.Content = new StackLayout { Padding = new Thickness(0, 16), Children = { new Label { Text = "This is TabPage2 using coffee.png icon.", FontAttributes = FontAttributes.Bold } } };
+			_page3 = new ContentPage { Title = "TabPage3" };
+			_page3.Content = new StackLayout { Padding = new Thickness(0, 16), Children = { new Label { Text = "This is TabPage3 without icon.", FontAttributes = FontAttributes.Bold } } };
+
+			Children.Add(_page1);
+			Children.Add(_page2);
+			Children.Add(_page3);
+
+			if (Device.RuntimePlatform == Device.UWP)
+				Children.Add(new HeaderIconsControlPage(this) { Title = "UWPSpecifics" });
+		}
+    }
+
+	class HeaderIconsControlPage : ContentPage
+	{
+		TabbedPage _target;
+		Button _toggleIconsButton;
+		Entry _iconWidthEntry;
+		Entry _iconHeightEntry;
+		Button _changeIconsSizeButton;
+		Button _getCurrentIconsSizeButton;
+
+		public HeaderIconsControlPage(TabbedPage target)
+		{
+			_target = target;
+
+			_toggleIconsButton = new Button();
+			_toggleIconsButton.Text = "Show Header Icons";
+			_toggleIconsButton.Clicked += (object sender, EventArgs e) => {
+				if (_target.On<Windows>().IsHeaderIconsEnabled())
+				{
+					_target.On<Windows>().DisableHeaderIcons();
+					_toggleIconsButton.Text = "Show Header Icons";
+				}
+				else
+				{
+					_target.On<Windows>().EnableHeaderIcons();
+					_toggleIconsButton.Text = "Hide Header Icons";
+				}
+			};
+
+			var iconWidthLabel = new Label { Text = "Head Icons Width:"};
+			var iconHeightLabel = new Label { Text = "Head Icons Height:" };
+
+			_iconWidthEntry = new Entry { Text = "16" };
+			_iconHeightEntry = new Entry { Text = "16" };
+
+			_changeIconsSizeButton = new Button();
+			_changeIconsSizeButton.Text = "Change Header Icons Size";
+			_changeIconsSizeButton.Clicked += (object sender, EventArgs e) => {
+				int width;
+				int height;
+
+				if (!Int32.TryParse(_iconWidthEntry.Text, out width))
+					width = 16;
+				if (!Int32.TryParse(_iconHeightEntry.Text, out height))
+					height = 16;
+
+				var currentSize = _target.On<Windows>().GetHeaderIconsSize();
+				if (currentSize.Width != width || currentSize.Height != height)
+					_target.On<Windows>().SetHeaderIconsSize(new Size(width, height));
+			};
+
+			_getCurrentIconsSizeButton = new Button();
+			_getCurrentIconsSizeButton.Text = "Load Current Header Icons Size";
+			_getCurrentIconsSizeButton.Clicked += (object sender, EventArgs e) => {
+
+				var currentSize = _target.On<Windows>().GetHeaderIconsSize();
+				_iconWidthEntry.Text = currentSize.Width.ToString();
+				_iconHeightEntry.Text = currentSize.Height.ToString();
+			};
+
+
+			Content = new StackLayout { Padding = new Thickness(0, 16), Children = {
+					new Label { Text = "Control page for header icons on UWP.", FontAttributes = FontAttributes.Bold },
+					_toggleIconsButton, iconWidthLabel, _iconWidthEntry, iconHeightLabel, _iconHeightEntry, _changeIconsSizeButton,
+					_getCurrentIconsSizeButton
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -239,6 +239,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1683.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1705_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1717.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60001.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60056.cs" />

--- a/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
@@ -9,10 +9,10 @@ namespace Xamarin.Forms.PlatformConfiguration.WindowsSpecific
 	public static class TabbedPage
 	{
 		public static readonly BindableProperty HeaderIconsEnabledProperty =
-			BindableProperty.Create("HeaderIconsEnabledProperty", typeof(bool), typeof(TabbedPage), false);
+			BindableProperty.Create(nameof(HeaderIconsEnabledProperty), typeof(bool), typeof(TabbedPage), false);
 
 		public static readonly BindableProperty HeaderIconsSizeProperty =
-			BindableProperty.Create("HeaderIconsSizeProperty ", typeof(Forms.Size), typeof(TabbedPage), new Forms.Size(16, 16));
+			BindableProperty.Create(nameof(HeaderIconsSizeProperty), typeof(Forms.Size), typeof(TabbedPage), new Forms.Size(16, 16));
 
 		public static void SetHeaderIconsEnabled(BindableObject element, bool value)
 		{

--- a/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms.PlatformConfiguration.WindowsSpecific
+{
+	using FormsElement = Forms.TabbedPage;
+
+	public static class TabbedPage
+	{
+		public static readonly BindableProperty HeaderIconsEnabledProperty =
+			BindableProperty.Create("HeaderIconsEnabledProperty", typeof(bool), typeof(TabbedPage), false);
+
+		public static readonly BindableProperty HeaderIconsSizeProperty =
+			BindableProperty.Create("HeaderIconsSizeProperty ", typeof(Forms.Size), typeof(TabbedPage), new Forms.Size(16, 16));
+
+		public static void SetHeaderIconsEnabled(BindableObject element, bool value)
+		{
+			element.SetValue(HeaderIconsEnabledProperty, value);
+		}
+
+		public static bool GetHeaderIconsEnabled(BindableObject element)
+		{
+			return (bool)element.GetValue(HeaderIconsEnabledProperty);
+		}
+
+		public static bool GetHeaderIconsEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			return GetHeaderIconsEnabled(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Windows, FormsElement> SetHeaderIconsEnabled(
+			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
+		{
+			SetHeaderIconsEnabled(config.Element, value);
+			return config;
+		}
+
+		public static bool IsHeaderIconsEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			return GetHeaderIconsEnabled(config.Element);
+		}
+
+		public static void EnableHeaderIcons(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			SetHeaderIconsEnabled(config.Element, true);
+		}
+
+		public static void DisableHeaderIcons(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			SetHeaderIconsEnabled(config.Element, false);
+		}
+
+		public static void SetHeaderIconsSize(BindableObject element, Forms.Size value)
+		{
+			element.SetValue(HeaderIconsSizeProperty, value);
+		}
+
+		public static Forms.Size GetHeaderIconsSize(BindableObject element)
+		{
+			return (Forms.Size)element.GetValue(HeaderIconsSizeProperty);
+		}
+
+		public static Forms.Size GetHeaderIconsSize(this IPlatformElementConfiguration<Windows, FormsElement> config)
+		{
+			return GetHeaderIconsSize(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Windows, FormsElement> SetHeaderIconsSize(
+			this IPlatformElementConfiguration<Windows, FormsElement> config, Forms.Size value)
+		{
+			SetHeaderIconsSize(config.Element, value);
+			return config;
+		}
+
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -19,119 +19,119 @@ using Specifics = Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage
 
 namespace Xamarin.Forms.Platform.UWP
 {
-    public class TabbedPageRenderer : IVisualElementRenderer, ITitleProvider, IToolbarProvider
-    {
-        const string TabBarHeaderStackPanelName = "TabbedPageHeaderStackPanel";
-        const string TabBarHeaderImageName = "TabbedPageHeaderImage";
-        const string TabBarHeaderTextBlockName = "TabbedPageHeaderTextBlock";
-        const string TabBarHeaderGridName = "TabbedPageHeaderGrid";
+	public class TabbedPageRenderer : IVisualElementRenderer, ITitleProvider, IToolbarProvider
+	{
+		const string TabBarHeaderStackPanelName = "TabbedPageHeaderStackPanel";
+		const string TabBarHeaderImageName = "TabbedPageHeaderImage";
+		const string TabBarHeaderTextBlockName = "TabbedPageHeaderTextBlock";
+		const string TabBarHeaderGridName = "TabbedPageHeaderGrid";
 
-        Color _barBackgroundColor;
-        Color _barTextColor;
-        bool _disposed;
-        bool _showTitle;
+		Color _barBackgroundColor;
+		Color _barTextColor;
+		bool _disposed;
+		bool _showTitle;
 
-        WTextAlignment _oldBarTextBlockTextAlignment;
-        WHorizontalAlignment _oldBarTextBlockHorinzontalAlignment;
+		WTextAlignment _oldBarTextBlockTextAlignment;
+		WHorizontalAlignment _oldBarTextBlockHorinzontalAlignment;
 
-        VisualElementTracker<Page, Pivot> _tracker;
+		VisualElementTracker<Page, Pivot> _tracker;
 
-        ITitleProvider TitleProvider => this;
+		ITitleProvider TitleProvider => this;
 
-        public FormsPivot Control { get; private set; }
+		public FormsPivot Control { get; private set; }
 
-        public TabbedPage Element { get; private set; }
+		public TabbedPage Element { get; private set; }
 
-        protected VisualElementTracker<Page, Pivot> Tracker
-        {
-            get { return _tracker; }
-            set
-            {
-                if (_tracker == value)
-                    return;
+		protected VisualElementTracker<Page, Pivot> Tracker
+		{
+			get { return _tracker; }
+			set
+			{
+				if (_tracker == value)
+					return;
 
-                if (_tracker != null)
-                    _tracker.Dispose();
+				if (_tracker != null)
+					_tracker.Dispose();
 
-                _tracker = value;
-            }
-        }
+				_tracker = value;
+			}
+		}
 
-        public void Dispose()
-        {
-            Dispose(true);
-        }
+		public void Dispose()
+		{
+			Dispose(true);
+		}
 
-        Brush ITitleProvider.BarBackgroundBrush
-        {
-            set { Control.ToolbarBackground = value; }
-        }
+		Brush ITitleProvider.BarBackgroundBrush
+		{
+			set { Control.ToolbarBackground = value; }
+		}
 
-        Brush ITitleProvider.BarForegroundBrush
-        {
-            set { Control.ToolbarForeground = value; }
-        }
+		Brush ITitleProvider.BarForegroundBrush
+		{
+			set { Control.ToolbarForeground = value; }
+		}
 
-        bool ITitleProvider.ShowTitle
-        {
-            get { return _showTitle; }
+		bool ITitleProvider.ShowTitle
+		{
+			get { return _showTitle; }
 
-            set
-            {
-                if (_showTitle == value)
-                    return;
-                _showTitle = value;
+			set
+			{
+				if (_showTitle == value)
+					return;
+				_showTitle = value;
 
-                UpdateTitleVisibility();
-            }
-        }
+				UpdateTitleVisibility();
+			}
+		}
 
-        string ITitleProvider.Title
-        {
-            get { return (string)Control?.Title; }
+		string ITitleProvider.Title
+		{
+			get { return (string)Control?.Title; }
 
-            set
-            {
-                if (Control != null && _showTitle)
-                    Control.Title = value;
-            }
-        }
+			set
+			{
+				if (Control != null && _showTitle)
+					Control.Title = value;
+			}
+		}
 
-        public Task<CommandBar> GetCommandBarAsync()
-        {
-            return (Control as IToolbarProvider)?.GetCommandBarAsync();
-        }
+		public Task<CommandBar> GetCommandBarAsync()
+		{
+			return (Control as IToolbarProvider)?.GetCommandBarAsync();
+		}
 
-        public FrameworkElement ContainerElement
-        {
-            get { return Control; }
-        }
+		public FrameworkElement ContainerElement
+		{
+			get { return Control; }
+		}
 
-        VisualElement IVisualElementRenderer.Element
-        {
-            get { return Element; }
-        }
+		VisualElement IVisualElementRenderer.Element
+		{
+			get { return Element; }
+		}
 
-        public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
-        public SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
-        {
-            var constraint = new Windows.Foundation.Size(widthConstraint, heightConstraint);
+		public SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			var constraint = new Windows.Foundation.Size(widthConstraint, heightConstraint);
 
-            double oldWidth = Control.Width;
-            double oldHeight = Control.Height;
+			double oldWidth = Control.Width;
+			double oldHeight = Control.Height;
 
-            Control.Height = double.NaN;
-            Control.Width = double.NaN;
+			Control.Height = double.NaN;
+			Control.Width = double.NaN;
 
-            Control.Measure(constraint);
-            var result = new Size(Math.Ceiling(Control.DesiredSize.Width), Math.Ceiling(Control.DesiredSize.Height));
+			Control.Measure(constraint);
+			var result = new Size(Math.Ceiling(Control.DesiredSize.Width), Math.Ceiling(Control.DesiredSize.Height));
 
-            Control.Width = oldWidth;
-            Control.Height = oldHeight;
+			Control.Width = oldWidth;
+			Control.Height = oldHeight;
 
-            return new SizeRequest(result);
-        }
+			return new SizeRequest(result);
+		}
 
 		UIElement IVisualElementRenderer.GetNativeElement()
 		{
@@ -139,293 +139,289 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 		public void SetElement(VisualElement element)
-        {
-            if (element != null && !(element is TabbedPage))
-                throw new ArgumentException("Element must be a TabbedPage", "element");
+		{
+			if (element != null && !(element is TabbedPage))
+				throw new ArgumentException("Element must be a TabbedPage", "element");
 
-            TabbedPage oldElement = Element;
-            Element = (TabbedPage)element;
+			TabbedPage oldElement = Element;
+			Element = (TabbedPage)element;
 
-            if (oldElement != null)
-            {
-                oldElement.PropertyChanged -= OnElementPropertyChanged;
-                ((INotifyCollectionChanged)oldElement.Children).CollectionChanged -= OnPagesChanged;
-            }
+			if (oldElement != null)
+			{
+				oldElement.PropertyChanged -= OnElementPropertyChanged;
+				((INotifyCollectionChanged)oldElement.Children).CollectionChanged -= OnPagesChanged;
+			}
 
-            if (element != null)
-            {
-                if (Control == null)
-                {
-                    Control = new FormsPivot
-                    {
-                        Style = (Windows.UI.Xaml.Style)Windows.UI.Xaml.Application.Current.Resources["TabbedPageStyle"],
-                    };
+			if (element != null)
+			{
+				if (Control == null)
+				{
+					Control = new FormsPivot {
+						Style = (Windows.UI.Xaml.Style)Windows.UI.Xaml.Application.Current.Resources["TabbedPageStyle"],
+					};
 
-                    Control.SelectionChanged += OnSelectionChanged;
+					Control.SelectionChanged += OnSelectionChanged;
 
-                    Tracker = new BackgroundTracker<Pivot>(Windows.UI.Xaml.Controls.Control.BackgroundProperty)
-                    {
-                        Element = (Page)element,
-                        Control = Control,
-                        Container = Control
-                    };
+					Tracker = new BackgroundTracker<Pivot>(Windows.UI.Xaml.Controls.Control.BackgroundProperty) {
+						Element = (Page)element,
+						Control = Control,
+						Container = Control
+					};
 
-                    Control.Loaded += OnLoaded;
-                    Control.Unloaded += OnUnloaded;
-                }
+					Control.Loaded += OnLoaded;
+					Control.Unloaded += OnUnloaded;
+				}
 
-                Control.DataContext = Element;
-                OnPagesChanged(Element.Children,
-                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+				Control.DataContext = Element;
+				OnPagesChanged(Element.Children,
+					new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 
-                UpdateCurrentPage();
-                UpdateToolbarPlacement();
+				UpdateCurrentPage();
+				UpdateToolbarPlacement();
 
-                ((INotifyCollectionChanged)Element.Children).CollectionChanged += OnPagesChanged;
-                element.PropertyChanged += OnElementPropertyChanged;
+				((INotifyCollectionChanged)Element.Children).CollectionChanged += OnPagesChanged;
+				element.PropertyChanged += OnElementPropertyChanged;
 
-                if (!string.IsNullOrEmpty(element.AutomationId))
+				if (!string.IsNullOrEmpty(element.AutomationId))
 					Control.SetValue(Windows.UI.Xaml.Automation.AutomationProperties.AutomationIdProperty, element.AutomationId);
-            }
+			}
 
-            OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
-        }
+			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
+		}
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposing || _disposed)
-                return;
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!disposing || _disposed)
+				return;
 
-            _disposed = true;
-            Element?.SendDisappearing();
-            SetElement(null);
-            Tracker = null;
-        }
+			_disposed = true;
+			Element?.SendDisappearing();
+			SetElement(null);
+			Tracker = null;
+		}
 
-        protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
-        {
-            EventHandler<VisualElementChangedEventArgs> changed = ElementChanged;
-            if (changed != null)
-                changed(this, e);
-        }
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
+		{
+			ElementChanged?.Invoke(this, e);
+		}
 
-        void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(TabbedPage.CurrentPage))
-            {
-                UpdateCurrentPage();
-                UpdateBarTextColor();
-                UpdateBarBackgroundColor();
-            }
-            else if (e.PropertyName == TabbedPage.BarTextColorProperty.PropertyName)
-                UpdateBarTextColor();
-            else if (e.PropertyName == TabbedPage.BarBackgroundColorProperty.PropertyName)
-                UpdateBarBackgroundColor();
-            else if (e.PropertyName == PlatformConfiguration.WindowsSpecific.Page.ToolbarPlacementProperty.PropertyName)
-                UpdateToolbarPlacement();
-            else if (e.PropertyName == Specifics.HeaderIconsEnabledProperty.PropertyName)
-                UpdateBarIcons();
-            else if (e.PropertyName == Specifics.HeaderIconsSizeProperty.PropertyName)
-                UpdateBarIcons();
-        }
+		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == nameof(TabbedPage.CurrentPage))
+			{
+				UpdateCurrentPage();
+				UpdateBarTextColor();
+				UpdateBarBackgroundColor();
+			}
+			else if (e.PropertyName == TabbedPage.BarTextColorProperty.PropertyName)
+				UpdateBarTextColor();
+			else if (e.PropertyName == TabbedPage.BarBackgroundColorProperty.PropertyName)
+				UpdateBarBackgroundColor();
+			else if (e.PropertyName == PlatformConfiguration.WindowsSpecific.Page.ToolbarPlacementProperty.PropertyName)
+				UpdateToolbarPlacement();
+			else if (e.PropertyName == Specifics.HeaderIconsEnabledProperty.PropertyName)
+				UpdateBarIcons();
+			else if (e.PropertyName == Specifics.HeaderIconsSizeProperty.PropertyName)
+				UpdateBarIcons();
+		}
 
-        void OnLoaded(object sender, RoutedEventArgs args)
-        {
-            Element?.SendAppearing();
+		void OnLoaded(object sender, RoutedEventArgs args)
+		{
+			Element?.SendAppearing();
 
-            UpdateBarTextColor();
-            UpdateBarBackgroundColor();
-            UpdateBarIcons();
-        }
+			UpdateBarTextColor();
+			UpdateBarBackgroundColor();
+			UpdateBarIcons();
+		}
 
-        void OnPagesChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            e.Apply(Element.Children, Control.Items);
+		void OnPagesChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			e.Apply(Element.Children, Control.Items);
 
-            // Potential performance issue, UpdateLayout () is called for every page change
-            Control.UpdateLayout();
-        }
+			// Potential performance issue, UpdateLayout () is called for every page change
+			Control.UpdateLayout();
+		}
 
-        void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (Element == null)
-                return;
+		void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (Element == null)
+				return;
 
-            Page page = e.AddedItems.Count > 0 ? (Page)e.AddedItems[0] : null;
-            Page currentPage = Element.CurrentPage;
-            if (currentPage == page)
-                return;
-            currentPage?.SendDisappearing();
-            Element.CurrentPage = page;
-            page?.SendAppearing();
-        }
+			Page page = e.AddedItems.Count > 0 ? (Page)e.AddedItems[0] : null;
+			Page currentPage = Element.CurrentPage;
+			if (currentPage == page)
+				return;
+			currentPage?.SendDisappearing();
+			Element.CurrentPage = page;
+			page?.SendAppearing();
+		}
 
-        void OnUnloaded(object sender, RoutedEventArgs args)
-        {
-            Element?.SendDisappearing();
-        }
+		void OnUnloaded(object sender, RoutedEventArgs args)
+		{
+			Element?.SendDisappearing();
+		}
 
-        Brush GetBarBackgroundBrush()
-        {
-            object defaultColor = new SolidColorBrush(Windows.UI.Colors.Transparent);
+		Brush GetBarBackgroundBrush()
+		{
+			object defaultColor = new SolidColorBrush(Windows.UI.Colors.Transparent);
 
-            if (Element.BarBackgroundColor.IsDefault && defaultColor != null)
-                return (Brush)defaultColor;
-            return Element.BarBackgroundColor.ToBrush();
-        }
+			if (Element.BarBackgroundColor.IsDefault && defaultColor != null)
+				return (Brush)defaultColor;
+			return Element.BarBackgroundColor.ToBrush();
+		}
 
-        Brush GetBarForegroundBrush()
-        {
-            object defaultColor = Windows.UI.Xaml.Application.Current.Resources["ApplicationForegroundThemeBrush"];
-            if (Element.BarTextColor.IsDefault && defaultColor != null)
-                return (Brush)defaultColor;
-            return Element.BarTextColor.ToBrush();
-        }
+		Brush GetBarForegroundBrush()
+		{
+			object defaultColor = Windows.UI.Xaml.Application.Current.Resources["ApplicationForegroundThemeBrush"];
+			if (Element.BarTextColor.IsDefault && defaultColor != null)
+				return (Brush)defaultColor;
+			return Element.BarTextColor.ToBrush();
+		}
 
-        void UpdateBarBackgroundColor()
-        {
-            if (Element == null) return;
-            var barBackgroundColor = Element.BarBackgroundColor;
+		void UpdateBarBackgroundColor()
+		{
+			if (Element == null) return;
+			var barBackgroundColor = Element.BarBackgroundColor;
 
-            if (barBackgroundColor == _barBackgroundColor) return;
-            _barBackgroundColor = barBackgroundColor;
+			if (barBackgroundColor == _barBackgroundColor) return;
+			_barBackgroundColor = barBackgroundColor;
 
-            var controlToolbarBackground = Control.ToolbarBackground;
-            if (controlToolbarBackground == null && barBackgroundColor.IsDefault) return;
+			var controlToolbarBackground = Control.ToolbarBackground;
+			if (controlToolbarBackground == null && barBackgroundColor.IsDefault) return;
 
-            var brush = GetBarBackgroundBrush();
-            if (brush == controlToolbarBackground) return;
+			var brush = GetBarBackgroundBrush();
+			if (brush == controlToolbarBackground) return;
 
-            TitleProvider.BarBackgroundBrush = brush;
+			TitleProvider.BarBackgroundBrush = brush;
 
-            foreach (WGrid tabBarGrid in Control.GetDescendantsByName<WGrid>(TabBarHeaderGridName))
-            {
-                tabBarGrid.Background = brush;
-            }
-        }
+			foreach (WGrid tabBarGrid in Control.GetDescendantsByName<WGrid>(TabBarHeaderGridName))
+			{
+				tabBarGrid.Background = brush;
+			}
+		}
 
-        void UpdateBarTextColor()
-        {
-            if (Element == null) return;
-            var barTextColor = Element.BarTextColor;
+		void UpdateBarTextColor()
+		{
+			if (Element == null) return;
+			var barTextColor = Element.BarTextColor;
 
-            if (barTextColor == _barTextColor) return;
-            _barTextColor = barTextColor;
+			if (barTextColor == _barTextColor) return;
+			_barTextColor = barTextColor;
 
-            var controlToolbarForeground = Control.ToolbarForeground;
-            if (controlToolbarForeground == null && barTextColor.IsDefault) return;
+			var controlToolbarForeground = Control.ToolbarForeground;
+			if (controlToolbarForeground == null && barTextColor.IsDefault) return;
 
-            var brush = GetBarForegroundBrush();
-            if (brush == controlToolbarForeground)
-                return;
+			var brush = GetBarForegroundBrush();
+			if (brush == controlToolbarForeground)
+				return;
 
-            TitleProvider.BarForegroundBrush = brush;
+			TitleProvider.BarForegroundBrush = brush;
 
-            foreach (WTextBlock tabBarTextBlock in Control.GetDescendantsByName<WTextBlock>(TabBarHeaderTextBlockName))
-            {
-                tabBarTextBlock.Foreground = brush;
-            }
-        }
+			foreach (WTextBlock tabBarTextBlock in Control.GetDescendantsByName<WTextBlock>(TabBarHeaderTextBlockName))
+			{
+				tabBarTextBlock.Foreground = brush;
+			}
+		}
 
-        void UpdateTitleVisibility()
-        {
-            Control.TitleVisibility = _showTitle ? WVisibility.Visible : WVisibility.Collapsed;
-        }
+		void UpdateTitleVisibility()
+		{
+			Control.TitleVisibility = _showTitle ? WVisibility.Visible : WVisibility.Collapsed;
+		}
 
-        void UpdateCurrentPage()
-        {
-            Page page = Element.CurrentPage;
+		void UpdateCurrentPage()
+		{
+			Page page = Element.CurrentPage;
 
-            var nav = page as NavigationPage;
-            TitleProvider.ShowTitle = nav != null;
+			var nav = page as NavigationPage;
+			TitleProvider.ShowTitle = nav != null;
 
 			// Enforce consistency rules on toolbar (show toolbar if visible Tab is Navigation Page)
 			Control.ShouldShowToolbar = nav != null;
 
-            if (page == null)
-                return;
+			if (page == null)
+				return;
 
-            Control.SelectedItem = page;
-        }
+			Control.SelectedItem = page;
+		}
 
-        void UpdateToolbarPlacement()
-        {
-            Control.ToolbarPlacement = Element.OnThisPlatform().GetToolbarPlacement();
-        }
+		void UpdateToolbarPlacement()
+		{
+			Control.ToolbarPlacement = Element.OnThisPlatform().GetToolbarPlacement();
+		}
 
-        void UpdateBarIcons()
-        {
-            if (Control == null)
-                return;
+		void UpdateBarIcons()
+		{
+			if (Control == null)
+				return;
 
-            if (Element.IsSet(Specifics.HeaderIconsEnabledProperty))
-            {
-                bool headerIconsEnabled = Element.OnThisPlatform().GetHeaderIconsEnabled();
-                bool invalidateMeasure = false;
+			if (Element.IsSet(Specifics.HeaderIconsEnabledProperty))
+			{
+				bool headerIconsEnabled = Element.OnThisPlatform().GetHeaderIconsEnabled();
+				bool invalidateMeasure = false;
 
-                // Get all stack panels affected by update.
-                var stackPanels = Control.GetDescendantsByName<WStackPanel>(TabBarHeaderStackPanelName);
-                foreach (var stackPanel in stackPanels)
-                {
-                    foreach (var stackPanelItem in stackPanel.Children)
-                    {
-                        if (stackPanelItem is WImage)
-                        {
-                            // Update icon image.
-                            var tabBarImage = stackPanelItem as WImage;
-                            if (tabBarImage.GetValue(FrameworkElement.NameProperty).ToString() == TabBarHeaderImageName)
-                            {
-                                if (headerIconsEnabled)
-                                {
-                                    if (Element.IsSet(Specifics.HeaderIconsSizeProperty))
-                                    {
-                                        Size iconSize = Element.OnThisPlatform().GetHeaderIconsSize();
-                                        tabBarImage.Height = iconSize.Height;
-                                        tabBarImage.Width = iconSize.Width;
-                                    }
-                                    tabBarImage.HorizontalAlignment = WHorizontalAlignment.Center;
-                                    tabBarImage.Visibility = WVisibility.Visible;
-                                }
-                                else
-                                {
-                                    tabBarImage.Visibility = WVisibility.Collapsed;
-                                }
+				// Get all stack panels affected by update.
+				var stackPanels = Control.GetDescendantsByName<WStackPanel>(TabBarHeaderStackPanelName);
+				foreach (var stackPanel in stackPanels)
+				{
+					int stackPanelChildCount = stackPanel.Children.Count;
+					for (int i = 0; i < stackPanelChildCount; i++)
+					{
+						var stackPanelItem = stackPanel.Children[i];
+						if (stackPanelItem is WImage tabBarImage)
+						{
+							// Update icon image.
+							if (tabBarImage.GetValue(FrameworkElement.NameProperty).ToString() == TabBarHeaderImageName)
+							{
+								if (headerIconsEnabled)
+								{
+									if (Element.IsSet(Specifics.HeaderIconsSizeProperty))
+									{
+										Size iconSize = Element.OnThisPlatform().GetHeaderIconsSize();
+										tabBarImage.Height = iconSize.Height;
+										tabBarImage.Width = iconSize.Width;
+									}
+									tabBarImage.HorizontalAlignment = WHorizontalAlignment.Center;
+									tabBarImage.Visibility = WVisibility.Visible;
+								}
+								else
+								{
+									tabBarImage.Visibility = WVisibility.Collapsed;
+								}
 
-                                invalidateMeasure = true;
-                            }
-                        }
-                        else if (stackPanelItem is WTextBlock)
-                        {
-                            // Update text block.
-                            var tabBarTextblock = stackPanelItem as WTextBlock;
-                            if (tabBarTextblock.GetValue(FrameworkElement.NameProperty).ToString() == TabBarHeaderTextBlockName)
-                            {
-                                if (headerIconsEnabled)
-                                {
-                                    // Remember old values so we can restore them if icons are collapsed.
-                                    // NOTE, since all Textblock instances in this stack panel comes from the same
-                                    // style, we just keep one copy of the value (since they should be identical).
-                                    _oldBarTextBlockTextAlignment = tabBarTextblock.TextAlignment;
-                                    _oldBarTextBlockHorinzontalAlignment = tabBarTextblock.HorizontalAlignment;
+								invalidateMeasure = true;
+							}
+						}
+						else if (stackPanelItem is WTextBlock tabBarTextblock)
+						{
+							// Update text block.
+							if (tabBarTextblock.GetValue(FrameworkElement.NameProperty).ToString() == TabBarHeaderTextBlockName)
+							{
+								if (headerIconsEnabled)
+								{
+									// Remember old values so we can restore them if icons are collapsed.
+									// NOTE, since all Textblock instances in this stack panel comes from the same
+									// style, we just keep one copy of the value (since they should be identical).
+									_oldBarTextBlockTextAlignment = tabBarTextblock.TextAlignment;
+									_oldBarTextBlockHorinzontalAlignment = tabBarTextblock.HorizontalAlignment;
 
-                                    tabBarTextblock.TextAlignment = WTextAlignment.Center;
-                                    tabBarTextblock.HorizontalAlignment = WHorizontalAlignment.Center;
-                                }
-                                else
-                                {
-                                    // Restore old values.
-                                    tabBarTextblock.TextAlignment = _oldBarTextBlockTextAlignment;
-                                    tabBarTextblock.HorizontalAlignment = _oldBarTextBlockHorinzontalAlignment;
-                                }
-                            }
-                        }
-                    }
-                }
+									tabBarTextblock.TextAlignment = WTextAlignment.Center;
+									tabBarTextblock.HorizontalAlignment = WHorizontalAlignment.Center;
+								}
+								else
+								{
+									// Restore old values.
+									tabBarTextblock.TextAlignment = _oldBarTextBlockTextAlignment;
+									tabBarTextblock.HorizontalAlignment = _oldBarTextBlockHorinzontalAlignment;
+								}
+							}
+						}
+					}
+				}
 
-                // If items have been made visible or collapsed in panel, invalidate current control measures.
-                if (invalidateMeasure)
-                    Control.InvalidateMeasure();
-            }
-        }
-    }
+				// If items have been made visible or collapsed in panel, invalidate current control measures.
+				if (invalidateMeasure)
+					Control.InvalidateMeasure();
+			}
+		}
+	}
 }

--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -31,8 +31,8 @@ namespace Xamarin.Forms.Platform.UWP
 		bool _disposed;
 		bool _showTitle;
 
-		WTextAlignment _oldBarTextBlockTextAlignment;
-		WHorizontalAlignment _oldBarTextBlockHorinzontalAlignment;
+		WTextAlignment _oldBarTextBlockTextAlignment = WTextAlignment.Center;
+		WHorizontalAlignment _oldBarTextBlockHorinzontalAlignment = WHorizontalAlignment.Center;
 
 		VisualElementTracker<Page, Pivot> _tracker;
 
@@ -401,11 +401,17 @@ namespace Xamarin.Forms.Platform.UWP
 									// Remember old values so we can restore them if icons are collapsed.
 									// NOTE, since all Textblock instances in this stack panel comes from the same
 									// style, we just keep one copy of the value (since they should be identical).
-									_oldBarTextBlockTextAlignment = tabBarTextblock.TextAlignment;
-									_oldBarTextBlockHorinzontalAlignment = tabBarTextblock.HorizontalAlignment;
+									if (tabBarTextblock.TextAlignment != WTextAlignment.Center)
+									{
+										_oldBarTextBlockTextAlignment = tabBarTextblock.TextAlignment;
+										tabBarTextblock.TextAlignment = WTextAlignment.Center;
+									}
 
-									tabBarTextblock.TextAlignment = WTextAlignment.Center;
-									tabBarTextblock.HorizontalAlignment = WHorizontalAlignment.Center;
+									if (tabBarTextblock.HorizontalAlignment != WHorizontalAlignment.Center)
+									{
+										_oldBarTextBlockHorinzontalAlignment = tabBarTextblock.HorizontalAlignment;
+										tabBarTextblock.HorizontalAlignment = WHorizontalAlignment.Center;
+									}
 								}
 								else
 								{

--- a/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
@@ -6,7 +6,10 @@
 		<Setter Property="HeaderTemplate">
 			<Setter.Value>
 				<DataTemplate>
-					<TextBlock Name="TabbedPageHeaderTextBlock" Text="{Binding Title}" Style="{ThemeResource BodyTextBlockStyle}" />
+					<StackPanel Orientation="Vertical" Name="TabbedPageHeaderStackPanel">
+						<Image Name="TabbedPageHeaderImage" DataContext="{Binding Icon, Converter={StaticResource ImageConverter}}" Source="{Binding Value}" Width="16" Height="16" Visibility="Collapsed" />
+						<TextBlock Name="TabbedPageHeaderTextBlock" Text="{Binding Title}" Style="{ThemeResource BodyTextBlockStyle}"/>
+					</StackPanel>
 				</DataTemplate>
 			</Setter.Value>
 		</Setter>
@@ -76,6 +79,9 @@
 
                         <Grid Grid.Row="1">
 							<Grid.Resources>
+								<Style TargetType="PivotHeaderItem">
+									<Setter Property="Height" Value="Auto" />
+								</Style>
 								<ControlTemplate x:Key="NextTemplate" TargetType="Button">
 									<Border x:Name="Root" BorderBrush="{ThemeResource SystemControlForegroundTransparentBrush}" BorderThickness="{ThemeResource PivotNavButtonBorderThemeThickness}" Background="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}">
 										<VisualStateManager.VisualStateGroups>

--- a/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
@@ -7,7 +7,7 @@
 			<Setter.Value>
 				<DataTemplate>
 					<StackPanel Orientation="Vertical" Name="TabbedPageHeaderStackPanel">
-						<Image Name="TabbedPageHeaderImage" DataContext="{Binding Icon, Converter={StaticResource ImageConverter}}" Source="{Binding Value}" Width="16" Height="16" Visibility="Collapsed" />
+						<Image Name="TabbedPageHeaderImage" DataContext="{Binding Icon, Converter={StaticResource ImageConverter}}" Source="{Binding Value}" Width="16" Height="16" Visibility="Collapsed" Margin="0,12,0,0"/>
 						<TextBlock Name="TabbedPageHeaderTextBlock" Text="{Binding Title}" Style="{ThemeResource BodyTextBlockStyle}"/>
 					</StackPanel>
 				</DataTemplate>
@@ -81,6 +81,7 @@
 							<Grid.Resources>
 								<Style TargetType="PivotHeaderItem">
 									<Setter Property="Height" Value="Auto" />
+									<Setter Property="MinHeight" Value="48" />
 								</Style>
 								<ControlTemplate x:Key="NextTemplate" TargetType="Button">
 									<Border x:Name="Root" BorderBrush="{ThemeResource SystemControlForegroundTransparentBrush}" BorderThickness="{ThemeResource PivotNavButtonBorderThemeThickness}" Background="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}">

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.WindowsSpecific/TabbedPage.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.PlatformConfiguration.WindowsSpecific/TabbedPage.xml
@@ -1,0 +1,272 @@
+<Type Name="TabbedPage" FullName="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage">
+  <TypeSignature Language="C#" Value="public static class TabbedPage" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit TabbedPage extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="DisableHeaderIcons">
+      <MemberSignature Language="C#" Value="public static void DisableHeaderIcons (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void DisableHeaderIcons(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="EnableHeaderIcons">
+      <MemberSignature Language="C#" Value="public static void EnableHeaderIcons (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void EnableHeaderIcons(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetHeaderIconsEnabled">
+      <MemberSignature Language="C#" Value="public static bool GetHeaderIconsEnabled (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetHeaderIconsEnabled(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetHeaderIconsEnabled">
+      <MemberSignature Language="C#" Value="public static bool GetHeaderIconsEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetHeaderIconsEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetHeaderIconsSize">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.Size GetHeaderIconsSize (Xamarin.Forms.BindableObject element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.Size GetHeaderIconsSize(class Xamarin.Forms.BindableObject element) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Size</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetHeaderIconsSize">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.Size GetHeaderIconsSize (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.Size GetHeaderIconsSize(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Size</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="HeaderIconsEnabledProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty HeaderIconsEnabledProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty HeaderIconsEnabledProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="HeaderIconsSizeProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty HeaderIconsSizeProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty HeaderIconsSizeProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsHeaderIconsEnabled">
+      <MemberSignature Language="C#" Value="public static bool IsHeaderIconsEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsHeaderIconsEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetHeaderIconsEnabled">
+      <MemberSignature Language="C#" Value="public static void SetHeaderIconsEnabled (Xamarin.Forms.BindableObject element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetHeaderIconsEnabled(class Xamarin.Forms.BindableObject element, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetHeaderIconsEnabled">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; SetHeaderIconsEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; SetHeaderIconsEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config, bool value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetHeaderIconsSize">
+      <MemberSignature Language="C#" Value="public static void SetHeaderIconsSize (Xamarin.Forms.BindableObject element, Xamarin.Forms.Size value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetHeaderIconsSize(class Xamarin.Forms.BindableObject element, valuetype Xamarin.Forms.Size value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="Xamarin.Forms.BindableObject" />
+        <Parameter Name="value" Type="Xamarin.Forms.Size" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetHeaderIconsSize">
+      <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; SetHeaderIconsSize (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config, Xamarin.Forms.Size value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; SetHeaderIconsSize(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config, valuetype Xamarin.Forms.Size value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+        <Parameter Name="value" Type="Xamarin.Forms.Size" />
+      </Parameters>
+      <Docs>
+        <param name="config">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -589,6 +589,7 @@
       <Type Name="MasterDetailPage" Kind="Class" />
       <Type Name="Page" Kind="Class" />
       <Type Name="SearchBar" Kind="Class" />
+      <Type Name="TabbedPage" Kind="Class" />
       <Type Name="ToolbarPlacement" Kind="Enumeration" />
       <Type Name="VisualElement" Kind="Class" />
       <Type Name="WebView" Kind="Class" />
@@ -4763,6 +4764,157 @@
           <summary>To be added.</summary>
         </Docs>
         <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar.SetIsSpellCheckEnabled(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.SearchBar},System.Boolean)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="DisableHeaderIcons">
+        <MemberSignature Language="C#" Value="public static void DisableHeaderIcons (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig void DisableHeaderIcons(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Void</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage.DisableHeaderIcons(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="EnableHeaderIcons">
+        <MemberSignature Language="C#" Value="public static void EnableHeaderIcons (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig void EnableHeaderIcons(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Void</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage.EnableHeaderIcons(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="GetHeaderIconsEnabled">
+        <MemberSignature Language="C#" Value="public static bool GetHeaderIconsEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetHeaderIconsEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage.GetHeaderIconsEnabled(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="GetHeaderIconsSize">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.Size GetHeaderIconsSize (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype Xamarin.Forms.Size GetHeaderIconsSize(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.Size</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage.GetHeaderIconsSize(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="IsHeaderIconsEnabled">
+        <MemberSignature Language="C#" Value="public static bool IsHeaderIconsEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsHeaderIconsEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage.IsHeaderIconsEnabled(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetHeaderIconsEnabled">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; SetHeaderIconsEnabled (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config, bool value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; SetHeaderIconsEnabled(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config, bool value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+          <Parameter Name="value" Type="System.Boolean" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage.SetHeaderIconsEnabled(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage},System.Boolean)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Xamarin.Forms.IPlatformElementConfiguration`2" />
+      </Targets>
+      <Member MemberName="SetHeaderIconsSize">
+        <MemberSignature Language="C#" Value="public static Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; SetHeaderIconsSize (this Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt; config, Xamarin.Forms.Size value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; SetHeaderIconsSize(class Xamarin.Forms.IPlatformElementConfiguration`2&lt;class Xamarin.Forms.PlatformConfiguration.Windows, class Xamarin.Forms.TabbedPage&gt; config, valuetype Xamarin.Forms.Size value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage&gt;" RefType="this" />
+          <Parameter Name="value" Type="Xamarin.Forms.Size" />
+        </Parameters>
+        <Docs>
+          <param name="config">To be added.</param>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage" Member="M:Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage.SetHeaderIconsSize(Xamarin.Forms.IPlatformElementConfiguration{Xamarin.Forms.PlatformConfiguration.Windows,Xamarin.Forms.TabbedPage},Xamarin.Forms.Size)" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>


### PR DESCRIPTION
### Description of Change ###

Implement icon support for TabbedPage on UWP.

Fixes #1705.

### API Changes ###

Added new Windows platform specific properties to enable/disable icons on tabbed page control as well as possibility to control icon size. 

Added:
- New bindable properties on Xamarin.Forms.PlatformConfiguration.WindowsSpecific.TabbedPage, "HeaderIconsEnabledProperty" and "HeaderIconsSizeProperty"
- TabbedPage.On<Windows>().IsHeaderIconsEnabled();
- TabbedPage.On<Windows>().SetHeaderIconsEnabled(true/false);
- TabbedPage.On<Windows>().GetHeaderIconsEnabled();
- TabbedPage.On<Windows>().EnableHeaderIcons();
- TabbedPage.On<Windows>().DisableHeaderIcons();
- TabbedPage.On<Windows>().SetHeaderIconsSize(true/false);
- TabbedPage.On<Windows>().GetHeaderIconsSize();

### Behavioral Changes ###

By default icons will remain disabled on tabbed page controls so current users shouldn't notice this change unless they explicitly enable it. One thing that does change for all users in TabbedPageStyle.xaml is the change from fixed PivotHeaderItem height to auto. This is needed in order to support different icon sizes without clipping. This shouldn't affect current users since they should already handled the case when headers get clipped, reducing the height to a value below old fixed header item size. If however a user relied on clipping behavior, this change will then affect their use of tabbed page control.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
