### PR TITLE
set csharp_space_after_keywords_in_control_flow_statements to true

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,4 @@ root = true
 
 [*.{cs,xaml}]
 indent_style = tab
+csharp_space_after_keywords_in_control_flow_statements = true


### PR DESCRIPTION
### Description of Change ###

set csharp_space_after_keywords_in_control_flow_statements to true in editor config to fit the development guidelines of having a space

```
if (
```


### API Changes ###

None
 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
