### PR TITLE
Add Application.PageAppearing/Dissapearing events

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/PageTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PageTests.cs
@@ -400,6 +400,39 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True (completed);
 		}
 
+		class PageTestApp : Application { }
+
+		[Test]
+		public void SendApplicationPageAppearing()
+		{
+			var app = new PageTestApp();
+			var page = new ContentPage();
+
+			Page actual = null;
+			app.MainPage = page;
+			app.PageAppearing += (sender, args) => actual = args;
+
+			((IPageController)page).SendAppearing();
+
+			Assert.AreSame(page, actual);
+		}
+
+		[Test]
+		public void SendApplicationPageDisappearing()
+		{
+			var app = new PageTestApp();
+			var page = new ContentPage();
+
+			Page actual = null;
+			app.MainPage = page;
+			app.PageDisappearing += (sender, args) => actual = args;
+
+			((IPageController)page).SendAppearing();
+			((IPageController)page).SendDisappearing();
+
+			Assert.AreSame(page, actual);
+		}
+
 		[Test]
 		public void SendAppearing ()
 		{
@@ -494,5 +527,5 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True (sentNav);
 			Assert.True (sent);
 		}
-	}	
+	}
 }

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -169,6 +169,10 @@ namespace Xamarin.Forms
 
 		public event EventHandler<ModalPushingEventArgs> ModalPushing;
 
+		public event EventHandler<Page> PageAppearing;
+
+		public event EventHandler<Page> PageDisappearing;
+
 		public async Task SavePropertiesAsync()
 		{
 			if (Device.IsInvokeRequired)
@@ -278,6 +282,12 @@ namespace Xamarin.Forms
 
 			return properties;
 		}
+
+		internal void OnPageAppearing(Page page)
+			=> PageAppearing?.Invoke(this, page);
+
+		internal void OnPageDisappearing(Page page)
+			=> PageDisappearing?.Invoke(this, page);
 
 		void OnModalPopped(Page modalPage)
 		{

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -317,6 +317,8 @@ namespace Xamarin.Forms
 
 			var pageContainer = this as IPageContainer<Page>;
 			pageContainer?.CurrentPage?.SendAppearing();
+
+			FindApplication(this)?.OnPageAppearing(this);
 		}
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -337,6 +339,16 @@ namespace Xamarin.Forms
 			EventHandler handler = Disappearing;
 			if (handler != null)
 				handler(this, EventArgs.Empty);
+
+			FindApplication(this)?.OnPageDisappearing(this);
+		}
+
+		Application FindApplication(Element element)
+		{
+			if (element == null)
+				return null;
+
+			return (element.Parent is Application app) ? app : FindApplication(element.Parent);
 		}
 
 		void InternalChildrenOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Application.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Application.xml
@@ -363,6 +363,36 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="PageAppearing">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Page&gt; PageAppearing;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Page&gt; PageAppearing" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Page&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PageDisappearing">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Xamarin.Forms.Page&gt; PageDisappearing;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Xamarin.Forms.Page&gt; PageDisappearing" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Xamarin.Forms.Page&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="PanGestureId">
       <MemberSignature Language="C#" Value="public int PanGestureId { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance int32 PanGestureId" />
@@ -455,7 +485,7 @@
           <AttributeName>System.Diagnostics.DebuggerStepThrough</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.Application/&lt;SavePropertiesAsync&gt;d__54))</AttributeName>
+          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.Application/&lt;SavePropertiesAsync&gt;d__60))</AttributeName>
         </Attribute>
       </Attributes>
       <ReturnValue>


### PR DESCRIPTION
In scenarios where you want to keep track of pages as they are
appearing on screen, it's useful to be able to subscribe to a
global event from the `Application` to track those pages for
later processing (i.e. showing a timeline for the app, reloading
XAML for some of those pages, maybe replaying the timeline, etc.)

The new events are automatically raised from the Page base class
right after sending the page-level Appearing/Disappearing events.