### PR TITLE
Simplify event raising invocation pattern

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -280,41 +280,23 @@ namespace Xamarin.Forms
 		}
 
 		void OnModalPopped(Page modalPage)
-		{
-			EventHandler<ModalPoppedEventArgs> handler = ModalPopped;
-			if (handler != null)
-				handler(this, new ModalPoppedEventArgs(modalPage));
-		}
+			=> ModalPopped?.Invoke(this, new ModalPoppedEventArgs(modalPage));
 
 		bool OnModalPopping(Page modalPage)
 		{
-			EventHandler<ModalPoppingEventArgs> handler = ModalPopping;
 			var args = new ModalPoppingEventArgs(modalPage);
-			if (handler != null)
-				handler(this, args);
+			ModalPopping?.Invoke(this, args);
 			return args.Cancel;
 		}
 
 		void OnModalPushed(Page modalPage)
-		{
-			EventHandler<ModalPushedEventArgs> handler = ModalPushed;
-			if (handler != null)
-				handler(this, new ModalPushedEventArgs(modalPage));
-		}
+			=> ModalPushed?.Invoke(this, new ModalPushedEventArgs(modalPage));
 
 		void OnModalPushing(Page modalPage)
-		{
-			EventHandler<ModalPushingEventArgs> handler = ModalPushing;
-			if (handler != null)
-				handler(this, new ModalPushingEventArgs(modalPage));
-		}
+			=> ModalPushing?.Invoke(this, new ModalPushingEventArgs(modalPage));
 
 		void OnPopCanceled()
-		{
-			EventHandler handler = PopCanceled;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
-		}
+			=> PopCanceled?.Invoke(this, EventArgs.Empty);
 
 		async Task SetPropertiesAsync()
 		{

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -147,18 +147,10 @@ namespace Xamarin.Forms
 		}
 
 		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
-		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null)
-				handler(this, new PropertyChangedEventArgs(propertyName));
-		}
+			=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
 		protected virtual void OnPropertyChanging([CallerMemberName] string propertyName = null)
-		{
-			PropertyChangingEventHandler changing = PropertyChanging;
-			if (changing != null)
-				changing(this, new PropertyChangingEventArgs(propertyName));
-		}
+			=> PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
 
 		protected void UnapplyBindings()
 		{
@@ -312,8 +304,7 @@ namespace Xamarin.Forms
 			BindingBase oldBinding = context.Binding;
 			context.Binding = binding;
 
-			if (targetProperty.BindingChanging != null)
-				targetProperty.BindingChanging(this, oldBinding, binding);
+			targetProperty.BindingChanging?.Invoke(this, oldBinding, binding);
 
 			binding.Apply(BindingContext, this, targetProperty);
 		}
@@ -551,8 +542,7 @@ namespace Xamarin.Forms
 		{
 			context.Binding.Unapply();
 
-			if (property.BindingChanging != null)
-				property.BindingChanging(this, context.Binding, null);
+			property.BindingChanging?.Invoke(this, context.Binding, null);
 
 			context.Binding = null;
 		}
@@ -585,8 +575,7 @@ namespace Xamarin.Forms
 			bool same = ReferenceEquals(context.Property, BindingContextProperty) ? ReferenceEquals(value, original) : Equals(value, original);
 			if (!silent && (!same || raiseOnEqual))
 			{
-				if (property.PropertyChanging != null)
-					property.PropertyChanging(this, original, value);
+				property.PropertyChanging?.Invoke(this, original, value);
 
 				OnPropertyChanging(property.PropertyName);
 			}

--- a/Xamarin.Forms.Core/Cells/Cell.cs
+++ b/Xamarin.Forms.Core/Cells/Cell.cs
@@ -119,17 +119,10 @@ namespace Xamarin.Forms
 		public event EventHandler Tapped;
 
 		protected internal virtual void OnTapped()
-		{
-			if (Tapped != null)
-				Tapped(this, EventArgs.Empty);
-		}
+			=> Tapped?.Invoke(this, EventArgs.Empty);
 
 		protected virtual void OnAppearing()
-		{
-			EventHandler handler = Appearing;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
-		}
+			=> Appearing?.Invoke(this, EventArgs.Empty);
 
 		protected override void OnBindingContextChanged()
 		{
@@ -143,11 +136,7 @@ namespace Xamarin.Forms
 		}
 
 		protected virtual void OnDisappearing()
-		{
-			EventHandler handler = Disappearing;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
-		}
+			=> Disappearing?.Invoke(this, EventArgs.Empty);
 
 		protected override void OnParentSet()
 		{
@@ -223,9 +212,7 @@ namespace Xamarin.Forms
 		{
 			// don't run more than once per 16 milliseconds
 			await Task.Delay(TimeSpan.FromMilliseconds(16));
-			EventHandler handler = ForceUpdateSizeRequested;
-			if (handler != null)
-				handler(this, null);
+			ForceUpdateSizeRequested?.Invoke(this, null);
 
 			_nextCallToForceUpdateSizeQueued = false;
 		}

--- a/Xamarin.Forms.Core/Cells/EntryCell.cs
+++ b/Xamarin.Forms.Core/Cells/EntryCell.cs
@@ -66,12 +66,8 @@ namespace Xamarin.Forms
 		public event EventHandler Completed;
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public void SendCompleted()
-		{
-			EventHandler handler = Completed;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
-		}
+		public void SendCompleted() 
+			=> Completed?.Invoke(this, EventArgs.Empty);
 
 		void ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(TextAlignment oldValue, TextAlignment newValue)
 		{

--- a/Xamarin.Forms.Core/Cells/SwitchCell.cs
+++ b/Xamarin.Forms.Core/Cells/SwitchCell.cs
@@ -7,9 +7,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty OnProperty = BindableProperty.Create("On", typeof(bool), typeof(SwitchCell), false, propertyChanged: (obj, oldValue, newValue) =>
 		{
 			var switchCell = (SwitchCell)obj;
-			EventHandler<ToggledEventArgs> handler = switchCell.OnChanged;
-			if (handler != null)
-				handler(obj, new ToggledEventArgs((bool)newValue));
+			switchCell.OnChanged?.Invoke(obj, new ToggledEventArgs((bool)newValue));
 		}, defaultBindingMode: BindingMode.TwoWay);
 
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(SwitchCell), default(string));

--- a/Xamarin.Forms.Core/DeviceInfo.cs
+++ b/Xamarin.Forms.Core/DeviceInfo.cs
@@ -46,10 +46,6 @@ namespace Xamarin.Forms.Internals
 		}
 
 		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
-		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null)
-				handler(this, new PropertyChangedEventArgs(propertyName));
-		}
+			=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 	}
 }

--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -8,12 +8,9 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_EditorRenderer))]
 	public class Editor : InputView, IEditorController, IFontElement, ITextElement, IElementConfiguration<Editor>
 	{
-		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(Editor), null, BindingMode.TwoWay, propertyChanged: (bindable, oldValue, newValue) =>
-		{
-			var editor = (Editor)bindable;
-			if (editor.TextChanged != null)
-				editor.TextChanged(editor, new TextChangedEventArgs((string)oldValue, (string)newValue));
-		});
+		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(Editor), null, BindingMode.TwoWay, propertyChanged: (bindable, oldValue, newValue) 
+			=> (bindable as Editor)?.TextChanged?.Invoke(bindable, new TextChangedEventArgs((string)oldValue, (string)newValue))
+		);
 
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
@@ -91,11 +88,7 @@ namespace Xamarin.Forms
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendCompleted()
-		{
-			EventHandler handler = Completed;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
-		}
+			=> Completed?.Invoke(this, EventArgs.Empty);
 
 		void ITextElement.OnTextColorPropertyChanged(Color oldValue, Color newValue)
 		{

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -161,13 +161,11 @@ namespace Xamarin.Forms
 				if (_platform == value)
 					return;
 				_platform = value;
-				if (PlatformSet != null)
-					PlatformSet(this, EventArgs.Empty);
+				PlatformSet?.Invoke(this, EventArgs.Empty);
 				foreach (Element descendant in Descendants())
 				{
 					descendant._platform = _platform;
-					if (descendant.PlatformSet != null)
-						descendant.PlatformSet(this, EventArgs.Empty);
+					descendant.PlatformSet?.Invoke(this, EventArgs.Empty);
 				}
 			}
 		}
@@ -371,8 +369,7 @@ namespace Xamarin.Forms
 
 			child.ApplyBindings(skipBindingContext: false, fromBindingContextChanged:true);
 
-			if (ChildAdded != null)
-				ChildAdded(this, new ElementEventArgs(child));
+			ChildAdded?.Invoke(this, new ElementEventArgs(child));
 
 			OnDescendantAdded(child);
 			foreach (Element element in child.Descendants())
@@ -383,8 +380,7 @@ namespace Xamarin.Forms
 		{
 			child.Parent = null;
 
-			if (ChildRemoved != null)
-				ChildRemoved(child, new ElementEventArgs(child));
+			ChildRemoved?.Invoke(child, new ElementEventArgs(child));
 
 			OnDescendantRemoved(child);
 			foreach (Element element in child.Descendants())
@@ -641,8 +637,7 @@ namespace Xamarin.Forms
 
 		void OnDescendantAdded(Element child)
 		{
-			if (DescendantAdded != null)
-				DescendantAdded(this, new ElementEventArgs(child));
+			DescendantAdded?.Invoke(this, new ElementEventArgs(child));
 
 			if (RealParent != null)
 				RealParent.OnDescendantAdded(child);
@@ -650,8 +645,7 @@ namespace Xamarin.Forms
 
 		void OnDescendantRemoved(Element child)
 		{
-			if (DescendantRemoved != null)
-				DescendantRemoved(this, new ElementEventArgs(child));
+			DescendantRemoved?.Invoke(this, new ElementEventArgs(child));
 
 			if (RealParent != null)
 				RealParent.OnDescendantRemoved(child);

--- a/Xamarin.Forms.Core/FormattedString.cs
+++ b/Xamarin.Forms.Core/FormattedString.cs
@@ -71,11 +71,7 @@ namespace Xamarin.Forms
 		}
 
 		void OnPropertyChanged([CallerMemberName] string propertyName = null)
-		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null)
-				handler(this, new PropertyChangedEventArgs(propertyName));
-		}
+			=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
 		class SpanCollection : ObservableCollection<Span>
 		{

--- a/Xamarin.Forms.Core/Interactivity/MultiCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/MultiCondition.cs
@@ -43,8 +43,7 @@ namespace Xamarin.Forms
 			if ((bool)oldValue == (bool)newValue)
 				return;
 
-			if (ConditionChanged != null)
-				ConditionChanged(bindable, (bool)oldValue, (bool)newValue);
+			ConditionChanged?.Invoke(bindable, (bool)oldValue, (bool)newValue);
 		}
 
 		void OnConditionChanged(BindableObject bindable, bool oldValue, bool newValue)

--- a/Xamarin.Forms.Core/Interactivity/PropertyCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/PropertyCondition.cs
@@ -106,8 +106,7 @@ namespace Xamarin.Forms
 			if ((bool)oldValue == (bool)newValue)
 				return;
 
-			if (ConditionChanged != null)
-				ConditionChanged(bindable, (bool)oldValue, (bool)newValue);
+			ConditionChanged?.Invoke(bindable, (bool)oldValue, (bool)newValue);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
+++ b/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
@@ -56,10 +56,7 @@ namespace Xamarin.Forms.Internals
 		public event EventHandler CollectionChanged;
 
 		void EmitCollectionChanged()
-		{
-			if (CollectionChanged != null)
-				CollectionChanged(this, EventArgs.Empty);
-		}
+			=> CollectionChanged?.Invoke(this, EventArgs.Empty);
 
 		IEnumerable<ToolbarItem> GetCurrentToolbarItems(Page page)
 		{

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -247,19 +247,11 @@ namespace Xamarin.Forms
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendCellAppearing(Cell cell)
-		{
-			EventHandler<ItemVisibilityEventArgs> handler = ItemAppearing;
-			if (handler != null)
-				handler(this, new ItemVisibilityEventArgs(cell.BindingContext));
-		}
+			=> ItemAppearing?.Invoke(this, new ItemVisibilityEventArgs(cell.BindingContext));
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendCellDisappearing(Cell cell)
-		{
-			EventHandler<ItemVisibilityEventArgs> handler = ItemDisappearing;
-			if (handler != null)
-				handler(this, new ItemVisibilityEventArgs(cell.BindingContext));
-		}
+			=> ItemDisappearing?.Invoke(this, new ItemVisibilityEventArgs(cell.BindingContext));
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendRefreshing()
@@ -569,25 +561,13 @@ namespace Xamarin.Forms
 		}
 
 		void OnRefreshing(EventArgs e)
-		{
-			EventHandler handler = Refreshing;
-			if (handler != null)
-				handler(this, e);
-		}
+			=> Refreshing?.Invoke(this, e);
 
 		void OnScrollToRequested(ScrollToRequestedEventArgs e)
-		{
-			EventHandler<ScrollToRequestedEventArgs> handler = ScrollToRequested;
-			if (handler != null)
-				handler(this, e);
-		}
+			=> ScrollToRequested?.Invoke(this, e);
 
 		static void OnSelectedItemChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			var list = (ListView)bindable;
-			if (list.ItemSelected != null)
-				list.ItemSelected(list, new SelectedItemChangedEventArgs(newValue));
-		}
+			=> (bindable as ListView)?.ItemSelected?.Invoke(bindable, new SelectedItemChangedEventArgs(newValue));
 
 		static bool ValidateHeaderFooterTemplate(BindableObject bindable, object value)
 		{

--- a/Xamarin.Forms.Core/MasterDetailPage.cs
+++ b/Xamarin.Forms.Core/MasterDetailPage.cs
@@ -220,12 +220,7 @@ namespace Xamarin.Forms
 		}
 
 		static void OnIsPresentedPropertyChanged(BindableObject sender, object oldValue, object newValue)
-		{
-			var page = (MasterDetailPage)sender;
-			EventHandler handler = page.IsPresentedChanged;
-			if (handler != null)
-				handler(page, EventArgs.Empty);
-		}
+			=> (sender as MasterDetailPage)?.IsPresentedChanged?.Invoke(sender, EventArgs.Empty);
 
 		static void OnIsPresentedPropertyChanging(BindableObject sender, object oldValue, object newValue)
 		{

--- a/Xamarin.Forms.Core/MenuItem.cs
+++ b/Xamarin.Forms.Core/MenuItem.cs
@@ -83,11 +83,7 @@ namespace Xamarin.Forms
 		public event EventHandler Clicked;
 
 		protected virtual void OnClicked()
-		{
-			EventHandler handler = Clicked;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
-		}
+			=> Clicked?.Invoke(this, EventArgs.Empty);
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void Activate()

--- a/Xamarin.Forms.Core/MultiPage.cs
+++ b/Xamarin.Forms.Core/MultiPage.cs
@@ -121,11 +121,7 @@ namespace Xamarin.Forms
 		}
 
 		protected virtual void OnPagesChanged(NotifyCollectionChangedEventArgs e)
-		{
-			NotifyCollectionChangedEventHandler handler = PagesChanged;
-			if (handler != null)
-				handler(this, e);
-		}
+			=> PagesChanged?.Invoke(this, e);
 
 		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{

--- a/Xamarin.Forms.Core/OpenGLView.cs
+++ b/Xamarin.Forms.Core/OpenGLView.cs
@@ -24,11 +24,7 @@ namespace Xamarin.Forms
 		public Action<Rectangle> OnDisplay { get; set; }
 
 		public void Display()
-		{
-			EventHandler handler = DisplayRequested;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
-		}
+			=> DisplayRequested?.Invoke(this, EventArgs.Empty);
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event EventHandler DisplayRequested;

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -264,9 +264,7 @@ namespace Xamarin.Forms
 
 				if (c.Bounds != startingLayout[i])
 				{
-					EventHandler handler = LayoutChanged;
-					if (handler != null)
-						handler(this, EventArgs.Empty);
+					LayoutChanged?.Invoke(this, EventArgs.Empty);
 					return;
 				}
 			}
@@ -311,9 +309,7 @@ namespace Xamarin.Forms
 				MessagingCenter.Send(this, BusySetSignalName, true);
 
 			OnAppearing();
-			EventHandler handler = Appearing;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Appearing?.Invoke(this, EventArgs.Empty);
 
 			var pageContainer = this as IPageContainer<Page>;
 			pageContainer?.CurrentPage?.SendAppearing();
@@ -334,9 +330,7 @@ namespace Xamarin.Forms
 			pageContainer?.CurrentPage?.SendDisappearing();
 
 			OnDisappearing();
-			EventHandler handler = Disappearing;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
+			Disappearing?.Invoke(this, EventArgs.Empty);
 		}
 
 		void InternalChildrenOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Xamarin.Forms.Core/ScrollView.cs
+++ b/Xamarin.Forms.Core/ScrollView.cs
@@ -288,9 +288,7 @@ namespace Xamarin.Forms
 		void OnScrollToRequested(ScrollToRequestedEventArgs e)
 		{
 			CheckTaskCompletionSource();
-			EventHandler<ScrollToRequestedEventArgs> handler = ScrollToRequested;
-			if (handler != null)
-				handler(this, e);
+			ScrollToRequested?.Invoke(this, e);
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Core/TableView.cs
+++ b/Xamarin.Forms.Core/TableView.cs
@@ -111,8 +111,7 @@ namespace Xamarin.Forms
 			foreach (Cell cell in Root.SelectMany(r => r))
 				cell.Parent = this;
 
-			if (ModelChanged != null)
-				ModelChanged(this, EventArgs.Empty);
+			ModelChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		[Obsolete("OnSizeRequest is obsolete as of version 2.2.0. Please use OnMeasure instead.")]

--- a/Xamarin.Forms.Core/TemplatedItemsList.cs
+++ b/Xamarin.Forms.Core/TemplatedItemsList.cs
@@ -929,11 +929,7 @@ namespace Xamarin.Forms.Internals
 		}
 
 		void OnInnerCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-		{
-			NotifyCollectionChangedEventHandler handler = GroupedCollectionChanged;
-			if (handler != null)
-				handler(sender, e);
-		}
+			=> GroupedCollectionChanged?.Invoke(sender, e);
 
 		void OnItemsSourceChanged(bool fromGrouping = false)
 		{

--- a/Xamarin.Forms.Core/Tweener.cs
+++ b/Xamarin.Forms.Core/Tweener.cs
@@ -74,8 +74,7 @@ namespace Xamarin.Forms
 
 				_lastMilliseconds = ms;
 
-				if (ValueUpdated != null)
-					ValueUpdated(this, EventArgs.Empty);
+				ValueUpdated?.Invoke(this, EventArgs.Empty);
 
 				if (Value >= 1.0f)
 				{
@@ -86,8 +85,7 @@ namespace Xamarin.Forms
 						return true;
 					}
 
-					if (Finished != null)
-						Finished(this, EventArgs.Empty);
+					Finished?.Invoke(this, EventArgs.Empty);
 					Value = 0.0f;
 					_timer = 0;
 					return false;
@@ -100,8 +98,7 @@ namespace Xamarin.Forms
 		{
 			Pause();
 			Value = 1.0f;
-			if (Finished != null)
-				Finished(this, EventArgs.Empty);
+			Finished?.Invoke(this, EventArgs.Empty);
 			Value = 0.0f;
 		}
 

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -440,8 +440,8 @@ namespace Xamarin.Forms
 		public void BatchCommit()
 		{
 			_batched = Math.Max(0, _batched - 1);
-			if (!Batched && BatchCommitted != null)
-				BatchCommitted(this, new EventArg<VisualElement>(this));
+			if (!Batched)
+				BatchCommitted?.Invoke(this, new EventArg<VisualElement>(this));
 		}
 
 		ResourceDictionary _resources;
@@ -624,10 +624,7 @@ namespace Xamarin.Forms
 		}
 
 		protected void OnChildrenReordered()
-		{
-			if (ChildrenReordered != null)
-				ChildrenReordered(this, EventArgs.Empty);
-		}
+			=> ChildrenReordered?.Invoke(this, EventArgs.Empty);
 
 		protected virtual SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
 		{
@@ -886,8 +883,7 @@ namespace Xamarin.Forms
 			Height = height;
 
 			SizeAllocated(width, height);
-			if (SizeChanged != null)
-				SizeChanged(this, EventArgs.Empty);
+			SizeChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		public class FocusRequestArgs : EventArgs

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -78,18 +78,10 @@ namespace Xamarin.Forms
 		}
 
 		public void GoBack()
-		{
-			EventHandler handler = GoBackRequested;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
-		}
+			=> GoBackRequested?.Invoke(this, EventArgs.Empty);
 
 		public void GoForward()
-		{
-			EventHandler handler = GoForwardRequested;
-			if (handler != null)
-				handler(this, EventArgs.Empty);
-		}
+			=> GoForwardRequested?.Invoke(this, EventArgs.Empty);
 
 		public event EventHandler<WebNavigatedEventArgs> Navigated;
 


### PR DESCRIPTION
This is effectively equivalent to the original code, yet nicer to read :)

This is also how it's being done elsewhere (i.e. fast renderers,
BindableObject, etc.), probably because that code is newer?
