### PR TITLE
[Android] attempt to load images from drawables before using bitmap

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1908.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1908.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1908, "Image reuse", PlatformAffected.Android)]
+	public class Issue1908 : TestContentPage
+	{
+
+		public Issue1908()
+		{
+
+		}
+
+		protected override void Init()
+		{
+			StackLayout listView = new StackLayout();
+
+			for (int i = 0; i < 1000; i++)
+			{
+				listView.Children.Add(new Image() { Source = "oasis.jpg",  ClassId = $"OASIS{i}", AutomationId = $"OASIS{i}" });
+			}
+
+			Content = new ScrollView() { Content = listView };
+		}
+
+
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void Issue1908Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("OASIS1"));
+			RunningApp.Screenshot("For manual review. Images load");
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -283,6 +283,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1660.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1665.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1908.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2981.cs" />


### PR DESCRIPTION
### Description of Change ###

If the provided source for an image is a FileImageSource then attempt to resolve the image as a drawable via GetResource opposed to creating a bitmap from the file itself.  This requires a lot less memory.  With the included Unit Test I can load 1000 Xamarin Forms Images without causing Out Of Memory Exceptions now. 


### Bugs Fixed ###

fixes #1908

### Behavioral Changes ###

This change was done in such a way that behavior should remain the same outside of some performance gains when an image is used in multtiple places

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
