### PR TITLE
[Xaml] add DesignMode flag

### DIFF
--- a/Xamarin.Forms.Core/DesignMode.cs
+++ b/Xamarin.Forms.Core/DesignMode.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms
+{
+	public static class DesignMode
+	{
+		public static bool IsDesignModeEnabled { get; internal set; }
+	}
+}

--- a/Xamarin.Forms.Core/Internals/ResourceLoader.cs
+++ b/Xamarin.Forms.Core/Internals/ResourceLoader.cs
@@ -5,8 +5,17 @@ namespace Xamarin.Forms.Internals
 {
 	public static class ResourceLoader
 	{
+		static Func<AssemblyName, string, string> resourceProvider;
+
 		//takes a resource path, returns string content
-		public static Func<AssemblyName, string, string> ResourceProvider { get; internal set; }
+		public static Func<AssemblyName, string, string> ResourceProvider {
+			get => resourceProvider;
+			internal set {
+				DesignMode.IsDesignModeEnabled = true;
+				resourceProvider = value;
+			}
+		}
+
 		internal static Action<Exception> ExceptionHandler { get; set; }
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePage.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePage.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		public WindowsBasePage()
 		{
-			if (!DesignMode.DesignModeEnabled)
+			if (!Windows.ApplicationModel.DesignMode.DesignModeEnabled)
 			{
 				Windows.UI.Xaml.Application.Current.Suspending += OnApplicationSuspending;
 				Windows.UI.Xaml.Application.Current.Resuming += OnApplicationResuming;

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -45,6 +45,7 @@ namespace Xamarin.Forms.Xaml.Internals
 			get { return xamlFileProvider; }
 			internal set {
 				xamlFileProvider = value;
+				Xamarin.Forms.DesignMode.IsDesignModeEnabled = true;
 				//¯\_(ツ)_/¯ the previewer forgot to set that bool
 				DoNotThrowOnExceptions = value != null;
 			}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/DesignMode.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/DesignMode.xml
@@ -1,0 +1,34 @@
+<Type Name="DesignMode" FullName="Xamarin.Forms.DesignMode">
+  <TypeSignature Language="C#" Value="public static class DesignMode" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit DesignMode extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="IsDesignModeEnabled">
+      <MemberSignature Language="C#" Value="public static bool IsDesignModeEnabled { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property bool IsDesignModeEnabled" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -196,6 +196,7 @@
       <Type Name="DependencyAttribute" Kind="Class" />
       <Type Name="DependencyFetchTarget" Kind="Enumeration" />
       <Type Name="DependencyService" Kind="Class" />
+      <Type Name="DesignMode" Kind="Class" />
       <Type Name="Device" Kind="Class" />
       <Type Name="Device+Styles" Kind="Class" />
       <Type Name="Easing" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###

this is a clean version of #1844

Adds a static class and static bool for DesignModeEnabled to Xamarin.Forms.Core. This is to address the F100 Issue (fixes #1731). This is only intended to address programmatic checks by a developer. It does not cover things like d:DesignHeight or other designer aware XAML elements and attributes.

Tooling would need to toggle the DesignModeEnabled property whenever appropriate so that developers can rely on it.


### Bugs Fixed ###

- fixes #1731

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - `public static DesignMode.DesignModeEnabled { get; }`

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
