### PR TITLE
[Tizen] Enhance the button renderer of tizen backend

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ButtonRenderer.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Button.TextColorProperty, UpdateTextColor);
 			RegisterPropertyHandler(Button.ImageProperty, UpdateBitmap);
 			RegisterPropertyHandler(Button.BorderColorProperty, UpdateBorder);
-			RegisterPropertyHandler(Button.BorderRadiusProperty, UpdateBorder);
+			RegisterPropertyHandler(Button.CornerRadiusProperty, UpdateBorder);
 			RegisterPropertyHandler(Button.BorderWidthProperty, UpdateBorder);
 		}
 
@@ -28,6 +28,8 @@ namespace Xamarin.Forms.Platform.Tizen
 					PropagateEvents = false,
 				});
 				Control.Clicked += OnButtonClicked;
+				Control.Pressed += OnButtonPressed;
+				Control.Released += OnButtonReleased;
 			}
 			base.OnElementChanged(e);
 		}
@@ -54,6 +56,8 @@ namespace Xamarin.Forms.Platform.Tizen
 				if (Control != null)
 				{
 					Control.Clicked -= OnButtonClicked;
+					Control.Pressed -= OnButtonPressed;
+					Control.Released -= OnButtonReleased;
 				}
 			}
 			base.Dispose(disposing);
@@ -62,6 +66,16 @@ namespace Xamarin.Forms.Platform.Tizen
 		void OnButtonClicked(object sender, EventArgs e)
 		{
 			(Element as IButtonController)?.SendClicked();
+		}
+
+		void OnButtonPressed(object sender, EventArgs e)
+		{
+			(Element as IButtonController)?.SendPressed();
+		}
+
+		void OnButtonReleased(object sender, EventArgs e)
+		{
+			(Element as IButtonController)?.SendReleased();
 		}
 
 		void UpdateText()


### PR DESCRIPTION
### Description of Change ###

This PR support to `Button.Pressed` and `Button.Released` events on tizen backend.  And ,removes the `warning CS0618: 'Button.BorderRadiusProperty' is obsolete` as well.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
