### PR TITLE
Fail the build if XML docs point to members that don't exist

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DocumentationFile>$(IntermediateOutputPath)\$(AssemblyName).ignore</DocumentationFile>
+    <!-- cref that points to non-existing API is wrong -->
+    <WarningsAsErrors>CS1574</WarningsAsErrors>
+    <!-- Missing API docs isn't, since we have api-docs for that -->
+    <NoWarn>CS1591</NoWarn>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
By adding this targets to the repository, a build will automatically
attempt to generate a temporary (not used for anything other than
this validation) obj\[assembly].ignore file that will contain the
XML API docs, and therefore cause the compiler to validate that
documentation too during build.

By flagging CS1574 as an error, the build will fail if a referenced
member (such as from https://github.com/xamarin/Xamarin.Forms/pull/1987/files#diff-4ef85a97239e80016dc4ddbfb0632998R83,
to document internal members consumed by other teams) is renamed.

The previous/current commits can be compared for such changes by
looking at the generated XML file too, to provide tooling that flags
such breakages.

Ignoring CS1591 is necessary since that's the warning generated when
public members lack documentation altogether, which isn't unexpected
since docs are authored in another repository.
