### PR TITLE
[CSS] use `class` instead of `StyleClass`

### DIFF
--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -278,9 +278,16 @@ namespace Xamarin.Forms
 			set { SetValue(StyleProperty, value); }
 		}
 
+
+		[Obsolete("Use @class")]
 		[TypeConverter(typeof(ListStringTypeConverter))]
-		public IList<string> StyleClass
-		{
+		public IList<string> StyleClass {
+			get { return @class; }
+			set { @class = value; }
+		}
+
+		[TypeConverter(typeof(ListStringTypeConverter))]
+		public IList<string> @class {
 			get { return _mergedStyle.StyleClass; }
 			set { _mergedStyle.StyleClass = value; }
 		}

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
@@ -331,6 +331,27 @@
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="class">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.IList&lt;string&gt; class { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Collections.Generic.IList`1&lt;string&gt; class" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.ListStringTypeConverter))</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IList&lt;System.String&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="DisableLayout">
       <MemberSignature Language="C#" Value="public bool DisableLayout { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance bool DisableLayout" />
@@ -1798,6 +1819,9 @@
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("Use @class")</AttributeName>
+        </Attribute>
         <Attribute>
           <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.ListStringTypeConverter))</AttributeName>
         </Attribute>


### PR DESCRIPTION
### Description of Change ###

[CSS] use `class` instead of `StyleClass`

### Bugs Fixed ###

 - fixes #2022

### API Changes ###

Added:
 - `public [TypeConverter(typeof(ListStringTypeConverter))] VisualElement.IList<string> @class { get; set;}`

Changed:
 - `public [TypeConverter(typeof(ListStringTypeConverter))] VisualElement.IList<string> StyleClass{ get; set;}` => Obsolete

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description) => Manually tested
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense