### PR TITLE
[Enhancement] Entry ReturnType

### DIFF
--- a/Xamarin.Forms.Controls/ControlGalleryPages/EntryReturnTypeGalleryPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/EntryReturnTypeGalleryPage.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Controls
+{
+	public class EntryReturnTypeGalleryPage: ContentPage
+	{
+		Picker picker;
+		Entry returnTypeEntry;
+		public EntryReturnTypeGalleryPage()
+		{
+			BackgroundColor = Color.LightBlue;
+			var layout = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.StartAndExpand
+			};
+
+			picker = new Picker
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand
+			};
+			picker.Items.Add(ReturnType.Done.ToString());
+			picker.Items.Add(ReturnType.Go.ToString());
+			picker.Items.Add(ReturnType.Next.ToString());
+			picker.Items.Add(ReturnType.Search.ToString());
+			picker.Items.Add(ReturnType.Send.ToString());
+			picker.Items.Add(ReturnType.Default.ToString());
+
+			returnTypeEntry = new Entry
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				Placeholder = $"Entry with {ReturnType.Go}",
+				ReturnCommand = new Command<string>(async obj => 
+				{
+					await DisplayAlert(obj, "Pressed", "Pressed ok");
+					await Navigation.PopAsync();
+				}),
+				ReturnCommandParameter = "hello titles",
+				AutomationId = "returnTypeEntry"
+			};
+
+			returnTypeEntry.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
+				{
+					returnTypeEntry.Placeholder = $"Entry with {returnTypeEntry.ReturnType}";
+				}
+			};
+
+			picker.SelectedIndexChanged += (s, e) =>
+			{
+				if (picker.SelectedItem.ToString() == ReturnType.Done.ToString())
+				{
+					returnTypeEntry.ReturnType = ReturnType.Done;
+				}
+				if (picker.SelectedItem.ToString() == ReturnType.Go.ToString())
+				{
+					returnTypeEntry.ReturnType = ReturnType.Go;
+				}
+				if (picker.SelectedItem.ToString() == ReturnType.Next.ToString())
+				{
+					returnTypeEntry.ReturnType = ReturnType.Next;
+				}
+				if (picker.SelectedItem.ToString() == ReturnType.Search.ToString())
+				{
+					returnTypeEntry.ReturnType = ReturnType.Search;
+				}
+				if (picker.SelectedItem.ToString() == ReturnType.Send.ToString())
+				{
+					returnTypeEntry.ReturnType = ReturnType.Send;
+				}
+				if (picker.SelectedItem.ToString() == ReturnType.Default.ToString())
+				{
+					returnTypeEntry.ReturnType = ReturnType.Default;
+				}
+			};
+
+			layout.Children.Add(returnTypeEntry);
+			layout.Children.Add(picker);
+			picker.SelectedIndex = 0;
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/ControlGalleryPages/EntryReturnTypeGalleryPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/EntryReturnTypeGalleryPage.cs
@@ -7,12 +7,17 @@ namespace Xamarin.Forms.Controls
 	{
 		Picker picker;
 		Entry returnTypeEntry;
+		Label lblCompleted;
 		public EntryReturnTypeGalleryPage()
 		{
 			BackgroundColor = Color.LightBlue;
 			var layout = new StackLayout
 			{
 				VerticalOptions = LayoutOptions.StartAndExpand
+			};
+			lblCompleted = new Label
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand
 			};
 
 			picker = new Picker
@@ -30,10 +35,9 @@ namespace Xamarin.Forms.Controls
 			{
 				HorizontalOptions = LayoutOptions.Fill,
 				Placeholder = $"Entry with {ReturnType.Go}",
-				ReturnCommand = new Command<string>(async obj => 
+				ReturnCommand = new Command<string>(obj => 
 				{
-					await DisplayAlert(obj, "Pressed", "Pressed ok");
-					await Navigation.PopAsync();
+					lblCompleted.Text = "Completed Fired";
 				}),
 				ReturnCommandParameter = "hello titles",
 				AutomationId = "returnTypeEntry"
@@ -77,6 +81,7 @@ namespace Xamarin.Forms.Controls
 
 			layout.Children.Add(returnTypeEntry);
 			layout.Children.Add(picker);
+			layout.Children.Add(lblCompleted);
 			picker.SelectedIndex = 0;
 
 			Content = layout;

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -246,6 +246,7 @@ namespace Xamarin.Forms.Controls
 
 		List<GalleryPageFactory> _pages = new List<GalleryPageFactory> {
 				new GalleryPageFactory(() => new Issues.PerformanceGallery(), "Performance"),
+				new GalleryPageFactory(() => new EntryReturnTypeGalleryPage(), "Entry ReturnType "),
 				new GalleryPageFactory(() => new VisualStateManagerGallery(), "VisualStateManager Gallery"),
 				new GalleryPageFactory(() => new FlowDirectionGalleryLandingPage(), "FlowDirection"),
 				new GalleryPageFactory(() => new AutomationPropertiesGallery(), "Accessibility"),

--- a/Xamarin.Forms.Core.UnitTests/EntryUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/EntryUnitTests.cs
@@ -52,7 +52,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (final, newValue);
 		}
 
-		[Test]
 		[TestCase(true)]
 		[TestCase(false)]
 		public void ReturnTypeCommand(bool isEnabled)
@@ -77,7 +76,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True(result == isEnabled ? true : false);
 		}
 
-		[Test]
 		[TestCase(true)]
 		[TestCase(false)]
 		public void ReturnTypeCommandNullTestIsEnabled(bool isEnabled)

--- a/Xamarin.Forms.Core.UnitTests/EntryUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/EntryUnitTests.cs
@@ -51,5 +51,52 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (initial, oldValue);
 			Assert.AreEqual (final, newValue);
 		}
+
+		[Test]
+		[TestCase(true)]
+		[TestCase(false)]
+		public void ReturnTypeCommand(bool isEnabled)
+		{
+			var entry = new Entry()
+			{
+				IsEnabled = isEnabled,
+			};
+
+			bool result = false;
+
+			var bindingContext = new
+			{
+				Command = new Command(() => { result = true; }, () => true)
+			};
+
+			entry.SetBinding(Entry.ReturnCommandProperty, "Command");
+			entry.BindingContext = bindingContext;
+
+			entry.SendCompleted();
+
+			Assert.True(result == isEnabled ? true : false);
+		}
+
+		[Test]
+		[TestCase(true)]
+		[TestCase(false)]
+		public void ReturnTypeCommandNullTestIsEnabled(bool isEnabled)
+		{
+			var entry = new Entry()
+			{
+				IsEnabled = isEnabled,
+			};
+
+			bool result = false;
+		
+			entry.SetBinding(Entry.ReturnCommandProperty, "Command");
+			entry.BindingContext = null;
+			entry.Completed += (s, e) => {
+				result = true;
+			};
+			entry.SendCompleted();
+
+			Assert.True(result == isEnabled ? true : false);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Windows.Input;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
@@ -8,6 +9,12 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_EntryRenderer))]
 	public class Entry : InputView, IFontElement, ITextElement, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>
 	{
+		public static readonly BindableProperty ReturnTypeProperty = BindableProperty.Create(nameof(ReturnType), typeof(ReturnType), typeof(Entry), ReturnType.Default);
+
+		public static readonly BindableProperty ReturnCommandProperty = BindableProperty.Create(nameof(ReturnCommand), typeof(ICommand), typeof(Entry));
+
+		public static readonly BindableProperty ReturnCommandParameterProperty = BindableProperty.Create(nameof(ReturnCommandParameter), typeof(object), typeof(Entry));
+
 		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create("Placeholder", typeof(string), typeof(Entry), default(string));
 
 		public static readonly BindableProperty IsPasswordProperty = BindableProperty.Create("IsPassword", typeof(bool), typeof(Entry), default(bool));
@@ -88,6 +95,24 @@ namespace Xamarin.Forms
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public ReturnType ReturnType
+		{
+			get => (ReturnType)GetValue(ReturnTypeProperty);
+			set => SetValue(ReturnTypeProperty, value);
+		}
+
+		public ICommand ReturnCommand
+		{
+			get => (ICommand)GetValue(ReturnCommandProperty);
+			set => SetValue(ReturnCommandProperty, value);
+		}
+
+		public object ReturnCommandParameter
+		{
+			get => GetValue(ReturnCommandParameterProperty);
+			set => SetValue(ReturnCommandParameterProperty, value);
+		}
+
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			Device.GetNamedSize(NamedSize.Default, (Entry)this);
 
@@ -102,7 +127,7 @@ namespace Xamarin.Forms
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			 InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
-		
+
 		public event EventHandler Completed;
 
 		public event EventHandler<TextChangedEventArgs> TextChanged;
@@ -110,7 +135,11 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendCompleted()
 		{
-			Completed?.Invoke(this, EventArgs.Empty);
+			if (IsEnabled)
+			{
+				Completed?.Invoke(this, EventArgs.Empty);
+				ReturnCommand?.Execute(ReturnCommandParameter);
+			}
 		}
 
 		static void OnTextChanged(BindableObject bindable, object oldValue, object newValue)

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -11,9 +11,9 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty ReturnTypeProperty = BindableProperty.Create(nameof(ReturnType), typeof(ReturnType), typeof(Entry), ReturnType.Default);
 
-		public static readonly BindableProperty ReturnCommandProperty = BindableProperty.Create(nameof(ReturnCommand), typeof(ICommand), typeof(Entry), null);
+		public static readonly BindableProperty ReturnCommandProperty = BindableProperty.Create(nameof(ReturnCommand), typeof(ICommand), typeof(Entry), default(ICommand));
 
-		public static readonly BindableProperty ReturnCommandParameterProperty = BindableProperty.Create(nameof(ReturnCommandParameter), typeof(object), typeof(Entry), null);
+		public static readonly BindableProperty ReturnCommandParameterProperty = BindableProperty.Create(nameof(ReturnCommandParameter), typeof(object), typeof(Entry), default(object));
 
 		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create("Placeholder", typeof(string), typeof(Entry), default(string));
 

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -11,9 +11,9 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty ReturnTypeProperty = BindableProperty.Create(nameof(ReturnType), typeof(ReturnType), typeof(Entry), ReturnType.Default);
 
-		public static readonly BindableProperty ReturnCommandProperty = BindableProperty.Create(nameof(ReturnCommand), typeof(ICommand), typeof(Entry));
+		public static readonly BindableProperty ReturnCommandProperty = BindableProperty.Create(nameof(ReturnCommand), typeof(ICommand), typeof(Entry), null);
 
-		public static readonly BindableProperty ReturnCommandParameterProperty = BindableProperty.Create(nameof(ReturnCommandParameter), typeof(object), typeof(Entry));
+		public static readonly BindableProperty ReturnCommandParameterProperty = BindableProperty.Create(nameof(ReturnCommandParameter), typeof(object), typeof(Entry), null);
 
 		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create("Placeholder", typeof(string), typeof(Entry), default(string));
 

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -139,7 +139,7 @@ namespace Xamarin.Forms
 			{
 				Completed?.Invoke(this, EventArgs.Empty);
 
-				if(ReturnCommand != null && ReturnCommand.CanExecute(ReturnCommandParameter))
+				if (ReturnCommand != null && ReturnCommand.CanExecute(ReturnCommandParameter))
 				{
 					ReturnCommand.Execute(ReturnCommandParameter);
 				}

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -138,7 +138,11 @@ namespace Xamarin.Forms
 			if (IsEnabled)
 			{
 				Completed?.Invoke(this, EventArgs.Empty);
-				ReturnCommand?.Execute(ReturnCommandParameter);
+
+				if(ReturnCommand != null && ReturnCommand.CanExecute(ReturnCommandParameter))
+				{
+					ReturnCommand.Execute(ReturnCommandParameter);
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Core/ReturnType.cs
+++ b/Xamarin.Forms.Core/ReturnType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	public enum ReturnType
+	{
+		Default,
+		Done,
+		Go,
+		Next,
+		Search,
+		Send,
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Extensions/EntryRendererExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/EntryRendererExtensions.cs
@@ -4,6 +4,28 @@ namespace Xamarin.Forms.Platform.Android
 {
 	internal static class EntryRendererExtensions
 	{
+
+		internal static ImeAction ToAndroidImeAction(this ReturnType returnType)
+		{
+			switch (returnType)
+			{
+				case ReturnType.Go:
+					return ImeAction.Go;
+				case ReturnType.Next:
+					return ImeAction.Next;
+				case ReturnType.Send:
+					return ImeAction.Send;
+				case ReturnType.Search:
+					return ImeAction.Search;
+				case ReturnType.Done:
+					return ImeAction.Done;
+				case ReturnType.Default:
+					return ImeAction.Done;
+				default:
+					throw new System.Exception("Return Type Not Supported");
+			}
+		}
+
 		public static ImeAction ToAndroidImeOptions(this PlatformConfiguration.AndroidSpecific.ImeFlags flags)
 		{
 			switch (flags)

--- a/Xamarin.Forms.Platform.Android/Extensions/EntryRendererExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/EntryRendererExtensions.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.Android
 				case ReturnType.Default:
 					return ImeAction.Done;
 				default:
-					throw new System.Exception("Return Type Not Supported");
+					throw new System.NotImplementedException($"ReturnType {returnType} not supported");
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -19,7 +19,6 @@ namespace Xamarin.Forms.Platform.Android
 		TextColorSwitcher _hintColorSwitcher;
 		TextColorSwitcher _textColorSwitcher;
 		bool _disposed;
-		//global::Android.Views.InputMethods.ImeFlags _defaultInputImeFlag;
 		ImeAction _currentInputImeFlag;
 
 		public EntryRenderer(Context context) : base(context)
@@ -98,6 +97,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdatePlaceholderColor();
 			UpdateMaxLength();
 			UpdateImeOptions();
+			UpdateReturnType();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -160,6 +160,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateMaxLength();
 			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.Entry.ImeOptionsProperty.PropertyName)
 				UpdateImeOptions();
+			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
+				UpdateReturnType();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -254,6 +256,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (currentControlText.Length > Element.MaxLength)
 				Control.Text = currentControlText.Substring(0, Element.MaxLength);
+		}
+
+		void UpdateReturnType()
+		{
+			if (Control == null || Element == null)
+				return;
+			
+			Control.ImeOptions = Element.ReturnType.ToAndroidImeAction();	
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -263,7 +263,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (Control == null || Element == null)
 				return;
 			
-			Control.ImeOptions = Element.ReturnType.ToAndroidImeAction();	
+			Control.ImeOptions = Element.ReturnType.ToAndroidImeAction();
+			_currentInputImeFlag = Control.ImeOptions;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Extensions/EntryExtensions.cs
+++ b/Xamarin.Forms.Platform.Tizen/Extensions/EntryExtensions.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				case ReturnType.Default:
 					return InputPanelReturnKeyType.Default;
 				default:
-					throw new System.Exception("Return Type Not Supported");
+					throw new System.NotImplementedException($"ReturnType {returnType} not supported");
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Extensions/EntryExtensions.cs
+++ b/Xamarin.Forms.Platform.Tizen/Extensions/EntryExtensions.cs
@@ -1,0 +1,29 @@
+﻿using ElmSharp;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	internal static class EntryExtensions
+	{
+		internal static InputPanelReturnKeyType ToInputPanelReturnKeyType(this ReturnType returnType)
+		{
+			switch (returnType)
+			{
+				case ReturnType.Go:
+					return InputPanelReturnKeyType.Go;
+				case ReturnType.Next:
+					return InputPanelReturnKeyType.Next;
+				case ReturnType.Send:
+					return InputPanelReturnKeyType.Send;
+				case ReturnType.Search:
+					return InputPanelReturnKeyType.Search;
+				case ReturnType.Done:
+					return InputPanelReturnKeyType.Done;
+				case ReturnType.Default:
+					return InputPanelReturnKeyType.Default;
+				default:
+					throw new System.Exception("Return Type Not Supported");
+			}
+		}
+
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -1,5 +1,4 @@
 using System;
-using ElmSharp;
 using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.Entry;
 
 namespace Xamarin.Forms.Platform.Tizen
@@ -19,6 +18,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Entry.PlaceholderProperty, UpdatePlaceholder);
 			RegisterPropertyHandler(Entry.PlaceholderColorProperty, UpdatePlaceholderColor);
 			RegisterPropertyHandler(InputView.MaxLengthProperty, UpdateMaxLength);
+			RegisterPropertyHandler(Entry.ReturnTypeProperty, UpdateReturnType);
 			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
 			{
 				RegisterPropertyHandler("FontWeight", UpdateFontWeight);
@@ -145,6 +145,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				return s;
 
 			return null;
+		}
+
+		void UpdateReturnType()
+		{
+			Control.SetInputPanelReturnKeyType(Element.ReturnType.ToInputPanelReturnKeyType());
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdatePlaceholderColor();
 				UpdateMaxLength();
 				UpdateDetectReadingOrderFromContent();
+				UpdateReturnType();
 			}
 		}
 
@@ -95,6 +96,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateMaxLength();
 			else if (e.PropertyName == Specifics.DetectReadingOrderFromContentProperty.PropertyName)
 				UpdateDetectReadingOrderFromContent();
+			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
+				UpdateReturnType();
 		}
 
 		protected override void UpdateBackgroundColor()
@@ -248,6 +251,14 @@ namespace Xamarin.Forms.Platform.UWP
 					Control.TextReadingOrder = TextReadingOrder.UseFlowDirection;
 				}
 			}
+		}
+
+		void UpdateReturnType()
+		{
+			if (Control == null || Element == null)
+				return;
+
+			Control.InputScope = Element.ReturnType.ToInputScope();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/Extensions.cs
+++ b/Xamarin.Forms.Platform.UAP/Extensions.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using Windows.Foundation;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Input;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -25,6 +26,38 @@ namespace Xamarin.Forms.Platform.UWP
 		public static void SetBinding(this FrameworkElement self, DependencyProperty property, string path, Windows.UI.Xaml.Data.IValueConverter converter)
 		{
 			self.SetBinding(property, new Windows.UI.Xaml.Data.Binding { Path = new PropertyPath(path), Converter = converter });
+		}
+
+		internal static InputScopeNameValue GetKeyboardButtonType(this ReturnType returnType)
+		{		
+			switch (returnType)
+			{
+				case ReturnType.Default:
+				case ReturnType.Done:
+				case ReturnType.Go:
+				case ReturnType.Next:
+				case ReturnType.Send:
+					return InputScopeNameValue.Default;
+				case ReturnType.Search:
+					return InputScopeNameValue.Search;
+				default:
+					throw new Exception("Return Type Not Supported");
+			}
+		}
+
+		internal static InputScope ToInputScope(this ReturnType returnType)
+		{
+			var scopeName = new InputScopeName()
+			{
+				NameValue = GetKeyboardButtonType(returnType)
+			};
+
+			var inputScope = new InputScope
+			{
+				Names = { scopeName }
+			};
+
+			return inputScope;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/Extensions.cs
+++ b/Xamarin.Forms.Platform.UAP/Extensions.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Platform.UWP
 				case ReturnType.Search:
 					return InputScopeNameValue.Search;
 				default:
-					throw new Exception("Return Type Not Supported");
+					throw new System.NotImplementedException($"ReturnType {returnType} not supported");
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -68,6 +68,27 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		internal static UIReturnKeyType ToUIReturnKeyType(this ReturnType returnType)
+		{
+			switch (returnType)
+			{
+				case ReturnType.Go:
+					return UIReturnKeyType.Go;
+				case ReturnType.Next:
+					return UIReturnKeyType.Next;
+				case ReturnType.Send:
+					return UIReturnKeyType.Send;
+				case ReturnType.Search:
+					return UIReturnKeyType.Search;
+				case ReturnType.Done:
+					return UIReturnKeyType.Done;
+				case ReturnType.Default:
+					return UIReturnKeyType.Default;
+				default:
+					throw new System.Exception("Return Type Not Supported");
+			}
+		}
+
 		internal static DeviceOrientation ToDeviceOrientation(this UIDeviceOrientation orientation)
 		{
 			switch (orientation)

--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Forms.Platform.iOS
 				case ReturnType.Default:
 					return UIReturnKeyType.Default;
 				default:
-					throw new System.Exception("Return Type Not Supported");
+					throw new System.NotImplementedException($"ReturnType {returnType} not supported");
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -108,6 +108,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateAlignment();
 			UpdateAdjustsFontSizeToFitWidth();
 			UpdateMaxLength();
+			UpdateReturnType();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -143,6 +144,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateAlignment();
 			else if (e.PropertyName == Xamarin.Forms.InputView.MaxLengthProperty.PropertyName)
 				UpdateMaxLength();
+			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
+				UpdateReturnType();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -278,5 +281,13 @@ namespace Xamarin.Forms.Platform.iOS
 			var newLength = textField?.Text?.Length + replacementString.Length - range.Length;
 			return newLength <= Element?.MaxLength;
 		}
+
+		void UpdateReturnType()
+		{
+			if (Control == null || Element == null)
+				return;
+			Control.ReturnKeyType = Element.ReturnType.ToUIReturnKeyType();
+		}
+
 	}
 }

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Entry.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Entry.xml
@@ -417,6 +417,99 @@ View CreateLoginForm ()
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="ReturnCommand">
+      <MemberSignature Language="C#" Value="public System.Windows.Input.ICommand ReturnCommand { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Windows.Input.ICommand ReturnCommand" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.Input.ICommand</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ReturnCommandParameter">
+      <MemberSignature Language="C#" Value="public object ReturnCommandParameter { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance object ReturnCommandParameter" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ReturnCommandParameterProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ReturnCommandParameterProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ReturnCommandParameterProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ReturnCommandProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ReturnCommandProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ReturnCommandProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ReturnType">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.ReturnType ReturnType { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.ReturnType ReturnType" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ReturnType</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ReturnTypeProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty ReturnTypeProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty ReturnTypeProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="SendCompleted">
       <MemberSignature Language="C#" Value="public void SendCompleted ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SendCompleted() cil managed" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/ReturnType.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/ReturnType.xml
@@ -1,0 +1,101 @@
+<Type Name="ReturnType" FullName="Xamarin.Forms.ReturnType">
+  <TypeSignature Language="C#" Value="public enum ReturnType" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed ReturnType extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Default">
+      <MemberSignature Language="C#" Value="Default" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ReturnType Default = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ReturnType</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Done">
+      <MemberSignature Language="C#" Value="Done" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ReturnType Done = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ReturnType</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Go">
+      <MemberSignature Language="C#" Value="Go" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ReturnType Go = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ReturnType</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Next">
+      <MemberSignature Language="C#" Value="Next" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ReturnType Next = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ReturnType</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Search">
+      <MemberSignature Language="C#" Value="Search" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ReturnType Search = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ReturnType</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Send">
+      <MemberSignature Language="C#" Value="Send" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.ReturnType Send = int32(5)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.ReturnType</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -368,6 +368,7 @@
       <Type Name="ResolutionGroupNameAttribute" Kind="Class" />
       <Type Name="ResourceDictionary" Kind="Class" />
       <Type Name="ResourceDictionary+RDSourceTypeConverter" Kind="Class" />
+      <Type Name="ReturnType" Kind="Enumeration" />
       <Type Name="RoutingEffect" Kind="Class" />
       <Type Name="RowDefinition" Kind="Class" />
       <Type Name="RowDefinitionCollection" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###

Adding option for specify a diferente UI for the Done button of the Entry control. Also allows to specify a command and command parameter 

All props go to @brminnick  https://github.com/brminnick/EntryCustomReturnPlugin.

Investigated how we could expand this to allow any Image or Text like suggested on the spec, but that's really hard on most platforms, and needs to be "hacked" in using native private api from the OS. 

### Bugs Fixed ###

- Fixes #1697 

### API Changes ###

```csharp

public static readonly BindableProperty ReturnButtonTypeProperty = BindableProperty.Create(
                nameof(ReturnButtonType),
                typeof(ReturnButtonType),
                typeof(Entry),
                ReturnButtonType.Default);

public static readonly BindableProperty ReturnCommandProperty =  BindableProperty.Create(
               nameof(ReturnCommand),
                typeof(ICommand),
                typeof(Entry));

public static readonly BindableProperty ReturnCommandParameterProperty  = BindableProperty.Create(
                nameof(ReturnCommandParameter),
                typeof(object),
                typeof(Entry));


public enum ReturnButtonType
{
	Default,
	Done,
	Go,
	Next,
	Search,
	Send,
}
```

### Behavioral Changes ###

Completed event will not fire is `IsEnabled = False
`
### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
# #