### PR TITLE
[XamlC] Find the real VisualState parent

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2034.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2034.xaml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Gh2034">
+    <FlexLayout StyleClass="login-form">
+        <Label >
+            <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroupList>
+                        <VisualStateGroup x:Name="StrengthStates">
+                                
+                            <VisualState x:Name="VeryWeak">
+                                <VisualState.Setters>
+                                    <Setter Property="Text" Value="foo"/>
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                </VisualStateGroupList>
+            </VisualStateManager.VisualStateGroups>
+        </Label>
+    </FlexLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2034.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2034.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh2034 : ContentPage
+	{
+		public Gh2034()
+		{
+			InitializeComponent();
+		}
+		public Gh2034(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true)]
+			public void Compiles(bool useCompiledXaml)
+			{
+				if (!useCompiledXaml)
+					return;
+				MockCompiler.Compile(typeof(Gh2034));
+				Assert.Pass();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -579,6 +579,9 @@
     <Compile Include="Issues\Gh1978.xaml.cs">
       <DependentUpon>Gh1978.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh2034.xaml.cs">
+      <DependentUpon>Gh2034.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" />
@@ -1033,6 +1036,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh1978.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh2034.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>


### PR DESCRIPTION
### Description of Change ###

[XamlC] Find the real VisualState parent

`VisualStateGroupList` can be implicit, and it looks like tht wasn't
tested. This adds a test, and a fix.

### Bugs Fixed ###

 - fixes #2034

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense