### PR TITLE
Added the Entry.IsTextPredictionEnabled property

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1677.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1677.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 1677, "[Enhancement] Entry: Control over text-prediction", PlatformAffected.All)]
+	public class Issue1677
+		: TestContentPage
+	{
+		protected override void Init()
+		{
+			var entryDefaults = new Entry();
+			var entryNoTextPrediction = new Entry { IsTextPredictionEnabled = false };
+			// IsTextPredictionEnabled should be ignored for email Entry
+			var entryEmail = new Entry { Text = "foo@example.com", Keyboard = Keyboard.Email, IsTextPredictionEnabled = true };
+			// IsTextPredictionEnabled should be ignored for numeric Entry
+			var entryNumeric = new Entry { Text = "01234", Keyboard = Keyboard.Numeric, IsTextPredictionEnabled = true };
+			// On Android disabling either spell checking or text prediction both turn off text suggestions so this Entry
+			// should behave the same as entryNoTextPrediction above
+			var entryNoSpellChecking = new Entry { IsSpellCheckEnabled = false };
+
+			var stackLayout = new StackLayout();
+			stackLayout.Children.Add(new Label { Text = "Defaults" });
+			stackLayout.Children.Add(entryDefaults);
+			stackLayout.Children.Add(new Label { Text = "Text prediction disabled" });
+			stackLayout.Children.Add(entryNoTextPrediction);
+			stackLayout.Children.Add(new Label { Text = "Spell checking disabled" });
+			stackLayout.Children.Add(entryNoSpellChecking);
+			stackLayout.Children.Add(new Label { Text = "Email" });
+			stackLayout.Children.Add(entryEmail);
+			stackLayout.Children.Add(new Label { Text = "Numeric" });
+			stackLayout.Children.Add(entryNumeric);
+
+			stackLayout.Padding = new Thickness(0, 20, 0, 0);
+			Content = stackLayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -238,6 +238,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59457.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1677.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1683.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1705_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1717.cs" />

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Entry), true, BindingMode.OneTime);
+
 		readonly Lazy<PlatformConfigurationRegistry<Entry>> _platformConfigurationRegistry;
 
 		public Entry()
@@ -86,6 +88,12 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(FontSizeProperty); }
 			set { SetValue(FontSizeProperty, value); }
+		}
+
+		public bool IsTextPredictionEnabled
+		{
+			get { return (bool)GetValue(IsTextPredictionEnabledProperty); }
+			set { SetValue(IsTextPredictionEnabledProperty, value); }
 		}
 
 		double IFontElement.FontSizeDefaultValueCreator() =>

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -144,6 +144,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateInputType();
 			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
 				UpdateInputType();
+			else if (e.PropertyName == Entry.IsTextPredictionEnabledProperty.PropertyName)
+				UpdateInputType();
 			else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
 				UpdateAlignment();
 			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
@@ -203,12 +205,23 @@ namespace Xamarin.Forms.Platform.Android
 			var keyboard = model.Keyboard;
 
 			Control.InputType = keyboard.ToInputType();
-			if (!(keyboard is Internals.CustomKeyboard) && model.IsSet(InputView.IsSpellCheckEnabledProperty))
+			if (!(keyboard is Internals.CustomKeyboard))
 			{
-				if ((Control.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+				if (model.IsSet(InputView.IsSpellCheckEnabledProperty))
 				{
-					if (!model.IsSpellCheckEnabled)
-						Control.InputType = Control.InputType | InputTypes.TextFlagNoSuggestions;
+					if ((Control.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsSpellCheckEnabled)
+							Control.InputType = Control.InputType | InputTypes.TextFlagNoSuggestions;
+					}
+				}
+				if (model.IsSet(Entry.IsTextPredictionEnabledProperty))
+				{
+					if ((Control.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsTextPredictionEnabled)
+							Control.InputType = Control.InputType | InputTypes.TextFlagNoSuggestions;
+					}
 				}
 			}
 

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -79,6 +79,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateInputScope();
 			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
 				UpdateInputScope();
+			else if (e.PropertyName == Entry.IsTextPredictionEnabledProperty.PropertyName)
+				UpdateInputScope();
 			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
 				UpdateFont();
 			else if (e.PropertyName == Entry.FontFamilyProperty.PropertyName)
@@ -178,7 +180,10 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 			else
 			{
-				Control.ClearValue(TextBox.IsTextPredictionEnabledProperty);
+				if (entry.IsSet(Entry.IsTextPredictionEnabledProperty))
+					Control.IsTextPredictionEnabled = entry.IsTextPredictionEnabled;
+				else
+					Control.ClearValue(TextBox.IsTextPredictionEnabledProperty);
 				if (entry.IsSet(InputView.IsSpellCheckEnabledProperty))
 					Control.IsSpellCheckEnabled = entry.IsSpellCheckEnabled;
 				else

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -124,6 +124,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateKeyboard();
 			else if (e.PropertyName == Xamarin.Forms.InputView.IsSpellCheckEnabledProperty.PropertyName)
 				UpdateKeyboard();
+			else if (e.PropertyName == Entry.IsTextPredictionEnabledProperty.PropertyName)
+				UpdateKeyboard();
 			else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
 				UpdateAlignment();
 			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
@@ -212,12 +214,23 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateKeyboard()
 		{
-			Control.ApplyKeyboard(Element.Keyboard);
-			if (!(Element.Keyboard is Internals.CustomKeyboard) && Element.IsSet(Xamarin.Forms.InputView.IsSpellCheckEnabledProperty))
+			var keyboard = Element.Keyboard;
+			Control.ApplyKeyboard(keyboard);
+			if (!(keyboard is Internals.CustomKeyboard))
 			{
-				if (!Element.IsSpellCheckEnabled)
+				if (Element.IsSet(Xamarin.Forms.InputView.IsSpellCheckEnabledProperty))
 				{
-					Control.SpellCheckingType = UITextSpellCheckingType.No;
+					if (!Element.IsSpellCheckEnabled)
+					{
+						Control.SpellCheckingType = UITextSpellCheckingType.No;
+					}
+				}
+				if (Element.IsSet(Xamarin.Forms.Entry.IsTextPredictionEnabledProperty))
+				{
+					if (!Element.IsTextPredictionEnabled)
+					{
+						Control.AutocorrectionType = UITextAutocorrectionType.No;
+					}
 				}
 			}
 			Control.ReloadInputViews();

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Entry.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Entry.xml
@@ -314,6 +314,37 @@ View CreateLoginForm ()
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="IsTextPredictionEnabled">
+      <MemberSignature Language="C#" Value="public bool IsTextPredictionEnabled { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool IsTextPredictionEnabled" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsTextPredictionEnabledProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty IsTextPredictionEnabledProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty IsTextPredictionEnabledProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="On&lt;T&gt;">
       <MemberSignature Language="C#" Value="public Xamarin.Forms.IPlatformElementConfiguration&lt;T,Xamarin.Forms.Entry&gt; On&lt;T&gt; () where T : Xamarin.Forms.IConfigPlatform;" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Xamarin.Forms.IPlatformElementConfiguration`2&lt;!!T, class Xamarin.Forms.Entry&gt; On&lt;(class Xamarin.Forms.IConfigPlatform) T&gt;() cil managed" />


### PR DESCRIPTION
Makes it easier for users to disable text prediction/autocomplete/autosuggest.
Fixes #1677.

### Description of Change ###

Added the `Entry.IsTextPredictionEnabledProperty` field and `Entry.IsTextPredictionEnabled` property. Modified `EntryRenderer.OnElementPropertyChanged()` for Android, iOS and UWP to react to changes to the new `IsTextPredictionEnabled` property.

On Android setting `IsTextPredictionEnabled` to `false` sets the `InputTypes.TextFlagNoSuggestions` flag on the native control's `InputType`.

On UWP the native control's `IsTextPredictionEnabled` will be set to the value of the `Entry.IsTextPredictionEnabled` property.

On iOS the native control's `AutocorrectionType` property will be set to `No` when `Entry.IsTextPredictionEnabled` is `false`.

### Bugs Fixed ###

- Fixes #1677 [Enhancement] Entry: Control over text-prediction

### API Changes ###

Added:
- `bool Entry.IsTextPredictionEnabled { get; set; } //Bindable Property`

### Behavioral Changes ###

When `IsTextPredictionEnabled ` is set to `false` (default is `true`) and no `CustomKeyboard` is in use the native text prediction feature will be disabled. This means that `CustomKeyboard` always has precedence. If a `Keyboard` has been set which disables text prediction, the `IsTextPredictionEnabled ` property is ignored. The property cannot be used to enable text prediction for a `Keyboard` which explicitly disables it.

**NOTE**: I discovered that Android 7.1 on my Nexus 6 totally ignores the TextFlagNoSuggestions so neither IsSpellCheckEnabled nor IsTextPredictionEnabled have any effect on my device. Googled around and it seems like turning off suggestions is impossible on some devices, probably depending on the keyboard being used. There doesn't seem to be much one can do about this.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
