### PR TITLE
Reinstate StyleClass but keep @class

### DIFF
--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -278,8 +278,7 @@ namespace Xamarin.Forms
 			set { SetValue(StyleProperty, value); }
 		}
 
-
-		[Obsolete("Use @class")]
+		
 		[TypeConverter(typeof(ListStringTypeConverter))]
 		public IList<string> StyleClass {
 			get { return @class; }

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/VisualElement.xml
@@ -1820,9 +1820,6 @@
       </AssemblyInfo>
       <Attributes>
         <Attribute>
-          <AttributeName>System.Obsolete("Use @class")</AttributeName>
-        </Attribute>
-        <Attribute>
           <AttributeName>Xamarin.Forms.TypeConverter(typeof(Xamarin.Forms.ListStringTypeConverter))</AttributeName>
         </Attribute>
       </Attributes>


### PR DESCRIPTION
### Description of Change ###

Reinstate StyleClass

### Bugs Fixed ###

None

### API Changes ###

Changed:
 - VisualElement.StyleClass is no longer Obsoleted

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
