### PR TITLE
[C] Update Bindings with "BindingContext" in path

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindableObjectUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindableObjectUnitTests.cs
@@ -1512,6 +1512,19 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/2019
+		public void EventSubscribingOnBindingContextChanged()
+		{
+			var source = new MockBindable();
+			var bindable = new MockBindable();
+			var property = BindableProperty.Create("foo", typeof(string), typeof(MockBindable), null);
+			bindable.SetBinding(property, new Binding("BindingContext", source: source));
+			Assert.That((string)bindable.GetValue(property), Is.EqualTo(null));
+			BindableObject.SetInheritedBindingContext(source, "bar"); //inherited BC, only trigger BCChanged
+			Assert.That((string)bindable.GetValue(property), Is.EqualTo("bar"));
+		}
+
+		[Test]
 		public void BindingsEditableAfterUnapplied()
 		{
 			var bindable = new MockBindable();

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -143,7 +143,8 @@ namespace Xamarin.Forms
 
 				if (mode == BindingMode.OneWay || mode == BindingMode.TwoWay)
 				{
-					if (current is INotifyPropertyChanged inpc && !ReferenceEquals(current, previous))
+					var inpc = current as INotifyPropertyChanged;
+					if (inpc != null && !ReferenceEquals(current, previous))
 						part.Subscribe(inpc);
 				}
 
@@ -442,7 +443,8 @@ namespace Xamarin.Forms
 
 			public void Unsubscribe()
 			{
-				if (_source.TryGetTarget(out INotifyPropertyChanged source) && source != null)
+				INotifyPropertyChanged source;
+				if (_source.TryGetTarget(out source) && source != null)
 					source.PropertyChanged -= _handler;
 				var bo = source as BindableObject;
 				if (bo != null)
@@ -454,7 +456,8 @@ namespace Xamarin.Forms
 
 			void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
 			{
-				if (_listener.TryGetTarget(out PropertyChangedEventHandler handler) && handler != null)
+				PropertyChangedEventHandler handler;
+				if (_listener.TryGetTarget(out handler) && handler != null)
 					handler(sender, e);
 				else
 					Unsubscribe();
@@ -484,7 +487,8 @@ namespace Xamarin.Forms
 
 			public void Subscribe(INotifyPropertyChanged handler)
 			{
-				if (_listener != null && _listener.Source.TryGetTarget(out INotifyPropertyChanged source) && ReferenceEquals(handler, source))
+				INotifyPropertyChanged source;
+				if (_listener != null && _listener.Source.TryGetTarget(out source) && ReferenceEquals(handler, source))
 					// Already subscribed
 					return;
 


### PR DESCRIPTION
### Description of Change ###

If the BindingContext is set using SetInheritedBindingContext, INPC
isn't fired, and bindings containing the "BindingContext" string in
the path ends up not being notified of the Change.

In addition to listening to PropertyChanged, this also hooks into
BindingContextChanged, and update the bindings accordingly.

### Bugs Fixed ###

- fixes #2019

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
