### PR TITLE
[Android] Fix issue where compressed layouts couldn't be removed from the visual hierarchy

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1601.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1601.cs
@@ -45,12 +45,11 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue1414Test()
+		public void Issue1601Test()
 		{
 			RunningApp.Screenshot("Start G1601");
 			RunningApp.WaitForElement(q => q.Marked("CRASH!"));
 			RunningApp.Tap (q => q.Marked ("CRASH!"));
-			RunningApp.WaitForElement(q => q.Marked("CRASH!"));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1601.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1601.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1601, "Exception thrown when `Removing Content Using LayoutCompression", PlatformAffected.Android)]
+	public class Issue1601 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var grid = new Grid();
+			Forms.CompressedLayout.SetIsHeadless(grid, true);
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+			grid.RowDefinitions.Add(new RowDefinition { Height = 40 });
+
+			var boxView = new BoxView { BackgroundColor = Color.Red };
+			var backgroundContainer = new Grid();
+			Forms.CompressedLayout.SetIsHeadless(backgroundContainer, true);
+			backgroundContainer.Children.Add(boxView);
+			grid.Children.Add(backgroundContainer);
+
+			var stack = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+			Forms.CompressedLayout.SetIsHeadless(stack, true);
+			var button = new Button { Text = "CRASH!", AutomationId = "TestButton" };
+			stack.Children.Add(button);
+			grid.Children.Add(stack, 0, 1);
+			
+			button.Clicked += (s, e) => Content = null;
+
+			Content = grid;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1414Test()
+		{
+			RunningApp.Screenshot("Start G1601");
+			RunningApp.WaitForElement(q => q.Marked("TestButton"));
+			RunningApp.Tap (q => q.Marked ("CRASH!"));
+			RunningApp.WaitForElement(q => q.Marked("TestButton"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1601.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1601.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Orientation = StackOrientation.Horizontal
 			};
 			Forms.CompressedLayout.SetIsHeadless(stack, true);
-			var button = new Button { Text = "CRASH!", AutomationId = "TestButton" };
+			var button = new Button { Text = "CRASH!" };
 			stack.Children.Add(button);
 			grid.Children.Add(stack, 0, 1);
 			
@@ -48,9 +48,9 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Issue1414Test()
 		{
 			RunningApp.Screenshot("Start G1601");
-			RunningApp.WaitForElement(q => q.Marked("TestButton"));
+			RunningApp.WaitForElement(q => q.Marked("CRASH!"));
 			RunningApp.Tap (q => q.Marked ("CRASH!"));
-			RunningApp.WaitForElement(q => q.Marked("TestButton"));
+			RunningApp.WaitForElement(q => q.Marked("CRASH!"));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -238,6 +238,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59457.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1601.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1717.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60001.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1355.cs" />

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -60,6 +60,15 @@ namespace Xamarin.Forms.Platform.Android
 					_childViews = null;
 				}
 
+				if (_childPackagers != null)
+				{
+					foreach (var kvp in _childPackagers)
+						kvp.Value.Dispose();
+
+					_childPackagers.Clear();
+					_childPackagers = null;
+				}
+
 				if (_renderer.Element != null)
 				{
 					_renderer.Element.ChildAdded -= _childAddedHandler;


### PR DESCRIPTION
### Description of Change ###

Pass down removal queues to children packages in VisualElementPackager. Also dispose child packagers properly.

### Bugs Fixed ###

Fixes #1601 

### API Changes ###

None

### Behavioral Changes ###

Doesn't crash anymore :)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
