### PR TITLE
Editor Auto Resize with Text Changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1733.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1733.cs
@@ -1,0 +1,287 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Editor)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1733, "Autoresizable Editor")]
+	public class Issue1733 : TestContentPage
+	{
+		public const string editorHeightShrinkWithPressureId = "editorHeightShrinkWithPressureId";
+		public const string editorHeightGrowId = "editorHeightGrowId";
+		public const string editorWidthGrow1Id = "editorWidthGrow1Id";
+		public const string editorWidthGrow2Id = "editorWidthGrow2Id";
+		public const string btnChangeFont = "Change the Font";
+		public const string btnChangeText = "Change the Text";
+		public const string btnChangeSizeOption = "Change the Size Option";
+
+		protected override void Init()
+		{
+			StackLayout container = new StackLayout()
+			{
+				BackgroundColor = Color.Purple
+			};
+
+			StackLayout layout = new StackLayout()
+			{
+				BackgroundColor = Color.Pink,
+				HeightRequest = 200
+			};
+
+			var editor = new Editor()
+			{
+				BackgroundColor = Color.Green,
+				MinimumHeightRequest = 10,
+				AutoSize = EditorAutoSizeOption.TextChanges,
+				AutomationId = editorHeightShrinkWithPressureId
+			};
+
+			var editorHeightGrow = new Editor()
+			{
+				BackgroundColor = Color.Green,
+				MinimumHeightRequest = 200,
+				AutoSize = EditorAutoSizeOption.TextChanges,
+				AutomationId = editorHeightGrowId
+			};
+
+
+			layout.Children.Add(editor);
+			layout.Children.Add(editorHeightGrow);
+
+			StackLayout layoutHorizontal = new StackLayout()
+			{
+				BackgroundColor = Color.Yellow,
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var editorWidthGrow1 = new Editor()
+			{
+				BackgroundColor = Color.Green,
+				MinimumWidthRequest = 10,
+				AutoSize = EditorAutoSizeOption.TextChanges,
+				AutomationId = editorWidthGrow1Id
+			};
+
+			var editorWidthGrow2 = new Editor()
+			{
+				BackgroundColor = Color.Green,
+				MinimumWidthRequest = 200,
+				AutoSize = EditorAutoSizeOption.TextChanges,
+				AutomationId = editorWidthGrow2Id,
+				ClassId = editorWidthGrow2Id
+			};
+
+
+			layoutHorizontal.Children.Add(editorWidthGrow1);
+			layoutHorizontal.Children.Add(editorWidthGrow2);
+
+			container.Children.Add(layout);
+			container.Children.Add(layoutHorizontal);
+
+
+			List<Editor> editors = new List<Editor>()
+			{
+				editor, editorHeightGrow, editorWidthGrow1, editorWidthGrow2
+			};
+
+			Button buttonChangeFont = new Button()
+			{
+				Text = btnChangeFont
+			};
+
+
+			Button buttonChangeText = new Button()
+			{
+				Text = btnChangeText
+			};
+
+			Button buttonChangeSizeOption = new Button()
+			{
+				Text = btnChangeSizeOption
+			};
+
+			double fontSizeInitial = editor.FontSize;
+			buttonChangeFont.Clicked += (x, y) =>
+			{
+				editors.ForEach(e =>
+				{
+					if (e.FontSize == fontSizeInitial)
+						e.FontSize = 40;
+					else
+						e.FontSize = fontSizeInitial;
+				});
+			};
+
+			buttonChangeText.Clicked += (_, __) =>
+			{
+				editors.ForEach(e =>
+				{
+					if (String.IsNullOrWhiteSpace(e.Text))
+						e.Text = String.Join(" ", Enumerable.Range(0, 100).Select(x => "f").ToArray());
+					else
+						e.Text = String.Empty;
+				});
+			};
+
+			buttonChangeSizeOption.Clicked += (_, __) =>
+			{
+				editors.ForEach(e =>
+				{
+					EditorAutoSizeOption option = EditorAutoSizeOption.TextChanges;
+					if (e.AutoSize == option)
+						option = EditorAutoSizeOption.Disabled;
+
+					e.AutoSize = option;
+				});
+			};
+
+			StackLayout commands = new StackLayout();
+			commands.Children.Add(buttonChangeFont);
+			commands.Children.Add(buttonChangeText);
+			commands.Children.Add(buttonChangeSizeOption);
+
+
+			Label sizeOption = new Label();
+			sizeOption.SetBinding(Label.TextProperty, new Binding(nameof(Editor.AutoSize), source: editor));
+
+			container.Children.Add(sizeOption);
+
+
+
+			editors.ForEach(e =>
+			{
+				StackLayout commandLayout = new StackLayout() { Orientation = StackOrientation.Horizontal };
+				commands.Children.Add(commandLayout);
+
+				Label automationLabelId = new Label();
+				automationLabelId.SetBinding(Label.TextProperty, new Binding(nameof(Editor.AutomationId), source: e));
+
+				Label width = new Label();
+				width.SetBinding(Label.TextProperty, new Binding(nameof(Editor.Width), source: e));
+				width.AutomationId = e.AutomationId + "_width";
+
+				Label height = new Label();
+				height.SetBinding(Label.TextProperty, new Binding(nameof(Editor.Height), source: e));
+				height.AutomationId = e.AutomationId + "_height";
+
+				commandLayout.Children.Add(automationLabelId);
+				commandLayout.Children.Add(width);
+				commandLayout.Children.Add(height);
+			});
+
+			StackLayout content = new StackLayout();
+
+			content.Children.Add(new ScrollView() { Content = container });
+			content.Children.Add(commands);
+
+			Content = content;
+		}
+
+#if UITEST
+		Dictionary<string, Size> results = null;
+
+		[Test]
+		public async Task Issue1733Test()
+		{
+			string[] editors = new string[] { editorHeightShrinkWithPressureId, editorHeightGrowId, editorWidthGrow1Id, editorWidthGrow2Id };
+			RunningApp.WaitForElement(q => q.Marked(editorHeightShrinkWithPressureId));
+
+			results = new Dictionary<string, Size>();
+
+			foreach (var editor in editors)
+			{
+				results.Add(editor, GetDimensions(editor));
+			}
+
+			RunningApp.Tap(q => q.Marked(btnChangeText));
+			await Task.Delay(10);
+			TestGrowth(false);
+			RunningApp.Tap(q => q.Marked(btnChangeFont));
+			await Task.Delay(10);
+			TestGrowth(true);
+
+
+			// Reset back to being empty and make sure everything sets back to original size
+			RunningApp.Tap(q => q.Marked(btnChangeFont));
+			RunningApp.Tap(q => q.Marked(btnChangeText));
+			await Task.Delay(10);
+
+			foreach (var editor in editors)
+			{
+				var allTheSame = GetDimensions(editor);
+				Assert.AreEqual(allTheSame.Width, results[editor].Width, editor);
+				Assert.AreEqual(allTheSame.Height, results[editor].Height, editor);
+			}
+
+
+			// this sets it back to not auto size and we click everything again to see if it grows
+			RunningApp.Tap(q => q.Marked(btnChangeSizeOption));
+			RunningApp.Tap(q => q.Marked(btnChangeFont));
+			RunningApp.Tap(q => q.Marked(btnChangeText));
+			foreach (var editor in editors)
+			{
+				var allTheSame = GetDimensions(editor);
+				Assert.AreEqual(allTheSame.Width, results[editor].Width, editor);
+				Assert.AreEqual(allTheSame.Height, results[editor].Height, editor);
+			}
+
+
+		}
+
+		void TestGrowth(bool heightPressureShrink)
+		{
+			var testSizes = GetDimensions(editorHeightShrinkWithPressureId);
+			Assert.AreEqual(testSizes.Width, results[editorHeightShrinkWithPressureId].Width, editorHeightShrinkWithPressureId);
+
+			if (heightPressureShrink)
+				Assert.Less(testSizes.Height, results[editorHeightShrinkWithPressureId].Height, editorHeightShrinkWithPressureId);
+			else
+				Assert.Greater(testSizes.Height, results[editorHeightShrinkWithPressureId].Height, editorHeightShrinkWithPressureId);
+
+			testSizes = GetDimensions(editorHeightGrowId);
+			Assert.AreEqual(testSizes.Width, results[editorHeightGrowId].Width, editorHeightGrowId);
+			Assert.Greater(testSizes.Height, results[editorHeightGrowId].Height, editorHeightGrowId);
+
+			var grow1 = GetDimensions(editorWidthGrow1Id);
+			Assert.Greater(grow1.Width, results[editorWidthGrow1Id].Width, editorWidthGrow1Id);
+			Assert.Greater(grow1.Height, results[editorWidthGrow1Id].Height, editorWidthGrow1Id);
+
+			var grow2 = GetDimensions(editorWidthGrow2Id);
+			Assert.Greater(grow2.Width, results[editorWidthGrow2Id].Width, editorWidthGrow2Id);
+			Assert.Greater(grow2.Height, results[editorWidthGrow2Id].Height, editorWidthGrow2Id);
+
+			//grow 1 has a lower minimum width request so it's width should be smaller than grow 2
+			Assert.Greater(grow2.Width, grow1.Width, "grow2.Width > grow1.Width");
+		}
+
+		Size GetDimensions(string editorName)
+		{
+			var height = RunningApp.Query(x => x.Marked($"{editorName}_height")).FirstOrDefault()?.Text;
+			var width = RunningApp.Query(x => x.Marked($"{editorName}_width")).FirstOrDefault()?.Text;
+
+			if (height == null)
+			{
+				throw new ArgumentException($"{editorName}_height not found");
+			}
+			if (width == null)
+			{
+				throw new ArgumentException($"{editorName}_width not found");
+			}
+			return new Size(Convert.ToDouble(width), Convert.ToDouble(height));
+		}
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -693,6 +693,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31688.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40092.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1426.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1733.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -860,7 +861,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla60045.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/EditorAutoSizeOption.cs
+++ b/Xamarin.Forms.Core/EditorAutoSizeOption.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms
+{
+	public enum EditorAutoSizeOption
+	{
+		Disabled = 0,
+		TextChanges = 1
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
@@ -142,14 +142,14 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 		/*
-		 * Purely invalidating the layout as text is added to the TextBox won't cause it to expand.
-		 * If the TextBox is set to WordWrap and it's part of the layout it will refuse to Measure itself beyond it's established width.
-		 * Giving it infinite contraints it will always just come back the same width but with a vertical growth.
-		 * The only way I was able to grow it was by setting this.Width to some value but then it just set it's own Width to that Width which isn't helpful.
+		 * Purely invalidating the layout as text is added to the TextBox will not cause it to expand.
+		 * If the TextBox is set to WordWrap and it is part of the layout it will refuse to Measure itself beyond its established width.
+		 * Even giving it infinite constraints will cause it to always set its DesiredSize to the same width but with a vertical growth.
+		 * The only way I was able to grow it was by setting layout renderers width explicitly to some value but then it just set its own Width to that Width which is not helpful.
 		 * Even vertically it would measure oddly in cases of rapid text changes.
 		 * Holding down the backspace key or enter key would cause the final result to be not quite right.
-		 * Both of these issues were fixed by just creating a static TextBox that isn't part of the layout which let me just measure
-		 * the size of the text as it would fit into the TextBox unconstrained.
+		 * Both of these issues were fixed by just creating a static TextBox that is not part of the layout which let me just measure
+		 * the size of the text as it would fit into the TextBox unconstrained and then just return that Size from the GetDesiredSize call.
 		 * */
 		Size GetCopyOfSize(FormsTextBox control, Windows.Foundation.Size constraint)
 		{

--- a/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
@@ -10,6 +11,8 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public class EditorRenderer : ViewRenderer<Editor, FormsTextBox>
 	{
+		private static FormsTextBox _copyOfTextBox;
+		static Windows.Foundation.Size _zeroSize = new Windows.Foundation.Size(0, 0);
 		bool _fontApplied;
 		Brush _backgroundColorFocusedDefaultBrush;
 		Brush _textDefaultBrush;
@@ -17,18 +20,24 @@ namespace Xamarin.Forms.Platform.UWP
 
 		IEditorController ElementController => Element;
 
+
+		FormsTextBox CreateTextBox()
+		{
+			return new FormsTextBox
+			{
+				AcceptsReturn = true,
+				TextWrapping = TextWrapping.Wrap,
+				Style = Windows.UI.Xaml.Application.Current.Resources["FormsTextBoxStyle"] as Windows.UI.Xaml.Style
+			};
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
 		{
 			if (e.NewElement != null)
 			{
 				if (Control == null)
 				{
-					var textBox = new FormsTextBox
-					{
-						AcceptsReturn = true,
-						TextWrapping = TextWrapping.Wrap,
-						Style = Windows.UI.Xaml.Application.Current.Resources["FormsTextBoxStyle"] as Windows.UI.Xaml.Style
-					};
+					var textBox = CreateTextBox();
 
 					SetNativeControl(textBox);
 
@@ -132,6 +141,76 @@ namespace Xamarin.Forms.Platform.UWP
 			Element.SetValueCore(Editor.TextProperty, Control.Text);
 		}
 
+		/*
+		 * Purely invalidating the layout as text is added to the TextBox won't cause it to expand.
+		 * If the TextBox is set to WordWrap and it's part of the layout it will refuse to Measure itself beyond it's established width.
+		 * Giving it infinite contraints it will always just come back the same width but with a vertical growth.
+		 * The only way I was able to grow it was by setting this.Width to some value but then it just set it's own Width to that Width which isn't helpful.
+		 * Even vertically it would measure oddly in cases of rapid text changes.
+		 * Holding down the backspace key or enter key would cause the final result to be not quite right.
+		 * Both of these issues were fixed by just creating a static TextBox that isn't part of the layout which let me just measure
+		 * the size of the text as it would fit into the TextBox unconstrained.
+		 * */
+		Size GetCopyOfSize(FormsTextBox control, Windows.Foundation.Size constraint)
+		{
+			if (_copyOfTextBox == null)
+			{
+				_copyOfTextBox = CreateTextBox();
+
+				// This causes the copy to be initially setup correctly. 
+				// I found that if the first measure of this copy occurs with Text then it will just keep defaulting to a measure with no text.
+				_copyOfTextBox.Measure(_zeroSize);
+			}
+
+			_copyOfTextBox.Text = control.Text;
+			_copyOfTextBox.FontSize = control.FontSize;
+			_copyOfTextBox.FontFamily = control.FontFamily;
+			_copyOfTextBox.FontStretch = control.FontStretch;
+			_copyOfTextBox.FontStyle = control.FontStyle;
+			_copyOfTextBox.FontWeight = control.FontWeight;
+			_copyOfTextBox.Margin = control.Margin;
+			_copyOfTextBox.Padding = control.Padding;
+
+			// have to reset the measure to zero before it will re-measure itself
+			_copyOfTextBox.Measure(_zeroSize);
+			_copyOfTextBox.Measure(constraint);
+
+			Size result = new Size
+			(
+				Math.Ceiling(_copyOfTextBox.DesiredSize.Width),
+				Math.Ceiling(_copyOfTextBox.DesiredSize.Height)
+			);
+
+			return result;
+		}
+
+
+		SizeRequest CalculateDesiredSizes(FormsTextBox control, Windows.Foundation.Size constraint, EditorAutoSizeOption sizeOption)
+		{
+			if (sizeOption == EditorAutoSizeOption.TextChanges)
+			{
+				Size result = GetCopyOfSize(control, constraint);
+				control.Measure(constraint);
+				return new SizeRequest(result);
+			}
+			else
+			{
+				control.Measure(constraint);
+				Size result = new Size(Math.Ceiling(control.DesiredSize.Width), Math.Ceiling(control.DesiredSize.Height));
+				return new SizeRequest(result);
+			}
+		}
+
+		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			FormsTextBox child = Control;
+
+			if (Children.Count == 0 || child == null)
+				return new SizeRequest();
+
+			return CalculateDesiredSizes(child, new Windows.Foundation.Size(widthConstraint, heightConstraint), Element.AutoSize);
+		}
+
 		void UpdateFont()
 		{
 			if (Control == null)
@@ -143,8 +222,8 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 
 			bool editorIsDefault = editor.FontFamily == null &&
-			                       editor.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Editor), true) &&
-			                       editor.FontAttributes == FontAttributes.None;
+								   editor.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Editor), true) &&
+								   editor.FontAttributes == FontAttributes.None;
 
 			if (editorIsDefault && !_fontApplied)
 				return;
@@ -232,7 +311,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (currentControlText.Length > Element.MaxLength)
 				Control.Text = currentControlText.Substring(0, Element.MaxLength);
 		}
-    
+
 		void UpdateDetectReadingOrderFromContent()
 		{
 			if (Element.IsSet(Specifics.DetectReadingOrderFromContentProperty))

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Editor.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Editor.xml
@@ -84,6 +84,37 @@ var editor = new Editor {
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="AutoSize">
+      <MemberSignature Language="C#" Value="public Xamarin.Forms.EditorAutoSizeOption AutoSize { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Forms.EditorAutoSizeOption AutoSize" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.EditorAutoSizeOption</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AutoSizeProperty">
+      <MemberSignature Language="C#" Value="public static readonly Xamarin.Forms.BindableProperty AutoSizeProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Xamarin.Forms.BindableProperty AutoSizeProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.BindableProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Completed">
       <MemberSignature Language="C#" Value="public event EventHandler Completed;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler Completed" />
@@ -350,6 +381,22 @@ var editor = new Editor {
         <summary>Identifies the Text bindable property.</summary>
         <remarks>
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UpdateAutoSizeOption">
+      <MemberSignature Language="C#" Value="protected void UpdateAutoSizeOption ();" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void UpdateAutoSizeOption() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Xamarin.Forms.Internals.IFontElement.FontSizeDefaultValueCreator">

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/EditorAutoSizeOption.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/EditorAutoSizeOption.xml
@@ -1,0 +1,45 @@
+<Type Name="EditorAutoSizeOption" FullName="Xamarin.Forms.EditorAutoSizeOption">
+  <TypeSignature Language="C#" Value="public enum EditorAutoSizeOption" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed EditorAutoSizeOption extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Disabled">
+      <MemberSignature Language="C#" Value="Disabled" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.EditorAutoSizeOption Disabled = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.EditorAutoSizeOption</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="TextChanges">
+      <MemberSignature Language="C#" Value="TextChanges" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Forms.EditorAutoSizeOption TextChanges = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.EditorAutoSizeOption</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -201,6 +201,7 @@
       <Type Name="Device+Styles" Kind="Class" />
       <Type Name="Easing" Kind="Class" />
       <Type Name="Editor" Kind="Class" />
+      <Type Name="EditorAutoSizeOption" Kind="Enumeration" />
       <Type Name="Effect" Kind="Class" />
       <Type Name="EffectiveFlowDirection" Kind="Enumeration" />
       <Type Name="EffectiveFlowDirectionExtensions" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###
fixes #1733

Added a property to Editor that will cause it to grow dynamically as the content of the Editor is changed. Basically as the text is changed the Editors size is recalculated and re-measured

#### Android
Android was the least amount of work and was able to resize itself purely based on having its measure invalidated.

#### iOS
iOS almost worked as seamlessly as Android. 
When a new line is added to the UITextView the vertical growth happens after the view has already scrolled meaning now you had a line of text partially scrolled off screen. I added an event to watch for Frame Changes on the UITextView and if these happened then I forced the ScrollPosition to go back to *(0,0)*  If the Editor is set to AutoSize then the Frame of the UITextView should never be scrolled if the internal content hasn't grown outside the max constraints of the UITextView. Once the UITextView has grown as much as it can then FrameChange events no longer fire so it's able to still scroll without any issues.

#### UWP 
UWP proved to be the most challenging to coerce into resizing to the text as the text changed.

Purely invalidating the layout as text is added to the TextBox won't cause it to expand horizontally.
If the TextBox is set to WordWrap and it's part of the layout it will refuse to Measure itself beyond its established width. Even giving it infinite constraints will cause it to always set its DesiredSize to the same width but with a vertical growth. The only way I was able to grow it was by setting layout renderers width explicitly to some value but then it just set its own Width to that Width which is not helpful. Even vertically it would measure oddly in cases of rapid text changes. Holding down the backspace key or enter key would cause the final result to be not quite right. Both of these issues were fixed by just creating a static TextBox that is not part of the layout which let me just measure the size of the text as it would fit into the TextBox unconstrained and then just return that Size from the GetDesiredSize call.

Before pictures if you added text to an already rendered Editor
![image](https://user-images.githubusercontent.com/5375137/37356759-52fd1808-26ac-11e8-89bc-804f3e9e021f.png)

Setting AutoSize to TextChanges will now resize the Editors to fit the text based on how much the Editor is allowed to grow
![image](https://user-images.githubusercontent.com/5375137/37356795-6d67ba90-26ac-11e8-955f-9fe59c6078b1.png)


### API Changes ###

Added:
 - public EditorAutoSizeOption AutoSize {get;set;} //Bindable Property

```csharp
namespace Xamarin.Forms
{
	public enum EditorAutoSizeOption
	{
		Disabled = 0,
		TextChanges = 1
	}
}
```

### Behavioral Changes ###

By default this is disabled so users should notice no behavioral changes unless they opt in for this setting

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
