### PR TITLE
[Core] Fixed leaking reference to popped Page in PopAsync()

### DIFF
--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -132,21 +132,19 @@ namespace Xamarin.Forms
 
 		public async Task<Page> PopAsync(bool animated)
 		{
+			var tcs = new TaskCompletionSource<bool>();
 			if (CurrentNavigationTask != null && !CurrentNavigationTask.IsCompleted)
 			{
-				var tcs = new TaskCompletionSource<bool>();
-				Task oldTask = CurrentNavigationTask;
+				var oldTask = CurrentNavigationTask;
 				CurrentNavigationTask = tcs.Task;
 				await oldTask;
-
-				Page page = await PopAsyncInner(animated, false);
-				tcs.SetResult(true);
-				return page;
 			}
+			else
+				CurrentNavigationTask = tcs.Task;
 
-			Task<Page> result = PopAsyncInner(animated, false);
-			CurrentNavigationTask = result;
-			return await result;
+			var result = await PopAsyncInner(animated, false);
+			tcs.SetResult(true);
+			return result;
 		}
 
 		public event EventHandler<NavigationEventArgs> Popped;


### PR DESCRIPTION
### Description of Change ###

This is #1818 but user didn't rebase for 15-5

### Bugs Fixed ###

- [https://bugzilla.xamarin.com/show_bug.cgi?id=31171](https://bugzilla.xamarin.com/show_bug.cgi?id=31171)
- fixes #1429 

### API Changes ##

None 

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense