### PR TITLE
[iOS] Use UINavigationBar.Appearance.LargeTitleTextAttributes if specified

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -169,12 +169,15 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				}
 			};
 
-			// 'Large' Title bar text
-			UINavigationBar.Appearance.LargeTitleTextAttributes = new UIStringAttributes
+			if (App.IOSVersion == 11)
 			{
-				ForegroundColor = UIColor.FromRGB(0xE7, 0x63, 0x3B), // e7963b dark
-				Font = UIFont.FromName("GillSans-Italic", 40)
-			};
+				// 'Large' Title bar text
+				UINavigationBar.Appearance.LargeTitleTextAttributes = new UIStringAttributes
+				{
+					ForegroundColor = UIColor.FromRGB(0xE7, 0x63, 0x3B), // e7963b dark
+					Font = UIFont.FromName("GillSans-Italic", 40)
+				};
+			}
 
 			var app = new App();
 			_app = app;

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -169,6 +169,13 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				}
 			};
 
+			// 'Large' Title bar text
+			UINavigationBar.Appearance.LargeTitleTextAttributes = new UIStringAttributes
+			{
+				ForegroundColor = UIColor.FromRGB(0xE7, 0x63, 0x3B), // e7963b dark
+				Font = UIFont.FromName("GillSans-Italic", 40)
+			};
+
 			var app = new App();
 			_app = app;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -633,7 +633,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if(Forms.IsiOS11OrNewer)
 			{
-				NavigationBar.LargeTitleTextAttributes = NavigationBar.TitleTextAttributes;      
+				var globalLargeTitleAttributes = UINavigationBar.Appearance.LargeTitleTextAttributes;
+				if(globalLargeTitleAttributes == null)
+					NavigationBar.LargeTitleTextAttributes = NavigationBar.TitleTextAttributes;      
 			}
 
 			var statusBarColorMode = (Element as NavigationPage).OnThisPlatform().GetStatusBarTextColorMode();


### PR DESCRIPTION
### Description of Change ###

By default we were copying the title attributes to the LargeTitle we shouldn't do that if the user specified some Appearance on the iOS platform fot LargeTitles

Added a visual test for our navigation bar on the gallery 

### Bugs Fixed ###

- fixes #1804 

### API Changes ###

None


### Behavioral Changes ###

If user specifies `UINavigationBar.Appearance.LargeTitleTextAttributes` we won't copy the titles color and font properties for the normal navigation bar title. 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense