### PR TITLE
[UWP] MDP should respect HasNavigationBar for current page

### DIFF
--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -315,7 +315,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (ContentTogglePaneButtonVisibility == Visibility.Visible)
 				DetailTitleVisibility = Visibility.Visible;
 
-			if(DetailTitleVisibility == Visibility.Visible && !ShouldShowNavigationBar)
+			if (DetailTitleVisibility == Visibility.Visible && !ShouldShowNavigationBar)
 				DetailTitleVisibility = Visibility.Collapsed;
 			
 		}

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -22,6 +22,9 @@ namespace Xamarin.Forms.Platform.UWP
 		public static readonly DependencyProperty ShouldShowSplitModeProperty = DependencyProperty.Register(nameof(ShouldShowSplitMode), typeof(bool), typeof(MasterDetailControl),
 			new PropertyMetadata(default(bool), OnShouldShowSplitModeChanged));
 
+		public static readonly DependencyProperty ShouldShowNavigationBarProperty = DependencyProperty.Register(nameof(ShouldShowNavigationBar), typeof(bool), typeof(MasterDetailControl),
+		new PropertyMetadata(true, OnShouldShowSplitModeChanged));
+
 		public static readonly DependencyProperty CollapseStyleProperty = DependencyProperty.Register(nameof(CollapseStyle), typeof(CollapseStyle), 
 			typeof(MasterDetailControl), new PropertyMetadata(CollapseStyle.Full, CollapseStyleChanged));
 
@@ -215,6 +218,12 @@ namespace Xamarin.Forms.Platform.UWP
 			set { SetValue(ToolbarForegroundProperty, value); }
 		}
 
+		public bool ShouldShowNavigationBar
+		{
+			get { return (bool)GetValue(ShouldShowNavigationBarProperty); }
+			set { SetValue(ShouldShowNavigationBarProperty, value); }
+		}
+
 		Task<CommandBar> IToolbarProvider.GetCommandBarAsync()
 		{
 			if (_commandBar != null)
@@ -302,9 +311,13 @@ namespace Xamarin.Forms.Platform.UWP
 			ContentTogglePaneButtonVisibility = _split.DisplayMode == SplitViewDisplayMode.Overlay 
 				? Visibility.Visible 
 				: Visibility.Collapsed;
-
+			
 			if (ContentTogglePaneButtonVisibility == Visibility.Visible)
 				DetailTitleVisibility = Visibility.Visible;
+
+			if(DetailTitleVisibility == Visibility.Visible && !ShouldShowNavigationBar)
+				DetailTitleVisibility = Visibility.Collapsed;
+			
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -331,6 +331,9 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			// Enforce consistency rules on toolbar
 			Control.ShouldShowToolbar = _detail is NavigationPage || _master is NavigationPage;
+			if(_detail is NavigationPage _detailNav)
+				Control.ShouldShowNavigationBar = NavigationPage.GetHasNavigationBar(_detailNav.CurrentPage);
+			
 		}
 
 		public void BindForegroundColor(AppBar appBar)


### PR DESCRIPTION
### Description of Change ###

When nesting `NavigationPage` inside the MDP on UWP we weren't handling correctly the check if we should or not show the navigationbar. Since the UpdateMode wasn't taking that in account and always forcing the NavBar to appear. 

### Bugs Fixed ###

- fixes #1437 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
