### PR TITLE
[iOS] Set UITabBarItem colours when they are added 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1323.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1323.cs
@@ -1,0 +1,52 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1323, "tabbed page BarTextColor is not pervasive and can't be applied after instantiation", PlatformAffected.iOS)]
+	public class Issue1323 : TestTabbedPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			BarBackgroundColor = Color.FromHex("#61a60e");
+			BarTextColor = Color.FromHex("#ffffff");
+			BackgroundColor = Color.FromHex("#61a60e");
+
+			var page = new ContentPage { Title = "Page 1", Content = new Button { Text = "Pop", Command = new Command(async () => await Navigation.PopModalAsync()) } };
+			var page2 = new ContentPage { Title = "Page 2" };
+			var page3 = new ContentPage { Title = "Page 3" };
+			var page4 = new ContentPage { Title = "Page 4" };
+
+			Children.Add(page);
+			Children.Add(page2);
+			Children.Add(page3);
+			Children.Add(page4);
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			BarTextColor = Color.White;
+			Children.RemoveAt(1);
+			Children.Insert(1, new ContentPage { Title = "Page5", Icon = "Loyalty.png" });
+
+			Children.RemoveAt(3);
+			Children.Insert(2, new ContentPage { Title = "Page6", Icon = "Gift.png" });
+			BarTextColor = Color.White;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1323Test()
+		{
+			RunningApp.Screenshot("All tab bar items text should be white");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -691,6 +691,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31688.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40092.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1426.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1323.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -207,6 +207,9 @@ namespace Xamarin.Forms.Platform.iOS
 				controller = GetViewController(Tabbed.CurrentPage);
 			if (controller != null && controller != base.SelectedViewController)
 				base.SelectedViewController = controller;
+
+			UpdateBarBackgroundColor();
+			UpdateBarTextColor();
 		}
 
 		void OnPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

We should update the TabBarItems color for text and background when we add new TabBarItems not only when we create the control

### Bugs Fixed ###

- fixes #1323 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
