### PR TITLE
[iOS] Encode url for UIWebView so it doesn't fail with non-ascii characters 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Issue1583Test ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("webview"));
-			RunningApp.Screenshot ("I didn'crash and i can see Skøyen");
+			RunningApp.Screenshot ("I didn't crash and i can see Skøyen");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -1,0 +1,35 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1583, "WebView fails to load from urlwebviewsource with non-ascii characters (works with Uri)", PlatformAffected.iOS, issueTestNumber: 1)]
+	public class Issue1583 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var webview = new WebView
+			{
+				AutomationId = "webview"	
+			};
+			webview.Source = new UrlWebViewSource { Url = "https://www.google.no/maps/place/Skøyen" };
+
+			Content = webview;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1583Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked ("webview"));
+			RunningApp.Screenshot ("I didn'crash and i can see Skøyen");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -691,6 +691,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla31688.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla40092.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1426.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1583_1.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -858,7 +859,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla60045.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -79,7 +79,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public void LoadUrl(string url)
 		{
-			LoadRequest(new NSUrlRequest(new NSUrl(url)));
+			var encodedStringUrl = new NSString(url).CreateStringByAddingPercentEscapes(NSStringEncoding.UTF8);
+			LoadRequest(new NSUrlRequest(new NSUrl(encodedStringUrl)));
 		}
 
 		public override void LayoutSubviews()


### PR DESCRIPTION
### Description of Change ###

Encode url so it doesn't fail with non-ascii characters

### Bugs Fixed ###

fixes #1583 

### API Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense