### PR TITLE
[Tizen] Enhance the Entry renderer of tizen backend

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Extensions/KeyboardExtensions.cs
+++ b/Xamarin.Forms.Platform.Tizen/Extensions/KeyboardExtensions.cs
@@ -1,4 +1,5 @@
-using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+using ElmSharp;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -31,6 +32,49 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				return Native.Keyboard.Normal;
 			}
+		}
+
+		public static AutoCapital ToAutoCapital(this KeyboardFlags keyboardFlags)
+		{
+			if (keyboardFlags.HasFlag(KeyboardFlags.CapitalizeSentence))
+			{
+				return AutoCapital.Sentence;
+			}
+			else if (keyboardFlags.HasFlag(KeyboardFlags.CapitalizeWord))
+			{
+				return AutoCapital.Word;
+			}
+			else if (keyboardFlags.HasFlag(KeyboardFlags.CapitalizeCharacter))
+			{
+				return AutoCapital.All;
+			}
+			else
+			{
+				return AutoCapital.None;
+			}
+		}
+
+		public static InputHints ToInputHints(this Keyboard keyboard, bool isSpellCheckEnabled)
+		{
+			if (keyboard is CustomKeyboard customKeyboard && customKeyboard.Flags.HasFlag(KeyboardFlags.Suggestions))
+			{
+				return InputHints.AutoComplete;
+			}
+			return isSpellCheckEnabled ? InputHints.AutoComplete : InputHints.None;
+		}
+
+		public static void UpdateKeyboard(this Native.Entry control, Keyboard keyboard, bool isSpellCheckEnabled)
+		{
+			control.Keyboard = keyboard.ToNative();
+			if (keyboard is CustomKeyboard customKeyboard)
+			{
+				control.AutoCapital = customKeyboard.Flags.ToAutoCapital();
+			}
+			else
+			{
+				control.AutoCapital = AutoCapital.None;
+			}
+			control.InputHint = keyboard.ToInputHints(isSpellCheckEnabled);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -14,6 +13,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Editor.FontAttributesProperty, UpdateFontAttributes);
 			RegisterPropertyHandler(Editor.KeyboardProperty, UpdateKeyboard);
 			RegisterPropertyHandler(InputView.MaxLengthProperty, UpdateMaxLength);
+			RegisterPropertyHandler(InputView.IsSpellCheckEnabledProperty, UpdateIsSpellCheckEnabled);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
@@ -115,8 +115,12 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (initialize && Element.Keyboard == Keyboard.Default)
 				return;
+			Control.UpdateKeyboard(Element.Keyboard, Element.IsSpellCheckEnabled);
+		}
 
-			Control.Keyboard = Element.Keyboard.ToNative();
+		void UpdateIsSpellCheckEnabled()
+		{
+			Control.InputHint = Element.Keyboard.ToInputHints(Element.IsSpellCheckEnabled);
 		}
 
 		void UpdateMaxLength()

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -19,6 +19,8 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Entry.PlaceholderColorProperty, UpdatePlaceholderColor);
 			RegisterPropertyHandler(InputView.MaxLengthProperty, UpdateMaxLength);
 			RegisterPropertyHandler(Entry.ReturnTypeProperty, UpdateReturnType);
+			RegisterPropertyHandler(InputView.IsSpellCheckEnabledProperty, UpdateIsSpellCheckEnabled);
+
 			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
 			{
 				RegisterPropertyHandler("FontWeight", UpdateFontWeight);
@@ -114,8 +116,12 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (initialize && Element.Keyboard == Keyboard.Default)
 				return;
+			Control.UpdateKeyboard(Element.Keyboard, Element.IsSpellCheckEnabled);
+		}
 
-			Control.Keyboard = Element.Keyboard.ToNative();
+		void UpdateIsSpellCheckEnabled()
+		{
+			Control.InputHint = Element.Keyboard.ToInputHints(Element.IsSpellCheckEnabled);
 		}
 
 		void UpdatePlaceholder()


### PR DESCRIPTION
### Description of Change ###
 Enable KeyboardFlags and IsSpellCheckEnabled on tizen backend

![image](https://user-images.githubusercontent.com/1029155/37503614-bca075bc-291c-11e8-8e04-0d515c3bbc0f.gif)


### Bugs Fixed ###
 #1683 [Enhancement] AutoCaptialization support for Entry/Editor 
 #1660 [Enhancement] IsSpellCheckEnabled on Entry/Editor.

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
