### PR TITLE
Create Sync version of SendSleep so lifecycle methods don't have to be async void

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2104.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2104.cs
@@ -120,7 +120,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap(q => q.Marked("Test")); 
 
 			var errorMessage = RunningApp.Query(x => x.Marked(ErrorMessage)).First().Text;
-			Assert.IsEmpty(errorMessage, errorMessage);
+			Assert.IsTrue(String.IsNullOrWhiteSpace(errorMessage), errorMessage);
 		}
 
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2104.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2104.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using NUnit.Framework;
+using System.Linq;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Editor)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2104, "Ensure Multiple Calls to Save Properties Doesn't Cause a Crash")]
+	public class Issue2104 : TestContentPage
+	{
+		const string ErrorMessage = "ErrorMessage";
+
+		protected override void Init()
+		{
+			var errorMessage = new Label() { AutomationId = ErrorMessage, HeightRequest = 100 };
+
+			Log.Listeners.Add(
+				new DelegateLogListener((c, m) => Device.BeginInvokeOnMainThread(() =>
+				{
+					errorMessage.Text = m;
+				})));
+
+			Dictionary<int, object> expectedValues = new Dictionary<int, object>();
+
+			for (int i = 0; i < 40; i++)
+			{
+				expectedValues.Add(i, DateTime.Now);
+
+			}
+
+			Button AddData = new Button()
+			{
+				Text = "Click Me To call Properties Save a bunch of times",
+				Command = new Command(() =>
+				{
+					Xamarin.Forms.Application.Current.Properties.Clear();
+					Xamarin.Forms.Application.Current.SendSleep();
+
+					for (int i = 0; i < 20; i++)
+					{
+						Xamarin.Forms.Application.Current.Properties[i.ToString()] = expectedValues[i];
+						Xamarin.Forms.Application.Current.SendSleep();
+					}
+
+					for (int i = 20; i < 40; i++)
+					{
+						Xamarin.Forms.Application.Current.Properties[i.ToString()] = expectedValues[i];
+						Task.Run(() =>
+						{
+							Xamarin.Forms.Application.Current.SendSleep();
+						});
+					}
+
+				}),
+				AutomationId = "FillUp"
+			};
+
+			Button ClearData = new Button()
+			{
+				Text = "Click to clear properties",
+				AutomationId = "Clear",
+				Command = new Command(() =>
+				{
+					Xamarin.Forms.Application.Current.Properties.Clear();
+					Xamarin.Forms.Application.Current.SendSleep();
+				}),
+			};
+
+
+			var deserializer = DependencyService.Get<IDeserializer>();
+
+			Button TestData = new Button()
+			{
+				Text = "Click to test for properties",
+				AutomationId = "Test",
+				Command = new Command(async () =>
+				{
+					IDictionary<string, object> properties = await deserializer.DeserializePropertiesAsync();
+					if (40 != properties.Count)
+					{
+						errorMessage.Text = "Invalid Property Count";
+					}
+
+					for (int i = 0; i < 40; i++)
+					{
+						if (!properties[i.ToString()].Equals(expectedValues[i]))
+						{
+							errorMessage.Text = $"Property Serialized Incorrectly: {properties[i.ToString()]} {expectedValues[i]}";
+						}
+					}
+				}),
+			};
+
+			var layout = new StackLayout();
+			layout.Children.Add(AddData);
+			layout.Children.Add(ClearData);
+			layout.Children.Add(TestData);
+			layout.Children.Add(errorMessage);
+			Content = layout;
+		}
+
+#if UITEST
+
+		[Test]
+		public void Issue2104Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Clear"));
+			RunningApp.Tap(q => q.Marked("Clear"));			
+			RunningApp.Tap(q => q.Marked("FillUp")); 
+			RunningApp.Tap(q => q.Marked("Test")); 
+
+			var errorMessage = RunningApp.Query(x => x.Marked(ErrorMessage)).First().Text;
+			Assert.IsEmpty(errorMessage, errorMessage);
+		}
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -289,6 +289,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1665.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1707.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2104.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1908.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Forms
 		public static Application Current
 		{
 			get { return s_current; }
-			set 
+			set
 			{
 				if (s_current == value)
 					return;
@@ -138,7 +138,8 @@ namespace Xamarin.Forms
 
 		public ResourceDictionary Resources
 		{
-			get {
+			get
+			{
 				if (_resources != null)
 					return _resources;
 
@@ -173,12 +174,42 @@ namespace Xamarin.Forms
 
 		public event EventHandler<Page> PageDisappearing;
 
+
+		async void SaveProperties()
+		{
+			try
+			{
+				await SetPropertiesAsync();
+			}
+			catch (Exception exc)
+			{
+				Internals.Log.Warning(nameof(Application), $"Exception while saving Application Properties: {exc}");
+			}
+		}
+
 		public async Task SavePropertiesAsync()
 		{
 			if (Device.IsInvokeRequired)
-				Device.BeginInvokeOnMainThread(async () => await SetPropertiesAsync());
+			{
+				Device.BeginInvokeOnMainThread(SaveProperties);
+			}
 			else
+			{
 				await SetPropertiesAsync();
+			}
+		}
+
+		// Don't use this unless there really is no better option
+		internal void SavePropertiesAsFireAndForget()
+		{
+			if (Device.IsInvokeRequired)
+			{
+				Device.BeginInvokeOnMainThread(SaveProperties);
+			}
+			else
+			{
+				SaveProperties();
+			}
 		}
 
 		public IPlatformElementConfiguration<T, Application> On<T>() where T : IConfigPlatform
@@ -255,6 +286,13 @@ namespace Xamarin.Forms
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendSleep()
+		{
+			OnSleep();
+			SavePropertiesAsFireAndForget();
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Task SendSleepAsync()
 		{
 			OnSleep();
@@ -311,14 +349,14 @@ namespace Xamarin.Forms
 		async Task SetPropertiesAsync()
 		{
 			await SaveSemaphore.WaitAsync();
-            try
-            {
-                await DependencyService.Get<IDeserializer>().SerializePropertiesAsync(Properties);
-            }
-            finally
-            {
-                SaveSemaphore.Release();
-            }
+			try
+			{
+				await DependencyService.Get<IDeserializer>().SerializePropertiesAsync(Properties);
+			}
+			finally
+			{
+				SaveSemaphore.Release();
+			}
 
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Forms.Platform.Android
 				RegisterHandlerForDefaultRenderer(typeof(NavigationPage), typeof(NavigationPageRenderer), typeof(NavigationRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(TabbedPage), typeof(TabbedPageRenderer), typeof(TabbedRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(MasterDetailPage), typeof(MasterDetailPageRenderer), typeof(MasterDetailRenderer));
-                RegisterHandlerForDefaultRenderer(typeof(Switch), typeof(AppCompat.SwitchRenderer), typeof(SwitchRenderer));
+				RegisterHandlerForDefaultRenderer(typeof(Switch), typeof(AppCompat.SwitchRenderer), typeof(SwitchRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(Picker), typeof(AppCompat.PickerRenderer), typeof(PickerRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(CarouselPage), typeof(AppCompat.CarouselPageRenderer), typeof(CarouselPageRenderer));
 
@@ -123,7 +123,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (application?.MainPage != null)
 			{
 				var iver = Platform.GetRenderer(application.MainPage);
-				if (iver != null) {
+				if (iver != null)
+				{
 					iver.Dispose();
 					application.MainPage.ClearValue(Platform.RendererProperty);
 				}
@@ -138,7 +139,7 @@ namespace Xamarin.Forms.Platform.Android
 			ActivityResultCallbackRegistry.InvokeCallback(requestCode, resultCode, data);
 		}
 
-		protected override async void OnCreate(Bundle savedInstanceState)
+		protected override void OnCreate(Bundle savedInstanceState)
 		{
 			if (!AllowFragmentRestore)
 			{
@@ -159,7 +160,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else
 				bar = new AToolbar(this);
-			
+
 			SetSupportActionBar(bar);
 
 			_layout = new ARelativeLayout(BaseContext);
@@ -170,7 +171,7 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnCreate;
 
-			await OnStateChanged();
+			OnStateChanged();
 
 			if (Forms.IsLollipopOrNewer)
 			{
@@ -194,7 +195,7 @@ namespace Xamarin.Forms.Platform.Android
 			CheckForAppLink(intent);
 		}
 
-		protected override async void OnPause()
+		protected override void OnPause()
 		{
 			_layout.HideKeyboard(true);
 
@@ -207,20 +208,20 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnPause;
 
-			await OnStateChanged();
+			OnStateChanged();
 		}
 
-		protected override async void OnRestart()
+		protected override void OnRestart()
 		{
 			base.OnRestart();
 
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnRestart;
 
-			await OnStateChanged();
+			OnStateChanged();
 		}
 
-		protected override async void OnResume()
+		protected override void OnResume()
 		{
 			// counterpart to OnPause
 			base.OnResume();
@@ -236,24 +237,24 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnResume;
 
-			await OnStateChanged();
+			OnStateChanged();
 		}
 
-		protected override async void OnStart()
+		protected override void OnStart()
 		{
 			base.OnStart();
 
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnStart;
 
-			await OnStateChanged();
+			OnStateChanged();
 		}
 
 		// Scenarios that stop and restart your app
 		// -- Switches from your app to another app, activity restarts when clicking on the app again.
 		// -- Action in your app that starts a new Activity, the current activity is stopped and the second is created, pressing back restarts the activity
 		// -- The user receives a phone call while using your app on his or her phone
-		protected override async void OnStop()
+		protected override void OnStop()
 		{
 			// writing to storage happens here!
 			// full UI obstruction
@@ -266,7 +267,7 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnStop;
 
-			await OnStateChanged();
+			OnStateChanged();
 		}
 
 		void AppOnPropertyChanged(object sender, PropertyChangedEventArgs args)
@@ -309,7 +310,7 @@ namespace Xamarin.Forms.Platform.Android
 			_layout.BringToFront();
 		}
 
-		async Task OnStateChanged()
+		void OnStateChanged()
 		{
 			if (_application == null)
 				return;
@@ -319,7 +320,7 @@ namespace Xamarin.Forms.Platform.Android
 			else if (_previousState == AndroidApplicationLifecycleState.OnStop && _currentState == AndroidApplicationLifecycleState.OnRestart)
 				_application.SendResume();
 			else if (_previousState == AndroidApplicationLifecycleState.OnPause && _currentState == AndroidApplicationLifecycleState.OnStop)
-				await _application.SendSleepAsync();
+				_application.SendSleep();
 		}
 
 		void RegisterHandlerForDefaultRenderer(Type target, Type handler, Type filter)

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -96,7 +96,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (application?.MainPage != null)
 			{
 				var iver = Platform.GetRenderer(application.MainPage);
-				if (iver != null) {
+				if (iver != null)
+				{
 					iver.Dispose();
 					application.MainPage.ClearValue(Platform.RendererProperty);
 				}
@@ -234,7 +235,7 @@ namespace Xamarin.Forms.Platform.Android
 			_layout.AddView(_canvas.GetViewGroup());
 		}
 
-		async void OnStateChanged()
+		void OnStateChanged()
 		{
 			if (_application == null)
 				return;
@@ -244,7 +245,7 @@ namespace Xamarin.Forms.Platform.Android
 			else if (_previousState == AndroidApplicationLifecycleState.OnStop && _currentState == AndroidApplicationLifecycleState.OnRestart)
 				_application.SendResume();
 			else if (_previousState == AndroidApplicationLifecycleState.OnPause && _currentState == AndroidApplicationLifecycleState.OnStop)
-				await _application.SendSleepAsync();
+				_application.SendSleep();
 		}
 
 		void SetMainPage()

--- a/Xamarin.Forms.Platform.GTK/FormsWindow.cs
+++ b/Xamarin.Forms.Platform.GTK/FormsWindow.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Platform.GTK
 				var windowState = args.Event.NewWindowState;
 
 				if (windowState == Gdk.WindowState.Iconified)
-					await _application.SendSleepAsync ();
+					_application.SendSleep();
 				else
 					_application.SendResume ();
 			}

--- a/Xamarin.Forms.Platform.MacOS/FormsApplicationDelegate.cs
+++ b/Xamarin.Forms.Platform.MacOS/FormsApplicationDelegate.cs
@@ -56,12 +56,12 @@ namespace Xamarin.Forms.Platform.MacOS
 			_application.SendResume();
 		}
 
-		public override async void DidResignActive(Foundation.NSNotification notification)
+		public override void DidResignActive(Foundation.NSNotification notification)
 		{
 			// applicationWillResignActive
 			if (_application == null) return;
 			_isSuspended = true;
-			await _application.SendSleepAsync();
+			_application.SendSleep();
 		}
 
 		void ApplicationOnPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
+++ b/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			base.OnPause();
 			if (_application != null)
 			{
-				_application.SendSleepAsync();
+				_application.SendSleep();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePage.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePage.cs
@@ -46,8 +46,14 @@ namespace Xamarin.Forms.Platform.UWP
 		async void OnApplicationSuspending(object sender, SuspendingEventArgs e)
 		{
 			SuspendingDeferral deferral = e.SuspendingOperation.GetDeferral();
-			await Application.Current.SendSleepAsync();
-			deferral.Complete();
+			try
+			{
+				await Application.Current.SendSleepAsync();
+			}
+			finally
+			{
+				deferral.Complete();
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/FormsApplicationPage.cs
+++ b/Xamarin.Forms.Platform.WPF/FormsApplicationPage.cs
@@ -44,14 +44,14 @@ namespace Xamarin.Forms.Platform.WPF
 		}
 
 		// when app gets tombstoned, user press back past first page
-		async void OnClosing(object sender, ExitEventArgs e)
+		void OnClosing(object sender, ExitEventArgs e)
 		{
-			await Application.SendSleepAsync();
+			Application.SendSleep();
 		}
 
-		async void OnDeactivated(object sender, System.EventArgs e)
+		void OnDeactivated(object sender, System.EventArgs e)
 		{
-			await Application.SendSleepAsync();
+			Application.SendSleep();
 		}
 
 		void OnLaunching(object sender, StartupEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/FormsApplicationDelegate.cs
@@ -74,13 +74,13 @@ namespace Xamarin.Forms.Platform.iOS
 		}
 
 		// transitioning to background
-		public override async void OnResignActivation(UIApplication uiApplication)
+		public override void OnResignActivation(UIApplication uiApplication)
 		{
 			// applicationWillResignActive
 			if (_application != null)
 			{
 				_isSuspended = true;
-				await _application.SendSleepAsync();
+				_application.SendSleep();
 			}
 		}
 

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/Application.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/Application.xml
@@ -485,7 +485,7 @@
           <AttributeName>System.Diagnostics.DebuggerStepThrough</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.Application/&lt;SavePropertiesAsync&gt;d__60))</AttributeName>
+          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.Application/&lt;SavePropertiesAsync&gt;d__61))</AttributeName>
         </Attribute>
       </Attributes>
       <ReturnValue>
@@ -540,6 +540,27 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Xamarin.Forms platform.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SendSleep">
+      <MemberSignature Language="C#" Value="public void SendSleep ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SendSleep() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
### Description of Change ###

SaveProperties being async caused a lot of the life cycle methods on the platforms to become *async void* which means that exceptions were just being swallowed causing the Application to fail much later after the initial cause had been swallowed

Outside of UWP none of the life cycle methods depend on the results of the call. They all just called

```
await _application.SendSleepAsync();
```
at the end of the method

I created an internal
```C#
SavePropertiesAsFireAndForget
```

Which can now be used by
```C#
SendSleep 
```

Which causes the call to execute in the same fire and forget fashion, except now it doesn't require a bunch of *async voids* to propagate up the call tree

So in principal it should be the same as it was before except now important exceptions during life cycle events should occur and make it more apparent why an application is failing

The *async voids* on life cycle methods came around from this PR
https://github.com/xamarin/Xamarin.Forms/pull/1075
But even the PR itself just mentions adding those just in case

I added a UI Test with this PR as well and if I comment out the *SemaphoreSLims* that were added as part of PR 1075 then I get the Shared Violation Exceptions PR 1075 is fixing. So the addition of the SemaphoreSlims is all that's really needed to combat the Shared Violation Exceptions and nothing was really gained by making the life cycle methods *async void*

### Bugs Fixed ###

https://github.com/xamarin/Xamarin.Forms/issues/2104

### API Changes ###

Added
```C#
		[EditorBrowsable(EditorBrowsableState.Never)]
		public void SendSleep()
		{
			OnSleep();
			SavePropertiesAsFireAndForget();
		}
```


### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
