### PR TITLE
[C] avoid exception on overriden indexer

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -288,7 +288,21 @@ namespace Xamarin.Forms
 
 				part.IndexerName = indexerName;
 
+#if NETSTANDARD2_0
+				try {
+					property = sourceType.GetDeclaredProperty(indexerName);
+				}
+				catch (AmbiguousMatchException) {
+					// Get most derived instance of property
+					foreach (var p in sourceType.GetProperties().Where(prop => prop.Name == indexerName)) {
+						if (property == null || property.DeclaringType.IsAssignableFrom(property.DeclaringType))
+							property = p;
+					}
+				}
+#else
 				property = sourceType.GetDeclaredProperty(indexerName);
+#endif
+
 				if (property == null) //is the indexer defined on the base class?
 					property = sourceType.BaseType.GetProperty(indexerName);
 				if (property == null) //is the indexer defined on implemented interface ?


### PR DESCRIPTION
### Description of Change ###

Binding to a Newtonsoft.Json.Linq.JObject with an indexer throws an
AmbiguousMatchException (because the Indexer is overriden). This fixes
the property finding code so it doesn't thorw, but returns the moste
derived indexer.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense