### PR TITLE
Adding line height to Label and Span

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1734.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1734.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 1734, "Add support for Label line height", PlatformAffected.All)]
+	public class Issue1734
+		: TestContentPage
+	{
+		Label _label;
+		Label _spannedLabel;
+
+		protected override void Init()
+		{
+			var text = "This is a very long text that hopefully spans over many many many many multiple beautiful lines!";
+
+			_label = new Label { FormattedText = text, LineBreakMode = LineBreakMode.WordWrap, BackgroundColor = Color.AliceBlue, TextColor = Color.DarkGray };
+			var lineHeight = new Entry();
+			lineHeight.TextChanged += LineHeightChanged;
+
+			FormattedString s = new FormattedString();
+			s.Spans.Add(new Span { Text = "0.8: This is a\nvery long text\n", LineHeight = 0.8, BackgroundColor = Color.BlueViolet });
+			s.Spans.Add(new Span { Text = "1.2: with multiple\nlines abc\n", LineHeight = 1.2, BackgroundColor = Color.Brown });
+			s.Spans.Add(new Span { Text = "0.2: def\ndef\n", LineHeight = 0.2, BackgroundColor = Color.Pink });
+			s.Spans.Add(new Span { Text = "1.5: ghi jkl\nmno\npqr stu vwx yz ", LineHeight = 1.5, BackgroundColor = Color.HotPink });
+			_spannedLabel = new Label { FormattedText = s, LineBreakMode = LineBreakMode.WordWrap };
+
+			var stackLayout = new StackLayout
+			{
+				Children = { new Label() { Text = "Line height" }, lineHeight, _label, _spannedLabel},
+				Padding = new Thickness() { Top = 20, Left = 10, Right = 100 }
+			};
+			
+			Content = new ScrollView { Content = stackLayout };
+		}
+
+		private void LineHeightChanged(object sender, TextChangedEventArgs e) {
+			var nr = ((Entry)sender).Text;
+			try
+			{
+				_label.LineHeight = double.Parse(nr);
+			} catch (FormatException fe) {
+				Debug.WriteLine($"Could not parse {nr}. {fe.Message}");
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -243,6 +243,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1677.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1801.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1734.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1683.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1705_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1396.cs" />

--- a/Xamarin.Forms.Core/ILineHeightElement.cs
+++ b/Xamarin.Forms.Core/ILineHeightElement.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel;
+
+namespace Xamarin.Forms.Internals
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	interface ILineHeightElement
+	{
+		double LineHeight { get; }
+
+		void OnLineHeightChanged(double oldValue, double newValue);
+	}
+}

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms
 {
 	[ContentProperty("Text")]
 	[RenderWith(typeof(_LabelRenderer))]
-	public class Label : View, IFontElement, ITextElement, ITextAlignmentElement, IElementConfiguration<Label>
+	public class Label : View, IFontElement, ITextElement, ITextAlignmentElement, ILineHeightElement, IElementConfiguration<Label>
 	{
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
@@ -76,7 +76,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(Label), LineBreakMode.WordWrap,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((Label)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
 
-		public static readonly BindableProperty LineHeightProperty = BindableProperty.Create("LineHeight", typeof(double), typeof(Label), -1.0);
+		public static readonly BindableProperty LineHeightProperty = LineHeightElement.LineHeightProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<Label>> _platformConfigurationRegistry;
 
@@ -188,6 +188,8 @@ namespace Xamarin.Forms
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			 InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		void ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		void OnFormattedTextChanged(object sender, PropertyChangedEventArgs e)
 		{

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -76,6 +76,8 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(Label), LineBreakMode.WordWrap,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((Label)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
 
+		public static readonly BindableProperty LineHeightProperty = BindableProperty.Create("LineHeight", typeof(double), typeof(Label), -1.0);
+
 		readonly Lazy<PlatformConfigurationRegistry<Label>> _platformConfigurationRegistry;
 
 		public Label()
@@ -164,6 +166,12 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(FontSizeProperty); }
 			set { SetValue(FontSizeProperty, value); }
+		}
+
+		public double LineHeight
+		{
+			get { return (double)GetValue(LineHeightProperty); }
+			set { SetValue(LineHeightProperty, value); }
 		}
 
 		double IFontElement.FontSizeDefaultValueCreator() =>

--- a/Xamarin.Forms.Core/LineHeightElement.cs
+++ b/Xamarin.Forms.Core/LineHeightElement.cs
@@ -1,0 +1,17 @@
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms
+{
+	static class LineHeightElement
+	{
+		public static readonly BindableProperty LineHeightProperty = 
+			BindableProperty.Create(nameof(ILineHeightElement.LineHeight), typeof(double), typeof(ILineHeightElement), -1.0d,
+									propertyChanged: OnLineHeightChanged);
+
+		static void OnLineHeightChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			((ILineHeightElement)bindable).OnLineHeightChanged((double)oldValue, (double)newValue);
+		}
+
+	}
+}

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -61,7 +61,7 @@ using Xamarin.Forms.StyleSheets;
 [assembly: StyleProperty("text-align", typeof(ITextAlignmentElement), nameof(TextAlignmentElement.HorizontalTextAlignmentProperty), Inherited = true)]
 [assembly: StyleProperty("visibility", typeof(VisualElement), nameof(VisualElement.IsVisibleProperty), Inherited = true)]
 [assembly: StyleProperty("width", typeof(VisualElement), nameof(VisualElement.WidthRequestProperty))]
-[assembly: StyleProperty("line-height", typeof(Label), nameof(Label.LineHeightProperty))]
+[assembly: StyleProperty("line-height", typeof(ILineHeightElement), nameof(LineHeightElement.LineHeightProperty), Inherited = true)]
 
 //flex
 [assembly: StyleProperty("align-content", typeof(FlexLayout), nameof(FlexLayout.AlignContentProperty))]

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -61,6 +61,7 @@ using Xamarin.Forms.StyleSheets;
 [assembly: StyleProperty("text-align", typeof(ITextAlignmentElement), nameof(TextAlignmentElement.HorizontalTextAlignmentProperty), Inherited = true)]
 [assembly: StyleProperty("visibility", typeof(VisualElement), nameof(VisualElement.IsVisibleProperty), Inherited = true)]
 [assembly: StyleProperty("width", typeof(VisualElement), nameof(VisualElement.WidthRequestProperty))]
+[assembly: StyleProperty("line-height", typeof(Label), nameof(Label.LineHeightProperty))]
 
 //flex
 [assembly: StyleProperty("align-content", typeof(FlexLayout), nameof(FlexLayout.AlignContentProperty))]

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms
 {
 	[ContentProperty("Text")]
-	public sealed class Span : GestureElement, IFontElement, ITextElement
+	public sealed class Span : GestureElement, IFontElement, ITextElement, ILineHeightElement
 	{
 		internal readonly MergedStyle _mergedStyle;
 
@@ -67,7 +67,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty LineHeightProperty = Label.LineHeightProperty;
+		public static readonly BindableProperty LineHeightProperty = LineHeightElement.LineHeightProperty;
 
 		[Obsolete("Font is obsolete as of version 1.3.0. Please use the Font properties directly.")]
 		public Font Font
@@ -96,8 +96,8 @@ namespace Xamarin.Forms
 		}
 
 		public double LineHeight {
-			get { return (double)GetValue(Label.LineHeightProperty); }
-			set { SetValue(Label.LineHeightProperty, value); }
+			get { return (double)GetValue(LineHeightElement.LineHeightProperty); }
+			set { SetValue(LineHeightElement.LineHeightProperty, value); }
 		}
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
@@ -131,6 +131,10 @@ namespace Xamarin.Forms
 				throw new InvalidOperationException($"{nameof(PanGestureRecognizer)} is not supported on a {nameof(Span)}");
 			if (gesture is PinchGestureRecognizer)
 				throw new InvalidOperationException($"{nameof(PinchGestureRecognizer)} is not supported on a {nameof(Span)}");
+		}
+
+		void ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue)
+		{
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -67,6 +67,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty LineHeightProperty = Label.LineHeightProperty;
+
 		[Obsolete("Font is obsolete as of version 1.3.0. Please use the Font properties directly.")]
 		public Font Font
 		{
@@ -91,6 +93,11 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(FontElement.FontSizeProperty); }
 			set { SetValue(FontElement.FontSizeProperty, value); }
+		}
+
+		public double LineHeight {
+			get { return (double)GetValue(Label.LineHeightProperty); }
+			set { SetValue(Label.LineHeightProperty, value); }
 		}
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -215,6 +215,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 				SkipNextInvalidate();
 				UpdateText();
+				UpdateLineHeight();
 				if (e.OldElement?.LineBreakMode != e.NewElement.LineBreakMode)
 					UpdateLineBreakMode();
 				if (e.OldElement?.HorizontalTextAlignment != e.NewElement.HorizontalTextAlignment
@@ -239,6 +240,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				UpdateLineBreakMode();
 			else if (e.PropertyName == Label.TextProperty.PropertyName || e.PropertyName == Label.FormattedTextProperty.PropertyName)
 				UpdateText();
+			else if (e.PropertyName == Label.LineHeightProperty.PropertyName)
+				UpdateLineHeight();
 		}
 
 		void UpdateColor()
@@ -314,6 +317,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				_wasFormatted = false;
 			}
 
+			_lastSizeRequest = null;
+		}
+
+		void UpdateLineHeight() {
+			SetLineSpacing(0, (float) Element.LineHeight);
 			_lastSizeRequest = null;
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormattedStringExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Diagnostics;
 using System.Text;
 using Android.Graphics;
 using Android.Text;
@@ -50,7 +52,10 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					spannable.SetSpan(new BackgroundColorSpan(span.BackgroundColor.ToAndroid()), start, end, SpanTypes.InclusiveExclusive);
 				}
-
+				if (span.LineHeight >= 0)
+				{
+					spannable.SetSpan(new LineHeightSpan(view, span.LineHeight), start, end, SpanTypes.InclusiveExclusive);
+				}
 				if (!span.IsDefault())
 #pragma warning disable 618 // We will need to update this when .Font goes away
 					spannable.SetSpan(new FontSpan(span.Font, view), start, end, SpanTypes.InclusiveInclusive);
@@ -89,6 +94,27 @@ namespace Xamarin.Forms.Platform.Android
 				float value = Font.ToScaledPixel();
 				paint.TextSize = TypedValue.ApplyDimension(ComplexUnitType.Sp, value, TextView.Resources.DisplayMetrics);
 			}
+		}
+		class LineHeightSpan : Java.Lang.Object, ILineHeightSpan
+		{
+			private double _lineHeight;
+			private int _ascent;
+			private int _descent;
+
+			public LineHeightSpan(TextView view, double lineHeight)
+			{
+				_lineHeight = lineHeight;
+				Paint.FontMetricsInt fm = view.Paint.GetFontMetricsInt();
+				_ascent = fm.Ascent;
+				_descent = fm.Descent;
+			}
+
+			public void ChooseHeight(Java.Lang.ICharSequence text, int start, int end, int spanstartv, int v, Paint.FontMetricsInt fm)
+			{
+				fm.Ascent = (int) (_ascent * _lineHeight);
+				fm.Descent = (int) (_descent * _lineHeight);
+			}
+
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -132,6 +132,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateLineBreakMode();
 			else if (e.PropertyName == Label.TextProperty.PropertyName || e.PropertyName == Label.FormattedTextProperty.PropertyName)
 				UpdateText();
+			else if (e.PropertyName == Label.LineHeightProperty.PropertyName)
+				UpdateLineHeight();
 		}
 
 		void UpdateColor()
@@ -181,6 +183,14 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			_view.SetLineBreakMode(Element.LineBreakMode);
 			_lastSizeRequest = null;
+		}
+
+		void UpdateLineHeight()
+		{
+			if (Element.LineHeight >= 0)
+			{
+				_view.SetLineSpacing(0, (float)Element.LineHeight);
+			}
 		}
 
 		void UpdateText()

--- a/Xamarin.Forms.Platform.UAP/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/LabelRenderer.cs
@@ -152,7 +152,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateAlign(Control);
 			else if (e.PropertyName == Specifics.DetectReadingOrderFromContentProperty.PropertyName)
 				UpdateDetectReadingOrderFromContent(Control);
-
+			else if (e.PropertyName == Label.LineHeightProperty.PropertyName)
+				UpdateLineHeight(Control);
 			base.OnElementPropertyChanged(sender, e);
 		}
 
@@ -294,6 +295,17 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					textBlock.TextReadingOrder = TextReadingOrder.UseFlowDirection;
 				}
+			}
+		}
+
+		void UpdateLineHeight(TextBlock textBlock) 
+		{
+			if (textBlock == null)
+				return;
+			
+			if (Element.LineHeight >= 0)
+			{
+				textBlock.LineHeight = Element.LineHeight * textBlock.FontSize;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
@@ -1,4 +1,5 @@
 using Foundation;
+using System;
 using Xamarin.Forms.Internals;
 #if __MOBILE__
 using UIKit;
@@ -52,7 +53,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			return attributed;
 		}
 
-		internal static NSAttributedString ToAttributed(this Span span, Element owner, Color defaultForegroundColor)
+		internal static NSAttributedString ToAttributed(this Span span, Element owner, Color defaultForegroundColor, double lineHeight = -1.0)
 		{
 			if (span == null)
 				return null;
@@ -60,6 +61,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			var text = span.Text;
 			if (text == null)
 				return null;
+
+			NSMutableParagraphStyle style = null;
+			lineHeight = span.LineHeight >= 0 ? span.LineHeight : lineHeight;
+			if (lineHeight >= 0)
+			{
+				style = new NSMutableParagraphStyle();
+				style.LineHeightMultiple = new nfloat(lineHeight);
+			}
 
 #if __MOBILE__
 			UIFont targetFont;
@@ -74,7 +83,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (fgcolor.IsDefault)
 				fgcolor = Color.Black; // as defined by apple docs
 
-			return new NSAttributedString(text, targetFont, fgcolor.ToUIColor(), span.BackgroundColor.ToUIColor());
+			return new NSAttributedString(text, targetFont, fgcolor.ToUIColor(), span.BackgroundColor.ToUIColor(), null, style);
 #else
 			NSFont targetFont;
 			if (span.IsDefault())
@@ -88,19 +97,21 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (fgcolor.IsDefault)
 				fgcolor = Color.Black; // as defined by apple docs
 
-			return new NSAttributedString(text, targetFont, fgcolor.ToNSColor(), span.BackgroundColor.ToNSColor());
+			return new NSAttributedString(text, targetFont, fgcolor.ToNSColor(), span.BackgroundColor.ToNSColor(),
+										  null, null, null, NSUnderlineStyle.None, NSUnderlineStyle.None, style);
 #endif
 		}
 
 		internal static NSAttributedString ToAttributed(this FormattedString formattedString, Element owner,
-			Color defaultForegroundColor)
+			Color defaultForegroundColor, double lineHeight = -1.0)
 		{
 			if (formattedString == null)
 				return null;
 			var attributed = new NSMutableAttributedString();
+
 			foreach (var span in formattedString.Spans)
 			{
-				var attributedString = span.ToAttributed(owner, defaultForegroundColor);				
+				var attributedString = span.ToAttributed(owner, defaultForegroundColor, lineHeight);
 				if (attributedString == null)
 					continue;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -2,8 +2,6 @@ using System;
 using System.ComponentModel;
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
-using Foundation;
-using System.Collections.Generic;
 
 #if __MOBILE__
 using UIKit;
@@ -159,6 +157,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateLineBreakMode();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateAlignment();
+			else if (e.PropertyName == Label.LineHeightProperty.PropertyName)
+				UpdateText();
 		}
 
 #if __MOBILE__
@@ -269,25 +269,23 @@ namespace Xamarin.Forms.Platform.MacOS
 		void UpdateText()
 		{
 			_perfectSizeValid = false;
-
 			var values = Element.GetValues(Label.FormattedTextProperty, Label.TextProperty, Label.TextColorProperty);
+
 			var formatted = values[0] as FormattedString;
+			if (formatted == null && Element.LineHeight >= 0)
+				formatted = (string)values[1];
+
 			if (formatted != null)
 			{
 #if __MOBILE__
-				Control.AttributedText = formatted.ToAttributed(Element, (Color)values[2]);
+				Control.AttributedText = formatted.ToAttributed(Element, (Color)values[2], Element.LineHeight);
 #else
-				Control.AttributedStringValue = formatted.ToAttributed(Element, (Color)values[2]);
+				Control.AttributedStringValue = formatted.ToAttributed(Element, (Color)values[2], Element.LineHeight);
 #endif
 				isTextFormatted = true;
 			}
 			else
 			{
-				if (isTextFormatted)
-				{
-					UpdateFont();
-					UpdateTextColor();
-				}
 #if __MOBILE__
 				Control.Text = (string)values[1];
 #else
@@ -329,7 +327,6 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 			UpdateLayout();
 		}
-
 		void UpdateLayout()
 		{
 #if __MOBILE__

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -126,12 +126,11 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 				}
 
+				UpdateLineBreakMode();
+				UpdateAlignment();
 				UpdateText();
 				UpdateTextColor();
 				UpdateFont();
-
-				UpdateLineBreakMode();
-				UpdateAlignment();
 			}
 
 			base.OnElementChanged(e);


### PR DESCRIPTION
### Description of Change ###

Fixes #1734 by adding LineHeight property to Label and Span. The unit of LineHeight is relative to the original line height or font size. Also know as *multiplier* on iOS and Android. For UWP the actual line height will be calculated as a multiple of the font size.

Setting LineHeight on Span doesn't work on UWP which doesn't
seem to support that on its `Run` class.

On Android the separate LineHeight on span only has effect if
the text has linebreaks within the string. Then it's possible
to set different line heights for individual lines using Span.
If the lines are automatically split using WordWrap for instance,
it seems like Android will use the LineHeight set on the last Span.

### API Changes ###

Added:
 - double Label.LineHeight { get; set; } //Bindable Property specifying the relative line height.
 - double Span.LineHeight { get; set; } //Bindable Property specifying the relative line height for a segment of the Label. Only works properly on Android currently.
- Added CSS property `line-height` on `Label`.

### Behavioral Changes ###

LineHeight can now be set on labels and spans.

### Before and after screenshots ###

Before:
![lineheight-before-capture](https://user-images.githubusercontent.com/3715975/37702361-8b1048fe-2cf2-11e8-8638-4233f9880505.PNG)

After:
![span line height after](https://user-images.githubusercontent.com/3715975/37778154-8837bbec-2de9-11e8-901d-b53f1a466e2b.png)

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
