### PR TITLE
[iOS] Allow user interaction with blurred elements

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/VisualElementiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/VisualElementiOS.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Input;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
@@ -20,8 +21,17 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 			Button button4 = GetButton(box, BlurEffectStyle.Dark);
 			var buttons = new StackLayout { Orientation = StackOrientation.Horizontal, Children = { button1, button2, button3, button4 } };
 
+			var tapGestureRecognizer = new TapGestureRecognizer();
+			tapGestureRecognizer.Tapped += OnImageTapped;
+			box.GestureRecognizers.Add(tapGestureRecognizer);
+
 			Content = new StackLayout { Children = { buttons, new AbsoluteLayout { Children = { image, box } } } };
 			Title = "Visual Element Features";
+		}
+
+		void OnImageTapped(object o, EventArgs args)
+		{
+			DisplayAlert("BoxView Tapped", "The tap gesture works", "OK");
 		}
 
 		Button GetButton(BoxView box, BlurEffectStyle value)

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -404,6 +404,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 
 			_blur = new UIVisualEffectView(blurEffect);
+			_blur.UserInteractionEnabled = false;
 			LayoutSubviews();
 		}
 #endif


### PR DESCRIPTION
### Description of Change ###

When the `BlurEffect` platform-specific is used on iOS, it prevents touch events on the blurred element(s) from working as the `UIVisualEffectView` is laid on top of it; setting `UserInteractionEnabled` to false lets the touch events pass through.

### Bugs Fixed ###

Fixes #2129

### API Changes ###

N/A

### Behavioral Changes ###

This could technically be an expected side effect on iOS when using the functionality as it currently exists, but probably needs to be documented if a change like this isn't made ([docs here](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/platform/platform-specifics/consuming/ios#applying-blur)). There is also an alternative route of adding an additional platform-specific value which updates the `UserInteractionEnabled` value, which we could do if desired, leaving the behavior as it is as the default and updating the documentation.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
