### PR TITLE
[iOS]Allow to change between datasource types on the UITableView

### DIFF
--- a/Xamarin.Forms.ControlGallery.MacOS/Xamarin.Forms.ControlGallery.MacOS.csproj
+++ b/Xamarin.Forms.ControlGallery.MacOS/Xamarin.Forms.ControlGallery.MacOS.csproj
@@ -415,4 +415,5 @@
     <InterfaceDefinition Include="Main.storyboard" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+  <Target Name="_VerifyBuildSignature" />
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56298.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56298.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 56298, "Issue Description", PlatformAffected.Default)]
+	public class Bugzilla56298 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+
+		ListView list;
+		Button button;
+		StackLayout layoutRoot;
+
+		ObservableCollection<Group> groups;
+		public static int Count = 0;
+
+		protected override void Init()
+		{
+			On<iOS>().SetUseSafeArea(true);
+			list = new ListView();
+
+			var template = new DataTemplate(typeof(UnevenViewCell));
+			//template.SetBinding(TextCell.TextProperty, "FullName");
+			//template.SetBinding(TextCell.DetailProperty, "Address");
+			list.ItemTemplate = template;
+
+			groups = new ObservableCollection<Group>();
+			list.ItemsSource = groups;
+			list.GroupDisplayBinding = new Binding(nameof(Group.Key));
+			list.GroupShortNameBinding = new Binding(nameof(Group.Key));
+			list.IsGroupingEnabled = true;
+
+			button = new Button { Text = "Add new data", AutomationId = "btnAdd" };
+			button.Clicked += Button_Clicked;
+
+			var button1 = new Button { Text = "Toogle Uneven rows", AutomationId = "btnToogle" };
+			button1.Clicked += Button_Clicked1;
+
+
+			layoutRoot = new StackLayout();
+			layoutRoot.Children.Add(list);
+			layoutRoot.Children.Add(button);
+			layoutRoot.Children.Add(button1);
+
+			this.Content = layoutRoot;
+		}
+
+		void Button_Clicked(object sender, EventArgs e)
+		{
+
+			var group = new Group()
+			{
+				Key = "A"
+			};
+			for (int i = 0; i < 59; i++)
+			{
+				group.Add(new Person1
+				{
+					FullName = "Andrew",
+					Address = "404 Somewhere"
+				});
+			}
+
+			groups.Add(group);
+		}
+
+		private void Button_Clicked1(object sender, EventArgs e)
+		{
+			list.HasUnevenRows = !list.HasUnevenRows;
+		}
+
+		[Preserve(AllMembers = true)]
+		class UnevenViewCell : ViewCell
+		{
+			public UnevenViewCell()
+			{
+
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, "FullName");
+				Height = Bugzilla56298.Count % 2 == 0 ? 50 : 100;
+				View = label;
+				View.BackgroundColor = Bugzilla56298.Count % 2 == 0 ? Color.Pink : Color.LightYellow;
+				Bugzilla56298.Count++;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class Person1
+		{
+			public string FullName { get; set; }
+			public string Address { get; set; }
+		}
+
+		class Group : ObservableCollection<Person1>
+		{
+			public string Key { get; set; }
+		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla56298Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("btnAdd"));
+			RunningApp.Tap(q => q.Marked("btnAdd"));
+			RunningApp.Tap(q => q.Marked("btnToogle"));
+			RunningApp.Screenshot("Verify we see uneven rows");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -411,6 +411,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1567.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1075.cs" />

--- a/Xamarin.Forms.Maps.MacOS/Xamarin.Forms.Maps.macOS.csproj
+++ b/Xamarin.Forms.Maps.MacOS/Xamarin.Forms.Maps.macOS.csproj
@@ -94,4 +94,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+  <Target Name="_VerifyBuildSignature" />
 </Project>

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -242,4 +242,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+  <Target Name="_VerifyBuildSignature" />
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -263,6 +263,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				_estimatedRowHeight = false;
 				Control.Source = _dataSource = Element.HasUnevenRows ? new UnevenListViewDataSource(_dataSource) : new ListViewDataSource(_dataSource);
+				Control.ReloadData();
 			}
 			else if (e.PropertyName == Xamarin.Forms.ListView.IsPullToRefreshEnabledProperty.PropertyName)
 				UpdatePullToRefreshEnabled();


### PR DESCRIPTION
### Description of Change ###

If we are changing the DataSource of our UITableView we need to call RefreshData to refresh the re-used cells. 

### Bugs Fixed ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=56298

### API Changes ###

- None

### Behavioral Changes ###

- None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
