### PR TITLE
[Enhancement] Add EvaluateJavaScript method to WebView

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
@@ -108,10 +108,30 @@ namespace Xamarin.Forms.Controls
 				jsAlertWebView
 			);
 
+			var evaluateJsWebView = new WebView
+			{
+				Source = new UrlWebViewSource { Url = "https://www.google.com/" },
+				HeightRequest = 50
+			};
+			var evaluateJsWebViewSourceContainer = new ViewContainer<WebView>(Test.WebView.EvaluateJavaScript,
+				evaluateJsWebView
+			);
+
+			var resultsLabel = new Label();
+			var execButton = new Button();
+			execButton.Text = "Evaluate Javascript";
+			execButton.Command = new Command(async() => resultsLabel.Text = await evaluateJsWebView.EvaluateJavaScriptAsync(
+												"var test = function(){ return 'This string came from Javascript!'; }; test();"));
+
+			evaluateJsWebViewSourceContainer.ContainerLayout.Children.Add(resultsLabel);
+			evaluateJsWebViewSourceContainer.ContainerLayout.Children.Add(execButton);
+
+
 			Add (urlWebViewSourceContainer);
 			Add (htmlWebViewSourceContainer);
 			Add (htmlFileWebSourceContainer);
 			Add (javascriptAlertWebSourceContainer);
+			Add (evaluateJsWebViewSourceContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/IWebViewController.cs
+++ b/Xamarin.Forms.Core/IWebViewController.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms
 		bool CanGoBack { get; set; }
 		bool CanGoForward { get; set; }
 		event EventHandler<EvalRequested> EvalRequested;
-		event WebView.EvaluateJavaScriptDelegate EvaluateJavaScriptRequested;
+		event EvaluateJavaScriptDelegate EvaluateJavaScriptRequested;
 		event EventHandler GoBackRequested;
 		event EventHandler GoForwardRequested;
 		void SendNavigated(WebNavigatedEventArgs args);

--- a/Xamarin.Forms.Core/IWebViewController.cs
+++ b/Xamarin.Forms.Core/IWebViewController.cs
@@ -1,5 +1,6 @@
 using System;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms
 {
@@ -8,6 +9,7 @@ namespace Xamarin.Forms
 		bool CanGoBack { get; set; }
 		bool CanGoForward { get; set; }
 		event EventHandler<EvalRequested> EvalRequested;
+		event WebView.EvaluateJavaScriptDelegate EvaluateJavaScriptRequested;
 		event EventHandler GoBackRequested;
 		event EventHandler GoForwardRequested;
 		void SendNavigated(WebNavigatedEventArgs args);

--- a/Xamarin.Forms.Core/Internals/EvalRequested.cs
+++ b/Xamarin.Forms.Core/Internals/EvalRequested.cs
@@ -1,8 +1,12 @@
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public delegate Task<string> EvaluateJavaScriptDelegate(string script);
+
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class EvalRequested : EventArgs
 	{

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -9,8 +9,6 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_WebViewRenderer))]
 	public class WebView : View, IWebViewController, IElementConfiguration<WebView>
 	{
-		public delegate Task<string> EvaluateJavaScriptDelegate(string script);
-
 		public static readonly BindableProperty SourceProperty = BindableProperty.Create("Source", typeof(WebViewSource), typeof(WebView), default(WebViewSource),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -85,6 +85,9 @@ namespace Xamarin.Forms
 		{
 			EvaluateJavaScriptDelegate handler = EvaluateJavaScriptRequested;
 
+			if (script == null)
+				return null;
+
 			//make all the platforms mimic Android's implementation, which is by far the most complete.
 			if (Xamarin.Forms.Device.RuntimePlatform != "Android")
 			{
@@ -180,6 +183,9 @@ namespace Xamarin.Forms
 
 		static string EscapeJsString(string js)
 		{
+			if (js == null)
+				return null;
+
 			if (!js.Contains("'"))
 				return js;
 

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -101,8 +101,12 @@ namespace Xamarin.Forms
 			//JSON.stringify wraps the result in literal quotes, we just want the actual returned result
 			//note that if the js function returns the string "null" we will get here and not above
 			else
-				result = result.Trim('"');
-
+			{
+				if (result != null)
+				{
+					result = result.Trim('"');
+				}
+			}
 
 
 			return result;

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -182,10 +182,11 @@ namespace Xamarin.Forms
 
 		private static string EscapeJsString(string js)
 		{
+			if (!js.Contains("'"))
+				return js;
+
 			//get every quote in the string along with all the backslashes preceding it
 			var singleQuotes = Regex.Matches(js, @"(\\*?)'");
-			if (singleQuotes.Count == 0)
-				return js;
 
 			var uniqueMatches = new List<string>();
 

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
@@ -8,6 +9,8 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_WebViewRenderer))]
 	public class WebView : View, IWebViewController, IElementConfiguration<WebView>
 	{
+		public delegate Task<string> EvaluateJavaScriptDelegate(string script);
+
 		public static readonly BindableProperty SourceProperty = BindableProperty.Create("Source", typeof(WebViewSource), typeof(WebView), default(WebViewSource),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
@@ -77,6 +80,12 @@ namespace Xamarin.Forms
 			handler?.Invoke(this, new EvalRequested(script));
 		}
 
+		public async Task<string> EvaluateJavaScriptAsync(string script)
+		{
+			EvaluateJavaScriptDelegate handler = EvaluateJavaScriptRequested;
+			return await handler?.Invoke(script);
+		}
+
 		public void GoBack()
 			=> GoBackRequested?.Invoke(this, EventArgs.Empty);
 
@@ -122,6 +131,9 @@ namespace Xamarin.Forms
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event EventHandler<EvalRequested> EvalRequested;
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EvaluateJavaScriptDelegate EvaluateJavaScriptRequested;
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event EventHandler GoBackRequested;

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -100,14 +100,8 @@ namespace Xamarin.Forms
 
 			//JSON.stringify wraps the result in literal quotes, we just want the actual returned result
 			//note that if the js function returns the string "null" we will get here and not above
-			else
-			{
-				if (result != null)
-				{
-					result = result.Trim('"');
-				}
-			}
-
+			else if (result != null)
+				result = result.Trim('"');
 
 			return result;
 		}
@@ -184,7 +178,7 @@ namespace Xamarin.Forms
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		private static string EscapeJsString(string js)
+		static string EscapeJsString(string js)
 		{
 			if (!js.Contains("'"))
 				return js;

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -197,7 +197,7 @@ namespace Xamarin.Forms
 				}
 			}
 
-			uniqueMatches.Sort((x, y) => y.CompareTo(x));
+			uniqueMatches.Sort((x, y) => y.Length.CompareTo(x.Length));
 
 			//escape all quotes from the script as well as add additional escaping to all quotes that were already escaped
 			for (var i=0; i < uniqueMatches.Count; i++)

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -689,7 +689,8 @@ namespace Xamarin.Forms.CustomAttributes
 			LoadHtml,
 			MixedContentDisallowed,
 			MixedContentAllowed,
-			JavaScriptAlert
+			JavaScriptAlert,
+			EvaluateJavaScript
 		}
 
 		public enum UrlWebViewSource {

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -266,7 +266,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		class JavascriptResult : Java.Lang.Object, IValueCallback
 		{
-			private TaskCompletionSource<string> source;
+			TaskCompletionSource<string> source;
 			public Task<string> JsResult { get { return source.Task; } }
 
 			public JavascriptResult()

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -277,14 +277,7 @@ namespace Xamarin.Forms.Platform.Android
 			public void OnReceiveValue(Java.Lang.Object result)
 			{
 				string json = ((Java.Lang.String)result).ToString();
-				if (json == "null")
-					source.SetResult("");
-				else
-				{
-					json = json.Trim('"');
-					source.SetResult(json);
-				}
-
+				source.SetResult(json);
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -276,16 +276,15 @@ namespace Xamarin.Forms.Platform.Android
 
 			public void OnReceiveValue(Java.Lang.Object result)
 			{
-				try
+				string json = ((Java.Lang.String)result).ToString();
+				if (json == "null")
+					source.SetResult("");
+				else
 				{
-					string json = ((Java.Lang.String)result).ToString();
 					json = json.Trim('"');
 					source.SetResult(json);
 				}
-				catch (Exception ex)
-				{
-					source.SetException(ex);
-				}
+
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -9,6 +9,7 @@ using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Xamarin.Forms.Internals;
 using MixedContentHandling = Android.Webkit.MixedContentHandling;
 using AWebView = Android.Webkit.WebView;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -99,6 +100,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				var oldElementController = e.OldElement as IWebViewController;
 				oldElementController.EvalRequested -= OnEvalRequested;
+				oldElementController.EvaluateJavaScriptRequested -= OnEvaluateJavaScriptRequested;
 				oldElementController.GoBackRequested -= OnGoBackRequested;
 				oldElementController.GoForwardRequested -= OnGoForwardRequested;
 			}
@@ -107,6 +109,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				var newElementController = e.NewElement as IWebViewController;
 				newElementController.EvalRequested += OnEvalRequested;
+				newElementController.EvaluateJavaScriptRequested += OnEvaluateJavaScriptRequested;
 				newElementController.GoBackRequested += OnGoBackRequested;
 				newElementController.GoForwardRequested += OnGoForwardRequested;
 
@@ -145,6 +148,15 @@ namespace Xamarin.Forms.Platform.Android
 		void OnEvalRequested(object sender, EvalRequested eventArg)
 		{
 			LoadUrl("javascript:" + eventArg.Script);
+		}
+
+		async Task<string> OnEvaluateJavaScriptRequested(string script)
+		{
+			var jsr = new JavascriptResult();
+
+			Control.EvaluateJavascript(script, jsr);
+
+			return await jsr.JsResult.ConfigureAwait(false);
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)
@@ -249,6 +261,31 @@ namespace Xamarin.Forms.Platform.Android
 				base.Dispose(disposing);
 				if (disposing)
 					_renderer = null;
+			}
+		}
+
+		class JavascriptResult : Java.Lang.Object, IValueCallback
+		{
+			private TaskCompletionSource<string> source;
+			public Task<string> JsResult { get { return source.Task; } }
+
+			public JavascriptResult()
+			{
+				source = new TaskCompletionSource<string>();
+			}
+
+			public void OnReceiveValue(Java.Lang.Object result)
+			{
+				try
+				{
+					string json = ((Java.Lang.String)result).ToString();
+					json = json.Trim('"');
+					source.SetResult(json);
+				}
+				catch (Exception ex)
+				{
+					source.SetException(ex);
+				}
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.GTK/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/WebViewRenderer.cs
@@ -206,15 +206,14 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             }
         }
 
-		async Task<string> OnEvaluateJavaScriptRequested(string script)
-		{
-			if (Control != null)
-			{
-				Control.ExecuteScript(script);
-			}
-
-			return null;
-		}
+        Task<string> OnEvaluateJavaScriptRequested(string script)
+        {
+	       if (Control != null)
+	       {
+		       Control.ExecuteScript(script);
+	       }
+               return null;
+        }
 
         private void OnGoBackRequested(object sender, EventArgs eventArgs)
         {

--- a/Xamarin.Forms.Platform.GTK/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/WebViewRenderer.cs
@@ -208,10 +208,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         Task<string> OnEvaluateJavaScriptRequested(string script)
         {
-	       if (Control != null)
-	       {
-		       Control.ExecuteScript(script);
-	       }
+		       Control?.ExecuteScript(script);
                return null;
         }
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/WebViewRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Platform.GTK.Renderers
 {
@@ -98,6 +99,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                     }
 
                     WebViewController.EvalRequested += OnEvalRequested;
+                    WebViewController.EvaluateJavaScriptRequested += OnEvaluateJavaScriptRequested;
                     WebViewController.GoBackRequested += OnGoBackRequested;
                     WebViewController.GoForwardRequested += OnGoForwardRequested;
                 }
@@ -129,6 +131,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 }
 
                 WebViewController.EvalRequested -= OnEvalRequested;
+                WebViewController.EvaluateJavaScriptRequested -= OnEvaluateJavaScriptRequested;
                 WebViewController.GoBackRequested -= OnGoBackRequested;
                 WebViewController.GoForwardRequested -= OnGoForwardRequested;
             }
@@ -202,6 +205,16 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 Control.ExecuteScript(eventArg?.Script);
             }
         }
+
+		async Task<string> OnEvaluateJavaScriptRequested(string script)
+		{
+			if (Control != null)
+			{
+				Control.ExecuteScript(script);
+			}
+
+			return null;
+		}
 
         private void OnGoBackRequested(object sender, EventArgs eventArgs)
         {

--- a/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
@@ -109,7 +109,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				tcr.SetResult(Control?.StringByEvaluatingJavaScriptFromString(script));
 			});
 
-			return await task;
+			return await task.ConfigureAwait(false);
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using AppKit;
 using Foundation;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
@@ -42,6 +43,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					Control.OnFailedLoading += OnNSWebViewFailedLoadWithError;
 
 					Element.EvalRequested += OnEvalRequested;
+					Element.EvaluateJavaScriptRequested += OnEvaluateJavaScriptRequested;
 					Element.GoBackRequested += OnGoBackRequested;
 					Element.GoForwardRequested += OnGoForwardRequested;
 
@@ -68,6 +70,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				Control.OnFinishedLoading -= OnNSWebViewFinishedLoad;
 				Control.OnFailedLoading -= OnNSWebViewFailedLoadWithError;
 				Element.EvalRequested -= OnEvalRequested;
+				Element.EvaluateJavaScriptRequested -= OnEvaluateJavaScriptRequested;
 				Element.GoBackRequested -= OnGoBackRequested;
 				Element.GoForwardRequested -= OnGoForwardRequested;
 			}
@@ -95,6 +98,18 @@ namespace Xamarin.Forms.Platform.MacOS
 		void OnEvalRequested(object sender, EvalRequested eventArg)
 		{
 			Control?.StringByEvaluatingJavaScriptFromString(eventArg?.Script);
+		}
+
+		async Task<string> OnEvaluateJavaScriptRequested(string script)
+		{
+			var tcr = new TaskCompletionSource<string>();
+			var task = tcr.Task;
+
+			Device.BeginInvokeOnMainThread(() => {
+				tcr.SetResult(Control?.StringByEvaluatingJavaScriptFromString(script));
+			});
+
+			return await task;
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/WebViewRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using Xamarin.Forms.Internals;
 using TChromium = Tizen.WebView.Chromium;
 using TWebView = Tizen.WebView.WebView;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -42,6 +43,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				if (Element != null)
 				{
 					Element.EvalRequested -= OnEvalRequested;
+					Element.EvaluateJavaScriptRequested -= OnEvaluateJavaScriptRequested;
 					Element.GoBackRequested -= OnGoBackRequested;
 					Element.GoForwardRequested -= OnGoForwardRequested;
 				}
@@ -72,6 +74,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (e.NewElement != null)
 			{
 				e.NewElement.EvalRequested += OnEvalRequested;
+				e.NewElement.EvaluateJavaScriptRequested += OnEvaluateJavaScriptRequested;
 				e.NewElement.GoForwardRequested += OnGoForwardRequested;
 				e.NewElement.GoBackRequested += OnGoBackRequested;
 				Load();
@@ -135,6 +138,12 @@ namespace Xamarin.Forms.Platform.Tizen
 		void OnEvalRequested(object sender, EvalRequested eventArg)
 		{
 			_control.Eval(eventArg.Script);
+		}
+
+		Task<string> OnEvaluateJavaScriptRequested(string script)
+		{
+			_control.Eval(script);
+			return null;
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -145,16 +145,7 @@ if(bases.length == 0){
 
 		async Task<string> OnEvaluateJavaScriptRequested(string script)
 		{
-			try
-			{
 				return await Control.InvokeScriptAsync("eval", new[] { script });
-			}
-			catch (Exception)
-			{
-				//we only get here if there's a script error.
-				//ios / macos / android / etc all return String.Empty in this case.
-				return string.Empty;
-			}
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -5,6 +5,7 @@ using Windows.UI.Xaml.Controls;
 using Xamarin.Forms.Internals;
 using static System.String;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
+using System.Threading.Tasks;
 
 
 namespace Xamarin.Forms.Platform.UWP
@@ -91,6 +92,7 @@ if(bases.length == 0){
 			{
 				var oldElement = e.OldElement;
 				oldElement.EvalRequested -= OnEvalRequested;
+				oldElement.EvaluateJavaScriptRequested -= OnEvaluateJavaScriptRequested;
 				oldElement.GoBackRequested -= OnGoBackRequested;
 				oldElement.GoForwardRequested -= OnGoForwardRequested;
 			}
@@ -109,6 +111,7 @@ if(bases.length == 0){
 
 				var newElement = e.NewElement;
 				newElement.EvalRequested += OnEvalRequested;
+				newElement.EvaluateJavaScriptRequested += OnEvaluateJavaScriptRequested;
 				newElement.GoForwardRequested += OnGoForwardRequested;
 				newElement.GoBackRequested += OnGoBackRequested;
 
@@ -138,6 +141,11 @@ if(bases.length == 0){
 		async void OnEvalRequested(object sender, EvalRequested eventArg)
 		{
 			await Control.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => await Control.InvokeScriptAsync("eval", new[] { eventArg.Script }));
+		}
+
+		async Task<string> OnEvaluateJavaScriptRequested(string script)
+		{
+			return await Control.InvokeScriptAsync("eval", new[] { script });
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -145,7 +145,16 @@ if(bases.length == 0){
 
 		async Task<string> OnEvaluateJavaScriptRequested(string script)
 		{
-			return await Control.InvokeScriptAsync("eval", new[] { script });
+			try
+			{
+				return await Control.InvokeScriptAsync("eval", new[] { script });
+			}
+			catch (Exception)
+			{
+				//we only get here if there's a script error.
+				//ios / macos / android / etc all return String.Empty in this case.
+				return string.Empty;
+			}
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -145,7 +145,7 @@ if(bases.length == 0){
 
 		async Task<string> OnEvaluateJavaScriptRequested(string script)
 		{
-				return await Control.InvokeScriptAsync("eval", new[] { script });
+			return await Control.InvokeScriptAsync("eval", new[] { script });
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
@@ -99,16 +99,7 @@ namespace Xamarin.Forms.Platform.WPF
 			var task = tcr.Task;
 
 			Device.BeginInvokeOnMainThread(() => {
-				try
-				{
 					tcr.SetResult((string)Control.InvokeScript("eval", new[] { script }));
-				}
-				catch(Exception)		
-				{
-					//we only get here if there's a script error OR the script returned a non-string).
-					//other platforms return String.Empty in this case.
-					tcr.SetResult(""); 
-				}
 			});
 
 			return await task.ConfigureAwait(false);

--- a/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
@@ -98,7 +98,18 @@ namespace Xamarin.Forms.Platform.WPF
 			var tcr = new TaskCompletionSource<string>();
 			var task = tcr.Task;
 
-			Device.BeginInvokeOnMainThread(() => { tcr.SetResult((string)Control.InvokeScript("eval", new[] { script })); });
+			Device.BeginInvokeOnMainThread(() => {
+				try
+				{
+					tcr.SetResult((string)Control.InvokeScript("eval", new[] { script }));
+				}
+				catch(Exception)		
+				{
+					//we only get here if there's a script error OR the script returned a non-string).
+					//other platforms return String.Empty in this case.
+					tcr.SetResult(""); 
+				}
+			});
 
 			return await task.ConfigureAwait(false);
 		}

--- a/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Platform.WPF
 			if (e.OldElement != null) // Clear old element event
 			{
 				e.OldElement.EvalRequested -= OnEvalRequested;
+				e.OldElement.EvaluateJavaScriptRequested -= OnEvaluateJavaScriptRequested;
 				e.OldElement.GoBackRequested -= OnGoBackRequested;
 				e.OldElement.GoForwardRequested -= OnGoForwardRequested;
 			}
@@ -40,6 +41,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 				// Suscribe element event
 				Element.EvalRequested += OnEvalRequested;
+				Element.EvaluateJavaScriptRequested += OnEvaluateJavaScriptRequested;
 				Element.GoBackRequested += OnGoBackRequested;
 				Element.GoForwardRequested += OnGoForwardRequested;
 			}
@@ -89,6 +91,16 @@ namespace Xamarin.Forms.Platform.WPF
 		void OnEvalRequested(object sender, EvalRequested eventArg)
 		{
 			Control.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() => Control.InvokeScript("eval", eventArg.Script)));
+		}
+
+		async Task<string> OnEvaluateJavaScriptRequested(string script)
+		{
+			var tcr = new TaskCompletionSource<string>();
+			var task = tcr.Task;
+
+			Device.BeginInvokeOnMainThread(() => { tcr.SetResult((string)Control.InvokeScript("eval", new[] { script })); });
+
+			return await task.ConfigureAwait(false);
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -37,6 +38,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Element = element;
 			Element.PropertyChanged += HandlePropertyChanged;
 			WebView.EvalRequested += OnEvalRequested;
+			WebView.EvaluateJavaScriptRequested += OnEvaluateJavaScriptRequested;
 			WebView.GoBackRequested += OnGoBackRequested;
 			WebView.GoForwardRequested += OnGoForwardRequested;
 			Delegate = new CustomWebViewDelegate(this);
@@ -100,6 +102,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				Element.PropertyChanged -= HandlePropertyChanged;
 				WebView.EvalRequested -= OnEvalRequested;
+				WebView.EvaluateJavaScriptRequested -= OnEvaluateJavaScriptRequested;
 				WebView.GoBackRequested -= OnGoBackRequested;
 				WebView.GoForwardRequested -= OnGoForwardRequested;
 
@@ -137,6 +140,16 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnEvalRequested(object sender, EvalRequested eventArg)
 		{
 			EvaluateJavascript(eventArg.Script);
+		}
+
+		async Task<string> OnEvaluateJavaScriptRequested(string script)
+		{
+			var tcr = new TaskCompletionSource<string>();
+			var task = tcr.Task;
+
+			Device.BeginInvokeOnMainThread(() => { tcr.SetResult(EvaluateJavascript(script)); });
+
+			return await task.ConfigureAwait(false);
 		}
 
 		void OnGoBackRequested(object sender, EventArgs eventArgs)

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EvaluateJavaScriptDelegate.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms.Internals/EvaluateJavaScriptDelegate.xml
@@ -1,0 +1,28 @@
+<Type Name="EvaluateJavaScriptDelegate" FullName="Xamarin.Forms.Internals.EvaluateJavaScriptDelegate">
+  <TypeSignature Language="C#" Value="public delegate System.Threading.Tasks.Task&lt;string&gt; EvaluateJavaScriptDelegate(string script);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed EvaluateJavaScriptDelegate extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Forms.Core</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Parameters>
+    <Parameter Name="script" Type="System.String" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Threading.Tasks.Task&lt;System.String&gt;</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="script">To be added.</param>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/IWebViewController.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/IWebViewController.xml
@@ -62,6 +62,21 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="EvaluateJavaScriptRequested">
+      <MemberSignature Language="C#" Value="public event Xamarin.Forms.Internals.EvaluateJavaScriptDelegate EvaluateJavaScriptRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class Xamarin.Forms.Internals.EvaluateJavaScriptDelegate EvaluateJavaScriptRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Internals.EvaluateJavaScriptDelegate</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="GoBackRequested">
       <MemberSignature Language="C#" Value="public event EventHandler GoBackRequested;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler GoBackRequested" />

--- a/docs/Xamarin.Forms.Core/Xamarin.Forms/WebView.xml
+++ b/docs/Xamarin.Forms.Core/Xamarin.Forms/WebView.xml
@@ -214,6 +214,54 @@ namespace FormsGallery
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="EvaluateJavaScriptAsync">
+      <MemberSignature Language="C#" Value="public System.Threading.Tasks.Task&lt;string&gt; EvaluateJavaScriptAsync (string script);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Threading.Tasks.Task`1&lt;string&gt; EvaluateJavaScriptAsync(string script) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.DebuggerStepThrough</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.AsyncStateMachine(typeof(Xamarin.Forms.WebView/&lt;EvaluateJavaScriptAsync&gt;d__21))</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task&lt;System.String&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="script" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="script">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="EvaluateJavaScriptRequested">
+      <MemberSignature Language="C#" Value="public event Xamarin.Forms.Internals.EvaluateJavaScriptDelegate EvaluateJavaScriptRequested;" />
+      <MemberSignature Language="ILAsm" Value=".event class Xamarin.Forms.Internals.EvaluateJavaScriptDelegate EvaluateJavaScriptRequested" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Xamarin.Forms.Internals.EvaluateJavaScriptDelegate</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="GoBack">
       <MemberSignature Language="C#" Value="public void GoBack ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void GoBack() cil managed" />

--- a/docs/Xamarin.Forms.Core/index.xml
+++ b/docs/Xamarin.Forms.Core/index.xml
@@ -471,6 +471,7 @@
       <Type Name="EffectUtilities" Kind="Class" />
       <Type Name="EnumerableExtensions" Kind="Class" />
       <Type Name="EvalRequested" Kind="Class" />
+      <Type Name="EvaluateJavaScriptDelegate" Kind="Delegate" />
       <Type Name="EventArg`1" DisplayName="EventArg&lt;T&gt;" Kind="Class" />
       <Type Name="ExpressionSearch" Kind="Class" />
       <Type Name="IDataTemplate" Kind="Interface" />


### PR DESCRIPTION
### Description of Change ###

fixes #1699 .

Adds the ability to execute and return the result of a passed javascript string from a platform's webview.

Platform support:

- [X] Android
- [X] iOS
- [X] macOS
- [X] UWP
- [X] WPF
- [ ] Tizen (no native platform support)
- [ ] GTK (no native platform support)

### API Changes ###

Added:
Task<string> WebView.EvaluateJavaScriptAsync

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
