### PR TITLE
Added the ListView.SelectionMode property

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59718.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59718.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Controls.Issues
 				})
 			};
 
-			_list.On<Windows>().SetSelectionMode(ListViewSelectionMode.Inaccessible);
+			_list.On<Windows>().SetSelectionMode(Xamarin.Forms.PlatformConfiguration.WindowsSpecific.ListViewSelectionMode.Inaccessible);
 
 			_list.ItemTapped += ListView_ItemTapped;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1801.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1801.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 1801, "[Enhancement] Add SelectionMode property to ListView", PlatformAffected.All)]
+	public class Issue1801
+		: TestContentPage
+	{
+		protected override void Init()
+		{
+			var list = new ListView { SelectionMode = ListViewSelectionMode.Single };
+//			var list = new ListView { SelectionMode = ListViewSelectionMode.None };
+			list.ItemsSource = new [] { "A1", "A2", "A3", "A4" };
+			var label = new Label { Text = "SelectionMode == " + list.SelectionMode };
+			var toggle = new Switch { IsToggled = list.SelectionMode == ListViewSelectionMode.Single };
+			var log = new Editor { HeightRequest = 200 };
+
+			var stackLayout = new StackLayout();
+			stackLayout.Children.Add(label);
+			stackLayout.Children.Add(list);
+			stackLayout.Children.Add(toggle);
+			stackLayout.Children.Add(new Label { Text = "Event log" });
+			stackLayout.Children.Add(log);
+
+			toggle.Toggled += (_, b) =>
+			{
+				list.SelectionMode = b.Value ? ListViewSelectionMode.Single : ListViewSelectionMode.None;
+				label.Text = "SelectionMode == " + list.SelectionMode;
+			};
+
+			Func<ListView, object, string, object> logEvent = (_, item, e) =>
+			{
+				var line = $"Item '{item}' {e}. SelectedItem = '{list.SelectedItem}'";
+				if (Device.RuntimePlatform == Device.Android)
+					// Android scrolls to show the last line so append to the log to make sure this line is visible
+					log.Text += line + "\n";
+				else
+					// iOS/UWP don't scroll to show the last line so prepend instead to make sure this line is visible
+					log.Text = line + "\n" + log.Text;
+				return null;
+			};
+			EventHandler<SelectedItemChangedEventArgs> itemSelected = (l, e) => logEvent((ListView)l, e.SelectedItem, "selected");
+			EventHandler<ItemTappedEventArgs> itemTapped = (l, e) => logEvent((ListView)l, e.Item, "tapped");
+
+			list.ItemSelected += itemSelected;
+			list.ItemTapped += itemTapped;
+
+			stackLayout.Padding = new Thickness(0, 20, 0, 0);
+			Content = stackLayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -239,6 +239,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1677.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1801.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1683.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1705_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1601.cs" />

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create("SelectedItem", typeof(object), typeof(ListView), null, BindingMode.OneWayToSource,
 			propertyChanged: OnSelectedItemChanged);
 
+		public static readonly BindableProperty SelectionModeProperty = BindableProperty.Create(nameof(SelectionMode), typeof(ListViewSelectionMode), typeof(ListView), ListViewSelectionMode.Single);
+
 		public static readonly BindableProperty HasUnevenRowsProperty = BindableProperty.Create("HasUnevenRows", typeof(bool), typeof(ListView), false);
 
 		public static readonly BindableProperty RowHeightProperty = BindableProperty.Create("RowHeight", typeof(int), typeof(ListView), -1);
@@ -201,6 +203,12 @@ namespace Xamarin.Forms
 		{
 			get { return GetValue(SelectedItemProperty); }
 			set { SetValue(SelectedItemProperty, value); }
+		}
+
+		public ListViewSelectionMode SelectionMode
+		{
+			get { return (ListViewSelectionMode)GetValue(SelectionModeProperty); }
+			set { SetValue(SelectionModeProperty, value); }
 		}
 
 		public Color SeparatorColor
@@ -406,7 +414,8 @@ namespace Xamarin.Forms
 			}
 
 			// Set SelectedItem before any events so we don't override any changes they may have made.
-			SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0));
+			if (SelectionMode != ListViewSelectionMode.None)
+				SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0));
 
 			cell?.OnTapped();
 

--- a/Xamarin.Forms.Core/ListViewSelectionMode.cs
+++ b/Xamarin.Forms.Core/ListViewSelectionMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.Forms
+{
+	public enum ListViewSelectionMode
+	{
+		None,
+		Single
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -459,7 +459,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (_lastSelected != view)
 				_fromNative = true;
-			Select(position, view);
+			if (_listView.SelectionMode != ListViewSelectionMode.None)
+				Select(position, view);
 			Controller.NotifyRowTapped(position, cell);
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -8,6 +8,7 @@ using AView = Android.Views.View;
 using Xamarin.Forms.Internals;
 using System;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+using Android.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -161,6 +162,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateFooter();
 				UpdateIsSwipeToRefreshEnabled();
 				UpdateFastScrollEnabled();
+				UpdateSelectionMode();
 			}
 		}
 
@@ -196,6 +198,8 @@ namespace Xamarin.Forms.Platform.Android
 				_adapter.NotifyDataSetChanged();
 			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.ListView.IsFastScrollEnabledProperty.PropertyName)
 				UpdateFastScrollEnabled();
+			else if (e.PropertyName == ListView.SelectionModeProperty.PropertyName)
+				UpdateSelectionMode();
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
@@ -392,6 +396,22 @@ namespace Xamarin.Forms.Platform.Android
 			if (Control != null)
 			{
 				Control.FastScrollEnabled = Element.OnThisPlatform().IsFastScrollEnabled();
+			}
+		}
+
+		void UpdateSelectionMode()
+		{
+			if (Control != null)
+			{
+				if (Element.SelectionMode == ListViewSelectionMode.None)
+				{
+					Control.ChoiceMode = ChoiceMode.None;
+					Element.SelectedItem = null;
+				}
+				else if (Element.SelectionMode == ListViewSelectionMode.Single)
+				{
+					Control.ChoiceMode = ChoiceMode.Single;
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -73,6 +73,7 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateHeader();
 				UpdateFooter();
 				UpdateSelectionMode();
+				UpdateWindowsSpecificSelectionMode();
 				ClearSizeEstimate();
 			}
 		}
@@ -115,9 +116,13 @@ namespace Xamarin.Forms.Platform.UWP
 				ClearSizeEstimate();
 				((CollectionViewSource)List.DataContext).Source = Element.ItemsSource;
 			}
-			else if (e.PropertyName == Specifics.SelectionModeProperty.PropertyName)
+			else if (e.PropertyName == ListView.SelectionModeProperty.PropertyName)
 			{
 				UpdateSelectionMode();
+			}
+			else if (e.PropertyName == Specifics.SelectionModeProperty.PropertyName)
+			{
+				UpdateWindowsSpecificSelectionMode();
 			}
 		}
 
@@ -255,6 +260,20 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 		void UpdateSelectionMode()
+		{
+			if (Element.SelectionMode == ListViewSelectionMode.None)
+			{
+				List.SelectionMode = Windows.UI.Xaml.Controls.ListViewSelectionMode.None;
+				List.SelectedIndex = -1;
+				Element.SelectedItem = null;
+			}
+			else if (Element.SelectionMode == ListViewSelectionMode.Single)
+			{
+				List.SelectionMode = Windows.UI.Xaml.Controls.ListViewSelectionMode.Single;
+			}
+		}
+
+		void UpdateWindowsSpecificSelectionMode()
 		{
 			if (Element.OnThisPlatform().GetSelectionMode() == PlatformConfiguration.WindowsSpecific.ListViewSelectionMode.Accessible)
 			{

--- a/Xamarin.Forms.Platform.UAP/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TableViewRenderer.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Platform.UWP
 						ItemTemplate = (Windows.UI.Xaml.DataTemplate)Windows.UI.Xaml.Application.Current.Resources["CellTemplate"],
 						GroupStyle = { new GroupStyle { HidesIfEmpty = false, HeaderTemplate = (Windows.UI.Xaml.DataTemplate)Windows.UI.Xaml.Application.Current.Resources["TableSection"] } },
 						HeaderTemplate = (Windows.UI.Xaml.DataTemplate)Windows.UI.Xaml.Application.Current.Resources["TableRoot"],
-						SelectionMode = ListViewSelectionMode.Single
+						SelectionMode = Windows.UI.Xaml.Controls.ListViewSelectionMode.Single
 					});
 
 					// You can't set ItemsSource directly to a CollectionViewSource, it crashes.

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -243,6 +243,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateIsRefreshing();
 				UpdateSeparatorColor();
 				UpdateSeparatorVisibility();
+				UpdateSelectionMode();
 
 				var selected = e.NewElement.SelectedItem;
 				if (selected != null)
@@ -279,6 +280,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateFooter();
 			else if (e.PropertyName == "RefreshAllowed")
 				UpdatePullToRefreshEnabled();
+			else if (e.PropertyName == Xamarin.Forms.ListView.SelectionModeProperty.PropertyName)
+				UpdateSelectionMode();
 		}
 
 		NSIndexPath[] GetPaths(int section, int index, int count)
@@ -654,6 +657,18 @@ namespace Xamarin.Forms.Platform.iOS
 					throw new ArgumentOutOfRangeException();
 			}
 		}
+
+		void UpdateSelectionMode()
+		{
+			if (Element.SelectionMode == ListViewSelectionMode.None)
+			{
+				Element.SelectedItem = null;
+				var selectedIndexPath = Control.IndexPathForSelectedRow;
+				if (selectedIndexPath != null)
+					Control.DeselectRow(selectedIndexPath, false);
+			}
+		}
+
 
 		internal class UnevenListViewDataSource : ListViewDataSource
 		{
@@ -1050,6 +1065,9 @@ namespace Xamarin.Forms.Platform.iOS
 					formsCell = (Cell)((INativeElementView)cell).Element;
 
 				SetCellBackgroundColor(cell, UIColor.Clear);
+
+				if (List.SelectionMode == ListViewSelectionMode.None)
+					tableView.DeselectRow(indexPath, false);
 
 				_selectionFromNative = true;
 


### PR DESCRIPTION
### Description of Change ###

Added the `ListView.SelectionMode` property and the `ListViewSelectionMode` enum. `ListViewSelectionMode.Single` is the default and retains the previous behavior. When `SelectionMode` is set to `ListViewSelectionMode.None` rows cannot be selected and `ItemSelected` will not be fired. `Tapped` events are still fired and the tapped row will be briefly highlighted during the tap. When  a row has been selected and the property is changed from `Single` to `None` the `SelectedItem` property will be set to `null` and a `ItemSelected` event with a `null` item  will be fired.

**NOTE**: The Xamarin Forms APIs already has an enum named `ListViewSelectionMode` in `Xamarin.Forms.PlatformConfiguration.WindowsSpecific`. This is obviously Windows specific and IIUC it's unrelated to the UWP `ListViewSelectionMode` enum which is a superset of the enum I'm adding in this PR. The existence of two enums with the same name in the APIs could be a source of confusion for users.

### Bugs Fixed ###

Fixes #1801 [Enhancement] Add SelectionMode property to ListView

### API Changes ###

Added:
 - `ListViewSelectionMode ListViewSelectionMode { get; set; } //Bindable Property`
 - `enum ListViewSelectionMode { None, Single }`

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
