### PR TITLE
[Tizen] Change the appearance of Entry/Editor even better

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
@@ -19,6 +19,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 		}
 
+		public EditfieldEntry(EvasObject parent, string style) : base(parent)
+		{
+			if (!string.IsNullOrEmpty(style))
+				_editfieldLayout.SetTheme("layout", "editfield", style);
+		}
+
 		protected override IntPtr CreateHandle(EvasObject parent)
 		{
 			var handle = base.CreateHandle(parent);
@@ -33,9 +39,13 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			}
 			Handle = handle;
 
-			_editfieldLayout.SetPartContent("elm.swallow.content", this);
+			if (!_editfieldLayout.SetPartContent("elm.swallow.content", this))
+			{
+				// Restore theme to default if editfield style is not available
+				_editfieldLayout.SetTheme("layout", "application", "default");
+				_editfieldLayout.SetPartContent("elm.swallow.content", this);
+			}
 
-			// The minimun size for the Content area of an Editfield. This is used to calculate the size when layouting.
 			_heightPadding = _editfieldLayout.EdjeObject["elm.swallow.content"].Geometry.Height;
 			return _editfieldLayout;
 		}
@@ -48,10 +58,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			layout.Unfocused += (s, e) =>
 			{
 				SetFocusOnTextBlock(false);
+				layout.SignalEmit("elm,state,unfocused", "");
 			};
 			layout.Focused += (s, e) =>
 			{
 				AllowFocus(false);
+				layout.SignalEmit("elm,state,focused", "");
 			};
 
 			layout.KeyDown += (s, e) =>
@@ -66,6 +78,17 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				}
 			};
 			Clicked += (s, e) => SetFocusOnTextBlock(true);
+
+			Focused += (s, e) =>
+			{
+				layout.RaiseTop();
+				layout.SignalEmit("elm,state,focused", "");
+			};
+
+			Unfocused += (s, e) =>
+			{
+				layout.SignalEmit("elm,state,unfocused", "");
+			};
 
 			return layout;
 		}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Editor.FontSizeProperty, UpdateFontSize);
 			RegisterPropertyHandler(Editor.FontFamilyProperty, UpdateFontFamily);
 			RegisterPropertyHandler(Editor.FontAttributesProperty, UpdateFontAttributes);
-			RegisterPropertyHandler(Editor.KeyboardProperty, UpdateKeyboard);
+			RegisterPropertyHandler(InputView.KeyboardProperty, UpdateKeyboard);
 			RegisterPropertyHandler(InputView.MaxLengthProperty, UpdateMaxLength);
 			RegisterPropertyHandler(InputView.IsSpellCheckEnabledProperty, UpdateIsSpellCheckEnabled);
 		}
@@ -20,7 +20,8 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (Control == null)
 			{
-				var entry = new Native.Entry(Forms.NativeParent)
+				// Multiline EditField style is only available on Mobile and TV profile
+				var entry = Device.Idiom == TargetIdiom.Phone || Device.Idiom == TargetIdiom.TV ? new Native.EditfieldEntry(Forms.NativeParent, "multiline") : new Native.Entry(Forms.NativeParent)
 				{
 					IsSingleLine = false,
 					PropagateEvents = false,
@@ -49,6 +50,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				}
 			}
 			base.Dispose(disposing);
+		}
+
+		protected override Size MinimumSize()
+		{
+			return (Control as Native.IMeasurable).Measure(Control.MinimumWidth, Control.MinimumHeight).ToDP();
 		}
 
 		void OnTextChanged(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Entry.FontFamilyProperty, UpdateFontFamily);
 			RegisterPropertyHandler(Entry.FontAttributesProperty, UpdateFontAttributes);
 			RegisterPropertyHandler(Entry.HorizontalTextAlignmentProperty, UpdateHorizontalTextAlignment);
-			RegisterPropertyHandler(Entry.KeyboardProperty, UpdateKeyboard);
+			RegisterPropertyHandler(InputView.KeyboardProperty, UpdateKeyboard);
 			RegisterPropertyHandler(Entry.PlaceholderProperty, UpdatePlaceholder);
 			RegisterPropertyHandler(Entry.PlaceholderColorProperty, UpdatePlaceholderColor);
 			RegisterPropertyHandler(InputView.MaxLengthProperty, UpdateMaxLength);
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (Control == null)
 			{
-				var entry = new Native.Entry(Forms.NativeParent)
+				var entry = new Native.EditfieldEntry(Forms.NativeParent)
 				{
 					IsSingleLine = true,
 					PropagateEvents = false,
@@ -58,6 +58,11 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 
 			base.Dispose(disposing);
+		}
+
+		protected override Size MinimumSize()
+		{
+			return (Control as Native.IMeasurable).Measure(Control.MinimumWidth, Control.MinimumHeight).ToDP();
 		}
 
 		void OnTextChanged(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

Use EditfileEntry as a default native control of Entry/Editor. The major change in this PR is UI style updates for Entry and Editor. The biggest problem with the existing style is that the boundaries of Entry and Editor are ambigous. Especially for TV, the default TextColor is the same as the default Background Color, so if you do NOT set the color arbitrarily, the text will not be visible. 

The following screenshots show before and after on each devices. 

|  |Before  | After |
|----|----|----|
|**Mobile** |   <p align="center"> <img src = "https://user-images.githubusercontent.com/1029134/37581469-26675ae4-2b8c-11e8-9f95-d37d7f58a5cc.png" width=240 align="middle"> </p> |  <p align="center"> <img src = "https://user-images.githubusercontent.com/1029134/37581480-2f488ef8-2b8c-11e8-9fad-0e08f686557d.png" width=240></p>|
|**TV** | <img src = "https://user-images.githubusercontent.com/1029134/37581487-353eb68e-2b8c-11e8-8928-b3fed348f29e.png" width=800> |   <img src = "https://user-images.githubusercontent.com/1029134/37581497-3c35c860-2b8c-11e8-864f-72d681df2364.png" width=800>|
| **Watch**  | <p align="center"><img src = "https://user-images.githubusercontent.com/1029134/37581509-44be1618-2b8c-11e8-95ce-34b80c8b5496.png" width=200> </p> |   <p align="center"><img src = "https://user-images.githubusercontent.com/1029134/37581517-4b4041be-2b8c-11e8-811e-b735fa6afa95.png" width=200> </p> |

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
