### PR TITLE
[Android] AppCompat version of EntryRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/EntryRenderer.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Android.Support.V7.Widget;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Android.Text;
+using Android.Views.InputMethods;
+using Java.Lang;
+using System.ComponentModel;
+using Android.Text.Method;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+using Android.Util;
+
+namespace Xamarin.Forms.Platform.Android.AppCompat
+{
+	public class EntryRenderer : ViewRenderer<Entry, AppCompatEditText>, ITextWatcher, TextView.IOnEditorActionListener
+	{
+		TextColorSwitcher _hintColorSwitcher;
+		TextColorSwitcher _textColorSwitcher;
+		bool _disposed;
+		ImeAction _currentInputImeFlag;
+
+		public EntryRenderer(Context context) : base(context)
+		{
+
+		}
+
+		void ITextWatcher.AfterTextChanged(IEditable s)
+		{
+			
+		}
+
+		void ITextWatcher.BeforeTextChanged(ICharSequence s, int start, int count, int after)
+		{
+			
+		}
+
+		void ITextWatcher.OnTextChanged(ICharSequence s, int start, int before, int count)
+		{
+			if (string.IsNullOrEmpty(Element.Text) && s.Length() == 0)
+				return;
+
+			((IElementController)Element).SetValueFromRenderer(Entry.TextProperty, s.ToString());
+		}
+
+		bool TextView.IOnEditorActionListener.OnEditorAction(TextView v, ImeAction actionId, KeyEvent e)
+		{
+			if (actionId == ImeAction.Done || actionId == _currentInputImeFlag || (actionId == ImeAction.ImeNull && e.KeyCode == Keycode.Enter && e.Action == KeyEventActions.Up))
+			{
+				Control.ClearFocus();
+				v.HideKeyboard();
+				((IEntryController)Element).SendCompleted();
+			}
+			return true;
+		}
+
+		protected override AppCompatEditText CreateNativeControl()
+		{
+			return new AppCompatEditText(Context);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
+		{
+			base.OnElementChanged(e);
+
+			HandleKeyboardOnFocus = true;
+
+			if (e.OldElement == null)
+			{
+				var textView = CreateNativeControl();
+
+				textView.AddTextChangedListener(this);
+				textView.SetOnEditorActionListener(this);
+				//textView.OnKeyboardBackPressed += OnKeyboardBackPressed;
+				
+				var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
+
+				_textColorSwitcher = new TextColorSwitcher(textView.TextColors, useLegacyColorManagement);
+				_hintColorSwitcher = new TextColorSwitcher(textView.HintTextColors, useLegacyColorManagement);
+				SetNativeControl(textView);
+			}
+
+			Control.Hint = Element.Placeholder;
+			Control.Text = Element.Text;
+
+			UpdateInputType();
+			UpdateColor();
+			UpdateAlignment();
+			UpdateFont();
+			UpdatePlaceholderColor();
+			UpdateMaxLength();
+			UpdateImeOptions();
+			UpdateReturnType();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				if (Control != null)
+				{
+					//Control.OnKeyboardBackPressed -= OnKeyboardBackPressed;
+				}
+			}
+
+			base.Dispose(disposing);
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == Entry.PlaceholderProperty.PropertyName)
+				Control.Hint = Element.Placeholder;
+			else if (e.PropertyName == Entry.IsPasswordProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == Entry.TextProperty.PropertyName)
+			{
+				if (Control.Text != Element.Text)
+				{
+					Control.Text = Element.Text;
+					if (Control.IsFocused)
+					{
+						Control.SetSelection(Control.Text.Length);
+						Control.ShowKeyboard();
+					}
+				}
+			}
+			else if (e.PropertyName == Entry.TextColorProperty.PropertyName)
+				UpdateColor();
+			else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == Entry.IsTextPredictionEnabledProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
+				UpdateAlignment();
+			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.FontFamilyProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.FontSizeProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
+				UpdatePlaceholderColor();
+			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
+				UpdateAlignment();
+			else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+				UpdateMaxLength();
+			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.Entry.ImeOptionsProperty.PropertyName)
+				UpdateImeOptions();
+			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
+				UpdateReturnType();
+
+			base.OnElementPropertyChanged(sender, e);
+		}
+
+		protected virtual NumberKeyListener GetDigitsKeyListener(InputTypes inputTypes)
+		{
+			// Override this in a custom renderer to use a different NumberKeyListener
+			// or to filter out input types you don't want to allow
+			// (e.g., inputTypes &= ~InputTypes.NumberFlagSigned to disallow the sign)
+			return LocalizedDigitsKeyListener.Create(inputTypes);
+		}
+
+		protected virtual void UpdateImeOptions()
+		{
+			if (Element == null || Control == null)
+				return;
+			var imeOptions = Element.OnThisPlatform().ImeOptions();
+			_currentInputImeFlag = imeOptions.ToAndroidImeOptions();
+			Control.ImeOptions = _currentInputImeFlag;
+		}
+
+		void UpdateAlignment()
+		{
+			Control.UpdateHorizontalAlignment(Element.HorizontalTextAlignment);
+		}
+
+		void UpdateColor()
+		{
+			_textColorSwitcher.UpdateTextColor(Control, Element.TextColor);
+		}
+
+		void UpdateFont()
+		{
+			Control.Typeface = Element.ToTypeface();
+			Control.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
+		}
+
+		void UpdateInputType()
+		{
+			Entry model = Element;
+			var keyboard = model.Keyboard;
+
+			Control.InputType = keyboard.ToInputType();
+			if (!(keyboard is Internals.CustomKeyboard))
+			{
+				if (model.IsSet(InputView.IsSpellCheckEnabledProperty))
+				{
+					if ((Control.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsSpellCheckEnabled)
+							Control.InputType = Control.InputType | InputTypes.TextFlagNoSuggestions;
+					}
+				}
+				if (model.IsSet(Entry.IsTextPredictionEnabledProperty))
+				{
+					if ((Control.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsTextPredictionEnabled)
+							Control.InputType = Control.InputType | InputTypes.TextFlagNoSuggestions;
+					}
+				}
+			}
+
+			if (keyboard == Keyboard.Numeric)
+			{
+				Control.KeyListener = GetDigitsKeyListener(Control.InputType);
+			}
+
+			if (model.IsPassword && ((Control.InputType & InputTypes.ClassText) == InputTypes.ClassText))
+				Control.InputType = Control.InputType | InputTypes.TextVariationPassword;
+			if (model.IsPassword && ((Control.InputType & InputTypes.ClassNumber) == InputTypes.ClassNumber))
+				Control.InputType = Control.InputType | InputTypes.NumberVariationPassword;
+		}
+
+		void UpdatePlaceholderColor()
+		{
+			_hintColorSwitcher.UpdateTextColor(Control, Element.PlaceholderColor, Control.SetHintTextColor);
+		}
+
+		void OnKeyboardBackPressed(object sender, EventArgs eventArgs)
+		{
+			Control?.ClearFocus();
+		}
+
+		void UpdateMaxLength()
+		{
+			var currentFilters = new List<IInputFilter>(Control?.GetFilters() ?? new IInputFilter[0]);
+
+			for (var i = 0; i < currentFilters.Count; i++)
+			{
+				if (currentFilters[i] is InputFilterLengthFilter)
+				{
+					currentFilters.RemoveAt(i);
+					break;
+				}
+			}
+
+			currentFilters.Add(new InputFilterLengthFilter(Element.MaxLength));
+
+			Control?.SetFilters(currentFilters.ToArray());
+
+			var currentControlText = Control?.Text;
+
+			if (currentControlText.Length > Element.MaxLength)
+				Control.Text = currentControlText.Substring(0, Element.MaxLength);
+		}
+
+		void UpdateReturnType()
+		{
+			if (Control == null || Element == null)
+				return;
+
+			Control.ImeOptions = Element.ReturnType.ToAndroidImeAction();
+			_currentInputImeFlag = Control.ImeOptions;
+		}
+
+	}
+}

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -92,6 +92,7 @@ namespace Xamarin.Forms.Platform.Android
 				RegisterHandlerForDefaultRenderer(typeof(Switch), typeof(AppCompat.SwitchRenderer), typeof(SwitchRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(Picker), typeof(AppCompat.PickerRenderer), typeof(PickerRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(CarouselPage), typeof(AppCompat.CarouselPageRenderer), typeof(CarouselPageRenderer));
+				RegisterHandlerForDefaultRenderer(typeof(Entry), typeof(AppCompat.EntryRenderer), typeof(EntryRenderer));
 
 				if (Forms.Flags.Contains(Flags.FastRenderersExperimental))
 				{

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -22,14 +22,12 @@
     <AndroidTlsProvider>
     </AndroidTlsProvider>
   </PropertyGroup>
-  
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-  </PropertyGroup>  
-  
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -110,6 +108,7 @@
     <Compile Include="ActivityResultCallbackRegistry.cs" />
     <Compile Include="AndroidApplicationLifecycleState.cs" />
     <Compile Include="AndroidTitleBarVisibility.cs" />
+    <Compile Include="AppCompat\EntryRenderer.cs" />
     <Compile Include="AppCompat\FrameRenderer.cs" />
     <Compile Include="ButtonBackgroundTracker.cs" />
     <Compile Include="Elevation.cs" />


### PR DESCRIPTION
### Description of Change ###

Ported EntryRenderer
fixes #1549

### Bugs Fixed ###

- No Bug Fix

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
