### PR TITLE
[Xaml[C]] don't fail if event has same name as ABP

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -753,7 +753,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var bpRef = GetBindablePropertyReference(parent, propertyName.NamespaceURI, ref localName, out attached, context, iXmlLineInfo);
 
 			//If the target is an event, connect
-			if (CanConnectEvent(parent, localName))
+			if (CanConnectEvent(parent, localName, attached))
 				return ConnectEvent(parent, localName, valueNode, iXmlLineInfo, context);
 
 			//If Value is DynamicResource, SetDynamicResource
@@ -817,10 +817,9 @@ namespace Xamarin.Forms.Build.Tasks
 			return bpRef;
 		}
 
-		static bool CanConnectEvent(VariableDefinition parent, string localName)
+		static bool CanConnectEvent(VariableDefinition parent, string localName, bool attached)
 		{
-			TypeReference _;
-			return parent.VariableType.GetEvent(ed => ed.Name == localName, out _) != null;
+			return !attached && parent.VariableType.GetEvent(ed => ed.Name == localName, out _) != null;
 		}
 
 		static IEnumerable<Instruction> ConnectEvent(VariableDefinition parent, string localName, INode valueNode, IXmlLineInfo iXmlLineInfo, ILContext context)

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2130.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2130.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+    x:Class="Xamarin.Forms.Xaml.UnitTests.Gh2130"
+    local:Gh2130Behavior.Appearing="false">
+	<ContentPage.Content>
+	</ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2130.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2130.xaml.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+using System.Windows.Input;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public static class Gh2130Behavior
+	{
+		public static readonly BindableProperty AppearingProperty =
+			BindableProperty.Create("Appearing", typeof(bool), typeof(Gh2130Behavior), default(bool));
+
+		public static bool GetAppearing(BindableObject bindable)
+		{
+			return (bool)bindable.GetValue(AppearingProperty);
+		}
+
+		public static void SetAppearing(BindableObject bindable, bool value)
+		{
+			bindable.SetValue(AppearingProperty, value);
+		}
+
+	}
+
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh2130 : ContentPage
+	{
+		public Gh2130()
+		{
+			InitializeComponent();
+		}
+
+		public Gh2130(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void AttachedBPWithEventName(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(Gh2130));
+				new Gh2130(useCompiledXaml);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -591,6 +591,9 @@
     <Compile Include="Issues\Gh2064.xaml.cs">
       <DependentUpon>Gh2064.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh2130.xaml.cs">
+      <DependentUpon>Gh2130.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   
@@ -1064,6 +1067,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh2064.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh2130.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -316,7 +316,7 @@ namespace Xamarin.Forms.Xaml
 			var property = GetBindableProperty(bpOwnerType, localName, lineInfo, false);
 
 			//If the target is an event, connect
-			if (xpe == null && TryConnectEvent(xamlelement, localName, value, rootElement, lineInfo, out xpe))
+			if (xpe == null && TryConnectEvent(xamlelement, localName, attached, value, rootElement, lineInfo, out xpe))
 				return;
 
 			//If Value is DynamicResource and it's a BP, SetDynamicResource
@@ -375,9 +375,12 @@ namespace Xamarin.Forms.Xaml
 			return null;
 		}
 
-		static bool TryConnectEvent(object element, string localName, object value, object rootElement, IXmlLineInfo lineInfo, out Exception exception)
+		static bool TryConnectEvent(object element, string localName, bool attached, object value, object rootElement, IXmlLineInfo lineInfo, out Exception exception)
 		{
 			exception = null;
+
+			if (attached)
+				return false;
 
 			var elementType = element.GetType();
 			var eventInfo = elementType.GetRuntimeEvent(localName);


### PR DESCRIPTION
### Description of Change ###

[Xaml[C]] don't fail if event has same name as ABP

### Bugs Fixed ###

- fixes #2130

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
