### PR TITLE
[Tizen] Enable Entry.IsTextPredicationEnabled property

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Extensions/KeyboardExtensions.cs
+++ b/Xamarin.Forms.Platform.Tizen/Extensions/KeyboardExtensions.cs
@@ -54,16 +54,16 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 		}
 
-		public static InputHints ToInputHints(this Keyboard keyboard, bool isSpellCheckEnabled)
+		public static InputHints ToInputHints(this Keyboard keyboard, bool isSpellCheckEnabled, bool isTextPredictionEnabled)
 		{
-			if (keyboard is CustomKeyboard customKeyboard && customKeyboard.Flags.HasFlag(KeyboardFlags.Suggestions))
+			if (keyboard is CustomKeyboard customKeyboard)
 			{
-				return InputHints.AutoComplete;
+				return customKeyboard.Flags.HasFlag(KeyboardFlags.Suggestions) || customKeyboard.Flags.HasFlag(KeyboardFlags.Spellcheck) ? InputHints.AutoComplete : InputHints.None;
 			}
-			return isSpellCheckEnabled ? InputHints.AutoComplete : InputHints.None;
+			return isSpellCheckEnabled && isTextPredictionEnabled ? InputHints.AutoComplete : InputHints.None;
 		}
 
-		public static void UpdateKeyboard(this Native.Entry control, Keyboard keyboard, bool isSpellCheckEnabled)
+		public static void UpdateKeyboard(this Native.Entry control, Keyboard keyboard, bool isSpellCheckEnabled, bool isTextPredictionEnabled)
 		{
 			control.Keyboard = keyboard.ToNative();
 			if (keyboard is CustomKeyboard customKeyboard)
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				control.AutoCapital = AutoCapital.None;
 			}
-			control.InputHint = keyboard.ToInputHints(isSpellCheckEnabled);
+			control.InputHint = keyboard.ToInputHints(isSpellCheckEnabled, isTextPredictionEnabled);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
@@ -121,12 +121,12 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (initialize && Element.Keyboard == Keyboard.Default)
 				return;
-			Control.UpdateKeyboard(Element.Keyboard, Element.IsSpellCheckEnabled);
+			Control.UpdateKeyboard(Element.Keyboard, Element.IsSpellCheckEnabled, true);
 		}
 
 		void UpdateIsSpellCheckEnabled()
 		{
-			Control.InputHint = Element.Keyboard.ToInputHints(Element.IsSpellCheckEnabled);
+			Control.InputHint = Element.Keyboard.ToInputHints(Element.IsSpellCheckEnabled, true);
 		}
 
 		void UpdateMaxLength()

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(InputView.MaxLengthProperty, UpdateMaxLength);
 			RegisterPropertyHandler(Entry.ReturnTypeProperty, UpdateReturnType);
 			RegisterPropertyHandler(InputView.IsSpellCheckEnabledProperty, UpdateIsSpellCheckEnabled);
+			RegisterPropertyHandler(Entry.IsTextPredictionEnabledProperty, UpdateIsSpellCheckEnabled);
 
 			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
 			{
@@ -121,12 +122,12 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (initialize && Element.Keyboard == Keyboard.Default)
 				return;
-			Control.UpdateKeyboard(Element.Keyboard, Element.IsSpellCheckEnabled);
+			Control.UpdateKeyboard(Element.Keyboard, Element.IsSpellCheckEnabled, Element.IsTextPredictionEnabled);
 		}
 
 		void UpdateIsSpellCheckEnabled()
 		{
-			Control.InputHint = Element.Keyboard.ToInputHints(Element.IsSpellCheckEnabled);
+			Control.InputHint = Element.Keyboard.ToInputHints(Element.IsSpellCheckEnabled, Element.IsTextPredictionEnabled);
 		}
 
 		void UpdatePlaceholder()


### PR DESCRIPTION
### Description of Change ###
 This PR is extension of [#2038](https://github.com/xamarin/Xamarin.Forms/pull/2038) for tizen backend. 

 AutoComplete of `ElmSharp.Entry` is enabled if Keyboard is`CustomKeyboard` and has (Suggestions or Spellcheck) flags or Keyboard is not `CustomKeyboard` and (`IsSpellCheckEnabled` and `IsTextPredictionEnabled`) are true. Otherwise, AutoComplete of `ElmSharp.Entry` is off.

| CustomKeyboard | KeyboardFlags. Suggestions | KeyboardFlags. Spellcheck | Entry. IsSpellCheckEnabled | Entry. IsTextPredictionEnabled | Tizen Native Entry AutoComplete |
| --- | --- | --- | --- | --- | --- |
| True | True | True | - | - | **True** |
| True | True | False | - | - | **True** |
| True | False | True | - | - | **True** |
| True | False | False | - | - | **False** |
| False | - | - | True | True | **True** |
| False | - | - | True | False | **False** |
| False | - | - | False | True | **False** |
| False | - | - | False | False | **False** |

![image](https://user-images.githubusercontent.com/1029155/37746589-55a2b766-2dbe-11e8-8d6c-e8b477f525c6.gif)


### Bugs Fixed ###
 Fixes #1677 [Enhancement] Entry: Control over text-prediction

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
