### PR TITLE
[Tizen] Set TargetIdom.Watch for Tizen wearable device

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/TextCellRenderer.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms.Platform.Tizen
 	{
 		bool _groupMode = false;
 		// TextCell.Detail property is not supported on TV profile due to UX limitation.
-		public TextCellRenderer() : this(Device.Idiom == TargetIdiom.Phone ? "double_label" : "default") { }
+		public TextCellRenderer() : this(Device.Idiom == TargetIdiom.Phone || Device.Idiom == TargetIdiom.Watch ? "double_label" : "default") { }
 
 		protected TextCellRenderer(string style) : base(style)
 		{

--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -247,6 +247,10 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				Device.SetIdiom(TargetIdiom.Desktop);
 			}
+			else if (profile == "wearable")
+			{
+				Device.SetIdiom(TargetIdiom.Watch);
+			}
 			else
 			{
 				Device.SetIdiom(TargetIdiom.Unsupported);

--- a/Xamarin.Forms.Platform.Tizen/Native/MasterDetailPage.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/MasterDetailPage.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// <summary>
 		/// The default master behavior (a.k.a mode).
 		/// </summary>
-		static readonly MasterBehavior s_defaultMasterBehavior = (Device.Idiom == TargetIdiom.Phone) ? MasterBehavior.Popover : MasterBehavior.SplitOnLandscape;
+		static readonly MasterBehavior s_defaultMasterBehavior = (Device.Idiom == TargetIdiom.Phone || Device.Idiom == TargetIdiom.Watch) ? MasterBehavior.Popover : MasterBehavior.SplitOnLandscape;
 
 		/// <summary>
 		/// The MasterPage native container.

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -52,42 +52,27 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 		{
-			// In case of TV profile The base named size sholud be lager than mobile profile
-			if (Device.Idiom != TargetIdiom.Phone)
-			{
-				switch (size)
-				{
-					case NamedSize.Micro:
-						return Forms.ConvertToDPFont(24);
-					case NamedSize.Small:
-						return Forms.ConvertToDPFont(26);
-					case NamedSize.Default:
-					case NamedSize.Medium:
-						return Forms.ConvertToDPFont(28);
-					case NamedSize.Large:
-						return Forms.ConvertToDPFont(84);
-					default:
-						throw new ArgumentOutOfRangeException();
-				}
-
-			}
-
-			double baseSize = Forms.ConvertToDPFont(19);
-			double baseSizeSpan = 3;
+			int pt;
+			// Actual font size depends on the target idiom.
 			switch (size)
 			{
 				case NamedSize.Micro:
-					return baseSize;
+					pt = Device.Idiom == TargetIdiom.TV || Device.Idiom == TargetIdiom.Watch ? 24 : 19;
+					break;
 				case NamedSize.Small:
-					return baseSize + baseSizeSpan;
+					pt = Device.Idiom == TargetIdiom.TV ? 26 : (Device.Idiom == TargetIdiom.Watch ? 30 : 22);
+					break;
 				case NamedSize.Default:
 				case NamedSize.Medium:
-					return baseSize + (baseSizeSpan * 2);
+					pt = Device.Idiom == TargetIdiom.TV ? 28 : (Device.Idiom == TargetIdiom.Watch ? 32 : 25);
+					break;
 				case NamedSize.Large:
-					return baseSize + (baseSizeSpan * 4);
+					pt = Device.Idiom == TargetIdiom.TV ? 84 : (Device.Idiom == TargetIdiom.Watch ? 36 : 31);
+					break;
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
+			return Forms.ConvertToDPFont(pt);
 		}
 
 		public void OpenUriAction(Uri uri)


### PR DESCRIPTION
### Description of Change ###

This PR includes :
 a) Set TargetIdom.Watch to Device in case of Tizen wearable profile
 b) Optimize font size and style for TargetIdiom.Watch

NamedSize  | Phone | TV | Wearable 
---| ---| ---|---
Micro | 19 pt | 24 pt | 24 pt
Small | 22 pt| 26 pt | 30 pt
Medium / Default | 25 pt | 28 pt | 32 pt
Large | 31 pt | 84 pt | 36 pt

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

`TargetIdiom.Watch` works well with Tizen wearable device (e.g. upcoming Samsung Gear S series)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
