### PR TITLE
[WPF] Fix bug : Xamarin.Forms WPF load local html throw ArgumentException with message "Relative URIs are not allowed"

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1864.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1864.cs
@@ -1,0 +1,28 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1864, "[WPF] Xamarin.Forms WPF load local html throw ArgumentException with message 'Relative URIs are not allowed'", PlatformAffected.WPF)]
+	public class Issue1864 : TestContentPage
+	{
+		protected override void Init()
+		{
+			WebView webView = new WebView();
+			var source = new HtmlWebViewSource()
+			{
+				Html = @"<html><body> <h1>Xamarin.Forms</h1> <p>Welcome to WebView.</p> </body> </html>"
+			};
+			webView.Source = source;
+			Content = webView;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -289,6 +289,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1665.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1707.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1864.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2104.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1908.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -147,6 +147,7 @@ namespace Xamarin.Forms.CustomAttributes
 		WinPhone = 1 << 2,
 		WinRT = 1 << 3,
 		UWP = 1 << 4,
+		WPF = 1 << 5,
 		All = ~0,
 		Default = 0
 	}

--- a/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
@@ -144,14 +144,17 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void WebBrowserOnNavigated(object sender, System.Windows.Navigation.NavigationEventArgs navigationEventArgs)
 		{
+			if (navigationEventArgs.Uri == null) return;
+
 			string url = navigationEventArgs.Uri.IsAbsoluteUri ? navigationEventArgs.Uri.AbsoluteUri : navigationEventArgs.Uri.OriginalString;
 			SendNavigated(new UrlWebViewSource { Url = url }, _eventState, WebNavigationResult.Success);
-
 			UpdateCanGoBackForward();
 		}
 
 		void WebBrowserOnNavigating(object sender, NavigatingCancelEventArgs navigatingEventArgs)
 		{
+			if (navigatingEventArgs.Uri == null) return;
+
 			string url = navigatingEventArgs.Uri.IsAbsoluteUri ? navigatingEventArgs.Uri.AbsoluteUri : navigatingEventArgs.Uri.OriginalString;
 			var args = new WebNavigatingEventArgs(_eventState, new UrlWebViewSource { Url = url }, url);
 
@@ -166,6 +169,8 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void WebBrowserOnNavigationFailed(object sender, NavigationFailedEventArgs navigationFailedEventArgs)
 		{
+			if (navigationFailedEventArgs.Uri == null) return;
+
 			string url = navigationFailedEventArgs.Uri.IsAbsoluteUri ? navigationFailedEventArgs.Uri.AbsoluteUri : navigationFailedEventArgs.Uri.OriginalString;
 			SendNavigated(new UrlWebViewSource { Url = url }, _eventState, WebNavigationResult.Failure);
 		}

--- a/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/WebViewRenderer.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.WPF
 	{
 		WebNavigationEvent _eventState;
 		bool _updating;
-		
+
 		protected override void OnElementChanged(ElementChangedEventArgs<WebView> e)
 		{
 			if (e.OldElement != null) // Clear old element event
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 			base.OnElementChanged(e);
 		}
-		
+
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
@@ -59,7 +59,7 @@ namespace Xamarin.Forms.Platform.WPF
 					Load();
 			}
 		}
-		
+
 		void Load()
 		{
 			if (Element.Source != null)
@@ -68,15 +68,12 @@ namespace Xamarin.Forms.Platform.WPF
 			UpdateCanGoBackForward();
 		}
 
-		public async void LoadHtml(string html, string baseUrl)
+		public void LoadHtml(string html, string baseUrl)
 		{
 			if (html == null)
 				return;
 
-			string fileName = string.Format("formslocal_{0}.html", DateTime.Now.Ticks);
-
-			await SaveToIsoStore(fileName, html);
-			Control.Navigate(new Uri(fileName, UriKind.Relative));
+			Control.NavigateToString(html);
 		}
 
 		public void LoadUrl(string url)
@@ -99,7 +96,7 @@ namespace Xamarin.Forms.Platform.WPF
 			var task = tcr.Task;
 
 			Device.BeginInvokeOnMainThread(() => {
-					tcr.SetResult((string)Control.InvokeScript("eval", new[] { script }));
+				tcr.SetResult((string)Control.InvokeScript("eval", new[] { script }));
 			});
 
 			return await task.ConfigureAwait(false);
@@ -126,16 +123,6 @@ namespace Xamarin.Forms.Platform.WPF
 			UpdateCanGoBackForward();
 		}
 
-		async Task SaveToIsoStore(string fileName, string html)
-		{
-			IIsolatedStorageFile store = Device.PlatformServices.GetUserStoreForApplication();
-			using (var file = await store.OpenFileAsync(fileName, FileMode.CreateNew, FileAccess.Write).ConfigureAwait(false))
-			{
-				byte[] bytes = Encoding.UTF8.GetBytes(html);
-				await file.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
-			}
-		}
-
 		void SendNavigated(UrlWebViewSource source, WebNavigationEvent evnt, WebNavigationResult result)
 		{
 			Console.WriteLine("SendNavigated : " + source.Url);
@@ -148,7 +135,7 @@ namespace Xamarin.Forms.Platform.WPF
 			UpdateCanGoBackForward();
 			_eventState = WebNavigationEvent.NewPage;
 		}
-		
+
 		void UpdateCanGoBackForward()
 		{
 			((IWebViewController)Element).CanGoBack = Control.CanGoBack;
@@ -157,10 +144,8 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void WebBrowserOnNavigated(object sender, System.Windows.Navigation.NavigationEventArgs navigationEventArgs)
 		{
-			Console.WriteLine("WebBrowserOnNavigated");
-
 			string url = navigationEventArgs.Uri.IsAbsoluteUri ? navigationEventArgs.Uri.AbsoluteUri : navigationEventArgs.Uri.OriginalString;
-		  	SendNavigated(new UrlWebViewSource { Url = url }, _eventState, WebNavigationResult.Success);
+			SendNavigated(new UrlWebViewSource { Url = url }, _eventState, WebNavigationResult.Success);
 
 			UpdateCanGoBackForward();
 		}
@@ -205,6 +190,7 @@ namespace Xamarin.Forms.Platform.WPF
 				if (Element != null)
 				{
 					Element.EvalRequested -= OnEvalRequested;
+					Element.EvaluateJavaScriptRequested -= OnEvaluateJavaScriptRequested;
 					Element.GoBackRequested -= OnGoBackRequested;
 					Element.GoForwardRequested -= OnGoForwardRequested;
 				}


### PR DESCRIPTION
### Description of Change ###

The original issue is Load local html with the following code will throw ArgumentException with message "Relative URIs are not allowed":

This PR fix this issue

### Bugs Fixed ###

fixes #1864

### API Changes ###

Add WPF in PlatformAffected enum (TestAttributes.cs)

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
