### PR TITLE
[Xaml[C]] properly parse nested markups

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2171.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2171.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Gh2171"
+             x:Name="this"
+             BindingContext="{local:Gh2171 Foo='foo', Binding={Binding Text, Source={x:Reference this}}, Bar='bar'}">
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2171.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2171.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh2171 : ContentPage
+	{
+		public Gh2171()
+		{
+			InitializeComponent();
+		}
+
+		public Gh2171(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void ParsingNestedMarkups(bool useCompiledXaml)
+			{
+				var layout = new Gh2171(useCompiledXaml);
+				var markup = layout.BindingContext as Gh2171Extension;
+				Assert.That(markup, Is.Not.Null);
+				Assert.That(markup.Foo, Is.EqualTo("foo"));
+				Assert.That(markup.Bar, Is.EqualTo("bar"));
+				Assert.That((markup.Binding as Binding).Path, Is.EqualTo("Text"));
+			}
+		}
+	}
+
+	public class Gh2171Extension : IMarkupExtension
+	{
+		public string Foo { get; set; }
+		public string Bar { get; set; }
+		public BindingBase Binding { get; set; }
+		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) => this;
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -594,6 +594,9 @@
     <Compile Include="Issues\Gh2130.xaml.cs">
       <DependentUpon>Gh2130.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh2171.xaml.cs">
+      <DependentUpon>Gh2171.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   
@@ -1071,6 +1074,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh2130.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh2171.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
+++ b/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
@@ -36,12 +36,12 @@ using System.Text;
 
 namespace Xamarin.Forms.Xaml
 {
-	internal abstract class MarkupExpressionParser
+	abstract class MarkupExpressionParser
 	{
 		public object ParseExpression(ref string expression, IServiceProvider serviceProvider)
 		{
 			if (serviceProvider == null)
-				throw new ArgumentNullException("serviceProvider");
+				throw new ArgumentNullException(nameof(serviceProvider));
 			if (expression.StartsWith("{}", StringComparison.Ordinal))
 				return expression.Substring(2);
 
@@ -130,6 +130,8 @@ namespace Xamarin.Forms.Xaml
 				remaining = remaining.TrimStart();
 
 				if (remaining.Length > 0 && remaining[0] == ',')
+					remaining = remaining.Substring(1);
+				else if (remaining.Length > 0 && remaining[0] == '}')
 					remaining = remaining.Substring(1);
 
 				str_value = value as string;


### PR DESCRIPTION
### Description of Change ###

[Xaml[C]] properly parse nested markups

don't stop parsing when the next char is `}`

### Bugs Fixed ###

- fixes #2171

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
