### PR TITLE
[Core] Centralizing visual state change checks and providing a method to override if users want to add/control state changes themselves

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
@@ -9,6 +9,8 @@ namespace Xamarin.Forms.Core.UnitTests
 	{
 		const string NormalStateName = "Normal";
 		const string InvalidStateName = "Invalid";
+		const string FocusedStateName = "Focused";
+		const string DisabledStateName = "Disabled";
 		const string CommonStatesName = "CommonStates";
 
 		static VisualStateGroupList CreateTestStateGroups()
@@ -17,9 +19,13 @@ namespace Xamarin.Forms.Core.UnitTests
 			var visualStateGroup = new VisualStateGroup { Name = CommonStatesName };
 			var normalState = new VisualState { Name = NormalStateName };
 			var invalidState = new VisualState { Name = InvalidStateName };
+			var focusedState = new VisualState { Name = FocusedStateName };
+			var disabledState = new VisualState { Name = DisabledStateName };
 
 			visualStateGroup.States.Add(normalState);
 			visualStateGroup.States.Add(invalidState);
+			visualStateGroup.States.Add(focusedState);
+			visualStateGroup.States.Add(disabledState);
 
 			stateGroups.Add(visualStateGroup);
 
@@ -172,9 +178,39 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			IList<VisualStateGroup> vsgs = CreateTestStateGroups();
 
-			var emptyStateName = new VisualState{Name = ""};
+			var emptyStateName = new VisualState { Name = "" };
 
 			Assert.Throws<InvalidOperationException>(() => vsgs[0].States.Add(emptyStateName));
+		}
+
+		[Test]
+		public void VerifyVisualStateChanges()
+		{
+			var label1 = new Label();
+			VisualStateManager.SetVisualStateGroups(label1, CreateTestStateGroups());
+
+			var groups1 = VisualStateManager.GetVisualStateGroups(label1);
+			Assert.That(groups1[0].CurrentState.Name, Is.EqualTo(NormalStateName));
+
+			label1.IsEnabled = false;
+
+			groups1 = VisualStateManager.GetVisualStateGroups(label1);
+			Assert.That(groups1[0].CurrentState.Name, Is.EqualTo(DisabledStateName));
+
+
+			label1.SetValue(VisualElement.IsFocusedPropertyKey, true);
+			groups1 = VisualStateManager.GetVisualStateGroups(label1);
+			Assert.That(groups1[0].CurrentState.Name, Is.EqualTo(DisabledStateName));
+
+			label1.IsEnabled = true;
+			groups1 = VisualStateManager.GetVisualStateGroups(label1);
+			Assert.That(groups1[0].CurrentState.Name, Is.EqualTo(FocusedStateName));
+
+
+			label1.SetValue(VisualElement.IsFocusedPropertyKey, false);
+			groups1 = VisualStateManager.GetVisualStateGroups(label1);
+			Assert.That(groups1[0].CurrentState.Name, Is.EqualTo(NormalStateName));
+
 		}
 	}
 }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -795,7 +795,7 @@ namespace Xamarin.Forms
 				focus(this, new FocusEventArgs(this, true));
 		}
 
-		protected virtual void ChangeVisualState()
+		protected internal virtual void ChangeVisualState()
 		{
 			if (!IsEnabled)
 			{

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty InputTransparentProperty = BindableProperty.Create("InputTransparent", typeof(bool), typeof(VisualElement), default(bool));
 
-		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool), 
+		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool),
 			typeof(VisualElement), true, propertyChanged: OnIsEnabledPropertyChanged);
 
 		static readonly BindablePropertyKey XPropertyKey = BindableProperty.CreateReadOnly("X", typeof(double), typeof(VisualElement), default(double));
@@ -89,7 +89,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty MinimumHeightRequestProperty = BindableProperty.Create("MinimumHeightRequest", typeof(double), typeof(VisualElement), -1d, propertyChanged: OnRequestChanged);
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static readonly BindablePropertyKey IsFocusedPropertyKey = BindableProperty.CreateReadOnly("IsFocused", 
+		public static readonly BindablePropertyKey IsFocusedPropertyKey = BindableProperty.CreateReadOnly("IsFocused",
 			typeof(bool), typeof(VisualElement), default(bool), propertyChanged: OnIsFocusedPropertyChanged);
 
 		public static readonly BindableProperty IsFocusedProperty = IsFocusedPropertyKey.BindableProperty;
@@ -278,15 +278,17 @@ namespace Xamarin.Forms
 			set { SetValue(StyleProperty, value); }
 		}
 
-		
+
 		[TypeConverter(typeof(ListStringTypeConverter))]
-		public IList<string> StyleClass {
+		public IList<string> StyleClass
+		{
 			get { return @class; }
 			set { @class = value; }
 		}
 
 		[TypeConverter(typeof(ListStringTypeConverter))]
-		public IList<string> @class {
+		public IList<string> @class
+		{
 			get { return _mergedStyle.StyleClass; }
 			set { _mergedStyle.StyleClass = value; }
 		}
@@ -455,7 +457,8 @@ namespace Xamarin.Forms
 
 		public ResourceDictionary Resources
 		{
-			get {
+			get
+			{
 				if (_resources != null)
 					return _resources;
 				_resources = new ResourceDictionary();
@@ -792,6 +795,22 @@ namespace Xamarin.Forms
 				focus(this, new FocusEventArgs(this, true));
 		}
 
+		protected virtual void ChangeVisualState()
+		{
+			if (!IsEnabled)
+			{
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Disabled);
+			}
+			else if (IsFocused)
+			{
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Focused);
+			}
+			else
+			{
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Normal);
+			}
+		}
+
 		static void FlowDirectionChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var self = bindable as IFlowDirectionController;
@@ -817,9 +836,7 @@ namespace Xamarin.Forms
 
 			var isEnabled = (bool)newValue;
 
-			VisualStateManager.GoToState(element, isEnabled 
-				? VisualStateManager.CommonStates.Normal 
-				: VisualStateManager.CommonStates.Disabled);
+			element.ChangeVisualState();
 		}
 
 		static void OnIsFocusedPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
@@ -841,9 +858,7 @@ namespace Xamarin.Forms
 				element.OnUnfocus();
 			}
 
-			VisualStateManager.GoToState(element, isFocused
-				? VisualStateManager.CommonStates.Focused
-				: VisualStateManager.CommonStates.Normal);
+			element.ChangeVisualState();
 		}
 
 		static void OnRequestChanged(BindableObject bindable, object oldvalue, object newvalue)
@@ -907,7 +922,8 @@ namespace Xamarin.Forms
 		{
 			public override object ConvertFromInvariantString(string value)
 			{
-				if (value != null) {
+				if (value != null)
+				{
 					if (value.Equals("true", StringComparison.OrdinalIgnoreCase))
 						return true;
 					if (value.Equals("visible", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
### Description of Change ###

Currently state changes apply in a very specific/narrow way when a property changes. This doesn't allow users to override and add their own states and it also doesn't take into account that you need to reassess all the properties before setting the state. For example when a control becomes enabled the state might need to go to focused and not directly to Normal

### API Changes ###

Added:
```C#
public partial class VisualElement
{
protected virtual void ChangeVisualState()
```
### Behavioral Changes ###

The only behavior change I can see is if something goes from disabled to enabled the state might go to Focused where as before it would just go to Normal.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
