### PR TITLE
[Android] Fix crash when TabbedPage is initialized to a tab > 0

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2035.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2035.cs
@@ -1,0 +1,34 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2035, "App crashes when setting CurrentPage on TabbedPage in ctor in 2.5.1pre1", PlatformAffected.Android)]
+	public class Issue2035 : TestTabbedPage 
+	{
+		const string Success = "Success";
+		protected override void Init()
+		{
+			Title = "Bug";
+			Children.Add(new ContentPage() { Title = "Page 1" });
+			Children.Add(new ContentPage() { Title = "Page 2", Content = new Label { Text = Success } });
+			Children.Add(new ContentPage() { Title = "Page 3" });
+			CurrentPage = Children[1];
+		}
+
+#if UITEST
+		[Test]
+		public void Issue2035Test()
+		{
+			RunningApp.WaitForElement (q => q.Marked (Success));
+			//if it doesn't crash, we're good.
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -343,6 +343,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1436.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1567.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1909.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2035.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1028.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			if(_previousPage != Element.CurrentPage)
 			{
-				_previousPage.SendDisappearing();
+				_previousPage?.SendDisappearing();
 				_previousPage = Element.CurrentPage;
 			}
 			Element.CurrentPage = Element.Children[position];


### PR DESCRIPTION
### Description of Change ###

Simply added a null check. 🤦‍♀️ 

### Bugs Fixed ###

- fixes #2035 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of 15-5 at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
