### PR TITLE
[Design] Allow numeric values for FontSize

### DIFF
--- a/Xamarin.Forms.Core.Design/AttributeTableBuilder.cs
+++ b/Xamarin.Forms.Core.Design/AttributeTableBuilder.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Core.Design
 			foreach (var fontElement in fontElements) {
 				AddCallback (fontElement, builder => builder.AddCustomAttributes (
 					"FontSize",
-					new System.ComponentModel.TypeConverterAttribute (typeof (EnumConverter<NamedSize>))));
+					new System.ComponentModel.TypeConverterAttribute (typeof (NonExclusiveEnumConverter<NamedSize>))));
 			}
 
 			// TODO: OnPlatform/OnIdiom

--- a/Xamarin.Forms.Core.Design/NonExclusiveEnumConverter.cs
+++ b/Xamarin.Forms.Core.Design/NonExclusiveEnumConverter.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel;
+
+namespace Xamarin.Forms.Core.Design
+{
+	internal class NonExclusiveEnumConverter<T> : EnumConverter<T>
+	{
+		public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+		{
+			return false;
+		}
+	}
+}

--- a/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
+++ b/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
@@ -51,6 +51,7 @@
   <ItemGroup Condition=" '$(OS)' != 'Unix' ">
     <Compile Include="AttributeTableBuilder.cs" />
     <Compile Include="EnumConverter.cs" />
+    <Compile Include="NonExclusiveEnumConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegisterMetadata.cs" />
   </ItemGroup>


### PR DESCRIPTION
This ensures that intellisense in Visual Studio
does not report an error when numeric values are
put in this property instead of the 'string' values
like 'Small', 'Large' etc

NOTE: This might need additional niceing up to ensure that actual invalid values are still marked as invalid.