### PR TITLE
[msbuild] setup inputs and outputs for XamlC target

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -85,10 +85,7 @@
 		</CompileDependsOn>
 	</PropertyGroup>
 
-	<Target Name="XamlC" AfterTargets="AfterCompile" Condition="'$(_XamlCAlreadyExecuted)'!='true'">
-		<PropertyGroup>
-			<_XamlCAlreadyExecuted>true</_XamlCAlreadyExecuted>
-		</PropertyGroup>
+	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp">
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
@@ -96,6 +93,9 @@
 			DebugSymbols = "$(DebugSymbols)"
 			DebugType = "$(DebugType)"
 			KeepXamlResources = "$(XFKeepXamlResources)" />
+		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True">
+			<Output TaskParameter="TouchedFiles" ItemName="FileWrites"/>
+		</Touch>
 	</Target>
 
 	<!-- CssG -->


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/jonathanpeppers/XamarinAndroidBuildTimes

After doing a profiling/review of Xamarin.Android project build times, I
noticed that the `XamlC` target was running on every build no matter
what. The project I used was the Forms Master/Detail template from VS
2017 15.6.4.

In my test repo, I was timing the following situations:
1. Completely clean/fresh build
2. Build again, no changes
3. Change C#, build again
4. Change `AndroidResource` XML, build again

In all cases `XamlC` was running, due to the task not having setup
proper inputs and outputs for the MSBuild target. Thinking about it, it
seemed like we could skip `XamlC` as long as the input assembly did not
change, such as case no. 2 or no. 4.

Changes to the `XamlC` target:
- Setup `$(IntermediateOutputPath)$(TargetFileName)` (the assembly) as input
- Setup a `XamlC.stamp` file as an output
- `<Touch />` the `XamlC.stamp` file after running the `XamlCTask`
- Add to the `FileWrites` MSBuild item, so that the `IncrementalClean`
target doesn't delete the stamp file
- Removed the `_XamlCAlreadyExecuted` property as it should not be 
needed after adding inputs and outputs

On my Windows machine, this improved the following build times for cases:
1. same (XamlC should run)
2. 3.685s -> 2.887s
3. same (XamlC should run) (would also be same as XAML changing)
4. 12.126s -> 11.214s

Since this was basically an empty project, I suspect the improvements
would be more drastic for apps with lots of XAML and using `XamlC`.

### Tests? ###

I didn't see any project where MSBuild-related tests live. Might be something needed? not sure how many MSBuild-related bugs are happening for XF.

Instead I tested the change by modifying `~\.nuget\packages\xamarin.forms\2.5.0.280555\build\netstandard1.0\Xamarin.Forms.targets` and saving MSBuild binary logs. Download [here](https://www.dropbox.com/s/6ndub7mp9073ekz/FormsBuildTime.zip?dl=0).

You can find the _before_ logs [here](https://github.com/jonathanpeppers/XamarinAndroidBuildTimes/releases).

### Bugs Fixed ###

n/a

### API Changes ###

n/a

### Behavioral Changes ###

`XamlC` should only run during a build if the input assembly has changed.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
