### PR TITLE
[iOS] Grouped ListView will no longer crash when its ItemSource is cleared

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45125.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45125.cs
@@ -87,16 +87,15 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
+			_status.Text = _groupsAppearing.Text = _groupsDisappearing.Text = "";
+			_Appearing = _Disappearing = 0;
+			_scroll.SetScrolledPosition(0, 0);
+
 			InitTest(ListViewCachingStrategy.RecycleElement, true);
 		}
 
 		void InitTest(ListViewCachingStrategy cachingStrategy, bool useTemplate)
 		{
-			_scroll.SetScrolledPosition(0, 0);
-
-			_status.Text = _groupsAppearing.Text = _groupsDisappearing.Text = "";
-			_Appearing = _Disappearing = 0;
-
 			List<GroupedData> groups = GetGroups();
 
 			var listView = new ListView(cachingStrategy)
@@ -147,6 +146,10 @@ namespace Xamarin.Forms.Controls.Issues
 
 		void NextButton_Clicked(object sender, EventArgs e)
 		{
+			_status.Text = _groupsAppearing.Text = _groupsDisappearing.Text = "";
+			_Appearing = _Disappearing = 0;
+			_scroll.SetScrolledPosition(0, 0);
+
 			switch (_TestNumber)
 			{
 				default:

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GroupListViewHeaderIndexOutOfRange.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GroupListViewHeaderIndexOutOfRange.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 5955, "Group ListView Crashes when ItemSource is Cleared", PlatformAffected.iOS)]
+	public class GroupListViewHeaderIndexOutOfRange : TestContentPage
+	{
+		const string ButtonId = "button";
+
+		public static ObservableCollection<SamplePack> Samples { get; set; }
+
+		public static ObservableCollection<Grouping<string, SamplePack>> Testing { get; set; }
+
+		public static void ResetList()
+		{
+			Testing.Clear();
+		}
+
+		protected override void Init()
+		{
+			Samples = new ObservableCollection<SamplePack>
+			{
+				new SamplePack {Info = "1"},
+				new SamplePack {Info = "2"},
+				new SamplePack {Info = "3"}
+			};
+
+			var sorted = from sampleData in Samples
+						 orderby sampleData.Info
+						 group sampleData by sampleData.Info
+						 into sampleGroup
+						 select new Grouping<string, SamplePack>(sampleGroup.Key, sampleGroup);
+
+			Testing = new ObservableCollection<Grouping<string, SamplePack>>(sorted);
+
+			var groupLabel = new Label { FontSize = 18, TextColor = Color.FromHex("#1f1f1f"), HorizontalOptions = LayoutOptions.Start, HorizontalTextAlignment = TextAlignment.Start };
+			groupLabel.SetBinding(Label.TextProperty, new Binding("Key", stringFormat: "{0} Music"));
+
+			var itemLabel = new Label { TextColor = Color.Black };
+			itemLabel.SetBinding(Label.TextProperty, new Binding("Info"));
+
+			ListView TestingList = new ListView()
+			{
+				IsPullToRefreshEnabled = true,
+				IsGroupingEnabled = true,
+				GroupHeaderTemplate = new DataTemplate(() => new ViewCell
+				{
+					Height = 283,
+					View = new StackLayout
+					{
+						Spacing = 0,
+						Padding = 10,
+						BackgroundColor = Color.Blue,
+						Children = {
+							new StackLayout{ Padding=5, BackgroundColor=Color.White, HeightRequest=30,  Children = { groupLabel } }
+						}
+					}
+				}),
+				ItemTemplate = new DataTemplate(() => new ViewCell
+				{
+					View = itemLabel
+				})
+			};
+
+			TestingList.ItemsSource = Testing;
+
+			TestingList.BindingContext = Testing;
+
+			TestingList.RefreshCommand = new Command(() =>
+
+			{
+				TestingList.IsRefreshing = true;
+
+				ResetList();
+
+				TestingList.IsRefreshing = false;
+			});
+
+			Button button = new Button { Text = "Click here to cause crash. Pass if no crash!", Command = new Command(() => ResetList()), AutomationId = ButtonId };
+			Content = new StackLayout { Children = { button, TestingList } };
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Grouping<K, T> : ObservableCollection<T>
+		{
+			public Grouping(K key, IEnumerable<T> items)
+			{
+				Key = key;
+
+				foreach (var item in items)
+				{
+					Items.Add(item);
+				}
+			}
+
+			public K Key { get; }
+		}
+
+		[Preserve(AllMembers = true)]
+		public class SamplePack
+		{
+			public string Info { get; set; }
+		}
+
+#if UITEST
+		[Test]
+		public void GroupListViewHeaderIndexOutOfRangeTest()
+		{
+			RunningApp.WaitForElement(q => q.Marked(ButtonId));
+			RunningApp.Tap(q => q.Marked(ButtonId));
+			RunningApp.WaitForElement(q => q.Marked(ButtonId));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -238,6 +238,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59457.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GroupListViewHeaderIndexOutOfRange.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1975.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1601.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1717.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -967,10 +967,10 @@ namespace Xamarin.Forms.Platform.iOS
 				if (cell.HasContextActions)
 					throw new NotSupportedException("Header cells do not support context actions");
 
-					var renderer = (CellRenderer)Internals.Registrar.Registered.GetHandlerForObject<IRegisterable>(cell);
+				var renderer = (CellRenderer)Internals.Registrar.Registered.GetHandlerForObject<IRegisterable>(cell);
 
-					view = new HeaderWrapperView();
-					view.AddSubview(renderer.GetCell(cell, null, tableView));
+				view = new HeaderWrapperView { Cell = cell };
+				view.AddSubview(renderer.GetCell(cell, null, tableView));
 
 				return view;
 			}
@@ -980,8 +980,11 @@ namespace Xamarin.Forms.Platform.iOS
 				if (!List.IsGroupingEnabled)
 					return;
 
-				var cell = TemplatedItemsView.TemplatedItems[(int)section];
-				cell.SendDisappearing();
+				if (headerView is HeaderWrapperView wrapper)
+				{
+					wrapper.Cell?.SendDisappearing();
+					wrapper.Cell = null;
+				}
 			}
 
 			public override nint NumberOfSections(UITableView tableView)
@@ -1254,6 +1257,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 	internal class HeaderWrapperView : UIView
 	{
+		public Cell Cell { get; set; }
 		public override void LayoutSubviews()
 		{
 			base.LayoutSubviews();


### PR DESCRIPTION
### Description of Change ###

Fixes issue where resetting a Grouped ListView on iOS can result in a crash due to an order of operations issue on the TIL. The best fix as always is to move the data into the container of the Cell itself and thus not have to touch the TIL.

### Bugs Fixed ###

Bug reported on Twitter and modified test 45125 to actually cover this case so we still have coverage.

### API Changes ###

None

### Behavioral Changes ###

Less crashy crash

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
