### PR TITLE
[UI Tests] Add missing preserve attributes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43161.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43161.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Controls.Issues
 		const string ListView2 = "Accessory with RecycleElement";
 		const string ListView3 = "Accessory with RetainElement";
 
+		[Preserve(AllMembers = true)]
 		public class AccessoryViewCell : ViewCell
 		{
 			public AccessoryViewCell()
@@ -29,6 +30,7 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
+		[Preserve(AllMembers = true)]
 		public class AccessoryViewCellWithContextActions : AccessoryViewCell
 		{
 			public AccessoryViewCellWithContextActions()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45284.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45284.xaml.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 			model.Change();
 		}
 	}
-
+	[Preserve(AllMembers = true)]
 	public class Bugzilla45284Model : INotifyPropertyChanged
 	{
 		public List<Bugzilla45284TabModel> Tabs => new List<Bugzilla45284TabModel> { 
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Controls.Issues
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Tabs)));
 		}
 	}
-
+	[Preserve(AllMembers = true)]
 	public class Bugzilla45284TabModel
 	{
 		public string Title { get; set; } = "Title";


### PR DESCRIPTION
### Description of Change ###

These tests do not render properly when the linker is enabled on Android. Adding `Preserve` attributes to fix that.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of 3.0.0 at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
