### PR TITLE
[Android] Disable long press detection so it doesn't prevent pans in TapAndPanGestureDetector

### DIFF
--- a/Xamarin.Forms.Platform.Android/GestureManager.cs
+++ b/Xamarin.Forms.Platform.Android/GestureManager.cs
@@ -63,10 +63,23 @@ namespace Xamarin.Forms.Platform.Android
 
 		public class TapAndPanGestureDetector : GestureDetector
 		{
-			InnerGestureListener _listener;
+			readonly InnerGestureListener _listener;
 			public TapAndPanGestureDetector(Context context, InnerGestureListener listener) : base(context, listener)
 			{
 				_listener = listener;
+				InitializeLongPressSettings();
+			}
+
+			void InitializeLongPressSettings()
+			{
+				// Right now this just disables long press, since we don't support a long press gesture
+				// in Forms. If we ever do, we'll need to selectively enable it, probably by hooking into the 
+				// InnerGestureListener and listening for the addition of any long press gesture recognizers.
+				// (since a long press will prevent a pan gesture from starting, we can't just leave support for it 
+				// on by default).
+				// Also, since the property is virtual we shouldn't just set it from the constructor.
+
+				IsLongpressEnabled = false;
 			}
 
 			public override bool OnTouchEvent(MotionEvent ev)


### PR DESCRIPTION
### Description of Change ###

Disables long press detection in TapAndPanGestureDetector; the long press firing prevents the scroll from initiating.

### Bugs Fixed ###

- fixes #2324 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
