### PR TITLE
[iOS, UWP] Explicitly dispose of children renderers that belong to Packager

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/AttachedStateEffectRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/AttachedStateEffectRenderer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Linq;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Controls.Effects;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportEffect(typeof(AttachedStateEffectRenderer), AttachedStateEffect.EffectName)]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class AttachedStateEffectRenderer : PlatformEffect
+	{
+		public AttachedStateEffect MyEffect { get; private set; }
+
+		protected override void OnAttached()
+		{
+			MyEffect = Element.Effects.OfType<AttachedStateEffect>().First();
+			MyEffect.Attached(Element);
+		}
+
+		protected override void OnDetached()
+		{
+			MyEffect.Detached(Element);
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -188,6 +188,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Activity1.cs" />
+    <Compile Include="AttachedStateEffectRenderer.cs" />
     <Compile Include="BorderEffect.cs" />
     <Compile Include="BrokenNativeControl.cs" />
     <Compile Include="CacheService.cs" />

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/AttachedStateEffectRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/AttachedStateEffectRenderer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Linq;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Controls.Effects;
+using Xamarin.Forms.Platform.UWP;
+
+[assembly: ExportEffect(typeof(AttachedStateEffectRenderer), AttachedStateEffect.EffectName)]
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	public class AttachedStateEffectRenderer : PlatformEffect
+	{
+		public AttachedStateEffect MyEffect { get; private set; }
+
+		protected override void OnAttached()
+		{
+			MyEffect = Element.Effects.OfType<AttachedStateEffect>().First();
+			MyEffect.Attached(Element);
+		}
+
+		protected override void OnDetached()
+		{
+			MyEffect.Detached(Element);
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -124,6 +124,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AttachedStateEffectRenderer.cs" />
     <Compile Include="BorderEffect.cs" />
     <Compile Include="DisposePageRenderer.cs" />
     <Compile Include="_2489CustomRenderer.cs" />

--- a/Xamarin.Forms.ControlGallery.iOS/AttachedStateEffectRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AttachedStateEffectRenderer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Linq;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Controls.Effects;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportEffect(typeof(AttachedStateEffectRenderer), AttachedStateEffect.EffectName)]
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class AttachedStateEffectRenderer : PlatformEffect
+	{
+		public AttachedStateEffect MyEffect { get; private set; }
+
+		protected override void OnAttached()
+		{
+			MyEffect = Element.Effects.OfType<AttachedStateEffect>().First();
+			MyEffect.Attached(Element);
+
+		}
+
+		protected override void OnDetached()
+		{
+			MyEffect.Detached(Element);
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -103,6 +103,7 @@
     <AppExtensionDebugBundleId />
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AttachedStateEffectRenderer.cs" />
     <Compile Include="BrokenImageSourceHandler.cs" />
     <Compile Include="BrokenNativeControl.cs" />
     <Compile Include="CustomRenderer40251.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects/AttachedStateEffect.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects/AttachedStateEffect.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Effects
+{
+
+	[Preserve(AllMembers = true)]
+	public class AttachedStateEffect : RoutingEffect
+	{
+		public const string EffectName = "AttachedStateEffect";
+		public string ElementIdentifier { get; private set; }
+		public AttachedState State { get; private set; } = AttachedState.Unknown;
+		public event EventHandler StateChanged;
+
+		public AttachedStateEffect() : base($"{Issues.Effects.ResolutionGroupName}.{EffectName}") { }
+
+		public AttachedStateEffect(Element element) : this()
+		{
+			ElementIdentifier = element.AutomationId ?? element.ClassId;
+		}
+
+		public void Attached(Element Element)
+		{
+			ElementIdentifier = Element.AutomationId ?? Element.ClassId;
+
+			if (State != AttachedStateEffect.AttachedState.Unknown)
+			{
+				throw new InvalidOperationException($"Invalid State: {State} expected {AttachedStateEffect.AttachedState.Unknown}");
+			}
+
+			State = AttachedStateEffect.AttachedState.Attached;
+			StateChanged?.Invoke(this, EventArgs.Empty);
+		}
+
+		public void Detached(Element Element)
+		{
+			if (State != AttachedStateEffect.AttachedState.Attached)
+			{
+				throw new InvalidOperationException($"Invalid State: {State} expected {AttachedStateEffect.AttachedState.Attached}");
+			}
+
+			State = AttachedStateEffect.AttachedState.Detached;
+			StateChanged?.Invoke(this, EventArgs.Empty);
+		}
+
+		public enum AttachedState
+		{
+			Unknown,
+			Attached,
+			Detached
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects/AttachedStateEffectList.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects/AttachedStateEffectList.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Threading.Tasks;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Effects
+{
+	[Preserve(AllMembers = true)]
+	public class AttachedStateEffectList : ObservableCollection<AttachedStateEffect>
+	{
+		public event EventHandler AllEventsAttached;
+		public event EventHandler AllEventsDetached;
+
+		public AttachedStateEffectList()
+		{
+
+		}
+
+		public void Add(Element element)
+		{
+			var effect = new AttachedStateEffect(element);
+			element.Effects.Add(effect);
+			this.Add(effect);
+		}
+
+		protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+		{
+			base.OnCollectionChanged(e);
+			if (e.NewItems != null)
+			{
+				foreach (AttachedStateEffect item in e.NewItems)
+				{
+					item.StateChanged += AttachedStateEffectStateChanged;
+				}
+			}
+
+			if (e.OldItems != null)
+			{
+				foreach (AttachedStateEffect item in e.OldItems)
+				{
+					item.StateChanged -= AttachedStateEffectStateChanged;
+				}
+
+			}
+		}
+
+		private async void AttachedStateEffectStateChanged(object sender, EventArgs e)
+		{
+			if (Count == 0) return;
+
+			bool allAttached = true;
+			bool allDetached = true;
+			foreach (AttachedStateEffect item in this)
+			{
+				allAttached &= item.State == AttachedStateEffect.AttachedState.Attached;
+				allDetached &= item.State == AttachedStateEffect.AttachedState.Detached;
+			}
+
+			if (allAttached)
+			{
+				await Task.Delay(10);
+				AllEventsAttached?.Invoke(this, EventArgs.Empty);
+			}
+
+			if (allDetached)
+			{
+				await Task.Delay(10);
+				AllEventsDetached?.Invoke(this, EventArgs.Empty);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2399.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2399.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using Xamarin.Forms.Controls.Effects;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2399, "Label Renderer Dispose never called")]
+	public class Issue2399 : TestNavigationPage
+	{
+		static AttachedStateEffectList AttachedStateEffects = new AttachedStateEffectList();
+		Label AllEffectsHaveDetached;
+		protected override void Init()
+		{
+			AllEffectsHaveDetached = new Label()
+			{
+				AutomationId = "AllEventsHaveDetached",
+				Text = "If this text doesn't change then all effects haven't detached"
+			};
+
+			var newPage = new ContentPage
+			{
+				Content =
+					new StackLayout()
+					{
+						Children =
+						{
+							new Button
+							{
+								Text = "Show New ListView",
+								Command = new Command(async o => await Navigation.PushAsync(new ListPage())),
+							},
+
+							new Button
+							{
+								Text = "Garbage Collection Things",
+								Command = new Command(() =>
+								{
+									GC.Collect();
+									GC.WaitForPendingFinalizers();
+									AttachedStateEffects.Clear();
+								}),
+							},
+							AllEffectsHaveDetached
+						}
+					},
+				AutomationId = "ContentPage"
+
+			};
+
+			AttachedStateEffects.AllEventsAttached += OnAllEventsAttached;
+			AttachedStateEffects.AllEventsDetached += OnAllEventsDetached;
+
+			var listPage = new ListPage();
+			Navigation.PushAsync(listPage);
+			Navigation.InsertPageBefore(newPage, listPage);
+		}
+
+		async void OnAllEventsAttached(object sender, EventArgs args)
+		{
+			AttachedStateEffects.AllEventsAttached -= OnAllEventsAttached;
+			// needed otherwise UWP crashes
+			await Task.Delay(100);
+			await Navigation.PopAsync();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+
+		void OnAllEventsDetached(object sender, EventArgs args)
+		{
+			AttachedStateEffects.Clear();
+			AttachedStateEffects.AllEventsDetached -= OnAllEventsDetached;
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			AllEffectsHaveDetached.Text = "Success";
+		}
+
+		[Preserve(AllMembers = true)]
+		public class ListPage : ContentPage
+		{
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+			}
+
+			public ListPage()
+			{
+				AutomationId = "ListPage";
+				Content = new ListView()
+				{
+					ItemTemplate = new DataTemplate(() => new Cell()),
+					ItemsSource = Enumerable.Range(0, 1),
+				};
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		class Cell : ViewCell
+		{
+			string guid = Guid.NewGuid().ToString();
+
+			public Cell()
+			{
+				AutomationId = "ViewCell";
+				Console.WriteLine("Constructor " + guid);
+				var internalLabel = new Label { Text = guid, AutomationId = "Label" };
+
+				AttachedStateEffects.Add(internalLabel);
+
+				View = new StackLayout
+				{
+					AutomationId = "StackLayout",
+					Children =
+					{
+						new ContentView
+						{
+							AutomationId = "ContentView",
+							Content = internalLabel,
+						}
+					}
+				};
+
+				AttachedStateEffects.Add(View);
+				AttachedStateEffects.Add((View as StackLayout).Children[0]);
+			}
+		}
+
+#if UITEST && !__ANDROID__
+		[Test]
+		public void WaitForAllEffectsToDetach()
+		{
+			RunningApp.WaitForElement(q => q.Text("Success"));
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -237,6 +237,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59248.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59457.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffect.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1677.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1801.cs" />
@@ -709,6 +711,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1733.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1583_1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1323.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2399.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				if (List == null)
 				{
-					List = new WListView 
+					List = new WListView
 					{
 						IsSynchronizedWithCurrentItem = false,
 						ItemTemplate = (Windows.UI.Xaml.DataTemplate)WApp.Current.Resources["CellTemplate"],
@@ -147,6 +147,11 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if (List != null)
 				{
+					foreach (ViewToRendererConverter.WrapperControl wrapperControl in FindDescendants<ViewToRendererConverter.WrapperControl>(List))
+					{
+						wrapperControl.CleanUp();
+					}
+
 					if (_subscribedToTapped)
 					{
 						_subscribedToTapped = false;
@@ -352,7 +357,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (viewer == null)
 			{
 				RoutedEventHandler loadedHandler = null;
-				loadedHandler = async (o, e) => 
+				loadedHandler = async (o, e) =>
 				{
 					List.Loaded -= loadedHandler;
 
@@ -545,7 +550,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				var templatedItems = TemplatedItemsView.TemplatedItems;
 				var selectedItemIndex = templatedItems.GetGlobalIndexOfItem(e.ClickedItem);
-				
+
 				OnListItemClicked(selectedItemIndex);
 			}
 		}

--- a/Xamarin.Forms.Platform.UAP/ViewToRendererConverter.cs
+++ b/Xamarin.Forms.Platform.UAP/ViewToRendererConverter.cs
@@ -31,11 +31,13 @@ namespace Xamarin.Forms.Platform.UWP
 			throw new NotSupportedException();
 		}
 
-		class WrapperControl : Panel
+		internal class WrapperControl : Panel
 		{
 			readonly View _view;
 
 			FrameworkElement FrameworkElement { get; }
+
+			internal void CleanUp() => _view?.Cleanup();
 
 			public WrapperControl(View view)
 			{
@@ -91,10 +93,10 @@ namespace Xamarin.Forms.Platform.UWP
 					result = new Windows.Foundation.Size(request.Width, request.Height);
 				}
 
-				_view.Layout(new Rectangle(0, 0, result.Width, result.Height)); 
+				_view.Layout(new Rectangle(0, 0, result.Width, result.Height));
 
 				FrameworkElement?.Measure(availableSize);
-				
+
 				return result;
 			}
 		}

--- a/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
@@ -52,6 +52,15 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_disposed = true;
 
+			if (ElementController != null)
+			{
+				for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
+				{
+					var child = ElementController.LogicalChildren[i] as VisualElement;
+					child?.Cleanup();
+				}
+			}
+
 			VisualElement element = _renderer.Element;
 			if (element != null)
 			{

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -54,6 +54,22 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (disposing)
 			{
+				if (ElementController != null)
+				{
+					for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
+					{
+						var child = ElementController.LogicalChildren[i] as VisualElement;
+						if (child == null)
+							continue;
+
+						var childRenderer = Platform.GetRenderer(child);
+						if (childRenderer == null)
+							continue;
+
+						childRenderer.Dispose();
+					}
+				}
+
 				SetElement(_element, null);
 				if (Renderer != null)
 				{
@@ -71,11 +87,14 @@ namespace Xamarin.Forms.Platform.MacOS
 				return;
 			var reference = Guid.NewGuid().ToString();
 			Performance.Start(reference);
-			if (CompressedLayout.GetIsHeadless(view)) {
+			if (CompressedLayout.GetIsHeadless(view))
+			{
 				var packager = new VisualElementPackager(Renderer, view);
 				view.IsPlatformEnabled = true;
 				packager.Load();
-			} else {
+			}
+			else
+			{
 				var viewRenderer = Platform.CreateRenderer(view);
 				Platform.SetRenderer(view, viewRenderer);
 
@@ -100,6 +119,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (Renderer.ViewController != null && viewRenderer.ViewController != null)
 				viewRenderer.ViewController.RemoveFromParentViewController();
+
+			viewRenderer.Dispose();
 		}
 
 		void EnsureChildrenOrder()


### PR DESCRIPTION
### Description of Change ###

#### iOS
Added code to VisualElementPackager to dispose of children. Renderers typically create cycle references due to watching the events of the Elements they represent

Renderer => HasElement => Wires it self to events that element owns => Element has Renderer
This causes the Renderers to not finalize because there's a reference cycle

#### UWP
When a ListViewRenderer is disposed nothing was trickling down that dispose operation to the cells/renderers inside the ListView.   Code was added to  Cleanup all the cells of a listview as well as disposing of children in UWP's version of a VisualElementPackager

### Bugs Fixed ###

- fixes #2399

### API Changes ###

None


### Behavioral Changes ###
Dispose is now going to be called on Renderers where it wasn't being called before. If users were  depending on this or have code in their dispose that's wrong then this change will effect those situations. 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense


