### PR TITLE
[UWP] Restore ShowAsyncQueue method for dialogs

### DIFF
--- a/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
@@ -276,7 +276,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 	// refer to http://stackoverflow.com/questions/29209954/multiple-messagedialog-app-crash for why this is used
 	// in order to allow for multiple MessageDialogs, or a crash occurs otherwise
-	public static class MessageDialogExtensions
+	internal static class MessageDialogExtensions
 	{
 		static TaskCompletionSource<ContentDialog> s_currentDialogShowRequest;
 


### PR DESCRIPTION
### Description of Change ###

This problem was originally fixed in https://github.com/xamarin/Xamarin.Forms/pull/347, but the fix was lost somewhere along the way. This change restores the method and updates it to work with the changes from https://github.com/xamarin/Xamarin.Forms/pull/881.

### Bugs Fixed ###

- fixes #2369 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
