### PR TITLE
add debug type full property to control gallery netstandard library so break points are hit

### DIFF
--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -12,6 +12,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429</NoWarn>
+    <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>TRACE;APP</DefineConstants>


### PR DESCRIPTION
https://developercommunity.visualstudio.com/content/problem/29331/pdbs-are-not-generated-when-building-a-uwp-app-tha.html

Adding debugtype pdbonly or full to the NetStandard library causes the break points to start working in the Control Gallery project.

Reading around I'm still not quite clear whether this is a tooling bug or expected behavior 