### PR TITLE
[UWP] Only display one alert at a time

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43469.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43469.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Controls
 	{
 		protected override void Init()
 		{
-			var button = new Button { Text = "Click to call DisplayAlert twice" };
+			var button = new Button { Text = "Click to call DisplayAlert three times" };
 
 			button.Clicked += (sender, args) =>
 			{
@@ -28,6 +28,11 @@ namespace Xamarin.Forms.Controls
 				Device.BeginInvokeOnMainThread(new Action(async () =>
 				{
 					await DisplayAlert("Second", "Text", "Cancel");
+				}));
+
+				Device.BeginInvokeOnMainThread(new Action(async () =>
+				{
+					await DisplayAlert("Three", "Text", "Cancel");
 				}));
 			};
 

--- a/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (options.Accept != null)
 				alertDialog.PrimaryButtonText = options.Accept;
 
-			if (s_currentAlert != null)
+			while (s_currentAlert != null)
 			{
 				await s_currentAlert;
 			}

--- a/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Platform.UWP
 	public abstract partial class Platform
 	{
 		internal static StatusBar MobileStatusBar => ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar") ? StatusBar.GetForCurrentView() : null;
+		static Task<bool> s_currentAlert;
 
 		IToolbarProvider _toolbarProvider;
 
@@ -102,12 +103,21 @@ namespace Xamarin.Forms.Platform.UWP
 			if (options.Accept != null)
 				alertDialog.PrimaryButtonText = options.Accept;
 
-			ContentDialogResult result = await alertDialog.ShowAsync();
+			if (s_currentAlert != null)
+			{
+				await s_currentAlert;
+			}
 
-			if (result == ContentDialogResult.Secondary)
-				options.SetResult(false);
-			else if (result == ContentDialogResult.Primary)
-				options.SetResult(true);
+			s_currentAlert = ShowAlert(alertDialog);
+			options.SetResult(await s_currentAlert);
+			s_currentAlert = null;
+		}
+
+		static async Task<bool> ShowAlert(ContentDialog alert)
+		{
+			ContentDialogResult result = await alert.ShowAsync();
+
+			return result == ContentDialogResult.Primary;
 		}
 
 		void ClearCommandBar()


### PR DESCRIPTION
### Description of Change ###

UWP cannot display multiple Alerts at one time, so this change forces new Alerts to wait until the current Alert is finished.

### Bugs Fixed ###

- fixes #2369 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
