### PR TITLE
[iOS] Picker IsFocused not being set back to false if nothing in picker was selected

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -39,7 +39,6 @@ namespace Xamarin.Forms.ControlGallery.Android
 			//Window.AddFlags(WindowManagerFlags.Fullscreen | WindowManagerFlags.TurnScreenOn);
 
 			base.OnCreate(bundle);
-			
 
 #if TEST_EXPERIMENTAL_RENDERERS
 			Forms.SetFlags("FastRenderers_Experimental");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2339.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2339.cs
@@ -2,15 +2,18 @@
 using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+#if UITEST
+using NUnit.Framework;
+#endif
 
 namespace Xamarin.Forms.Controls
 {
 	[Preserve (AllMembers=true)]
-	[Issue (IssueTracker.Github, 2339, "Picker not shown when .Focus() is called", PlatformAffected.WinPhone)]
-	public class Issue2339 : ContentPage
+	[Issue (IssueTracker.Github, 2339, "Picker not shown when .Focus() is called")]
+	public class Issue2339 : TestContentPage
 	{
-		public Issue2339 ()
-		{
+		protected override void Init()
+		{ 
 			var picker = new Picker { Items = {"One", "Two", "Three"} };
 			var pickerBtn = new Button {
 				Text = "Click me to call .Focus on Picker"
@@ -63,5 +66,25 @@ namespace Xamarin.Forms.Controls
 				}
 			};
 		}
+
+
+#if UITEST
+		[Test]
+#if __WINDOWS__
+		[Ignore("Focus Behavior is different on UWP")]
+#endif
+		public void Issue2339_FocusAndUnFocusMultipleTimes ()
+		{
+			RunningApp.WaitForElement("btnFocus");
+			RunningApp.Tap (c => c.Marked ("btnFocus"));
+			RunningApp.WaitForElement(cw => cw.Marked("Picker Focused: 1"));
+			RunningApp.Tap(c => c.Marked("btnUnFocus"));  
+			RunningApp.WaitForElement(cw => cw.Marked("Picker UnFocused: 1")); 
+			RunningApp.Tap (c => c.Marked ("btnFocus"));
+			RunningApp.WaitForElement(cw => cw.Marked("Picker Focused: 2"));
+			RunningApp.Tap(c => c.Marked("btnUnFocus"));  
+			RunningApp.WaitForElement(cw => cw.Marked("Picker UnFocused: 2")); 
+		} 
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2339.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2339.cs
@@ -6,37 +6,45 @@ using Xamarin.Forms.Internals;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
-	[Preserve (AllMembers=true)]
-	[Issue (IssueTracker.Github, 2339, "Picker not shown when .Focus() is called")]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2339, "Picker not shown when .Focus() is called")]
 	public class Issue2339 : TestContentPage
 	{
 		protected override void Init()
-		{ 
-			var picker = new Picker { Items = {"One", "Two", "Three"} };
-			var pickerBtn = new Button {
-				Text = "Click me to call .Focus on Picker"
+		{
+			var picker = new Picker { Items = { "One", "Two", "Three" } };
+			var pickerBtn = new Button
+			{
+				Text = "Click me to call .Focus on Picker",
+				AutomationId = "btnFocus"
 			};
 
-			pickerBtn.Clicked += (sender, args) => {
-				picker.Focus ();
+			pickerBtn.Clicked += (sender, args) =>
+			{
+				picker.Focus();
 			};
 
-			var pickerBtn2 = new Button {
-				Text = "Click me to call .Unfocus on Picker"
+			var pickerBtn2 = new Button
+			{
+				Text = "Click me to call .Unfocus on Picker",
+				AutomationId = "btnUnFocus"
 			};
 
-			pickerBtn2.Clicked += (sender, args) => {
-				picker.Unfocus ();
+			pickerBtn2.Clicked += (sender, args) =>
+			{
+				picker.Unfocus();
 			};
 
-			var pickerBtn3 = new Button {
+			var pickerBtn3 = new Button
+			{
 				Text = "Click me to .Focus () picker, wait 2 seconds, and .Unfocus () picker",
-				Command = new Command (async () => {
-					picker.Focus ();
-					await Task.Delay (2000);
-					picker.Unfocus ();
+				Command = new Command(async () =>
+				{
+					picker.Focus();
+					await Task.Delay(2000);
+					picker.Unfocus();
 				})
 			};
 
@@ -46,18 +54,21 @@ namespace Xamarin.Forms.Controls
 			var focusFiredLabel = new Label { Text = "Picker Focused: " + focusFiredCount };
 			var unfocusedFiredLabel = new Label { Text = "Picker UnFocused: " + unfocusFiredCount };
 
-			picker.Focused += (s, e) => {
+			picker.Focused += (s, e) =>
+			{
 				focusFiredCount++;
 				focusFiredLabel.Text = "Picker Focused: " + focusFiredCount;
 			};
-			picker.Unfocused += (s, e) => {
+			picker.Unfocused += (s, e) =>
+			{
 				unfocusFiredCount++;
 				unfocusedFiredLabel.Text = "Picker UnFocused: " + unfocusFiredCount;
 			};
 
-			Content = new StackLayout {
+			Content = new StackLayout
+			{
 				Children = {
-					focusFiredLabel, 
+					focusFiredLabel,
 					unfocusedFiredLabel,
 					pickerBtn,
 					pickerBtn2,
@@ -65,15 +76,14 @@ namespace Xamarin.Forms.Controls
 					picker
 				}
 			};
-		}
-
+		} 
 
 #if UITEST
 		[Test]
 #if __WINDOWS__
 		[Ignore("Focus Behavior is different on UWP")]
 #endif
-		public void Issue2339_FocusAndUnFocusMultipleTimes ()
+		public void FocusAndUnFocusMultipleTimes ()
 		{
 			RunningApp.WaitForElement("btnFocus");
 			RunningApp.Tap (c => c.Marked ("btnFocus"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2339.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2339.cs
@@ -45,7 +45,8 @@ namespace Xamarin.Forms.Controls.Issues
 					picker.Focus();
 					await Task.Delay(2000);
 					picker.Unfocus();
-				})
+				}),
+				AutomationId = "btnFocusThenUnFocus"
 			};
 
 			var focusFiredCount = 0;
@@ -85,14 +86,12 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 		public void FocusAndUnFocusMultipleTimes ()
 		{
-			RunningApp.WaitForElement("btnFocus");
-			RunningApp.Tap (c => c.Marked ("btnFocus"));
+			RunningApp.WaitForElement("btnFocusThenUnFocus");
+			RunningApp.Tap (c => c.Marked ("btnFocusThenUnFocus"));
 			RunningApp.WaitForElement(cw => cw.Marked("Picker Focused: 1"));
-			RunningApp.Tap(c => c.Marked("btnUnFocus"));  
 			RunningApp.WaitForElement(cw => cw.Marked("Picker UnFocused: 1")); 
-			RunningApp.Tap (c => c.Marked ("btnFocus"));
+			RunningApp.Tap (c => c.Marked ("btnFocusThenUnFocus"));
 			RunningApp.WaitForElement(cw => cw.Marked("Picker Focused: 2"));
-			RunningApp.Tap(c => c.Marked("btnUnFocus"));  
 			RunningApp.WaitForElement(cw => cw.Marked("Picker UnFocused: 2")); 
 		} 
 #endif

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -96,9 +96,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
 			var s = (PickerSource)_picker.Model;
-			if (s.SelectedIndex == -1)
-				return;
-			if (s.SelectedIndex != _picker.SelectedRowInComponent(0))
+			if (s.SelectedIndex != -1 && s.SelectedIndex != _picker.SelectedRowInComponent(0))
 			{
 				_picker.Select(s.SelectedIndex, 0, false);
 			}


### PR DESCRIPTION
### Description of Change ###

Fixed picker on iOS so when nothing gets selected and it's closed that IsFocused gets correctly set back to false

This is a 2.5.1 to 3.0.0 regression so let me know if you want me to retarget this to 3.0.0

### Bugs Fixed ###

fixes #2398

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
