### PR TITLE
[WPF] Fix bug : StackLayout VerticalOptions = LayoutOptions.End is not working

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2394.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2394.cs
@@ -1,0 +1,49 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2394, "[WPF] StackLayout VerticalOptions = LayoutOptions.End is not working", PlatformAffected.WPF)]
+	public class Issue2394 : TestContentPage
+	{
+		protected override void Init()
+		{
+			if (Device.RuntimePlatform == Device.iOS && Device.Idiom == TargetIdiom.Tablet)
+				Padding = new Thickness(0, 0, 0, 60);
+
+			var stack = new StackLayout { VerticalOptions = LayoutOptions.End };
+			Button b1 = new Button { Text = "Boring", HeightRequest = 100, MinimumHeightRequest = 50 };
+			Button b2 = new Button
+			{
+				Text = "Exciting!",
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				HorizontalOptions = LayoutOptions.CenterAndExpand
+			};
+			Button b3 = new Button { Text = "Amazing!", VerticalOptions = LayoutOptions.FillAndExpand };
+			Button b4 = new Button { Text = "Meh", HeightRequest = 100, MinimumHeightRequest = 50 };
+			b1.Clicked += (sender, e) => {
+				b1.Text = "clicked1";
+			};
+			b2.Clicked += (sender, e) => {
+				b2.Text = "clicked2";
+			};
+			b3.Clicked += (sender, e) => {
+				b3.Text = "clicked3";
+			};
+			b4.Clicked += (sender, e) => {
+				b4.Text = "clicked4";
+			};
+			stack.Children.Add(b1);
+			stack.Children.Add(b2);
+			stack.Children.Add(b3);
+			stack.Children.Add(b4);
+			Content = stack;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -294,6 +294,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1864.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2104.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1908.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2394.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2981.cs" />

--- a/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
@@ -1,14 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Threading;
 using WControl = System.Windows.Controls.Control;
 
 namespace Xamarin.Forms.Platform.WPF
@@ -125,8 +119,7 @@ namespace Xamarin.Forms.Platform.WPF
 			var args = new VisualElementChangedEventArgs(e.OldElement, e.NewElement);
 			for (var i = 0; i < _elementChangedHandlers.Count; i++)
 				_elementChangedHandlers[i](this, args);
-
-			UpdateRequests();
+			
 			ElementChanged?.Invoke(this, e);
 		}
 
@@ -134,10 +127,10 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateEnabled();
-			else if (e.PropertyName == Frame.HeightRequestProperty.PropertyName)
-				UpdateRequests();
-			else if (e.PropertyName == Frame.WidthRequestProperty.PropertyName)
-				UpdateRequests();
+			else if (e.PropertyName == Frame.HeightProperty.PropertyName)
+				UpdateHeight();
+			else if (e.PropertyName == Frame.WidthProperty.PropertyName)
+				UpdateWidth();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackground();
 			else if (e.PropertyName == View.HorizontalOptionsProperty.PropertyName || e.PropertyName == View.VerticalOptionsProperty.PropertyName)
@@ -201,15 +194,22 @@ namespace Xamarin.Forms.Platform.WPF
 			control.UpdateDependencyColor(WControl.BackgroundProperty, Element.BackgroundColor);
 		}
 
-		protected virtual void UpdateRequests()
+		protected virtual void UpdateHeight()
+		{
+			if (Control == null || Element == null)
+				return;
+			
+			Control.Height = Element.Height > 0 ? Element.Height : Double.NaN;
+		}
+
+		protected virtual void UpdateWidth()
 		{
 			if (Control == null || Element == null)
 				return;
 
-			Control.Width = Element.WidthRequest >= 0 ? Element.WidthRequest : Double.NaN;
-			Control.Height = Element.HeightRequest >= 0 ? Element.HeightRequest : Double.NaN;
+			Control.Width = Element.Width > 0 ? Element.Width : Double.NaN;
 		}
-
+		
 		protected virtual void UpdateNativeWidget()
 		{
 			UpdateEnabled();

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -185,7 +185,6 @@ Global
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{a34ebe01-25bf-4e69-a2dc-2288dc625541}*SharedItemsImports = 4
 		Xamarin.Flex\Xamarin.Flex.projitems*{a6703c7d-d362-452a-a7a5-73771194d38c}*SharedItemsImports = 13
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{cb9c96ce-125c-4a68-b6a1-c3ff1fbf93e1}*SharedItemsImports = 4
-		docs\APIDocs.projitems*{dc1f3933-ac99-4887-8b09-e13c2b346d4f}*SharedItemsImports = 13
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{e175485b-3c8c-47d7-8dd5-f7fed627eb25}*SharedItemsImports = 13
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{eadd8100-b3ae-4a31-92c4-267a64a1c6eb}*SharedItemsImports = 4
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{eadd8100-b3ae-4a31-92c4-267a64a1c6eb}*SharedItemsImports = 4

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -185,6 +185,7 @@ Global
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{a34ebe01-25bf-4e69-a2dc-2288dc625541}*SharedItemsImports = 4
 		Xamarin.Flex\Xamarin.Flex.projitems*{a6703c7d-d362-452a-a7a5-73771194d38c}*SharedItemsImports = 13
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{cb9c96ce-125c-4a68-b6a1-c3ff1fbf93e1}*SharedItemsImports = 4
+		docs\APIDocs.projitems*{dc1f3933-ac99-4887-8b09-e13c2b346d4f}*SharedItemsImports = 13
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{e175485b-3c8c-47d7-8dd5-f7fed627eb25}*SharedItemsImports = 13
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{eadd8100-b3ae-4a31-92c4-267a64a1c6eb}*SharedItemsImports = 4
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{eadd8100-b3ae-4a31-92c4-267a64a1c6eb}*SharedItemsImports = 4


### PR DESCRIPTION
### Description of Change ###

The original issue is  StackLayout VerticalOptions = LayoutOptions.End is not working

This PR fix this issue

### Bugs Fixed ###

fixes #2394 

### Before ###
![image](https://user-images.githubusercontent.com/25939826/38702978-535d99f4-3ea2-11e8-90b7-ca9ad4880d15.png)

### After ###
![image](https://user-images.githubusercontent.com/25939826/38702989-59652506-3ea2-11e8-90d6-8e5d4890ff32.png)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
