### PR TITLE
[UWP] Only reset ListView DataContext on INotifyCollectionChanged Reset

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Platform.UWP
 					new CollectionViewSource { Source = Element.ItemsSource, IsSourceGrouped = Element.IsGroupingEnabled };
 			}
 
-      List.UpdateLayout();
+			List.UpdateLayout();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -79,7 +81,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
-			List.DataContext = new CollectionViewSource { Source = Element.ItemsSource, IsSourceGrouped = Element.IsGroupingEnabled };
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				List.DataContext =
+					new CollectionViewSource { Source = Element.ItemsSource, IsSourceGrouped = Element.IsGroupingEnabled };
+			}
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

UWP ListView's DataContext is being reset on every CollectionChanged event; this change limits those resets to `NotifyCollectionChangedAction.Reset`.

The relevant tests here are `Issue1875` and `Bugzilla57674` - the fix for 57674 (#1235) introduced the crash/regression.

### Bugs Fixed ###

- fixes #2332 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
