### PR TITLE
[Tizen] Supports Switch.OnColor to tizen

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/SwitchRenderer.cs
@@ -1,16 +1,23 @@
 using System;
-using System.ComponentModel;
 using ElmSharp;
 using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
 using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.VisualElement;
+using EColor = ElmSharp.Color;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
 	public class SwitchRenderer : ViewRenderer<Switch, Check>
 	{
+		readonly string _onColorPart;
+		readonly bool _isTV;
+		string _onColorEdjePart;
+
 		public SwitchRenderer()
 		{
+			_isTV = Device.Idiom == TargetIdiom.TV;
+			_onColorPart = _isTV ? "slider_on" : Device.Idiom == TargetIdiom.Watch ? "outer_bg_on" : "bg_on";
 			RegisterPropertyHandler(Switch.IsToggledProperty, HandleToggled);
+			RegisterPropertyHandler(Switch.OnColorProperty, UpdateOnColor);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Switch> e)
@@ -23,6 +30,7 @@ namespace Xamarin.Forms.Platform.Tizen
 					Style = SwitchStyle.Toggle
 				});
 				Control.StateChanged += OnStateChanged;
+				_onColorEdjePart = Control.ClassName.ToLower().Replace("elm_", "") + "/" + _onColorPart;
 			}
 			base.OnElementChanged(e);
 		}
@@ -68,6 +76,26 @@ namespace Xamarin.Forms.Platform.Tizen
 		void HandleToggled()
 		{
 			Control.IsChecked = Element.IsToggled;
+		}
+
+		void UpdateOnColor(bool initialize)
+		{
+			if (initialize && Element.OnColor.IsDefault)
+				return;
+
+			if (Element.OnColor.IsDefault)
+			{
+				Control.EdjeObject.DeleteColorClass(_onColorEdjePart);
+				if (_isTV)
+					Control.EdjeObject.DeleteColorClass(_onColorEdjePart.Replace(_onColorPart, "slider_focused_on"));
+			}
+			else
+			{
+				EColor color = Element.OnColor.ToNative();
+				Control.SetPartColor(_onColorPart, color);
+				if (_isTV)
+					Control.SetPartColor("slider_focused_on", color);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This PR is tizen implementation of #1662 and is an addendum to the changes in #1929.

fixes #1662

**- Phone**

 Default | OnColor (Red)
---|---
<img src ="https://user-images.githubusercontent.com/1029134/38538079-2bcac866-3ccd-11e8-8ad9-a886eebc7f89.png" width=320>| <img src ="https://user-images.githubusercontent.com/1029134/38538083-2f8c169e-3ccd-11e8-8b64-835f836839f6.png" width=320>

**- Watch**

 Default | OnColor (Red)
---|---
<img src ="https://user-images.githubusercontent.com/1029134/38785438-03ef1f8a-415b-11e8-9a7b-a9f2cb96b428.png" width=200> | <img src ="https://user-images.githubusercontent.com/1029134/38538069-1e69ec92-3ccd-11e8-8061-210db6f0508c.png " width=200>

**- TV**
  -  Default 
  <img src ="https://user-images.githubusercontent.com/1029134/38538061-1302c1c6-3ccd-11e8-9ccb-2dac968ae7be.png" width=600>

  - OnColor (Red) 
<img src ="https://user-images.githubusercontent.com/1029134/38538056-0a2a89bc-3ccd-11e8-82b1-b377cde7e72d.png" width=600>

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense