### PR TITLE
[UWP] Fixes the search bar query, when you type text quickly

### DIFF
--- a/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
@@ -102,6 +102,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs e)
 		{
+			// Modifies the text of the control if it does not match the query.
+			// This is possible because OnTextChanged is fired with a delay
+			if (e.QueryText != Element.Text)
+				Element.SetValueFromRenderer(SearchBar.TextProperty, e.QueryText);
+
 			Element.OnSearchButtonPressed();
 		}
 


### PR DESCRIPTION
### Description of Change ###

Modifies the text of the SearchBar element if it does not match the query.

### Bugs Fixed ###

Fixes #2439

### API Changes ###

--

### Behavioral Changes ###

What will be typed in the search bar will be in the query regardless of the speed of typing.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
