### PR TITLE
Adding support for tapping on iOS Slider to set value

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1729.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1729.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 1729, "iOS PlatformSpecific for UISlider", PlatformAffected.iOS)]
+	public class Issue1729 : TestContentPage
+	{
+		Slider _slider1;
+
+		protected override void Init()
+		{
+			
+			_slider1 = new Slider();
+
+			var label = new Label {Text = "Enable TapOnUpdate"};
+			var toggle = new Switch {IsToggled = false};
+			toggle.Toggled += Toggled;
+
+			var stackLayout = new StackLayout
+			{
+				Children = {label, toggle, _slider1},
+				Padding = new Thickness(0, 20, 0, 0)
+			};
+			Content = stackLayout;
+		}
+
+		void Toggled(object sender, ToggledEventArgs e)
+		{
+			_slider1.On<PlatformConfiguration.iOS>().SetUpdateOnTap(((Switch)sender).IsToggled);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -712,6 +712,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1583_1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1323.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2399.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1729.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Slider.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Slider.cs
@@ -1,0 +1,30 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.Slider;
+
+	public static class Slider
+	{
+		public static readonly BindableProperty UpdateOnTapProperty = BindableProperty.Create("UpdateOnTap", typeof(bool), typeof(Slider), false);
+
+		public static bool GetUpdateOnTap(BindableObject element)
+		{
+			return (bool)element.GetValue(UpdateOnTapProperty);
+		}
+
+		public static void SetUpdateOnTap(BindableObject element, bool value)
+		{
+			element.SetValue(UpdateOnTapProperty, value);
+		}
+
+		public static bool GetUpdateOnTap(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetUpdateOnTap(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateOnTap(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		{
+			SetUpdateOnTap(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
@@ -2,6 +2,8 @@ using System;
 using System.ComponentModel;
 using UIKit;
 using SizeF = CoreGraphics.CGSize;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using Specifics = Xamarin.Forms.PlatformConfiguration.iOSSpecific.Slider;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -9,6 +11,7 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		SizeF _fitSize;
 		UIColor defaultmintrackcolor, defaultmaxtrackcolor, defaultthumbcolor;
+		UITapGestureRecognizer _sliderTapRecognizer;
 
 		public override SizeF SizeThatFits(SizeF size)
 		{
@@ -18,7 +21,9 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void Dispose(bool disposing)
 		{
 			if (Control != null)
+			{
 				Control.ValueChanged -= OnControlValueChanged;
+			}
 
 			base.Dispose(disposing);
 		}
@@ -152,11 +157,45 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateThumbImage();
 			else if (e.PropertyName == Slider.ThumbColorProperty.PropertyName)
 				UpdateThumbColor();
+			else if (e.PropertyName == Specifics.UpdateOnTapProperty.PropertyName)
+				UpdateTapRecognizer();
 		}
 
 		void OnControlValueChanged(object sender, EventArgs eventArgs)
 		{
 			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, Control.Value);
+		}
+
+		void UpdateTapRecognizer()
+		{
+			if (Element != null && Element.IsSet(Specifics.UpdateOnTapProperty))
+			{
+				if (Element.OnThisPlatform().GetUpdateOnTap())
+				{
+					if (_sliderTapRecognizer == null)
+					{
+						_sliderTapRecognizer = new UITapGestureRecognizer((recognizer) =>
+						{
+							var control = Control;
+							var tappedLocation = recognizer.LocationInView(control);
+							var val = (tappedLocation.X - control.Frame.X) * control.MaxValue / control.Frame.Size.Width;
+
+							Element.SetValueFromRenderer(Slider.ValueProperty, val);
+
+						});
+						Control.AddGestureRecognizer(_sliderTapRecognizer);
+					}
+				}
+				else
+				{
+					if (_sliderTapRecognizer != null)
+					{
+						Control.RemoveGestureRecognizer(_sliderTapRecognizer);
+						_sliderTapRecognizer = null;
+					}
+				}
+			}
+
 		}
 
 		void UpdateMaximum()

--- a/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
@@ -23,6 +23,11 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Control != null)
 			{
 				Control.ValueChanged -= OnControlValueChanged;
+				if (_sliderTapRecognizer != null)
+				{
+					Control.RemoveGestureRecognizer(_sliderTapRecognizer);
+					_sliderTapRecognizer = null;
+				}
 			}
 
 			base.Dispose(disposing);
@@ -177,11 +182,15 @@ namespace Xamarin.Forms.Platform.iOS
 						_sliderTapRecognizer = new UITapGestureRecognizer((recognizer) =>
 						{
 							var control = Control;
-							var tappedLocation = recognizer.LocationInView(control);
-							var val = (tappedLocation.X - control.Frame.X) * control.MaxValue / control.Frame.Size.Width;
-
-							Element.SetValueFromRenderer(Slider.ValueProperty, val);
-
+							if (control != null)
+							{
+								var tappedLocation = recognizer.LocationInView(control);
+								if (tappedLocation != null)
+								{
+									var val = (tappedLocation.X - control.Frame.X) * control.MaxValue / control.Frame.Size.Width;
+									Element.SetValueFromRenderer(Slider.ValueProperty, val);
+								}
+							}
 						});
 						Control.AddGestureRecognizer(_sliderTapRecognizer);
 					}


### PR DESCRIPTION
### Description of Change ###

This PR adds support for tapping a slider on iOS to set the value which is not natively support by a standard `UISlider`. This new behaviour is triggered by setting a new iOS specific property `UpdateOnTap` to `true`.

### Bugs Fixed ###

- fixes #1729 

### API Changes ###

Added:
 - bool Slider.UpdateOnTap { get; set; } //iOS specific Bindable Property

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
