### PR TITLE
[XamlG] depends on PrepareResourceNames

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -63,7 +63,7 @@
 		</CoreCompileDependsOn>
 	</PropertyGroup>
 
-	<Target Name="XamlG" BeforeTargets="BeforeCompile" Condition="'$(_XamlGAlreadyExecuted)'!='true'">
+	<Target Name="XamlG" BeforeTargets="BeforeCompile" DependsOnTargets="PrepareResourceNames" Condition="'$(_XamlGAlreadyExecuted)'!='true'">
 		<PropertyGroup>
 			<_XamlGAlreadyExecuted>true</_XamlGAlreadyExecuted>
 		</PropertyGroup>
@@ -105,7 +105,7 @@
 			$(CoreCompileDependsOn);
 		</CoreCompileDependsOn>
 	</PropertyGroup>
-	<Target Name="CssG" BeforeTargets="BeforeCompile" Condition="'$(_CssGAlreadyExecuted)'!='true'">
+	<Target Name="CssG" BeforeTargets="BeforeCompile"  DependsOnTargets="PrepareResourceNames" Condition="'$(_CssGAlreadyExecuted)'!='true'">
 		<PropertyGroup>
 			<_CssGAlreadyExecuted>true</_CssGAlreadyExecuted>
 		</PropertyGroup>


### PR DESCRIPTION
### Description of Change ###

[XamlG] depends on PrepareResourceNames

make sure TargetPath and ManifestResourceNames metadata are assigned
before running XamlG

### Bugs Fixed ###

- fixes #2395


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
