### PR TITLE
[UWP] Fixes the reduced height of the main page

### DIFF
--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Forms.Platform.UWP
 		
 		CommandBar _commandBar;
 		readonly ToolbarPlacementHelper _toolbarPlacementHelper = new ToolbarPlacementHelper();
+		bool _firstLoad;
 
 		public bool ShouldShowToolbar
 		{
@@ -142,8 +143,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 				// On first load, the _commandBar will still occupy space by the time this is called.
 				// Check ShouldShowToolbar to make sure the _commandBar will still be there on render.
-				if (_commandBar != null && ShouldShowToolbar)
+				if (_firstLoad && _commandBar != null && ShouldShowToolbar)
+				{
 					height -= _commandBar.ActualHeight;
+					_firstLoad = false;
+				}
 
 				if (_split != null)
 					width = _split.OpenPaneLength;
@@ -317,7 +321,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (DetailTitleVisibility == Visibility.Visible && !ShouldShowNavigationBar)
 				DetailTitleVisibility = Visibility.Collapsed;
-			
+
+			_firstLoad = true;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

When calculating the size of the main page added check the first load after updating the mode `MainDetailControl`
Screencast: https://www.screencast.com/t/P6PJyxT6d

### Bugs Fixed ###

Fixes https://github.com/xamarin/Xamarin.Forms/issues/2228

### API Changes ###

--

### Behavioral Changes ###

Height of main page calculates correctly

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
