### PR TITLE
[UWP] Activating vertical scrolling in the Alert dialog box.

### DIFF
--- a/Xamarin.Forms.Platform.UAP/AlertDialog.cs
+++ b/Xamarin.Forms.Platform.UAP/AlertDialog.cs
@@ -1,0 +1,21 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	public class AlertDialog : ContentDialog
+	{
+		public ScrollBarVisibility VerticalScrollBarVisibility { get; set; }
+
+		protected override void OnApplyTemplate()
+		{
+			base.OnApplyTemplate();
+
+			// The child template name is derived from the default style
+			// https://msdn.microsoft.com/en-us/library/windows/apps/mt299120.aspx
+			var scrollName = "ContentScrollViewer";
+			if (GetTemplateChild(scrollName) is ScrollViewer contentScrollViewer)
+				contentScrollViewer.VerticalScrollBarVisibility = VerticalScrollBarVisibility;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
@@ -91,10 +91,11 @@ namespace Xamarin.Forms.Platform.UWP
 			string content = options.Message ?? string.Empty;
 			string title = options.Title ?? string.Empty;
 
-			var alertDialog = new ContentDialog
+			var alertDialog = new AlertDialog
 			{
 				Content = content,
-				Title = title
+				Title = title,
+				VerticalScrollBarVisibility = ScrollBarVisibility.Auto
 			};
 
 			if (options.Cancel != null)

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="ColorExtensions.cs" />
     <Compile Include="FormsCancelButton.cs" />
+    <Compile Include="AlertDialog.cs" />
     <Compile Include="FormsPivot.cs" />
     <Compile Include="AlignmentExtensions.cs" />
     <Compile Include="BrushHelpers.cs" />


### PR DESCRIPTION
### Description of Change ###

Activating vertical scrolling in the Alert dialog box.
Screencast: http://recordit.co/f4TrhdqvEd

### Bugs Fixed ###

Fixes #2355

### API Changes ###

--

### Behavioral Changes ###

UWP Alert box now uses `AlertDialog` subclass of `ContentDialog`.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
