### PR TITLE
[Core] Improve Renderer registration order

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -30,14 +30,12 @@
     </AndroidTlsProvider>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-  </PropertyGroup>    
-
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <AndroidKeyStore>True</AndroidKeyStore>
     <AndroidSigningKeyStore>$(SolutionDir)debug.keystore</AndroidSigningKeyStore>
@@ -208,6 +206,7 @@
     <Compile Include="StringProvider.cs" />
     <Compile Include="TestCloudService.cs" />
     <Compile Include="_1909CustomRenderer.cs" />
+    <Compile Include="_2489CustomRenderer.cs" />
     <Compile Include="_38989CustomRenderer.cs" />
     <Compile Include="BrokenImageSourceHandler.cs" />
     <Compile Include="_50787CustomRenderer.cs" />

--- a/Xamarin.Forms.ControlGallery.Android/_2489CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_2489CustomRenderer.cs
@@ -1,0 +1,24 @@
+﻿using Android.Content;
+using System;
+using System.Linq;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Page), typeof(_2489CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class _2489CustomRenderer : PageRenderer
+	{
+		public _2489CustomRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Page> e)
+		{
+			base.OnElementChanged(e);
+
+			System.Diagnostics.Debug.WriteLine($"{e.NewElement.GetType()} is replaced by _2489CustomRenderer");
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -126,6 +126,7 @@
   <ItemGroup>
     <Compile Include="BorderEffect.cs" />
     <Compile Include="DisposePageRenderer.cs" />
+    <Compile Include="_2489CustomRenderer.cs" />
     <Compile Include="_57114Renderer.cs" />
     <Compile Include="_58406EffectRenderer.cs" />
     <Compile Include="_60122ImageRenderer.cs" />

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/_2489CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/_2489CustomRenderer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Platform.UWP;
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Page), typeof(_2489CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	public class _2489CustomRenderer : PageRenderer
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Page> e)
+		{
+			base.OnElementChanged(e);
+
+			System.Diagnostics.Debug.WriteLine($"{e.NewElement.GetType()} is replaced by _2489CustomRenderer");
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
     <Compile Include="PerformanceTrackerRenderer.cs" />
+    <Compile Include="_2489CustomRenderer.cs" />
     <Compile Include="_57114Renderer.cs" />
     <Compile Include="_58406EffectRenderer.cs" />
     <Compile Include="_60122ImageRenderer.cs" />

--- a/Xamarin.Forms.ControlGallery.iOS/_2489CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/_2489CustomRenderer.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Linq;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Controls;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(Page), typeof(_2489CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class _2489CustomRenderer : PageRenderer
+	{
+		protected override void OnElementChanged(VisualElementChangedEventArgs e)
+		{
+			base.OnElementChanged(e);
+
+			System.Diagnostics.Debug.WriteLine($"{e.NewElement.GetType()} is replaced by _2489CustomRenderer");
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -11,11 +11,12 @@ using Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries;
 
 namespace Xamarin.Forms.Controls
 {
+	[Preserve(AllMembers = true)]
 	public static class Messages
 	{
 		public const string ChangeRoot = "com.xamarin.ChangeRoot";
 	}
-
+	[Preserve(AllMembers = true)]
 	internal class CoreCarouselPage : CarouselPage
 	{
 		public CoreCarouselPage ()
@@ -25,7 +26,7 @@ namespace Xamarin.Forms.Controls
 			Children.Add (new CoreRootPage (this, NavigationBehavior.PushModalAsync) { Title = "Page 2" });
 		}
 	}
-
+	[Preserve(AllMembers = true)]
 	internal class CoreContentPage : ContentPage
 	{
 		public CoreContentPage ()
@@ -35,7 +36,7 @@ namespace Xamarin.Forms.Controls
 			Content = new StackLayout { Children = { new CoreRootView (), new CorePageView (this, NavigationBehavior.PushModalAsync) } };
 		}
 	}
-
+	[Preserve(AllMembers = true)]
 	internal class CoreMasterDetailPage : MasterDetailPage
 	{
 		public CoreMasterDetailPage ()
@@ -61,7 +62,7 @@ namespace Xamarin.Forms.Controls
 			Detail = detailPage;
 		}
 	}
-
+	[Preserve(AllMembers = true)]
 	internal class CoreNavigationPage : NavigationPage
 	{
 		public CoreNavigationPage ()
@@ -182,7 +183,7 @@ namespace Xamarin.Forms.Controls
 			PageType = pageType;
 		}
 	}
-
+	[Preserve(AllMembers = true)]
 	public class CoreRootView : ListView
 	{
 		public CoreRootView ()
@@ -216,8 +217,8 @@ namespace Xamarin.Forms.Controls
 		}
 	}
 
-	
 
+	[Preserve(AllMembers = true)]
 	internal class CorePageView : ListView
 	{
 		internal class GalleryPageFactory
@@ -407,7 +408,7 @@ namespace Xamarin.Forms.Controls
 			await PushPage (page);
 		}
 	}
-
+	[Preserve(AllMembers = true)]
 	internal class CoreRootPage : ContentPage
 	{
 		public CoreRootPage (Page rootPage, NavigationBehavior navigationBehavior = NavigationBehavior.PushAsync)
@@ -458,12 +459,12 @@ namespace Xamarin.Forms.Controls
 			};
 		}
 	}
-
+	[Preserve(AllMembers = true)]
 	public interface IStringProvider
 	{
 		string CoreGalleryTitle { get; }
 	}
-
+	[Preserve(AllMembers = true)]
 	public static class CoreGallery
 	{
 		public static Page GetMainPage ()

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -94,37 +94,18 @@ namespace Xamarin.Forms.Internals
 
 		public Type GetHandlerType(Type viewType)
 		{
-			Type type;
-			if (LookupHandlerType(viewType, out type))
-				return type;
+			// 1. Do we have this specific type registered already?
+			if (LookupHandlerType(viewType, false, out Type specificTypeRenderer))
+				return specificTypeRenderer;
 
-			// lazy load render-view association with RenderWithAttribute (as opposed to using ExportRenderer)
-			var attribute = viewType.GetTypeInfo().GetCustomAttribute<RenderWithAttribute>();
-			if (attribute == null)
-			{
-				Register(viewType, null); // Cache this result so we don't have to do GetCustomAttribute again
+			// 2. Do we have a RenderWith for this type or its base types? Register them now.
+			RegisterRenderWithTypes(viewType);
+
+			// 3. Do we have a custom renderer for a base type or did we just register an appropriate renderer from RenderWith?
+			if (LookupHandlerType(viewType, true, out Type baseTypeRenderer))
+				return baseTypeRenderer;
+			else
 				return null;
-			}
-
-			type = attribute.Type;
-
-			if (type.Name.StartsWith("_", StringComparison.Ordinal))
-			{
-				// TODO: Remove attribute2 once renderer names have been unified across all platforms
-				var attribute2 = type.GetTypeInfo().GetCustomAttribute<RenderWithAttribute>();
-				if (attribute2 != null)
-					type = attribute2.Type;
-
-				if (type.Name.StartsWith("_", StringComparison.Ordinal))
-				{
-					Register(viewType, null); // Cache this result so we don't work through this chain again
-					return null;
-				}
-			}
-
-			Register(viewType, type); // Register this so we don't have to look for the RenderWith Attibute again in the future
-
-			return type;
 		}
 
 		public Type GetHandlerTypeForObject(object obj)
@@ -138,7 +119,7 @@ namespace Xamarin.Forms.Internals
 			return GetHandlerType(type);
 		}
 
-		bool LookupHandlerType(Type viewType, out Type handlerType)
+		bool LookupHandlerType(Type viewType, bool includeBaseTypes, out Type handlerType)
 		{
 			Type type = viewType;
 
@@ -150,11 +131,61 @@ namespace Xamarin.Forms.Internals
 					return true;
 				}
 
-				type = type.GetTypeInfo().BaseType;
+				if (includeBaseTypes)
+					type = type.GetTypeInfo().BaseType;
+				else
+					type = null;
 			}
 
 			handlerType = null;
 			return false;
+		}
+
+		void RegisterRenderWithTypes(Type viewType)
+		{
+			Type type = viewType;
+
+			// We're going to go through each type in this viewType's inheritance chain to look for classes
+			// decorated with a RenderWithAttribute. We're going to register each specific type with its
+			// renderer. 
+
+			while (type != null)
+			{
+				// Only go through this process if we have not registered something for this type;
+				// we don't want RenderWith renderers to override ExportRenderers that are already registered.
+				// Plus, there's no need to do this again if we already have a renderer registered.
+				if (!LookupHandlerType(type, false, out Type specificTypeRenderer))
+				{
+					// get RenderWith attribute for just this type, do not inherit attributes from base types
+					var attribute = type.GetTypeInfo().GetCustomAttributes<RenderWithAttribute>(false).FirstOrDefault();
+					if (attribute == null)
+					{
+						Register(type, null); // Cache this result so we don't have to do GetCustomAttributes again
+					}
+					else
+					{
+						specificTypeRenderer = attribute.Type;
+
+						if (specificTypeRenderer.Name.StartsWith("_", StringComparison.Ordinal))
+						{
+							// TODO: Remove attribute2 once renderer names have been unified across all platforms
+							var attribute2 = specificTypeRenderer.GetTypeInfo().GetCustomAttribute<RenderWithAttribute>();
+							if (attribute2 != null)
+								specificTypeRenderer = attribute2.Type;
+
+							if (specificTypeRenderer.Name.StartsWith("_", StringComparison.Ordinal))
+							{
+								Register(type, null); // Cache this result so we don't work through this chain again
+								continue;
+							}
+						}
+
+						Register(type, specificTypeRenderer); // Register this so we don't have to look for the RenderWithAttibute again in the future
+					}
+				}
+
+				type = type.GetTypeInfo().BaseType;
+			}
 		}
 	}
 

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms.Internals
 		{
 			Type type = viewType;
 
-			while (type != null)
+			while (type != null && type != typeof(Element))
 			{
 				if (_handlers.ContainsKey(type))
 				{
@@ -149,7 +149,7 @@ namespace Xamarin.Forms.Internals
 			// decorated with a RenderWithAttribute. We're going to register each specific type with its
 			// renderer. 
 
-			while (type != null)
+			while (type != null && type != typeof(Element))
 			{
 				// Only go through this process if we have not registered something for this type;
 				// we don't want RenderWith renderers to override ExportRenderers that are already registered.
@@ -176,6 +176,8 @@ namespace Xamarin.Forms.Internals
 							if (specificTypeRenderer.Name.StartsWith("_", StringComparison.Ordinal))
 							{
 								Register(type, null); // Cache this result so we don't work through this chain again
+
+								type = type.GetTypeInfo().BaseType;
 								continue;
 							}
 						}

--- a/Xamarin.Forms.Platform.Android/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.Android/Properties/AssemblyInfo.cs
@@ -19,6 +19,9 @@ using Xamarin.Forms.Platform.Android;
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
 
+
+// These renderers are now registered via the RenderWithAttribute in the Android Forwarders project.
+// Note that AppCompat and FastRenderers are also registered conditionally in FormsAppCompatActivity.LoadApplication
 #if ROOT_RENDERERS
 [assembly: ExportRenderer (typeof (BoxView), typeof (BoxRenderer))]
 [assembly: ExportRenderer (typeof (Entry), typeof (EntryRenderer))]

--- a/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
@@ -18,6 +18,8 @@ using UIKit;
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
 
+// These renderers are now registered via the RenderWithAttribute in the iOS Forwarders project.
+#if ROOT_RENDERERS
 [assembly: ExportRenderer(typeof(BoxView), typeof(BoxRenderer))]
 [assembly: ExportRenderer(typeof(Entry), typeof(EntryRenderer))]
 [assembly: ExportRenderer(typeof(Editor), typeof(EditorRenderer))]
@@ -47,6 +49,8 @@ using UIKit;
 [assembly: ExportRenderer(typeof(Page), typeof(PageRenderer))]
 [assembly: ExportRenderer(typeof(MasterDetailPage), typeof(PhoneMasterDetailRenderer), UIUserInterfaceIdiom.Phone)]
 [assembly: ExportRenderer(typeof(MasterDetailPage), typeof(TabletMasterDetailRenderer), UIUserInterfaceIdiom.Pad)]
+#endif
+
 [assembly: ExportCell(typeof(Cell), typeof(CellRenderer))]
 [assembly: ExportCell(typeof(ImageCell), typeof(ImageCellRenderer))]
 [assembly: ExportCell(typeof(EntryCell), typeof(EntryCellRenderer))]


### PR DESCRIPTION
### Description of Change ###

Renderers are registered in three ways in Xamarin.Forms:

1. Via the `RenderWithAttribute`. This is how core renderers are registered for Android.
2. Via the `ExportRendererAttribute`. This is how core renderers are registered for iOS, UWP, and how users typically register their custom renderers.
3. Via `RegisterHandlerForDefaultRenderer`. This is how core renderers are registered for AppCompat and Fast Renderers.

After we introduced the `RenderWith` model, it became possible for the `Registrar` to return a less specific renderer for a type if a renderer for a base type was registered first.

This change alters the order in which we hunt for the most specific renderer and also ensures that we are registering the proper types with the proper renderers.

It also moves iOS to the `RenderWith` model.

### Bugs Fixed ###

- fixes #2489

### API Changes ###

None


### Behavioral Changes ###

None observed, but this is a significant core change that should be tested thoroughly.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
