### PR TITLE
[UITests] Bump delay on UITest 32898

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32898.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32898.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issu32898Test()
 		{
-			var timeout = Timeout + 500; // Give this a little slop to set the result text
+			var timeout = Timeout + 1500; // Give this a little slop to set the result text
 			RunningApp.WaitForElement(Success, timeout: TimeSpan.FromMilliseconds(timeout));
 		}
 #endif


### PR DESCRIPTION
### Description of Change ###

Try fix failing test 32898, Works fine on emulators and devices , was tested on device with API23 .

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
