### PR TITLE
[macOS] Fixes issue with hiding master page of `MasterDetailPage`

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/MasterDetailPageRenderer.cs
@@ -144,6 +144,11 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (view == null)
 				return;
 
+			// Ignore the IsPresented value being set to false for Split mode on desktop
+			// and allow the master view to be made initially visible
+			if (Device.Idiom == TargetIdiom.Desktop && !view.Hidden)
+				return;
+
 			if (MasterDetailPage.IsPresented && view.Hidden)
 				view.Hidden = false;
 			else if (!MasterDetailPage.IsPresented && !view.Hidden)


### PR DESCRIPTION
### Description of Change ###

Fixes issue with hiding master page of `MasterDetailPage`

### Bugs Fixed ###

Fixes https://github.com/xamarin/Xamarin.Forms/issues/2507

### API Changes ###

None

### Behavioral Changes ###

On desktop `macOS` changes `IsPresentedProperty` have no effect to hide the master page.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
