### PR TITLE
Controlling Caret position on iOS,Android,UWP and color on iOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1667.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1667.cs
@@ -28,6 +28,14 @@ namespace Xamarin.Forms.Controls.Issues
 			_updateButton = new Button { Text = "Update" };
 			_updateButton.Clicked += UpdateCursor;
 
+			var red = new Button { Text = "Red", TextColor = Color.Red};
+			red.Clicked += (sender, e) => _entry.CursorColor = Color.Red;
+
+			var blue = new Button { Text = "Blue", TextColor = Color.Blue};
+			blue.Clicked += (sender, e) => _entry.CursorColor = Color.Blue;
+
+			var defaultColor = new Button { Text = "Default" };
+			defaultColor.Clicked += (sender, e) => _entry.CursorColor = Color.Default;
 			Content = new StackLayout
 			{
 				Margin = new Thickness(10, 40),
@@ -38,7 +46,10 @@ namespace Xamarin.Forms.Controls.Issues
 					_cursorStartPosition,
 					new Label {Text = "Selection Length:"},
 					_selectionLength,
-					_updateButton
+					_updateButton,
+					red,
+					blue,
+					defaultColor
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1667.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1667.cs
@@ -5,6 +5,11 @@ using System.Linq;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using NUnit.Framework;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
@@ -19,7 +24,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init ()
 		{
-			_entry = new Entry {Text = "Enter cursor position below"};
+			_entry = new Entry {Text = "Enter cursor position below", AutomationId = "TextField"};
 			_entry.PropertyChanged += ReadCursor;
 
 			_cursorStartPosition = new Entry();
@@ -73,5 +78,25 @@ namespace Xamarin.Forms.Controls.Issues
 			_cursorStartPosition.Text = _entry.CursorPosition.ToString();
 			_selectionLength.Text = _entry.SelectionLength.ToString();
 		}
+
+		#if UITEST
+		[Test]
+		public void Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("TextField"));
+			_entry.CursorPosition = 2;
+			_entry.SelectionLength = 3;
+			RunningApp.Screenshot("Text selection from char 2 length 3.");
+			Assert.AreEqual("2", _cursorStartPosition.Text);
+			Assert.AreEqual("3", _selectionLength.Text);
+
+			RunningApp.Tap(q => q.Marked("Textfield"));
+
+			Assert.AreEqual(_entry.Text.Length, _entry.CursorPosition);
+			Assert.AreEqual(0, _entry.SelectionLength);
+
+
+		}
+		#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1667.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1667.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers = true)]
+	[Issue (IssueTracker.Github, 1667, "Entry: Position and color of caret", PlatformAffected.All)]
+	public class Issue1667 : TestContentPage
+	{
+		Entry _entry;
+		Entry _cursorStartPosition;
+		Entry _selectionLength;
+		Button _updateButton;
+		Button _readButton;
+
+		protected override void Init ()
+		{
+			_entry = new Entry {Text = "Enter cursor position below"};
+			_entry.PropertyChanged += ReadCursor;
+
+			_cursorStartPosition = new Entry();
+			_selectionLength = new Entry();
+
+			_updateButton = new Button { Text = "Update" };
+			_updateButton.Clicked += UpdateCursor;
+
+			Content = new StackLayout
+			{
+				Margin = new Thickness(10, 40),
+				Children =
+				{
+					_entry,
+					new Label {Text = "Start:"},
+					_cursorStartPosition,
+					new Label {Text = "Selection Length:"},
+					_selectionLength,
+					_updateButton
+				}
+			};
+		}
+
+		void UpdateCursor(object sender, EventArgs args)
+		{
+			var start = 0;
+			var length = 0;
+			if (int.TryParse(_cursorStartPosition.Text, out start))
+			{
+				_entry.CursorPosition = start;
+			}
+			if (int.TryParse(_selectionLength.Text, out length))
+			{
+				_entry.SelectionLength = length;
+			}
+		}
+
+		void ReadCursor(object sender, EventArgs args)
+		{
+			_cursorStartPosition.Text = _entry.CursorPosition.ToString();
+			_selectionLength.Text = _entry.SelectionLength.ToString();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1667.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1667.cs
@@ -1,48 +1,44 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.ComponentModel;
 
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 #if UITEST
+using Xamarin.UITest;
 using Xamarin.Forms.Core.UITests;
 using NUnit.Framework;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
-	[Preserve (AllMembers = true)]
-	[Issue (IssueTracker.Github, 1667, "Entry: Position and color of caret", PlatformAffected.All)]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1667, "Entry: Position and color of caret", PlatformAffected.All)]
 	public class Issue1667 : TestContentPage
 	{
+		readonly string CursorTextEntryText = "Enter cursor position and selection length";
 		Entry _entry;
 		Entry _cursorStartPosition;
 		Entry _selectionLength;
 		Button _updateButton;
-		Button _readButton;
 
-		protected override void Init ()
+		protected override void Init()
 		{
-			_entry = new Entry {Text = "Enter cursor position below", AutomationId = "TextField"};
+			_entry = new Entry { Text = CursorTextEntryText, AutomationId = "CursorTextEntry" };
 			_entry.PropertyChanged += ReadCursor;
 
-			_cursorStartPosition = new Entry();
-			_selectionLength = new Entry();
+			_cursorStartPosition = new Entry { AutomationId = "CursorStart" };
+			_selectionLength = new Entry { AutomationId = "SelectionLength" };
 
 			_updateButton = new Button { Text = "Update" };
 			_updateButton.Clicked += UpdateCursor;
 
-			var red = new Button { Text = "Red", TextColor = Color.Red};
-			red.Clicked += (sender, e) => _entry.CursorColor = Color.Red;
-
-			var blue = new Button { Text = "Blue", TextColor = Color.Blue};
-			blue.Clicked += (sender, e) => _entry.CursorColor = Color.Blue;
-
-			var defaultColor = new Button { Text = "Default" };
-			defaultColor.Clicked += (sender, e) => _entry.CursorColor = Color.Default;
-			Content = new StackLayout
+			var layout = new StackLayout
 			{
+				AutomationId = "MainContent",
 				Margin = new Thickness(10, 40),
 				Children =
 				{
@@ -51,12 +47,28 @@ namespace Xamarin.Forms.Controls.Issues
 					_cursorStartPosition,
 					new Label {Text = "Selection Length:"},
 					_selectionLength,
-					_updateButton,
-					red,
-					blue,
-					defaultColor
+					_updateButton
 				}
 			};
+
+			if (Device.RuntimePlatform == Device.iOS)
+			{
+				var red = new Button { Text = "Red", TextColor = Color.Red };
+				red.Clicked += (sender, e) => _entry.On<PlatformConfiguration.iOS>().SetCursorColor(Color.Red);
+
+				var blue = new Button { Text = "Blue", TextColor = Color.Blue };
+				blue.Clicked += (sender, e) => _entry.On<PlatformConfiguration.iOS>().SetCursorColor(Color.Blue);
+
+				var defaultColor = new Button { Text = "Default" };
+				defaultColor.Clicked += (sender, e) => _entry.On<PlatformConfiguration.iOS>().SetCursorColor(Color.Default);
+
+				layout.Children.Add(red);
+				layout.Children.Add(blue);
+				layout.Children.Add(defaultColor);
+			}
+
+			Content = layout;
+
 		}
 
 		void UpdateCursor(object sender, EventArgs args)
@@ -73,30 +85,53 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-		void ReadCursor(object sender, EventArgs args)
+		void ReadCursor(object sender, PropertyChangedEventArgs args)
 		{
-			_cursorStartPosition.Text = _entry.CursorPosition.ToString();
-			_selectionLength.Text = _entry.SelectionLength.ToString();
+			if (args.PropertyName == Entry.CursorPositionProperty.PropertyName)
+				_cursorStartPosition.Text = _entry.CursorPosition.ToString();
+			else if (args.PropertyName == Entry.SelectionLengthProperty.PropertyName)
+				_selectionLength.Text = _entry.SelectionLength.ToString();
 		}
 
-		#if UITEST
+#if UITEST
 		[Test]
-		public void Test()
+		[NUnit.Framework.Category(UITestCategories.ManualReview)]
+		public void TestCursorPositionAndSelection()
 		{
-			RunningApp.WaitForElement(q => q.Marked("TextField"));
-			_entry.CursorPosition = 2;
-			_entry.SelectionLength = 3;
+			RunningApp.WaitForElement("CursorTextEntry");
+
+			RunningApp.ClearText( "CursorStart");
+			RunningApp.EnterText("CursorStart", "2");
+			RunningApp.ClearText("SelectionLength");
+			RunningApp.EnterText("SelectionLength", "3");
+			RunningApp.DismissKeyboard();
+			RunningApp.Tap("Update");
 			RunningApp.Screenshot("Text selection from char 2 length 3.");
-			Assert.AreEqual("2", _cursorStartPosition.Text);
-			Assert.AreEqual("3", _selectionLength.Text);
 
-			RunningApp.Tap(q => q.Marked("Textfield"));
+			RunningApp.Tap("CursorTextEntry");
+			Assert.AreEqual("0", RunningApp.WaitForElement("SelectionLength")[0].Text);
+		}
 
-			Assert.AreEqual(_entry.Text.Length, _entry.CursorPosition);
-			Assert.AreEqual(0, _entry.SelectionLength);
+#if __IOS__
+		[Test]
+		[NUnit.Framework.Category(UITestCategories.ManualReview)]
+		public void TestCursorColorOniOS()
+		{
+			RunningApp.WaitForElement("CursorTextEntry");
+			RunningApp.Tap("Red");
+			RunningApp.Tap("CursorTextEntry");
+			RunningApp.Screenshot("Cursor is red.");
 
+			RunningApp.Tap("Blue");
+			RunningApp.Tap("CursorTextEntry");
+			RunningApp.Screenshot("Cursor is blue.");
+
+			RunningApp.Tap("Default");
+			RunningApp.Tap("CursorTextEntry");
+			RunningApp.Screenshot("Cursor is default color.");
 
 		}
-		#endif
+#endif
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -725,6 +725,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1323.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2399.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1729.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1667.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -35,6 +35,10 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Entry), true, BindingMode.OneTime);
 
+		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(Entry), 0);
+
+		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(Entry), 0);
+
 		readonly Lazy<PlatformConfigurationRegistry<Entry>> _platformConfigurationRegistry;
 
 		public Entry()
@@ -101,12 +105,24 @@ namespace Xamarin.Forms
 		{
 			get { return (bool)GetValue(IsTextPredictionEnabledProperty); }
 			set { SetValue(IsTextPredictionEnabledProperty, value); }
-    }
+		}
     
 		public ReturnType ReturnType
 		{
 			get => (ReturnType)GetValue(ReturnTypeProperty);
 			set => SetValue(ReturnTypeProperty, value);
+		}
+
+		public int CursorPosition
+		{
+			get { return (int)GetValue(CursorPositionProperty); }
+			set { SetValue(CursorPositionProperty, value); }
+		}
+
+		public int SelectionLength
+		{
+			get { return (int)GetValue(SelectionLengthProperty); }
+			set { SetValue(SelectionLengthProperty, value); }
 		}
 
 		public ICommand ReturnCommand

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -39,6 +39,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(Entry), 0);
 
+		public static readonly BindableProperty CursorColorProperty = BindableProperty.Create(nameof(CursorColor), typeof(Color), typeof(Entry), Color.Default);
+
 		readonly Lazy<PlatformConfigurationRegistry<Entry>> _platformConfigurationRegistry;
 
 		public Entry()
@@ -123,6 +125,12 @@ namespace Xamarin.Forms
 		{
 			get { return (int)GetValue(SelectionLengthProperty); }
 			set { SetValue(SelectionLengthProperty, value); }
+		}
+
+		public Color CursorColor
+		{
+			get { return (Color)GetValue(CursorColorProperty); }
+			set { SetValue(CursorColorProperty, value); }
 		}
 
 		public ICommand ReturnCommand

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -39,8 +39,6 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(Entry), 0);
 
-		public static readonly BindableProperty CursorColorProperty = BindableProperty.Create(nameof(CursorColor), typeof(Color), typeof(Entry), Color.Default);
-
 		readonly Lazy<PlatformConfigurationRegistry<Entry>> _platformConfigurationRegistry;
 
 		public Entry()
@@ -125,12 +123,6 @@ namespace Xamarin.Forms
 		{
 			get { return (int)GetValue(SelectionLengthProperty); }
 			set { SetValue(SelectionLengthProperty, value); }
-		}
-
-		public Color CursorColor
-		{
-			get { return (Color)GetValue(CursorColorProperty); }
-			set { SetValue(CursorColorProperty, value); }
 		}
 
 		public ICommand ReturnCommand

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Entry.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Entry.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 		public static readonly BindableProperty AdjustsFontSizeToFitWidthProperty =
 			BindableProperty.Create("AdjustsFontSizeToFitWidth", typeof(bool),
 				typeof(Entry), false);
+		public static readonly BindableProperty CursorColorProperty = BindableProperty.Create("CursorColor", typeof(Color), typeof(Entry), Color.Default);
 
 		public static bool GetAdjustsFontSizeToFitWidth(BindableObject element)
 		{
@@ -43,6 +44,27 @@ namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 			this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			SetAdjustsFontSizeToFitWidth(config.Element, false);
+			return config;
+		}
+
+		public static Color GetCursorColor(BindableObject element)
+		{
+			return (Color)element.GetValue(CursorColorProperty);
+		}
+
+		public static void SetCursorColor(BindableObject element, Color value)
+		{
+			element.SetValue(CursorColorProperty, value);
+		}
+
+		public static Color GetCursorColor(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetCursorColor(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetCursorColor(this IPlatformElementConfiguration<iOS, FormsElement> config, Color value)
+		{
+			SetCursorColor(config.Element, value);
 			return config;
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -289,14 +289,17 @@ namespace Xamarin.Forms.Platform.Android
 		void SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 			var control = Control;
+			if (control == null || Element == null)
+				return;
+
 			var start = Element.CursorPosition;
 
 			if (control.SelectionStart != start)
-				ElementController.SetValueFromRenderer(Entry.CursorPositionProperty, control.SelectionStart);
+				ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, control.SelectionStart);
 
 			var selectionLength = control.SelectionEnd - control.SelectionStart;
 			if (selectionLength != Element.SelectionLength)
-				ElementController.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+				ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
 		}
 
 
@@ -306,13 +309,16 @@ namespace Xamarin.Forms.Platform.Android
 			if (control == null || Element == null)
 				return;
 
-			var start = Element.CursorPosition;
-			var end = System.Math.Min(control.Length(), Element.CursorPosition + Element.SelectionLength);
-
-			if (control.SelectionStart != start || control.SelectionEnd != end)
+			if (Element.IsSet(Entry.CursorPositionProperty) || Element.IsSet(Entry.SelectionLengthProperty))
 			{
-				control.SetSelection(start, end);
-				control.RequestFocus();
+				var start = Element.CursorPosition;
+				var end = System.Math.Min(control.Length(), Element.CursorPosition + Element.SelectionLength);
+
+				if (control.SelectionStart != start || control.SelectionEnd != end)
+				{
+					control.SetSelection(start, end);
+					control.RequestFocus();
+				}
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Platform.Android
 		TextColorSwitcher _textColorSwitcher;
 		bool _disposed;
 		ImeAction _currentInputImeFlag;
+		IElementController ElementController => Element as IElementController;
 
 		public EntryRenderer(Context context) : base(context)
 		{
@@ -79,6 +80,7 @@ namespace Xamarin.Forms.Platform.Android
 				textView.AddTextChangedListener(this);
 				textView.SetOnEditorActionListener(this);
 				textView.OnKeyboardBackPressed += OnKeyboardBackPressed;
+				textView.SelectionChanged += SelectionChanged;
 
 				var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
 
@@ -98,6 +100,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateMaxLength();
 			UpdateImeOptions();
 			UpdateReturnType();
+			UpdateCursorSelection();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -114,6 +117,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (Control != null)
 				{
 					Control.OnKeyboardBackPressed -= OnKeyboardBackPressed;
+					Control.SelectionChanged -= SelectionChanged;
 				}
 			}
 
@@ -164,6 +168,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateImeOptions();
 			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
 				UpdateReturnType();
+			else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName || e.PropertyName == Entry.SelectionLengthProperty.PropertyName)
+				UpdateCursorSelection();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -278,6 +284,36 @@ namespace Xamarin.Forms.Platform.Android
 			
 			Control.ImeOptions = Element.ReturnType.ToAndroidImeAction();
 			_currentInputImeFlag = Control.ImeOptions;
+		}
+
+		void SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			var control = Control;
+			var start = Element.CursorPosition;
+
+			if (control.SelectionStart != start)
+				ElementController.SetValueFromRenderer(Entry.CursorPositionProperty, control.SelectionStart);
+
+			var selectionLength = control.SelectionEnd - control.SelectionStart;
+			if (selectionLength != Element.SelectionLength)
+				ElementController.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+		}
+
+
+		void UpdateCursorSelection()
+		{
+			var control = Control;
+			if (control == null || Element == null)
+				return;
+
+			var start = Element.CursorPosition;
+			var end = System.Math.Min(control.Length(), Element.CursorPosition + Element.SelectionLength);
+
+			if (control.SelectionStart != start || control.SelectionEnd != end)
+			{
+				control.SetSelection(start, end);
+				control.RequestFocus();
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsEditText.cs
@@ -41,7 +41,26 @@ namespace Xamarin.Forms.Platform.Android
 			return (this as IDescendantFocusToggler).RequestFocus(this, () => base.RequestFocus(direction, previouslyFocusedRect));
 		}
 
+		protected override void OnSelectionChanged(int selStart, int selEnd)
+		{
+			base.OnSelectionChanged(selStart, selEnd);
+			SelectionChanged?.Invoke(this, new SelectionChangedEventArgs(selStart, selEnd));
+		}
+
 		internal event EventHandler OnKeyboardBackPressed;
+		internal event EventHandler<SelectionChangedEventArgs> SelectionChanged;
+	}
+
+	public class SelectionChangedEventArgs : EventArgs
+	{
+		public int Start { get; private set; }
+		public int End { get; private set; }
+
+		public SelectionChangedEventArgs(int start, int end)
+		{
+			Start = start;
+			End = end;
+		}
 	}
 
 	[Obsolete("EntryEditText is obsolete as of version 2.4.0. Please use Xamarin.Forms.Platform.Android.FormsEditText instead.")]

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Platform.UWP
 		Brush _textDefaultBrush;
 		Brush _defaultTextColorFocusBrush;
 		Brush _defaultPlaceholderColorFocusBrush;
+		IElementController ElementController => Element as IElementController;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
 		{
@@ -32,7 +33,7 @@ namespace Xamarin.Forms.Platform.UWP
 					SetNativeControl(textBox);
 					textBox.TextChanged += OnNativeTextChanged;
 					textBox.KeyUp += TextBoxOnKeyUp;
-
+					textBox.SelectionChanged += SelectionChanged;
 					// If the Forms VisualStateManager is in play or the user wants to disable the Forms legacy
 					// color stuff, then the underlying textbox should just use the Forms VSM states
 					textBox.UseFormsVsm = e.NewElement.HasVisualStateGroups()
@@ -50,6 +51,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateMaxLength();
 				UpdateDetectReadingOrderFromContent();
 				UpdateReturnType();
+				UpdateCursorPosition();
+				UpdateSelectionLength();
 			}
 		}
 
@@ -59,6 +62,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				Control.TextChanged -= OnNativeTextChanged;
 				Control.KeyUp -= TextBoxOnKeyUp;
+				Control.SelectionChanged -= SelectionChanged;
 			}
 
 			base.Dispose(disposing);
@@ -100,6 +104,10 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateDetectReadingOrderFromContent();
 			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
 				UpdateReturnType();
+			else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName)
+				UpdateCursorPosition();
+			else if (e.PropertyName == Entry.SelectionLengthProperty.PropertyName)
+				UpdateSelectionLength();
 		}
 
 		protected override void UpdateBackgroundColor()
@@ -264,6 +272,47 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 
 			Control.InputScope = Element.ReturnType.ToInputScope();
+		}
+
+		void SelectionChanged(object sender, RoutedEventArgs e)
+		{
+			var control = Control;
+			var start = Element.CursorPosition;
+
+			if (control.SelectionStart != start)
+				ElementController.SetValueFromRenderer(Entry.CursorPositionProperty, control.SelectionStart);
+
+			var selectionLength = control.SelectionLength;
+			if (selectionLength != Element.SelectionLength)
+				ElementController.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+		}
+
+		void UpdateSelectionLength()
+		{
+			var control = Control;
+			if (control == null || Element == null)
+				return;
+
+			var selectionLength = Element.SelectionLength;
+			if (selectionLength != control.SelectionLength)
+			{
+				control.SelectionLength = selectionLength;
+				control.Focus(FocusState.Programmatic);
+			}
+		}
+
+		void UpdateCursorPosition()
+		{
+			var control = Control;
+			if (control == null || Element == null)
+				return;
+
+			var start = Element.CursorPosition;
+			if (start != control.SelectionStart)
+			{
+				control.SelectionStart = start;
+				control.Focus(FocusState.Programmatic);
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -277,14 +277,17 @@ namespace Xamarin.Forms.Platform.UWP
 		void SelectionChanged(object sender, RoutedEventArgs e)
 		{
 			var control = Control;
+			if (control == null || Element == null)
+				return;
+
 			var start = Element.CursorPosition;
 
 			if (control.SelectionStart != start)
-				ElementController.SetValueFromRenderer(Entry.CursorPositionProperty, control.SelectionStart);
+				ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, control.SelectionStart);
 
 			var selectionLength = control.SelectionLength;
 			if (selectionLength != Element.SelectionLength)
-				ElementController.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+				ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
 		}
 
 		void UpdateSelectionLength()
@@ -293,11 +296,14 @@ namespace Xamarin.Forms.Platform.UWP
 			if (control == null || Element == null)
 				return;
 
-			var selectionLength = Element.SelectionLength;
-			if (selectionLength != control.SelectionLength)
+			if (Element.IsSet(Entry.SelectionLengthProperty))
 			{
-				control.SelectionLength = selectionLength;
-				control.Focus(FocusState.Programmatic);
+				var selectionLength = Element.SelectionLength;
+				if (selectionLength != control.SelectionLength)
+				{
+					control.SelectionLength = selectionLength;
+					control.Focus(FocusState.Programmatic);
+				}
 			}
 		}
 
@@ -307,11 +313,14 @@ namespace Xamarin.Forms.Platform.UWP
 			if (control == null || Element == null)
 				return;
 
-			var start = Element.CursorPosition;
-			if (start != control.SelectionStart)
+			if (Element.IsSet(Entry.CursorPositionProperty))
 			{
-				control.SelectionStart = start;
-				control.Focus(FocusState.Programmatic);
+				var start = Element.CursorPosition;
+				if (start != control.SelectionStart)
+				{
+					control.SelectionStart = start;
+					control.Focus(FocusState.Programmatic);
+				}
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -340,12 +340,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (Element.IsSet(Entry.CursorPositionProperty) || Element.IsSet(Entry.SelectionLengthProperty)) {
 
+				control.BecomeFirstResponder();
 				var start = control.GetPosition(control.BeginningOfDocument, Element.CursorPosition);
 				var end = control.GetPosition(start, System.Math.Min(control.Text.Length - Element.CursorPosition, Element.SelectionLength));
 				var currentSelection = control.SelectedTextRange;
 				if (currentSelection.Start != start || currentSelection.End != end)
 				{
-					control.BecomeFirstResponder();
 					_selectedTextRangeIsUpdating = true;
 					control.SelectedTextRange = control.GetTextRange(start, end);
 					_selectedTextRangeIsUpdating = false;

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -6,6 +6,7 @@ using CoreGraphics;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using Specifics = Xamarin.Forms.PlatformConfiguration.iOSSpecific.Entry;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -155,7 +156,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateReturnType();
 			else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName || e.PropertyName == Entry.SelectionLengthProperty.PropertyName)
 				UpdateCursorSelection();
-			else if (e.PropertyName == Entry.CursorColorProperty.PropertyName)
+			else if (e.PropertyName == Specifics.CursorColorProperty.PropertyName)
 				UpdateCursorColor();
 
 			base.OnElementPropertyChanged(sender, e);
@@ -358,13 +359,13 @@ namespace Xamarin.Forms.Platform.iOS
 			if (control == null || Element == null)
 				return;
 
-			if (Element.IsSet(Entry.CursorColorProperty))
+			if (Element.IsSet(Specifics.CursorColorProperty))
 			{
-				var color = Element.CursorColor;
+				var color = Element.OnThisPlatform().GetCursorColor();
 				if (color == Color.Default)
 					control.TintColor = _defaultCursorColor;
 				else
-					control.TintColor = Element.CursorColor.ToUIColor();
+					control.TintColor = color.ToUIColor();
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		bool _disposed;
 		IDisposable _selectedTextRangeObserver;
+		bool _selectedTextRangeIsUpdating;
 
 		static readonly int baseHeight = 30;
 		static CGSize initialSize = CGSize.Empty;
@@ -168,6 +169,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnEditingChanged(object sender, EventArgs eventArgs)
 		{
 			ElementController.SetValueFromRenderer(Entry.TextProperty, Control.Text);
+			UpdateCursorFromControl(null);
 		}
 
 		void OnEditingEnded(object sender, EventArgs e)
@@ -310,13 +312,11 @@ namespace Xamarin.Forms.Platform.iOS
 			Control.ReturnKeyType = Element.ReturnType.ToUIReturnKeyType();
 		}
 
-		bool _selectedTextRangeIsUpdating;
-
 		void UpdateCursorFromControl(NSObservedChange obj)
 		{
-			if (_selectedTextRangeIsUpdating)
-				return;
 			var control = Control;
+			if (_selectedTextRangeIsUpdating || control == null || Element == null)
+				return;
 
 			var currentSelection = control.SelectedTextRange;
 			int selectionLength = (int)control.GetOffsetFromPosition(currentSelection.Start, currentSelection.End);
@@ -324,10 +324,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_selectedTextRangeIsUpdating = true;
 			if (newCursorPosition != Element.CursorPosition)
-				ElementController.SetValueFromRenderer(Entry.CursorPositionProperty, newCursorPosition);
+				ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, newCursorPosition);
 
 			if (selectionLength != Element.SelectionLength)
-				ElementController.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+				ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
 			_selectedTextRangeIsUpdating = false;
 		}
 


### PR DESCRIPTION
### Description of Change ###

This PR adds support for getting and setting
caret position on a text Entry on iOS, Android and UWP.

Also adding support for setting CursorColor but only for iOS since
it seems unsupported on UWP and couldn't figure out how to do it
on Android in an not too complicated manner.

### Bugs Fixed ###

- Fixes #1667 except for cursor color functionality on UWP and Android.

### API Changes ###

Added:
 - `int Entry.CursorPosition { get; set; } //Bindable Property`
 - `int Entry.SelectionLength { get; set; } // Bindable Property`
 - `Color Entry<iOS>.CursorColor { get; set; } // iOS specific Bindable Property`

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
