### PR TITLE
Fix .css files not excluded from default None items

### DIFF
--- a/.nuspec/Xamarin.Forms.DefaultItems.targets
+++ b/.nuspec/Xamarin.Forms.DefaultItems.targets
@@ -12,7 +12,7 @@
 		<None Remove="**\*.xaml" Condition="'$(EnableDefaultNoneItems)'=='True'" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(EnableDefaultItems)'=='True' And '$(EnableDefaultCssItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
-		<None Remove="**\*.xaml" Condition="'$(EnableDefaultNoneItems)'=='True'" />
+		<None Remove="**\*.css" Condition="'$(EnableDefaultNoneItems)'=='True'" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description of Change ###

Fixes duplicate CSS files in solution pad in VS Mac.

### Bugs Fixed ###

- Fixes VSTS #606364 - CSS files are duplicated in solution pad

### API Changes ###

None

### Behavioral Changes ###


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense