### PR TITLE
Improve warning message, since the calling code isn't on Device

### DIFF
--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -113,7 +113,7 @@ namespace Xamarin.Forms
             return GetNamedSize(size, targetElementType, false);
         }
 
-        [Obsolete("OnPlatform is obsolete as of version 2.3.4. Please use switch(RuntimePlatform) instead.")]
+        [Obsolete("OnPlatform is obsolete as of version 2.3.4. Please use 'switch (Device.RuntimePlatform)' instead.")]
         public static void OnPlatform(Action iOS = null, Action Android = null, Action WinPhone = null, Action Default = null)
         {
             switch (OS)
@@ -144,7 +144,7 @@ namespace Xamarin.Forms
             }
         }
 
-        [Obsolete("OnPlatform<> (generic) is obsolete as of version 2.3.4. Please use switch(RuntimePlatform) instead.")]
+        [Obsolete("OnPlatform<> (generic) is obsolete as of version 2.3.4. Please use 'switch (Device.RuntimePlatform)' instead.")]
         public static T OnPlatform<T>(T iOS, T Android, T WinPhone)
         {
             switch (OS)


### PR DESCRIPTION
The existing message is confusing since the `RuntimePlatform` is not a member of the calling code 
but of `Device`. So use the full member name in the suggested API usage.

Reduces the confusion of:

![image](https://user-images.githubusercontent.com/169707/39269540-7efff3f2-48a9-11e8-88c3-0bfcd47ee7ea.png)

Followed by:

![image](https://user-images.githubusercontent.com/169707/39269550-86518de6-48a9-11e8-8d24-ea6f3157eee2.png)
