### PR TITLE
Namescope enhancements

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
@@ -48,16 +48,18 @@ namespace Xamarin.Forms.Build.Tasks
 		{
 			VariableDefinition namescopeVarDef;
 			IList<string> namesInNamescope;
+			var setNameScope = false;
 			if (parentNode == null || IsDataTemplate(node, parentNode) || IsStyle(node, parentNode) || IsVisualStateGroupList(node)) {
 				namescopeVarDef = CreateNamescope();
 				namesInNamescope = new List<string>();
+				setNameScope = true;
 			} else {
 				namescopeVarDef = Context.Scopes[parentNode].Item1;
 				namesInNamescope = Context.Scopes[parentNode].Item2;
 			}
-			if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference(("Xamarin.Forms.Core","Xamarin.Forms","BindableObject"))))
+			if (setNameScope && Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference(("Xamarin.Forms.Core","Xamarin.Forms","BindableObject"))))
 				SetNameScope(node, namescopeVarDef);
-			Context.Scopes[node] = new System.Tuple<VariableDefinition, IList<string>>(namescopeVarDef, namesInNamescope);
+			Context.Scopes[node] = new Tuple<VariableDefinition, IList<string>>(namescopeVarDef, namesInNamescope);
 		}
 	
 		public void Visit(RootNode node, INode parentNode)

--- a/Xamarin.Forms.Core/ConstraintExpression.cs
+++ b/Xamarin.Forms.Core/ConstraintExpression.cs
@@ -31,27 +31,33 @@ namespace Xamarin.Forms
 		public Constraint ProvideValue(IServiceProvider serviceProvider)
 		{
 			MethodInfo minfo;
-			switch (Type)
-			{
-				default:
-				case ConstraintType.RelativeToParent:
-					if (string.IsNullOrEmpty(Property))
-						return null;
-					minfo = typeof(View).GetProperties().First(pi => pi.Name == Property && pi.CanRead && pi.GetMethod.IsPublic).GetMethod;
-					return Constraint.RelativeToParent(p => (double)minfo.Invoke(p, new object[] { }) * Factor + Constant);
-				case ConstraintType.Constant:
-					return Constraint.Constant(Constant);
-				case ConstraintType.RelativeToView:
-					if (string.IsNullOrEmpty(Property))
-						return null;
-					if (string.IsNullOrEmpty(ElementName))
-						return null;
-					minfo = typeof(View).GetProperties().First(pi => pi.Name == Property && pi.CanRead && pi.GetMethod.IsPublic).GetMethod;
-					var valueProvider = serviceProvider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+			switch (Type) {
+			default:
+			case ConstraintType.RelativeToParent:
+				if (string.IsNullOrEmpty(Property))
+					return null;
+				minfo = typeof(View).GetProperties().First(pi => pi.Name == Property && pi.CanRead && pi.GetMethod.IsPublic).GetMethod;
+				return Constraint.RelativeToParent(p => (double)minfo.Invoke(p, new object[] { }) * Factor + Constant);
+			case ConstraintType.Constant:
+				return Constraint.Constant(Constant);
+			case ConstraintType.RelativeToView:
+				if (string.IsNullOrEmpty(Property))
+					return null;
+				if (string.IsNullOrEmpty(ElementName))
+					return null;
+				minfo = typeof(View).GetProperties().First(pi => pi.Name == Property && pi.CanRead && pi.GetMethod.IsPublic).GetMethod;
+				var referenceProvider = serviceProvider.GetService<IReferenceProvider>();
+
+				View view;
+				if (referenceProvider != null)
+					view = (View)referenceProvider.FindByName(ElementName);
+				else { //legacy path
+					var valueProvider = serviceProvider.GetService<IProvideValueTarget>();
 					if (valueProvider == null || !(valueProvider.TargetObject is INameScope))
 						return null;
-					var view = ((INameScope)valueProvider.TargetObject).FindByName<View>(ElementName);
-					return Constraint.RelativeToView(view, delegate(RelativeLayout p, View v) { return (double)minfo.Invoke(v, new object[] { }) * Factor + Constant; });
+					view = ((INameScope)valueProvider.TargetObject).FindByName<View>(ElementName);
+				}
+				return Constraint.RelativeToView(view, delegate (RelativeLayout p, View v) { return (double)minfo.Invoke(v, new object[] { }) * Factor + Constant; });
 			}
 		}
 	}

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -283,9 +283,9 @@ namespace Xamarin.Forms
 			return false;
 		}
 
-		object INameScope.FindByName(string name)
+		public object FindByName(string name)
 		{
-			INameScope namescope = GetNameScope();
+			var namescope = GetNameScope();
 			if (namescope == null)
 				throw new InvalidOperationException("this element is not in a namescope");
 			return namescope.FindByName(name);
@@ -293,27 +293,10 @@ namespace Xamarin.Forms
 
 		void INameScope.RegisterName(string name, object scopedElement)
 		{
-			INameScope namescope = GetNameScope();
+			var namescope = GetNameScope();
 			if (namescope == null)
 				throw new InvalidOperationException("this element is not in a namescope");
 			namescope.RegisterName(name, scopedElement);
-		}
-
-		[Obsolete]
-		void INameScope.RegisterName(string name, object scopedElement, IXmlLineInfo xmlLineInfo)
-		{
-			INameScope namescope = GetNameScope();
-			if (namescope == null)
-				throw new InvalidOperationException("this element is not in a namescope");
-			namescope.RegisterName(name, scopedElement, xmlLineInfo);
-		}
-
-		void INameScope.UnregisterName(string name)
-		{
-			INameScope namescope = GetNameScope();
-			if (namescope == null)
-				throw new InvalidOperationException("this element is not in a namescope");
-			namescope.UnregisterName(name);
 		}
 
 		public event EventHandler<ElementEventArgs> ChildAdded;
@@ -625,30 +608,25 @@ namespace Xamarin.Forms
 
 		INameScope GetNameScope()
 		{
-			INameScope namescope = NameScope.GetNameScope(this);
-			Element p = RealParent;
-			while (namescope == null && p != null)
-			{
-				namescope = NameScope.GetNameScope(p);
-				p = p.RealParent;
-			}
-			return namescope;
+			var element = this;
+			do {
+				var ns = NameScope.GetNameScope(element);
+				if (ns != null)
+					return ns;
+			} while ((element = element.RealParent) != null);
+			return null;
 		}
 
 		void OnDescendantAdded(Element child)
 		{
 			DescendantAdded?.Invoke(this, new ElementEventArgs(child));
-
-			if (RealParent != null)
-				RealParent.OnDescendantAdded(child);
+			RealParent?.OnDescendantAdded(child);
 		}
 
 		void OnDescendantRemoved(Element child)
 		{
 			DescendantRemoved?.Invoke(this, new ElementEventArgs(child));
-
-			if (RealParent != null)
-				RealParent.OnDescendantRemoved(child);
+			RealParent?.OnDescendantRemoved(child);
 		}
 
 		void OnResourceChanged(BindableProperty property, object value)

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -606,7 +606,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		INameScope GetNameScope()
+		internal INameScope GetNameScope()
 		{
 			var element = this;
 			do {

--- a/Xamarin.Forms.Core/Internals/INameScope.cs
+++ b/Xamarin.Forms.Core/Internals/INameScope.cs
@@ -9,7 +9,5 @@ namespace Xamarin.Forms.Internals
 	{
 		object FindByName(string name);
 		void RegisterName(string name, object scopedElement);
-		void UnregisterName(string name);
-		[Obsolete]void RegisterName(string name, object scopedElement, IXmlLineInfo xmlLineInfo);
 	}
 }

--- a/Xamarin.Forms.Core/Internals/INamescopeProvider.cs
+++ b/Xamarin.Forms.Core/Internals/INamescopeProvider.cs
@@ -3,6 +3,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Xaml.Internals
 {
+	[Obsolete]
 	interface INameScopeProvider
 	{
 		INameScope NameScope { get; }

--- a/Xamarin.Forms.Core/Internals/NameScope.cs
+++ b/Xamarin.Forms.Core/Internals/NameScope.cs
@@ -1,49 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Xml;
-using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Internals
 {
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NameScope : INameScope
 	{
-		public static readonly BindableProperty NameScopeProperty = BindableProperty.CreateAttached("NameScope", typeof(INameScope), typeof(NameScope), default(INameScope));
+		public static readonly BindableProperty NameScopeProperty =
+			BindableProperty.CreateAttached("NameScope", typeof(INameScope), typeof(NameScope), default(INameScope));
 
 		readonly Dictionary<string, object> _names = new Dictionary<string, object>();
 
 		object INameScope.FindByName(string name)
-		{
-			if (_names.ContainsKey(name))
-				return _names[name];
-			return null;
-		}
+			=> _names.TryGetValue(name, out var element) ? element : null;
 
 		void INameScope.RegisterName(string name, object scopedElement)
 		{
 			if (_names.ContainsKey(name))
-				throw new ArgumentException("An element with the same key already exists in NameScope", "name");
+				throw new ArgumentException("An element with the same key already exists in NameScope", nameof(name));
 
 			_names[name] = scopedElement;
-		}
-
-		[Obsolete]
-		void INameScope.RegisterName(string name, object scopedElement, IXmlLineInfo xmlLineInfo)
-		{
-			try
-			{
-				((INameScope)this).RegisterName(name, scopedElement);
-			}
-			catch (ArgumentException)
-			{
-				throw new XamlParseException(string.Format("An element with the name \"{0}\" already exists in this NameScope", name), xmlLineInfo);
-			}
-		}
-
-		void INameScope.UnregisterName(string name)
-		{
-			_names.Remove(name);
 		}
 
 		public static INameScope GetNameScope(BindableObject bindable)

--- a/Xamarin.Forms.Core/NameScopeExtensions.cs
+++ b/Xamarin.Forms.Core/NameScopeExtensions.cs
@@ -5,13 +5,9 @@ namespace Xamarin.Forms
 	public static class NameScopeExtensions
 	{
 		public static T FindByName<T>(this Element element, string name)
-		{
-			return ((INameScope)element).FindByName<T>(name);
-		}
+		=> (T)element.FindByName(name);
 
 		internal static T FindByName<T>(this INameScope namescope, string name)
-		{
-			return (T)namescope.FindByName(name);
-		}
+			=> (T)namescope.FindByName(name);
 	}
 }

--- a/Xamarin.Forms.Core/ReferenceTypeConverter.cs
+++ b/Xamarin.Forms.Core/ReferenceTypeConverter.cs
@@ -18,10 +18,19 @@ namespace Xamarin.Forms
 		{
 			if (serviceProvider == null)
 				throw new ArgumentNullException(nameof(serviceProvider));
+
+			var referenceProvider = serviceProvider.GetService<IReferenceProvider>();
+			if (referenceProvider != null) {
+				return referenceProvider.FindByName(value)
+					   ?? throw new XamlParseException($"Can't resolve name '{value}' on Element", serviceProvider?.GetService<IXmlLineInfoProvider>()?.XmlLineInfo ?? new XmlLineInfo());
+			}
+
+#pragma warning disable CS0612 // Type or member is obsolete
+			//legacy path
+			var namescopeprovider = serviceProvider.GetService(typeof(INameScopeProvider)) as INameScopeProvider;
 			var valueProvider = serviceProvider.GetService(typeof(IProvideValueTarget)) as IProvideParentValues;
 			if (valueProvider == null)
 				throw new ArgumentException("serviceProvider does not provide an IProvideValueTarget");
-			var namescopeprovider = serviceProvider.GetService(typeof(INameScopeProvider)) as INameScopeProvider;
 			if (namescopeprovider != null && namescopeprovider.NameScope != null) {
 				var element = namescopeprovider.NameScope.FindByName(value);
 				if (element != null)
@@ -37,6 +46,7 @@ namespace Xamarin.Forms
 					return element;
 			}
 			throw new Exception("Can't resolve name on Element");
+#pragma warning restore CS0612 // Type or member is obsolete
 		}
 
 		public override object ConvertFromInvariantString(string value)

--- a/Xamarin.Forms.Core/Xaml/IReferenceProvider.cs
+++ b/Xamarin.Forms.Core/Xaml/IReferenceProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms.Xaml
+{
+	public interface IReferenceProvider
+	{
+		object FindByName(string name);
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/DynamicResource.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DynamicResource.xaml.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 
 using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -22,8 +23,19 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		public class Tests
 		{
-			[TestCase (false)]
-			[TestCase (true)]
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase (false), TestCase (true)]
 			public void TestDynamicResources (bool useCompiledXaml)
 			{
 				var layout = new DynamicResource (useCompiledXaml);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2517.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2517.xaml.cs
@@ -24,7 +24,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		class Tests
 		{
-
 			[SetUp]
 			public void Setup()
 			{

--- a/Xamarin.Forms.Xaml.UnitTests/NameScopeTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/NameScopeTests.cs
@@ -39,9 +39,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That (Forms.Internals.NameScope.GetNameScope (layout), Is.TypeOf<Forms.Internals.NameScope> ());
 
 			foreach (var child in layout.Children) {
-				Assert.IsNotNull (Forms.Internals.NameScope.GetNameScope (child));
-				Assert.That (Forms.Internals.NameScope.GetNameScope (child), Is.TypeOf<Forms.Internals.NameScope> ());
-				Assert.AreSame (Forms.Internals.NameScope.GetNameScope (layout), Forms.Internals.NameScope.GetNameScope (child));
+				Assert.IsNull (Forms.Internals.NameScope.GetNameScope (child));
+				Assert.AreSame (Forms.Internals.NameScope.GetNameScope (layout), child.GetNameScope());
 			}
 		}
 

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -114,7 +114,7 @@ namespace Xamarin.Forms.Xaml
 				INode xKey;
 				if (!node.Properties.TryGetValue(XmlName.xKey, out xKey))
 					xKey = null;
-				
+
 				node.Properties.Clear();
 				node.CollectionItems.Clear();
 
@@ -124,8 +124,9 @@ namespace Xamarin.Forms.Xaml
 				Values[node] = value;
 			}
 
-			if (value is BindableObject)
-				NameScope.SetNameScope(value as BindableObject, node.Namescope);
+			var bindableValue = value as BindableObject;
+			if (bindableValue != null)
+				NameScope.SetNameScope(bindableValue, node.Namescope);
 		}
 
 		public void Visit(RootNode node, INode parentNode)

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Forms.Xaml
 			}
 
 			var bindableValue = value as BindableObject;
-			if (bindableValue != null)
+			if (bindableValue != null && node.Namescope != (parentNode as IElementNode)?.Namescope)
 				NameScope.SetNameScope(bindableValue, node.Namescope);
 		}
 

--- a/Xamarin.Forms.Xaml/MarkupExtensions/ReferenceExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/ReferenceExtension.cs
@@ -13,20 +13,27 @@ namespace Xamarin.Forms.Xaml
 		{
 			if (serviceProvider == null)
 				throw new ArgumentNullException(nameof(serviceProvider));
-			var valueProvider = serviceProvider.GetService(typeof (IProvideValueTarget)) as IProvideParentValues;
-			if (valueProvider == null)
-				throw new ArgumentException("serviceProvider does not provide an IProvideValueTarget");
-			var namescopeprovider = serviceProvider.GetService(typeof (INameScopeProvider)) as INameScopeProvider;
-			if (namescopeprovider != null && namescopeprovider.NameScope != null)
-			{
+			var referenceProvider = serviceProvider.GetService<IReferenceProvider>();
+			if (referenceProvider != null)
+				return referenceProvider.FindByName(Name)
+					   ?? throw new XamlParseException($"Can not find the object referenced by `{Name}`", serviceProvider?.GetService<IXmlLineInfoProvider>()?.XmlLineInfo ?? new XmlLineInfo());
+
+#pragma warning disable CS0612 // Type or member is obsolete
+			//legacy path. could be hit by code processed by previous versions of XamlC
+			var valueProvider = serviceProvider.GetService<IProvideValueTarget>() as IProvideParentValues
+											   ?? throw new ArgumentException("serviceProvider does not provide an IProvideValueTarget");
+			var namescopeprovider = serviceProvider.GetService<INameScopeProvider>();
+			if (namescopeprovider != null && namescopeprovider.NameScope != null) {
 				var value = namescopeprovider.NameScope.FindByName(Name);
 				if (value != null)
 					return value;
 			}
 
-			foreach (var target in valueProvider.ParentObjects)
-			{
-				var ns = target as INameScope;
+			foreach (var target in valueProvider.ParentObjects) {
+				var bo = target as BindableObject;
+				if (bo == null)
+					continue;
+				var ns = NameScope.GetNameScope(bo) as INameScope;
 				if (ns == null)
 					continue;
 				var value = ns.FindByName(Name);
@@ -34,8 +41,9 @@ namespace Xamarin.Forms.Xaml
 					return value;
 			}
 
-			var lineInfo = (serviceProvider?.GetService(typeof(IXmlLineInfoProvider)) as IXmlLineInfoProvider)?.XmlLineInfo ?? new XmlLineInfo();
+			var lineInfo = serviceProvider?.GetService<IXmlLineInfoProvider>()?.XmlLineInfo ?? new XmlLineInfo();
 			throw new XamlParseException($"Can not find the object referenced by `{Name}`", lineInfo);
+#pragma warning restore CS0612 // Type or member is obsolete
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml/NamescopingVisitor.cs
+++ b/Xamarin.Forms.Xaml/NamescopingVisitor.cs
@@ -3,14 +3,12 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Xaml
 {
-	internal class NamescopingVisitor : IXamlNodeVisitor
+	class NamescopingVisitor : IXamlNodeVisitor
 	{
-		readonly Dictionary<INode, INameScope> scopes = new Dictionary<INode, INameScope>();
+		readonly Dictionary<INode, INameScope> _scopes = new Dictionary<INode, INameScope>();
 
 		public NamescopingVisitor(HydrationContext context)
-		{
-			Values = context.Values;
-		}
+			=> Values = context.Values;
 
 		Dictionary<INode, object> Values { get; set; }
 
@@ -22,55 +20,36 @@ namespace Xamarin.Forms.Xaml
 		public bool IsResourceDictionary(ElementNode node) => false;
 
 		public void Visit(ValueNode node, INode parentNode)
-		{
-			scopes[node] = scopes[parentNode];
-		}
+			=> _scopes[node] = _scopes[parentNode];
 
 		public void Visit(MarkupNode node, INode parentNode)
-		{
-			scopes[node] = scopes[parentNode];
-		}
+			=> _scopes[node] = _scopes[parentNode];
 
 		public void Visit(ElementNode node, INode parentNode)
-		{
-			var ns = parentNode == null || IsDataTemplate(node, parentNode) || IsStyle(node, parentNode) || IsVisualStateGroupList(node)
-				? new NameScope()
-				: scopes[parentNode];
-			node.Namescope = ns;
-			scopes[node] = ns;
-		}
+			=> _scopes[node] = node.Namescope = (parentNode == null || IsDataTemplate(node, parentNode) || IsStyle(node, parentNode) || IsVisualStateGroupList(node))
+								   ? new NameScope()
+								   : _scopes[parentNode];
 
 		public void Visit(RootNode node, INode parentNode)
-		{
-			var ns = new NameScope();
-			node.Namescope = ns;
-			scopes[node] = ns;
-		}
+			=> _scopes[node] = node.Namescope = new NameScope();
 
-		public void Visit(ListNode node, INode parentNode)
-		{
-			scopes[node] = scopes[parentNode];
-		}
+		public void Visit(ListNode node, INode parentNode) =>
+			_scopes[node] = _scopes[parentNode];
 
 		static bool IsDataTemplate(INode node, INode parentNode)
 		{
 			var parentElement = parentNode as IElementNode;
-			INode createContent;
-			if (parentElement != null && parentElement.Properties.TryGetValue(XmlName._CreateContent, out createContent) &&
-			    createContent == node)
+			if (   parentElement != null
+			    && parentElement.Properties.TryGetValue(XmlName._CreateContent, out var createContent)
+			    && createContent == node)
 				return true;
 			return false;
 		}
 
 		static bool IsStyle(INode node, INode parentNode)
-		{
-			var pnode = parentNode as ElementNode;
-			return pnode != null && pnode.XmlType.Name == "Style";
-		}
+			=> (parentNode as ElementNode)?.XmlType.Name == "Style";
 
 		static bool IsVisualStateGroupList(ElementNode node)
-		{
-			return node != null  && node.XmlType.Name == "VisualStateGroup" && node.Parent is IListNode;
-		}
+			=> node?.XmlType.Name == "VisualStateGroup" && node?.Parent is IListNode;
 	}
 }

--- a/Xamarin.Forms.Xaml/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Xaml/Properties/AssemblyInfo.cs
@@ -17,4 +17,6 @@ using Xamarin.Forms.Internals;
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
 
+#pragma warning disable CS0612 // Type or member is obsolete
 [assembly: TypeForwardedTo(typeof(Xamarin.Forms.Xaml.Internals.INameScopeProvider))]
+#pragma warning restore CS0612 // Type or member is obsolete

--- a/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
+++ b/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
@@ -1,5 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml.Internals;
 
 namespace Xamarin.Forms.Xaml
 {

--- a/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
+++ b/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
@@ -1,11 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Reflection;
-using System.Xml;
-using Xamarin.Forms.Internals;
-using Xamarin.Forms.Xaml.Internals;
 
 namespace Xamarin.Forms.Xaml
 {


### PR DESCRIPTION
### Description of Change ###

 - turn Element.FindByName() public
 - reduce the amount of time (both Xaml and XamlC) we need to actually set the NameScope on an object
 - add a IReferenceProvider
   - allows custom markups replicating x:Reference
   - more efficient x:Reference
  

### Bugs Fixed ###

/

### API Changes ###

Added
```
public object Element.FindByName(string name);

public interface Xamarin.Forms.Xaml.IReferenceProvider
{
    object FindByName(string name);
}
```

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense