### PR TITLE
[iOS] Fixes App crash when clicking "undo", "cut", "delete" on Picker

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -1,12 +1,28 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using Foundation;
+using ObjCRuntime;
 using UIKit;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {
+	internal class ReadOnlyField : NoCaretField
+	{
+		readonly HashSet<string> enableActions;
+
+		public ReadOnlyField() {
+			string[] actions = { "copy:", "select:", "selectAll:" };
+			enableActions = new HashSet<string> (actions);
+		}
+
+		public override bool CanPerform (Selector action, NSObject withSender)
+			=> enableActions.Contains(action.Name);
+	}
+
 	public class PickerRenderer : ViewRenderer<Picker, UITextField>
 	{
 		UIPickerView _picker;
@@ -25,7 +41,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (Control == null)
 				{
-					var entry = new NoCaretField { BorderStyle = UITextBorderStyle.RoundedRect };
+					// disabled cut, delete, and toggle actions because they can throw an unhandlled native exception
+					var entry = new ReadOnlyField { BorderStyle = UITextBorderStyle.RoundedRect };
 
 					entry.EditingDidBegin += OnStarted;
 					entry.EditingDidEnd += OnEnded;
@@ -91,6 +108,8 @@ namespace Xamarin.Forms.Platform.iOS
 			var selectedIndex = Element.SelectedIndex;
 			var items = Element.Items;
 			Control.Text = selectedIndex == -1 || items == null ? "" : items[selectedIndex];
+			// Also clears the undo stack (undo/redo possible on iPad's)
+			Control.UndoManager.RemoveAllActions();
 		}
 
 		void OnEnded(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (Control == null)
 				{
-					// disabled cut, delete, and toggle actions because they can throw an unhandlled native exception
+					// disabled cut, delete, and toggle actions because they can throw an unhandled native exception
 					var entry = new ReadOnlyField { BorderStyle = UITextBorderStyle.RoundedRect };
 
 					entry.EditingDidBegin += OnStarted;
@@ -108,7 +108,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var selectedIndex = Element.SelectedIndex;
 			var items = Element.Items;
 			Control.Text = selectedIndex == -1 || items == null ? "" : items[selectedIndex];
-			// Also clears the undo stack (undo/redo possible on iPad's)
+			// Also clears the undo stack (undo/redo possible on iPads)
 			Control.UndoManager.RemoveAllActions();
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fixes App crash when clicking `undo`, `cut`, `delete` on Picker
Screenshot: https://prnt.sc/jbwlje

### Bugs Fixed ###

Fixes #2465

### API Changes ###

None

### Behavioral Changes ###

- disabled `paste`, `delete` and `cut` action on the Picker
- in the text box of Picker, you can only `select` and `copy` text
- clear the undo stack when typing with a keyboard

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
