### PR TITLE
TitleView

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/SearchbarEffect.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/SearchbarEffect.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportEffect(typeof(SearchbarEffect), "SearchbarEffect")]
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class SearchbarEffect : PlatformEffect
+	{
+		UIColor _defaultBackColor;
+		UIColor _defaultTintColor;
+		UIImage _defaultBackImage;
+		protected override void OnAttached()
+		{
+			if (_defaultBackColor == null)
+				_defaultBackColor = Control.BackgroundColor;
+
+			Control.BackgroundColor = Color.Cornsilk.ToUIColor();
+			
+			if (Control is UISearchBar searchBar)
+			{
+				if (_defaultTintColor == null)
+					_defaultTintColor = searchBar.BarTintColor;
+
+				if (_defaultBackImage == null)
+					_defaultBackImage = searchBar.BackgroundImage;
+
+				searchBar.BarTintColor = Color.Goldenrod.ToUIColor();
+				searchBar.BackgroundImage = new UIImage();
+			}
+		}
+
+		protected override void OnDetached()
+		{
+			Control.BackgroundColor = _defaultBackColor;
+
+			if (Control is UISearchBar searchBar)
+			{
+				searchBar.BarTintColor = _defaultTintColor;
+				searchBar.BackgroundImage = _defaultBackImage;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -106,6 +106,7 @@
     <Compile Include="AttachedStateEffectRenderer.cs" />
     <Compile Include="BrokenImageSourceHandler.cs" />
     <Compile Include="BrokenNativeControl.cs" />
+    <Compile Include="SearchbarEffect.cs" />
     <Compile Include="CustomRenderer40251.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
@@ -82,7 +82,11 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Content = new StackLayout { Children = { testRunRef, nextButton, _PerformanceTracker } };
 
-			ViewModel.BenchmarkResults = await PerformanceDataManager.GetScenarioResults(_DeviceIdentifier);
+			try
+			{
+				ViewModel.BenchmarkResults = await PerformanceDataManager.GetScenarioResults(_DeviceIdentifier);
+			}
+			catch { }
 
 			nextButton.IsEnabled = true;
 			nextButton.Text = Next;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using System.IO;
+using System.Threading.Tasks;
 
 #if UITEST
 using Xamarin.UITest;
@@ -43,7 +44,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		PerformanceViewModel ViewModel => BindingContext as PerformanceViewModel;
 
-		protected override async void Init()
+		protected override void Init()
 		{
 			_BuildInfo = GetBuildNumber();
 
@@ -82,11 +83,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Content = new StackLayout { Children = { testRunRef, nextButton, _PerformanceTracker } };
 
-			try
-			{
-				ViewModel.BenchmarkResults = await PerformanceDataManager.GetScenarioResults(_DeviceIdentifier);
-			}
-			catch { }
+			ViewModel.BenchmarkResults = Task.Run(() => PerformanceDataManager.GetScenarioResults(_DeviceIdentifier)).GetAwaiter().GetResult();
 
 			nextButton.IsEnabled = true;
 			nextButton.Text = Next;

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -386,6 +386,7 @@ namespace Xamarin.Forms.Controls
 			if (navigationBehavior == NavigationBehavior.PushAsync && rootPage.GetType () == typeof (CoreNavigationPage))
 			{
 				_pages.Insert (0, new GalleryPageFactory(() => new NavigationBarGallery((NavigationPage)rootPage), "NavigationBar Gallery - Legacy"));
+				_pages.Insert(1, new GalleryPageFactory(() => new TitleView(), "TitleView"));
 			}
 
 			var template = new DataTemplate(typeof(TextCell));

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -383,9 +383,9 @@ namespace Xamarin.Forms.Controls
 			_titleToPage = _pages.ToDictionary(o => o.Title);
 
 			// avoid NRE for root pages without NavigationBar
-			if (navigationBehavior == NavigationBehavior.PushAsync && rootPage.GetType() == typeof(CoreNavigationPage))
+			if (navigationBehavior == NavigationBehavior.PushAsync && rootPage.GetType () == typeof (CoreNavigationPage))
 			{
-				_pages.Add(new GalleryPageFactory(() => new NavigationBarGallery((NavigationPage)rootPage), "NavigationBar Gallery - Legacy"));
+				_pages.Insert (0, new GalleryPageFactory(() => new NavigationBarGallery((NavigationPage)rootPage), "NavigationBar Gallery - Legacy"));
 			}
 
 			var template = new DataTemplate(typeof(TextCell));

--- a/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
@@ -1,64 +1,161 @@
-using System.Diagnostics;
-
 namespace Xamarin.Forms.Controls
 {
 	public class NavigationBarGallery : ContentPage
 	{
-		public NavigationBarGallery (NavigationPage rootNavPage)
+		public NavigationBarGallery(NavigationPage rootNavPage)
 		{
-
 			int toggleBarTextColor = 0;
 			int toggleBarBackgroundColor = 0;
 
-			Content = new StackLayout {
-				Children = {
-					new Button {
-						Text = "Change BarTextColor", 
-						Command = new Command (() => {
-							if (toggleBarTextColor % 2 == 0) {
-								rootNavPage.BarTextColor = Color.Teal;	
-							} else {
-								rootNavPage.BarTextColor = Color.Default;
-							}
-							toggleBarTextColor++;
-						})
-					},
-					new Button {
-						Text = "Change BarBackgroundColor", 
-						Command = new Command (() => {
-							if (toggleBarBackgroundColor % 2 == 0) {
-								rootNavPage.BarBackgroundColor = Color.Navy;
-							} else {
-								rootNavPage.BarBackgroundColor = Color.Default;
-							}
-							toggleBarBackgroundColor++;
+			ToolbarItems.Add(new ToolbarItem { Text = "Save" });
 
-						})
-					},
-					new Button {
-						Text = "Change Both to default", 
-						Command = new Command (() => {
-							rootNavPage.BarTextColor = Color.Default;
-							rootNavPage.BarBackgroundColor = Color.Default;
-						})
-					},
-					new Button {
-						Text = "Make sure Tint still works", 
-						Command = new Command (() => {
-#pragma warning disable 618
-							rootNavPage.Tint = Color.Red;
-#pragma warning restore 618
-						})
-					},
-					new Button {
-						Text = "Black background, white text", 
-						Command = new Command (() => {
-							rootNavPage.BarTextColor = Color.White;
-							rootNavPage.BarBackgroundColor = Color.Black;
-						})
+			NavigationPage.SetTitleIcon(this, "coffee.png");
+
+			NavigationPage.SetTitleView(this, CreateTitleView());
+
+			rootNavPage.BarHeight = 450;
+
+			Content = new ScrollView { Content = 
+					new StackLayout
+					{
+						Children = {
+						new Button {
+							Text = "Change BarTextColor",
+							Command = new Command (() => {
+								if (toggleBarTextColor % 2 == 0) {
+									rootNavPage.BarTextColor = Color.Teal;
+								} else {
+									rootNavPage.BarTextColor = Color.Default;
+								}
+								toggleBarTextColor++;
+							})
+						},
+						new Button {
+							Text = "Change BarBackgroundColor",
+							Command = new Command (() => {
+								if (toggleBarBackgroundColor % 2 == 0) {
+									rootNavPage.BarBackgroundColor = Color.Navy;
+								} else {
+									rootNavPage.BarBackgroundColor = Color.Default;
+								}
+								toggleBarBackgroundColor++;
+
+							})
+						},
+						new Button {
+							Text = "Change Both to default",
+							Command = new Command (() => {
+								rootNavPage.BarTextColor = Color.Default;
+								rootNavPage.BarBackgroundColor = Color.Default;
+							})
+						},
+						new Button {
+							Text = "Make sure Tint still works",
+							Command = new Command (() => {
+	#pragma warning disable 618
+								rootNavPage.Tint = Color.Red;
+	#pragma warning restore 618
+							})
+						},
+						new Button {
+							Text = "Black background, white text",
+							Command = new Command (() => {
+								rootNavPage.BarTextColor = Color.White;
+								rootNavPage.BarBackgroundColor = Color.Black;
+							})
+						},
+						new Button {
+							Text = "Toggle TitleIcon",
+							Command = new Command (() => {
+
+								var titleIcon = NavigationPage.GetTitleIcon(this);
+
+								if (titleIcon == null)
+									titleIcon = "coffee.png";
+								else
+									titleIcon = null;
+
+								NavigationPage.SetTitleIcon(this, titleIcon);
+							})
+						},
+						new Button {
+							Text = "Toggle TitleView",
+							Command = new Command (() => {
+
+								var titleView = NavigationPage.GetTitleView(this);
+
+								if (titleView == null)
+									titleView = CreateTitleView();
+								else
+									titleView = null;
+
+								NavigationPage.SetTitleView(this, titleView);
+							})
+						},
+						new Button {
+							Text = "Toggle Back Title",
+							Command = new Command (() => {
+
+								var backTitle = NavigationPage.GetBackButtonTitle(rootNavPage);
+
+								if (backTitle == null)
+									backTitle= "Go back home";
+								else
+									backTitle = null;
+
+								NavigationPage.SetBackButtonTitle(rootNavPage, backTitle);
+							})
+						},
+						new Button {
+							Text = "Toggle Toolbar Item",
+							Command = new Command (() => {
+
+								if (ToolbarItems.Count > 0)
+									ToolbarItems.Clear();
+								else
+									ToolbarItems.Add(new ToolbarItem { Text = "Save" });
+							})
+						},
+						new Button {
+							Text = "Toggle Title",
+							Command = new Command (() => {
+
+								if (Title == null)
+									Title = "NavigationBar Gallery - Legacy";
+								else
+									Title = null;
+							})
+						},
+						new Button {
+							Text = "Toggle BarHeight",
+							Command = new Command (() => {
+
+								if (rootNavPage.BarHeight == -1)
+									rootNavPage.BarHeight= 450;
+								else
+									rootNavPage.ClearValue(NavigationPage.BarHeightProperty);
+							})
+						}
 					}
 				}
 			};
+		}
+
+		static VisualElement CreateTitleView()
+		{
+			var titleView = new StackLayout
+			{
+				Children = {
+						new Label { Text = "TitleView", FontSize = 20, HorizontalTextAlignment = TextAlignment.Center },
+						new Label { Text = "it's lovely", HorizontalTextAlignment = TextAlignment.Center },
+						new SearchBar { VerticalOptions = LayoutOptions.Center }
+				},
+				Spacing = 0,
+				BackgroundColor = Color.Pink,
+				Margin = new Thickness(50, 0),
+				HorizontalOptions = LayoutOptions.Fill
+			};
+			return titleView;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
@@ -9,8 +9,11 @@ namespace Xamarin.Forms.Controls
 {
 	public class NavigationBarGallery : ContentPage
 	{
+		NavigationPage _rootNavPage;
 		public NavigationBarGallery(NavigationPage rootNavPage)
 		{
+			_rootNavPage = rootNavPage;
+
 			int toggleBarTextColor = 0;
 			int toggleBarBackgroundColor = 0;
 
@@ -154,6 +157,12 @@ namespace Xamarin.Forms.Controls
 					}
 					}
 			};
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+			_rootNavPage.ClearValue(BarHeightProperty);
 		}
 
 		static VisualElement CreateTitleView()

--- a/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
@@ -3,6 +3,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat;
+using static Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat.NavigationPage;
 namespace Xamarin.Forms.Controls
 {
 	public class NavigationBarGallery : ContentPage
@@ -18,7 +20,7 @@ namespace Xamarin.Forms.Controls
 
 			NavigationPage.SetTitleView(this, CreateTitleView());
 
-			rootNavPage.BarHeight = 450;
+			rootNavPage.On<Android>().SetBarHeight(450);
 
 			Content = new ScrollView
 			{
@@ -143,10 +145,10 @@ namespace Xamarin.Forms.Controls
 							Text = "Toggle BarHeight",
 							Command = new Command (() => {
 
-								if (rootNavPage.BarHeight == -1)
-									rootNavPage.BarHeight= 450;
+								if (rootNavPage.On<Android>().GetBarHeight() == -1)
+									rootNavPage.On<Android>().SetBarHeight(450);
 								else
-									rootNavPage.ClearValue(NavigationPage.BarHeightProperty);
+									rootNavPage.ClearValue(BarHeightProperty);
 							})
 						}
 					}

--- a/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
@@ -165,7 +165,7 @@ namespace Xamarin.Forms.Controls
 			_rootNavPage.ClearValue(BarHeightProperty);
 		}
 
-		static VisualElement CreateTitleView()
+		static View CreateTitleView()
 		{
 			var titleView = new StackLayout
 			{

--- a/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
@@ -21,7 +21,30 @@ namespace Xamarin.Forms.Controls
 
 			NavigationPage.SetTitleIcon(this, "coffee.png");
 
-			NavigationPage.SetTitleView(this, CreateTitleView());
+			var controls = new List<View>
+			{
+				new ActivityIndicator{ IsRunning = true },
+				new BoxView{ BackgroundColor = Color.Red},
+				new Button{ Text = "Button!"},
+				new DatePicker{},
+				new Editor{Text = "Editor"},
+				new Entry{Placeholder = "Entry"},
+				new Image{ Source = "crimson.jpg", HeightRequest = 44, WidthRequest = 375 },
+				new Label{ Text = "Title View Label!"},
+				//new ListView{}, nope, don't do that!
+				new Picker{ ItemsSource = Enumerable.Range(0,10).Select(i => $"Item {i}").ToList() },
+				new ProgressBar{ Progress = 50},
+				new SearchBar{ },
+				new Slider{},
+				new Stepper{},
+				new Switch{},
+				//new TableView{}, nope, don't do that!
+				new TimePicker{}
+			};
+
+			int idx = 0;
+
+			NavigationPage.SetTitleView(this, CreateTitleView(controls[idx]));
 
 			rootNavPage.On<Android>().SetBarHeight(450);
 			rootNavPage.On<iOS>().SetPrefersLargeTitles(false);
@@ -104,9 +127,22 @@ namespace Xamarin.Forms.Controls
 								var titleView = NavigationPage.GetTitleView(this);
 
 								if (titleView == null)
-									titleView = CreateTitleView();
+									titleView = CreateTitleView(controls[idx]);
 								else
 									titleView = null;
+
+								NavigationPage.SetTitleView(this, titleView);
+							})
+						},
+						new Button {
+							Text = "Next TitleView",
+							Command = new Command (() => {
+
+								idx++;
+								if(idx >=controls.Count)
+									idx = 0;
+
+								var titleView = CreateTitleView(controls[idx]);
 
 								NavigationPage.SetTitleView(this, titleView);
 							})
@@ -166,20 +202,17 @@ namespace Xamarin.Forms.Controls
 			_rootNavPage.ClearValue(BarHeightProperty);
 		}
 
-		static View CreateTitleView()
+		static View CreateTitleView(View control)
 		{
+			control.HorizontalOptions = LayoutOptions.Center;
+			control.VerticalOptions = LayoutOptions.CenterAndExpand;
+
 			var titleView = new StackLayout
 			{
-				Children = {
-						new Label { Text = "TitleView", FontSize = 20, HorizontalTextAlignment = TextAlignment.Center },
-						new Label { Text = "it's lovely", HorizontalTextAlignment = TextAlignment.Center },
-						new SearchBar { VerticalOptions = LayoutOptions.Center }
-				},
-				Spacing = 0,
-				BackgroundColor = Color.Pink,
+				Children = { control },
+				BackgroundColor = Color.FromHex("#ccc"),
 				Margin = new Thickness(50, 0),
-				HorizontalOptions = LayoutOptions.Fill,
-				VerticalOptions = LayoutOptions.Fill
+				HeightRequest = 100
 			};
 			return titleView;
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Controls
 
 			SearchBar searchBar = new SearchBar { HeightRequest = 44, WidthRequest = 100 };
 
+			// Note: Large and complex controls, such as ListView and TableView, are not recommended.
 			var controls = new List<View>
 			{
 				searchBar,
@@ -34,13 +35,11 @@ namespace Xamarin.Forms.Controls
 				new Entry{ Placeholder = "Entry"},
 				new Image{ Source = "crimson.jpg", HeightRequest = 44 },
 				new Label{ Text = "Title View Label!" },
-				//new ListView{}, nope, don't do that!
 				new Picker{ ItemsSource = Enumerable.Range(0,10).Select(i => $"Item {i}").ToList(), Title = "Picker" },
 				new ProgressBar{ Progress = 50 },
 				new Slider{},
 				new Stepper{},
 				new Switch{},
-				//new TableView{}, nope, don't do that!
 				new TimePicker{}
 			};
 

--- a/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
@@ -21,20 +21,22 @@ namespace Xamarin.Forms.Controls
 
 			NavigationPage.SetTitleIcon(this, "coffee.png");
 
+			SearchBar searchBar = new SearchBar { HeightRequest = 44, WidthRequest = 100 };
+
 			var controls = new List<View>
 			{
+				searchBar,
 				new ActivityIndicator{ IsRunning = true },
-				new BoxView{ BackgroundColor = Color.Red},
+				new BoxView{ BackgroundColor = Color.Red },
 				new Button{ Text = "Button!"},
 				new DatePicker{},
-				new Editor{Text = "Editor"},
-				new Entry{Placeholder = "Entry"},
-				new Image{ Source = "crimson.jpg", HeightRequest = 44, WidthRequest = 375 },
-				new Label{ Text = "Title View Label!"},
+				new Editor{ Text = "Editor"},
+				new Entry{ Placeholder = "Entry"},
+				new Image{ Source = "crimson.jpg", HeightRequest = 44 },
+				new Label{ Text = "Title View Label!" },
 				//new ListView{}, nope, don't do that!
-				new Picker{ ItemsSource = Enumerable.Range(0,10).Select(i => $"Item {i}").ToList() },
-				new ProgressBar{ Progress = 50},
-				new SearchBar{ },
+				new Picker{ ItemsSource = Enumerable.Range(0,10).Select(i => $"Item {i}").ToList(), Title = "Picker" },
+				new ProgressBar{ Progress = 50 },
 				new Slider{},
 				new Stepper{},
 				new Switch{},
@@ -204,15 +206,14 @@ namespace Xamarin.Forms.Controls
 
 		static View CreateTitleView(View control)
 		{
-			control.HorizontalOptions = LayoutOptions.Center;
+			control.HorizontalOptions = LayoutOptions.Fill;
 			control.VerticalOptions = LayoutOptions.CenterAndExpand;
 
 			var titleView = new StackLayout
 			{
 				Children = { control },
 				BackgroundColor = Color.FromHex("#ccc"),
-				Margin = new Thickness(50, 0),
-				HeightRequest = 100
+				Margin = new Thickness(15, 0),
 			};
 			return titleView;
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.TitleView">
+
+	<NavigationPage.TitleView>
+		<StackLayout>
+			<Label Text="This is my TitleView" />
+			<Label Text="I can be a subtitle" />
+		</StackLayout>
+	</NavigationPage.TitleView>
+
+	<StackLayout>
+		<Label Text="Welcome to Xamarin.Forms!"
+                VerticalOptions="CenterAndExpand" 
+                HorizontalOptions="CenterAndExpand" />
+	</StackLayout>
+
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class TitleView : ContentPage
+	{
+		public TitleView ()
+		{
+			InitializeComponent ();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -43,6 +43,9 @@
     <Compile Update="GalleryPages\VisualStateManagerGalleries\OnPlatformExample.xaml.cs">
       <DependentUpon>OnPlatformExample.xaml</DependentUpon>
     </Compile>
+    <EmbeddedResource Update="GalleryPages\TitleView.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\VisualStateManagerGalleries\ButtonDisabledStatesGallery.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
@@ -339,6 +339,49 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void TitleViewSetProperty()
+		{
+			var root = new ContentPage();
+			var nav = new NavigationPage(root);
+
+			VisualElement target = new VisualElement();
+
+			NavigationPage.SetTitleView(root, target);
+
+			var result = NavigationPage.GetTitleView(root);
+
+			Assert.AreSame(result, target);
+		}
+
+		[Test]
+		public void TitleViewSetsParentWhenAdded()
+		{
+			var root = new ContentPage();
+			var nav = new NavigationPage(root);
+
+			VisualElement target = new VisualElement();
+
+			NavigationPage.SetTitleView(root, target);
+
+			Assert.AreSame(root, target.Parent);
+		}
+
+		[Test]
+		public void TitleViewClearsParentWhenRemoved()
+		{
+			var root = new ContentPage();
+			var nav = new NavigationPage(root);
+
+			VisualElement target = new VisualElement();
+
+			NavigationPage.SetTitleView(root, target);
+
+			NavigationPage.SetTitleView(root, null);
+
+			Assert.IsNull(target.Parent);
+		}
+
+		[Test]
 		public async Task NavigationChangedEventArgs ()
 		{
 			var rootPage = new ContentPage { Title = "Root" };

--- a/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
@@ -344,7 +344,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var root = new ContentPage();
 			var nav = new NavigationPage(root);
 
-			VisualElement target = new VisualElement();
+			View target = new View();
 
 			NavigationPage.SetTitleView(root, target);
 
@@ -359,7 +359,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var root = new ContentPage();
 			var nav = new NavigationPage(root);
 
-			VisualElement target = new VisualElement();
+			View target = new View();
 
 			NavigationPage.SetTitleView(root, target);
 
@@ -372,7 +372,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var root = new ContentPage();
 			var nav = new NavigationPage(root);
 
-			VisualElement target = new VisualElement();
+			View target = new View();
 
 			NavigationPage.SetTitleView(root, target);
 

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -18,6 +18,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty HasBackButtonProperty = BindableProperty.CreateAttached("HasBackButton", typeof(bool), typeof(NavigationPage), true);
 
+		public static readonly BindableProperty BarHeightProperty = BindableProperty.Create(nameof(BarHeight), typeof(int), typeof(NavigationPage), -1);
+
 		[Obsolete("TintProperty is obsolete as of version 1.2.0. Please use BarBackgroundColorProperty and BarTextColorProperty to change NavigationPage bar color properties.")] 
 		public static readonly BindableProperty TintProperty = BindableProperty.Create("Tint", typeof(Color), typeof(NavigationPage), Color.Default);
 
@@ -51,6 +53,12 @@ namespace Xamarin.Forms
 		{
 			get { return (Color)GetValue(BarBackgroundColorProperty); }
 			set { SetValue(BarBackgroundColorProperty, value); }
+		}
+
+		public int BarHeight
+		{
+			get { return (int)GetValue(BarHeightProperty); }
+			set { SetValue(BarHeightProperty, value); }
 		}
 
 		public Color BarTextColor
@@ -133,6 +141,11 @@ namespace Xamarin.Forms
 			if (page == null)
 				throw new ArgumentNullException("page");
 			return (bool)page.GetValue(HasBackButtonProperty);
+		}
+
+		public static int GetBarHeight(BindableObject page)
+		{
+			return (int)page.GetValue(BarHeightProperty);
 		}
 
 		public static bool GetHasNavigationBar(BindableObject page)
@@ -240,6 +253,11 @@ namespace Xamarin.Forms
 		public static void SetHasNavigationBar(BindableObject page, bool value)
 		{
 			page.SetValue(HasNavigationBarProperty, value);
+		}
+
+		public static void SetBarHeight(BindableObject page, int value)
+		{
+			page.SetValue(BarHeightProperty, value);
 		}
 
 		public static void SetTitleIcon(BindableObject bindable, FileImageSource value)

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty TitleIconProperty = BindableProperty.CreateAttached("TitleIcon", typeof(FileImageSource), typeof(NavigationPage), default(FileImageSource));
 
+		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(VisualElement), typeof(NavigationPage), null, propertyChanged: TitleViewPropertyChanged);
+
 		static readonly BindablePropertyKey CurrentPagePropertyKey = BindableProperty.CreateReadOnly("CurrentPage", typeof(Page), typeof(NavigationPage), null);
 		public static readonly BindableProperty CurrentPageProperty = CurrentPagePropertyKey.BindableProperty;
 
@@ -103,6 +105,24 @@ namespace Xamarin.Forms
 			private set { SetValue(RootPagePropertyKey, value); }
 		}
 
+		static void TitleViewPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (oldValue == newValue)
+				return;
+
+			if (oldValue != null)
+			{
+				var oldElem = (VisualElement)oldValue;
+				oldElem.Parent = null;
+			}
+
+			if (newValue != null && bindable != null)
+			{
+				var newElem = (VisualElement)newValue;
+				newElem.Parent = (Page)bindable;
+			}
+		}
+
 		public static string GetBackButtonTitle(BindableObject page)
 		{
 			return (string)page.GetValue(BackButtonTitleProperty);
@@ -123,6 +143,11 @@ namespace Xamarin.Forms
 		public static FileImageSource GetTitleIcon(BindableObject bindable)
 		{
 			return (FileImageSource)bindable.GetValue(TitleIconProperty);
+		}
+
+		public static VisualElement GetTitleView(BindableObject bindable)
+		{
+			return (VisualElement)bindable.GetValue(TitleViewProperty);
 		}
 
 		public Task<Page> PopAsync()
@@ -220,6 +245,11 @@ namespace Xamarin.Forms
 		public static void SetTitleIcon(BindableObject bindable, FileImageSource value)
 		{
 			bindable.SetValue(TitleIconProperty, value);
+		}
+
+		public static void SetTitleView(BindableObject bindable, VisualElement value)
+		{
+			bindable.SetValue(TitleViewProperty, value);
 		}
 
 		protected override bool OnBackButtonPressed()

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty TitleIconProperty = BindableProperty.CreateAttached("TitleIcon", typeof(FileImageSource), typeof(NavigationPage), default(FileImageSource));
 
-		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(VisualElement), typeof(NavigationPage), null, propertyChanged: TitleViewPropertyChanged);
+		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(View), typeof(NavigationPage), null, propertyChanged: TitleViewPropertyChanged);
 
 		static readonly BindablePropertyKey CurrentPagePropertyKey = BindableProperty.CreateReadOnly("CurrentPage", typeof(Page), typeof(NavigationPage), null);
 		public static readonly BindableProperty CurrentPageProperty = CurrentPagePropertyKey.BindableProperty;
@@ -112,13 +112,13 @@ namespace Xamarin.Forms
 
 			if (oldValue != null)
 			{
-				var oldElem = (VisualElement)oldValue;
+				var oldElem = (View)oldValue;
 				oldElem.Parent = null;
 			}
 
 			if (newValue != null && bindable != null)
 			{
-				var newElem = (VisualElement)newValue;
+				var newElem = (View)newValue;
 				newElem.Parent = (Page)bindable;
 			}
 		}
@@ -145,9 +145,9 @@ namespace Xamarin.Forms
 			return (FileImageSource)bindable.GetValue(TitleIconProperty);
 		}
 
-		public static VisualElement GetTitleView(BindableObject bindable)
+		public static View GetTitleView(BindableObject bindable)
 		{
-			return (VisualElement)bindable.GetValue(TitleViewProperty);
+			return (View)bindable.GetValue(TitleViewProperty);
 		}
 
 		public Task<Page> PopAsync()
@@ -247,7 +247,7 @@ namespace Xamarin.Forms
 			bindable.SetValue(TitleIconProperty, value);
 		}
 
-		public static void SetTitleView(BindableObject bindable, VisualElement value)
+		public static void SetTitleView(BindableObject bindable, View value)
 		{
 			bindable.SetValue(TitleViewProperty, value);
 		}

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -18,8 +18,6 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty HasBackButtonProperty = BindableProperty.CreateAttached("HasBackButton", typeof(bool), typeof(NavigationPage), true);
 
-		public static readonly BindableProperty BarHeightProperty = BindableProperty.Create(nameof(BarHeight), typeof(int), typeof(NavigationPage), -1);
-
 		[Obsolete("TintProperty is obsolete as of version 1.2.0. Please use BarBackgroundColorProperty and BarTextColorProperty to change NavigationPage bar color properties.")] 
 		public static readonly BindableProperty TintProperty = BindableProperty.Create("Tint", typeof(Color), typeof(NavigationPage), Color.Default);
 
@@ -53,12 +51,6 @@ namespace Xamarin.Forms
 		{
 			get { return (Color)GetValue(BarBackgroundColorProperty); }
 			set { SetValue(BarBackgroundColorProperty, value); }
-		}
-
-		public int BarHeight
-		{
-			get { return (int)GetValue(BarHeightProperty); }
-			set { SetValue(BarHeightProperty, value); }
 		}
 
 		public Color BarTextColor
@@ -141,11 +133,6 @@ namespace Xamarin.Forms
 			if (page == null)
 				throw new ArgumentNullException("page");
 			return (bool)page.GetValue(HasBackButtonProperty);
-		}
-
-		public static int GetBarHeight(BindableObject page)
-		{
-			return (int)page.GetValue(BarHeightProperty);
 		}
 
 		public static bool GetHasNavigationBar(BindableObject page)
@@ -253,11 +240,6 @@ namespace Xamarin.Forms
 		public static void SetHasNavigationBar(BindableObject page, bool value)
 		{
 			page.SetValue(HasNavigationBarProperty, value);
-		}
-
-		public static void SetBarHeight(BindableObject page, int value)
-		{
-			page.SetValue(BarHeightProperty, value);
 		}
 
 		public static void SetTitleIcon(BindableObject bindable, FileImageSource value)

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty TitleIconProperty = BindableProperty.CreateAttached("TitleIcon", typeof(FileImageSource), typeof(NavigationPage), default(FileImageSource));
 
-		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(View), typeof(NavigationPage), null, propertyChanged: TitleViewPropertyChanged);
+		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(View), typeof(NavigationPage), null, propertyChanging: TitleViewPropertyChanging);
 
 		static readonly BindablePropertyKey CurrentPagePropertyKey = BindableProperty.CreateReadOnly("CurrentPage", typeof(Page), typeof(NavigationPage), null);
 		public static readonly BindableProperty CurrentPageProperty = CurrentPagePropertyKey.BindableProperty;
@@ -105,7 +105,7 @@ namespace Xamarin.Forms
 			private set { SetValue(RootPagePropertyKey, value); }
 		}
 
-		static void TitleViewPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		static void TitleViewPropertyChanging(BindableObject bindable, object oldValue, object newValue)
 		{
 			if (oldValue == newValue)
 				return;

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
@@ -1,0 +1,30 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat
+{
+	using FormsElement = Forms.NavigationPage;
+
+	public static class NavigationPage
+	{
+		public static readonly BindableProperty BarHeightProperty = BindableProperty.Create("BarHeight", typeof(int), typeof(NavigationPage), default(int));
+
+		public static int GetBarHeight(BindableObject element)
+		{
+			return (int)element.GetValue(BarHeightProperty);
+		}
+
+		public static void SetBarHeight(BindableObject element, int value)
+		{
+			element.SetValue(BarHeightProperty, value);
+		}
+
+		public static int GetBarHeight(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetBarHeight(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetBarHeight(this IPlatformElementConfiguration<Android, FormsElement> config, int value)
+		{
+			SetBarHeight(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
@@ -72,6 +72,7 @@ namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 		}
 		#endregion
 
+		#region PrefersLargeTitles
 		public static readonly BindableProperty PrefersLargeTitlesProperty = BindableProperty.Create(nameof(PrefersLargeTitles), typeof(bool), typeof(Page), false);
 
 		public static bool GetPrefersLargeTitles(BindableObject element)
@@ -94,5 +95,31 @@ namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 		{
 			return GetPrefersLargeTitles(config.Element);
 		}
+		#endregion
+
+		#region HideNavigationBarSeparator
+		public static readonly BindableProperty HideNavigationBarSeparatorProperty = BindableProperty.Create(nameof(HideNavigationBarSeparator), typeof(bool), typeof(Page), false);
+
+		public static bool GetHideNavigationBarSeparator(BindableObject element)
+		{
+			return (bool)element.GetValue(HideNavigationBarSeparatorProperty);
+		}
+
+		public static void SetHideNavigationBarSeparator(BindableObject element, bool value)
+		{
+			element.SetValue(HideNavigationBarSeparatorProperty, value);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetHideNavigationBarSeparator(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		{
+			SetHideNavigationBarSeparator(config.Element, value);
+			return config;
+		}
+
+		public static bool HideNavigationBarSeparator(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetHideNavigationBarSeparator(config.Element);
+		}
+		#endregion
 	}
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -24,6 +24,8 @@ using FragmentManager = Android.Support.V4.App.FragmentManager;
 using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
 using Object = Java.Lang.Object;
 using static Android.Views.View;
+using System.IO;
+using Android.Widget;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -45,6 +47,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		DrawerLayout _drawerLayout;
 		MasterDetailPage _masterDetailPage;
 		bool _toolbarVisible;
+		IVisualElementRenderer _titleViewRenderer;
+		Container _titleView;
+		ImageView _titleIconView;
+		ImageSource _imageSource;
 		bool _isAttachedToWindow;
 
 		// The following is based on https://android.googlesource.com/platform/frameworks/support.git/+/4a7e12af4ec095c3a53bb8481d8d92f63157c3b7/v4/java/android/support/v4/app/FragmentManager.java#677
@@ -132,6 +138,20 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				_disposed = true;
 
+				if (_titleViewRenderer != null)
+				{
+					Android.Platform.ClearRenderer(_titleViewRenderer.View);
+					_titleViewRenderer.Dispose();
+					_titleViewRenderer = null;
+				}
+
+				_toolbar.RemoveView(_titleView);
+				_titleView?.Dispose();
+				_titleView = null;
+
+				_toolbar.RemoveView(_titleIconView);
+				_titleIconView?.Dispose();
+				_titleIconView = null;
 
 				if (_toolbarTracker != null)
 				{
@@ -309,6 +329,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateToolbar();
 			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName)
 				UpdateToolbar();
+			else if (e.PropertyName == NavigationPage.BackButtonTitleProperty.PropertyName)
+				UpdateToolbar();
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
@@ -412,7 +434,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (actionBarHeight <= 0)
 				return Device.Info.CurrentOrientation.IsPortrait() ? (int)Context.ToPixels(56) : (int)Context.ToPixels(48);
-			
+
 			if (((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentStatus) || ((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentNavigation))
 			{
 				if (_toolbar.PaddingTop == 0)
@@ -435,7 +457,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			valueAnim.Update += (s, a) => icon.Progress = (float)a.Animation.AnimatedValue;
 			valueAnim.Start();
 		}
-		
+
 		int GetStatusBarHeight()
 		{
 			if (_statusbarHeight > 0)
@@ -472,6 +494,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			else if (e.PropertyName == Page.TitleProperty.PropertyName)
 				UpdateToolbar();
 			else if (e.PropertyName == NavigationPage.HasBackButtonProperty.PropertyName)
+				UpdateToolbar();
+			else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName ||
+					 e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
 				UpdateToolbar();
 		}
 
@@ -642,11 +667,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			_toolbar = null;
 
 			SetupToolbar();
-			
+
 			// if the old toolbar had padding from transluscentflags, set it to the new toolbar
 			if (oldToolbar.PaddingTop != 0)
 				_toolbar.SetPadding(0, oldToolbar.PaddingTop, 0, 0);
-			
+
 			RegisterToolbar();
 			UpdateToolbar();
 			UpdateMenu();
@@ -843,6 +868,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			bool isNavigated = ((INavigationPageController)Element).StackDepth > 1;
 			bar.NavigationIcon = null;
+			Page currentPage = Element.CurrentPage;
 
 			if (isNavigated)
 			{
@@ -852,7 +878,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					toggle.SyncState();
 				}
 
-				if (NavigationPage.GetHasBackButton(Element.CurrentPage))
+				if (NavigationPage.GetHasBackButton(currentPage))
 				{
 					var icon = new DrawerArrowDrawable(activity.SupportActionBar.ThemedContext);
 					icon.Progress = 1;
@@ -896,7 +922,112 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (!textColor.IsDefault)
 				bar.SetTitleTextColor(textColor.ToAndroid().ToArgb());
 
-			bar.Title = Element.CurrentPage.Title ?? "";
+			bar.Title = currentPage.Title ?? "";
+
+			UpdateTitleIcon();
+
+			UpdateTitleView();
+		}
+
+		void UpdateTitleIcon()
+		{
+			Page currentPage = Element.CurrentPage;
+			var source = NavigationPage.GetTitleIcon(currentPage);
+
+			if (source == null)
+			{
+				_toolbar.RemoveView(_titleIconView);
+				_titleIconView?.Dispose();
+				_titleIconView = null;
+				_imageSource = null;
+				return;
+			}
+
+			if (_titleIconView == null)
+			{
+				_titleIconView = new ImageView(Context);
+				_toolbar.AddView(_titleIconView, 0);
+			}
+
+			UpdateBitmap(source, _imageSource);
+			_imageSource = source;
+		}
+
+		async void UpdateBitmap(ImageSource source, ImageSource previousSource = null)
+		{
+			if (Equals(source, previousSource))
+				return;
+
+			_titleIconView.SetImageResource(global::Android.Resource.Color.Transparent);
+
+			Bitmap bitmap = null;
+			IImageSourceHandler handler;
+
+			if (source != null && (handler = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
+			{
+				try
+				{
+					bitmap = await handler.LoadImageAsync(source, Context);
+				}
+				catch (TaskCanceledException)
+				{
+				}
+				catch (IOException ex)
+				{
+					Internals.Log.Warning("Xamarin.Forms.Platform.Android.AppCompat.NavigationPageRenderer", "Error updating bitmap: {0}", ex);
+				}
+			}
+
+			if (bitmap == null && source is FileImageSource)
+				_titleIconView.SetImageResource(ResourceManager.GetDrawableByName(((FileImageSource)source).File));
+			else
+				_titleIconView.SetImageBitmap(bitmap);
+
+			bitmap?.Dispose();
+		}
+
+		void UpdateTitleView()
+		{
+			AToolbar bar = _toolbar;
+
+			if (bar == null)
+				return;
+
+			Page currentPage = Element.CurrentPage;
+			VisualElement titleView = NavigationPage.GetTitleView(currentPage);
+			if (_titleViewRenderer != null)
+			{
+				var reflectableType = _titleViewRenderer as System.Reflection.IReflectableType;
+				var rendererType = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : _titleViewRenderer.GetType();
+				if (titleView == null || Registrar.Registered.GetHandlerTypeForObject(titleView) != rendererType)
+				{
+					if (_titleView != null)
+						_titleView.Child = null;
+					Android.Platform.ClearRenderer(_titleViewRenderer.View);
+					_titleViewRenderer.Dispose();
+					_titleViewRenderer = null;
+				}
+			}
+
+			if (titleView == null)
+				return;
+
+			if (_titleViewRenderer != null)
+				_titleViewRenderer.SetElement(titleView);
+			else
+			{
+				_titleViewRenderer = Android.Platform.CreateRenderer(titleView, Context);
+
+				if (_titleView == null)
+				{
+					_titleView = new Container(Context);
+					bar.AddView(_titleView);
+				}
+
+				_titleView.Child = _titleViewRenderer;
+			}
+
+			Android.Platform.SetRenderer(titleView, _titleViewRenderer);
 		}
 
 		void AddTransitionTimer(TaskCompletionSource<bool> tcs, Fragment fragment, FragmentManager fragmentManager, IReadOnlyCollection<Fragment> fragmentsToRemove, int duration, bool shouldUpdateToolbar)
@@ -953,6 +1084,66 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			public void OnClick(AView v)
 			{
 				_element?.PopAsync();
+			}
+		}
+
+		internal class Container : ViewGroup
+		{
+			IVisualElementRenderer _child;
+
+			public Container(IntPtr p, global::Android.Runtime.JniHandleOwnership o) : base(p, o)
+			{
+				// Added default constructor to prevent crash when accessing header/footer row in Dispose
+			}
+
+			public Container(Context context) : base(context)
+			{
+			}
+
+			public IVisualElementRenderer Child
+			{
+				set
+				{
+					if (_child != null)
+						RemoveView(_child.View);
+
+					_child = value;
+
+					if (value != null)
+						AddView(value.View);
+				}
+			}
+
+			protected override void OnLayout(bool changed, int l, int t, int r, int b)
+			{
+				if (_child == null)
+					return;
+
+				_child.UpdateLayout();
+			}
+
+			protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+			{
+				if (_child == null)
+				{
+					SetMeasuredDimension(0, 0);
+					return;
+				}
+
+				VisualElement element = _child.Element;
+
+				Context ctx = Context;
+
+				var width = (int)ctx.FromPixels(MeasureSpecFactory.GetSize(widthMeasureSpec));
+
+				SizeRequest request = _child.Element.Measure(width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+				Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion(_child.Element, new Rectangle(0, 0, width, request.Request.Height));
+
+				int widthSpec = MeasureSpecFactory.MakeMeasureSpec((int)ctx.ToPixels(width), MeasureSpecMode.Exactly);
+				int heightSpec = MeasureSpecFactory.MakeMeasureSpec((int)ctx.ToPixels(request.Request.Height), MeasureSpecMode.Exactly);
+
+				_child.View.Measure(widthMeasureSpec, heightMeasureSpec);
+				SetMeasuredDimension(widthSpec, heightSpec);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -153,6 +153,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				_titleIconView?.Dispose();
 				_titleIconView = null;
 
+				_imageSource = null;
+
 				if (_toolbarTracker != null)
 				{
 					_toolbarTracker.CollectionChanged -= ToolbarTrackerOnCollectionChanged;
@@ -331,6 +333,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateToolbar();
 			else if (e.PropertyName == NavigationPage.BackButtonTitleProperty.PropertyName)
 				UpdateToolbar();
+			else if (e.PropertyName == NavigationPage.BarHeightProperty.PropertyName)
+				UpdateToolbar();
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
@@ -342,6 +346,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			base.OnLayout(changed, l, t, r, b);
 
 			int barHeight = ActionBarHeight();
+
+			if (Element.IsSet(NavigationPage.BarHeightProperty))
+				barHeight = Element.BarHeight;
 
 			if (barHeight != _lastActionBarHeight && _lastActionBarHeight > 0)
 			{
@@ -661,6 +668,20 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void ResetToolbar()
 		{
 			AToolbar oldToolbar = _toolbar;
+
+			if (_titleViewRenderer != null)
+			{
+				Android.Platform.ClearRenderer(_titleViewRenderer.View);
+				_titleViewRenderer = null;
+			}
+
+			_toolbar.RemoveView(_titleView);
+			_titleView = null;
+
+			_toolbar.RemoveView(_titleIconView);
+			_titleIconView = null;
+
+			_imageSource = null;
 
 			_toolbar.RemoveFromParent();
 			_toolbar.SetNavigationOnClickListener(null);

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -1115,7 +1115,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			public Container(IntPtr p, global::Android.Runtime.JniHandleOwnership o) : base(p, o)
 			{
-				// Added default constructor to prevent crash when accessing header/footer row in Dispose
+				// Added default constructor to prevent crash in Dispose
 			}
 
 			public Container(Context context) : base(context)

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -23,6 +23,7 @@ using Fragment = Android.Support.V4.App.Fragment;
 using FragmentManager = Android.Support.V4.App.FragmentManager;
 using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
 using Object = Java.Lang.Object;
+using static Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat.NavigationPage;
 using static Android.Views.View;
 using System.IO;
 using Android.Widget;
@@ -333,7 +334,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateToolbar();
 			else if (e.PropertyName == NavigationPage.BackButtonTitleProperty.PropertyName)
 				UpdateToolbar();
-			else if (e.PropertyName == NavigationPage.BarHeightProperty.PropertyName)
+			else if (e.PropertyName == BarHeightProperty.PropertyName)
 				UpdateToolbar();
 		}
 
@@ -347,8 +348,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			int barHeight = ActionBarHeight();
 
-			if (Element.IsSet(NavigationPage.BarHeightProperty))
-				barHeight = Element.BarHeight;
+			if (Element.IsSet(BarHeightProperty))
+				barHeight = Element.OnThisPlatform().GetBarHeight();
 
 			if (barHeight != _lastActionBarHeight && _lastActionBarHeight > 0)
 			{

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -17,6 +17,7 @@ using Android.Widget;
 using Xamarin.Forms.Platform.Android.AppCompat;
 using FragmentManager = Android.Support.V4.App.FragmentManager;
 using Xamarin.Forms.Internals;
+using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -296,6 +297,23 @@ namespace Xamarin.Forms.Platform.Android
 		void INavigation.RemovePage(Page page)
 		{
 			throw new InvalidOperationException("RemovePage is not supported globally on Android, please use a NavigationPage.");
+		}
+
+		public static void ClearRenderer(AView renderedView)
+		{
+			var element = (renderedView as IVisualElementRenderer)?.Element;
+			var view = element as View;
+			if (view != null)
+			{
+				var renderer = GetRenderer(view);
+				if (renderer == renderedView)
+					element.ClearValue(RendererProperty);
+				renderer?.Dispose();
+				renderer = null;
+			}
+			var layout = view as IVisualElementRenderer;
+			layout?.Dispose();
+			layout = null;
 		}
 
 		[Obsolete("CreateRenderer(VisualElement) is obsolete as of version 2.5. Please use CreateRendererWithContext(VisualElement, Context) instead.")]

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (_headerRenderer != null)
 				{
-					ClearRenderer(_headerRenderer.View);
+					Platform.ClearRenderer(_headerRenderer.View);
 					_headerRenderer.Dispose();
 					_headerRenderer = null;
 				}
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (_footerRenderer != null)
 				{
-					ClearRenderer(_footerRenderer.View);
+					Platform.ClearRenderer(_footerRenderer.View);
 					_footerRenderer.Dispose();
 					_footerRenderer = null;
 				}
@@ -286,23 +286,6 @@ namespace Xamarin.Forms.Platform.Android
 				Control.SetSelectionFromTop(realPositionWithHeader, y);
 		}
 
-		void ClearRenderer(AView renderedView)
-		{
-			var element = (renderedView as IVisualElementRenderer)?.Element;
-			var view = element as View;
-			if (view != null)
-			{
-				var renderer = Platform.GetRenderer(view);
-				if (renderer == renderedView)
-					element.ClearValue(Platform.RendererProperty);
-				renderer?.Dispose();
-				renderer = null;
-			}
-			var layout = view as IVisualElementRenderer;
-			layout?.Dispose();
-			layout = null;
-		}
-
 		void UpdateFooter()
 		{
 			var footer = (VisualElement)Controller.FooterElement;
@@ -314,7 +297,7 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					if (_footerView != null)
 						_footerView.Child = null;
-					ClearRenderer(_footerRenderer.View);
+					Platform.ClearRenderer(_footerRenderer.View);
 					_footerRenderer.Dispose();
 					_footerRenderer = null;
 				}
@@ -346,7 +329,7 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					if (_headerView != null)
 						_headerView.Child = null;
-					ClearRenderer(_headerRenderer.View);
+					Platform.ClearRenderer(_headerRenderer.View);
 					_headerRenderer.Dispose();
 					_headerRenderer = null;
 				}

--- a/Xamarin.Forms.Platform.UAP/Extensions.cs
+++ b/Xamarin.Forms.Platform.UAP/Extensions.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Input;
+using Xamarin.Forms.Internals;
+using WImageSource = Windows.UI.Xaml.Media.ImageSource;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -26,6 +29,27 @@ namespace Xamarin.Forms.Platform.UWP
 		public static void SetBinding(this FrameworkElement self, DependencyProperty property, string path, Windows.UI.Xaml.Data.IValueConverter converter)
 		{
 			self.SetBinding(property, new Windows.UI.Xaml.Data.Binding { Path = new PropertyPath(path), Converter = converter });
+		}
+
+		public static async Task<WImageSource> ToWindowsImageSource(this ImageSource source)
+		{
+			IImageSourceHandler handler;
+			if (source != null && (handler = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
+			{
+				try
+				{
+					return await handler.LoadImageAsync(source);
+				}
+				catch (OperationCanceledException)
+				{
+					return null;
+				}
+
+			}
+			else
+			{
+				return null;
+			}
 		}
 
 		internal static InputScopeNameValue GetKeyboardButtonType(this ReturnType returnType)

--- a/Xamarin.Forms.Platform.UAP/ITitleIconProvider.cs
+++ b/Xamarin.Forms.Platform.UAP/ITitleIconProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms.Platform.UWP
+{
+	internal interface ITitleIconProvider
+	{
+		Windows.UI.Xaml.Media.ImageSource TitleIcon { get; set; }
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/ITitleViewProvider.cs
+++ b/Xamarin.Forms.Platform.UAP/ITitleViewProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms.Platform.UWP
+{
+	internal interface ITitleViewProvider
+	{
+		View TitleView { get; set; }
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -4,6 +4,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
+using WImageSource = Windows.UI.Xaml.Media.ImageSource;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -33,6 +34,10 @@ namespace Xamarin.Forms.Platform.UWP
 
 		public static readonly DependencyProperty DetailTitleProperty = DependencyProperty.Register("DetailTitle", typeof(string), typeof(MasterDetailControl), new PropertyMetadata(default(string)));
 
+		public static readonly DependencyProperty DetailTitleIconProperty = DependencyProperty.Register(nameof(DetailTitleIcon), typeof(WImageSource), typeof(MasterDetailControl), new PropertyMetadata(default(WImageSource)));
+
+		public static readonly DependencyProperty DetailTitleViewProperty = DependencyProperty.Register(nameof(DetailTitleView), typeof(View), typeof(MasterDetailControl), new PropertyMetadata(default(View), OnTitleViewPropertyChanged));
+
 		public static readonly DependencyProperty ToolbarForegroundProperty = DependencyProperty.Register("ToolbarForeground", typeof(Brush), typeof(MasterDetailControl),
 			new PropertyMetadata(default(Brush)));
 
@@ -43,6 +48,9 @@ namespace Xamarin.Forms.Platform.UWP
 			new PropertyMetadata(default(Visibility)));
 
 		public static readonly DependencyProperty DetailTitleVisibilityProperty = DependencyProperty.Register("DetailTitleVisibility", typeof(Visibility), typeof(MasterDetailControl),
+			new PropertyMetadata(default(Visibility)));
+
+		public static readonly DependencyProperty DetailTitleViewVisibilityProperty = DependencyProperty.Register(nameof(DetailTitleViewVisibility), typeof(Visibility), typeof(MasterDetailControl),
 			new PropertyMetadata(default(Visibility)));
 
 		public static readonly DependencyProperty MasterToolbarVisibilityProperty = DependencyProperty.Register("MasterToolbarVisibility", typeof(Visibility), typeof(MasterDetailControl),
@@ -66,6 +74,7 @@ namespace Xamarin.Forms.Platform.UWP
 		FrameworkElement _detailPresenter;
 		SplitView _split;
 	    ToolbarPlacement _toolbarPlacement;
+		FrameworkElement _titleViewPresenter;
 
 	    public MasterDetailControl()
 		{
@@ -110,10 +119,28 @@ namespace Xamarin.Forms.Platform.UWP
 			set { SetValue(DetailTitleProperty, value); }
 		}
 
+		public WImageSource DetailTitleIcon
+		{
+			get { return (WImageSource)GetValue(DetailTitleIconProperty); }
+			set { SetValue(DetailTitleIconProperty, value); }
+		}
+
+		public View DetailTitleView
+		{
+			get { return (View)GetValue(DetailTitleViewProperty); }
+			set { SetValue(DetailTitleViewProperty, value); }
+		}
+
 		public Visibility DetailTitleVisibility
 		{
 			get { return (Visibility)GetValue(DetailTitleVisibilityProperty); }
 			set { SetValue(DetailTitleVisibilityProperty, value); }
+		}
+
+		public Visibility DetailTitleViewVisibility
+		{
+			get { return (Visibility)GetValue(DetailTitleViewVisibilityProperty); }
+			set { SetValue(DetailTitleViewVisibilityProperty, value); }
 		}
 
 		public bool IsPaneOpen
@@ -260,6 +287,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_masterPresenter = GetTemplateChild("MasterPresenter") as FrameworkElement;
 			_detailPresenter = GetTemplateChild("DetailPresenter") as FrameworkElement;
+			_titleViewPresenter = GetTemplateChild("TitleViewPresenter") as FrameworkElement;
 
 			_commandBar = GetTemplateChild("CommandBar") as CommandBar;
 			_toolbarPlacementHelper.Initialize(_commandBar, () => ToolbarPlacement, GetTemplateChild);
@@ -285,9 +313,22 @@ namespace Xamarin.Forms.Platform.UWP
 			((MasterDetailControl)dependencyObject).UpdateMode();
 		}
 
+		static void OnTitleViewPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+		{
+			((MasterDetailControl)dependencyObject).UpdateTitleViewPresenter();
+		}
+
 		void OnToggleClicked(object sender, RoutedEventArgs args)
 		{
 			IsPaneOpen = !IsPaneOpen;
+		}
+
+		void OnTitleViewPresenterLoaded(object sender, RoutedEventArgs e)
+		{
+			if (DetailTitleView == null || _titleViewPresenter == null || _commandBar == null)
+				return;
+
+			_titleViewPresenter.Width = _commandBar.ActualWidth;
 		}
 
 		void UpdateMode()
@@ -323,6 +364,24 @@ namespace Xamarin.Forms.Platform.UWP
 				DetailTitleVisibility = Visibility.Collapsed;
 
 			_firstLoad = true;
+		}
+
+		void UpdateTitleViewPresenter()
+		{
+			if (DetailTitleView == null)
+			{
+				DetailTitleViewVisibility = Visibility.Collapsed;
+
+				if (_titleViewPresenter != null)
+					_titleViewPresenter.Loaded -= OnTitleViewPresenterLoaded;
+			}
+			else
+			{
+				DetailTitleViewVisibility = Visibility.Visible;
+
+				if (_titleViewPresenter != null)
+					_titleViewPresenter.Loaded += OnTitleViewPresenterLoaded;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
@@ -30,19 +30,30 @@
 								</Grid.RowDefinitions>
 
 								<Border x:Name="TopCommandBarArea" HorizontalAlignment="Stretch" Background="{TemplateBinding ToolbarBackground}">
-									<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" MinHeight="{ThemeResource TitleBarHeight}">
+									<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" MinHeight="{ThemeResource TitleBarHeight}" HorizontalAlignment="Stretch">
 										<uwp:FormsCommandBar.Content>
-											<Border x:Name="TitleArea" Height="{ThemeResource TitleBarHeight}" Visibility="{TemplateBinding DetailTitleVisibility}">
-												<StackPanel Orientation="Horizontal" VerticalAlignment="Center" Background="{TemplateBinding ToolbarBackground}" >
+											<Border x:Name="TitleArea" Height="{ThemeResource TitleBarHeight}" Visibility="{TemplateBinding DetailTitleVisibility}" HorizontalAlignment="Stretch">
+												<Grid x:Name="TitleViewPresenter" VerticalAlignment="Center" Background="{TemplateBinding ToolbarBackground}" HorizontalAlignment="Stretch">
 
-													<Button Name="ContentTogglePane" Style="{ThemeResource PaneButton}" Foreground="{TemplateBinding ToolbarForeground}"  
+													<Grid.ColumnDefinitions>
+														<ColumnDefinition Width="Auto"/>
+														<ColumnDefinition Width="Auto"/>
+														<ColumnDefinition Width="Auto"/>
+														<ColumnDefinition Width="*"/>
+													</Grid.ColumnDefinitions>
+
+													<Button Grid.Column="0" Name="ContentTogglePane" Style="{ThemeResource PaneButton}" Foreground="{TemplateBinding ToolbarForeground}"  
 															Visibility="{TemplateBinding ContentTogglePaneButtonVisibility}" />
 
-													<Border Height="{ThemeResource TitleBarHeight}" Visibility="{TemplateBinding DetailTitleVisibility}">
+													<Image Grid.Column="1" Source="{TemplateBinding DetailTitleIcon}" />
+
+													<Border Grid.Column="2" Height="{ThemeResource TitleBarHeight}" Visibility="{TemplateBinding DetailTitleVisibility}">
 														<TextBlock Text="{TemplateBinding DetailTitle}" VerticalAlignment="Center" Margin="10,0,0,0" Foreground="{TemplateBinding ToolbarForeground}" Style="{ThemeResource TitleTextBlockStyle}" />
 													</Border>
 
-												</StackPanel>
+													<ContentPresenter Grid.Column="3" Content="{Binding DetailTitleView, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource ViewToRenderer}}" Visibility="{TemplateBinding DetailTitleViewVisibility}" HorizontalAlignment="Stretch" />
+
+												</Grid>
 											</Border>
 										</uwp:FormsCommandBar.Content>
 									</uwp:FormsCommandBar>

--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -245,12 +245,18 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnDetailPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == Page.TitleProperty.PropertyName || e.PropertyName == NavigationPage.CurrentPageProperty.PropertyName)
+			if (e.PropertyName == Page.TitleProperty.PropertyName)
 				UpdateDetailTitle();
-			else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName || e.PropertyName == NavigationPage.CurrentPageProperty.PropertyName)
+			else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName)
 				UpdateDetailTitleIcon();
-			else if (e.PropertyName == NavigationPage.TitleViewProperty.PropertyName || e.PropertyName == NavigationPage.CurrentPageProperty.PropertyName)
+			else if (e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
 				UpdateDetailTitleView();
+			else if (e.PropertyName == NavigationPage.CurrentPageProperty.PropertyName)
+			{
+				UpdateDetailTitle();
+				UpdateDetailTitleIcon();
+				UpdateDetailTitleView();
+			}
 		}
 
 		void OnIsPaneOpenChanged(DependencyObject sender, DependencyProperty dp)

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -11,12 +11,14 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Xamarin.Forms.Internals;
+using static Xamarin.Forms.PlatformConfiguration.WindowsSpecific.Page;
+using WImageSource = Windows.UI.Xaml.Media.ImageSource;
 
 
 using Windows.UI.Core;
 namespace Xamarin.Forms.Platform.UWP
 {
-	public partial class NavigationPageRenderer : IVisualElementRenderer, ITitleProvider, IToolbarProvider
+	public partial class NavigationPageRenderer : IVisualElementRenderer, ITitleProvider, ITitleIconProvider, ITitleViewProvider, IToolbarProvider
 	{
 		PageControl _container;
 		Page _currentPage;
@@ -27,6 +29,7 @@ namespace Xamarin.Forms.Platform.UWP
 		MasterDetailPage _parentMasterDetailPage;
 		TabbedPage _parentTabbedPage;
 		bool _showTitle = true;
+		WImageSource _titleIcon;
 		VisualElementTracker<Page, PageControl> _tracker;
 		EntranceThemeTransition _transition;
 
@@ -88,6 +91,24 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			get { return _currentPage?.Title; }
 
+			set { }
+		}
+
+		public WImageSource TitleIcon
+		{
+			get => _titleIcon;
+			set => _titleIcon = value;
+		}
+
+		public View TitleView
+		{
+			get
+			{
+				if (_currentPage == null)
+					return null;
+
+				return NavigationPage.GetTitleView(_currentPage) as View;
+			}
 			set { }
 		}
 
@@ -175,6 +196,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTitleColor();
 				UpdateNavigationBarBackground();
 				UpdateToolbarPlacement();
+				UpdateTitleIcon();
+				UpdateTitleView();
 
 				// Enforce consistency rules on toolbar (show toolbar if top-level page is Navigation Page)
 				_container.ShouldShowToolbar = _parentMasterDetailPage == null && _parentTabbedPage == null;
@@ -283,12 +306,20 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdateShowTitle();
 
 			UpdateTitleOnParents();
+
+			UpdateTitleIcon();
+
+			UpdateTitleView();
 		}
 
 		void MultiPagePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == "CurrentPage" || e.PropertyName == "Detail")
+			{
 				UpdateTitleOnParents();
+				UpdateTitleIcon();
+				UpdateTitleView();
+			}
 		}
 
 		async void OnBackClicked(object sender, RoutedEventArgs e)
@@ -311,6 +342,10 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTitleVisible();
 			else if (e.PropertyName == Page.TitleProperty.PropertyName)
 				UpdateTitleOnParents();
+			else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName)
+				UpdateTitleIcon();
+			else if (e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
+				UpdateTitleView();
 		}
 
 		void OnElementAppearing(object sender, EventArgs e)
@@ -327,9 +362,12 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateNavigationBarBackground();
 			else if (e.PropertyName == Page.PaddingProperty.PropertyName)
 				UpdatePadding();
-
-			else if (e.PropertyName == PlatformConfiguration.WindowsSpecific.Page.ToolbarPlacementProperty.PropertyName)
+			else if (e.PropertyName == ToolbarPlacementProperty.PropertyName)
 				UpdateToolbarPlacement();
+			else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName)
+				UpdateTitleIcon();
+			else if (e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
+				UpdateTitleView();
 		}
 
 		void OnLoaded(object sender, RoutedEventArgs args)
@@ -424,6 +462,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			UpdateTitleVisible();
 			UpdateTitleOnParents();
+			UpdateTitleIcon();
+			UpdateTitleView();
 
 			if (isAnimated && _transition == null)
 			{
@@ -483,6 +523,35 @@ namespace Xamarin.Forms.Platform.UWP
 		void UpdateTitleColor()
 		{
 			(this as ITitleProvider).BarForegroundBrush = GetBarForegroundBrush();
+		}
+
+		async void UpdateTitleIcon()
+		{
+			if (_currentPage == null)
+				return;
+
+			ImageSource source = NavigationPage.GetTitleIcon(_currentPage);
+
+			_titleIcon = await source.ToWindowsImageSource();
+
+			_container.TitleIcon = _titleIcon;
+
+			if (_parentMasterDetailPage != null && Platform.GetRenderer(_parentMasterDetailPage) is ITitleIconProvider parent)
+				parent.TitleIcon = _titleIcon;
+
+			_container.UpdateLayout();
+			UpdateContainerArea();
+		}
+
+		void UpdateTitleView()
+		{
+			if (_currentPage == null)
+				return;
+
+			_container.TitleView = TitleView;
+
+			if (_parentMasterDetailPage != null && Platform.GetRenderer(_parentMasterDetailPage) is ITitleViewProvider parent)
+				parent.TitleView = TitleView;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			get { return _currentPage?.Title; }
 
-			set { }
+			set { /*Not implemented but required by interface*/ }
 		}
 
 		public WImageSource TitleIcon
@@ -109,7 +109,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				return NavigationPage.GetTitleView(_currentPage) as View;
 			}
-			set { }
+			set { /*Not implemented but required by interface*/ }
 		}
 
 		Task<CommandBar> IToolbarProvider.GetCommandBarAsync()

--- a/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
@@ -9,22 +9,38 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="uwp:PageControl">
 					<Grid Background="{TemplateBinding Background}">
-						
+
 						<Grid.RowDefinitions>
 							<RowDefinition Height="Auto" />
 							<RowDefinition Height="*" />
 							<RowDefinition Height="Auto" />
 						</Grid.RowDefinitions>
 
-                        <Border x:Name="TopCommandBarArea" HorizontalAlignment="Stretch" Background="{TemplateBinding ToolbarBackground}">
-                            <uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" MinHeight="{ThemeResource TitleBarHeight}">
-                                <uwp:FormsCommandBar.Content>
-                                    <Border x:Name="TitleArea" Visibility="{TemplateBinding TitleVisibility}" Height="{ThemeResource TitleBarHeight}">
-                                        <TextBlock Text="{Binding Title}" TextWrapping="NoWrap" VerticalAlignment="Center" Margin="10,0,0,0" Foreground="{TemplateBinding TitleBrush}" Style="{ThemeResource TitleTextBlockStyle}" />
-                                    </Border>
-                                </uwp:FormsCommandBar.Content>
-                             </uwp:FormsCommandBar>
-                        </Border>
+						<Border x:Name="TopCommandBarArea" HorizontalAlignment="Stretch" Background="{TemplateBinding ToolbarBackground}">
+							<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" MinHeight="{ThemeResource TitleBarHeight}" HorizontalAlignment="Stretch">
+								<uwp:FormsCommandBar.Content>
+									<Border x:Name="TitleArea" Height="{ThemeResource TitleBarHeight}" Visibility="{TemplateBinding TitleVisibility}" HorizontalAlignment="Stretch">
+										<Grid x:Name="TitleViewPresenter" VerticalAlignment="Center" Background="{TemplateBinding ToolbarBackground}" HorizontalAlignment="Stretch">
+
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="Auto"/>
+												<ColumnDefinition Width="Auto"/>
+												<ColumnDefinition Width="*"/>
+											</Grid.ColumnDefinitions>
+
+											<Image Grid.Column="0" Source="{TemplateBinding TitleIcon}" />
+
+											<Border Grid.Column="1" Height="{ThemeResource TitleBarHeight}" Visibility="{TemplateBinding TitleVisibility}">
+												<TextBlock Text="{Binding Title}" TextWrapping="NoWrap" VerticalAlignment="Center" Margin="10,0,0,0" Foreground="{TemplateBinding TitleBrush}" Style="{ThemeResource TitleTextBlockStyle}" />
+											</Border>
+
+											<ContentPresenter Grid.Column="2" Content="{Binding TitleView, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource ViewToRenderer}}" Visibility="{TemplateBinding TitleViewVisibility}" HorizontalAlignment="Stretch" />
+
+										</Grid>
+									</Border>
+								</uwp:FormsCommandBar.Content>
+							</uwp:FormsCommandBar>
+						</Border>
 
 						<uwp:FormsPresenter Margin="{TemplateBinding ContentMargin}" ContentTransitions="{TemplateBinding ContentTransitions}" x:Name="presenter" Grid.Row="1" />
 

--- a/Xamarin.Forms.Platform.UAP/ViewToRendererConverter.cs
+++ b/Xamarin.Forms.Platform.UAP/ViewToRendererConverter.cs
@@ -68,9 +68,9 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				_view.IsInNativeLayout = true;
 				Layout.LayoutChildIntoBoundingRegion(_view, new Rectangle(0, 0, finalSize.Width, finalSize.Height));
+				FrameworkElement?.Arrange(new Rect(_view.X, _view.Y, _view.Width, _view.Height));
 				_view.IsInNativeLayout = false;
 
-				FrameworkElement?.Arrange(new Rect(_view.X, _view.Y, _view.Width, _view.Height));
 				return finalSize;
 			}
 
@@ -93,7 +93,7 @@ namespace Xamarin.Forms.Platform.UWP
 					result = new Windows.Foundation.Size(request.Width, request.Height);
 				}
 
-				_view.Layout(new Rectangle(0, 0, result.Width, result.Height));
+				Layout.LayoutChildIntoBoundingRegion(_view, new Rectangle(0, 0, result.Width, result.Height));
 
 				FrameworkElement?.Measure(availableSize);
 

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -56,7 +56,9 @@
     <Compile Include="FormsComboBox.cs" />
     <Compile Include="InterceptVisualStateManager.cs" />
     <Compile Include="HorizontalTextAlignmentConverter.cs" />
+    <Compile Include="ITitleIconProvider.cs" />
     <Compile Include="ITitleProvider.cs" />
+    <Compile Include="ITitleViewProvider.cs" />
     <Compile Include="IToolbarProvider.cs" />
     <Compile Include="NativeBindingExtensions.cs" />
     <Compile Include="NativeEventWrapper.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1343,9 +1343,10 @@ namespace Xamarin.Forms.Platform.iOS
 				Frame = new RectangleF(Frame.X, Frame.Y, Bounds.Width, height);
 
 				if (_icon != null)
-					_icon.Frame = new RectangleF(0, 0, IconWidth, IconHeight);
+					_icon.Frame = new RectangleF(0, 0, IconWidth, Math.Min(toolbarHeight, IconHeight));
 
-				_child?.Element.Layout(new Rectangle(IconWidth, 0, Bounds.Width - IconWidth, height));
+				if (_child.Element != null)
+					Layout.LayoutChildIntoBoundingRegion(_child.Element, new Rectangle(IconWidth, 0, Bounds.Width - IconWidth, height));
 			}
 
 			public void DisposeChild()

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -31,6 +31,7 @@ namespace Xamarin.Forms.Platform.iOS
 		nfloat _navigationBottom = 0;
 		bool _hasNavigationBar;
 		UIImage _defaultNavBarShadowImage;
+		UIImage _defaultNavBarBackImage;
 
 		public NavigationRenderer()
 		{
@@ -480,6 +481,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			bool shouldHide = NavPage.OnThisPlatform().HideNavigationBarSeparator();
 
+			// Just setting the ShadowImage is good for iOS11
 			if (_defaultNavBarShadowImage == null)
 				_defaultNavBarShadowImage = NavigationBar.ShadowImage;
 
@@ -487,6 +489,19 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationBar.ShadowImage = new UIImage();
 			else
 				NavigationBar.ShadowImage = _defaultNavBarShadowImage;
+
+			if (!Forms.IsiOS11OrNewer)
+			{ 
+				// For iOS 10 and lower, you need to set the background image. 
+				// If you set this for iOS11, you'll remove the background color.
+				if (_defaultNavBarBackImage == null)
+					_defaultNavBarBackImage = NavigationBar.GetBackgroundImage(UIBarMetrics.Default);
+
+				if (shouldHide)
+					NavigationBar.SetBackgroundImage(new UIImage(), UIBarMetrics.Default);
+				else
+					NavigationBar.SetBackgroundImage(_defaultNavBarBackImage, UIBarMetrics.Default);
+			}
 		}
 
 		void UpdateCurrentPagePreferredStatusBarUpdateAnimation()

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1301,9 +1301,6 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			}
 
-			// Prevent Frame from being 0,0
-			public override SizeF IntrinsicContentSize => UILayoutFittingExpandedSize;
-
 			public override SizeF SizeThatFits(SizeF size)
 			{
 				IVisualElementRenderer renderer = _child;
@@ -1320,10 +1317,20 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				base.LayoutSubviews();
 
+				// Navigation bar will not stretch past these values. Prevent content clipping.
+				// iOS11 does this for us automatically, but apparently iOS10 doesn't.
+				int toolbarHeight = 44;
+				if (Device.Idiom == TargetIdiom.Phone && Device.Info.CurrentOrientation.IsLandscape())
+					toolbarHeight = 32;
+
+				double height = Math.Min(toolbarHeight, Bounds.Height);
+
+				Frame = new RectangleF(Frame.X, Frame.Y, Bounds.Width, height);
+
 				if (_icon != null)
 					_icon.Frame = new RectangleF(0, 0, IconWidth, IconHeight);
 
-				_child?.Element.Layout(new Rectangle(IconWidth, 0, Bounds.Width - IconWidth, Bounds.Height));
+				_child?.Element.Layout(new Rectangle(IconWidth, 0, Bounds.Width - IconWidth, height));
 			}
 
 			public void DisposeChild()


### PR DESCRIPTION
### Description of Change ###

`TitleView`, like `TitleIcon`, is an attached property on `NavigationPage`. You can set it on any `Page`, and when that `Page` is pushed onto a `NavigationPage`, it will respect the value of the property.

Xaml:
```xaml
<?xml version="1.0" encoding="utf-8" ?>
<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
             x:Class="Xamarin.Forms.Controls.GalleryPages.TitleView">

	<NavigationPage.TitleView>
		<StackLayout>
			<Label Text="This is my TitleView" />
			<Label Text="I can be a subtitle" />
		</StackLayout>
	</NavigationPage.TitleView>
	
	<StackLayout>
		<Label Text="Welcome to Xamarin.Forms!"
                VerticalOptions="CenterAndExpand" 
                HorizontalOptions="CenterAndExpand" />
	</StackLayout>
</ContentPage>
```

C#:
```csharp
NavigationPage.SetTitleView(this, CreateTitleView());
```

With `TitleView`, you can add any Xamarin.Forms `View` to the navigation bar of a `NavigationPage`.  However, you are limited to the standard `Height` of the navigation bar, with the exception of Android. If you would like to increase the `BarHeight` of the `NavigationPage` on Android, you may use the new Android.AppCompat platform configuration.
```csharp
using Xamarin.Forms.PlatformConfiguration;
using Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat;

navPage.On<Android>().SetBarHeight(450);
```
To give the impression of an extended navigation bar, you may also try putting some of your header content in a view at the very top of your `Page`'s content and color match the navigation bar area. As an example, please see the `NavigationBarGallery SearchBarTitlePage` in this PR (https://github.com/xamarin/Xamarin.Forms/pull/2586/commits/7027da2a247736f22435fec0d11528804e8ced3e).

<img src="https://user-images.githubusercontent.com/7827070/39594735-6586051e-4ec2-11e8-9106-29b415fc1f63.jpg" width=200 />

If you want to do the extended navigation bar on iOS, you will probably want to remove the separator line and shadow that is at the bottom of the navigation bar by default. You can use the new iOS platform configuration to do that.
```csharp
using Xamarin.Forms.PlatformConfiguration;
using Xamarin.Forms.PlatformConfiguration.iOSSpecific;

navPage.On<iOS>().SetHideNavigationBarSeparator(true);
```
Note: We did hope to implement `BarHeight` on iOS and UWP, but there are platform limitations. iOS does not support changing the height of the navigation bar at all, although Apple has indicated that if the demand is great enough, they may consider adding it as a feature in a later version. UWP's `CommandBar` does support changing the Height, but design guidelines prevent the entire content of the `CommandBar` from being shown unless the `CommandBar` is open. Thus, the extended content is clipped while the `CommandBar` is closed. UWP recommends hooking into the `Opening` and `Closing` events of the `CommandBar` to show and hide the content, but that is currently outside the scope of this feature. Some alternatives may be considered in the future.

As part of this enhancement, we have also enabled `TitleIcon` on Android `FormsAppCompatActivity` and UWP.

### Known Issues/Limitations ###

- `SearchBar` needs to be wrapped in a `Layout` with `HorizontalOptions = LayoutOptions.Fill` and `VerticalOptions = LayoutOptions.Fill` OR a specificed `WidthRequest` and `HeightRequest` to display properly on iOS.
- `TitleView` is not supported on Android `FormsApplicationActivity`. You must use Android `FormsAppCompatActivity`.
- Content may not be larger than the default size of the navigation bar on iOS/UWP. Clipping will occur.
- Since `BackTitle`, `Title`, `TitleIcon`, and `TitleView` all occupy the same space on the navigation bar, you can expect that there will be conflicts and limited space to support all of these properties at the same time. This will vary by platform and screen size. You may find that you can better achieve your desired design by using just `TitleView` instead of attempting to use a combination of properties. 

### Screenshots ###

#### iOS 11+

Note that iOS TitleViews show is a different position depending on whether Large Titles is enabled.

<img src="https://user-images.githubusercontent.com/7827070/41746620-da61f42e-755f-11e8-8463-fc3963be78c5.png" width=300/>
<img src="https://user-images.githubusercontent.com/7827070/41746621-da7e27c0-755f-11e8-9747-e54c4133ce30.png" width=300/>
<img src="https://user-images.githubusercontent.com/7827070/41746622-da9d8f02-755f-11e8-9541-4cc1008047af.png" width=300/>
<img src="https://user-images.githubusercontent.com/7827070/41746623-dabff2f4-755f-11e8-9716-068c77cd25a2.png" width=300/>

#### iOS 10

<img src="https://user-images.githubusercontent.com/7827070/41747254-27e9c72e-7562-11e8-83b3-262364aba5e0.png" width=300/>
<img src="https://user-images.githubusercontent.com/7827070/41747255-28070816-7562-11e8-9d5b-3c07166a9962.png" width=300/>
<img src="https://user-images.githubusercontent.com/7827070/41747256-2823e85a-7562-11e8-8432-f0352d73aca5.png" width=300/>
<img src="https://user-images.githubusercontent.com/7827070/41747257-2841d018-7562-11e8-97b9-48437ee22ba1.png" width=300/>

#### Android

Note that Android supports `BarHeight`

<img src="https://user-images.githubusercontent.com/7827070/41746636-efbe9980-755f-11e8-9622-441e7e90c588.png" width=300/>
<img src="https://user-images.githubusercontent.com/7827070/41746637-efdeebf4-755f-11e8-9ca8-bfcf8b3e499d.png" width=300/>
<img src="https://user-images.githubusercontent.com/7827070/41746638-f0035bb0-755f-11e8-9e0e-fc6c7dd72065.png" width=300/>

#### UWP

<img width="300" alt="capture" src="https://user-images.githubusercontent.com/7827070/41746775-6f77767e-7560-11e8-8d4e-671ba52bf56b.PNG">
<img width="300" alt="capture2" src="https://user-images.githubusercontent.com/7827070/41746777-6f98872e-7560-11e8-95ad-3da054dec074.PNG">
<img width="300" alt="capture3" src="https://user-images.githubusercontent.com/7827070/41746778-6fb94e5a-7560-11e8-9f27-921286ba9306.PNG">

### Bugs Fixed ###

- Fixes #1716
- `TitleIcon` now works on Android AppCompat
- `TitleIcon` now works on UWP

### API Changes ###

Added:
- `NavigationPage.On<Android>().SetBarHeight(int);`
- `int NavigationPage.On<Android>().GetBarHeight();`
- `NavigationPage.On<iOS>().SetHideNavigationBarSeparator(bool);`
- `bool NavigationPage.On<iOS>().GetHideNavigationBarSeparator();`
- `View NavigationPage.TitleView { get; set; } //bindable property`

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense


