### PR TITLE
Expose the Source for a StyleSheet

### DIFF
--- a/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
+++ b/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Forms.StyleSheets
 		{
 		}
 
+		public Uri Source { get; internal set; }
+
 		internal IDictionary<Selector, Style> Styles { get; set; } = new Dictionary<Selector, Style>();
 
 		public static StyleSheet FromAssemblyResource(Assembly assembly, string resourceId, IXmlLineInfo lineInfo = null)

--- a/Xamarin.Forms.Xaml.UnitTests/StyleSheet.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/StyleSheet.xaml.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using NUnit.Framework;
-
 using Xamarin.Forms.Core.UnitTests;
-using NUnit.Framework.Constraints;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -41,6 +42,44 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				var layout = new StyleSheet(useCompiledXaml);
 				Assert.That(layout.label0.TextColor, Is.EqualTo(Color.Azure));
 				Assert.That(layout.label0.BackgroundColor, Is.EqualTo(Color.AliceBlue));
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void StyleSheetSourceIsApplied(bool useCompiledXaml)
+			{
+				// Having a custom ResourceProvider forces the LoadFromXaml code path 
+				// for both XamlC and non-XamlC
+				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = GetResource;
+
+				var layout = new StyleSheet(useCompiledXaml);
+
+				Assert.AreEqual("css/foo.css", layout.Resources.StyleSheets[0].Source.OriginalString);
+
+				// Reset state to its initial
+				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = null;
+				DesignMode.IsDesignModeEnabled = false;
+			}
+
+			string GetResource(AssemblyName name, string path)
+			{
+				var assembly = Assembly.Load(name);
+				var resourceId = assembly
+					.GetCustomAttributes<XamlResourceIdAttribute>()
+					.Where(x => x.Path == path)
+					.Select(x => x.ResourceId)
+					.FirstOrDefault();
+
+				if (!string.IsNullOrEmpty(resourceId))
+				{
+					using (var stream = assembly.GetManifestResourceStream(resourceId))
+					{
+						if (stream != null)
+							using (var reader = new StreamReader(stream))
+								return reader.ReadToEnd();
+					}
+				}
+
+				return null;
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml/MarkupExtensions/StyleSheetExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/StyleSheetExtension.cs
@@ -35,7 +35,9 @@ namespace Xamarin.Forms.Xaml
 				var rootTargetPath = XamlResourceIdAttribute.GetPathForType(rootObjectType);
 				var resourcePath = ResourceDictionary.RDSourceTypeConverter.GetResourcePath(Source, rootTargetPath);
 				var resString = DependencyService.Get<IResourcesLoader>().GetResource(resourcePath, rootObjectType.GetTypeInfo().Assembly, lineInfo);
-				return StyleSheet.FromString(resString);
+				var styleSheet = StyleSheet.FromString(resString);
+				styleSheet.Source = new Uri(resourcePath, UriKind.Relative);
+				return styleSheet;
 			}
 
 			if (!string.IsNullOrEmpty(Style)) {


### PR DESCRIPTION
This would allow previewer/designer/reloader to determine the source of a
stylesheet and refresh its content when appropriate.
