### PR TITLE
[Flex] do not layout invisible children

### DIFF
--- a/Xamarin.Flex/Flex.cs
+++ b/Xamarin.Flex/Flex.cs
@@ -262,7 +262,7 @@ namespace Xamarin.Flex
 
 		/// <summary>This property defines the bottom edge absolute position of the item. It also defines the item's height if <see cref="P:Xamarin.Flex.Item.Top" /> is also set and if <see cref="P:Xamarin.Flex.Item.Height" /> isn't set. It is ignored if <see cref="P:Xamarin.Flex.Item.Position" /> isn't set to Absolute.</summary>
 		/// <value>The value for the property.</value>
-        /// <remarks>The default value for this property is NaN.</remarks>
+		/// <remarks>The default value for this property is NaN.</remarks>
 		public float Bottom { get; set; } = float.NaN;
 
 		/// <summary>This property defines the direction and main-axis of child items. If set to Column (or ColumnReverse), the main-axis will be the y-axis and items will be stacked vertically. If set to Row (or RowReverse), the main-axis will be the x-axis and items will be stacked horizontally.</summary>
@@ -279,6 +279,8 @@ namespace Xamarin.Flex
 		/// <value>The height size dimension.</value>
 		/// <remarks>The default value for this property is NaN.</remarks>
 		public float Height { get; set; } = float.NaN;
+
+		public bool IsVisible { get; set; } = true;
 
 		/// <summary>This property defines how the layout engine will distribute space between and around child items along the main-axis.</summary>
 		/// <value>Any value part of the<see cref="T:Xamarin.Flex.Align" /> enumeration, with the exception of Stretch and Auto.</value>
@@ -479,6 +481,8 @@ namespace Xamarin.Flex
 			int relative_children_count = 0;
 			for (int i = 0; i < item.Count; i++) {
 				var child = layout.child_at(item, i);
+				if (!child.IsVisible) continue;
+
 				// Items with an absolute position have their frames determined
 				// directly and are skipped during layout.
 				if (child.Position == Position.Absolute) {
@@ -745,8 +749,8 @@ namespace Xamarin.Flex
 			}
 
 			for (int i = child_begin; i < child_end; i++) {
-
 				Item child = layout.child_at(item, i);
+				if (!child.IsVisible) continue;
 				if (child.Position == Position.Absolute) {
 					// Already positioned.
 					continue;

--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
@@ -427,5 +427,48 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Layout(new Rectangle(0, 0, 300, 300));
 			Assert.That(label0.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 300)));
 		}
+
+		[Test]
+		public void TestIsVisible()
+		//https://github.com/xamarin/Xamarin.Forms/issues/2593
+		{
+			var platform = new UnitPlatform();
+			var label0 = new Label {
+				Platform = platform,
+				IsPlatformEnabled = true,
+			};
+			var label1 = new Label {
+				Platform = platform,
+				IsPlatformEnabled = true,
+			};
+			var label2 = new Label {
+				Platform = platform,
+				IsPlatformEnabled = true,
+			};
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Column,
+				Children = {
+					label0,
+					label1,
+					label2,
+				}
+			};
+
+			layout.Layout(new Rectangle(0, 0, 300, 300));
+			Assert.That(label0.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 20)));
+			Assert.That(label1.Bounds, Is.EqualTo(new Rectangle(0, 20, 300, 20)));
+			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(0, 40, 300, 20)));
+
+			label1.IsVisible = false;
+			Assert.That(label0.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 20)));
+			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(0, 20, 300, 20)));
+
+			label0.IsVisible = false;
+			label1.IsVisible = true;
+			Assert.That(label1.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 20)));
+			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(0, 20, 300, 20)));
+		}	
 	}
 }

--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -302,7 +302,8 @@ namespace Xamarin.Forms
 										AlignSelfProperty,
 										MarginProperty,
 										WidthRequestProperty,
-										HeightRequestProperty);
+										HeightRequestProperty,
+										IsVisibleProperty);
 			item.Order = (int)values[0];
 			item.Grow = (float)values[1];
 			item.Shrink = (float)values[2];
@@ -314,6 +315,7 @@ namespace Xamarin.Forms
 			item.MarginBottom = (float)((Thickness)values[5]).Bottom;
 			item.Width = (double)values[6] < 0 ? float.NaN : (float)(double)values[6];
 			item.Height = (double)values[7] < 0 ? float.NaN : (float)(double)values[7];
+			item.IsVisible = (bool)values[8];
 			if (view is FlexLayout) {
 				var padding = view.GetValue(PaddingProperty);
 				item.PaddingLeft = (float)((Thickness)padding).Left;
@@ -370,6 +372,13 @@ namespace Xamarin.Forms
 				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 				UpdateChildrenLayout();
 				return;
+			}
+
+			if (e.PropertyName == IsVisibleProperty.PropertyName) {
+				var item = (sender as FlexLayout)?._root ?? GetFlexItem((BindableObject)sender);
+				if (item == null)
+					return;
+				item.IsVisible = (bool)((View)sender).GetValue(IsVisibleProperty);
 			}
 
 			if (   e.PropertyName == OrderProperty.PropertyName


### PR DESCRIPTION
### Description of Change ###

[Flex] do not layout invisible children

### Bugs Fixed ###

- fixes #2593

### API Changes ###

/

### Behavioral Changes ###

children with `IsVisible` `false` won't take space in a flex layout

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense