### PR TITLE
[CSS] lightgray is spelled lightgrey in CSS world

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/ColorTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/ColorTypeConverter.cs
@@ -39,7 +39,8 @@ namespace Xamarin.Forms.Core.XamlC
 				var parts = value.Split('.');
 				if (parts.Length == 1 || (parts.Length == 2 && parts [0] == "Color")) {
 					var color = parts [parts.Length - 1];
-
+					if (color == "lightgrey")
+						color = "lightgray";
 					var fieldReference = module.ImportFieldReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Color"),
 																	 color,
 																	 isStatic: true,

--- a/Xamarin.Forms.Core/ColorTypeConverter.cs
+++ b/Xamarin.Forms.Core/ColorTypeConverter.cs
@@ -156,6 +156,7 @@ namespace Xamarin.Forms
 					case "lightcoral": return Color.LightCoral;
 					case "lightcyan": return Color.LightCyan;
 					case "lightgoldenrodyellow": return Color.LightGoldenrodYellow;
+					case "lightgrey":
 					case "lightgray": return Color.LightGray;
 					case "lightgreen": return Color.LightGreen;
 					case "lightpink": return Color.LightPink;


### PR DESCRIPTION
### Description of Change ###

[CSS] lightgray is spelled lightgrey in CSS world

### Bugs Fixed ###

- fixes #2596

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
