### PR TITLE
[Core] Fixes replace action in NotifyCollectionChangedEventArgsExtensions

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub2598.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub2598.cs
@@ -1,0 +1,50 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2598, "Replacing page in CarouselPage does not work the first time", PlatformAffected.All)]
+	public class GitHub2598 : TestCarouselPage
+	{
+		private ContentPage CreatePage(string labelText, Color bg)
+		{
+			return new ContentPage
+			{
+				Content = new Label { Text = labelText },
+				BackgroundColor = bg
+			};
+		}
+
+		protected override void Init()
+		{
+			var firstPage = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Button()
+						{
+							Text = "Replace Page2. It should be green",
+							TextColor = Color.White,
+							BackgroundColor = Color.Green,
+							Command =  new Command(() =>
+							{
+								var newPage = CreatePage("This is the new Page 2", Color.Green);
+								Children[1] = newPage;
+							})
+						}
+					}
+				},
+				BackgroundColor = Color.Blue
+			};
+			Children.Add(firstPage);
+
+			var secondPage = CreatePage("Page 2", Color.Red);
+			Children.Add(secondPage);
+
+			CurrentPage = firstPage;			
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -239,6 +239,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GitHub2598.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1677.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1801.cs" />

--- a/Xamarin.Forms.Core.UnitTests/NotifyCollectionChangedEventArgsExtensionsTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/NotifyCollectionChangedEventArgsExtensionsTests.cs
@@ -70,5 +70,26 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			CollectionAssert.AreEqual (items, applied);
 		}
+
+		[Test]
+		public void Replace()
+		{
+			List<string> applied = new List<string> { "foo", "bar", "baz" };
+
+			Action reset = () => Assert.Fail("Reset should not be called");
+			Action<object, int, bool> insert = (o, i, create) => {
+				Assert.That(create, Is.True);
+				applied.Insert(i, (string)o);
+			};
+
+			Action<object, int> removeAt = (o, i) => applied.RemoveAt(i);
+
+			var items = new ObservableCollection<string>(applied);
+			items.CollectionChanged += (s, e) => e.Apply(insert, removeAt, reset);
+
+			items[1] = "monkey";
+
+			CollectionAssert.AreEqual(items, applied);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
+++ b/Xamarin.Forms.Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
@@ -65,13 +65,13 @@ namespace Xamarin.Forms.Internals
 					break;
 
 				case NotifyCollectionChangedAction.Replace:
-					if (self.OldStartingIndex < 0)
+					if (self.OldStartingIndex < 0 || self.OldItems.Count != self.NewItems.Count)
 						goto case NotifyCollectionChangedAction.Reset;
 
 					for (var i = 0; i < self.OldItems.Count; i++)
 					{
 						removeAt(self.OldItems[i], i + self.OldStartingIndex);
-						insert(self.OldItems[i], i + self.OldStartingIndex, true);
+						insert(self.NewItems[i], i + self.OldStartingIndex, true);
 					}
 					break;
 


### PR DESCRIPTION
### Description of Change ###

Fixes replace action in `NotifyCollectionChangedEventArgsExtensions` class
**Screencasts**
UWP: http://recordit.co/WaOGnn0rON
iOS: http://recordit.co/Y0nEJSuxvd

### Bugs Fixed ###

Fixes #2598 
Fixes #2585

### API Changes ###

/

### Behavioral Changes ###

Fixed replacement of items in`NotifyCollection'

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
