### PR TITLE
[UWP] Deadlock if you rapid fire alerts  fixes #2607

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43469.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43469.cs
@@ -8,35 +8,67 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 43469, "Calling DisplayAlert twice in WinRT causes a crash", PlatformAffected.WinRT)]
 	public class Bugzilla43469 : TestContentPage
 	{
+		const string kButtonText = "Click to call DisplayAlert six times";
 		protected override void Init()
 		{
-			var button = new Button { Text = "Click to call DisplayAlert three times" };
+			var button = new Button { Text = "Click to call DisplayAlert six times" };
 
-			button.Clicked += (sender, args) =>
+			button.Clicked += async (sender, args) =>
 			{
+				await DisplayAlert("First", "Text", "OK", "Cancel");
+				await DisplayAlert("Second", "Text", "OK", "Cancel");
+				await DisplayAlert("Three", "Text", "OK", "Cancel");
 				Device.BeginInvokeOnMainThread(new Action(async () =>
 				{
-					await DisplayAlert("First", "Text", "Cancel");
+					await DisplayAlert("Fourth", "Text", "OK", "Cancel");
 				}));
 
 				Device.BeginInvokeOnMainThread(new Action(async () =>
 				{
-					await DisplayAlert("Second", "Text", "Cancel");
+					await DisplayAlert("Fifth", "Text", "OK", "Cancel");
 				}));
 
 				Device.BeginInvokeOnMainThread(new Action(async () =>
 				{
-					await DisplayAlert("Three", "Text", "Cancel");
+					await DisplayAlert("Sixth", "Text", "OK", "Cancel");
 				}));
 			};
 
 			Content = button;
 		}
+
+
+#if UITEST
+
+		[Test]
+		public async void Bugzilla43469Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(kButtonText));
+			RunningApp.Tap(kButtonText);
+			RunningApp.WaitForElement(q => q.Marked("First"));
+			RunningApp.Tap(q => q.Marked("OK"));
+			RunningApp.WaitForElement(q => q.Marked("Second"));
+			RunningApp.Tap(q => q.Marked("OK"));
+			RunningApp.WaitForElement(q => q.Marked("Three"));
+			RunningApp.Tap(q => q.Marked("OK"));
+
+
+			await Task.Delay(100);
+			RunningApp.Tap(q => q.Marked("OK"));
+			await Task.Delay(100);
+			RunningApp.Tap(q => q.Marked("OK"));
+			await Task.Delay(100);
+			RunningApp.Tap(q => q.Marked("OK"));
+			await Task.Delay(100);
+			RunningApp.WaitForElement(q => q.Marked(kButtonText));
+		}
+#endif
+
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 		static void OnPageActionSheet(object sender, ActionSheetArguments options)
-		{ 
+		{
 			bool userDidSelect = false;
 			var flyoutContent = new FormsFlyout(options);
 
@@ -110,7 +110,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			s_currentAlert = ShowAlert(alertDialog);
-			options.SetResult(await s_currentAlert);
+			options.SetResult(await s_currentAlert.ConfigureAwait(false));
 			s_currentAlert = null;
 		}
 


### PR DESCRIPTION
### Description of Change ###

fixes #2607

Added ConfigureAwait(false) to the process waiting for the dialog to close so as to not cause a deadlock with the await in the while loop above it

```C#
options.SetResult(await s_currentAlert.ConfigureAwait(false));
```

Also slightly modified the Bugzilla test that started this all to include the case which was causing the deadlocks on UWP

### Bugs Fixed ###

- Provide links to bugs here

### API Changes ###
None
 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
