### PR TITLE
[UWP] NRE when checking IsInNativeLayout during OnScrollToRequested

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
@@ -41,9 +41,10 @@ namespace Xamarin.Forms.Platform.UWP
 		protected override void Dispose(bool disposing)
 		{
 			if (Control != null)
-			{
 				Control.ViewChanged -= OnViewChanged;
-			}
+
+			if (Element != null)
+				Element.ScrollToRequested -= OnScrollToRequested;
 
 			base.Dispose(disposing);
 		}
@@ -135,7 +136,7 @@ namespace Xamarin.Forms.Platform.UWP
 			// values. The ScrollViewRenderer for Android does something similar by waiting up
 			// to 10ms for layout to occur.
 			int cycle = 0;
-			while (!Element.IsInNativeLayout)
+			while (Element != null && !Element.IsInNativeLayout)
 			{
 				await Task.Delay(TimeSpan.FromMilliseconds(1));
 				cycle++;
@@ -143,6 +144,9 @@ namespace Xamarin.Forms.Platform.UWP
 				if (cycle >= 10)
 					break;
 			}
+
+			if (Element == null)
+				return;
 
 			double x = e.ScrollX, y = e.ScrollY;
 
@@ -212,7 +216,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		UwpScrollBarVisibility ScrollBarVisibilityToUwp(ScrollBarVisibility visibility)
 		{
-			switch(visibility)
+			switch (visibility)
 			{
 				case ScrollBarVisibility.Always:
 					return UwpScrollBarVisibility.Visible;


### PR DESCRIPTION
### Description of Change ###
- Added null check on ScrollView Element in UWP Scroll View Renderer
- unsubscribe from ScrollToRequested in dispose to improve cleanup

### Bugs Fixed ###

fixes #2336

### API Changes ###
None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
