### PR TITLE
Enable Droid Shared Runtime + Fast Deploy

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -51,10 +51,10 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+    <AndroidUseSharedRuntime>true</AndroidUseSharedRuntime>
     <AndroidLinkMode>Full</AndroidLinkMode>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
-    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+    <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
     <CustomCommands>
       <CustomCommands>
         <Command>


### PR DESCRIPTION
Flip on Shared Runtime + Fast Deploy for Android Gallery Project. We'd like 'em flipped on because the deploys should be faster. They've been off up to now because we've thought the debugger is more stable with 'em off. However the debugger seems to be working well enough with 'em flipped on in my recent testing. And if we flip it on then we can find more VS debugger bugs in our preferred configuration. 
