### PR TITLE
[iOS] Added icon to context menu actions instead of text 

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Platform.iOS
 				PropertyChanged(this, e);
 		}
 
-		internal static UITableViewCell GetNativeCell(UITableView tableView, Cell cell, bool recycleCells = false, string templateId = "")
+		internal static UITableViewCell GetNativeCell(UITableView tableView, Cell cell, bool recycleCells = false, string templateId = "", ContextActionCellDisplay contextActionDisplayType = ContextActionCellDisplay.Text)
 		{
 			var id = cell.GetType().FullName;
 
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Platform.iOS
 				contextCell = (ContextActionsCell)tableView.DequeueReusableCell(ContextActionsCell.Key + templateId);
 				if (contextCell == null)
 				{
-					contextCell = new ContextActionsCell(templateId);
+					contextCell = new ContextActionsCell(templateId, contextActionDisplayType);
 					reusableCell = tableView.DequeueReusableCell(id);
 				}
 				else

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	internal class ContextActionsCell : UITableViewCell, INativeElementView
 	{
+		readonly ContextActionCellDisplay _displayType;
+
 		public const string Key = "ContextActionsCell";
 
 		static readonly UIImage DestructiveBackground;
@@ -48,8 +50,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 		}
 
-		public ContextActionsCell(string templateId) : base(UITableViewCellStyle.Default, Key + templateId)
+		public ContextActionsCell(string templateId, ContextActionCellDisplay displayType) : base(UITableViewCellStyle.Default, Key + templateId)
 		{
+			_displayType = displayType;
 		}
 
 		public UITableViewCell ContentCell { get; private set; }
@@ -407,9 +410,19 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				button.SetBackgroundImage(DestructiveBackground, UIControlState.Normal);
 
-			button.SetTitle(item.Text, UIControlState.Normal);
-			button.TitleEdgeInsets = new UIEdgeInsets(0, 15, 0, 15);
+			switch (_displayType)
+			{
+				case ContextActionCellDisplay.Icon:
+					button.SetImage(new UIImage(item.Icon.File), UIControlState.Normal);
+					break;
 
+				case ContextActionCellDisplay.Text:
+				default:
+					button.SetTitle(item.Text, UIControlState.Normal);
+					break;
+			}
+
+			button.TitleEdgeInsets = new UIEdgeInsets(0, 15, 0, 15);
 			button.Enabled = item.IsEnabled;
 
 			return button;

--- a/Xamarin.Forms.Platform.iOS/ContextActionCellDisplay.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCellDisplay.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.Forms.Platform.iOS
+{
+	public enum ContextActionCellDisplay
+	{
+		Text, 
+		Icon
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected TableView View;
 
+		protected virtual ContextActionCellDisplay ContextActionDisplayType { get; }
+
 		public TableViewModelRenderer(TableView model)
 		{
 			View = model;
@@ -31,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var cell = View.Model.GetCell(indexPath.Section, indexPath.Row);
 
-			var nativeCell = CellTableViewCell.GetNativeCell(tableView, cell);
+			var nativeCell = CellTableViewCell.GetNativeCell(tableView, cell, contextActionDisplayType: ContextActionDisplayType);
 			return nativeCell;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -110,6 +110,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CellExtensions.cs" />
     <Compile Include="CADisplayLinkTicker.cs" />
+    <Compile Include="ContextActionCellDisplay.cs" />
     <Compile Include="EffectUtilities.cs" />
     <Compile Include="ExportCellAttribute.cs" />
     <Compile Include="ExportImageSourceHandlerAttribute.cs" />


### PR DESCRIPTION
### Description of Change ###

Changed context action menu of ViewCells to Icons like it is in native apps and on Android instead of Text. This only happens if the ListViewRenderer is overwritten and the virtual protected property `ContextActionDisplayType` is set to `ContextActionCellDisplay.Icon`. This way this is not a breaking change as you mentioned here: https://github.com/xamarin/Xamarin.Forms/pull/1487 

**Note**: This is a updated version from #2579 due to a few problems with the rebase.

### Bugs Fixed ###

- None

### API Changes ###

 - None

### Behavioral Changes ###

Instead of text the icon will appear in context actions like it is on Android.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
