### PR TITLE
[Android] Force ScrollView layout when changing ContentView content

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1760.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1760.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1760, "Content set after an await is not visible", PlatformAffected.Android)]
+	public class Issue1760 : TestMasterDetailPage
+	{
+		const string Before = "Before";
+		const string After = "After";
+		const int Wait = 3;
+
+		protected override void Init()
+		{
+			Master = new _1760Master();
+			Detail = new _1760TestPage();
+			IsPresented = true;
+		}
+
+		[Preserve(AllMembers = true)]
+		public class _1760Master : ContentPage
+		{
+			public _1760Master()
+			{
+				var instructions = new Label { Text = $"Select one of the menu items. The detail page text should change to {Before}. After {Wait} seconds the text should change to {After}." };
+
+				var menuView = new ListView(ListViewCachingStrategy.RetainElement)
+				{
+					ItemsSource = new List<string> { "Test Page 1", "Test Page 2" }
+				};
+
+				menuView.ItemSelected += OnMenuClicked;
+
+				Content = new StackLayout{Children = { instructions, menuView }};
+				Title = "GH 1760 Test App";
+			}
+
+			void OnMenuClicked(object sender, SelectedItemChangedEventArgs e)
+			{
+				var mainPage = (MasterDetailPage)Parent;
+				mainPage.Detail = new _1760TestPage();
+				mainPage.IsPresented = false;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class _1760TestPage : ContentPage
+		{
+			public async Task DisplayPage()
+			{
+				IsBusy = true;
+				HeaderPageContent = new Label {Text = Before, TextColor = Color.Black};
+
+				await Task.Delay(Wait * 1000);
+
+				HeaderPageContent = new Label { Text = After, TextColor = Color.Black};
+				IsBusy = false;
+			}
+
+			ContentView _headerPageContent;
+			public View HeaderPageContent
+			{
+				set => _headerPageContent.Content = value;
+			}
+
+			public _1760TestPage()
+			{
+				CreateHeaderPage();
+				DisplayPage();
+			}
+
+			void CreateHeaderPage()
+			{
+
+				_headerPageContent = new ContentView
+				{
+					Content = new Label { Text = "_1760 Test Page Content" },
+					BackgroundColor = Color.White,
+					Margin = 40
+				};
+
+				Title = "_1760 Test Page";
+
+				Content = new ScrollView
+				{
+					Content = _headerPageContent
+				};
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2595.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2595.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Timers;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2595, "ScrollView.Content is not re-layouted on Android", PlatformAffected.Android)]
+	public class Issue2595 : TestMasterDetailPage
+	{
+		protected override void Init()
+		{
+			Master = new _2595Master();
+			Detail = new _2595ScrollPage();
+			IsPresented = true;
+		}
+
+		[Preserve(AllMembers = true)]
+		public class _2595Master : ContentPage
+		{
+			public _2595Master()
+			{
+				var instructions = new Label { Text = $"Select one of the menu items. The detail page text should "
+				                                      + $"display a label which disappears after 1 second and is"
+				                                      + $" replaced by an updating list of labels which grows vertically." };
+
+				var menuView = new ListView(ListViewCachingStrategy.RetainElement)
+				{
+					ItemsSource = new List<string> { "Test Page 1", "Test Page 2" }
+				};
+
+				menuView.ItemSelected += OnMenuClicked;
+
+				Content = new StackLayout{Children = { instructions, menuView }};
+				Title = "GH 2595 Test App";
+			}
+
+			void OnMenuClicked(object sender, SelectedItemChangedEventArgs e)
+			{
+				var mainPage = (MasterDetailPage)Parent;
+				mainPage.Detail = new _2595ScrollPage ();
+				mainPage.IsPresented = false;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class _2595ScrollPage : ContentPage
+		{
+			readonly Timer _timer = new Timer(1000);
+			protected Label Label;
+
+			public _2595ScrollPage() {
+				Content = new ScrollView {
+
+					BackgroundColor = Color.Red,
+
+					Content = new StackLayout {
+						BackgroundColor = Color.BlueViolet,
+						Children = {
+							(Label = new Label {
+								Text = "this text should disappear after 1 sec",
+								BackgroundColor = Color.LightBlue,
+								HorizontalOptions = LayoutOptions.StartAndExpand,
+							})
+						}
+					}
+				};
+			}
+
+			protected StackLayout ScrollContent {
+				get => (Content as ScrollView).Content as StackLayout;
+				set => (Content as ScrollView).Content = value;
+			}
+
+			protected override void OnAppearing() {
+				base.OnAppearing();
+				_timer.Elapsed += (s, e) => Device.BeginInvokeOnMainThread(OnTimerElapsed);
+
+				_timer.Start();
+			}
+
+			void OnTimerElapsed() {
+				Label.Text = $"{ DateTime.Now.ToString() }: expecting {ScrollContent?.Children.Count} dates to show up.";
+				ScrollContent.Children.Add(new Label { Text = DateTime.Now.ToString() });
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -303,7 +303,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1908.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1672.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2394.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue1908.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2595.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -248,6 +248,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1415.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2247.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GroupListViewHeaderIndexOutOfRange.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1760.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1975.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1601.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1717.cs" />
@@ -302,6 +303,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1908.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1672.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2394.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1908.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2595.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2981.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
@@ -25,10 +25,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				RemoveAllViews();
 
-				if (_childView is Layout layout1)
-				{
-					layout1.LayoutChanged -= OnChildLayoutChanged;
-				}
+				UnsubscribeChildLayoutChanges();
 
 				_childView = value;
 
@@ -61,12 +58,22 @@ namespace Xamarin.Forms.Platform.Android
 			RequestLayout();
 		}
 
+		void UnsubscribeChildLayoutChanges()
+		{
+			if (_childView is Layout layout)
+			{
+				layout.LayoutChanged -= OnChildLayoutChanged;
+			}
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			base.Dispose(disposing);
 
 			if (disposing)
 			{
+				UnsubscribeChildLayoutChanges();
+
 				if (ChildCount > 0)
 					GetChildAt(0).Dispose();
 				RemoveAllViews();

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
@@ -1,3 +1,5 @@
+using System;
+using System.ComponentModel;
 using Android.Content;
 using Android.Views;
 
@@ -23,6 +25,11 @@ namespace Xamarin.Forms.Platform.Android
 
 				RemoveAllViews();
 
+				if (_childView is Layout layout1)
+				{
+					layout1.LayoutChanged -= OnLayoutChanged;
+				}
+
 				_childView = value;
 
 				if (_childView == null)
@@ -36,7 +43,17 @@ namespace Xamarin.Forms.Platform.Android
 					renderer.View.RemoveFromParent();
 
 				AddView(renderer.View);
+
+				if (_childView is Layout layout)
+				{ 
+					layout.LayoutChanged += OnLayoutChanged;
+				}
 			}
+		}
+
+		void OnLayoutChanged(object sender, EventArgs e)
+		{
+			RequestLayout();
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (_childView is Layout layout1)
 				{
-					layout1.LayoutChanged -= OnLayoutChanged;
+					layout1.LayoutChanged -= OnChildLayoutChanged;
 				}
 
 				_childView = value;
@@ -46,13 +46,18 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (_childView is Layout layout)
 				{ 
-					layout.LayoutChanged += OnLayoutChanged;
+					layout.LayoutChanged += OnChildLayoutChanged;
 				}
 			}
 		}
 
-		void OnLayoutChanged(object sender, EventArgs e)
+		void OnChildLayoutChanged(object sender, EventArgs e)
 		{
+			if (IsInLayout)
+			{
+				return;
+			}
+
 			RequestLayout();
 		}
 


### PR DESCRIPTION
### Description of Change ###

ScrollView on Android does not automatically trigger a re-layout when its content changes; in some circumstances, this can cause incorrect or out-of-date layouts.

This change triggers a re-layout on the ScrollViewContainer when the content of the ScrollViewContainer is a Layout and that content's layout changes.

### Bugs Fixed ###

- fixes #1760 
- fixes #2595 
- fixes #1332 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
