### PR TITLE
Call ChangeVisualState when new states are added

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2625.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2625.xaml
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue2625">
+    <ContentPage.Content>
+        <StackLayout>
+			
+			<Label Text="The buttons below should have their background colors set by the VisualStateManager. If they have the default button background color, this test has failed."></Label>
+
+			<Button
+				HorizontalOptions="Center"
+				Text="I should have a Lime background"
+				VerticalOptions="Center">
+				<VisualStateManager.VisualStateGroups>
+					<VisualStateGroup x:Name="CommonStates">
+						<VisualState x:Name="Normal">
+							<VisualState.Setters>
+								<Setter Property="BackgroundColor" Value="Lime" />
+							</VisualState.Setters>
+						</VisualState>
+					</VisualStateGroup>
+				</VisualStateManager.VisualStateGroups>
+			</Button>
+			
+			<Button
+				HorizontalOptions="Center"
+				Text="I should have a Pink background"
+				IsEnabled="False"
+				VerticalOptions="Center">
+				<VisualStateManager.VisualStateGroups>
+					<VisualStateGroup x:Name="CommonStates">
+						<VisualState x:Name="Disabled">
+							<VisualState.Setters>
+								<Setter Property="BackgroundColor" Value="Pink" />
+							</VisualState.Setters>
+						</VisualState>
+					</VisualStateGroup>
+				</VisualStateManager.VisualStateGroups>
+			</Button>
+
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2625.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2625.xaml.cs
@@ -18,7 +18,9 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public Issue2625 ()
 		{
+#if APP
 			InitializeComponent ();
+#endif
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2625.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2625.xaml.cs
@@ -11,7 +11,9 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if APP
 	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 2625, "VisualStateManager attached to Button seems to not work on Android", PlatformAffected.Android)]
 	public partial class Issue2625 : ContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2625.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2625.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2625, "VisualStateManager attached to Button seems to not work on Android", PlatformAffected.Android)]
+	public partial class Issue2625 : ContentPage
+	{
+		public Issue2625 ()
+		{
+			InitializeComponent ();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -291,6 +291,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1665.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1908.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2625.xaml.cs">
+      <DependentUpon>Issue2625.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2981.cs" />
@@ -869,6 +873,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla60045.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2625.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -878,7 +878,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2625.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
@@ -212,5 +212,55 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That(groups1[0].CurrentState.Name, Is.EqualTo(NormalStateName));
 
 		}
+
+		[Test]
+		public void VisualElementGoesToCorrectStateWhenAvailable()
+		{
+			var label = new Label();
+			double targetBottomMargin = 1.5;
+
+			var group = new VisualStateGroup();
+			var list = new VisualStateGroupList();
+
+			var normalState = new VisualState { Name = NormalStateName };
+			normalState.Setters.Add(new Setter { Property = View.MarginBottomProperty, Value = targetBottomMargin });
+
+			list.Add(group);
+			group.States.Add(normalState);
+
+			VisualStateManager.SetVisualStateGroups(label, list);
+
+			Assert.That(label.Margin.Bottom, Is.EqualTo(targetBottomMargin));
+		}
+
+		[Test]
+		public void VisualElementGoesToCorrectStateWhenAvailableFromSetter()
+		{
+			double targetBottomMargin = 1.5;
+
+			var group = new VisualStateGroup();
+			var list = new VisualStateGroupList();
+
+			var normalState = new VisualState { Name = NormalStateName };
+			normalState.Setters.Add(new Setter { Property = View.MarginBottomProperty, Value = targetBottomMargin });
+
+			var x = new Setter
+			{
+				Property = VisualStateManager.VisualStateGroupsProperty,
+				Value = list
+			};
+
+			list.Add(group);
+			group.States.Add(normalState);
+
+			var label1 = new Label();
+			var label2 = new Label();
+
+			x.Apply(label1);
+			x.Apply(label2);
+
+			Assert.That(label1.Margin.Bottom, Is.EqualTo(targetBottomMargin));
+			Assert.That(label2.Margin.Bottom, Is.EqualTo(targetBottomMargin));
+		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
@@ -113,6 +113,18 @@
 				</VisualStateGroup>
 			</VisualStateManager.VisualStateGroups>
 		</Entry>
+		
+		<Entry x:Name="Button1">
+			<VisualStateManager.VisualStateGroups>
+				<VisualStateGroup x:Name="CommonStates">
+					<VisualState x:Name="Normal">
+						<VisualState.Setters>
+							<Setter Property="BackgroundColor" Value="Lime" />
+						</VisualState.Setters>
+					</VisualState>
+				</VisualStateGroup>
+			</VisualStateManager.VisualStateGroups>
+		</Entry>
 
 	</StackLayout>
 

--- a/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml.cs
@@ -170,6 +170,17 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.That(normal.Setters.Count, Is.EqualTo(0));
 				Assert.That(disabled.Setters.Count, Is.EqualTo(2));
 			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void VisualElementGoesToCorrectStateWhenAvailable(bool useCompiledXaml)
+			{
+				var layout = new VisualStateManagerTests(useCompiledXaml);
+
+				var button = layout.Button1;
+
+				Assert.That(button.BackgroundColor, Is.EqualTo(Color.Lime));
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Previously the setting of the initial VisualState for a VisualElement happened when the VisualStateGroupList was set; however, this means an empty VisualStateGroupList when the list is initially created with the DefaultValueCreator. 

This change adds monitoring to the VisualStateGroupList to allow the VisualElement to update its current state as new states are added, which means that any default states (e.g. "Normal" or "Disabled") are immediately set.

### Bugs Fixed ###

- fixes #2625 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
