### PR TITLE
[Core] Fixes getting the accelerator keys, if the key is equal to the separator

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/MenuItemTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MenuItemTests.cs
@@ -56,7 +56,19 @@ namespace Xamarin.Forms.Core.UnitTests
 		
 			Assert.AreEqual(MenuItem.GetAccelerator(item).ToString(), shourtCutKeyBinding);
 		}
-		
+
+		[Test]
+		public void AcceleratorPlus ()
+		{
+			var item = new MenuItem ();
+			string shourtCutKeyLikeSeparator = "+";
+			MenuItem.SetAccelerator (item, Xamarin.Forms.Accelerator.FromString (shourtCutKeyLikeSeparator));
+
+			var accelerator = MenuItem.GetAccelerator(item);
+			Assert.AreEqual (accelerator.ToString (), shourtCutKeyLikeSeparator);
+			Assert.AreEqual (accelerator.Keys.FirstOrDefault(), shourtCutKeyLikeSeparator);
+		}
+
 		protected override T CreateSource()
 		{
 			return new T();

--- a/Xamarin.Forms.Core/Accelerator.cs
+++ b/Xamarin.Forms.Core/Accelerator.cs
@@ -53,8 +53,12 @@ namespace Xamarin.Forms
 
 			}
 
-			var keys = text.Split(new char[] { Separator }, StringSplitOptions.RemoveEmptyEntries);
-			accelarat.Keys = keys;
+			if (text != Separator.ToString()) {
+				var keys = text.Split(new char[] { Separator }, StringSplitOptions.RemoveEmptyEntries);
+				accelarat.Keys = keys;
+			} else {
+				accelarat.Keys = new[] { text };
+			}
 			return accelarat;
 		}
 


### PR DESCRIPTION
### Description of Change ###

if the accelerator text is equal to the `separator` (+) then his keys equals his text

### Bugs Fixed ###

Fixes #1639

### API Changes ###

/

### Behavioral Changes ###

`Accelerator` will support `+` key

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
