### PR TITLE
[Android Maps] Fix pins not being removed

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.cs
@@ -76,6 +76,12 @@ namespace Xamarin.Forms.Controls
 				map.MoveToRegion (MapSpan.FromCenterAndRadius (new Position (41.890202, 12.492049), Distance.FromMiles (0.5)));
 			};
 
+			var buttonRemove = new Button { Text = "Remove Pin" };
+			buttonRemove.Clicked += (a, e) =>
+			{
+				map.Pins.RemoveAt(0);
+			};
+
 			_stack = new StackLayout {
 				Spacing = 0,
 				Padding = new Thickness (30, 0)
@@ -102,6 +108,7 @@ namespace Xamarin.Forms.Controls
 			_stack.Children.Add (buttonAddressFromPosition);
 			_stack.Children.Add (buttonHome);
 			_stack.Children.Add (buttonZoomPin);
+			_stack.Children.Add (buttonRemove);
 
 			Content = _stack;
 		}

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -336,7 +336,7 @@ namespace Xamarin.Forms.Maps.Android
 
 			foreach (Pin p in pins)
 			{
-				var marker = _markers.FirstOrDefault(m => (object)m.Id == p.Id);
+				var marker = _markers.FirstOrDefault(m => m.Id == (string)p.Id);
 				if (marker == null)
 				{
 					continue;


### PR DESCRIPTION
### Description of Change ###

Fix the Android MapRenderer so markers are found and removed from the GoogleMap when Pins are removed from the Map.

### Bugs Fixed ###

fixes #2411

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
