### PR TITLE
[Android] Fix issue #2634. Draw no border if no BorderColor is set

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -247,7 +247,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				return;
 
 			Color borderColor = Element.BorderColor;
-			_backgroundDrawable.SetStroke(3, borderColor.IsDefault ? AColor.White : borderColor.ToAndroid());
+
+			if (borderColor.IsDefault)
+				_backgroundDrawable.SetStroke(0, AColor.Transparent);
+			else
+				_backgroundDrawable.SetStroke(3, borderColor.ToAndroid());
 		}
 
 		void UpdateShadow()


### PR DESCRIPTION
### Description of Change ###

This is a fix for issue #2634. On Android, when no BorderColor is set, a white border is always drawn around a Frame. That is a regression bug introduced in 3.0.0

### Bugs Fixed ###

fixes #2634 

### API Changes ###

None

### Behavioral Changes ###

Android only: no border will be drawn around a frame if BorderColor is not set or is set to Color.Default. Previously, a white border was drawn

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [x] Consolidate commits as makes sense

Android FrameRenderer doesn't seem to have any tests.