### PR TITLE
[Maps] Handle Pin.PropertyChanged events

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.cs
@@ -91,7 +91,19 @@ namespace Xamarin.Forms.Controls
 				map.Pins.Add (new Pin { Position = pos, Label = "Rui" });
 				map.MoveToRegion (MapSpan.FromCenterAndRadius (pos, Distance.FromMiles (0.5)));
 			};
-			
+
+			var buttonEditPin = new Button { Text = "Edit Pin" };
+			buttonEditPin.Clicked += (a, e) =>
+			{
+				var pin = map.Pins.First();
+
+				pin.Label += " Edited";
+				pin.Address = "Edited";
+
+				var pos = new Position(pin.Position.Latitude + 1, pin.Position.Longitude + 1);
+				pin.Position = pos;
+				map.MoveToRegion(MapSpan.FromCenterAndRadius(pos, Distance.FromMiles(0.5)));
+			};
 
 			map.VerticalOptions = LayoutOptions.FillAndExpand;
 			_stack.Children.Add (searchAddress);
@@ -102,6 +114,7 @@ namespace Xamarin.Forms.Controls
 			_stack.Children.Add (buttonAddressFromPosition);
 			_stack.Children.Add (buttonHome);
 			_stack.Children.Add (buttonZoomPin);
+			_stack.Children.Add(buttonEditPin);
 
 			Content = _stack;
 		}

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -73,6 +73,11 @@ namespace Xamarin.Forms.Maps.Android
 				{
 					MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
 					((ObservableCollection<Pin>)Element.Pins).CollectionChanged -= OnCollectionChanged;
+
+					foreach (Pin pin in Element.Pins)
+					{
+						pin.PropertyChanged -= PinOnPropertyChanged;
+					}
 				}
 
 				if (NativeMap != null)
@@ -105,6 +110,11 @@ namespace Xamarin.Forms.Maps.Android
 			{
 				Map oldMapModel = e.OldElement;
 				((ObservableCollection<Pin>)oldMapModel.Pins).CollectionChanged -= OnCollectionChanged;
+
+				foreach (Pin pin in oldMapModel.Pins)
+				{
+					pin.PropertyChanged -= PinOnPropertyChanged;
+				}
 
 				MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
 
@@ -229,10 +239,36 @@ namespace Xamarin.Forms.Maps.Android
 				var opts = CreateMarker(pin);
 				var marker = map.AddMarker(opts);
 
+				pin.PropertyChanged += PinOnPropertyChanged;
+
 				// associate pin with marker for later lookup in event handlers
 				pin.Id = marker.Id;
 				return marker;
 			}));
+		}
+
+		void PinOnPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			Pin pin = (Pin)sender;
+			Marker marker = _markers.FirstOrDefault(m => m.Id == (string)pin.Id);
+
+			if (marker == null)
+			{
+				return;
+			}
+
+			if (e.PropertyName == Pin.LabelProperty.PropertyName)
+			{
+				marker.Title = pin.Label;
+			}
+			else if (e.PropertyName == Pin.AddressProperty.PropertyName)
+			{
+				marker.Snippet = pin.Address;
+			}
+			else if (e.PropertyName == Pin.PositionProperty.PropertyName)
+			{
+				marker.Position = new LatLng(pin.Position.Latitude, pin.Position.Longitude);
+			}
 		}
 
 		void MapOnMarkerClick(object sender, GoogleMap.InfoWindowClickEventArgs eventArgs)
@@ -336,6 +372,8 @@ namespace Xamarin.Forms.Maps.Android
 
 			foreach (Pin p in pins)
 			{
+				p.PropertyChanged -= PinOnPropertyChanged;
+
 				var marker = _markers.FirstOrDefault(m => (object)m.Id == p.Id);
 				if (marker == null)
 				{


### PR DESCRIPTION
### Description of Change ###

Map renderers listen for the PropertyChanged event on each Pin in Map.Pins to update Label, Address, and Position of native pins when changed in cross-platform code.

### Bugs Fixed ###

- Fixes #2121

### API Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
