### PR TITLE
[Android] Fix drawables to load using AppCompat and change ImageCell to use standard image loading code

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47923.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla47923.cs
@@ -17,108 +17,125 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			PushAsync(new LandingPage());
 		}
-	}
 
-	public class VectorImagePage : ContentPage
-	{
-		public VectorImagePage(Aspect aspect)
+		[Preserve(AllMembers = true)]
+		public class VectorImagePage : ContentPage
 		{
-			var scrollView = new ScrollView();
-			var stackLayout = new StackLayout
+			public VectorImagePage(Aspect aspect)
 			{
-				Orientation = StackOrientation.Vertical,
-				Spacing = 10
-			};
-
-			var vectors = new[] { "cartman", "heart", "error" };
-
-			for (var i = 0; i < vectors.Length; i++)
-			{
-				for (var j = 0; j < 3; j++)
+				var scrollView = new ScrollView();
+				var stackLayout = new StackLayout
 				{
-					var image = new Image
+					Orientation = StackOrientation.Vertical,
+					Spacing = 10
+				};
+
+				var vectors = new[] { "cartman", "heart", "error" };
+
+				for (var i = 0; i < vectors.Length; i++)
+				{
+					for (var j = 0; j < 3; j++)
 					{
-						Source = vectors[i],
-						WidthRequest = j == 1 ? 150 : 300,
-						HeightRequest = j == 2 ? 150 : 300,
-						BackgroundColor = i == 0 ? Color.Red : (i == 1 ? Color.Green : Color.Yellow),
-						HorizontalOptions = LayoutOptions.Center,
-						Aspect = aspect
-					};
-					stackLayout.Children.Add(image);
+						var image = new Image
+						{
+							Source = vectors[i],
+							WidthRequest = j == 1 ? 150 : 300,
+							HeightRequest = j == 2 ? 150 : 300,
+							BackgroundColor = i == 0 ? Color.Red : (i == 1 ? Color.Green : Color.Yellow),
+							HorizontalOptions = LayoutOptions.Center,
+							Aspect = aspect
+						};
+						stackLayout.Children.Add(image);
+					}
 				}
+
+				scrollView.Content = stackLayout;
+				Content = scrollView;
 			}
-
-			scrollView.Content = stackLayout;
-			Content = scrollView;
 		}
-	}
 
-	public class CellViewPage : ContentPage
-	{
-		public CellViewPage()
+		[Preserve(AllMembers = true)]
+		public class CellViewPage : ContentPage
 		{
-			var list = new List<int>();
-			for (var i = 0; i < 50; i++)
-				list.Add(i);
-
-			var listView = new ListView
+			public CellViewPage()
 			{
-				ItemsSource = list,
-				ItemTemplate = new DataTemplate(() => new ImageCell { ImageSource = "cartman" })
-			};
+				var list = new List<int>();
+				for (var i = 0; i < 50; i++)
+					list.Add(i);
 
-			Content = listView;
+				var listView = new ListView
+				{
+					ItemsSource = list,
+					ItemTemplate = new DataTemplate(() => new ImageCell { ImageSource = "cartman" })
+				};
+
+				Content = listView;
+			}
 		}
-	}
 
-	public class LandingPage : ContentPage
-	{
-		public LandingPage()
+		[Preserve(AllMembers = true)]
+		public class LandingPage : ContentPage
 		{
-			var scrollView = new ScrollView();
-			var stackLayout = new StackLayout
+			public LandingPage()
 			{
-				Orientation = StackOrientation.Vertical,
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center,
-				Spacing = 10
-			};
+				var scrollView = new ScrollView();
+				var stackLayout = new StackLayout
+				{
+					Orientation = StackOrientation.Vertical,
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center,
+					Spacing = 10
+				};
 
-			var button1 = new Button
-			{
-				Text = "AspectFit",
-				Command = new Command(() => { Navigation.PushAsync(new VectorImagePage(Aspect.AspectFit)); }),
-				HorizontalOptions = LayoutOptions.Center
-			};
-			stackLayout.Children.Add(button1);
+				var button1 = new Button
+				{
+					Text = "AspectFit",
+					Command = new Command(() => { Navigation.PushAsync(new VectorImagePage(Aspect.AspectFit)); }),
+					HorizontalOptions = LayoutOptions.Center
+				};
+				stackLayout.Children.Add(button1);
 
-			var button2 = new Button
-			{
-				Text = "AspectFill",
-				Command = new Command(() => { Navigation.PushAsync(new VectorImagePage(Aspect.AspectFill)); }),
-				HorizontalOptions = LayoutOptions.Center
-			};
-			stackLayout.Children.Add(button2);
+				var button2 = new Button
+				{
+					Text = "AspectFill",
+					Command = new Command(() => { Navigation.PushAsync(new VectorImagePage(Aspect.AspectFill)); }),
+					HorizontalOptions = LayoutOptions.Center
+				};
+				stackLayout.Children.Add(button2);
 
-			var button3 = new Button
-			{
-				Text = "Fill",
-				Command = new Command(() => { Navigation.PushAsync(new VectorImagePage(Aspect.Fill)); }),
-				HorizontalOptions = LayoutOptions.Center
-			};
-			stackLayout.Children.Add(button3);
+				var button3 = new Button
+				{
+					Text = "Fill",
+					Command = new Command(() => { Navigation.PushAsync(new VectorImagePage(Aspect.Fill)); }),
+					HorizontalOptions = LayoutOptions.Center
+				};
+				stackLayout.Children.Add(button3);
 
-			var button4 = new Button
-			{
-				Text = "Test cell views",
-				Command = new Command(() => { Navigation.PushAsync(new CellViewPage()); }),
-				HorizontalOptions = LayoutOptions.Center
-			};
-			stackLayout.Children.Add(button4);
+				var button4 = new Button
+				{
+					Text = "Test cell views",
+					Command = new Command(() => { Navigation.PushAsync(new CellViewPage()); }),
+					HorizontalOptions = LayoutOptions.Center
+				};
+				stackLayout.Children.Add(button4);
 
-			scrollView.Content = stackLayout;
-			Content = scrollView;
+				scrollView.Content = stackLayout;
+				Content = scrollView;
+			}
 		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla47923Test()
+		{
+			foreach (var testString in new[] { "AspectFit", "AspectFill", "Fill", "Test cell views" })
+			{
+				RunningApp.WaitForElement(q => q.Marked(testString));
+				RunningApp.Tap(q => q.Marked(testString));
+				RunningApp.Back();
+			}
+		}
+#endif
+
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
@@ -189,35 +189,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		async void UpdateBitmap(ImageSource source, ImageSource previousSource = null)
 		{
-			if (Equals(source, previousSource))
-				return;
-
-			_imageView.SetImageResource(global::Android.Resource.Color.Transparent);
-
-			Bitmap bitmap = null;
-			IImageSourceHandler handler;
-
-			if (source != null && (handler = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
-			{
-				try
-				{
-					bitmap = await handler.LoadImageAsync(source, Context);
-				}
-				catch (TaskCanceledException)
-				{
-				}
-				catch (IOException ex)
-				{
-					Log.Warning("Xamarin.Forms.Platform.Android.BaseCellView", "Error updating bitmap: {0}", ex);
-				}
-			}
-
-			if (bitmap == null && source is FileImageSource)
-				_imageView.SetImageResource(ResourceManager.GetDrawableByName(((FileImageSource)source).File));
-			else
-				_imageView.SetImageBitmap(bitmap);
-
-			bitmap?.Dispose();
+			await _imageView.UpdateBitmap(null, source, null, previousSource);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -9,6 +9,7 @@ using Android.Graphics.Drawables;
 using Android.Support.V4.Content;
 using Path = System.IO.Path;
 using Xamarin.Forms.Internals;
+using AndroidAppCompat = Android.Support.V7.Content.Res.AppCompatResources;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -22,7 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var file = fileImageSource.File;
 			Drawable drawable = context.GetDrawable(fileImageSource);
-			if(drawable == null)
+			if (drawable == null)
 			{
 				var bitmap = GetBitmap(context.Resources, file) ?? BitmapFactory.DecodeFile(file);
 				if (bitmap == null)
@@ -57,7 +58,7 @@ namespace Xamarin.Forms.Platform.Android
 			return BitmapFactory.DecodeResourceAsync(resource, IdFromTitle(name, DrawableClass));
 		}
 
-		[Obsolete("GetDrawable(this Resources, string) is obsolete as of version 2.5. " 
+		[Obsolete("GetDrawable(this Resources, string) is obsolete as of version 2.5. "
 			+ "Please use GetDrawable(this Context, string) instead.")]
 		public static Drawable GetDrawable(this Resources resource, string name)
 		{
@@ -68,7 +69,7 @@ namespace Xamarin.Forms.Platform.Android
 				return null;
 			}
 
-			return ContextCompat.GetDrawable(Forms.Context, id);
+			return AndroidAppCompat.GetDrawable(Forms.Context, id);
 		}
 
 		public static Drawable GetDrawable(this Context context, string name)
@@ -80,7 +81,7 @@ namespace Xamarin.Forms.Platform.Android
 				return null;
 			}
 
-			return ContextCompat.GetDrawable(context, id);
+			return AndroidAppCompat.GetDrawable(context, id);
 		}
 
 		public static int GetDrawableByName(string name)


### PR DESCRIPTION
### Description of Change ###
- Change drawables to pull via appcompat 
- Change ImageCell to use ImageViewExtensions so that it benefits and just reuses the same image loading code.  Currently ImageCell isn't using the code that will reuse drawables and thus it will crash if too many rows are created with the same drawable
Fixes  #1872

### Bugs Fixed ###
Fixes  #1872


### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
