### PR TITLE
[Android] Only set line height value if needed

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -321,7 +321,10 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		}
 
 		void UpdateLineHeight() {
-			SetLineSpacing(0, (float) Element.LineHeight);
+			if (Element.LineHeight >= 0)
+			{
+				SetLineSpacing(0, (float)Element.LineHeight);
+			}
 			_lastSizeRequest = null;
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

We were applying line height of 0 on Fast Renderers 

### Bugs Fixed ###

- Failing tests

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense