### PR TITLE
[iOS] Export MDP tablet renderer fixes #2630

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
@@ -48,8 +48,9 @@ using UIKit;
 [assembly: ExportRenderer(typeof(CarouselPage), typeof(CarouselPageRenderer))]
 [assembly: ExportRenderer(typeof(Page), typeof(PageRenderer))]
 [assembly: ExportRenderer(typeof(MasterDetailPage), typeof(PhoneMasterDetailRenderer), UIUserInterfaceIdiom.Phone)]
-[assembly: ExportRenderer(typeof(MasterDetailPage), typeof(TabletMasterDetailRenderer), UIUserInterfaceIdiom.Pad)]
 #endif
+
+[assembly: ExportRenderer(typeof(MasterDetailPage), typeof(TabletMasterDetailRenderer), UIUserInterfaceIdiom.Pad)]
 
 [assembly: ExportCell(typeof(Cell), typeof(CellRenderer))]
 [assembly: ExportCell(typeof(ImageCell), typeof(ImageCellRenderer))]


### PR DESCRIPTION
### Description of Change ###

Fixes regression from #2519, we were not exporting the MDP renderer. 

### Bugs Fixed ###

- fixes #2630

### API Changes ###

None

### Behavioral Changes ###

On iOS when the UIIDiom is Pad it will export the TabletMasterDetailPageRenderer

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
