### PR TITLE
[Android] Label line height default value support

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -22,6 +22,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		float _lastTextSize = -1f;
 		Typeface _lastTypeface;
 		Color _lastUpdateColor = Color.Default;
+		float _lineSpacingExtraDefault = -1.0f;
+		float _lineSpacingMultiplierDefault = -1.0f;
 		VisualElementTracker _visualElementTracker;
 		VisualElementRenderer _visualElementRenderer;
 		readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
@@ -321,7 +323,16 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		}
 
 		void UpdateLineHeight() {
-			SetLineSpacing(0, (float) Element.LineHeight);
+			if (_lineSpacingExtraDefault < 0)
+				_lineSpacingExtraDefault = LineSpacingExtra;
+			if (_lineSpacingMultiplierDefault < 0)
+				_lineSpacingMultiplierDefault = LineSpacingMultiplier;
+
+			if (Element.LineHeight == -1)
+				SetLineSpacing(_lineSpacingExtraDefault, _lineSpacingMultiplierDefault);
+			else if (Element.LineHeight >= 0)
+				SetLineSpacing(0, (float) Element.LineHeight);
+
 			_lastSizeRequest = null;
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Forms.Platform.Android
 	public class LabelRenderer : ViewRenderer<Label, TextView>
 	{
 		ColorStateList _labelTextColorDefault;
+		float _lineSpacingExtraDefault;
+		float _lineSpacingMultiplierDefault;
 		int _lastConstraintHeight;
 		int _lastConstraintWidth;
 
@@ -96,6 +98,8 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				_view = (FormsTextView)CreateNativeControl();
 				_labelTextColorDefault = _view.TextColors;
+				_lineSpacingMultiplierDefault = _view.LineSpacingMultiplier;
+				_lineSpacingExtraDefault = _view.LineSpacingExtra;
 				SetNativeControl(_view);
 			}
 
@@ -187,10 +191,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateLineHeight()
 		{
-			if (Element.LineHeight >= 0)
-			{
+			if (Element.LineHeight == -1)
+				_view.SetLineSpacing(_lineSpacingExtraDefault, _lineSpacingMultiplierDefault);
+			else if (Element.LineHeight >= 0)
 				_view.SetLineSpacing(0, (float)Element.LineHeight);
-			}
 		}
 
 		void UpdateText()


### PR DESCRIPTION
Storing initial line spacing values that can be used
if `LineHeight` is reverted back to the default value
(-1.0).

### Description of Change ###

Describe your changes here.

### Bugs Fixed ###

- Labels were invisible on Android 19 since we always set line
spacing in the Android fast renderer even when LineHeight was 
default value -1.0.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
