### PR TITLE
[Android] Add null-check to VisualElementPackager.RemoveChild

### DIFF
--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -184,7 +184,7 @@ namespace Xamarin.Forms.Platform.Android
 			IVisualElementRenderer renderer = Platform.GetRenderer(view);
 			if (renderer == null) // child is itself a compressed layout
 			{
-				if (_childPackagers.TryGetValue (view, out VisualElementPackager packager))
+				if (_childPackagers != null && _childPackagers.TryGetValue (view, out VisualElementPackager packager))
 				{
 					foreach (var child in view.LogicalChildren)
 					{


### PR DESCRIPTION
There can be a NullReferenceException when accessing the field _childPackagers because it is initialized in AddChild and not in ctor.

### Description of Change ###

Add null-check.

### Bugs Fixed ###

None that I am aware of

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
