### PR TITLE
[Mac] Fix deleting main menu items

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/FormsApplicationDelegate.cs
+++ b/Xamarin.Forms.Platform.MacOS/FormsApplicationDelegate.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Forms.Platform.MacOS
 	{
 		Application _application;
 		bool _isSuspended;
+		static int _storyboardMainMenuCount;
 
 		public abstract NSWindow MainWindow { get; }
 
@@ -28,6 +29,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			Application.SetCurrentApplication(application);
 			_application = application;
+			_storyboardMainMenuCount = (int)NSApplication.SharedApplication.MainMenu.Count;
 
 			application.PropertyChanged += ApplicationOnPropertyChanged;
 		}
@@ -119,8 +121,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		static void ClearNSMenu(NSMenu menu)
 		{
-			//for now we can't remove the 1st menu item		
-			for (var i = menu.Count - 1; i > 0; i--)
+			// remove the menu that was created in the code
+			for (var i = menu.Count - _storyboardMainMenuCount; i > 0; i--)
 				menu.RemoveItemAt(i);
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

On `Mac` clearing main menu affects only menu items created in code.
**Screencast:** http://recordit.co/C4T494i8QL

### Bugs Fixed ###

Fixes #2659 

### API Changes ###

/

### Behavioral Changes ###

When launch application the menu created in `storyboard` is not deleted

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
