### PR TITLE
[Binding] FallbackValue and TargetNullValue

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2211,5 +2211,25 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That(view.GetValue(bp1w), Is.EqualTo("qux"));
 			Assert.That(view.GetValue(bp1t), Is.EqualTo("qux"));
 		}
+
+		[Test]
+		public void FallbackValueWhenSourceIsNull()
+		{
+			var bindable = new MockBindable();
+			var property = BindableProperty.Create("Foo", typeof(string), typeof(MockBindable), "default");
+			bindable.SetBinding(property, new Binding("Foo.Bar") { FallbackValue = "fallback" });
+			Assert.That(bindable.GetValue(property), Is.EqualTo("fallback"));
+		}
+
+		[Test]
+		public void TargetNullValue()
+		{
+			var bindable = new MockBindable();
+			var property = BindableProperty.Create("Foo", typeof(string), typeof(MockBindable), "default");
+			bindable.SetBinding(property, new Binding("Text") { TargetNullValue = "fallback" });
+			Assert.That(bindable.GetValue(property), Is.EqualTo("default"));
+			bindable.BindingContext = new MockViewModel();
+			Assert.That(bindable.GetValue(property), Is.EqualTo("fallback"));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Binding.cs
+++ b/Xamarin.Forms.Core/Binding.cs
@@ -28,9 +28,9 @@ namespace Xamarin.Forms
 		public Binding(string path, BindingMode mode = BindingMode.Default, IValueConverter converter = null, object converterParameter = null, string stringFormat = null, object source = null)
 		{
 			if (path == null)
-				throw new ArgumentNullException("path");
+				throw new ArgumentNullException(nameof(path));
 			if (string.IsNullOrWhiteSpace(path))
-				throw new ArgumentException("path can not be an empty string", "path");
+				throw new ArgumentException("path can not be an empty string", nameof(path));
 
 			Path = path;
 			Converter = converter;
@@ -98,10 +98,9 @@ namespace Xamarin.Forms
 											  string stringFormat = null)
 		{
 			if (propertyGetter == null)
-				throw new ArgumentNullException("propertyGetter");
+				throw new ArgumentNullException(nameof(propertyGetter));
 
-			string path = GetBindingPath(propertyGetter);
-			return new Binding(path, mode, converter, converterParameter, stringFormat);
+			return new Binding(GetBindingPath(propertyGetter), mode, converter, converterParameter, stringFormat);
 		}
 
 		internal override void Apply(bool fromTarget)
@@ -114,17 +113,17 @@ namespace Xamarin.Forms
 			_expression.Apply(fromTarget);
 		}
 
-		internal override void Apply(object newContext, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged = false)
+		internal override void Apply(object context, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged = false)
 		{
 			object src = _source;
 			var isApplied = IsApplied;
 
-			base.Apply(src ?? newContext, bindObj, targetProperty, fromBindingContextChanged: fromBindingContextChanged);
+			base.Apply(src ?? context, bindObj, targetProperty, fromBindingContextChanged: fromBindingContextChanged);
 
 			if (src != null && isApplied && fromBindingContextChanged)
 				return;
 
-			object bindingContext = src ?? Context ?? newContext;
+			object bindingContext = src ?? Context ?? context;
 			if (_expression == null && bindingContext != null)
 				_expression = new BindingExpression(this, SelfPath);
 
@@ -133,7 +132,15 @@ namespace Xamarin.Forms
 
 		internal override BindingBase Clone()
 		{
-			return new Binding(Path, Mode) { Converter = Converter, ConverterParameter = ConverterParameter, StringFormat = StringFormat, Source = Source, UpdateSourceEventName = UpdateSourceEventName };
+			return new Binding(Path, Mode) {
+				Converter = Converter,
+				ConverterParameter = ConverterParameter,
+				StringFormat = StringFormat,
+				Source = Source,
+				UpdateSourceEventName = UpdateSourceEventName,
+				TargetNullValue = TargetNullValue,
+				FallbackValue = FallbackValue,
+			};
 		}
 
 		internal override object GetSourceValue(object value, Type targetPropertyType)

--- a/Xamarin.Forms.Core/BindingBase.cs
+++ b/Xamarin.Forms.Core/BindingBase.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Forms
 
 		BindingMode _mode = BindingMode.Default;
 		string _stringFormat;
+		object _targetNullValue;
+		object _fallbackValue;
 
 		internal BindingBase()
 		{
@@ -41,6 +43,23 @@ namespace Xamarin.Forms
 				ThrowIfApplied();
 
 				_stringFormat = value;
+			}
+		}
+
+		public object TargetNullValue
+		{
+			get { return _targetNullValue; }
+			set {
+				ThrowIfApplied();
+				_targetNullValue = value;
+			}
+		}
+
+		public object FallbackValue {
+			get => _fallbackValue;
+			set {
+				ThrowIfApplied();
+				_fallbackValue = value;
 			}
 		}
 
@@ -88,6 +107,9 @@ namespace Xamarin.Forms
 
 		internal virtual object GetSourceValue(object value, Type targetPropertyType)
 		{
+			if (TargetNullValue != null)
+				return TargetNullValue;
+
 			if (StringFormat != null)
 				return string.Format(StringFormat, value);
 

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -162,7 +162,7 @@ namespace Xamarin.Forms
 					value = Binding.GetSourceValue(value, property.ReturnType);
 				}
 				else
-					value = property.DefaultValue;
+					value = Binding.FallbackValue ?? property.DefaultValue;
 
 				if (!TryConvert(part, ref value, property.ReturnType, true))
 				{

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -199,7 +199,7 @@ namespace Xamarin.Forms.Internals
 				Subscribe((TSource)sourceObject);
 
 			if (needsGetter) {
-				var value = property.DefaultValue;
+				var value = FallbackValue ?? property.DefaultValue;
 				if (isTSource) {
 					try {
 						value = GetSourceValue(_getter((TSource)sourceObject), property.ReturnType);

--- a/Xamarin.Forms.Xaml/MarkupExtensions/BindingExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/BindingExtension.cs
@@ -7,32 +7,25 @@ namespace Xamarin.Forms.Xaml
 	[AcceptEmptyServiceProvider]
 	public sealed class BindingExtension : IMarkupExtension<BindingBase>
 	{
-		public BindingExtension()
-		{
-			Mode = BindingMode.Default;
-			Path = Binding.SelfPath;
-		}
-
-		public string Path { get; set; }
-
-		public BindingMode Mode { get; set; }
-
+		public string Path { get; set; } = Binding.SelfPath;
+		public BindingMode Mode { get; set; } = BindingMode.Default;
 		public IValueConverter Converter { get; set; }
-
 		public object ConverterParameter { get; set; }
-
 		public string StringFormat { get; set; }
-
 		public object Source { get; set; }
-
 		public string UpdateSourceEventName { get; set; }
-
+		public object TargetNullValue { get; set; }
+		public object FallbackValue { get; set; }
 		public TypedBindingBase TypedBinding { get; set; }
 
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
 			if (TypedBinding == null)
-				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source) { UpdateSourceEventName = UpdateSourceEventName };
+				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source) {
+					UpdateSourceEventName = UpdateSourceEventName,
+					FallbackValue = FallbackValue,
+					TargetNullValue = TargetNullValue,
+				};
 
 			TypedBinding.Mode = Mode;
 			TypedBinding.Converter = Converter;
@@ -40,6 +33,8 @@ namespace Xamarin.Forms.Xaml
 			TypedBinding.StringFormat = StringFormat;
 			TypedBinding.Source = Source;
 			TypedBinding.UpdateSourceEventName = UpdateSourceEventName;
+			TypedBinding.FallbackValue = FallbackValue;
+			TypedBinding.TargetNullValue = TargetNullValue;
 			return TypedBinding;
 		}
 


### PR DESCRIPTION
### Description of Change ###

[Binding] FallbackValue and TargetNullValue

Changes applies to
 - Bindings
 - CompiledBindings
 - {Binding} markup extension
### Bugs Fixed ###

- fixes #1803

### API Changes ###

**Added**
```csharp
public object BindingBase.FallbackValue { get; set; }
public object BindingBase.TargetNullValue { get; set; }
```

### Behavioral Changes ###

#### FallbackValue
Prior to this, when a path (or part of the path) wasn't resolved, the `BindableProperty.DefaultValue` was applied.
Now, if the `Binding.FallbackValue` is non-null, the `FallbackValue` is used.

Converters are never applied.

#### TargetNullValue
Prior to this, a source value of `null` was eventually converted (if a converter was present), eventually formatted (if stringFormat was defined), and the result was then applied.
Now, the value is eventually converted, and if it's still null after the conversion, the TargetNullValue (if non-null) is used. StringFormatting is not applied if TargetNullValue is set.

when those properties aren't used, the previous behavior is unchanged.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense