### PR TITLE
Fixes HorizontalTextAlignment not being applied to TextView Elements

### DIFF
--- a/Xamarin.Forms.Platform.Android/Extensions/FlowDirectionExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/FlowDirectionExtensions.cs
@@ -35,9 +35,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal static void UpdateHorizontalAlignment(this EditText view, TextAlignment alignment)
 		{
-			if ((int)Build.VERSION.SdkInt < 17)
-				view.Gravity = alignment.ToHorizontalGravityFlags();
-			else
+			view.Gravity = alignment.ToHorizontalGravityFlags();
+
+			if ((int)Build.VERSION.SdkInt >= 17)
 				view.TextAlignment = alignment.ToTextAlignment();
 		}
 	}


### PR DESCRIPTION
### Description of Change ###
Still set the TextView.Gravity property based on the Horizontal Alignment

In my testing just setting TextAlignment was unreliable. For example in the ControlGallery project it works fine but if you create a new XF project and try to set the HorizontalTextAlignment there on an Entry field it wouldn't work.

In the latter case whenever the View.TextAlignment was set to Center android was just reverting it back to Gravity.

### Bugs Fixed ###
https://github.com/xamarin/Xamarin.Forms/issues/2167


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
