### PR TITLE
fixes #2653 on uwp set the Z Index when children aren't added to the end of the stack

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2653.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2653.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2653, "[UWP] Grid insert z-order on UWP broken in Forms 3",
+		PlatformAffected.UWP)]
+	public class Issue2653 : TestContentPage
+	{
+		BoxView bv = null;
+		Grid layout = null;
+		const string ButtonText = "Insert Box View";
+		const string MoveUp = "Move Box View Up";
+		const string MoveDown = "Move Box View Down";
+		const string BoxViewIsOverlappingButton = "Box View Is Overlapping";
+		const string Success = "BoxView Not Overlapping";
+		string instructions = $"Click {ButtonText}. If Box View shows up over me test has failed.";
+		const string TestForButtonClicked = "Test For Clicked";
+
+
+		protected override void Init()
+		{
+			layout = new Grid { BackgroundColor = Color.Red, VerticalOptions = LayoutOptions.FillAndExpand, HorizontalOptions = LayoutOptions.FillAndExpand };
+
+			layout.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+			layout.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Star });
+			layout.Children.Add(new Button()
+			{
+				Text = ButtonText,
+				BackgroundColor = Color.Green,
+				Margin = 10,
+				TextColor = Color.White,
+				Command = new Command(() =>
+				{
+					if (!AddBoxView())
+					{
+						layout.Children.Remove(bv);
+					}
+				})
+			});
+
+			this.On<iOS>().SetUseSafeArea(true);
+
+			var labelInstructions = new Label { Text = instructions };
+			
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					labelInstructions,
+					new Button(){ Text = MoveUp, AutomationId = MoveUp, Command = new Command(() =>
+					{
+						AddBoxView();
+						layout.RaiseChild(bv);
+					}),  HeightRequest = 45},
+					new Button(){ Text = MoveDown, AutomationId = MoveDown, Command = new Command(() =>
+					{
+						AddBoxView();
+						layout.LowerChild(bv);
+					}),  HeightRequest = 45},
+					layout,
+					new Button(){ Text = TestForButtonClicked, Command = new Command(() =>
+					{
+						if(!layout.Children.Contains(bv))
+						{
+							labelInstructions.Text = Success;
+						}
+						else
+						{
+							labelInstructions.Text = BoxViewIsOverlappingButton;
+						}
+					}),  HeightRequest = 45}
+				}
+			};
+		}
+
+		bool AddBoxView()
+		{
+			if (bv != null && layout.Children.Contains(bv))
+				return false;
+
+			bv = new BoxView
+			{
+				Color = Color.Purple,
+				WidthRequest = 3000,
+				HeightRequest = 3000,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			layout.Children.Insert(0, bv);
+			return true;
+		}
+
+#if UITEST
+		[Test]
+		public void ZIndexWhenInsertingChildren()
+		{
+			RunningApp.WaitForElement(x => x.Marked(ButtonText));
+			RunningApp.Tap(x => x.Marked(ButtonText));
+			RunningApp.Tap(x => x.Marked(ButtonText));
+			RunningApp.Tap(x => x.Marked(TestForButtonClicked));
+			RunningApp.WaitForElement(x => x.Marked(Success));
+		}
+
+
+		[Test]
+		public void MoveUpAndMoveDown()
+		{
+			RunningApp.WaitForElement(x => x.Marked(MoveUp));
+			RunningApp.Tap(x => x.Marked(ButtonText));
+			RunningApp.Tap(x => x.Marked(TestForButtonClicked));
+			RunningApp.WaitForElement(x => x.Marked(BoxViewIsOverlappingButton));
+
+			RunningApp.Tap(x => x.Marked(MoveUp));
+			RunningApp.Tap(x => x.Marked(MoveDown));
+			RunningApp.Tap(x => x.Marked(ButtonText));
+			RunningApp.Tap(x => x.Marked(TestForButtonClicked));
+			RunningApp.WaitForElement(x => x.Marked(Success));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -240,6 +240,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1396.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1415.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2653.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2247.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GroupListViewHeaderIndexOutOfRange.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1975.cs" />

--- a/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Platform.UWP
 		readonly int _rowSpan;
 		bool _disposed;
 		bool _isLoaded;
-		bool _isZChanged;
 
 		public VisualElementPackager(IVisualElementRenderer renderer)
 		{
@@ -92,17 +91,10 @@ namespace Xamarin.Forms.Platform.UWP
 				IVisualElementRenderer childRenderer = Platform.GetRenderer(child);
 
 				if (childRenderer == null)
-				{
 					continue;
-				}
 
 				if (Canvas.GetZIndex(childRenderer.ContainerElement) != (z + 1))
-				{
-					if (!_isZChanged)
-						_isZChanged = true;
-
 					Canvas.SetZIndex(childRenderer.ContainerElement, z + 1);
-				}
 			}
 		}
 
@@ -127,7 +119,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_panel.Children.Add(childRenderer.ContainerElement);
 
-			if (_isZChanged)
+			if (ElementController.LogicalChildren[ElementController.LogicalChildren.Count - 1] != view)
 				EnsureZIndex();
 		}
 


### PR DESCRIPTION
### Description of Change ###

Changes were made in this PR https://github.com/xamarin/Xamarin.Forms/pull/1196 so that less calls were made to set the ZIndex on UWP. This only took into account when RaiseUp and Down were called and didn't factor in when a child element is inserted out of order

### Bugs Fixed ###

Fixes #2653


### Behavioral Changes ###
None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
