### PR TITLE
[Core] Fix Padding of Layout update Issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2763.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2763.cs
@@ -1,0 +1,139 @@
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Controls
+{
+	// This test covers the issue reported in https://github.com/xamarin/Xamarin.Forms/issues/2763
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2763,
+		"[Core] StakLayout Padding update issue", NavigationBehavior.PushAsync)]
+	public class Issue2763 : TestContentPage
+	{
+		protected override void Init()
+		{
+			StackLayout parentLayout1 = null;
+			StackLayout parentLayout2 = null;
+			StackLayout parentLayout3 = null;
+
+			StackLayout stackLayout = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				BackgroundColor = Color.Blue,
+				Children =
+				{
+					new BoxView
+					{
+						Color = Color.Red,
+						HeightRequest = 100,
+						WidthRequest = 100,
+					}
+				}
+			};
+
+			ContentView contentView = new ContentView
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				BackgroundColor = Color.Blue,
+				Content =
+				new BoxView
+				{
+					Color = Color.Red,
+					HeightRequest = 100,
+					WidthRequest = 100,
+				}
+			};
+
+			FlexLayout flex = new FlexLayout
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				BackgroundColor = Color.Blue,
+				Children =
+				{
+					new BoxView
+					{
+						Color = Color.Red,
+						HeightRequest = 100,
+						WidthRequest = 100,
+					}
+				}
+			};
+
+			Slider paddingSlider = new Slider
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Minimum = 0.0,
+				Maximum = 100.0,
+			};
+
+			stackLayout.SetBinding(Forms.Layout.PaddingProperty, new Binding() { Path = "Value", Source = paddingSlider });
+			contentView.SetBinding(Forms.Layout.PaddingProperty, new Binding() { Path = "Value", Source = paddingSlider });
+			flex.SetBinding(Forms.Layout.PaddingProperty, new Binding() { Path = "Value", Source = paddingSlider });
+
+			// Build the page.
+			this.Padding = new Thickness(20);
+			this.Content = new StackLayout
+			{
+				Spacing = 20,
+				Children =
+				{
+					new StackLayout
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							new Label
+							{
+								Text = "Padding"
+							},
+							paddingSlider,
+						}
+					},
+					new Button()
+					{
+						Text = "Force update",
+						Command = new Command(() =>
+						{
+							var boxview = new BoxView();
+							parentLayout1.Children.Add(boxview);
+							parentLayout1.Children.Remove(boxview);
+							parentLayout2.Children.Add(boxview);
+							parentLayout2.Children.Remove(boxview);
+							parentLayout3.Children.Add(boxview);
+							parentLayout3.Children.Remove(boxview);
+						})
+					},
+					new ScrollView
+					{
+						HorizontalOptions = LayoutOptions.FillAndExpand,
+						VerticalOptions = LayoutOptions.FillAndExpand,
+						Content = new StackLayout
+						{
+							Spacing = 20,
+							Children =
+							{
+								(parentLayout1 = new StackLayout
+								{
+									Children = { new Label { Text = "StackLayout" }, stackLayout },
+								}),
+								(parentLayout2 = new StackLayout
+								{
+									Children = { new Label { Text = "ContentView" }, contentView }
+								}),
+								(parentLayout3 = new StackLayout
+								{
+									Children = { new Label { Text = "FlexLayout" }, flex }
+								})
+
+							}
+						}
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -250,6 +250,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1396.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1415.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1942.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2763.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2247.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GroupListViewHeaderIndexOutOfRange.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1760.cs" />

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -102,7 +102,7 @@ namespace Xamarin.Forms
 
 		void IPaddingElement.OnPaddingPropertyChanged(Thickness oldValue, Thickness newValue)
 		{
-			UpdateChildrenLayout();
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
 		internal ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();


### PR DESCRIPTION
### Description of Change ###
 Update `IPaddingElement.OnPaddingPropertyChanged` on Layout to inform change of measure

Size of Layout could be changed by Padding
https://github.com/xamarin/Xamarin.Forms/blob/882bf07917bea57b93d0d9becd768dcab739c26f/Xamarin.Forms.Core/Layout.cs#L129-L134

### Bugs Fixed ###
fixes 2763

As is
![Image](https://user-images.githubusercontent.com/1029155/40216198-1958640e-5aa0-11e8-89e3-587ff90ef257.gif) ![Image](https://user-images.githubusercontent.com/1029155/40216482-e064774e-5aa1-11e8-9266-d49ab7dc9aad.gif)

Fixed
 ![Image](https://user-images.githubusercontent.com/1029155/40216225-549f74b2-5aa0-11e8-8213-cc39cbab57a5.gif) ![Image](https://user-images.githubusercontent.com/1029155/40216485-e8092d5a-5aa1-11e8-94aa-669fe27947fd.gif)


### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
