### PR TITLE
[Core] Fix Slider Maximum , Minimum binding issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2761.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2761.cs
@@ -1,0 +1,94 @@
+﻿using System;
+
+using Xamarin.Forms.CustomAttributes;
+using System.Collections.Generic;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2761, "[Core] Slider unable to update Maximum , Minimum by binding")]
+	public class Issue2761 : TestContentPage
+	{
+		class RangeModel
+		{
+			public double Max { get; set; }
+			public double Min { get; set; }
+		}
+		protected override void Init()
+		{
+			Slider slider = new Slider
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+			};
+
+			var minLabel = new Label { };
+			var maxLabel = new Label { };
+			var logLabel = new Label { Text = "Log : \n" };
+			minLabel.SetBinding(Label.TextProperty, new Binding("Minimum") { StringFormat = "Min : {0:F2}" });
+			maxLabel.SetBinding(Label.TextProperty, new Binding("Maximum") { StringFormat = "Max : {0:F2}" });
+			minLabel.BindingContext = slider;
+			maxLabel.BindingContext = slider;
+
+			slider.SetBinding(Slider.MaximumProperty, new Binding("Max"));
+			slider.SetBinding(Slider.MinimumProperty, new Binding("Min"));
+
+			System.Console.WriteLine($"Slider.MaximumProperty.DefaultBindingMode = {Slider.MaximumProperty.DefaultBindingMode}");
+
+			RangeModel range1 = new RangeModel { Min = -100, Max = -1 };
+			RangeModel range2 = new RangeModel { Min = 0, Max = 49 };
+			RangeModel range3 = new RangeModel { Min = 50, Max = 100 };
+
+			Padding = new Thickness(20);
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new StackLayout
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							new Button() { Text = "-100 ~ -1", Command = new Command(() => {
+								try
+								{
+									slider.BindingContext = range1;
+								}
+								catch (Exception e)
+								{
+									logLabel.Text += e.Message + "\n";
+								}
+							})},
+							new Button() { Text = "0 ~ 49", Command = new Command(() => {
+								try
+								{
+									slider.BindingContext = range2;
+								}
+								catch (Exception e)
+								{
+									logLabel.Text += e.Message + "\n";
+								}
+							})},
+							new Button() { Text = "50 ~ 100", Command = new Command(() => {
+								try
+								{
+									slider.BindingContext = range3;
+								}
+								catch (Exception e)
+								{
+									logLabel.Text += e.Message  + "\n";
+								}
+							})},
+						}
+					},
+					new StackLayout
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children = { minLabel, slider, maxLabel },
+					},
+					logLabel,
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -311,6 +311,7 @@
       <DependentUpon>Issue2625.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2761.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2981.cs" />

--- a/Xamarin.Forms.Core/Slider.cs
+++ b/Xamarin.Forms.Core/Slider.cs
@@ -7,26 +7,26 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_SliderRenderer))]
 	public class Slider : View, IElementConfiguration<Slider>
 	{
-		public static readonly BindableProperty MinimumProperty = BindableProperty.Create("Minimum", typeof(double), typeof(Slider), 0d, validateValue: (bindable, value) =>
+		public static readonly BindableProperty MinimumProperty = BindableProperty.Create("Minimum", typeof(double), typeof(Slider), 0d, coerceValue: (bindable, value) =>
 		{
 			var slider = (Slider)bindable;
-			return (double)value < slider.Maximum;
-		}, coerceValue: (bindable, value) =>
-		{
-			var slider = (Slider)bindable;
-			slider.Value = slider.Value.Clamp((double)value, slider.Maximum);
+			slider.Value = Math.Max((double)value, slider.Value);
 			return value;
+		}, propertyChanged: (bindable, oldValue, newValue) =>
+		{
+			var slider = (Slider)bindable;
+			slider.SetValueCore(MaximumProperty, Math.Max(slider.Maximum, (double)newValue));
 		});
 
-		public static readonly BindableProperty MaximumProperty = BindableProperty.Create("Maximum", typeof(double), typeof(Slider), 1d, validateValue: (bindable, value) =>
+		public static readonly BindableProperty MaximumProperty = BindableProperty.Create("Maximum", typeof(double), typeof(Slider), 1d, coerceValue: (bindable, value) =>
 		{
 			var slider = (Slider)bindable;
-			return (double)value > slider.Minimum;
-		}, coerceValue: (bindable, value) =>
-		{
-			var slider = (Slider)bindable;
-			slider.Value = slider.Value.Clamp(slider.Minimum, (double)value);
+			slider.Value = Math.Min((double)value, slider.Value);
 			return value;
+		}, propertyChanged: (bindable, oldvalue, newValue) =>
+		{
+			var slider = (Slider)bindable;
+			slider.SetValueCore(MinimumProperty, Math.Min(slider.Minimum, (double)newValue));
 		});
 
 		public static readonly BindableProperty ValueProperty = BindableProperty.Create("Value", typeof(double), typeof(Slider), 0d, BindingMode.TwoWay, coerceValue: (bindable, value) =>


### PR DESCRIPTION
### Description of Change ###
 Remove validateValue handler on Maximum/Minimum properties
 Use propertyChanged for Maximum/Minimum integrity

### Bugs Fixed ###
- fixes #1943
- fixes #2761

### API Changes ###
None

### Behavioral Changes ###
Allow set Minimum value that greater than Maximum value, after Minimum was updated, Maximum value is changed to Max(Minimum, Maximum)

Allow set Maximum value that smaller than Minimum, after Maximum was updated, Minimum value is changed to Min(Minimum, Maximum)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
