### PR TITLE
[Binding] avoid AmbiguousME on redefined property

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -337,9 +337,13 @@ namespace Xamarin.Forms
 					}
 				}
 			}
-			else
-				property = sourceType.GetDeclaredProperty(part.Content) ?? sourceType.BaseType?.GetProperty(part.Content);
-
+			else {
+				TypeInfo type = sourceType;
+				while (type != null && property == null) {
+					property = type.GetDeclaredProperty(part.Content);
+					type = type.BaseType?.GetTypeInfo();
+				}
+			}
 			if (property != null)
 			{
 				if (property.CanRead && property.GetMethod.IsPublic && !property.GetMethod.IsStatic)

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2632.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2632.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<local:Gh2632Base xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Gh2632"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+             x:Name="Page">
+	<Label Text="{Binding BindingContext.Foo, Source={x:Reference Page}}" />
+</local:Gh2632Base>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2632.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2632.xaml.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh2632Base : ContentPage
+	{
+		public new Gh2632Context BindingContext {
+			get => base.BindingContext as Gh2632Context;
+			set => base.BindingContext = value;
+		}
+
+		public class Gh2632Context
+		{
+			public string Foo { get; set; }
+		}
+	}
+
+	public partial class Gh2632 : Gh2632Base
+	{
+		public Gh2632()
+		{
+			InitializeComponent();
+		}
+
+		public Gh2632(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+
+		[TestFixture]
+		class Tests
+		{
+
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void BindingDoesNotThrowOnRedefinedProperty(bool useCompiledXaml)
+			{
+				var layout = new Gh2632(useCompiledXaml);
+				layout.BindingContext = new Gh2632Base.Gh2632Context { Foo = "foo" };
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -606,6 +606,9 @@
     <Compile Include="Issues\Gh2517.xaml.cs">
       <DependentUpon>Gh2517.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh2632.xaml.cs">
+      <DependentUpon>Gh2632.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   
@@ -1099,6 +1102,10 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh2517.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh2632.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>


### PR DESCRIPTION
### Description of Change ###

[Binding] avoid AmbiguousMatchException on redefined property

this bug appeared with the `netstandard20` migration

### Bugs Fixed ###

- fixes #2632

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
