### PR TITLE
[UWP] moved UpdateLayout call in ListViewRenderer into BeginInvokeOnMainThread

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2681.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2681.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2681, "[UWP] Label inside Listview gets stuck inside infinite loop",
+		PlatformAffected.UWP)]
+	public class Issue2681 : TestNavigationPage
+	{
+		const string NavigateToPage = "Click Me.";
+		protected override void Init()
+		{
+			PushAsync(new ContentPage() { Title = "Freeze Test", Content = new Button() { Text = NavigateToPage, Command = new Command(() => this.PushAsync(new FreezeMe())) } });
+		}
+
+		[Preserve(AllMembers = true)]
+		public partial class FreezeMe : ContentPage
+		{
+			public List<int> Items { get; set; }
+
+			public FreezeMe()
+			{
+				this.BindingContext = this;
+				var lv = new ListView()
+				{
+					Margin = new Thickness(20, 5, 5, 5)
+				};
+
+				lv.ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label() { Text = "sassifrass" };
+					label.SetBinding(Label.TextProperty, ".");
+					return new ViewCell() { View = label };
+				});
+
+				lv.SetBinding(ListView.ItemsSourceProperty, "Items");
+
+				this.Content = new ScrollView()
+				{
+					Content = new StackLayout()
+					{
+						Children =
+						{
+							new Label(){ Text = "If page is not frozen this test has passed" },
+							new StackLayout()
+							{
+								Orientation = StackOrientation.Horizontal,
+								Children = {lv  }
+							}
+						}
+					}
+				};
+
+				this.Appearing += (s, e) =>
+				{
+					this.Items = new List<int> { 1, 2, 3 };
+					this.OnPropertyChanged("Items");
+				};
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void ListViewDoesntFreezeApp()
+		{
+			RunningApp.Tap(x => x.Marked(NavigateToPage));
+			RunningApp.WaitForElement("3");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -295,6 +295,7 @@
       <DependentUpon>Issue2625.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2681.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2983.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2981.cs" />

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				if (List == null)
 				{
-					List = new WListView 
+					List = new WListView
 					{
 						IsSynchronizedWithCurrentItem = false,
 						ItemTemplate = (Windows.UI.Xaml.DataTemplate)WApp.Current.Resources["CellTemplate"],
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Platform.UWP
 					new CollectionViewSource { Source = Element.ItemsSource, IsSourceGrouped = Element.IsGroupingEnabled };
 			}
 
-			List.UpdateLayout();
+			Device.BeginInvokeOnMainThread(() => List.UpdateLayout());
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -345,7 +345,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (viewer == null)
 			{
 				RoutedEventHandler loadedHandler = null;
-				loadedHandler = async (o, e) => 
+				loadedHandler = async (o, e) =>
 				{
 					List.Loaded -= loadedHandler;
 
@@ -542,7 +542,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				var templatedItems = TemplatedItemsView.TemplatedItems;
 				var selectedItemIndex = templatedItems.GetGlobalIndexOfItem(e.ClickedItem);
-				
+
 				OnListItemClicked(selectedItemIndex);
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

moved UpdateLayout call in ListViewRenderer into BeginInvokeOnMainThread otherwise UWP was creating a duplicate Cell and causing a deadlock in some cases

I found that the change here https://github.com/xamarin/Xamarin.Forms/pull/2436 was causing an extra non visible CellControl to generate.

This was causing two different cell controls to contain the same Label which was then causing a ping pong effect of Measurement Invalidations.

This exception wasn't happening on master because of this addition of this call
https://github.com/xamarin/Xamarin.Forms/pull/2515

I'm not really sure why having that was short circuiting the Measurement deadlocks. Either way it's not great to have 2 CellControls for one label.   It would only create an extra CellControl for the first element not any additional

I attempted to recreate the issue fixed by
https://github.com/xamarin/Xamarin.Forms/pull/2436
by commenting out the UpdateLayout call but I couldn't recreate the issue and as far as I can tell my change here doesn't re-break anything



### Bugs Fixed ###

- fixes #2681
### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
