### PR TITLE
Fix ControlsGallery SearchBar HeightRequest issue

### DIFF
--- a/Xamarin.Forms.Controls/TestCases.cs
+++ b/Xamarin.Forms.Controls/TestCases.cs
@@ -267,7 +267,7 @@ namespace Xamarin.Forms.Controls
 			};
 
 			var searchBar = new SearchBar() {
-				HeightRequest = 42, // Need this for Android N, see https://bugzilla.xamarin.com/show_bug.cgi?id=43975
+				MinimumHeightRequest = 42, // Need this for Android N, see https://bugzilla.xamarin.com/show_bug.cgi?id=43975
 				AutomationId = "SearchBarGo"
 			};
 


### PR DESCRIPTION
### Description of Change ###
The SearchBar on the TestCases page is not visible due to narrow height in Tizen
It was set 42 to show correctly in Android N So change to MinimumHeightRequest from HeightRequest

### Bugs Fixed ###
Bug
![searchbar-bug](https://user-images.githubusercontent.com/1029155/40285794-31079cc2-5cdb-11e8-8095-5f76022c5335.png)

Fixed
![searchbar-fixed](https://user-images.githubusercontent.com/1029155/40285796-33b8a664-5cdb-11e8-83f2-7ff19d8190f5.png)
 

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
