### PR TITLE
[Core] Remove Guid.NewGuid() calls from performance tracking

### DIFF
--- a/Xamarin.Forms.Core/Performance.cs
+++ b/Xamarin.Forms.Core/Performance.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System;
+using System.Threading;
 
 namespace Xamarin.Forms.Internals
 {
@@ -15,6 +16,8 @@ namespace Xamarin.Forms.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class Performance
 	{
+		static long Reference;
+
 		public static IPerformanceProvider Provider { get; private set; }
 
 		public static void SetProvider(IPerformanceProvider instance)
@@ -24,7 +27,13 @@ namespace Xamarin.Forms.Internals
 
 		public static void Start(out string reference, string tag = null, [CallerFilePath] string path = null, [CallerMemberName] string member = null)
 		{
-			reference = Guid.NewGuid().ToString();
+			if (Provider == null)
+			{
+				reference = String.Empty;
+				return;
+			}
+
+			reference = Interlocked.Increment(ref Reference).ToString();
 			Provider?.Start(reference, tag, path, member);
 		}
 

--- a/Xamarin.Forms.Core/Performance.cs
+++ b/Xamarin.Forms.Core/Performance.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Internals
 			}
 
 			reference = Interlocked.Increment(ref Reference).ToString();
-			Provider?.Start(reference, tag, path, member);
+			Provider.Start(reference, tag, path, member);
 		}
 
 		public static void Start(string reference, string tag = null, [CallerFilePath] string path = null,

--- a/Xamarin.Forms.Core/Performance.cs
+++ b/Xamarin.Forms.Core/Performance.cs
@@ -22,7 +22,14 @@ namespace Xamarin.Forms.Internals
 			Provider = instance;
 		}
 
-		public static void Start(string reference, string tag = null, [CallerFilePath] string path = null, [CallerMemberName] string member = null)
+		public static void Start(out string reference, string tag = null, [CallerFilePath] string path = null, [CallerMemberName] string member = null)
+		{
+			reference = Guid.NewGuid().ToString();
+			Provider?.Start(reference, tag, path, member);
+		}
+
+		public static void Start(string reference, string tag = null, [CallerFilePath] string path = null,
+			[CallerMemberName] string member = null)
 		{
 			Provider?.Start(reference, tag, path, member);
 		}
@@ -46,11 +53,11 @@ namespace Xamarin.Forms.Internals
 
 			public DisposablePerformanceReference(string tag, string path, string member)
 			{
-				_reference = Guid.NewGuid().ToString();
 				_tag = tag;
 				_path = path;
 				_member = member;
-				Start(_reference, _tag, _path, _member);
+				Start(out string reference, _tag, _path, _member);
+				_reference = reference;
 			}
 
 			public void Dispose()

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -165,8 +165,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			// FIXME: potential crash
 			IVisualElementRenderer visualElementRenderer = Android.Platform.GetRenderer(view);

--- a/Xamarin.Forms.Platform.Android/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/CellRenderer.cs
@@ -23,8 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public AView GetCell(Cell item, AView convertView, ViewGroup parent, Context context)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 			
 			Cell = item;
 			Cell.PropertyChanged -= PropertyChangedHandler;
@@ -69,8 +68,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual AView GetCellCore(Cell item, AView convertView, ViewGroup parent, Context context)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference, "GetCellCore");
+			Performance.Start(out string reference, "GetCellCore");
 
 			LayoutInflater inflater = LayoutInflater.FromContext(context);
 			const int type = global::Android.Resource.Layout.SimpleListItem1;

--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -12,8 +12,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		protected override AView GetCellCore(Cell item, AView convertView, ViewGroup parent, Context context)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference, "GetCellCore");
+			Performance.Start(out string reference, "GetCellCore");
 			var cell = (ViewCell)item;
 
 			var container = convertView as ViewCellContainer;
@@ -150,9 +149,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			public void Update(ViewCell cell)
 			{
-				var reference = Guid.NewGuid().ToString();
-				Performance.Start(reference);
-
+				Performance.Start(out string reference);
 				var renderer = GetChildAt(0) as IVisualElementRenderer;
 				var viewHandlerType = Registrar.Registered.GetHandlerTypeForObject(cell.View) ?? typeof(Platform.DefaultRenderer);
 				var reflectableType = renderer as System.Reflection.IReflectableType;
@@ -211,8 +208,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			protected override void OnLayout(bool changed, int l, int t, int r, int b)
 			{
-				var reference = Guid.NewGuid().ToString();
-				Performance.Start(reference);
+				Performance.Start(out string reference);
 
 				double width = Context.FromPixels(r - l);
 				double height = Context.FromPixels(b - t);
@@ -227,8 +223,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 			{
-				var reference = Guid.NewGuid().ToString();
-				Performance.Start(reference);
+				Performance.Start(out string reference);
 
 				int width = MeasureSpec.GetSize(widthMeasureSpec);
 				int height;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -122,8 +122,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			VisualElement oldElement = Button;
 			Button = (Button)element;
 
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			if (oldElement != null)
 			{

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -112,8 +112,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			Image oldElement = _element;
 			_element = image;
 
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			if (oldElement != null)
 				oldElement.PropertyChanged -= OnElementPropertyChanged;

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1232,8 +1232,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			// FIXME: potential crash
 			IVisualElementRenderer visualElementRenderer = GetRenderer(view);

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -194,8 +194,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Cell cell = null;
 
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			ListViewCachingStrategy cachingStrategy = Controller.CachingStrategy;
 			var nextCellIsHeader = false;

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -89,8 +89,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void AddChild(VisualElement view, IVisualElementRenderer oldRenderer = null, RendererPool pool = null, bool sameChildren = false)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			if (CompressedLayout.GetIsHeadless(view))
 			{
@@ -165,8 +164,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnChildRemoved(object sender, ElementEventArgs e)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 			var view = e.Element as VisualElement;
 			if (view != null)
 				RemoveChild(view);
@@ -203,8 +201,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void SetElement(VisualElement oldElement, VisualElement newElement)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			var sameChildrenTypes = false;
 

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -130,8 +130,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void UpdateLayout()
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 			Tracker?.UpdateLayout();
 			Performance.Stop(reference);
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -301,8 +301,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateNativeView(object sender, EventArgs e)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			VisualElement view = _renderer.Element;
 			AView aview = _renderer.View;
@@ -328,8 +327,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateOpacity()
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			VisualElement view = _renderer.Element;
 			AView aview = _renderer.View;

--- a/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
@@ -12,8 +12,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public virtual UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			var tvc = reusableCell as CellTableViewCell ?? new CellTableViewCell(UITableViewCellStyle.Default, item.GetType().FullName);
 

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -11,8 +11,7 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			var viewCell = (ViewCell)item;
 
@@ -77,8 +76,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public override void LayoutSubviews()
 			{
-				var reference = Guid.NewGuid().ToString();
-				Performance.Start(reference);
+				Performance.Start(out string reference);
 
 				//This sets the content views frame.
 				base.LayoutSubviews();
@@ -107,8 +105,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public override SizeF SizeThatFits(SizeF size)
 			{
-				var reference = Guid.NewGuid().ToString();
-				Performance.Start(reference);
+				Performance.Start(out string reference);
 
 				IVisualElementRenderer renderer;
 				if (!_rendererRef.TryGetTarget(out renderer))
@@ -167,8 +164,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			void UpdateCell(ViewCell cell)
 			{
-				var reference = Guid.NewGuid().ToString();
-				Performance.Start(reference);
+				Performance.Start(out string reference);
 
 				if (_viewCell != null)
 					Device.BeginInvokeOnMainThread(_viewCell.SendDisappearing);

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -182,8 +182,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			var renderView = GetRenderer(view);
 			if (renderView == null || renderView.NativeView == null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -892,8 +892,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Cell cell;
 				UITableViewCell nativeCell;
 
-				var reference = Guid.NewGuid().ToString();
-				Performance.Start(reference);
+				Performance.Start(out string reference);
 
 				var cachingStrategy = List.CachingStrategy;
 				if (cachingStrategy == ListViewCachingStrategy.RetainElement)

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -69,9 +69,9 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (_isDisposed)
 				return;
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
-			if (CompressedLayout.GetIsHeadless(view)) {
+			Performance.Start(out string reference);
+			if (CompressedLayout.GetIsHeadless(view))
+			{
 				var packager = new VisualElementPackager(Renderer, view);
 				view.IsPlatformEnabled = true;
 				packager.Load();
@@ -152,8 +152,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (oldElement == newElement)
 				return;
 
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			_element = newElement;
 

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -155,8 +155,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			var oldElement = Element;
 			Element = element;
 
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			if (oldElement != null)
 				oldElement.PropertyChanged -= _propertyChangedHandler;

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -300,8 +300,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateNativeControl()
 		{
-			var reference = Guid.NewGuid().ToString();
-			Performance.Start(reference);
+			Performance.Start(out string reference);
 
 			if (_disposed)
 				return;


### PR DESCRIPTION
### Description of Change ###

Unless there is a `PerformanceProvider`, we should not waste time creating a reference for the tracker.

### Bugs Fixed ###

- N/A

### API Changes ###

Added parameter to internal `Performance.Start` method

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
