### PR TITLE
Initial implementation of Segues

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -399,12 +399,7 @@ namespace Xamarin.Forms
 
 			async Task OnPushModal(ValueSegue segue, SegueTarget target)
 			{
-				var modal = target.TryCreatePage();
-				if (modal == null)
-				{
-					await base.OnSegue(segue, target);
-					return;
-				}
+				var modal = target.ToPage();
 
 				// IMPORTANT! If the target was a template, create a new SegueTarget from
 				//  the instantiated page.

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -369,7 +369,21 @@ namespace Xamarin.Forms
 				_owner = owner;
 			}
 
-			protected override async Task<Page> OnPopModal(bool animated)
+			protected internal override Task OnSegue(ValueSegue segue, SegueTarget target)
+			{
+				switch (segue.Action)
+				{
+					case NavigationAction.PopModal:
+					case NavigationAction.Pop when this.ShouldPopModal():
+						return OnPopModal(segue);
+
+					case NavigationAction.Modal:
+						return OnPushModal(segue, target);
+				}
+				return base.OnSegue(segue, target);
+			}
+
+			async Task<Page> OnPopModal(ValueSegue segue)
 			{
 				Page modal = ModalStack[ModalStack.Count - 1];
 				if (_owner.OnModalPopping(modal))
@@ -377,14 +391,26 @@ namespace Xamarin.Forms
 					_owner.OnPopCanceled();
 					return null;
 				}
-				Page result = await base.OnPopModal(animated);
+				Page result = await ((Task<Page>)base.OnSegue(segue, null));
 				result.Parent = null;
 				_owner.OnModalPopped(result);
 				return result;
 			}
 
-			protected override async Task OnPushModal(Page modal, bool animated)
+			async Task OnPushModal(ValueSegue segue, SegueTarget target)
 			{
+				var modal = target.TryCreatePage();
+				if (modal == null)
+				{
+					await base.OnSegue(segue, target);
+					return;
+				}
+
+				// IMPORTANT! If the target was a template, create a new SegueTarget from
+				//  the instantiated page.
+				if (target.IsTemplate)
+					target = (SegueTarget)modal;
+
 				_owner.OnModalPushing(modal);
 
 				modal.Parent = _owner;
@@ -392,11 +418,11 @@ namespace Xamarin.Forms
 				if (modal.NavigationProxy.ModalStack.Count == 0)
 				{
 					modal.NavigationProxy.Inner = this;
-					await base.OnPushModal(modal, animated);
+					await base.OnSegue(segue, target);
 				}
 				else
 				{
-					await base.OnPushModal(modal, animated);
+					await base.OnSegue(segue, target);
 					modal.NavigationProxy.Inner = this;
 				}
 

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -172,16 +172,6 @@ namespace Xamarin.Forms
 			return bpcontext != null && bpcontext.Binding != null;
 		}
 
-		internal bool GetIsManuallySet(BindableProperty targetProperty)
-		{
-			if (targetProperty == null)
-				throw new ArgumentNullException(nameof(targetProperty));
-
-			var bpcontext = GetContext(targetProperty);
-			return bpcontext != null
-				&& (bpcontext.Attributes & BindableContextAttributes.IsManuallySet) == BindableContextAttributes.IsManuallySet;
-		}
-
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public object[] GetValues(BindableProperty property0, BindableProperty property1)
 		{

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -172,6 +172,16 @@ namespace Xamarin.Forms
 			return bpcontext != null && bpcontext.Binding != null;
 		}
 
+		internal bool GetIsManuallySet(BindableProperty targetProperty)
+		{
+			if (targetProperty == null)
+				throw new ArgumentNullException(nameof(targetProperty));
+
+			var bpcontext = GetContext(targetProperty);
+			return bpcontext != null
+				&& (bpcontext.Attributes & BindableContextAttributes.IsManuallySet) == BindableContextAttributes.IsManuallySet;
+		}
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public object[] GetValues(BindableProperty property0, BindableProperty property1)
 		{

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -8,7 +8,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_ButtonRenderer))]
-	public class Button : View, IFontElement, ITextElement, IBorderElement, IButtonController, IElementConfiguration<Button>, IPaddingElement
+	public class Button : View, IFontElement, ITextElement, IBorderElement, IButtonController, IElementConfiguration<Button>, IPaddingElement, ICommandableElement
 	{
 		const double DefaultSpacing = 10;
 		const int DefaultBorderRadius = 5;

--- a/Xamarin.Forms.Core/Cells/TextCell.cs
+++ b/Xamarin.Forms.Core/Cells/TextCell.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Windows.Input;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	public class TextCell : Cell
+	public class TextCell : Cell, ICommandableElement
 	{
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(TextCell), default(ICommand),
 			propertyChanging: (bindable, oldvalue, newvalue) =>

--- a/Xamarin.Forms.Core/ClickGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/ClickGestureRecognizer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Windows.Input;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
@@ -11,7 +12,7 @@ namespace Xamarin.Forms
 		Secondary = 1 << 1
 	}
 
-	public sealed class ClickGestureRecognizer : GestureRecognizer
+	public sealed class ClickGestureRecognizer : GestureRecognizer, ICommandableElement
 	{
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(ClickGestureRecognizer), null);
 

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_EntryRenderer))]
-	public class Entry : InputView, IFontElement, ITextElement, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>
+	public class Entry : InputView, IFontElement, ITextElement, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>, ICommandableElement
 	{
 		public static readonly BindableProperty ReturnTypeProperty = BindableProperty.Create(nameof(ReturnType), typeof(ReturnType), typeof(Entry), ReturnType.Default);
 
@@ -135,6 +135,18 @@ namespace Xamarin.Forms
 		{
 			get => GetValue(ReturnCommandParameterProperty);
 			set => SetValue(ReturnCommandParameterProperty, value);
+		}
+
+		ICommand ICommandableElement.Command
+		{
+			get => ReturnCommand;
+			set => ReturnCommand = value;
+		}
+
+		object ICommandableElement.CommandParameter
+		{
+			get => ReturnCommandParameter;
+			set => ReturnCommandParameter = value;
 		}
 
 		double IFontElement.FontSizeDefaultValueCreator() =>

--- a/Xamarin.Forms.Core/ICommandableElement.cs
+++ b/Xamarin.Forms.Core/ICommandableElement.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Input;
+using System.ComponentModel;
+
+namespace Xamarin.Forms.Internals
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public interface ICommandableElement
+	{
+		ICommand Command { get; set; }
+		object CommandParameter { get; set; }
+	}
+}

--- a/Xamarin.Forms.Core/ICommandableElement.cs
+++ b/Xamarin.Forms.Core/ICommandableElement.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms.Internals
 {
+	// implementing classes must be castable to Element
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface ICommandableElement
 	{

--- a/Xamarin.Forms.Core/INavigation.cs
+++ b/Xamarin.Forms.Core/INavigation.cs
@@ -23,6 +23,10 @@ namespace Xamarin.Forms
 		Task PushModalAsync(Page page);
 		Task PushModalAsync(Page page, bool animated);
 
+		Task ShowAsync(Page page);
+		Task ShowAsync(Page page, bool animated);
+		Task SegueAsync(Segue segue, SegueTarget target);
+
 		void RemovePage(Page page);
 	}
 }

--- a/Xamarin.Forms.Core/Internals/SegueRequestedEventArgs.cs
+++ b/Xamarin.Forms.Core/Internals/SegueRequestedEventArgs.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Internals
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public class SegueRequestedEventArgs
+	{
+		public ValueSegue Segue { get; }
+		public SegueTarget Target { get; }
+		public Task Task { get; set; }
+
+		internal SegueRequestedEventArgs(ValueSegue segue, SegueTarget target)
+		{
+			Segue = segue;
+			Target = target;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Internals/SegueRequestedEventArgs.cs
+++ b/Xamarin.Forms.Core/Internals/SegueRequestedEventArgs.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.Internals
 		public ValueSegue Segue { get; }
 		public SegueTarget Target { get; }
 		public Task Task { get; set; }
+		public bool Handled { get; set; }
 
 		internal SegueRequestedEventArgs(ValueSegue segue, SegueTarget target)
 		{

--- a/Xamarin.Forms.Core/MenuItem.cs
+++ b/Xamarin.Forms.Core/MenuItem.cs
@@ -2,11 +2,12 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Input;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
 
-	public class MenuItem : BaseMenuItem, IMenuItemController
+	public class MenuItem : BaseMenuItem, IMenuItemController, ICommandableElement
 	{
 		public static readonly BindableProperty AcceleratorProperty = BindableProperty.CreateAttached(nameof(Accelerator), typeof(Accelerator), typeof(MenuItem), null);
 

--- a/Xamarin.Forms.Core/NavigationProxy.cs
+++ b/Xamarin.Forms.Core/NavigationProxy.cs
@@ -178,25 +178,16 @@ namespace Xamarin.Forms.Internals
 			INavigation currentInner = Inner;
 			if (currentInner == null)
 			{
-				Page page = null;
-				if (segue.Action.RequiresTarget())
-				{
-					if (target == null)
-						throw new ArgumentNullException(nameof(target));
-					page = (Page)target.TryCreatePage();
-					if (page == null)
-						throw new InvalidOperationException($"Navigation must be rooted for non-Page target");
-				}
 				switch (segue.Action)
 				{
 					case NavigationAction.Show:
 						throw new InvalidOperationException($"Navigation must be rooted to use {nameof(NavigationAction.Show)}");
 
 					case NavigationAction.Push:
-						_pushStack.Value.Add(page);
+						_pushStack.Value.Add(target.ToPage());
 						return Task.CompletedTask;
 					case NavigationAction.Modal:
-						_modalStack.Value.Add(page);
+						_modalStack.Value.Add(target.ToPage());
 						return Task.CompletedTask;
 
 					// It's important these Pop* cases (except PopToRoot) return Task<Page>
@@ -213,7 +204,7 @@ namespace Xamarin.Forms.Internals
 						_pushStack.Value.Add(root);
 						return Task.CompletedTask;
 				}
-				return this.NavigateAsync(segue.Action, page, segue.IsAnimated);
+				return this.NavigateAsync(segue.Action, target, segue.IsAnimated);
 			}
 			return currentInner.SegueAsync(segue, target);
 		}

--- a/Xamarin.Forms.Core/NavigationProxy.cs
+++ b/Xamarin.Forms.Core/NavigationProxy.cs
@@ -71,32 +71,32 @@ namespace Xamarin.Forms.Internals
 
 		public Task<Page> PopAsync()
 		{
-			return OnPopAsync(true);
+			return PopAsync(true);
 		}
 
 		public Task<Page> PopAsync(bool animated)
 		{
-			return OnPopAsync(animated);
+			return (Task<Page>)OnSegue(new ValueSegue(NavigationAction.PopPushed, animated), null);
 		}
 
 		public Task<Page> PopModalAsync()
 		{
-			return OnPopModal(true);
+			return PopModalAsync(true);
 		}
 
 		public Task<Page> PopModalAsync(bool animated)
 		{
-			return OnPopModal(animated);
+			return (Task<Page>)OnSegue(new ValueSegue(NavigationAction.PopModal, animated), null);
 		}
 
 		public Task PopToRootAsync()
 		{
-			return OnPopToRootAsync(true);
+			return PopToRootAsync(true);
 		}
 
 		public Task PopToRootAsync(bool animated)
 		{
-			return OnPopToRootAsync(animated);
+			return OnSegue(new ValueSegue(NavigationAction.PopToRoot, animated), null);
 		}
 
 		public Task PushAsync(Page root)
@@ -108,7 +108,7 @@ namespace Xamarin.Forms.Internals
 		{
 			if (root.RealParent != null)
 				throw new InvalidOperationException("Page must not already have a parent.");
-			return OnPushAsync(root, animated);
+			return OnSegue(new ValueSegue(NavigationAction.Push, animated), (SegueTarget)root);
 		}
 
 		public Task PushModalAsync(Page modal)
@@ -120,7 +120,24 @@ namespace Xamarin.Forms.Internals
 		{
 			if (modal.RealParent != null)
 				throw new InvalidOperationException("Page must not already have a parent.");
-			return OnPushModal(modal, animated);
+			return OnSegue(new ValueSegue(NavigationAction.Modal, animated), (SegueTarget)modal);
+		}
+
+		public Task ShowAsync(Page page)
+		{
+			return ShowAsync(page, true);
+		}
+
+		public Task ShowAsync(Page page, bool animated)
+		{
+			if (page.RealParent != null)
+				throw new InvalidOperationException("Page must not already have a parent.");
+			return OnSegue(new ValueSegue(NavigationAction.Show, animated), (SegueTarget)page);
+		}
+
+		public Task SegueAsync(Segue segue, SegueTarget target)
+		{
+			return OnSegue(segue, target);
 		}
 
 		public void RemovePage(Page page)
@@ -156,51 +173,49 @@ namespace Xamarin.Forms.Internals
 			}
 		}
 
-		protected virtual Task<Page> OnPopAsync(bool animated)
-		{
-			INavigation inner = Inner;
-			return inner == null ? Task.FromResult(Pop()) : inner.PopAsync(animated);
-		}
-
-		protected virtual Task<Page> OnPopModal(bool animated)
-		{
-			INavigation innerNav = Inner;
-			return innerNav == null ? Task.FromResult(PopModal()) : innerNav.PopModalAsync(animated);
-		}
-
-		protected virtual Task OnPopToRootAsync(bool animated)
+		protected internal virtual Task OnSegue(ValueSegue segue, SegueTarget target)
 		{
 			INavigation currentInner = Inner;
 			if (currentInner == null)
 			{
-				Page root = _pushStack.Value.Last();
-				_pushStack.Value.Clear();
-				_pushStack.Value.Add(root);
-				return Task.FromResult(root);
-			}
-			return currentInner.PopToRootAsync(animated);
-		}
+				Page page = null;
+				if (segue.Action.RequiresTarget())
+				{
+					if (target == null)
+						throw new ArgumentNullException(nameof(target));
+					page = (Page)target.TryCreatePage();
+					if (page == null)
+						throw new InvalidOperationException($"Navigation must be rooted for non-Page target");
+				}
+				switch (segue.Action)
+				{
+					case NavigationAction.Show:
+						throw new InvalidOperationException($"Navigation must be rooted to use {nameof(NavigationAction.Show)}");
 
-		protected virtual Task OnPushAsync(Page page, bool animated)
-		{
-			INavigation currentInner = Inner;
-			if (currentInner == null)
-			{
-				_pushStack.Value.Add(page);
-				return Task.FromResult(page);
-			}
-			return currentInner.PushAsync(page, animated);
-		}
+					case NavigationAction.Push:
+						_pushStack.Value.Add(page);
+						return Task.CompletedTask;
+					case NavigationAction.Modal:
+						_modalStack.Value.Add(page);
+						return Task.CompletedTask;
 
-		protected virtual Task OnPushModal(Page modal, bool animated)
-		{
-			INavigation currentInner = Inner;
-			if (currentInner == null)
-			{
-				_modalStack.Value.Add(modal);
-				return Task.FromResult<object>(null);
+					// It's important these Pop* cases (except PopToRoot) return Task<Page>
+					case NavigationAction.Pop:
+						return Task.FromResult(this.ShouldPopModal() ? PopModal() : Pop());
+					case NavigationAction.PopPushed:
+						return Task.FromResult(Pop());
+					case NavigationAction.PopModal:
+						return Task.FromResult(PopModal());
+
+					case NavigationAction.PopToRoot:
+						Page root = _pushStack.Value.Last();
+						_pushStack.Value.Clear();
+						_pushStack.Value.Add(root);
+						return Task.CompletedTask;
+				}
+				return this.NavigateAsync(segue.Action, page, segue.IsAnimated);
 			}
-			return currentInner.PushModalAsync(modal, animated);
+			return currentInner.SegueAsync(segue, target);
 		}
 
 		protected virtual void OnRemovePage(Page page)

--- a/Xamarin.Forms.Core/SearchBar.cs
+++ b/Xamarin.Forms.Core/SearchBar.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_SearchBarRenderer))]
-	public class SearchBar : View, IFontElement, ITextElement, ITextAlignmentElement, ISearchBarController, IElementConfiguration<SearchBar>
+	public class SearchBar : View, IFontElement, ITextElement, ITextAlignmentElement, ISearchBarController, IElementConfiguration<SearchBar>, ICommandableElement
 	{
 		public static readonly BindableProperty SearchCommandProperty = BindableProperty.Create("SearchCommand", typeof(ICommand), typeof(SearchBar), null, propertyChanged: OnCommandChanged);
 
@@ -110,6 +110,18 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(FontSizeProperty); }
 			set { SetValue(FontSizeProperty, value); }
+		}
+
+		ICommand ICommandableElement.Command
+		{
+			get => SearchCommand;
+			set => SearchCommand = value;
+		}
+
+		object ICommandableElement.CommandParameter
+		{
+			get => SearchCommandParameter;
+			set => SearchCommandParameter = value;
 		}
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)

--- a/Xamarin.Forms.Core/Segues/ISegueExecution.cs
+++ b/Xamarin.Forms.Core/Segues/ISegueExecution.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Internals
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public interface ISegueExecution
+	{
+		Task<bool> OnBeforeExecute(SegueTarget target);
+	}
+}

--- a/Xamarin.Forms.Core/Segues/NavigationAction.cs
+++ b/Xamarin.Forms.Core/Segues/NavigationAction.cs
@@ -1,0 +1,80 @@
+﻿using System;
+
+using Xamarin.Forms;
+
+namespace Xamarin.Forms
+{
+	[TypeConverter(typeof(NavigationActionConverter))]
+	public enum NavigationAction
+	{
+		/// <summary>
+		/// Corresponds to calling <see cref="INavigation.ShowAsync"/>
+		/// </summary>
+		Show = 0,
+
+		/// <summary>
+		/// Corresponds to calling <see cref="INavigation.PushAsync"/>.
+		/// </summary>
+		Push = 1,
+
+		/// <summary>
+		/// Corresponds to calling <see cref="INavigation.PushModalAsync"/>.
+		/// </summary>
+		Modal = 2,
+
+		/// <summary>
+		/// Corresponds to setting <see cref="Application.MainPage"/>.
+		/// </summary>
+		MainPage = 3,
+
+		/// <summary>
+		/// Corresponds to calling either <see cref="INavigation.PopAsync"/> or
+		///  <see cref="INavigation.PopModalAsync"/>, as appropriate.
+		/// </summary>
+		Pop = 4,
+
+		/// <summary>
+		/// Corresponds to calling <see cref="INavigation.PopAsync"/>.
+		/// </summary>
+		PopPushed = Pop | Push,
+
+		/// <summary>
+		/// Corresponds to calling <see cref="INavigation.PopModalAsync"/>.
+		/// </summary>
+		PopModal = Pop | Modal,
+
+		/// <summary>
+		/// Corresponds to calling <see cref="INavigation.PopToRootAsync"/>.
+		/// </summary>
+		PopToRoot = Pop | MainPage,
+	}
+
+	public class NavigationActionConverter : TypeConverter
+	{
+		public static bool TryParse(string value, out NavigationAction action)
+		{
+			switch (value.ToLowerInvariant()) {
+			case "show"     : action = NavigationAction.Show; return true;
+			case "push"     : action = NavigationAction.Push; return true;
+			case "modal"    : action = NavigationAction.Modal; return true;
+			case "mainpage" : action = NavigationAction.MainPage; return true;
+			case "pop"      : action = NavigationAction.Pop; return true;
+			case "poppushed": action = NavigationAction.PopPushed; return true;
+			case "popmodal" : action = NavigationAction.PopModal; return true;
+			case "poptoroot": action = NavigationAction.PopToRoot; return true;
+			}
+			action = default(NavigationAction);
+			return false;
+		}
+
+		public static NavigationAction Parse(string value)
+		{
+			NavigationAction result;
+			if (!TryParse(value, out result))
+				throw new ArgumentException();
+			return result;
+		}
+
+		public override object ConvertFromInvariantString(string value) => Parse(value);
+	}
+}

--- a/Xamarin.Forms.Core/Segues/Segue.cs
+++ b/Xamarin.Forms.Core/Segues/Segue.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.ComponentModel;
+using System.Windows.Input;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms
+{
+	/// <summary>
+	/// A navigational transition from one <see cref="Page"/> to another.
+	/// </summary>
+	public class Segue : BindableObject, ISegueExecution
+	{
+		public static readonly BindableProperty ActionProperty =
+			BindableProperty.Create(nameof(Action), typeof(NavigationAction), typeof(Segue), default(NavigationAction));
+
+		public static readonly BindableProperty IsAnimatedProperty =
+			BindableProperty.Create(nameof(IsAnimated), typeof(bool), typeof(Segue), defaultValue: true);
+
+		public static readonly BindableProperty IsEnabledProperty =
+			BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(Segue), defaultValue: true, 
+				propertyChanged: (s, _, __) => ((Segue)s).OnCanExecuteChanged());
+
+		public static readonly BindableProperty SourceElementProperty =
+			BindableProperty.Create(nameof(SourceElement), typeof(Element), typeof(Segue));
+
+		public static readonly BindableProperty TargetProperty =
+			BindableProperty.CreateAttached("Target", typeof(SegueTarget), typeof(Segue), defaultValue: null,
+				propertyChanged: (obj, oldVal, newVal) => {
+					if ((oldVal == null || newVal == null) && obj is ICommandableElement e && e.Command is Segue.Command c)
+						c.OnCanExecuteChanged();
+				});
+
+		/// <summary>
+		/// Gets or sets the navigation action this <see cref="Segue"/> will perform when executed.
+		/// </summary>
+		public NavigationAction Action {
+			get => (NavigationAction)GetValue(ActionProperty);
+			set => SetValue(ActionProperty, value);
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="Segue"/> is animated when executed.
+		/// </summary>
+		/// <value><c>true</c> if animated; otherwise, <c>false</c>.</value>
+		public bool IsAnimated {
+			get => (bool)GetValue(IsAnimatedProperty);
+			set => SetValue(IsAnimatedProperty, value);
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="Segue"/> is enabled.
+		/// </summary>
+		/// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
+		public bool IsEnabled {
+			get => (bool)GetValue(IsEnabledProperty);
+			set => SetValue(IsEnabledProperty, value);
+		}
+
+		/// <summary>
+		/// Gets the exact element that triggered this <see cref="Segue"/>, or <c>null</c>
+		///  if one wasn't provided.
+		/// </summary>
+		/// <remarks>
+		/// This property is set automatically when the <c>{Segue}</c> markup extension is used,
+		///  or by the <see cref="ICommand"/> returned by <see cref="ToCommand"/> when the
+		///  <c>source</c> parameter is provided. Setting or binding this property explicitly
+		///  disables that automatic behavior.
+		/// </remarks>
+		public Element SourceElement {
+			get => (Element)GetValue(SourceElementProperty);
+			set => SetValue(SourceElementProperty, value);
+		}
+
+		public event EventHandler<SegueBeforeExecuteEventArgs> BeforeExecute;
+
+		/// <summary>
+		/// Called before execution of this <see cref="Segue"/> to raise the <see cref="BeforeExecute"/> event.
+		/// </summary>
+		/// <remarks>
+		/// Execution of the segue is deferred until the returned <see cref="Task"/> completes with the result <c>true</c>.
+		///  If the result is <c>false</c>, execution of the segue is cancelled. You can use this method to display
+		///  an alert to the user to cancel the navigation, or to perform any asynchronous loading or clean up before
+		///  navigating to the next page.
+		/// </remarks>
+		/// <returns><c>true</c> to execute the segue, or <c>false</c> to cancel it.</returns>
+		/// <param name="target">The destination <see cref="SegueTarget"/> for this segue.</param>
+		protected virtual Task<bool> OnBeforeExecute(SegueTarget target)
+		{
+			var beforeExec = BeforeExecute;
+			if (beforeExec != null) {
+				var args = new SegueBeforeExecuteEventArgs(target);
+				beforeExec(this, args);
+				return Task.FromResult(!args.Cancelled);
+			}
+			return Task.FromResult(true);
+		}
+		Task<bool> ISegueExecution.OnBeforeExecute(SegueTarget target) => OnBeforeExecute(target);
+
+		public static SegueTarget GetTarget(BindableObject obj)
+		{
+			return (SegueTarget)obj.GetValue(TargetProperty);
+		}
+
+		public static void SetTarget(BindableObject obj, SegueTarget value)
+		{
+			obj.SetValue(TargetProperty, value);
+		}
+
+		#region ICommand adapters
+
+		event EventHandler CanExecuteChanged;
+
+		/// <summary>
+		/// Raises the <see cref="CanExecuteChanged"/> event.
+		/// </summary>
+		protected virtual void OnCanExecuteChanged()
+		{
+			CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+		}
+
+		/// <remarks>
+		/// If you override this method, be sure to call <see cref="OnCanExecuteChanged"/> as appropriate.
+		/// </remarks>
+		/// <param name="source">The source object that triggered this segue.</param>
+		/// <param name="parameter">Parameter passed to <see cref="ICommand.CanExecute(object)"/>.</param>
+		protected internal virtual bool CanExecuteCommand(Element source, object parameter)
+		{
+			return DefaultCanExecuteCommand(this, source);
+		}
+
+		internal static bool DefaultCanExecuteCommand(ValueSegue seg, Element source)
+		{
+			if (!seg.IsEnabled)
+				return false;
+
+			if (GetTarget(source) == null)
+				return !seg.Action.RequiresTarget();
+
+			return true;
+		}
+
+		/// <summary>
+		/// Called when an <see cref="ICommand"/> that was vended by <see cref="ToCommand"/> is executed.
+		/// </summary>
+		/// <param name="source">The source object that triggered this segue.</param>
+		/// <param name="parameter">Parameter passed to <see cref="ICommand.Execute(object)"/>.</param>
+		protected internal virtual Task ExecuteCommand(Element source, object parameter)
+		{
+			return DefaultExecuteCommand(this, source);
+		}
+
+		internal static Task DefaultExecuteCommand(ValueSegue seg, Element source)
+		{
+			if (!seg.IsEnabled)
+				throw new InvalidOperationException("IsEnabled is false");
+
+			var s = seg.Segue;
+			if (s != null)
+			{
+				// Set SourceElement property if it wasn't manually set or bound by the user
+				if (!(s.GetIsBound(SourceElementProperty) || s.GetIsManuallySet(SourceElementProperty)))
+					s.SetValueCore(SourceElementProperty, source);
+			}
+
+			var nav = FindVisualElement(source)?.Navigation;
+			if (nav == null)
+				throw new NotSupportedException("Source must be in the view hierarchy");
+
+ 			return nav.SegueAsync(seg, GetTarget(source));
+		}
+
+		static VisualElement FindVisualElement(Element elem)
+		{
+			while (elem != null) {
+				if (elem is VisualElement visElem)
+					return visElem;
+				elem = elem.Parent;
+			}
+			return null;
+		}
+
+		sealed class Command : ICommand
+		{
+			ValueSegue seg;
+			Element source;
+			EventHandler canExecuteChanged;
+
+			public event EventHandler CanExecuteChanged {
+				add {
+					if (canExecuteChanged == null && seg.Segue != null)
+						seg.Segue.CanExecuteChanged += Segue_CanExecuteChanged;
+					canExecuteChanged += value;
+				}
+				remove {
+					canExecuteChanged -= value;
+					if (canExecuteChanged == null && seg.Segue != null)
+						seg.Segue.CanExecuteChanged -= Segue_CanExecuteChanged;
+				}
+			}
+
+			public Command(ValueSegue seg, Element source)
+			{
+				this.seg = seg;
+				this.source = source;
+			}
+
+			public void OnCanExecuteChanged() => canExecuteChanged?.Invoke(this, EventArgs.Empty);
+			void Segue_CanExecuteChanged(object sender, EventArgs e) => OnCanExecuteChanged();
+
+			public bool CanExecute(object parameter) => seg.CanExecuteCommand(source, parameter);
+			public void Execute(object parameter) => seg.ExecuteCommand(source, parameter);
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="ICommand"/> instance for triggering this segue
+		///  from the given source element.
+		/// </summary>
+		public ICommand ToCommand(Element source)
+		{
+			if (source == null)
+				throw new ArgumentNullException(nameof(source));
+			return new Command(this, source);
+		}
+
+		/// <summary>
+		/// Creates an <see cref="ICommand"/> to trigger the default <see cref="Segue"/>
+		///  from the given source <see cref="Element"/> with the given <see cref="NavigationAction"/>.
+		/// </summary>
+		/// <remarks>
+		/// Optimized equivalent to this:
+		/// <code>
+		///   new Segue { Action = action }.ToCommand(source)
+		/// </code>
+		/// </remarks>
+		public static ICommand CreateCommand(Element source, NavigationAction action, bool animated = true)
+		{
+			if (source == null)
+				throw new ArgumentNullException(nameof(source));
+			return new Command(new ValueSegue(action, animated), source);
+		}
+
+		#endregion
+	}
+}

--- a/Xamarin.Forms.Core/Segues/Segue.cs
+++ b/Xamarin.Forms.Core/Segues/Segue.cs
@@ -24,9 +24,6 @@ namespace Xamarin.Forms
 			BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(Segue), defaultValue: true, 
 				propertyChanged: (s, _, __) => ((Segue)s).OnCanExecuteChanged());
 
-		public static readonly BindableProperty SourceElementProperty =
-			BindableProperty.Create(nameof(SourceElement), typeof(Element), typeof(Segue));
-
 		public static readonly BindableProperty TargetProperty =
 			BindableProperty.CreateAttached("Target", typeof(SegueTarget), typeof(Segue), defaultValue: null,
 				propertyChanged: (obj, oldVal, newVal) => {
@@ -58,21 +55,6 @@ namespace Xamarin.Forms
 		public bool IsEnabled {
 			get => (bool)GetValue(IsEnabledProperty);
 			set => SetValue(IsEnabledProperty, value);
-		}
-
-		/// <summary>
-		/// Gets the exact element that triggered this <see cref="Segue"/>, or <c>null</c>
-		///  if one wasn't provided.
-		/// </summary>
-		/// <remarks>
-		/// This property is set automatically when the <c>{Segue}</c> markup extension is used,
-		///  or by the <see cref="ICommand"/> returned by <see cref="ToCommand"/> when the
-		///  <c>source</c> parameter is provided. Setting or binding this property explicitly
-		///  disables that automatic behavior.
-		/// </remarks>
-		public Element SourceElement {
-			get => (Element)GetValue(SourceElementProperty);
-			set => SetValue(SourceElementProperty, value);
 		}
 
 		public event EventHandler<SegueBeforeExecuteEventArgs> BeforeExecute;
@@ -157,14 +139,6 @@ namespace Xamarin.Forms
 		{
 			if (!seg.IsEnabled)
 				throw new InvalidOperationException("IsEnabled is false");
-
-			var s = seg.Segue;
-			if (s != null)
-			{
-				// Set SourceElement property if it wasn't manually set or bound by the user
-				if (!(s.GetIsBound(SourceElementProperty) || s.GetIsManuallySet(SourceElementProperty)))
-					s.SetValueCore(SourceElementProperty, source);
-			}
 
 			var nav = FindVisualElement(source)?.Navigation;
 			if (nav == null)

--- a/Xamarin.Forms.Core/Segues/SegueBeforeExecuteEventArgs.cs
+++ b/Xamarin.Forms.Core/Segues/SegueBeforeExecuteEventArgs.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace Xamarin.Forms
+{
+	public class SegueBeforeExecuteEventArgs : EventArgs
+	{
+		public SegueTarget Target { get; }
+		public bool Cancelled { get; set; }
+		public SegueBeforeExecuteEventArgs(SegueTarget target)
+		{
+			Target = target;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Segues/SegueExtensions.cs
+++ b/Xamarin.Forms.Core/Segues/SegueExtensions.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms
+{
+	public static class SegueExtensions
+	{
+		/// <summary>
+		/// Performs the given <see cref="NavigationAction"/>.
+		/// </summary>
+		public static Task NavigateAsync(this INavigation nav, NavigationAction action, Page page, bool animated = true)
+		{
+			switch (action)
+			{
+				case NavigationAction.Show:
+					return nav.ShowAsync(page, animated);
+				case NavigationAction.Push:
+					return nav.PushAsync(page, animated);
+				case NavigationAction.Modal:
+					return nav.PushModalAsync(page, animated);
+				case NavigationAction.Pop:
+					return nav.ShouldPopModal() ? nav.PopModalAsync(animated) : nav.PopAsync(animated);
+				case NavigationAction.PopPushed:
+					return nav.PopAsync(animated);
+				case NavigationAction.PopModal:
+					return nav.PopModalAsync(animated);
+				case NavigationAction.PopToRoot:
+					return nav.PopToRootAsync(animated);
+				case NavigationAction.MainPage:
+					Application.Current.MainPage = page;
+					return Task.CompletedTask;
+			}
+			throw new ArgumentException("Unknown action", nameof(action));
+		}
+
+		public static Task NavigateAsync(this INavigation nav, NavigationAction action, SegueTarget target, bool animated = true)
+		{
+			return SegueAsync(nav, new ValueSegue(action, animated), target);
+		}
+
+		public static Task SegueAsync(this INavigation nav, Segue segue, Page page)
+		{
+			return nav.SegueAsync(segue, (SegueTarget)page);
+		}
+
+		internal static Task SegueAsync(this INavigation nav, ValueSegue seg, SegueTarget target)
+		{
+			// If possible, call direct to save us some hand waving and allocations..
+			if (nav is NavigationProxy proxy)
+				return proxy.OnSegue(seg, target);
+
+			// If this is a simple navigation, bypass the Segue machinery...
+			Page page = null;
+			if (seg.Segue == null && (target == null || (page = target.TryCreatePage()) != null))
+				return nav.NavigateAsync(seg.Action, page, seg.IsAnimated);
+
+			// This is potentially the most expensive..
+			return nav.SegueAsync(seg.GetOrCreateSegue(), target);
+		}
+
+		public static void SetSegue(this ICommandableElement trigger, Segue segue, SegueTarget target)
+			=> SetSegue(trigger, new ValueSegue(segue), target);
+
+		public static void SetSegue(this ICommandableElement trigger, NavigationAction action, SegueTarget target, bool animated = true)
+			=> SetSegue(trigger, new ValueSegue(action, animated), target);
+
+		static void SetSegue(ICommandableElement trigger, ValueSegue segue, SegueTarget target)
+		{
+			var elem = (Element)trigger;
+			Segue.SetTarget(elem, target);
+			trigger.Command = segue.ToCommand(elem);
+		}
+
+		public static bool RequiresTarget(this NavigationAction action) => !action.IsPopping();
+		internal static bool IsPopping(this NavigationAction action) => (action & NavigationAction.Pop) == NavigationAction.Pop;
+		internal static bool ShouldPopModal(this INavigation nav) => nav.ModalStack.Count > 0;
+	}
+}

--- a/Xamarin.Forms.Core/Segues/SegueExtensions.cs
+++ b/Xamarin.Forms.Core/Segues/SegueExtensions.cs
@@ -53,12 +53,10 @@ namespace Xamarin.Forms
 				return proxy.OnSegue(seg, target);
 
 			// If this is a simple navigation, bypass the Segue machinery...
-			Page page = null;
-			if (seg.Segue == null && (target == null || (page = target.TryCreatePage()) != null))
-				return nav.NavigateAsync(seg.Action, page, seg.IsAnimated);
+			if (seg.Segue == null)
+				return nav.NavigateAsync(seg.Action, target?.ToPage(), seg.IsAnimated);
 
-			// This is potentially the most expensive..
-			return nav.SegueAsync(seg.GetOrCreateSegue(), target);
+			return nav.SegueAsync(seg.Segue, target);
 		}
 
 		public static void SetSegue(this ICommandableElement trigger, Segue segue, SegueTarget target)

--- a/Xamarin.Forms.Core/Segues/SegueTarget.cs
+++ b/Xamarin.Forms.Core/Segues/SegueTarget.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Xamarin.Forms
+{
+	public class SegueTarget
+	{
+		object target;
+
+		// This is set in the DataTemplate case below, or when Reject is called
+		WeakReference cachedValue;
+
+		// We don't know what type a DataTemplate will construct until we actually create it.
+		//  Here we attempt to avoid creating a lot of garbage when TryCreateValue is called
+		//  for types other than what our DataTemplate returns..
+		Type templatedType;
+
+		// Allow platforms to register their own SegueTarget subclasses that will
+		//  be used for implicit conversion from DataTemplate, etc..
+		protected static Func<object,SegueTarget> CreateFromObjectHandler { private get; set; } =
+			obj => new SegueTarget(obj);
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public virtual bool IsTemplate {
+			get {
+				switch (target)
+				{
+					case Type _: return true;
+					case DataTemplate _: return true;
+				}
+				return false;
+			}
+		}
+
+		public Page Page {
+			get {
+				if (IsTemplate)
+					throw new InvalidOperationException("Target is a template");
+				return TryCreatePage();
+			}
+		}
+
+		protected SegueTarget(object target)
+		{
+			this.target = target;
+		}
+
+		// Convenience
+		internal Page TryCreatePage()
+		{
+			return (Page)TryCreateValue(typeof(Page));
+		}
+
+		/// <summary>
+		/// For internal use.
+		/// </summary>
+		/// <remarks>
+		/// Generally, you will want to pass <see cref="Page"/> or a platform-specific
+		///  type for <see cref="targetType"/>. This call might be expensive.
+		/// </remarks>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public virtual object TryCreateValue(Type targetType)
+		{
+			var cached = cachedValue?.Target;
+			if (cached != null && targetType.IsAssignableFrom(cached.GetType()))
+			{
+				cachedValue = null;
+				return cached;
+			}
+			if (targetType.IsAssignableFrom(target.GetType()))
+				return target;
+			switch (target)
+			{
+				case Type ty when targetType.IsAssignableFrom(ty):
+					return Activator.CreateInstance(ty);
+
+				case DataTemplate dt when templatedType == null || targetType.IsAssignableFrom(templatedType):
+				{
+					var content = dt.CreateContent();
+					if (templatedType != null)
+						return content;
+
+					templatedType = content.GetType();
+					if (targetType.IsAssignableFrom(templatedType))
+						return content;
+
+					// Oops, we can't use content this time. But at least we have
+					//  a chance of using it next time if it's not collected..
+					Reject(content);
+					break;
+				}
+			}
+			return null;
+		}
+
+		protected void Reject(object value)
+		{
+			if (IsTemplate)
+				cachedValue = new WeakReference(value);
+		}
+
+		protected static SegueTarget CreateFromObject(object obj)
+		{
+			return (obj == null) ? null : CreateFromObjectHandler(obj);
+		}
+
+		public static implicit operator SegueTarget(Type ty) => CreateFromObject(ty);
+		public static implicit operator SegueTarget(DataTemplate dt) => CreateFromObject(dt);
+
+		// The conversion from Page is explicit because we don't want people accidently
+		//  using raw Page in XAML when they should be using DataTemplate..
+		public static explicit operator SegueTarget(Page page) => CreateFromObject(page);
+	}
+}

--- a/Xamarin.Forms.Core/Segues/ValueSegue.cs
+++ b/Xamarin.Forms.Core/Segues/ValueSegue.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Windows.Input;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Internals
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public struct ValueSegue
+	{
+		Segue segue; // may be null
+		NavigationAction action;
+		bool animated;
+
+		public Segue Segue => segue;
+		public NavigationAction Action => segue?.Action ?? action;
+		public bool IsAnimated => segue?.IsAnimated ?? animated;
+		public bool IsEnabled => segue?.IsEnabled ?? true;
+
+		public ValueSegue(Segue segue) : this()
+		{
+			this.segue = segue;
+		}
+
+		public ValueSegue(NavigationAction action, bool animated)
+		{
+			this.segue = null;
+			this.action = action;
+			this.animated = animated;
+		}
+
+		public ICommand ToCommand(Element source)
+		{
+			if (segue != null)
+				return segue.ToCommand(source);
+
+			return Segue.CreateCommand(source, action, animated);
+		}
+
+		public bool CanExecuteCommand(Element source, object parameter)
+		{
+			if (segue != null)
+				return segue.CanExecuteCommand(source, parameter);
+
+			return Segue.DefaultCanExecuteCommand(this, source);
+		}
+
+		public Task ExecuteCommand(Element source, object parameter)
+		{
+			if (segue != null)
+				return segue.ExecuteCommand(source, parameter);
+
+			return Segue.DefaultExecuteCommand(this, source);
+		}
+
+		public Segue GetOrCreateSegue()
+		{
+			return segue ?? new Segue { Action = action, IsAnimated = animated };
+		}
+
+		public static implicit operator ValueSegue(Segue seg) => new ValueSegue(seg);
+	}
+}

--- a/Xamarin.Forms.Core/Segues/ValueSegue.cs
+++ b/Xamarin.Forms.Core/Segues/ValueSegue.cs
@@ -53,11 +53,6 @@ namespace Xamarin.Forms.Internals
 			return Segue.DefaultExecuteCommand(this, source);
 		}
 
-		public Segue GetOrCreateSegue()
-		{
-			return segue ?? new Segue { Action = action, IsAnimated = animated };
-		}
-
 		public static implicit operator ValueSegue(Segue seg) => new ValueSegue(seg);
 	}
 }

--- a/Xamarin.Forms.Core/TapGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/TapGestureRecognizer.cs
@@ -1,10 +1,11 @@
 using System;
 using System.ComponentModel;
 using System.Windows.Input;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	public sealed class TapGestureRecognizer : GestureRecognizer
+	public sealed class TapGestureRecognizer : GestureRecognizer, ICommandableElement
 	{
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(TapGestureRecognizer), null);
 

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -16,5 +16,8 @@
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Segues\" />
+  </ItemGroup>
   <Import Project="..\Xamarin.Flex\Xamarin.Flex.projitems" Label="Shared" Condition="Exists('..\Xamarin.Flex\Xamarin.Flex.projitems')" />
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -105,7 +105,6 @@ namespace Xamarin.Forms
 			Internals.Registrar.RegisterAll(new[]
 				{ typeof(ExportRendererAttribute), typeof(ExportCellAttribute), typeof(ExportImageSourceHandlerAttribute) });
 			ExpressionSearch.Default = new iOSExpressionSearch();
-			ViewControllerSegueTarget.Init();
 		}
 
 		public static event EventHandler<ViewInitializedEventArgs> ViewInitialized;

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -105,6 +105,7 @@ namespace Xamarin.Forms
 			Internals.Registrar.RegisterAll(new[]
 				{ typeof(ExportRendererAttribute), typeof(ExportCellAttribute), typeof(ExportImageSourceHandlerAttribute) });
 			ExpressionSearch.Default = new iOSExpressionSearch();
+			ViewControllerSegueTarget.Init();
 		}
 
 		public static event EventHandler<ViewInitializedEventArgs> ViewInitialized;

--- a/Xamarin.Forms.Platform.iOS/NativePageWrapper.cs
+++ b/Xamarin.Forms.Platform.iOS/NativePageWrapper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	public class NativePageWrapper : Page
+	{
+		public UIViewController ViewController { get; }
+
+		public NativePageWrapper (UIViewController viewController)
+		{
+			ViewController = viewController;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/NativePageWrapperRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/NativePageWrapperRenderer.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+using UIKit;
+using CoreGraphics;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	public class NativePageWrapperRenderer : IVisualElementRenderer {
+
+		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+
+		public NativePageWrapper Element { get; private set; }
+
+		VisualElement IVisualElementRenderer.Element => Element;
+
+		public UIView NativeView => Element?.ViewController.View;
+
+		public UIViewController ViewController => Element?.ViewController;
+
+		public SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			return NativeView.GetSizeRequest(widthConstraint, heightConstraint);
+		}
+
+		public void SetElement(VisualElement element)
+		{
+			VisualElement oldElement = Element;
+			Element = (NativePageWrapper)element;
+
+			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
+		}
+
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
+		{
+			ElementChanged?.Invoke(this, e);
+		}
+
+		public void SetElementSize(Size size)
+		{
+			NativeView.Frame = new CGRect(0, 0, size.Width, size.Height);
+			Element.Layout(new Rectangle(Element.X, Element.Y, size.Width, size.Height));
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (disposing && Element != null) {
+				Platform.SetRenderer(Element, null);
+				Element = null;
+			}
+		}
+
+		public void Dispose() => Dispose(true);
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/NativeValueConverterService.cs
+++ b/Xamarin.Forms.Platform.iOS/NativeValueConverterService.cs
@@ -19,10 +19,15 @@ namespace Xamarin.Forms.Platform.MacOS
 		public bool ConvertTo(object value, Type toType, out object nativeValue)
 		{
 			nativeValue = null;
-			if (typeof(UIView).IsInstanceOfType(value) && toType.IsAssignableFrom(typeof(View)))
+			switch (value)
 			{
-				nativeValue = ((UIView)value).ToView();
-				return true;
+				case UIView nativeView when toType.IsAssignableFrom(typeof(View)):
+					nativeValue = nativeView.ToView();
+					return true;
+
+				case UIViewController nativeViewController when toType.IsAssignableFrom(typeof(Page)):
+					nativeValue = nativeViewController.ToPage();
+					return true;
 			}
 			return false;
 		}

--- a/Xamarin.Forms.Platform.iOS/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/PageExtensions.cs
@@ -35,5 +35,10 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			return Xamarin.Forms.PageExtensions.CreateViewController(page);
 		}
+
+		public static Page ToPage(this UIViewController viewController)
+		{
+			return new NativePageWrapper(viewController);
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
@@ -51,6 +51,7 @@ using UIKit;
 
 [assembly: ExportRenderer(typeof(MasterDetailPage), typeof(TabletMasterDetailRenderer), UIUserInterfaceIdiom.Pad)]
 [assembly: ExportRenderer(typeof(NativeViewWrapper), typeof(NativeViewWrapperRenderer))]
+[assembly: ExportRenderer(typeof(NativePageWrapper), typeof(NativePageWrapperRenderer))]
 
 [assembly: ExportCell(typeof(Cell), typeof(CellRenderer))]
 [assembly: ExportCell(typeof(ImageCell), typeof(ImageCellRenderer))]

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -218,6 +218,7 @@ namespace Xamarin.Forms.Platform.iOS
 			navPage.PopToRootRequested += OnPopToRootRequested;
 			navPage.RemovePageRequested += OnRemovedPageRequested;
 			navPage.InsertPageBeforeRequested += OnInsertPageBeforeRequested;
+			navPage.SegueRequested += OnSegueRequested;
 
 			UpdateTint();
 			UpdateBarBackgroundColor();
@@ -258,6 +259,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var navPage = (NavigationPage)Element;
 				navPage.PropertyChanged -= HandlePropertyChanged;
 
+				navPage.SegueRequested -= OnSegueRequested;
 				navPage.PushRequested -= OnPushRequested;
 				navPage.PopRequested -= OnPopRequested;
 				navPage.PopToRootRequested -= OnPopToRootRequested;
@@ -534,6 +536,70 @@ namespace Xamarin.Forms.Platform.iOS
 			View?.Window?.EndEditing(true);
 
 			e.Task = PushPageAsync(e.Page, e.Animated);
+		}
+
+		void OnSegueRequested(object sender, SegueRequestedEventArgs e)
+		{
+			e.Task = SegueAsync(e.Segue, e.Target);
+		}
+
+		async Task SegueAsync(ValueSegue seg, SegueTarget target)
+		{
+			var action = seg.Action;
+			var exec = seg.Segue as ISegueExecution;
+			UIViewController vc = null;
+
+			// adjust target and action as needed
+			switch (action)
+			{
+				case NavigationAction.Pop:
+					action = NavigationAction.PopPushed;
+					goto case NavigationAction.PopPushed;
+
+				case NavigationAction.PopPushed:
+					if (exec != null)
+					{
+						var stack = ViewControllers;
+						vc = stack[stack.Length - 2];
+					}
+					break;
+
+				case NavigationAction.PopToRoot:
+					if (exec != null)
+						vc = ViewControllers[0];
+					break;
+			}
+
+			if (vc == null)
+			{
+				vc = (UIViewController)target.TryCreateValue(typeof(UIViewController));
+				if (vc == null)
+					throw new ArgumentException("Unsupported target type", nameof(target));
+			}
+			if (exec != null)
+			{
+				target = new ViewControllerSegueTarget(vc); // clone so we don't risk recreating it
+				if (!await exec.OnBeforeExecute(target))
+					return;
+			}
+
+			// If we don't need a target, or can retrieve it as a Page, route it through classic Forms navigation..
+			Page page = null;
+			if (!action.RequiresTarget() || (page = ViewControllerSegueTarget.GetPage(vc)) != null)
+			{
+				await Element.Navigation.NavigateAsync(action, page, seg.IsAnimated);
+				return;
+			}
+
+			// Otherwise, perform a native transition..
+			switch (action)
+			{
+				case NavigationAction.Show:
+				case NavigationAction.Push:
+					//FIXME: figure out how to await this
+					PushViewController(vc, seg.IsAnimated);
+					return;
+			}
 		}
 
 		void OnRemovedPageRequested(object sender, NavigationRequestedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Segues/ViewControllerSegueTarget.cs
+++ b/Xamarin.Forms.Platform.iOS/Segues/ViewControllerSegueTarget.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Diagnostics.Contracts;
+using System.Linq;
+
+using UIKit;
+
+using Xamarin.Forms.Platform.iOS;
+
+namespace Xamarin.Forms
+{
+	public class ViewControllerSegueTarget : SegueTarget
+	{
+		internal static void Init()
+		{
+			SegueTarget.CreateFromObjectHandler = obj => new ViewControllerSegueTarget(obj);
+		}
+
+		public UIViewController ViewController {
+			get {
+				if (IsTemplate)
+					throw new InvalidOperationException("Target is a template");
+				return (UIViewController)TryCreateValue(typeof(UIViewController));
+			}
+		}
+
+		protected ViewControllerSegueTarget(object obj) : base(obj)
+		{
+		}
+
+		public ViewControllerSegueTarget(UIViewController viewController)
+			: base (viewController)
+		{
+			if (viewController == null)
+				throw new ArgumentNullException();
+		}
+
+		public override object TryCreateValue(Type targetType)
+		{
+			var result = base.TryCreateValue(targetType);
+			if (result == null)
+			{
+				if (targetType.IsAssignableFrom(typeof(Page)))
+				{
+					var vc = (UIViewController)TryCreateValue(typeof(UIViewController));
+					result = GetPage(vc);
+					if (result == null)
+						Reject(vc);
+				}
+				else if (targetType.IsAssignableFrom(typeof(UIViewController)))
+				{
+					var page = (Page)base.TryCreateValue(typeof(Page));
+					if (page == null)
+						return null;
+
+					var renderer = Platform.iOS.Platform.GetRenderer(page);
+					if (renderer == null)
+					{
+						renderer = Platform.iOS.Platform.CreateRenderer(page);
+						Platform.iOS.Platform.SetRenderer(page, renderer);
+					}
+					return renderer.ViewController;
+				}
+			}
+			return result;
+		}
+
+		internal static Page GetPage(UIViewController vc)
+		{
+			if (vc == null)
+				return null;
+			return ((vc as IVisualElementRenderer)?.Element as Page) ?? GetPage(vc.ChildViewControllers.FirstOrDefault());
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Segues/ViewControllerSegueTarget.cs
+++ b/Xamarin.Forms.Platform.iOS/Segues/ViewControllerSegueTarget.cs
@@ -8,67 +8,28 @@ using Xamarin.Forms.Platform.iOS;
 
 namespace Xamarin.Forms
 {
-	public class ViewControllerSegueTarget : SegueTarget
+	public sealed class ViewControllerSegueTarget : SegueTarget
 	{
-		internal static void Init()
-		{
-			SegueTarget.CreateFromObjectHandler = obj => new ViewControllerSegueTarget(obj);
-		}
+		public UIViewController ViewController { get; }
 
-		public UIViewController ViewController {
-			get {
-				if (IsTemplate)
-					throw new InvalidOperationException("Target is a template");
-				return (UIViewController)TryCreateValue(typeof(UIViewController));
-			}
-		}
-
-		protected ViewControllerSegueTarget(object obj) : base(obj)
-		{
-		}
-
-		public ViewControllerSegueTarget(UIViewController viewController)
-			: base (viewController)
+		internal ViewControllerSegueTarget(UIViewController viewController)
 		{
 			if (viewController == null)
 				throw new ArgumentNullException();
+			ViewController = viewController;
 		}
 
-		public override object TryCreateValue(Type targetType)
+		public override Page ToPage()
 		{
-			var result = base.TryCreateValue(targetType);
-			if (result == null)
-			{
-				if (targetType.IsAssignableFrom(typeof(Page)))
-				{
-					var vc = (UIViewController)TryCreateValue(typeof(UIViewController));
-					result = GetPage(vc);
-					if (result == null)
-						Reject(vc);
-				}
-				else if (targetType.IsAssignableFrom(typeof(UIViewController)))
-				{
-					var page = (Page)base.TryCreateValue(typeof(Page));
-					if (page == null)
-						return null;
-
-					var renderer = Platform.iOS.Platform.GetRenderer(page);
-					if (renderer == null)
-					{
-						renderer = Platform.iOS.Platform.CreateRenderer(page);
-						Platform.iOS.Platform.SetRenderer(page, renderer);
-					}
-					return renderer.ViewController;
-				}
-			}
-			return result;
+			return GetPage(ViewController);
 		}
 
-		internal static Page GetPage(UIViewController vc)
+		static Page GetPage(UIViewController vc)
 		{
 			if (vc == null)
 				return null;
-			return ((vc as IVisualElementRenderer)?.Element as Page) ?? GetPage(vc.ChildViewControllers.FirstOrDefault());
+			return (vc as IVisualElementRenderer)?.Element as Page
+			    ?? GetPage(vc.ChildViewControllers.FirstOrDefault());
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -140,6 +140,8 @@
     <Compile Include="NativeValueConverterService.cs" />
     <Compile Include="NativeBindingService.cs" />
     <Compile Include="Segues\ViewControllerSegueTarget.cs" />
+    <Compile Include="NativePageWrapper.cs" />
+    <Compile Include="NativePageWrapperRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\StringResources.ar.resx" />

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Extensions\LayoutExtensions.cs" />
     <Compile Include="NativeValueConverterService.cs" />
     <Compile Include="NativeBindingService.cs" />
+    <Compile Include="Segues\ViewControllerSegueTarget.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\StringResources.ar.resx" />
@@ -193,5 +194,8 @@
     <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Segues\" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Xaml/MarkupExtensions/SegueExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/SegueExtension.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Reflection;
+using System.Collections;
+using System.Collections.Generic;
+using System.Windows.Input;
+
+namespace Xamarin.Forms.Xaml
+{
+	[ContentProperty(nameof(SegueExtension.Action))]
+	public class SegueExtension : IMarkupExtension<ICommand>
+	{
+		/// <summary>
+		/// Gets or sets the action that this segue will perform.
+		/// </summary>
+		/// <remarks>
+		/// Values should correspond to values of the <see cref="NavigationAction"/> enumeration. 
+		/// </remarks>
+		public string Action { get; set; }
+
+		/// <summary>
+		/// Gets or sets the type of custom segue to be created.
+		/// </summary>
+		/// Gets or sets a value indicating whether this segue is animated when executed.
+		/// </summary>
+		/// <value><c>true</c> if animated (default); otherwise, <c>false</c>.</value>
+		public bool IsAnimated { get; set; }
+
+		public SegueExtension()
+		{
+			IsAnimated = true;
+		}
+
+		public ICommand ProvideValue(IServiceProvider serviceProvider)
+		{
+			var targetProvider = serviceProvider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+			if (targetProvider == null)
+				throw new ArgumentException();
+
+			var target = targetProvider.TargetObject as Element;
+			if (target == null)
+				XamlError("Segue may only be used on Elements", serviceProvider);
+
+			var action = default(NavigationAction);
+			if (Action != null && !NavigationActionConverter.TryParse(Action, out action))
+				XamlError($"Unknown segue action \"{Action}\"", serviceProvider);
+
+			return Segue.CreateCommand(target, action, IsAnimated);
+		}
+
+		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) => ProvideValue(serviceProvider);
+
+		static void XamlError(string message, IServiceProvider serviceProvider)
+		{
+			var lineInfoProvider = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) as IXmlLineInfoProvider;
+			var lineInfo = lineInfoProvider?.XmlLineInfo ?? new XmlLineInfo();
+			throw new XamlParseException(message, lineInfo);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Segues are objects that represent navigational actions. These objects can be created and wired up entirely in XAML without any codebehind (or with code, if you prefer).

This PR is an evolution of https://github.com/chkn/Xamarin.Forms.Segues integrated into Core. This integration has some benefits:

- Integrates into navigation
    + New `NavigationAction` enum maps to `INavigation` methods
    + New internal type, `ValueSegue`: a lightweight struct that holds either a simple `NavigationAction` or a full `Segue` instance
    + A lot of navigation internals have been refactored in terms of these, which I believe simplifies and streamlines things.
- Pay only for what you use
    + Overloads of new methods are provided that take `NavigationAction` when a full `Segue` instance is not needed
    + `{Segue}` markup extension does not actually instantiate `Segue` (returns a lightweight `ICommand` that triggers the same behavior)
    + Full `Segue` instance can be provided by user if they want to enable/disable it, subclass it, bind properties, or to perform actions when the segue is executed.
- Ultimately, will enable custom transitions (to come later in a separate PR)

I've included the platform implementation for iOS only for now. If we decide we want to proceed with this approach, I could implement Android and UWP as well.

#### NavigationAction

This introduces the `NavigationAction` enum, whose values mostly represent method calls on `INavigation`. However, there are a couple differences:

##### Show

This PR introduces `INavigation.ShowAsync` and `NavigationAction.Show`. This action is designed to do the right thing in most common cases, and as such, is the default `NavigationAction` for segues. If the user does not want this default behavior, they can specify one of the other navigation actions explicitly.

Behavior depends on the context. Here are the rules:

- If the source page's ancestor is a `NavigationPage`, calls `INavigation.PushAsync`.
- Otherwise, calls `INavigation.PushModalAsync`.

I also had a couple other interesting ideas for this action in the context of a `MultiPage` or `MasterDetailPage`, but I did not implement them for this PR.

**Caveat:** Throws an `InvalidOperationException` if this action is used when navigation is not rooted (i.e. `NavigationProxy.Inner == null`). It might be possible to remove this limitation, but there are some issues that would need to be resolved.

##### Pop

This PR also introduces `NavigationAction.Pop`. Note that this is NOT the equivalent of calling `INavigation.PopAsync`, which is an existing API that corresponds to the new `NavigationAction.PopPushed`.

Like the above, `NavigationAction.Pop` tries to do the right thing depending on the context:

- If there is anything on the modal stack, call `INavigation.PopModalAsync`.
- Otherwise, call `INavigation.PopAsync`.

##### MainPage

Sometimes you either don't want stack-based navigation, or you want to reset the root of your app easily. As such, `NavigationAction.MainPage` is included that trivially sets `Application.Current.MainPage` to the target page.

#### Native Segues

Segues may be used to navigate to native screens. This functionality is analogous to the native view support (https://docs.microsoft.com/en-us/xamarin/xamarin-forms/platform/native-views/). 

### Examples ###

#### Attach a segue to a button from XAML

```xml
<Button Text="Go to next page"
        Command="{Segue}"
        Segue.Target="{x:Type local:NextPage}" />
```
Note that `Segue.Target` can also be a `DataTemplate`.

#### Attach a segue to a button from code

```csharp
// Attaches a segue to be executed when the button is clicked
button.SetSegue(NavigationAction.Show, new DataTemplate(typeof(NextPage)));
```

#### Imperatively perform a segue from code

```csharp
// Executes the segue now
await Navigation.NavigateAsync(NavigationAction.Show, new NextPage());
```

### Bugs Fixed ###

None

### API Changes ###

Added:

```csharp
namespace Xamarin.Forms
{
    // The following public types have been added:
    public enum NavigationAction
    public class NavigationActionConverter : TypeConverter
    public class Segue : BindableObject, ISegueExecution
    public class SegueBeforeExecuteEventArgs : EventArgs
    public static class SegueExtensions
    public class SegueTarget

    // The following members have been added:
    Task INavigation.ShowAsync(Page page);
    Task INavigation.ShowAsync(Page page, bool animated);
    Task INavigation.SegueAsync(Segue segue, SegueTarget target);

    public event EventHandler<SegueRequestedEventArgs> NavigationPage.SegueRequested;

    public Task NavigationProxy.ShowAsync(Page page)
    public Task NavigationProxy.ShowAsync(Page page, bool animated)
    public Task NavigationProxy.SegueAsync(Segue segue, SegueTarget target)
}

namespace Xamarin.Forms.Internals
{
    // The following public types have been added:
    public interface ICommandableElement
    public interface ISegueExecution
    public class SegueRequestedEventArgs
    public struct ValueSegue
}

namespace Xamarin.Forms.Xaml
{
    public class SegueExtension : IMarkupExtension<ICommand>
}

namespace Xamarin.Forms.Platform.iOS
{
    // The following public types have been added:
    public class NativePageWrapper
    public class NativePageWrapperRenderer : IVisualElementRenderer
    public sealed class ViewControllerSegueTarget : SegueTarget

    // The following members have been added:
    public static Page PageExtensions.ToPage(this UIViewController viewController)
}
```

Changed:

```csharp
namespace Xamarin.Forms
{
    // The following public types now implement `Xamarin.Forms.Internals.ICommandableElement`:
    public class Button : ICommandableElement
    public class TextCell : ICommandableElement
    public class ClickGestureRecognizer : ICommandableElement
    public class Entry : ICommandableElement
    public class SearchBar : ICommandableElement
    public class MenuItem : ICommandableElement
    public class TapGestureRecognizer : ICommandableElement
}
```

### Behavioral Changes ###

None intended.

### PR Checklist ###

- [ ] Has tests (if someone can point me at similar tests, I will add some)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
