### PR TITLE
[XamlG] builds incrementally, add MSBuild integration tests

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -64,18 +64,23 @@
 		</CoreCompileDependsOn>
 	</PropertyGroup>
 
-	<Target Name="XamlG" BeforeTargets="BeforeCompile" DependsOnTargets="PrepareResourceNames" Condition="'$(_XamlGAlreadyExecuted)'!='true'">
-		<PropertyGroup>
-			<_XamlGAlreadyExecuted>true</_XamlGAlreadyExecuted>
-		</PropertyGroup>
+	<Target Name="_FindXamlGFiles" DependsOnTargets="PrepareResourceNames">
+		<ItemGroup>
+			<_XamlGInputs Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.xaml' AND '$(DefaultLanguageSourceExtension)' == '.cs' AND '%(TargetPath)' != ''" />
+			<_XamlGOutputs Include="@(_XamlGInputs->'$(IntermediateOutputPath)%(TargetPath).g.cs')" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="XamlG" BeforeTargets="BeforeCompile" DependsOnTargets="_FindXamlGFiles" Inputs="@(_XamlGInputs)" Outputs="@(_XamlGOutputs)">
 		<XamlGTask
-			XamlFiles="@(EmbeddedResource)" Condition="'%(Extension)' == '.xaml' AND '$(DefaultLanguageSourceExtension)' == '.cs'"
-			Language = "$(Language)"
-			AssemblyName = "$(AssemblyName)"
-			OutputPath = "$(IntermediateOutputPath)">
-			<Output ItemName="FilesWrite" TaskParameter="GeneratedCodeFiles" />
-			<Output ItemName="Compile" TaskParameter="GeneratedCodeFiles" />
-		</XamlGTask>
+			XamlFiles="@(_XamlGInputs)"
+			OutputFiles="@(_XamlGOutputs)"
+			Language="$(Language)"
+			AssemblyName="$(AssemblyName)" />
+		<ItemGroup>
+			<FileWrites Include="@(_XamlGOutputs)" />
+			<Compile Include="@(_XamlGOutputs)" />
+		</ItemGroup>
 	</Target>
 
 	<!-- XamlC -->
@@ -86,10 +91,7 @@
 		</CompileDependsOn>
 	</PropertyGroup>
 
-	<Target Name="XamlC" AfterTargets="AfterCompile" Condition="'$(_XamlCAlreadyExecuted)'!='true'">
-		<PropertyGroup>
-			<_XamlCAlreadyExecuted>true</_XamlCAlreadyExecuted>
-		</PropertyGroup>
+	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp">
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
@@ -97,6 +99,10 @@
 			DebugSymbols = "$(DebugSymbols)"
 			DebugType = "$(DebugType)"
 			KeepXamlResources = "$(XFKeepXamlResources)" />
+		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True" />
+		<ItemGroup>
+			<FileWrites Include="$(IntermediateOutputPath)XamlC.stamp" />
+		</ItemGroup>
 	</Target>
 
 	<!-- CssG -->
@@ -115,7 +121,7 @@
 			Language = "$(Language)"
 			AssemblyName = "$(AssemblyName)"
 			OutputPath = "$(IntermediateOutputPath)">
-			<Output ItemName="FilesWrite" TaskParameter="GeneratedCodeFiles" />
+			<Output ItemName="FileWrites" TaskParameter="GeneratedCodeFiles" />
 			<Output ItemName="Compile" TaskParameter="GeneratedCodeFiles" />
 		</CssGTask>
 	</Target>

--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 
@@ -10,44 +9,45 @@ namespace Xamarin.Forms.Build.Tasks
 {
 	public class XamlGTask : Task
 	{
-		List<ITaskItem> _generatedCodeFiles = new List<ITaskItem>();
-
 		[Required]
 		public ITaskItem[] XamlFiles { get; set; }
 
-		[Output]
-		public ITaskItem[] GeneratedCodeFiles => _generatedCodeFiles.ToArray();
+		[Required]
+		public ITaskItem[] OutputFiles { get; set; }
 
 		public string Language { get; set; }
 		public string AssemblyName { get; set; }
-		public string OutputPath { get; set; }
 
 		public override bool Execute()
 		{
 			bool success = true;
 			Log.LogMessage(MessageImportance.Normal, "Generating code behind for XAML files");
 
-			if (XamlFiles == null) {
+			//NOTE: should not happen due to [Required], but there appears to be a place this is class is called directly
+			if (XamlFiles == null || OutputFiles == null) {
 				Log.LogMessage("Skipping XamlG");
 				return true;
 			}
 
-			foreach (var xamlFile in XamlFiles) {
-				//when invoked from `UpdateDesigntimeXaml` target, the `TargetPath` isn't set, use a random one instead
-				var targetPath = xamlFile.GetMetadata("TargetPath");
-				if (string.IsNullOrWhiteSpace(targetPath))
-					targetPath = $".{Path.GetRandomFileName()}";
+			if (XamlFiles.Length != OutputFiles.Length) {
+				Log.LogError("\"{2}\" refers to {0} item(s), and \"{3}\" refers to {1} item(s). They must have the same number of items.", XamlFiles.Length, OutputFiles.Length, "XamlFiles", "OutputFiles");
+				return false;
+			}
 
-				var outputFile = Path.Combine(OutputPath, $"{targetPath}.g.cs");
+			for (int i = 0; i < XamlFiles.Length; i++) {
+				var xamlFile = XamlFiles[i];
+				var outputFile = OutputFiles[i].ItemSpec;
 				if (Path.DirectorySeparatorChar == '/' && outputFile.Contains(@"\"))
 					outputFile = outputFile.Replace('\\','/');
 				else if (Path.DirectorySeparatorChar == '\\' && outputFile.Contains(@"/"))
 					outputFile = outputFile.Replace('/', '\\');
-	
+
 				var generator = new XamlGenerator(xamlFile, Language, AssemblyName, outputFile, Log);
 				try {
-					if (generator.Execute())
-						_generatedCodeFiles.Add(new TaskItem(Microsoft.Build.Evaluation.ProjectCollection.Escape(outputFile)));
+					if (!generator.Execute()) {
+						//If Execute() fails, the file still needs to exist because it is added to the <Compile/> ItemGroup
+						File.WriteAllText (outputFile, string.Empty);
+					}
 				}
 				catch (XmlException xe) {
 					Log.LogError(null, null, null, xamlFile.ItemSpec, xe.LineNumber, xe.LinePosition, 0, 0, xe.Message, xe.HelpLink, xe.Source);

--- a/Xamarin.Forms.Xaml.UnitTests/MSBuild/DummyBuildEngine.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MSBuild/DummyBuildEngine.cs
@@ -1,21 +1,31 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.Framework;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
 	public class DummyBuildEngine : IBuildEngine
 	{
+		public List<BuildErrorEventArgs> Errors { get; } = new List<BuildErrorEventArgs> ();
+
+		public List<BuildWarningEventArgs> Warnings { get; } = new List<BuildWarningEventArgs> ();
+
+		public List<BuildMessageEventArgs> Messages { get; } = new List<BuildMessageEventArgs> ();
+
 		public void LogErrorEvent (BuildErrorEventArgs e)
 		{
+			Errors.Add (e);
 		}
 
 		public void LogWarningEvent (BuildWarningEventArgs e)
 		{
+			Warnings.Add (e);
 		}
 
 		public void LogMessageEvent (BuildMessageEventArgs e)
 		{
+			Messages.Add (e);
 		}
 
 		public void LogCustomEvent (CustomBuildEventArgs e)

--- a/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -1,0 +1,459 @@
+﻿using Microsoft.Build.Locator;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using static Xamarin.Forms.Xaml.UnitTests.MSBuildXmlExtensions;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	//This set of tests is for validating Xamarin.Forms.targets
+	[TestFixture]
+	public class MSBuildTests
+	{
+		static readonly string XamarinFormsTargets = Path.Combine ("..", "..", "..", "..", "..", ".nuspec", "Xamarin.Forms.targets");
+
+		static readonly string [] references = new []
+		{
+			"mscorlib",
+			"System",
+			"Xamarin.Forms.Core.dll",
+			"Xamarin.Forms.Xaml.dll",
+		};
+
+		class Xaml
+		{
+			const string XamarinFormsDefaultNamespace = "http://xamarin.com/schemas/2014/forms";
+			const string XamarinFormsXNamespace = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+			public static readonly string MainPage = $@"
+				<ContentPage
+					xmlns=""{XamarinFormsDefaultNamespace}""
+					xmlns:x=""{XamarinFormsXNamespace}""
+					x:Class=""Xamarin.Forms.Xaml.UnitTests.MainPage"">
+					<Label x:Name=""label0""/>
+				</ContentPage>";
+
+			public static readonly string CustomView = $@"
+				<ContentView
+					xmlns=""{XamarinFormsDefaultNamespace}""
+					xmlns:x=""{XamarinFormsXNamespace}""
+					x:Class=""Xamarin.Forms.Xaml.UnitTests.CustomView"">
+					<Label x:Name=""label0""/>
+				</ContentView>";
+		}
+
+		string testDirectory;
+		string tempDirectory;
+		string intermediateDirectory;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			testDirectory = TestContext.CurrentContext.TestDirectory;
+			tempDirectory = Path.Combine (testDirectory, "temp", TestContext.CurrentContext.Test.Name);
+			intermediateDirectory = Path.Combine (tempDirectory, "obj", "Debug");
+			Directory.CreateDirectory (tempDirectory);
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			//NOTE: Windows can throw IOException: The process cannot access the file XYZ because it is being used by another process.
+			//A simple retry-and-give-up approach should be good enough
+			for (int i = 0; i < 3; i++) {
+				try {
+					if (Directory.Exists (tempDirectory)) {
+						Directory.Delete (tempDirectory, true);
+					}
+					break; //Success
+				} catch (IOException) {
+					System.Threading.Thread.Sleep (100);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Creates a base csproj file for these unit tests
+		/// </summary>
+		/// <param name="sdkStyle">If true, uses a new SDK-style project</param>
+		XElement NewProject (bool sdkStyle)
+		{
+			var path = Path.GetTempFileName ();
+			var project = NewElement ("Project");
+
+			var propertyGroup = NewElement ("PropertyGroup");
+			if (sdkStyle) {
+				project.WithAttribute ("Sdk", "Microsoft.NET.Sdk");
+				propertyGroup.Add (NewElement ("TargetFramework").WithValue ("netstandard2"));
+				//NOTE: we don't want SDK-style projects to auto-add files, tests should be able to control this
+				propertyGroup.Add (NewElement ("EnableDefaultCompileItems").WithValue ("False"));
+				//NOTE: SDK-style output paths are different
+				if (!intermediateDirectory.EndsWith ("netstandard2"))
+					intermediateDirectory = Path.Combine (intermediateDirectory, "netstandard2");
+			} else {
+				propertyGroup.Add (NewElement ("Configuration").WithValue ("Debug"));
+				propertyGroup.Add (NewElement ("Platform").WithValue ("AnyCPU"));
+				propertyGroup.Add (NewElement ("OutputType").WithValue ("Library"));
+				propertyGroup.Add (NewElement ("OutputPath").WithValue ("bin\\Debug"));
+				propertyGroup.Add (NewElement ("TargetFrameworkVersion").WithValue ("v4.7"));
+			}
+			project.Add (propertyGroup);
+
+			var itemGroup = NewElement ("ItemGroup");
+			foreach (var assembly in references) {
+				var reference = NewElement ("Reference").WithAttribute ("Include", assembly);
+				if (assembly.EndsWith (".dll", StringComparison.OrdinalIgnoreCase)) {
+					reference.Add (NewElement ("HintPath").WithValue (Path.Combine ("..", "..", assembly)));
+				} else if (sdkStyle) {
+					//NOTE: SDK-style projects don't need system references
+					continue;
+				}
+				itemGroup.Add (reference);
+			}
+			project.Add (itemGroup);
+
+			//Let's enable XamlC assembly-wide
+			project.Add (AddFile ("AssemblyInfo.cs", "Compile", "[assembly: Xamarin.Forms.Xaml.XamlCompilation (Xamarin.Forms.Xaml.XamlCompilationOptions.Compile)]"));
+
+			if (!sdkStyle)
+				project.Add (NewElement ("Import").WithAttribute ("Project", @"$(MSBuildBinPath)\Microsoft.CSharp.targets"));
+			project.Add (NewElement ("Import").WithAttribute ("Project", XamarinFormsTargets));
+			return project;
+		}
+
+		XElement AddFile (string name, string buildAction, string contents)
+		{
+			var filePath = Path.Combine (tempDirectory, name.Replace ('\\', Path.DirectorySeparatorChar).Replace ('/', Path.DirectorySeparatorChar));
+			Directory.CreateDirectory (Path.GetDirectoryName (filePath));
+			File.WriteAllText (filePath, contents);
+			var itemGroup = NewElement ("ItemGroup");
+			itemGroup.Add (NewElement (buildAction).WithAttribute ("Include", name));
+			return itemGroup;
+		}
+
+		string FindMSBuild ()
+		{
+			//On Windows we have to "find" MSBuild
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+				foreach (var visualStudioInstance in MSBuildLocator.QueryVisualStudioInstances ().OrderByDescending (v => v.Version)) {
+					return Path.Combine (visualStudioInstance.MSBuildPath, "MSBuild.exe");
+				}
+			}
+
+			return "msbuild";
+		}
+
+		void RestoreIfNeeded (string projectFile, bool sdkStyle)
+		{
+			//If using an SDK-style project, we need to run the Restore target
+			if (sdkStyle) {
+				Build (projectFile, "Restore");
+			}
+		}
+
+		void Build (string projectFile, string target = "Build", string additionalArgs = "")
+		{
+			var psi = new ProcessStartInfo {
+				FileName = FindMSBuild (),
+				Arguments = $"/v:minimal /nologo {projectFile} /t:{target} /bl {additionalArgs}",
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+				UseShellExecute = false,
+				RedirectStandardError = true,
+				RedirectStandardOutput = true,
+				WorkingDirectory = tempDirectory,
+			};
+			using (var p = new Process { StartInfo = psi }) {
+				p.ErrorDataReceived += (s, e) => Console.Error.WriteLine (e.Data);
+				p.OutputDataReceived += (s, e) => Console.WriteLine (e.Data);
+
+				p.Start ();
+				p.BeginErrorReadLine ();
+				p.BeginOutputReadLine ();
+				p.WaitForExit ();
+				Assert.AreEqual (0, p.ExitCode, "MSBuild exited with {0}", p.ExitCode);
+			}
+		}
+
+		void AssertExists (string path, bool nonEmpty = false)
+		{
+			if (!File.Exists (path))
+				Assert.Fail ($"{path} should exist!");
+
+			if (nonEmpty && new FileInfo (path).Length == 0)
+				Assert.Fail ($"{path} is empty!");
+		}
+
+		void AssertDoesNotExist (string path)
+		{
+			if (File.Exists (path))
+				Assert.Fail ($"{path} should *not* exist!");
+		}
+
+		[Test]
+		public void BuildAProject ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile ("MainPage.xaml", "EmbeddedResource", Xaml.MainPage));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile);
+
+			AssertExists (Path.Combine (intermediateDirectory, "test.dll"), nonEmpty: true);
+			AssertExists (Path.Combine (intermediateDirectory, "MainPage.xaml.g.cs"), nonEmpty: true);
+			AssertExists (Path.Combine (intermediateDirectory, "XamlC.stamp"));
+		}
+
+		/// <summary>
+		/// Tests that XamlG and XamlC targets skip, as well as checking IncrementalClean doesn't delete generated files
+		/// </summary>
+		[Test]
+		public void TargetsShouldSkip ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile ("MainPage.xaml", "EmbeddedResource", Xaml.MainPage));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile);
+
+			var mainPageXamlG = Path.Combine (intermediateDirectory, "MainPage.xaml.g.cs");
+			var xamlCStamp = Path.Combine (intermediateDirectory, "XamlC.stamp");
+			AssertExists (mainPageXamlG, nonEmpty: true);
+			AssertExists (xamlCStamp);
+
+			var expectedXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
+			var expectedXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
+
+			//Build again
+			Build (projectFile);
+			AssertExists (mainPageXamlG, nonEmpty: true);
+			AssertExists (xamlCStamp);
+
+			var actualXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
+			var actualXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
+			Assert.AreEqual (expectedXamlG, actualXamlG, $"Timestamps should match for {mainPageXamlG}.");
+			Assert.AreEqual (expectedXamlC, actualXamlC, $"Timestamps should match for {xamlCStamp}.");
+		}
+
+		/// <summary>
+		/// Checks that XamlG and XamlC files are cleaned
+		/// </summary>
+		[Test]
+		public void Clean ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile ("MainPage.xaml", "EmbeddedResource", Xaml.MainPage));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile);
+
+			var mainPageXamlG = Path.Combine (intermediateDirectory, "MainPage.xaml.g.cs");
+			var xamlCStamp = Path.Combine (intermediateDirectory, "XamlC.stamp");
+			AssertExists (mainPageXamlG, nonEmpty: true);
+			AssertExists (xamlCStamp);
+
+			//Clean
+			Build (projectFile, "Clean");
+			AssertDoesNotExist (mainPageXamlG);
+			AssertDoesNotExist (xamlCStamp);
+		}
+
+		[Test]
+		public void LinkedFile ([Values (false, true)] bool sdkStyle)
+		{
+			var folder = Path.Combine (tempDirectory, "A", "B");
+			Directory.CreateDirectory (folder);
+			File.WriteAllText (Path.Combine (folder, "MainPage.xaml"), Xaml.MainPage);
+
+			var project = NewProject (sdkStyle);
+			var itemGroup = NewElement ("ItemGroup");
+			var embeddedResource = NewElement ("EmbeddedResource").WithAttribute ("Include", @"A\B\MainPage.xaml");
+			embeddedResource.Add (NewElement ("Link").WithValue (@"Pages\MainPage.xaml"));
+			itemGroup.Add (embeddedResource);
+			project.Add (itemGroup);
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile);
+
+			AssertExists (Path.Combine (intermediateDirectory, "test.dll"), nonEmpty: true);
+			AssertExists (Path.Combine (intermediateDirectory, "Pages", "MainPage.xaml.g.cs"), nonEmpty: true);
+			AssertExists (Path.Combine (intermediateDirectory, "XamlC.stamp"));
+		}
+
+		//https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md
+		//https://daveaglick.com/posts/running-a-design-time-build-with-msbuild-apis
+		[Test]
+		public void DesignTimeBuild ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile (@"Pages\MainPage.xaml", "EmbeddedResource", Xaml.MainPage));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+
+			//NOTE: CompileDesignTime target only exists on Windows
+			var target = Environment.OSVersion.Platform == PlatformID.Win32NT ? "CompileDesignTime" : "Compile";
+			Build (projectFile, target, "/p:DesignTimeBuild=True /p:BuildingInsideVisualStudio=True /p:SkipCompilerExecution=True /p:ProvideCommandLineArgs=True");
+
+			var assembly = Path.Combine (intermediateDirectory, "test.dll");
+			var mainPageXamlG = Path.Combine (intermediateDirectory, "Pages", "MainPage.xaml.g.cs");
+			var xamlCStamp = Path.Combine (intermediateDirectory, "XamlC.stamp");
+
+			//The assembly should not be compiled
+			AssertDoesNotExist (assembly);
+			AssertExists (mainPageXamlG, nonEmpty: true);
+			AssertExists (xamlCStamp);
+
+			var expectedXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
+			var expectedXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
+
+			//Build again, a full build
+			Build (projectFile);
+			AssertExists (assembly, nonEmpty: true);
+			AssertExists (mainPageXamlG, nonEmpty: true);
+			AssertExists (xamlCStamp);
+
+			var actualXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
+			var actualXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
+			Assert.AreEqual (expectedXamlG, actualXamlG, $"Timestamps should match for {mainPageXamlG}.");
+			Assert.AreNotEqual (expectedXamlC, actualXamlC, $"Timestamps should *not* match for {xamlCStamp}.");
+		}
+
+		//I believe the designer might invoke this target manually
+		[Test]
+		public void UpdateDesignTimeXaml ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile (@"Pages\MainPage.xaml", "EmbeddedResource", Xaml.MainPage));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile, "UpdateDesignTimeXaml");
+
+			AssertExists (Path.Combine (intermediateDirectory, "Pages", "MainPage.xaml.g.cs"), nonEmpty: true);
+			AssertDoesNotExist (Path.Combine (intermediateDirectory, "XamlC.stamp"));
+		}
+
+		[Test]
+		public void AddNewFile ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile ("MainPage.xaml", "EmbeddedResource", Xaml.MainPage));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile);
+
+			var mainPageXamlG = Path.Combine (intermediateDirectory, "MainPage.xaml.g.cs");
+			var customViewXamlG = Path.Combine (intermediateDirectory, "CustomView.xaml.g.cs");
+			var xamlCStamp = Path.Combine (intermediateDirectory, "XamlC.stamp");
+			AssertExists (mainPageXamlG, nonEmpty: true);
+			AssertExists (xamlCStamp);
+
+			var expectedXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
+			var expectedXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
+
+			//Build again, after adding a file, this triggers a full XamlG and XamlC
+			project.Add (AddFile ("CustomView.xaml", "EmbeddedResource", Xaml.CustomView));
+			project.Save (projectFile);
+			Build (projectFile);
+			AssertExists (mainPageXamlG, nonEmpty: true);
+			AssertExists (customViewXamlG, nonEmpty: true);
+			AssertExists (xamlCStamp);
+
+			var actualXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
+			var actualXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
+			var actualNewFile = new FileInfo (customViewXamlG).LastAccessTimeUtc;
+			Assert.AreNotEqual (expectedXamlG, actualXamlG, $"Timestamps should *not* match for {mainPageXamlG}.");
+			Assert.AreNotEqual (expectedXamlG, actualNewFile, $"Timestamps should *not* match for {actualNewFile}.");
+			Assert.AreNotEqual (expectedXamlC, actualXamlC, $"Timestamps should *not* match for {xamlCStamp}.");
+		}
+
+		[Test]
+		public void TouchXamlFile ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile ("MainPage.xaml", "EmbeddedResource", Xaml.MainPage));
+			project.Add (AddFile ("CustomView.xaml", "EmbeddedResource", Xaml.CustomView));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile);
+
+			var mainPageXamlG = Path.Combine (intermediateDirectory, "MainPage.xaml.g.cs");
+			var customViewXamlG = Path.Combine (intermediateDirectory, "CustomView.xaml.g.cs");
+			var xamlCStamp = Path.Combine (intermediateDirectory, "XamlC.stamp");
+			AssertExists (mainPageXamlG, nonEmpty: true);
+			AssertExists (customViewXamlG, nonEmpty: true);
+			AssertExists (xamlCStamp);
+
+			var expectedMainPageXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
+			var expectedCustomViewXamlG = new FileInfo (customViewXamlG).LastWriteTimeUtc;
+			var expectedXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
+
+			//Build again, after modifying the timestamp on a Xaml file, should trigger a partial XamlG and full XamlC
+			//https://github.com/xamarin/xamarin-android/blob/61851599fb1999964bd200ec1c373b6e395933f3/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs#L342
+			File.SetLastWriteTimeUtc (customViewXamlG, expectedCustomViewXamlG.AddDays (1));
+			File.SetLastAccessTimeUtc (customViewXamlG, expectedCustomViewXamlG.AddDays (1));
+			Build (projectFile);
+			AssertExists (mainPageXamlG, nonEmpty: true);
+			AssertExists (customViewXamlG, nonEmpty: true);
+			AssertExists (xamlCStamp);
+
+			var actualMainPageXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
+			var actualCustomViewXamlG = new FileInfo (customViewXamlG).LastAccessTimeUtc;
+			var actualXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
+			Assert.AreEqual (expectedMainPageXamlG, actualMainPageXamlG, $"Timestamps should match for {mainPageXamlG}.");
+			Assert.AreNotEqual (expectedMainPageXamlG, actualCustomViewXamlG, $"Timestamps should *not* match for {actualCustomViewXamlG}.");
+			Assert.AreNotEqual (expectedXamlC, actualXamlC, $"Timestamps should *not* match for {xamlCStamp}.");
+		}
+
+		[Test]
+		public void RandomXml ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile ("MainPage.xaml", "EmbeddedResource", "<xml></xml>"));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile);
+
+			AssertExists (Path.Combine (intermediateDirectory, "test.dll"), nonEmpty: true);
+			AssertExists (Path.Combine (intermediateDirectory, "MainPage.xaml.g.cs"));
+			AssertExists (Path.Combine (intermediateDirectory, "XamlC.stamp"));
+		}
+
+		[Test, ExpectedException (typeof(AssertionException))]
+		public void InvalidXml ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile ("MainPage.xaml", "EmbeddedResource", "notxmlatall"));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile);
+		}
+
+		[Test]
+		public void RandomEmbeddedResource ([Values (false, true)] bool sdkStyle)
+		{
+			var project = NewProject (sdkStyle);
+			project.Add (AddFile ("MainPage.txt", "EmbeddedResource", "notxmlatall"));
+			var projectFile = Path.Combine (tempDirectory, "test.csproj");
+			project.Save (projectFile);
+			RestoreIfNeeded (projectFile, sdkStyle);
+			Build (projectFile);
+
+			AssertExists (Path.Combine (intermediateDirectory, "test.dll"), nonEmpty: true);
+			AssertDoesNotExist (Path.Combine (intermediateDirectory, "MainPage.txt.g.cs"));
+			AssertExists (Path.Combine (intermediateDirectory, "XamlC.stamp"));
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildXmlExtensions.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildXmlExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Xml.Linq;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	static class MSBuildXmlExtensions
+	{
+		static readonly XNamespace ns = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
+
+		public static XElement NewElement (string name) => new XElement (ns + name);
+
+		public static XElement WithAttribute (this XElement element, string name, object value)
+		{
+			element.SetAttributeValue (name, value);
+			return element;
+		}
+
+		public static XElement WithValue (this XElement element, object value)
+		{
+			element.SetValue (value);
+			return element;
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -36,12 +36,16 @@
     <NoWarn>0672;0219;0414</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build.Locator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Build.Locator.1.0.13\lib\net46\Microsoft.Build.Locator.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="Mono.Cecil">
       <HintPath>..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
@@ -109,6 +113,8 @@
       <DependentUpon>Bz41296.xaml</DependentUpon>
     </Compile>
     <Compile Include="LoaderTests.cs" />
+    <Compile Include="MSBuild\MSBuildTests.cs" />
+    <Compile Include="MSBuild\MSBuildXmlExtensions.cs" />
     <Compile Include="PlatformSpecifics.xaml.cs">
       <DependentUpon>PlatformSpecifics.xaml</DependentUpon>
     </Compile>
@@ -135,7 +141,7 @@
     <Compile Include="Issues\Issue1641.cs" />
     <Compile Include="Issues\Issue1594.cs" />
     <Compile Include="XamlgFileLockTests.cs" />
-    <Compile Include="DummyBuildEngine.cs" />
+    <Compile Include="MSBuild\DummyBuildEngine.cs" />
     <Compile Include="Issues\Issue1794.cs" />
     <Compile Include="StyleTests.xaml.cs">
       <DependentUpon>StyleTests.xaml</DependentUpon>
@@ -611,10 +617,8 @@
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('..\.nuspec\Xamarin.Forms.Build.Tasks.dll')" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
-  
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
       <Project>{57B8B73D-C3B5-4C42-869E-7B2F17D354AC}</Project>
@@ -1150,14 +1154,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="css\" />
-  </ItemGroup>
-  <ItemGroup />
-
-  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="VisualStateManagerTests.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>

--- a/Xamarin.Forms.Xaml.UnitTests/XamlgFileLockTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlgFileLockTests.cs
@@ -34,13 +34,13 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				BuildEngine= new DummyBuildEngine(),
 				AssemblyName = "test",
 				Language = "C#",
-				XamlFiles = new[] { item},
-				OutputPath = Path.GetDirectoryName(xamlInputFile),
+				XamlFiles = new[] { item },
+				OutputFiles = new[] { new TaskItem(xamlInputFile + ".g.cs") }
 			};
 
 			generator.Execute();
 
-			string xamlOutputFile = generator.GeneratedCodeFiles.First().ItemSpec;
+			string xamlOutputFile = generator.OutputFiles.First().ItemSpec;
 			File.Delete (xamlOutputFile);
 
 			Assert.DoesNotThrow (() => File.Delete (xamlInputFile));

--- a/Xamarin.Forms.Xaml.UnitTests/XamlgTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlgTests.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using Microsoft.Build.Framework;
 using NUnit.Framework;
-using System.IO;
 using System.CodeDom;
-using Xamarin.Forms.Build.Tasks;
-using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using Xamarin.Forms.Build.Tasks;
 
 using Xamarin.Forms.Core.UnitTests;
 
@@ -307,6 +306,24 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.That(generator.NamedFields.First(cmf => cmf.Name == "internalLabel").Attributes, Is.EqualTo(MemberAttributes.Assembly));
 				Assert.That(generator.NamedFields.First(cmf => cmf.Name == "publicLabel").Attributes, Is.EqualTo(MemberAttributes.Public));
 			}
+		}
+		
+		[Test]
+		public void XamlGDifferentInputOutputLengths ()
+		{
+			var engine = new DummyBuildEngine ();
+			var generator = new XamlGTask () {
+				BuildEngine = engine,
+				AssemblyName = "test",
+				Language = "C#",
+				XamlFiles = new ITaskItem [1],
+				OutputFiles = new ITaskItem [2],
+			};
+
+			Assert.IsFalse (generator.Execute (), "XamlGTask.Execute() should fail.");
+			Assert.AreEqual (1, engine.Errors.Count, "XamlGTask should have 1 error.");
+			var error = engine.Errors.First ();
+			Assert.AreEqual ("\"XamlFiles\" refers to 1 item(s), and \"OutputFiles\" refers to 2 item(s). They must have the same number of items.", error.Message);
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/app.config
+++ b/Xamarin.Forms.Xaml.UnitTests/app.config
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Mono.Cecil" publicKeyToken="0738eb9f132ed756" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-0.9.6.0" newVersion="0.9.6.0"/>
+        <assemblyIdentity name="Mono.Cecil" publicKeyToken="0738eb9f132ed756" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.9.6.0" newVersion="0.9.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" /></startup></configuration>

--- a/Xamarin.Forms.Xaml.UnitTests/packages.config
+++ b/Xamarin.Forms.Xaml.UnitTests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Build.Framework" version="15.5.180" targetFramework="net47" />
+  <package id="Microsoft.Build.Locator" version="1.0.13" targetFramework="net47" />
   <package id="Microsoft.Build.Tasks.Core" version="15.5.180" targetFramework="net47" />
   <package id="Microsoft.Build.Utilities.Core" version="15.5.180" targetFramework="net47" />
   <package id="Mono.Cecil" version="0.10.0-beta7" targetFramework="net47" />

--- a/Xamarin.Forms.Xaml.Xamlg/Xamlg.cs
+++ b/Xamarin.Forms.Xaml.Xamlg/Xamlg.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Forms.Xaml
 					AssemblyName = "test",
 					Language = "C#",
 					XamlFiles = new[] { item },
-					OutputPath = Path.GetDirectoryName(f),
+					OutputFiles = new[] { new TaskItem(f + ".g.cs") }
 				};
 
 


### PR DESCRIPTION
Context: https://github.com/xamarin/Xamarin.Forms/pull/2230

The main performance problem with the collection of MSBuild targets in
`Xamarin.Forms.targets` is they don't build incrementally. I addressed
this with `XamlC` using a "stamp" file; however, it is not quite so
easy to setup the same thing with `XamlG`.

They way "incremental" builds are setup in MSBuild, is by specifying
the `Inputs` and `Outputs` of a `<Target />`. MSBuild will partially
build a target when some outputs are not up to date, and skip it
entirely if they are all up to date.

The best docs I can find on MSBuild incremental builds:
https://msdn.microsoft.com/en-us/library/ms171483.aspx

Unfortunately a few things had to happen to make this work for
`XamlG`:
- Define a new target `_FindXamlGFiles` that is invoked before `XamlG`
- `_FindXamlGFiles` defines the `_XamlGInputs` and `_XamlGOutputs`
  `<ItemGroup />`'s
- `_FindXamlGFiles` must also define `<Compile />` and `<FileWrites />`,
  in case the `XamlG` target is skipped
- `XamlGTask` now needs to get passed in a list of `OutputFiles`,
  since we have computed these paths ahead of time
- `XamlGTask` should validate the lengths of `XamlFiles` and
  `OutputFiles` match, used error message from MSBuild proper:
  https://github.com/Microsoft/msbuild/blob/a691a44f0e515e9a03ede8df0bff22185681c8b9/src/Tasks/Copy.cs#L505

`XamlG` now builds incrementally!

To give some context on how much improvement we can see with build
times, consider the following command:

    msbuild Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj

If you run it once, it will take a while--this change will not improve
the first build. On the second build with the exact same command, it
*should* be much faster.

Before this commit, the second build on my machine takes:

    40.563s

After the change:

    23.692s

`XamlG` has cascading impact on build times when it isn't built
incrementally:
- The C# assembly always changes
- Hence, `XamlC` will always run
- Hence, `GenerateJavaStubs` will always run
- Hence, `javac.exe` and `dx.jar` will always run

I am making other improvements like this in Xamarin.Android itself,
that will further improve these times, such as:
https://github.com/xamarin/xamarin-android/pull/1693

~~ New MSBuild Integration Tests ~~

Added some basic MSBuild testing infrastructure:
- Tests write project files to `bin/Debug/temp/TestName`
- Each test has an `sdkStyle` flag for testing the new project system
  versus the old one
- `[TearDown]` deletes the entire directory, with a retry for
  `IOException` on Windows
- Used the `Microsoft.Build.Locator` NuGet package for locating
  `MSBuild.exe` on Windows
- These tests take 2-5 seconds each

So for example, the simplest test, `BuildAProject` writes to
`Xamarin.Forms.Xaml.UnitTests\bin\Debug\temp\BuildAProject(False)\test.csproj`:

    <?xml version="1.0" encoding="utf-8"?>
    <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
      <PropertyGroup>
        <Configuration>Debug</Configuration>
        <Platform>AnyCPU</Platform>
        <OutputType>Library</OutputType>
        <OutputPath>bin\Debug</OutputPath>
        <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
      </PropertyGroup>
      <ItemGroup>
        <Reference Include="mscorlib" />
        <Reference Include="System" />
        <Reference Include="Xamarin.Forms.Core.dll">
          <HintPath>..\..\Xamarin.Forms.Core.dll</HintPath>
        </Reference>
        <Reference Include="Xamarin.Forms.Xaml.dll">
          <HintPath>..\..\Xamarin.Forms.Xaml.dll</HintPath>
        </Reference>
      </ItemGroup>
      <ItemGroup>
        <Compile Include="AssemblyInfo.cs" />
      </ItemGroup>
      <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
      <Import Project="..\..\..\..\..\.nuspec\Xamarin.Forms.targets" />
      <ItemGroup>
        <EmbeddedResource Include="MainPage.xaml" />
      </ItemGroup>
    </Project>

Invokes `msbuild`, and checks the intermediate output for files being
generated.

Tested scenarios:
- Build a simple project
- Build, then build again, and make sure targets were skipped
- Build, then clean, make sure files are gone
- Build, with linked files
- Design-time build
- Call `UpdateDesignTimeXaml` directly
- Build, add a new file, build again
- Build, update timestamp on a file, build again
- XAML file with random XML content
- XAML file with invalid XML content
- A general `EmbeddedResource` that shouldn't go through XamlG

Adding these tests found a bug! `IncrementalClean` was deleting
`XamlC.stamp`. I fixed this by using `<ItemGroup />`, which will be
propery evaluated even if the target is skipped.

~~ Other Changes ~~

- `FilesWrite` is actually supposed to be `FileWrites`, see canonical
  source of how `Clean` works and what `FileWrites` is here:
  https://github.com/Microsoft/msbuild/issues/2408#issuecomment-321082997
- Moved `DummyBuildEngine` into `MSBuild` directory--makes sense?
  maybe don't need to?
- Added a `XamlGDifferentInputOutputLengths` test to check the error
  message
- Expanded `DummyBuildEngine` so you can assert against log messages
- Changed a setting in `.Xamarin.Forms.Android.sln` so the unit test
  project is built
- My VS IDE monkeyed with a few files, and I kept any *good* (or
  relevant) changes: `Xamarin.Forms.UnitTests.csproj`,
  `Xamarin.Forms.Xaml.UnitTests\app.config`, etc.

There were some checks for `%(TargetPath)` being blank in the C# code
of `XamlGTask`. In that case it was using `Path.GetRandomFileName`,
but we can't do this if we are setting up inputs and outputs for
`XamlG`. I presume this is from the designer and/or design-time builds
before `DependsOnTargets="PrepareResourceNames"` was added. I tested
design-time builds in VS on Windows, and `$(TargetPath)` was set. To
be sure we don't break anything here, I exclude inputs to `XamlG` if
`%(TargetPath)` is somehow blank.

See relevant MSBuild code for `%(TargetPath)` here:

https://github.com/Microsoft/msbuild/blob/05151780901c38b4613b2f236ab8b091349dbe94/src/Tasks/Microsoft.Common.CurrentVersion.targets#L2822

~~ Future changes ~~

CssG needs the exact same setup, as it was patterned after `XamlG`.
This should probably be done in a future PR.

### Description of Change ###

Describe your changes here.

### Bugs Fixed ###

- Provide links to bugs here

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
