### PR TITLE
Support default value for value types in BindableProperty

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindablePropertyUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindablePropertyUnitTests.cs
@@ -148,5 +148,49 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (1, bindable.GetValue (prop));
 		}
 
+		enum TestEnum
+		{
+			One,Two,Three
+		}
+
+		[Test]
+		public void EnumPropertyDefaultValue ()
+		{
+			// Create BindableProperty without explicit default value
+			var prop = BindableProperty.Create ("foo", typeof(TestEnum), typeof(MockBindable));
+			Assert.AreEqual (typeof(TestEnum), prop.ReturnType);
+
+			Assert.AreEqual(prop.DefaultValue, default(TestEnum));
+
+			var bindable = new MockBindable ();
+			Assert.AreEqual (default(TestEnum), bindable.GetValue (prop));
+
+			bindable.SetValue (prop, TestEnum.Two);
+			Assert.AreEqual (TestEnum.Two, bindable.GetValue (prop));
+		}
+
+		struct TestStruct
+		{
+			public int IntValue;
+		}
+
+		[Test]
+		public void StructPropertyDefaultValue ()
+		{
+			// Create BindableProperty without explicit default value
+			var prop = BindableProperty.Create ("foo", typeof(TestStruct), typeof(MockBindable));
+			Assert.AreEqual (typeof(TestStruct), prop.ReturnType);
+
+			Assert.AreEqual(((TestStruct)prop.DefaultValue).IntValue, default(int));
+
+			var bindable = new MockBindable ();
+			Assert.AreEqual (default(int), ((TestStruct)bindable.GetValue (prop)).IntValue);
+
+			var propStruct = new TestStruct {IntValue = 1};
+
+			bindable.SetValue (prop, propStruct);
+			Assert.AreEqual (1, ((TestStruct)bindable.GetValue (prop)).IntValue);
+		}
+
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/BindablePropertyUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindablePropertyUnitTests.cs
@@ -131,5 +131,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			bindable.SetValue (prop, null);
 			Assert.AreEqual (null, bindable.GetValue (prop));
 		}
+
+		[Test]
+		public void ValueTypePropertyDefaultValue ()
+		{
+			// Create BindableProperty without explicit default value
+			var prop = BindableProperty.Create ("foo", typeof(int), typeof(MockBindable));
+			Assert.AreEqual (typeof(int), prop.ReturnType);
+
+			Assert.AreEqual(prop.DefaultValue, 0);
+
+			var bindable = new MockBindable ();
+			Assert.AreEqual (0, bindable.GetValue (prop));
+
+			bindable.SetValue (prop, 1);
+			Assert.AreEqual (1, bindable.GetValue (prop));
+		}
+
 	}
 }

--- a/Xamarin.Forms.Core/BindableProperty.cs
+++ b/Xamarin.Forms.Core/BindableProperty.cs
@@ -68,10 +68,13 @@ namespace Xamarin.Forms
 			// don't use Enum.IsDefined as its redonkulously expensive for what it does
 			if (defaultBindingMode != BindingMode.Default && defaultBindingMode != BindingMode.OneWay && defaultBindingMode != BindingMode.OneWayToSource && defaultBindingMode != BindingMode.TwoWay && defaultBindingMode != BindingMode.OneTime)
 				throw new ArgumentException("Not a valid type of BindingMode", "defaultBindingMode");
+			
 			if (defaultValue == null && Nullable.GetUnderlyingType(returnType) == null && returnType.GetTypeInfo().IsValueType)
-				throw new ArgumentException("Not a valid default value", "defaultValue");
+				defaultValue = Activator.CreateInstance(returnType);
+
 			if (defaultValue != null && !returnType.IsInstanceOfType(defaultValue))
 				throw new ArgumentException("Default value did not match return type", "defaultValue");
+
 			if (defaultBindingMode == BindingMode.Default)
 				defaultBindingMode = BindingMode.OneWay;
 


### PR DESCRIPTION
According to the [documentation](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/xaml/bindable-properties), when no default value is provided in a call to BindableProperty.Create(), it will use the default value of the property type. However, this is not how it behaves for value types. When no explicit default value is provided for a value type property, an exception will be thrown.

### Description of Change ###

When a BindableProperty is created for a value type and the default value is null, the default value will be set to the default for the type.

### API Changes ###

No API changes

### Behavioral Changes ###

BindableProperty.Create() will no longer throw an exception when no default value is provided and the property type is a value type. The default value will be the default value for the property type.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
