### PR TITLE
Use GestureDetector constructor that takes in Context since the one without it is going to be deprecated

### DIFF
--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -90,12 +90,12 @@ namespace Xamarin.Forms.Platform.Android
 						return _longPressGestureDetector;
 					}
 
-					_longPressGestureDetector = new GestureDetector(new LongPressGestureListener(TriggerLongClick));
+					_longPressGestureDetector = new GestureDetector(Context, new LongPressGestureListener(TriggerLongClick));
 					return _longPressGestureDetector;
 				}
 			}
 
-			public ViewCellContainer(Context context, IVisualElementRenderer view, ViewCell viewCell, View parent, 
+			public ViewCellContainer(Context context, IVisualElementRenderer view, ViewCell viewCell, View parent,
 				BindableProperty unevenRows, BindableProperty rowHeight) : base(context)
 			{
 				_view = view;
@@ -127,7 +127,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (!Enabled)
 					return true;
-				
+
 				return base.OnInterceptTouchEvent(ev);
 			}
 
@@ -253,13 +253,13 @@ namespace Xamarin.Forms.Platform.Android
 				// to conflict with one another - the Tap Gesture handling will prevent the ListViewAdapter's
 				// LongClick handling from happening. So we need to watch locally for LongPress and if we see it,
 				// trigger the LongClick manually.
-				_watchForLongPress = _viewCell.ContextActions.Count > 0 
+				_watchForLongPress = _viewCell.ContextActions.Count > 0
 					&& HasTapGestureRecognizers(vw);
 			}
 
 			static bool HasTapGestureRecognizers(View view)
 			{
-				return view.GestureRecognizers.Any(t => t is TapGestureRecognizer) 
+				return view.GestureRecognizers.Any(t => t is TapGestureRecognizer)
 					|| view.LogicalChildren.OfType<View>().Any(HasTapGestureRecognizers);
 			}
 
@@ -303,7 +303,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				public void OnShowPress(MotionEvent e)
 				{
-					
+
 				}
 
 				public bool OnSingleTapUp(MotionEvent e)


### PR DESCRIPTION
### Description of Change ###

The constructor for *GestureDetector* that doesn't take Context is going to be deprecated. This switches to a constructor that won't be


### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
