### PR TITLE
[UWP] Fixes returning an incorrect index of Cell if the list contains duplicate items

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2617.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2617.cs
@@ -1,0 +1,90 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2617, "Error on binding ListView with duplicated items", PlatformAffected.UWP)]
+	public class Issue2617 : TestContentPage
+	{
+		class MyHeaderViewCell : ViewCell
+		{
+			public MyHeaderViewCell()
+			{
+				Height = 25;
+				var label = new Label { VerticalOptions = LayoutOptions.Center };
+				label.SetBinding(Label.TextProperty, nameof(GroupedItem.Name));
+				View = label;
+			}
+		}
+
+		class GroupedItem: List<string>
+		{
+			public GroupedItem()
+			{
+				AddRange(Enumerable.Range(0, 3).Select(i => "Group item"));
+			}
+			public string Name { get; set; }
+		}
+
+		protected override void Init()
+		{
+			var listView = new ListView
+			{
+				ItemsSource = Enumerable.Range(0, 3).Select(x => "Item 1"),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					Label nameLabel = new Label();
+					nameLabel.SetBinding(Label.TextProperty, new Binding("."));
+					var cell = new ViewCell
+					{
+						View = new Frame()
+						{
+							Content = nameLabel
+						},
+					};
+					return cell;
+				})
+			};
+			var listViewIsGrooped = new ListView
+			{
+				ItemsSource = Enumerable.Range(0, 3).Select(x => new GroupedItem() { Name = $"Group {x}" }),
+				IsGroupingEnabled = true,
+				GroupHeaderTemplate = new DataTemplate(typeof(MyHeaderViewCell)),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					Label nameLabel = new Label();
+					nameLabel.SetBinding(Label.TextProperty, new Binding("."));
+					var cell = new ViewCell
+					{
+						View = new Frame()
+						{
+							Content = nameLabel
+						},
+					};
+					return cell;
+				})
+			};
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Button()
+					{
+						Text = "Send one million same items to ItemsSource",
+						Command = new Command(() => listView.ItemsSource = Enumerable.Range(0, 1000000).Select(x => "Item 1"))
+					},
+					new Button()
+					{
+						Text = "Clear ItemsSource",
+						Command = new Command(() => listView.ItemsSource = null)
+					},
+					listView,
+					listViewIsGrooped
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -242,6 +242,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ViewHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1396.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1415.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2617.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2653.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2247.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GroupListViewHeaderIndexOutOfRange.cs" />

--- a/Xamarin.Forms.Core/IListProxy.cs
+++ b/Xamarin.Forms.Core/IListProxy.cs
@@ -9,5 +9,6 @@ namespace Xamarin.Forms
 		event NotifyCollectionChangedEventHandler CollectionChanged;
 		IEnumerable ProxiedEnumerable { get; }
 		bool TryGetValue(int index, out object value);
+		bool HasCollisions(object item);
 	}
 }

--- a/Xamarin.Forms.Core/ListProxy.cs
+++ b/Xamarin.Forms.Core/ListProxy.cs
@@ -65,18 +65,15 @@ namespace Xamarin.Forms
 		{
 			if (item == null || ProxiedEnumerable == null)
 				return false;
-#if NETSTANDARD1_0
-			if (!(item is string))
-				return false;
-#else
-			var itemType = item.GetType();
-			var isValueType = item is string || itemType.IsValueType || itemType.IsEnum;
+#if !NETSTANDARD1_0
+			Type itemType = item.GetType();
+			bool isValueType = item is string || itemType.IsValueType || itemType.IsEnum;
 			if (!isValueType)
 				return false;
 #endif
 			int count = 0;
-
-			foreach (var current in ProxiedEnumerable)
+			int index = 0;
+			while (TryGetValue(index++, out object current))
 			{
 				if (current.Equals(item) && ++count > 1)
 				{

--- a/Xamarin.Forms.Core/ListProxy.cs
+++ b/Xamarin.Forms.Core/ListProxy.cs
@@ -59,6 +59,44 @@ namespace Xamarin.Forms
 		}
 
 		/// <summary>
+		/// If context is value type like as `string` possible conflict between equals elements.
+		/// </summary>
+		public bool HasCollisions(object item)
+		{
+			if (item == null || ProxiedEnumerable == null)
+				return false;
+#if NETSTANDARD1_0
+			if (!(item is string))
+				return false;
+#else
+			var itemType = item.GetType();
+			var isValueType = item is string || itemType.IsValueType || itemType.IsEnum;
+			if (!isValueType)
+				return false;
+#endif
+			int count = 0;
+
+			foreach (var current in ProxiedEnumerable)
+			{
+				if (current.Equals(item) && ++count > 1)
+				{
+					return true;
+				}
+				else if (current is IEnumerable _group)
+				{
+					foreach (var _grItem in _group)
+					{
+						if (_grItem.Equals(item) && ++count > 1)
+						{
+							return true;
+						}
+					}
+				}
+			}
+			return false;
+		}
+
+		/// <summary>
 		///     Gets whether or not the current window contains the <paramref name="item" />.
 		/// </summary>
 		/// <param name="item">The item to search for.</param>

--- a/Xamarin.Forms.Core/TemplatedItemsList.cs
+++ b/Xamarin.Forms.Core/TemplatedItemsList.cs
@@ -337,6 +337,8 @@ namespace Xamarin.Forms.Internals
 			get { return GetOrCreateContent(index, ListProxy[index]); }
 		}
 
+		public bool HasCollisions(object item) => ListProxy.HasCollisions(item);
+
 		public int GetDescendantCount()
 		{
 			if (!IsGroupingEnabled)

--- a/Xamarin.Forms.Platform.UAP/CellControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CellControl.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Platform.UWP
 			_propertyChangedHandler = OnCellPropertyChanged;
 		}
 
-		public Cell Cell		
+		public Cell Cell
 		{
 			get { return (Cell)GetValue(CellProperty); }
 			set { SetValue(CellProperty, value); }
@@ -222,15 +222,23 @@ namespace Xamarin.Forms.Platform.UWP
 
 				if (template != null)
 				{
-					if (lv.IsGroupingEnabled)
+					// if there are several such elements, it is impossible to know the index of the element.
+					if (lv.TemplatedItems.HasCollisions(newContext))
 					{
-						cell = isGroupHeader 
-							? RealizeGroupedHeaderTemplate(lv.TemplatedItems, template, newContext) 
-							: RealizeGroupedItemTemplate(lv.TemplatedItems, template, newContext);
+						cell = template.CreateContent() as Cell;
 					}
 					else
 					{
-						cell = RealizeItemTemplate(lv.TemplatedItems, template, newContext);
+						if (lv.IsGroupingEnabled)
+						{
+							cell = isGroupHeader
+								? RealizeGroupedHeaderTemplate(lv.TemplatedItems, template, newContext)
+								: RealizeGroupedItemTemplate(lv.TemplatedItems, template, newContext);
+						}
+						else
+						{
+							cell = RealizeItemTemplate(lv.TemplatedItems, template, newContext);
+						}
 					}
 				}
 				else


### PR DESCRIPTION
### Description of Change

Added check for collision of items in `ListProxy`.

### Bugs Fixed

Fixes #2486
Fixes #2617

### API Changes

None

### Behavioral Changes

Check for duplicating value type elements when obtaining an index.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense