### PR TITLE
 [iOS] Correct encoding in WebViewRenderer.LoadUrl

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -12,15 +12,54 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 1583, "WebView fails to load from urlwebviewsource with non-ascii characters (works with Uri)", PlatformAffected.iOS, issueTestNumber: 1)]
 	public class Issue1583 : TestContentPage
 	{
+		WebView _webview;
+		Label _label;
+
 		protected override void Init()
 		{
-			var webview = new WebView
+			_webview = new WebView
 			{
 				AutomationId = "webview"	
 			};
-			webview.Source = new UrlWebViewSource { Url = "https://www.google.no/maps/place/Skøyen" };
+			_label = new Label();
 
-			Content = webview;
+			var hashButton = new Button { Text = "1:hash", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "hashButton" };
+			hashButton.Clicked += (sender, args) => Load("https://github.com/xamarin/Xamarin.Forms/issues/2736#issuecomment-389443737");
+
+			var unicodeButton = new Button { Text = "2:unicode", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "unicodeButton" };
+			unicodeButton.Clicked += (sender, args) => Load("https://www.google.no/maps/place/Skøyen");
+
+			var queryButton = new Button { Text = "3:query", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "queryButton" };
+			queryButton.Clicked += (sender, args) => Load("https://www.google.com/search?q=http%3A%2F%2Fmicrosoft.com");
+
+			var punycodeButton = new Button { Text = "4:punycode", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "punycodeButton" };
+			punycodeButton.Clicked += (sender, args) => Load("http://δπθ.gr");
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					_label,
+					new StackLayout
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children = { unicodeButton, hashButton, punycodeButton, queryButton }
+					},
+					_webview
+				}
+			};
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			Load("https://www.google.no/maps/place/Skøyen");
+		}
+
+		void Load(string url)
+		{
+			_webview.Source = new UrlWebViewSource { Url = url };
+			_label.Text = $"Loaded {url}";
 		}
 
 #if UITEST
@@ -29,6 +68,12 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement (q => q.Marked ("webview"), "Could not find webview", System.TimeSpan.FromSeconds(60), null, null);
 			RunningApp.Screenshot ("I didn't crash and i can see Skøyen");
+			RunningApp.Tap("hashButton");
+			RunningApp.Screenshot ("I didn't crash and i can see the GitHub comment #issuecomment-389443737");
+			RunningApp.Tap("punycodeButton");
+			RunningApp.Screenshot ("I didn't crash and i can see the punycode website");
+			RunningApp.Tap("queryButton");
+			RunningApp.Screenshot ("I didn't crash and i can see google search for http://microsoft.com");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -2,7 +2,8 @@
 using Xamarin.Forms.Internals;
 
 #if UITEST
-using Xamarin.UITest;
+using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 #endif
 
@@ -21,7 +22,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				AutomationId = "webview"	
 			};
-			_label = new Label();
+			_label = new Label { AutomationId = "label" };
 
 			var hashButton = new Button { Text = "1:hash", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "hashButton" };
 			hashButton.Clicked += (sender, args) => Load("https://github.com/xamarin/Xamarin.Forms/issues/2736#issuecomment-389443737");
@@ -32,9 +33,6 @@ namespace Xamarin.Forms.Controls.Issues
 			var queryButton = new Button { Text = "3:query", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "queryButton" };
 			queryButton.Clicked += (sender, args) => Load("https://www.google.com/search?q=http%3A%2F%2Fmicrosoft.com");
 
-			var punycodeButton = new Button { Text = "4:punycode", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "punycodeButton" };
-			punycodeButton.Clicked += (sender, args) => Load("http://δπθ.gr");
-
 			Content = new StackLayout
 			{
 				Children =
@@ -43,7 +41,7 @@ namespace Xamarin.Forms.Controls.Issues
 					new StackLayout
 					{
 						Orientation = StackOrientation.Horizontal,
-						Children = { unicodeButton, hashButton, punycodeButton, queryButton }
+						Children = { hashButton, unicodeButton, queryButton }
 					},
 					_webview
 				}
@@ -64,15 +62,16 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue1583Test ()
+		public async Task Issue1583Test ()
 		{
-			RunningApp.WaitForElement (q => q.Marked ("webview"), "Could not find webview", System.TimeSpan.FromSeconds(60), null, null);
+			RunningApp.WaitForElement (q => q.Marked ("label"), "Could not find label", TimeSpan.FromSeconds(10), null, null);
+			await Task.Delay(TimeSpan.FromSeconds(3));
 			RunningApp.Screenshot ("I didn't crash and i can see Skøyen");
 			RunningApp.Tap("hashButton");
+			await Task.Delay(TimeSpan.FromSeconds(3));
 			RunningApp.Screenshot ("I didn't crash and i can see the GitHub comment #issuecomment-389443737");
-			RunningApp.Tap("punycodeButton");
-			RunningApp.Screenshot ("I didn't crash and i can see the punycode website");
 			RunningApp.Tap("queryButton");
+			await Task.Delay(TimeSpan.FromSeconds(3));
 			RunningApp.Screenshot ("I didn't crash and i can see google search for http://microsoft.com");
 		}
 #endif

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Internals;
+using Uri = System.Uri;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -79,8 +80,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public void LoadUrl(string url)
 		{
-			var encodedStringUrl = new NSString(url).CreateStringByAddingPercentEscapes(NSStringEncoding.UTF8);
-			LoadRequest(new NSUrlRequest(new NSUrl(encodedStringUrl)));
+			var uri = new Uri(url);
+			var safeHostUri = new Uri($"{uri.Scheme}://{uri.IdnHost}", UriKind.Absolute);
+			var safeRelativeUri = new Uri($"{uri.PathAndQuery}{uri.Fragment}", UriKind.Relative);
+			LoadRequest(new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri)));
 		}
 
 		public override void LayoutSubviews()


### PR DESCRIPTION
### Description of Change

In WebViewRenderer.LoadUrl, the given string was encoded regardless how the url was structured or if it was already encoded. This commit fixes it by parsing the string as System.Uri and using IdnHost and the existing implicit operator from Uri to NSUrl which has the correct encoding mechanism.

The following URI structures were not accessible but are again after these changes:
1. Fragments (hashes) e.g. http://example.com/page#anchor
2. Queries with encoding e.g. https://www.google.com/search?q=http%3A%2F%2Fmicrosoft.com

### Bugs Fixed

fixes #2736

### API Changes

None

### Behavioral Changes

The app will not crash when a host name with unicode characters is navigated.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense