### PR TITLE
[Android] Keep track of created ConditionalFocusLayouts so they can all be disposed of

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -23,6 +23,8 @@ using Android.Text;
 using Android.Text.Method;
 using Xamarin.Forms.Controls.Issues;
 
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Effects.AttachedStateEffectLabel), typeof(AttachedStateEffectLabelRenderer))]
 [assembly: ExportRenderer(typeof(Bugzilla31395.CustomContentView), typeof(CustomContentRenderer))]
 [assembly: ExportRenderer(typeof(NativeListView), typeof(NativeListViewRenderer))]
 [assembly: ExportRenderer(typeof(NativeListView2), typeof(NativeAndroidListViewRenderer))]
@@ -45,6 +47,23 @@ using Xamarin.Forms.Controls.Issues;
 #endif
 namespace Xamarin.Forms.ControlGallery.Android
 {
+	public class AttachedStateEffectLabelRenderer : LabelRenderer
+	{
+		public AttachedStateEffectLabelRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			foreach(var effect in Element.Effects.OfType<Controls.Effects.AttachedStateEffect>())
+			{
+				effect.Detached(Element);
+			}
+
+			base.Dispose(disposing);
+		}
+	}
+
 	public class NativeDroidMasterDetail : Xamarin.Forms.Platform.Android.AppCompat.MasterDetailPageRenderer
 	{
 		MasterDetailPage _page;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects/AttachedStateEffectLabel.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects/AttachedStateEffectLabel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Effects
+{
+	[Preserve(AllMembers = true)]
+	public class AttachedStateEffectLabel : Label
+	{
+		// Android renderers don't detach effects when the renderers get disposed
+		// so this is a hack setup to detach those effects when testing if dispose is called from a renderer
+		// https://github.com/xamarin/Xamarin.Forms/issues/2520
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects/AttachedStateEffectList.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Effects/AttachedStateEffectList.cs
@@ -41,7 +41,6 @@ namespace Xamarin.Forms.Controls.Effects
 				{
 					item.StateChanged -= AttachedStateEffectStateChanged;
 				}
-
 			}
 		}
 
@@ -54,7 +53,9 @@ namespace Xamarin.Forms.Controls.Effects
 			foreach (AttachedStateEffect item in this)
 			{
 				allAttached &= item.State == AttachedStateEffect.AttachedState.Attached;
-				allDetached &= item.State == AttachedStateEffect.AttachedState.Detached;
+
+				if (item.State != AttachedStateEffect.AttachedState.Unknown)
+					allDetached &= item.State == AttachedStateEffect.AttachedState.Detached;
 			}
 
 			if (allAttached)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2829.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2829.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using Xamarin.Forms.Controls.Effects;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2829, "[Android] Renderers associated with ListView cells are occasionaly not being disposed of which causes left over events to propagate to disposed views",
+		PlatformAffected.Android)]
+	public class Issue2829 : TestNavigationPage
+	{
+		AttachedStateEffectList attachedStateEffectList = new AttachedStateEffectList();
+		const string kScrollMe = "kScrollMe";
+		const string kSuccess = "SUCCESS";
+		const string kCreateListViewButton = "kCreateListViewButton";
+		StackLayout layout = null;
+
+		protected override void Init()
+		{
+			var label = new Label() { Text = "Click the button then click back" };
+
+			layout = new StackLayout()
+			{
+				Children =
+					{
+						label,
+						new Button()
+						{
+							AutomationId = kCreateListViewButton,
+							Text    = "Create ListView",
+							Command = new Command(() =>
+							{
+								attachedStateEffectList.ToList().ForEach(x=> attachedStateEffectList.Remove(x));
+								label.Text = "FAILURE";
+								Navigation.PushAsync(CreateListViewPage());
+							})
+						}
+					}
+			};
+
+			var page = new ContentPage()
+			{
+				Content = layout
+			};
+
+
+			PushAsync(page);
+			attachedStateEffectList.AllEventsDetached += (_, __) =>
+			{
+				label.Text = kSuccess;
+			};
+		}
+
+		ListView CreateListView()
+		{
+			ListView view = new ListView(ListViewCachingStrategy.RecycleElement);
+			view.ItemTemplate = new DataTemplate(() =>
+			{
+				ViewCell cell = new ViewCell();
+				AttachedStateEffectLabel label = new AttachedStateEffectLabel();
+				label.TextColor = Color.Black;
+				label.BackgroundColor = Color.White;
+				label.SetBinding(Label.TextProperty, "Text");
+				attachedStateEffectList.Add(label);
+				label.BindingContextChanged += (_, __) =>
+				{
+					if (label.AutomationId == null)
+						label.AutomationId = ((Data)label.BindingContext).Text.ToString();
+				};
+
+				cell.View = new ContentView()
+				{
+					Content = new StackLayout()
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							label,
+							new Image{ Source = "coffee.png"}
+						}
+					},
+					HeightRequest = 40
+				};
+
+				return cell;
+			});
+			var data = new ObservableCollection<Data>(Enumerable.Range(0, 72).Select(index => new Data() { Text = index.ToString() }));
+			view.ItemsSource = data;
+
+			return view;
+		}
+
+		Page CreateListViewPage()
+		{
+			var view = CreateListView();
+			var data = view.ItemsSource as ObservableCollection<Data>;
+
+			Button scrollMe = new Button()
+			{
+				Text = "Scroll ListView",
+				AutomationId = kScrollMe,
+				Command = new Command(() =>
+				{
+					view.ScrollTo(data.Last(), ScrollToPosition.MakeVisible, true);
+				})
+			};
+
+			return new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children = { scrollMe, view }
+				}
+			};
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Data : INotifyPropertyChanged
+		{
+			private string _text;
+
+			public string Text
+			{
+				get => _text;
+				set
+				{
+					_text = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Text)));
+				}
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+		}
+
+#if UITEST
+		[Test]
+		public void ViewCellsAllDisposed()
+		{
+			RunningApp.Tap(kCreateListViewButton);
+			RunningApp.WaitForElement("0");
+			RunningApp.Tap(kScrollMe);
+			RunningApp.WaitForElement("70");
+			RunningApp.Back();
+			RunningApp.WaitForElement(kSuccess);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -238,6 +238,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59457.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffect.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2767.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
@@ -249,6 +250,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1705_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1396.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1415.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2829.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2653.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2247.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GroupListViewHeaderIndexOutOfRange.cs" />


### PR DESCRIPTION
### Description of Change

Currently _DisposeCells_ only iterates using GetChildAt which will only return visible cells. When you would scroll a listview this would cause a cell to not be visible and would thus return NULL for GetChildAt but the ConditionalFocusLayout would still exist in memory. This fix keeps track of created Layouts in an internal list to ensure that all resources get disposed of

I can't say for sure if this is the only cause of https://github.com/xamarin/Xamarin.Forms/issues/2829 but it definitely fixes a case where Dispose wasn't being called for a given cell.  

### Bugs Fixed

fixes #2829

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense