### PR TITLE
[iOS] Fix secondary toolbaritems

### DIFF
--- a/Xamarin.Forms.Controls/ControlGalleryPages/ToolbarItems.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/ToolbarItems.cs
@@ -41,12 +41,21 @@ namespace Xamarin.Forms.Controls
 			tb4.Text = "tb4";
 			tb4.Order = ToolbarItemOrder.Secondary;
 			tb4.Command = command;
+			tb4.Icon = "coffee";
 			tb4.AutomationId = "toolbaritem_secondary2";
+
+			var tb5 = new ToolbarItem();
+			tb5.Text = "tb5";
+			tb5.Icon = "bank.png";
+			tb5.Order = ToolbarItemOrder.Secondary;
+			tb5.Command = command;
+			tb5.AutomationId = "toolbaritem_secondary5";
 
 			ToolbarItems.Add(tb1);
 			ToolbarItems.Add(tb2);
 			ToolbarItems.Add(tb3);
 			ToolbarItems.Add(tb4);
+			ToolbarItems.Add(tb5);
 
 			Content = new StackLayout
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -765,6 +765,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		class SecondaryToolbar : UIToolbar
 		{
+			nfloat _toolbarWidth;
+
 			readonly List<UIView> _lines = new List<UIView>();
 
 			public SecondaryToolbar()
@@ -792,6 +794,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			void LayoutToolbarItems(nfloat toolbarWidth, nfloat toolbarHeight, nfloat padding)
 			{
+				if (_toolbarWidth == toolbarWidth)
+					return;
+
+				_toolbarWidth = toolbarWidth;
+
 				var x = padding;
 				var y = 0;
 				var itemH = toolbarHeight;


### PR DESCRIPTION
### Description of Change ###

Don't redraw the toolbaritems if the available size didn't change,. Seems LayoutSubviews is called more times on IOS10 and our code was setting the frame of the buttons after they were layout with the correct size.

### Bugs Fixed ###

- fixes #2798 

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
