### PR TITLE
[UWP,iOS] Enable screen readers to read non-interactive elements

### DIFF
--- a/Xamarin.Forms.Controls/ControlGalleryPages/AutomationPropertiesGallery.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/AutomationPropertiesGallery.cs
@@ -91,10 +91,6 @@ namespace Xamarin.Forms.Controls
 			image.GestureRecognizers.Add(new TapGestureRecognizer { Command = new Command(() => DisplayAlert("Success", "You tapped the image", "OK")) });
 			image.SetAutomationPropertiesName(ImageName);
 			image.SetAutomationPropertiesHelpText(ImageHelpText);
-			// Images are ignored by default on iOS (at least, Forms Images are); 
-			// make accessible in order to enable the gesture and narration
-			image.SetAutomationPropertiesIsInAccessibleTree(true);
-
 
 			var instructions6 = new Label { Text = boxInstructions };
 			var boxView = new BoxView { Color = Color.Purple };
@@ -102,7 +98,7 @@ namespace Xamarin.Forms.Controls
 			boxView.GestureRecognizers.Add(new TapGestureRecognizer { Command = new Command(() => DisplayAlert("Success", "You tapped the box", "OK")) });
 			boxView.SetAutomationPropertiesName(BoxName);
 			boxView.SetAutomationPropertiesHelpText(BoxHelpText);
-			// BoxViews are ignored by default on iOS and Win; 
+			// BoxViews are ignored by default on Win; 
 			// make accessible in order to enable the gesture and narration
 			boxView.SetAutomationPropertiesIsInAccessibleTree(true);
 

--- a/Xamarin.Forms.Platform.UAP/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/LabelRenderer.cs
@@ -35,16 +35,20 @@ namespace Xamarin.Forms.Platform.UWP
 		SizeRequest _perfectSize;
 		bool _perfectSizeValid;
 
-		protected override AutomationPeer OnCreateAutomationPeer()
-		{
-			// We need an automation peer so we can interact with this in automated tests
-			if (Control == null)
-			{
-				return new FrameworkElementAutomationPeer(this);
-			}
+		//TODO: We need to revisit this later when we complete the UI Tests for UWP.
+		// Changing the AutomationPeer here prevents the Narrator from functioning properly.
+		// Oddly, it affects more than just the TextBlocks. It seems to break the entire scan mode.
 
-			return new FrameworkElementAutomationPeer(Control);
-		}
+		//protected override AutomationPeer OnCreateAutomationPeer()
+		//{
+		//	// We need an automation peer so we can interact with this in automated tests
+		//	if (Control == null)
+		//	{
+		//		return new FrameworkElementAutomationPeer(this);
+		//	}
+
+		//	return new TextBlockAutomationPeer(Control);
+		//}
 
 		protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)
 		{

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -205,6 +205,12 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 #if __MOBILE__
 			_defaultColor = uiview.BackgroundColor;
+
+			// UIKit UIViews created via storyboard default IsAccessibilityElement to true, BUT
+			// UIViews created programmatically default IsAccessibilityElement to false.
+			// We need to default to true to allow all elements to be accessible by default and
+			// allow users to override this later via AutomationProperties.IsInAccessibleTree
+			uiview.IsAccessibilityElement = true;
 #else
 			uiview.WantsLayer = true;
 			_defaultColor = uiview.Layer.BackgroundColor;


### PR DESCRIPTION
### Description of Change ###

We expect screen readers to be able to read content by default. On iOS and UWP, this was not true for non-interactive elements such as Labels.

#### iOS
We create iOS views programmatically, in which case the `IsAccessibilityElement` value defaults to `false`. We expected it to default to `true`, as it states in the documentation, but this apparently is only the case when using storyboards. We are now explicitly setting `IsAccessibilityElement` to true for all controls.

#### UWP
This functionality was originally working, but it was thwarted by a change made later for UI testing. Reverting that change for now until we can find a better alternative.

### Bugs Fixed ###

- fixes #1946

### API Changes ###

None

### Behavioral Changes ###

- UWP UI Tests will probably fail
- Anyone explicitly setting `UIView.IsAccessibilityElement` to `false` in custom renderers should ensure they do so after `SetNativeControl` is called. Otherwise, it will be overridden to `true`.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
