### PR TITLE
[Tizen] Remove legacy tizen specific available condition

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -21,11 +21,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Entry.ReturnTypeProperty, UpdateReturnType);
 			RegisterPropertyHandler(InputView.IsSpellCheckEnabledProperty, UpdateIsSpellCheckEnabled);
 			RegisterPropertyHandler(Entry.IsTextPredictionEnabledProperty, UpdateIsSpellCheckEnabled);
-
-			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
-			{
-				RegisterPropertyHandler("FontWeight", UpdateFontWeight);
-			}
+			RegisterPropertyHandler(Specific.FontWeightProperty, UpdateFontWeight);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ImageRenderer.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				UpdateIsOpaque();
 			}
-			else if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable && e.PropertyName == "BlendColor")
+			else if (e.PropertyName == Specific.BlendColorProperty.PropertyName)
 			{
 				UpdateBlendColor();
 			}
@@ -64,10 +64,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		protected virtual void UpdateAfterLoading()
 		{
 			UpdateIsOpaque();
-			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
-			{
-				UpdateBlendColor();
-			}
+			UpdateBlendColor();
 		}
 
 		void UpdateAspect()

--- a/Xamarin.Forms.Platform.Tizen/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/LabelRenderer.cs
@@ -1,6 +1,4 @@
-using ElmSharp;
 using Xamarin.Forms.Platform.Tizen.Native;
-using EColor = ElmSharp.Color;
 using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.Label;
 
 namespace Xamarin.Forms.Platform.Tizen
@@ -20,10 +18,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Label.VerticalTextAlignmentProperty, UpdateVerticalTextAlignment);
 			RegisterPropertyHandler(Label.FormattedTextProperty, UpdateFormattedText);
 			RegisterPropertyHandler(Label.LineHeightProperty, UpdateLineHeight);
-			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
-			{
-				RegisterPropertyHandler("FontWeight", UpdateFontWeight);
-			}
+			RegisterPropertyHandler(Specific.FontWeightProperty, UpdateFontWeight);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/NavigationPageRenderer.cs
@@ -8,6 +8,8 @@ using ElmSharp;
 using EButton = ElmSharp.Button;
 using EToolbar = ElmSharp.Toolbar;
 using EToolbarItem = ElmSharp.ToolbarItem;
+using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.NavigationPage;
+using SpecificPage = Xamarin.Forms.PlatformConfiguration.TizenSpecific.Page;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -138,7 +140,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			// Tizen does not support 'Tint', but only 'BarBackgroundColor'
 			else if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor(CurrentNaviItem);
-			else if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable && e.PropertyName == "HasBreadCrumbsBar")
+			else if (e.PropertyName == Specific.HasBreadCrumbsBarProperty.PropertyName)
 				UpdateBreadCrumbsBar(CurrentNaviItem);
 
 		}
@@ -168,7 +170,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				UpdateHasBackButton(sender as Page);
 			else if (e.PropertyName == Page.TitleProperty.PropertyName)
 				UpdateTitle(sender as Page);
-			else if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable && e.PropertyName == "BreadCrumb")
+			else if (e.PropertyName == SpecificPage.BreadCrumbProperty.PropertyName)
 				UpdateBreadCrumbsBar(GetNaviItemForPage(sender as Page));
 		}
 
@@ -183,8 +185,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			item.TitleBarVisible = (bool)page.GetValue(NavigationPage.HasNavigationBarProperty);
 			UpdateToolbarItem(page, item);
 			UpdateBarBackgroundColor(item);
-			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
-				UpdateBreadCrumbsBar(item);
+			UpdateBreadCrumbsBar(item);
 		}
 
 		void UpdateToolbarItem(Page page, NaviItem item = null)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ProgressBarRenderer.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				UpdateProgress();
 			}
-			else if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable && e.PropertyName == "ProgressBarPulsingStatus")
+			else if (e.PropertyName == Specific.ProgressBarPulsingStatusProperty.PropertyName)
 			{
 				UpdatePulsingStatus();
 			}
@@ -62,10 +62,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		void UpdateAll()
 		{
 			UpdateProgress();
-			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
-			{
-				UpdatePulsingStatus();
-			}
+			UpdatePulsingStatus();
 		}
 
 		void UpdateProgressColor(bool initialize)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/VisualElementRenderer.cs
@@ -51,20 +51,16 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(VisualElement.InputTransparentProperty, UpdateInputTransparent);
 			RegisterPropertyHandler(VisualElement.BackgroundColorProperty, UpdateBackgroundColor);
 
-			// Use TizenSpecific APIs only if available
-			if (TizenPlatformServices.AppDomain.IsTizenSpecificAvailable)
-			{
-				RegisterPropertyHandler("ThemeStyle", UpdateThemeStyle);
-				RegisterPropertyHandler("IsFocusAllowed", UpdateFocusAllowed);
-				RegisterPropertyHandler("NextFocusDirection", UpdateFocusDirection);
-				RegisterPropertyHandler("NextFocusUpView", UpdateFocusUpView);
-				RegisterPropertyHandler("NextFocusDownView", UpdateFocusDownView);
-				RegisterPropertyHandler("NextFocusLeftView", UpdateFocusLeftView);
-				RegisterPropertyHandler("NextFocusRightView", UpdateFocusRightView);
-				RegisterPropertyHandler("NextFocusBackView", UpdateFocusBackView);
-				RegisterPropertyHandler("NextFocusForwardView", UpdateFocusForwardView);
-				RegisterPropertyHandler("ToolTip", UpdateToolTip);
-			}
+			RegisterPropertyHandler(Specific.StyleProperty, UpdateThemeStyle);
+			RegisterPropertyHandler(Specific.IsFocusAllowedProperty, UpdateFocusAllowed);
+			RegisterPropertyHandler(Specific.NextFocusDirectionProperty, UpdateFocusDirection);
+			RegisterPropertyHandler(Specific.NextFocusUpViewProperty, UpdateFocusUpView);
+			RegisterPropertyHandler(Specific.NextFocusDownViewProperty, UpdateFocusDownView);
+			RegisterPropertyHandler(Specific.NextFocusLeftViewProperty, UpdateFocusLeftView);
+			RegisterPropertyHandler(Specific.NextFocusRightViewProperty, UpdateFocusRightView);
+			RegisterPropertyHandler(Specific.NextFocusBackViewProperty, UpdateFocusBackView);
+			RegisterPropertyHandler(Specific.NextFocusForwardViewProperty, UpdateFocusForwardView);
+			RegisterPropertyHandler(Specific.ToolTipProperty, UpdateToolTip);
 
 			RegisterPropertyHandler(VisualElement.AnchorXProperty, ApplyTransformation);
 			RegisterPropertyHandler(VisualElement.AnchorYProperty, ApplyTransformation);

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -180,8 +180,6 @@ namespace Xamarin.Forms.Platform.Tizen
 
 			List<Assembly> _assemblies;
 
-			public static bool IsTizenSpecificAvailable { get; private set; }
-
 			static AppDomain()
 			{
 				CurrentDomain = new AppDomain();
@@ -210,13 +208,6 @@ namespace Xamarin.Forms.Platform.Tizen
 						{
 							Assembly refAsm = Assembly.Load(refName);
 							RegisterAssemblyRecursively(refAsm);
-							if (refName.Name == "Xamarin.Forms.Core")
-							{
-								if (refAsm.GetType("Xamarin.Forms.PlatformConfiguration.TizenSpecific.VisualElement") != null)
-								{
-									IsTizenSpecificAvailable = true;
-								}
-							}
 						}
 						catch
 						{


### PR DESCRIPTION
### Description of Change ###

Remove unnecessary property for checking whether tizen specific is available or not. Since Xamarin.Forms 3.0 (support tizen backend) this is no longer necessary.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
