### PR TITLE
[Android] ignore bugzilla test crashing UI Tests until related issue gets resolved

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32462.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32462.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[Ignore("Ignore regression for now so UI Tests can pass")]
 		public void Bugzilla36729Test ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("Click!"));


### PR DESCRIPTION
### Description of Change ###
bugzilla32462 is currently crashing the UI Test runner. Unfortunately it's testing a regression that was missed but has been regressed for some time and already lives in the wild.

Here's a current issue a user logged related to this bug
https://github.com/xamarin/Xamarin.Forms/issues/2011

Once that bug has been prioritized then we can re-fix but for now it's not providing any benefit to have this test crashing UI Tests