### PR TITLE
[Core] Report binding failures

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using System.Diagnostics;
 
 namespace Xamarin.Forms
 {
@@ -23,6 +24,27 @@ namespace Xamarin.Forms
 
 		static SemaphoreSlim SaveSemaphore = new SemaphoreSlim(1, 1);
 
+		static Lazy<DelegateLogListener> _applicationOutputListener;
+		static bool _logWarningsToApplicationOutput;
+
+		public static bool LogWarningsToApplicationOutput
+		{
+			get => _logWarningsToApplicationOutput;
+			set
+			{
+				_logWarningsToApplicationOutput = value;
+
+				if (_logWarningsToApplicationOutput)
+				{
+					Log.Listeners.Add(_applicationOutputListener.Value);
+				}
+				else
+				{
+					Log.Listeners.Remove(_applicationOutputListener.Value);
+				}
+			}
+		}
+
 		public Application()
 		{
 			var f = false;
@@ -34,6 +56,10 @@ namespace Xamarin.Forms
 			SystemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
 			SystemResources.ValuesChanged += OnParentResourcesChanged;
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Application>>(() => new PlatformConfigurationRegistry<Application>(this));
+			_applicationOutputListener = new Lazy<DelegateLogListener>(() => new DelegateLogListener((arg1, arg2) =>
+			{
+				Debug.WriteLine($"{arg1}: {arg2}");
+			}));
 		}
 
 		public void Quit()

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -36,11 +36,17 @@ namespace Xamarin.Forms
 
 				if (_logWarningsToApplicationOutput)
 				{
-					Log.Listeners.Add(_applicationOutputListener.Value);
+					if (!Log.Listeners.Contains(_applicationOutputListener.Value))
+					{
+						Log.Listeners.Add(_applicationOutputListener.Value);
+					}
 				}
 				else
 				{
-					Log.Listeners.Remove(_applicationOutputListener.Value);
+					if (Log.Listeners.Contains(_applicationOutputListener.Value))
+					{
+						Log.Listeners.Remove(_applicationOutputListener.Value);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

 A lot of logging happens internally, for example when a binding fails. In order to make these logs more accessible to the end-user, the `Application.LogWarningsToApplicationOutput` property was introduced. WIth this, logging will also be outputted to the debug console.

### Bugs Fixed ###

- fixes #2639

### API Changes ###

Added: 
```csharp
public static bool Application.LogWarningsToApplicationOutput { get; set; }
```

### Behavioral Changes ###

When `Application.LogWarningsToApplicationOutput` is set to true, a `LogListener` is attached to the internal logging system which outputs the messages through a `Debug.Writeline`. When set to false the `LogListener` is removed again.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense