### PR TITLE
[GTK] Fixed Issue 2810: Wrong state in GTK Entry using Placeholder and Text

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
@@ -99,7 +99,6 @@ namespace Xamarin.Forms.Platform.GTK.Controls
         {
             if (string.IsNullOrEmpty(_entry.Text) && !string.IsNullOrEmpty(_placeholder.Text))
             {
-                Entry.Sensitive = false;
                 _placeholderContainer.GdkWindow?.Raise();
             }
             else

--- a/Xamarin.Forms.Platform.GTK/FormsWindow.cs
+++ b/Xamarin.Forms.Platform.GTK/FormsWindow.cs
@@ -126,7 +126,7 @@ namespace Xamarin.Forms.Platform.GTK
 			}
 		}
 
-		private async void OnWindowStateEvent (object o, WindowStateEventArgs args)
+		private void OnWindowStateEvent (object o, WindowStateEventArgs args)
 		{
 			if (args.Event.ChangedMask == Gdk.WindowState.Iconified) {
 				var windowState = args.Event.NewWindowState;


### PR DESCRIPTION
### Description of Change ###

Fixed wrong state in GTK Entry using Placeholder and Text.
![2810-issue](https://user-images.githubusercontent.com/6755973/40886522-c9994acc-6739-11e8-9cdf-4c56393ad7a0.gif)

### Bugs Fixed ###

- fixes #2810

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
