### PR TITLE
[UWP] Fixes of calculation of heights in the MasterDetailPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1648.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1648.cs
@@ -1,0 +1,63 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1648, "MasterDetailPage throws ArgumentOutOfRangeException", PlatformAffected.UWP)]
+	public class GitHub1648 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			Navigation.PushAsync(new MasterDetailPage
+			{
+				Master = new NavigationPage(new ContentPage())
+				{
+					Title = "Master"
+				},
+				Detail = new ContentPage(),
+			});
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			Navigation.PushModalAsync(new SimplePage());
+		}
+
+		class SimplePage : ContentPage
+		{
+			public SimplePage ()
+			{
+				Content = new StackLayout()
+				{
+					Children = {
+						new Label {
+							Text = "Success"
+						},
+						new Button
+						{
+							Text = "Reload",
+							Command = new Command(() => Navigation.PopModalAsync())
+						}
+					}
+				};
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void GitHub1648Test()
+		{
+			RunningApp.WaitForElement("Reload");
+			RunningApp.Tap("Reload");
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -239,6 +239,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GitHub1648.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1702.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub2598.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControl.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Forms.Platform.UWP
 				double height = ActualHeight;
 				double width = ActualWidth;
 
-				if (_commandBar != null)
+				if (_commandBar != null && height != 0)
 					height -= _commandBar.ActualHeight;
 
 				if (ShouldShowSplitMode && IsPaneOpen)
@@ -100,7 +100,7 @@ namespace Xamarin.Forms.Platform.UWP
 						width -= _masterPresenter.ActualWidth;
 				}
 
-				return new Windows.Foundation.Size(width >= 0 ? width : 0, height);
+				return new Windows.Foundation.Size(width > 0 ? width : 0, height);
 			}
 		}
 
@@ -143,7 +143,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				// On first load, the _commandBar will still occupy space by the time this is called.
 				// Check ShouldShowToolbar to make sure the _commandBar will still be there on render.
-				if (_firstLoad && _commandBar != null && ShouldShowToolbar)
+				if (_firstLoad && height != 0 && _commandBar != null && ShouldShowToolbar)
 				{
 					height -= _commandBar.ActualHeight;
 					_firstLoad = false;


### PR DESCRIPTION
### Description of Change ###

Added zero `height` check before subtraction from it.

![screenshot_3](https://user-images.githubusercontent.com/27482193/40916205-97888c9a-6807-11e8-924f-eb0b95c15e0c.png)

### Bugs Fixed ###

- Fixes #1648

### API Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
