### PR TITLE
[Android] Fixes crash with Tabbed Page when image for icon doesn't exist

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1323.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1323.cs
@@ -45,6 +45,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue1323Test()
 		{
+			RunningApp.WaitForElement(X => X.Marked("Page 1"));
+			RunningApp.WaitForElement(X => X.Marked("Page5"));
 			RunningApp.Screenshot("All tab bar items text should be white");
 		}
 #endif

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -619,7 +619,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		protected virtual void SetTabIcon(TabLayout.Tab tab, FileImageSource icon)
 		{
-			tab.SetIcon(ResourceManager.IdFromTitle(icon, ResourceManager.DrawableClass));
+			tab.SetIcon(Context.GetDrawable(icon));
 			this.SetIconColorFilter(tab);
 		}
 

--- a/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
@@ -12,6 +12,7 @@ using AColorDraw = Android.Graphics.Drawables.ColorDrawable;
 using Xamarin.Forms.Internals;
 using Android.Support.V4.Widget;
 using Android.OS;
+using System;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -189,7 +190,14 @@ namespace Xamarin.Forms.Platform.Android
 
 		async void UpdateBitmap(ImageSource source, ImageSource previousSource = null)
 		{
-			await _imageView.UpdateBitmap(null, source, null, previousSource);
+			try
+			{
+				await _imageView.UpdateBitmap(null, source, null, previousSource);
+			}
+			catch (Exception ex)
+			{
+				Log.Warning(nameof(BaseCellView), "Error loading image: {0}", ex);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

* fixed unit test to verify crash didn't happen
* added try catch to BaseCellView and TabbedPageRenderer when image can't load


### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
