### PR TITLE
[Flex] Make sure layout is invalidated on time

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
@@ -469,6 +469,30 @@ namespace Xamarin.Forms.Core.UnitTests
 			label1.IsVisible = true;
 			Assert.That(label1.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 20)));
 			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(0, 20, 300, 20)));
-		}	
+		}
+
+		[Test]
+		public void ChangingGrowTriggersLayout()
+		//https://github.com/xamarin/Xamarin.Forms/issues/2821
+		{
+			var platform = new UnitPlatform();
+			var layout = new FlexLayout {
+				Platform = platform,
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Column,
+			};
+
+			layout.Layout(new Rectangle(0, 0, 300, 300));
+			for (var i = 0; i < 3; i++) {
+				var box = new BoxView {
+					Platform = platform,
+					IsPlatformEnabled = true,
+				};
+				layout.Children.Add(box);
+				FlexLayout.SetGrow(box, 1f);
+			}
+
+			Assert.That(layout.Children[2].Bounds, Is.EqualTo(new Rectangle(0, 200, 300, 100)));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -126,6 +126,7 @@ namespace Xamarin.Forms
 			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).Order = (int)newValue;
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.Undefined);
 		}
 
 		static void OnGrowPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -133,6 +134,7 @@ namespace Xamarin.Forms
 			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).Grow = (float)newValue;
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
 		static void OnShrinkPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -140,6 +142,7 @@ namespace Xamarin.Forms
 			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).Shrink = (float)newValue;
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
 		static void OnAlignSelfPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -147,6 +150,7 @@ namespace Xamarin.Forms
 			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).AlignSelf = (Flex.AlignSelf)(FlexAlignSelf)newValue;
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
 		static void OnBasisPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -154,6 +158,7 @@ namespace Xamarin.Forms
 			if (!bindable.IsSet(FlexItemProperty))
 				return;
 			GetFlexItem(bindable).Basis = ((FlexBasis)newValue).ToFlexBasis();
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
 		static void OnDirectionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -379,13 +384,6 @@ namespace Xamarin.Forms
 				if (item == null)
 					return;
 				item.IsVisible = (bool)((View)sender).GetValue(IsVisibleProperty);
-			}
-
-			if (   e.PropertyName == OrderProperty.PropertyName
-				|| e.PropertyName == GrowProperty.PropertyName
-				|| e.PropertyName == ShrinkProperty.PropertyName
-				|| e.PropertyName == BasisProperty.PropertyName
-				|| e.PropertyName == AlignSelfProperty.PropertyName) {
 				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 				UpdateChildrenLayout();
 				return;


### PR DESCRIPTION
### Description of Change ###

[Flex] Make sure layout is invalidated on time

When a BP changes, the BP value changes, the propertyChanged event is
fired, then the propertyChanged delegate is executed.

As the invalidation was done in the event, and setting the flexitem
property was done in the delegate, the invalidation, and relayout, was
executed with an out-of-date flexitem.

With this change, we invalidate the child size, and that'll bubble up to
invalidate the layout, as part of the property changed delegate

### Bugs Fixed ###

- fixes #2821

### API Changes ###

/

### Behavioral Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense