### PR TITLE
Fix issue #2943. [UWP] Set correct Z-Index for last element added to …

### DIFF
--- a/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
@@ -119,8 +119,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_panel.Children.Add(childRenderer.ContainerElement);
 
-			if (ElementController.LogicalChildren[ElementController.LogicalChildren.Count - 1] != view)
-				EnsureZIndex();
+			EnsureZIndex();
 		}
 
 		void OnChildRemoved(object sender, ElementEventArgs e)

--- a/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Platform.UWP
 		readonly int _rowSpan;
 		bool _disposed;
 		bool _isLoaded;
+		bool _hasZIndexes;
 
 		public VisualElementPackager(IVisualElementRenderer renderer)
 		{
@@ -96,6 +97,8 @@ namespace Xamarin.Forms.Platform.UWP
 				if (Canvas.GetZIndex(childRenderer.ContainerElement) != (z + 1))
 					Canvas.SetZIndex(childRenderer.ContainerElement, z + 1);
 			}
+
+			_hasZIndexes = true;
 		}
 
 		void OnChildAdded(object sender, ElementEventArgs e)
@@ -119,7 +122,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_panel.Children.Add(childRenderer.ContainerElement);
 
-			EnsureZIndex();
+			if (_hasZIndexes || ElementController.LogicalChildren[ElementController.LogicalChildren.Count - 1] != view)
+				EnsureZIndex();
 		}
 
 		void OnChildRemoved(object sender, ElementEventArgs e)


### PR DESCRIPTION
Fix issue #2943 - Set correct Z-Index for last element added to layout

### Description of Change ###

For some reason, the last added element to a layout on UWP would not have the Z-Index set. The result was that the last UI element was rendered **under** all other elements instead of on top.

In PR #2762, a test was done to see if the element being added was the last element, and if it was, the Z-Index recalculation was not performed, which is incorrect. This PR removes that test. It's unclear why that test was there in the first place.

### Bugs Fixed ###

- #2943

### API Changes ###

List all API changes here (or just put None), example:

None

### Behavioral Changes ###

None
### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense

There's no apparent way to test the Z-Index of inserted elements so no test was written.
