### PR TITLE
[UWP] Ignore setting the Z Index on initial load

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2653.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2653.cs
@@ -30,7 +30,8 @@ namespace Xamarin.Forms.Controls.Issues
 		const string Success = "BoxView Not Overlapping";
 		string instructions = $"Click {ButtonText}. If Box View shows up over me test has failed.";
 		const string TestForButtonClicked = "Test For Clicked";
-
+		const string FailureText = "If this is visible test fails";
+		const string ClickShouldAddText = "Clicking me should add a top layer of text";
 
 		protected override void Init()
 		{
@@ -38,6 +39,19 @@ namespace Xamarin.Forms.Controls.Issues
 
 			layout.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
 			layout.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Star });
+			layout.Children.Add(new Grid()
+			{
+				Children =
+				{
+					new Label()
+					{
+						Margin = 10,
+						Text = FailureText,
+						BackgroundColor = Color.White
+					}
+				}
+			});
+
 			layout.Children.Add(new Button()
 			{
 				Text = ButtonText,
@@ -73,17 +87,45 @@ namespace Xamarin.Forms.Controls.Issues
 						layout.LowerChild(bv);
 					}),  HeightRequest = 45},
 					layout,
-					new Button(){ Text = TestForButtonClicked, Command = new Command(() =>
+					new Button()
 					{
-						if(!layout.Children.Contains(bv))
+						Text = TestForButtonClicked, Command = new Command(() =>
 						{
-							labelInstructions.Text = Success;
-						}
-						else
+							if(bv == null)
+							{
+								labelInstructions.Text = String.Empty;
+							}
+							else if(!layout.Children.Contains(bv))
+							{
+								labelInstructions.Text = Success;
+							}
+							else
+							{
+								labelInstructions.Text = BoxViewIsOverlappingButton;
+							}
+						}),
+						HeightRequest = 45
+					},
+					new Button()
+					{
+						Text = ClickShouldAddText, Command = new Command(() =>
 						{
-							labelInstructions.Text = BoxViewIsOverlappingButton;
-						}
-					}),  HeightRequest = 45}
+							layout.Children.Insert(0, new Label());
+							layout.Children.Add(new Grid()
+							{
+								Children =
+								{
+									new Label()
+									{
+										Margin = 10,
+										Text = "If you can't see me test has failed",
+										BackgroundColor = Color.White
+									}
+								}
+							});
+						}),
+						HeightRequest = 45
+					}
 				}
 			};
 		}
@@ -117,16 +159,29 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(x => x.Marked(Success));
 		}
 
+		[Test]
+		public void InsertThenAddSetsZIndex()
+		{
+			RunningApp.WaitForElement(x => x.Marked(ClickShouldAddText));
+			RunningApp.Tap(x => x.Marked(ButtonText));
+			RunningApp.Tap(x => x.Marked(ClickShouldAddText));
+			RunningApp.Tap(x => x.Marked(ButtonText));
+			RunningApp.Tap(x => x.Marked(TestForButtonClicked));
+			RunningApp.WaitForElement(x => x.Marked(BoxViewIsOverlappingButton));
+		}
+		
+
 
 		[Test]
 		public void MoveUpAndMoveDown()
 		{
 			RunningApp.WaitForElement(x => x.Marked(MoveUp));
 			RunningApp.Tap(x => x.Marked(ButtonText));
+			RunningApp.Tap(x => x.Marked(MoveUp));
+			RunningApp.Tap(x => x.Marked(ButtonText));
 			RunningApp.Tap(x => x.Marked(TestForButtonClicked));
 			RunningApp.WaitForElement(x => x.Marked(BoxViewIsOverlappingButton));
 
-			RunningApp.Tap(x => x.Marked(MoveUp));
 			RunningApp.Tap(x => x.Marked(MoveDown));
 			RunningApp.Tap(x => x.Marked(ButtonText));
 			RunningApp.Tap(x => x.Marked(TestForButtonClicked));

--- a/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementPackager.cs
@@ -73,7 +73,10 @@ namespace Xamarin.Forms.Platform.UWP
 			ReadOnlyCollection<Element> children = ElementController.LogicalChildren;
 			for (var i = 0; i < children.Count; i++)
 			{
-				OnChildAdded(_renderer.Element, new ElementEventArgs(children[i]));
+				var view = children[i] as VisualElement;
+				if (view == null) continue;
+
+				SetupVisualElement(view);
 			}
 		}
 
@@ -93,18 +96,15 @@ namespace Xamarin.Forms.Platform.UWP
 				if (childRenderer == null)
 					continue;
 
-				if (Canvas.GetZIndex(childRenderer.ContainerElement) != (z + 1))
-					Canvas.SetZIndex(childRenderer.ContainerElement, z + 1);
+				// default ZIndex is -1 so subtract another one to get everyone below default
+				var zIndex = (z - ElementController.LogicalChildren.Count) - 1;
+				if (Canvas.GetZIndex(childRenderer.ContainerElement) != (zIndex))
+					Canvas.SetZIndex(childRenderer.ContainerElement, zIndex);
 			}
 		}
 
-		void OnChildAdded(object sender, ElementEventArgs e)
+		void SetupVisualElement(VisualElement view)
 		{
-			var view = e.Element as VisualElement;
-
-			if (view == null)
-				return;
-
 			IVisualElementRenderer childRenderer = Platform.CreateRenderer(view);
 			Platform.SetRenderer(view, childRenderer);
 
@@ -118,9 +118,19 @@ namespace Xamarin.Forms.Platform.UWP
 				Windows.UI.Xaml.Controls.Grid.SetColumnSpan(childRenderer.ContainerElement, _columnSpan);
 
 			_panel.Children.Add(childRenderer.ContainerElement);
+		}
 
+		void OnChildAdded(object sender, ElementEventArgs e)
+		{
+			var view = e.Element as VisualElement;
+
+			if (view == null)
+				return;
+
+			SetupVisualElement(view);
 			if (ElementController.LogicalChildren[ElementController.LogicalChildren.Count - 1] != view)
 				EnsureZIndex();
+
 		}
 
 		void OnChildRemoved(object sender, ElementEventArgs e)


### PR DESCRIPTION
### Description of Change ###

* When elements are first added to the visual tree don't set the Z-Index https://github.com/xamarin/Xamarin.Forms/issues/2943 and https://bugzilla.xamarin.com/show_bug.cgi?id=60143
* When elements are re-orderered call Ensure Z Index to assert the ordering (https://bugzilla.xamarin.com/show_bug.cgi?id=60143)
* When elements are added/inserted after initial load make sure to reset the Z-Index to represent newly added children (https://github.com/xamarin/Xamarin.Forms/issues/2653)
### Bugs Fixed ###

https://bugzilla.xamarin.com/show_bug.cgi?id=60143
fixes #2943
fixes #2653


### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
