### PR TITLE
Use UpdateOnTap setting for Slider to fix broken gesture bubbling test

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 #if UITEST
 using NUnit.Framework;
@@ -205,10 +206,9 @@ namespace Xamarin.Forms.Controls.Issues
 			col2.Children.Add(MenuButton(nameof(DatePicker), () => new DatePicker()));
 			col2.Children.Add(MenuButton(nameof(TimePicker), () => new TimePicker()));
 
-			if (DateTime.Now > new DateTime(2018, 5, 28))
-			{
-				col2.Children.Add(MenuButton(nameof(Slider), () => new Slider()));
-			}
+			var slider = new Slider();
+			slider.On<iOS>().SetUpdateOnTap(true);
+			col2.Children.Add(MenuButton(nameof(Slider), () => slider));
 
 			col2.Children.Add(MenuButton(nameof(Switch), () => new Switch()));
 			col2.Children.Add(MenuButton(nameof(Stepper), () => new Stepper()));

--- a/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
@@ -60,6 +60,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateMinimum();
 				UpdateValue();
 				UpdateSliderColors();
+				UpdateTapRecognizer();
 			}
 
 			base.OnElementChanged(e);


### PR DESCRIPTION
### Description of Change ###

Sets UpdateOnTap to true for the Slider in the gesture bubbling tests (on iOS).

Also fixes a bug where the initial setting for UpdateOnTap is ignored by the SliderRenderer.
