### PR TITLE
[Tizen] Ensures various button styles work well on watch

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/StyleValues.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/StyleValues.cs
@@ -5,6 +5,8 @@ namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific
 		public const string Default = "default";
 		public const string Circle = "circle";
 		public const string Bottom = "bottom";
+		public const string Text = "textbutton";
+		public const string SelectMode = "select_mode";
 	}
 
 	public static class SwitchStyle

--- a/Xamarin.Forms.Platform.Tizen/Native/Button.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Button.cs
@@ -1,5 +1,6 @@
-using ElmSharp;
 using System;
+using ElmSharp;
+using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
 using EButton = ElmSharp.Button;
 using EColor = ElmSharp.Color;
 using ESize = ElmSharp.Size;
@@ -179,17 +180,19 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// <summary>
 		/// Implementation of the IMeasurable.Measure() method.
 		/// </summary>
-		public ESize Measure(int availableWidth, int availableHeight)
+		public virtual ESize Measure(int availableWidth, int availableHeight)
 		{
-			switch (Style)
+			if (Style == ButtonStyle.Circle)
 			{
-				case "bottom":
-				case "circle":
-					return new ESize(MinimumWidth, MinimumHeight);
+				return new ESize(MinimumWidth, MinimumHeight);
+			}
+			else
+			{
+				if (Image != null)
+					MinimumWidth += Image.Geometry.Width;
 
-				default:
-					var rawSize = TextHelper.GetRawTextBlockSize(this);
-					return new ESize(rawSize.Width + MinimumWidth, Math.Max(MinimumHeight, rawSize.Height));
+				var rawSize = TextHelper.GetRawTextBlockSize(this);
+				return new ESize(rawSize.Width + MinimumWidth , Math.Max(MinimumHeight, rawSize.Height));
 			}
 		}
 
@@ -273,10 +276,10 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			if (Style != style)
 			{
 				Style = style;
-				if (Style == "circle")
-					_span.HorizontalTextAlignment = TextAlignment.Center;
-				else
+				if (Style == ButtonStyle.Default)
 					_span.HorizontalTextAlignment = TextAlignment.Auto;
+				else
+					_span.HorizontalTextAlignment = TextAlignment.Center;
 				ApplyTextAndStyle();
 			}
 		}

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchButton.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchButton.cs
@@ -1,0 +1,31 @@
+using System;
+using ElmSharp;
+using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
+using ESize = ElmSharp.Size;
+
+namespace Xamarin.Forms.Platform.Tizen.Native.Watch
+{
+	public class WatchButton : Button, IMeasurable
+	{
+		public WatchButton(EvasObject parent) : base(parent)
+		{
+		}
+
+		public override ESize Measure(int availableWidth, int availableHeight)
+		{
+			if (Style == ButtonStyle.Default)
+			{
+				//Should gurantee the finger size (40)
+				MinimumWidth = MinimumWidth < 40 ? 40 : MinimumWidth;
+				if (Image != null)
+					MinimumWidth += Image.Geometry.Width;
+				var rawSize = TextHelper.GetRawTextBlockSize(this);
+				return new ESize(rawSize.Width + MinimumWidth, Math.Max(MinimumHeight, rawSize.Height));
+			}
+			else
+			{
+				return new ESize(MinimumWidth, MinimumHeight);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ButtonRenderer.cs
@@ -1,5 +1,4 @@
 using System;
-using Xamarin.Forms.Platform.Tizen.Native;
 using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.VisualElement;
 
 namespace Xamarin.Forms.Platform.Tizen
@@ -23,7 +22,11 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (Control == null)
 			{
-				SetNativeControl(new Native.Button(Forms.NativeParent));
+				if (Device.Idiom == TargetIdiom.Watch)
+					SetNativeControl(new Native.Watch.WatchButton(Forms.NativeParent));
+				else
+					SetNativeControl(new Native.Button(Forms.NativeParent));
+
 				Control.Clicked += OnButtonClicked;
 				Control.Pressed += OnButtonPressed;
 				Control.Released += OnButtonReleased;


### PR DESCRIPTION
### Description of Change ###

This PR  make certain that various button styles work well on watch devices. It also includes fixes about determining the button size correctly if button has icon. 

In order to change button theme style, user can just use something like -
 ```cs
button.On<Tizen>().SetStyle(ButtonStyle.Circle);
```

<img src ="https://user-images.githubusercontent.com/1029134/41077534-242d3f64-6a52-11e8-9f00-2b40cdfb2242.gif" width=300>

### Bugs Fixed ###

The size of the button is determined correctly across target idioms. 

### API Changes ###

Added:

Xamarin.Forms.PlatformConfiguration.TizenSpecific
 - string ButtonStyle.Text; 
 - string ButtonStyle.SelectMode; 

### Behavioral Changes ###

None. 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
