### PR TITLE
[WPF] Fixed Build: Remove "pattern matching" from ImageRenderer

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ImageRenderer.cs
@@ -142,10 +142,11 @@ namespace Xamarin.Forms.Platform.WPF
 		public async Task<System.Windows.Media.ImageSource> LoadImageAsync(ImageSource imagesource, CancellationToken cancelationToken = new CancellationToken())
 		{
 			BitmapImage bitmapImage = null;
+			StreamImageSource streamImageSource = imagesource as StreamImageSource;
 
-			if (imagesource is StreamImageSource streamsource && streamsource.Stream != null)
+			if (streamImageSource != null && streamImageSource.Stream != null)
 			{
-				using (Stream stream = await ((IStreamImageSource)streamsource).GetStreamAsync(cancelationToken))
+				using (Stream stream = await ((IStreamImageSource)streamImageSource).GetStreamAsync(cancelationToken))
 				{
 					bitmapImage = new BitmapImage();
 					bitmapImage.BeginInit();


### PR DESCRIPTION
### Description of Change ###

Fixed WPF Build removing C# "pattern matching".

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense