### PR TITLE
[Android]  Set vertical center on gravity for Search Bar

### DIFF
--- a/Xamarin.Forms.Platform.Android/Extensions/FlowDirectionExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/FlowDirectionExtensions.cs
@@ -3,6 +3,7 @@ using Android.Widget;
 using Xamarin.Forms.Internals;
 using ALayoutDirection = Android.Views.LayoutDirection;
 using AView = Android.Views.View;
+using AGravityFlags = Android.Views.GravityFlags;
 
 
 namespace Xamarin.Forms.Platform.Android
@@ -33,10 +34,10 @@ namespace Xamarin.Forms.Platform.Android
 				view.LayoutDirection = ALayoutDirection.Ltr;
 		}
 
-		internal static void UpdateHorizontalAlignment(this EditText view, TextAlignment alignment, bool hasRtlSupport)
+		internal static void UpdateHorizontalAlignment(this EditText view, TextAlignment alignment, bool hasRtlSupport, AGravityFlags orMask = AGravityFlags.NoGravity)
 		{
 			if ((int)Build.VERSION.SdkInt < 17 || !hasRtlSupport)
-				view.Gravity = alignment.ToHorizontalGravityFlags();
+				view.Gravity = alignment.ToHorizontalGravityFlags() | orMask;
 			else
 				view.TextAlignment = alignment.ToTextAlignment();
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -141,7 +141,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_editText == null)
 				return;
 
-			_editText.UpdateHorizontalAlignment(Element.HorizontalTextAlignment, Context.HasRtlSupport());
+			_editText.UpdateHorizontalAlignment(Element.HorizontalTextAlignment, Context.HasRtlSupport(), Xamarin.Forms.TextAlignment.Center.ToVerticalGravityFlags());
 		}
 
 		void UpdateCancelButtonColor()


### PR DESCRIPTION
### Description of Change ###

For non RTL we need to set the vertical gravity to center on the Search Bar so it centers correctly.

Caused by https://github.com/xamarin/Xamarin.Forms/pull/1222.

### Bugs Fixed ###

fixes #2936


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
