### PR TITLE
[UWP] Fix listview not rendering when ItemsSource is initially null

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -171,7 +171,7 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (e.PropertyName == ListView.ItemsSourceProperty.PropertyName)
 			{
 				ClearSizeEstimate();
-				((CollectionViewSource)List.DataContext).Source = Element.ItemsSource;
+				ReloadData();
 			}
 			else if (e.PropertyName == Specifics.SelectionModeProperty.PropertyName)
 			{


### PR DESCRIPTION
### Description of Change ###

Fix listview not rendering when ItemsSource is initially null

When ItemsSource is initially null, the DataContext is not set, and it is never set when the ItemsSource property is set later. This fix will call ReloadData() when the ItemsSource property is changed on the XF ListView control.

### Bugs Fixed ###

No bug reported yet

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
