### PR TITLE
[Tizen] Adjust the platform creation timing

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
+++ b/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
@@ -131,18 +131,6 @@ namespace Xamarin.Forms.Platform.Tizen
 				throw new InvalidOperationException("Call Forms.Init (UIApplication) before this");
 			}
 
-			if (_platform != null)
-			{
-				_platform.SetPage(page);
-				return;
-			}
-
-			_platform = Platform.CreatePlatform(BaseLayout);
-			_platform.HasAlpha = MainWindow.Alpha;
-			BaseLayout.SetContent(_platform.GetRootNativeView());
-
-			_platform.RootNativeViewChanged += (s, e) => BaseLayout.SetContent(e.RootNativeView);
-
 			if (_application != null)
 			{
 				_application.Platform = _platform;
@@ -191,6 +179,11 @@ namespace Xamarin.Forms.Platform.Tizen
 					}
 				}
 			};
+
+			_platform = Platform.CreatePlatform(BaseLayout);
+			_platform.HasAlpha = MainWindow.Alpha;
+			BaseLayout.SetContent(_platform.GetRootNativeView());
+			_platform.RootNativeViewChanged += (s, e) => BaseLayout.SetContent(e.RootNativeView);
 		}
 
 		public void Run()

--- a/Xamarin.Forms.Platform.Tizen/LightweightPlatform.cs
+++ b/Xamarin.Forms.Platform.Tizen/LightweightPlatform.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 			_page.Platform = this;
 
-			var renderer = Platform.AttachRenderer(_page);
+			var renderer = Platform.CreateRenderer(_page);
 			_rootView = renderer.NativeView;
 			RootNativeViewChanged?.Invoke(this, new RootNativeViewChangedEventArgs(_rootView));
 			_rootView.Show();

--- a/Xamarin.Forms.Platform.Tizen/Platform.cs
+++ b/Xamarin.Forms.Platform.Tizen/Platform.cs
@@ -35,19 +35,17 @@ namespace Xamarin.Forms.Platform.Tizen
 		/// Gets the renderer associated with the <c>view</c>. If it doesn't exist, creates a new one.
 		/// </summary>
 		/// <returns>Renderer associated with the <c>view</c>.</returns>
-		/// <param name="view">View for which the renderer is going to be returned.</param>
-		public static IVisualElementRenderer GetOrCreateRenderer(VisualElement view)
+		/// <param name="element">VisualElement for which the renderer is going to be returned.</param>
+		public static IVisualElementRenderer GetOrCreateRenderer(VisualElement element)
 		{
-			return GetRenderer(view) ?? AttachRenderer(view);
+			return GetRenderer(element) ?? CreateRenderer(element);
 		}
 
-		internal static IVisualElementRenderer AttachRenderer(VisualElement view)
+		internal static IVisualElementRenderer CreateRenderer(VisualElement element)
 		{
-			IVisualElementRenderer visualElementRenderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(view) ?? new DefaultRenderer();
-
-			visualElementRenderer.SetElement(view);
-
-			return visualElementRenderer;
+			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultRenderer();
+			renderer.SetElement(element);
+			return renderer;
 		}
 
 		internal static ITizenPlatform CreatePlatform(EvasObject parent)
@@ -160,7 +158,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			Page = newRoot;
 			Page.Platform = this;
 
-			IVisualElementRenderer pageRenderer = Platform.AttachRenderer(Page);
+			IVisualElementRenderer pageRenderer = Platform.CreateRenderer(Page);
 			var naviItem = _internalNaviframe.Push(pageRenderer.NativeView);
 			naviItem.TitleBarVisible = false;
 
@@ -282,7 +280,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		async Task INavigation.PushModalAsync(Page modal, bool animated)
 		{
 			var previousPage = CurrentPageController;
-			Device.BeginInvokeOnMainThread(()=> previousPage?.SendDisappearing());
+			Device.BeginInvokeOnMainThread(() => previousPage?.SendDisappearing());
 
 			_navModel.PushModal(modal);
 


### PR DESCRIPTION
### Description of Change ###

This PR is about adjusting `Platform` creation timing to ensure native contols can be created before Page is set. 

<img src="https://user-images.githubusercontent.com/1029134/41140897-e6ba6f7e-6b2a-11e8-95f3-3aa56211c922.png" width=300>


### Bugs Fixed ###

Fixed an issue where ControlGallery would not run after #2772 was merged.

### API Changes ###

None

### Behavioral Changes ###

You can create a native control (via renderer) before the Page is set, just like what ControlGallery currently does.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
