### PR TITLE
[UWP] Fixes setting SelectedItem inside ItemSelected event

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1469.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1469.cs
@@ -1,0 +1,40 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1469, "Setting SelectedItem to null inside ItemSelected event handler does not work", PlatformAffected.UWP)]
+	public class Issue1469 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var statusLabel = new Label();
+			var _items = Enumerable.Range(1, 4).Select(i => $"Item {i}").ToArray();
+			var list = new ListView()
+			{
+				ItemsSource = _items
+			};
+			list.ItemSelected += (_, e) =>
+			{
+				if (e.SelectedItem == null)
+				{
+					statusLabel.Text = "Success"; // last selected item must be null
+					return;
+				}
+				statusLabel.Text = "Fail";
+				list.SelectedItem = null;
+			};
+			Content = new StackLayout
+			{
+				Children = {
+					statusLabel,
+					new Button { Text = "Select 3rd item", Command = new Command(() => list.SelectedItem = _items[2]) },
+					new Button { Text = "Clear selection", Command = new Command(() => list.SelectedItem = list.SelectedItem = null) },
+					list
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1469.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1469.cs
@@ -1,6 +1,12 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using System.Linq;
+using System.Threading.Tasks;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
@@ -10,31 +16,43 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			var statusLabel = new Label();
+			var statusLabel = new Label() { FontSize = 40 };
 			var _items = Enumerable.Range(1, 4).Select(i => $"Item {i}").ToArray();
 			var list = new ListView()
 			{
 				ItemsSource = _items
 			};
-			list.ItemSelected += (_, e) =>
+
+			list.ItemSelected += async (_, e) =>
 			{
 				if (e.SelectedItem == null)
-				{
-					statusLabel.Text = "Success"; // last selected item must be null
 					return;
-				}
-				statusLabel.Text = "Fail";
 				list.SelectedItem = null;
+
+				statusLabel.Text = "One moment please...";
+				await Task.Delay(500);
+				statusLabel.Text = list.SelectedItem == null ? "Success" : "Fail";
 			};
+
 			Content = new StackLayout
 			{
 				Children = {
-					statusLabel,
+					new Label { Text = "If you click an item in the list it should not become selected" },
 					new Button { Text = "Select 3rd item", Command = new Command(() => list.SelectedItem = _items[2]) },
 					new Button { Text = "Clear selection", Command = new Command(() => list.SelectedItem = list.SelectedItem = null) },
+					statusLabel,
 					list
 				}
 			};
 		}
+
+#if UITEST
+		[Test]
+		public void Issue1469Test()
+		{
+			RunningApp.Tap("Select 3rd item");
+			RunningApp.WaitForElement("Success");
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -237,6 +237,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59248.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59457.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59580.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1469.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -635,8 +635,13 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnControlSelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if (Element.SelectedItem != List.SelectedItem && !_itemWasClicked)
-				((IElementController)Element).SetValueFromRenderer(ListView.SelectedItemProperty, List.SelectedItem);
+			if (Element.SelectedItem != List.SelectedItem)
+			{
+				if (_itemWasClicked)
+					List.SelectedItem = Element.SelectedItem;
+				else
+					((IElementController)Element).SetValueFromRenderer(ListView.SelectedItemProperty, List.SelectedItem);
+			}
 
 			_itemWasClicked = false;
 		}


### PR DESCRIPTION
### Description of Change ###

Added synchronization between the abstract and native `SelectedItem` when it was changed by clicking.

### Bugs Fixed ###

- Fixes #1469

### API Changes ###

/

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
