### PR TITLE
[Android] ignore layering test on android

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2653.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2653.cs
@@ -148,7 +148,8 @@ namespace Xamarin.Forms.Controls.Issues
 			return true;
 		}
 
-#if UITEST
+// https://github.com/xamarin/Xamarin.Forms/issues/2989
+#if UITEST && !__ANDROID__
 		[Test]
 		public void ZIndexWhenInsertingChildren()
 		{


### PR DESCRIPTION
### Description of Change ###

https://github.com/xamarin/Xamarin.Forms/issues/2989

A layering bug that's been around for awhile was revealed by the addition of some UWP tests. Ignore test on Android for now until issue is resolved
