### PR TITLE
[UWP] Fixes core debugging when debugging UWP.

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -61,6 +61,7 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PostBuildEvent>if exist "$(TargetDir)AppX\" (xcopy "$(TargetDir)*.pdb" "$(TargetDir)AppX\" /Y)</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -86,6 +87,7 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PostBuildEvent>if exist "$(TargetDir)AppX\" (xcopy "$(TargetDir)*.pdb" "$(TargetDir)AppX\" /Y)</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>


### PR DESCRIPTION
### Description of Change ###

When you start UWP debugger on a local machine, symbols are not copied to the folder with the application running in `AppX` folder. It does not allow to make breakpoints in Xamarin.Forms.Core.
To fix this problem after the build all the symbols are copied to the `AppX` folder.

### API Changes ###

/

### Behavioral Changes ###

Added post build script that copies all the *.pdb files to the `AppX` folder.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
