### PR TITLE
Fixed multiple issues with Pickers.

### DIFF
--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -261,7 +261,10 @@ namespace Xamarin.Forms
 		void UpdateSelectedItem()
 		{
 			if (SelectedIndex == -1)
+			{
+				SelectedItem = null;
 				return;
+			}
 
 			Object selectedItem = null;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -182,7 +182,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (Element.SelectedIndex == -1 || Element.Items == null)
 				Control.Text = null;
-			else
+			else if (Element.Items.Count > Element.SelectedIndex)
 				Control.Text = Element.Items[Element.SelectedIndex];
 
 			if (oldText != Control.Text)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PickerRenderer.cs
@@ -46,6 +46,21 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			Control.RemoveAllItems();
 			Control.AddItems(Element.Items.ToArray());
+			UpdateIsEnabled();
+		}
+
+		protected override void UpdateIsEnabled()
+		{
+			if (Element == null || Control == null)
+				return;
+
+			if (Element.Items.Count > 0)
+			{
+				if (Control.Enabled != Element.IsEnabled)
+					Control.Enabled = Element.IsEnabled;
+			}
+			else
+				Control.Enabled = false;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -130,7 +145,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			UpdateItems();
 
 			if (items == null || items.Count == 0 || selectedIndex < 0)
+			{
+				Control.Title = "";
 				return;
+			}
 
 			Control.SelectItem(selectedIndex);
 		}

--- a/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
+			if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName || e.PropertyName == Picker.ItemsSourceProperty.PropertyName)
 				UpdateSelectedIndex();
 			else if (e.PropertyName == Picker.TitleProperty.PropertyName)
 				UpdateTitle();
@@ -199,7 +199,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateSelectedIndex()
 		{
-			Control.SelectedIndex = Element.SelectedIndex;
+			if (Control == null || Element == null)
+				return;
+
+			if (Control.SelectedIndex != Element.SelectedIndex && Control.Items != null && Control.Items.Count > Element.SelectedIndex)
+				Control.SelectedIndex = Element.SelectedIndex;
 		}
 
 		void UpdateTextColor()

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -107,7 +107,10 @@ namespace Xamarin.Forms.Platform.iOS
 			// Reset the TextField's Text so it appears as if typing with a keyboard does not work.
 			var selectedIndex = Element.SelectedIndex;
 			var items = Element.Items;
-			Control.Text = selectedIndex == -1 || items == null ? "" : items[selectedIndex];
+			String text = (selectedIndex != -1 && items != null && items.Count > selectedIndex) ? items[selectedIndex] : "";
+			if (Control.Text != text)
+				Control.Text = text;
+
 			// Also clears the undo stack (undo/redo possible on iPads)
 			Control.UndoManager.RemoveAllActions();
 		}
@@ -143,7 +146,12 @@ namespace Xamarin.Forms.Platform.iOS
 			var items = Element.Items;
 			Control.Placeholder = Element.Title;
 			var oldText = Control.Text;
-			Control.Text = selectedIndex == -1 || items == null ? "" : items[selectedIndex];
+
+			if (selectedIndex == -1 || items == null)
+				Control.Text = null;
+			else if (items.Count > selectedIndex)
+				Control.Text = items[selectedIndex];
+
 			UpdatePickerNativeSize(oldText);
 			_picker.ReloadAllComponents();
 			if (items == null || items.Count == 0)
@@ -172,8 +180,15 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdatePickerSelectedIndex(int formsIndex)
 		{
 			var source = (PickerSource)_picker.Model;
-			source.SelectedIndex = formsIndex;
-			source.SelectedItem = formsIndex >= 0 ? Element.Items[formsIndex] : null;
+
+			if (source.SelectedIndex != formsIndex)
+				source.SelectedIndex = formsIndex;
+
+			String selectedItem = (formsIndex >= 0 && Element.Items.Count > formsIndex) ? Element.Items[formsIndex] : null;
+
+			if (source.SelectedItem != selectedItem)
+				source.SelectedItem = selectedItem;
+
 			_picker.Select(Math.Max(formsIndex, 0), 0, true);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fixes a bunch of known issues with the Picker control.

One of the main problems was trying to sync up SelectedIndex, SelectedItem, and ItemsSource.  What this will mainly do besides the other fixes listed below is to make sure the ItemsSource is no longer in charge of the SelectedIndex/SelectedItem.  There are numerous issues allowing the ItemsSource to control what is selected when the selection is bound but the notorious reseting of the SelectedItem to null is a standout.  Users should expect if the same item is in the list and the list is reset or changed in any way that the SelectedItem should retain its value.

Fixes:

[macOS]
*Fixes issue where drop downs look like they could be selected when there were no items in the list.
*Fixes issue of always showing the first item in the list as selected even though it is not.

[UWP]
*Fixes crash by index not existing in the list.
*Fixes issue of not rendering the correct size if the width was set to auto and not fill.
*Fixes issue of not selecting if the ItemsSource changes (Issue between Items and ItemsSource).

[iOS]
*Fixes an issue where the control text was different from the selected item in the list.  Also correctly resets to blank if no selection.

[Core]
*Removes ItemsSource's ability to reset the SelectedItem.
*Fixes crash on trying to get the SelectedIndex if the Items's collection was locked.
*Fixes ItemsSource nulling out selection.
*Fixes SelectedIndex not tell the respective renderers to update on Items collection changed.

Tests omitted as there have been plenty created at this point through the numerous reports.


### Bugs Fixed ###

There are alot of the same bug opened and too many to really list them all.  I can link them in as I find them all.

- fixes #2751
- fixes #1879
- fixes #1996

Havent tested yet, but for reference:
- untested #2032

### API Changes ###

None.

### Behavioral Changes ###

Pickers should work correctly at this point.  The main difference is the ItemsSource has been removed from parental control on syncing.  We have ran this over our 100's of pickers that are used in different circumstances with changing lists to more properties like SelectedValue which isnt implemented here and all work great at this point.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
