### PR TITLE
[macOS] Entry focus unfocus events

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/EntryUnfocusedImmediately.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/EntryUnfocusedImmediately.cs
@@ -2,6 +2,10 @@
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+#if UITEST
+using NUnit.Framework;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
@@ -10,7 +14,8 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		Label _focusedCountLabel = new Label
 		{
-			Text = "Focused count: 0"
+			Text = "Focused count: 0",
+			AutomationId = "FocusedCountLabel"
 		};
 		int _focusedCount;
 		int FocusedCount
@@ -25,7 +30,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 		Label _unfocusedCountLabel = new Label
 		{
-			Text = "Unfocused count: 0"
+			Text = "Unfocused count: 0",
+			AutomationId = "UnfocusedCountLabel"
 		};
 		int _unfocusedCount;
 		int UnfocusedCount
@@ -40,7 +46,10 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			var entry = new Entry();
+			var entry = new Entry
+			{
+				AutomationId = "FocusTargetEntry"
+			};
 			entry.Focused += (sender, e) =>
 			{
 				FocusedCount++;
@@ -52,7 +61,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var dumbyEntry = new Entry()
 			{
-				Placeholder = "I'm just here as another focus target"
+				Placeholder = "I'm just here as another focus target",
+				AutomationId = "DumbyEntry"
 			};
 
 			var divider = new BoxView
@@ -70,5 +80,23 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Content = stackLayout;
 		}
+
+#if UITEST
+#if __MACOS__
+		[Test]
+		public void EntryUnfocusedImmediatelyTest()
+		{
+			RunningApp.WaitForElement(q => q.Marked("DumbyEntry"));
+			RunningApp.Tap(q => q.Marked("DumbyEntry"));
+			
+			RunningApp.WaitForElement(q => q.Marked("FocusTargetEntry"));
+			RunningApp.Tap(q => q.Marked("FocusTargetEntry"));
+			Assert.AreEqual(0, _unfocusedCount, "Unfocused should not have fired");
+
+			RunningApp.Tap(q => q.Marked("DumbyEntry"));
+			Assert.AreEqual(1, _unfocusedCount, "Unfocused should have been fired once");
+		}
+#endif
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/EntryUnfocusedImmediately.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/EntryUnfocusedImmediately.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "[macOS] Entry unfocus behavior", PlatformAffected.macOS)]
+	public class EntryUnfocusedImmediately : TestContentPage
+	{
+		Label _focusedCountLabel = new Label
+		{
+			Text = "Focused count: 0"
+		};
+		int _focusedCount;
+		int FocusedCount
+		{
+			get { return _focusedCount; }
+			set
+			{
+				_focusedCount = value;
+				_focusedCountLabel.Text = $"Focused count: {value}";
+			}
+		}
+
+		Label _unfocusedCountLabel = new Label
+		{
+			Text = "Unfocused count: 0"
+		};
+		int _unfocusedCount;
+		int UnfocusedCount
+		{
+			get { return _unfocusedCount; }
+			set
+			{
+				_unfocusedCount = value;
+				_unfocusedCountLabel.Text = $"Unfocused count: {value}";
+			}
+		}
+
+		protected override void Init()
+		{
+			var entry = new Entry();
+			entry.Focused += (sender, e) =>
+			{
+				FocusedCount++;
+			};
+			entry.Unfocused += (sender, e) =>
+			{
+				UnfocusedCount++;
+			};
+
+			var dumbyEntry = new Entry()
+			{
+				Placeholder = "I'm just here as another focus target"
+			};
+
+			var divider = new BoxView
+			{
+				HeightRequest = 1,
+				BackgroundColor = Color.Black
+			};
+
+			StackLayout stackLayout = new StackLayout();
+			stackLayout.Children.Add(dumbyEntry);
+			stackLayout.Children.Add(divider);
+			stackLayout.Children.Add(entry);
+			stackLayout.Children.Add(_focusedCountLabel);
+			stackLayout.Children.Add(_unfocusedCountLabel);
+
+			Content = stackLayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3012.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3012.cs
@@ -9,8 +9,8 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.None, 0, "[macOS] Entry unfocus behavior", PlatformAffected.macOS)]
-	public class EntryUnfocusedImmediately : TestContentPage
+	[Issue(IssueTracker.Github, 3012, "[macOS] Entry focus / unfocus behavior", PlatformAffected.macOS)]
+	public class Issue3012 : TestContentPage
 	{
 		Label _focusedCountLabel = new Label
 		{
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 #if __MACOS__
 		[Test]
-		public void EntryUnfocusedImmediatelyTest()
+		public void Issue3012Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("DumbyEntry"));
 			RunningApp.Tap(q => q.Marked("DumbyEntry"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -738,7 +738,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1729.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2728.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1667.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)EntryUnfocusedImmediately.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3012.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -738,6 +738,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1729.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2728.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1667.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)EntryUnfocusedImmediately.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -148,6 +148,7 @@ namespace Xamarin.Forms.CustomAttributes
 		WinRT = 1 << 3,
 		UWP = 1 << 4,
 		WPF = 1 << 5,
+		macOS = 1 << 6,
 		All = ~0,
 		Default = 0
 	}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -69,9 +69,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			void HandleWindowDidBecomeKey(object sender, EventArgs args)
 			{
 				if (CurrentEditor == Window.FirstResponder)
-				{
 					FocusChanged?.Invoke(this, new BoolEventArgs(true));
-				}
 			}
 		}
 
@@ -189,7 +187,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		void OnChanged(object sender, EventArgs eventArgs)
 		{
 			UpdateMaxLength();
-			
+
 			ElementController.SetValueFromRenderer(Entry.TextProperty, Control.StringValue);
 		}
 

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			bool _windowEventsSet;
 
+			bool _disposed;
+
 			public override bool ResignFirstResponder()
 			{
 				return base.ResignFirstResponder();
@@ -41,6 +43,22 @@ namespace Xamarin.Forms.Platform.MacOS
 					FocusChanged?.Invoke(this, new BoolEventArgs(false));
 				}
 				base.DidEndEditing(notification);
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (disposing && !_disposed)
+				{
+					_disposed = true;
+
+					if (Window != null)
+					{
+						Window.DidResignKey -= HandleWindowDidResignKey;
+						Window.DidBecomeKey -= HandleWindowDidBecomeKey;
+					}
+				}
+
+				base.Dispose(disposing);
 			}
 
 			void HandleWindowDidResignKey(object sender, EventArgs args)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -39,9 +39,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			public override void DidEndEditing(NSNotification notification)
 			{
 				if (CurrentEditor != Window.FirstResponder)
-				{
 					FocusChanged?.Invoke(this, new BoolEventArgs(false));
-				}
+				
 				base.DidEndEditing(notification);
 			}
 

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using AppKit;
+using Foundation;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
@@ -9,15 +10,50 @@ namespace Xamarin.Forms.Platform.MacOS
 		class FormsNSTextField : NSTextField
 		{
 			public EventHandler<BoolEventArgs> FocusChanged;
+
+			bool _windowEventsSet;
+
 			public override bool ResignFirstResponder()
 			{
-				FocusChanged?.Invoke(this, new BoolEventArgs(false));
 				return base.ResignFirstResponder();
 			}
+
 			public override bool BecomeFirstResponder()
 			{
 				FocusChanged?.Invoke(this, new BoolEventArgs(true));
-				return base.BecomeFirstResponder();
+
+				var result = base.BecomeFirstResponder();
+
+				if (!_windowEventsSet)
+				{
+					_windowEventsSet = true;
+					Window.DidResignKey += HandleWindowDidResignKey;
+					Window.DidBecomeKey += HandleWindowDidBecomeKey;
+				}
+
+				return result;
+			}
+
+			public override void DidEndEditing(NSNotification notification)
+			{
+				if (CurrentEditor != Window.FirstResponder)
+				{
+					FocusChanged?.Invoke(this, new BoolEventArgs(false));
+				}
+				base.DidEndEditing(notification);
+			}
+
+			void HandleWindowDidResignKey(object sender, EventArgs args)
+			{
+				FocusChanged?.Invoke(this, new BoolEventArgs(false));
+			}
+
+			void HandleWindowDidBecomeKey(object sender, EventArgs args)
+			{
+				if (CurrentEditor == Window.FirstResponder)
+				{
+					FocusChanged?.Invoke(this, new BoolEventArgs(true));
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Improve the conditions which an Entry's Focused and Unfocused events fire running on macOS. Previously when the Entry element was clicked, the Focused event would be invoked, and immediately be followed by the Unfocused event being invoked. This was a result of the macOS FirstResponder quirks with NSTextField. 

Reference https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/EventHandlingBasics/EventHandlingBasics.html#//apple_ref/doc/uid/10000060i-CH5-SW23 

### Bugs Fixed ###

- fixes #3012 

### API Changes ###

None

### Behavioral Changes ###

The Entry element on macOS will no longer invoke Focused and Unfocused events when the Entry is clicked. 

The Entry's Focused event is now invoked only when the element obtains FirstResponder or when the Entry was previously focused when the window lost key status and the window has since regained key status.

The Entry's Unfocused event is now invoked when the native NSTextField's DidEndEditing method is called, or when the window loses key status. 

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
