### PR TITLE
[C] Fixes setting to Null Binding Context in Picker

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2499.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2499.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2499, "Binding Context set to Null in Picker", PlatformAffected.All)]
+	public class Issue2499 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var _picker = new Picker()
+			{
+				ItemsSource = new List<string> { "cat", "mouse", "rabbit" },
+				AutomationId = "picker",
+			};
+			_picker.SelectedIndexChanged += (_, __) => _picker.ItemsSource = null;
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					_picker
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void Issue2499Test ()
+		{
+			RunningApp.Tap ("picker");
+			AppResult[] items = RunningApp.Query("cat");
+			Assert.AreNotEqual(items.Length, 0);
+
+			RunningApp.Tap ("cat");
+			items = RunningApp.Query("cat");
+			Assert.AreEqual(items.Length, 0);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -241,6 +241,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2767.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2499.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ISampleNativeControl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ViewHelper.cs" />

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Core.UITests
 			if (Session == null)
 			{
 				DesiredCapabilities appCapabilities = new DesiredCapabilities();
-				appCapabilities.SetCapability("app", "0d4424f6-1e29-4476-ac00-ba22c3789cb6_wzjw7qdpbr1br!App");
+				appCapabilities.SetCapability("app", "0d4424f6-1e29-4476-ac00-ba22c3789cb6_ph1m9x8skttmg!App");
 				appCapabilities.SetCapability("deviceName", "WindowsPC");
 				Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
 				Assert.IsNotNull(Session);

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -150,8 +150,11 @@ namespace Xamarin.Forms
 
 		void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
-			UpdateSelectedItem();
+			var oldIndex = SelectedIndex;
+			var newIndex = SelectedIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
+			// If the index has not changed, still need to change the selected item
+			if (newIndex == oldIndex)
+				UpdateSelectedItem(newIndex);
 		}
 
 		static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
@@ -214,13 +217,13 @@ namespace Xamarin.Forms
 			((LockableObservableListWrapper)Items).InternalClear();
 			foreach (object item in ItemsSource)
 				((LockableObservableListWrapper)Items).InternalAdd(GetDisplayMember(item));
-			UpdateSelectedItem();
+			UpdateSelectedItem(SelectedIndex);
 		}
 
 		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)
 		{
 			var picker = (Picker)bindable;
-			picker.UpdateSelectedItem();
+			picker.UpdateSelectedItem(picker.SelectedIndex);
 			picker.SelectedIndexChanged?.Invoke(bindable, EventArgs.Empty);
 		}
 
@@ -239,19 +242,19 @@ namespace Xamarin.Forms
 			SelectedIndex = Items.IndexOf(selectedItem);
 		}
 
-		void UpdateSelectedItem()
+		void UpdateSelectedItem(int index)
 		{
-			if (SelectedIndex == -1) {
+			if (index == -1) {
 				SelectedItem = null;
 				return;
 			}
 
 			if (ItemsSource != null) {
-				SelectedItem = ItemsSource [SelectedIndex];
+				SelectedItem = ItemsSource [index];
 				return;
 			}
 
-			SelectedItem = Items [SelectedIndex];
+			SelectedItem = Items [index];
 		}
 
 		public IPlatformElementConfiguration<T, Picker> On<T>() where T : IConfigPlatform


### PR DESCRIPTION
## Description of Change ###

**This is a retargeted version of #2833. See discussion, and reviews, over there**

In the `UpdateSelectedItem` sends the real `selectedIndex`

### Bugs Fixed ###

 - Fixes #2499
 - Fixes #2815
 - closes #2833

### API Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense