### PR TITLE
[Android,IOS] Fix inserting page and popping current

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2837.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2837.cs
@@ -1,0 +1,39 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2837, " Exception thrown during NavigationPage.Navigation.PopAsync", PlatformAffected.Android)]
+	public class Issue2837 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		string _labelText = "worked";
+		protected override async void Init()
+		{
+			// Initialize ui here instead of ctor
+			await PushAsync(new ContentPage() { Title = "MainPage" });
+		}
+
+		protected override async void OnAppearing()
+		{
+			var nav = (NavigationPage)this;
+
+			nav.Navigation.InsertPageBefore(new ContentPage() { Title = "SecondPage ", Content = new Label { Text = _labelText } }, nav.CurrentPage);
+			await nav.Navigation.PopAsync(false);
+			base.OnAppearing();
+		}
+
+#if UITEST
+		[Test]
+		public void Issue2837Test()
+		{
+			RunningApp.WaitForElement(q => q.Text (_labelText));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -426,6 +426,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1567.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2035.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2837.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -46,6 +46,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		MasterDetailPage _masterDetailPage;
 		bool _toolbarVisible;
 		bool _isAttachedToWindow;
+		bool _didInitialPushPages;
+
 
 		// The following is based on https://android.googlesource.com/platform/frameworks/support.git/+/4a7e12af4ec095c3a53bb8481d8d92f63157c3b7/v4/java/android/support/v4/app/FragmentManager.java#677
 		// Must be overriden in a custom renderer to match durations in XML animation resource files
@@ -491,6 +493,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void InsertPageBefore(Page page, Page before)
 		{
+			if (!_isAttachedToWindow)
+				PushCurrentPages();
+
 			UpdateToolbar();
 
 			int index = PageController.InternalChildren.IndexOf(before);
@@ -606,6 +611,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void RemovePage(Page page)
 		{
+			if (!_isAttachedToWindow)
+				PushCurrentPages();
+
 			Fragment fragment = GetPageFragment(page);
 
 			if (fragment == null)
@@ -765,7 +773,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			// pop
 			if (removed)
-				return _fragmentStack[Math.Max(0,_fragmentStack.Count - 2)];
+				return _fragmentStack[_fragmentStack.Count - 2];
 
 			// pop to root
 			if (popToRoot)
@@ -918,15 +926,19 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				return false;
 			});
 		}
-
+		
 		void PushCurrentPages()
 		{
+			if (_didInitialPushPages)
+				return;
+
 			var navController = (INavigationPageController)Element;
 
 			foreach (Page page in navController.Pages)
 			{
 				PushViewAsync(page, false);
 			}
+			_didInitialPushPages = true;
 		}
 
 		bool IsAttachedToRoot()

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -765,7 +765,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			// pop
 			if (removed)
-				return _fragmentStack[_fragmentStack.Count - 2];
+				return _fragmentStack[Math.Max(0,_fragmentStack.Count - 2)];
 
 			// pop to root
 			if (popToRoot)

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -321,9 +321,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (poppedViewController == null)
 			{
 				//// this happens only when the user does something REALLY dumb like pop right after putting the page as visible.
-				//poppedViewController = TopViewController;
-				//var newControllers = ViewControllers.Remove(poppedViewController);
-				//ViewControllers = newControllers;
+				poppedViewController = TopViewController;
+				var newControllers = ViewControllers.Remove(poppedViewController);
+				ViewControllers = newControllers;
 				actuallyRemoved = true;
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -320,16 +320,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (poppedViewController == null)
 			{
-				// this happens only when the user does something REALLY dumb like pop right after putting the page as visible.
-				poppedViewController = TopViewController;
-				var newControllers = ViewControllers.Remove(poppedViewController);
-				ViewControllers = newControllers;
+				//// this happens only when the user does something REALLY dumb like pop right after putting the page as visible.
+				//poppedViewController = TopViewController;
+				//var newControllers = ViewControllers.Remove(poppedViewController);
+				//ViewControllers = newControllers;
 				actuallyRemoved = true;
 			}
 			else
 				actuallyRemoved = !await task;
 
-			poppedViewController.Dispose();
+			poppedViewController?.Dispose();
 
 			UpdateToolBarVisible();
 			return actuallyRemoved;

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -276,9 +276,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
 		{
-			var changed = ElementChanged;
-			if (changed != null)
-				changed(this, e);
+			ElementChanged?.Invoke(this, e);
 		}
 
 		protected virtual async Task<bool> OnPopToRoot(Page page, bool animated)
@@ -318,16 +316,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UIViewController poppedViewController;
 			poppedViewController = base.PopViewController(animated);
 
-			if (poppedViewController == null)
-			{
-				//// this happens only when the user does something REALLY dumb like pop right after putting the page as visible.
-				poppedViewController = TopViewController;
-				var newControllers = ViewControllers.Remove(poppedViewController);
-				ViewControllers = newControllers;
-				actuallyRemoved = true;
-			}
-			else
-				actuallyRemoved = !await task;
+			actuallyRemoved = (poppedViewController == null) ? true : !await task;
 
 			poppedViewController?.Dispose();
 


### PR DESCRIPTION
### Description of Change ###

Android
If there was only 1 element on the stack the the índex was trying to remove a element of out bounds. 
IOS
Was removing the top and only controller

### Bugs Fixed ###

- fixes #2837 

### API Changes ###

None

### Behavioral Changes ###

Should not crash when removing the previous page when appearing on Android

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
