### PR TITLE
[XamlC] should not run during Design-Time Builds

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -91,7 +91,7 @@
 		</CompileDependsOn>
 	</PropertyGroup>
 
-	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp">
+	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp" Condition=" '$(DesignTimeBuild)' != 'True' ">
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"

--- a/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -356,11 +356,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			AssertDoesNotExist (assembly);
 			AssertExists (mainPageXamlG, nonEmpty: true);
 			AssertExists (fooCssG, nonEmpty: true);
-			AssertExists (xamlCStamp);
+			AssertDoesNotExist (xamlCStamp); //XamlC should be skipped
 
 			var expectedXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
 			var expectedCssG = new FileInfo (fooCssG).LastWriteTimeUtc;
-			var expectedXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
 
 			//Build again, a full build
 			Build (projectFile);
@@ -371,10 +370,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var actualXamlG = new FileInfo (mainPageXamlG).LastWriteTimeUtc;
 			var actualCssG = new FileInfo (fooCssG).LastWriteTimeUtc;
-			var actualXamlC = new FileInfo (xamlCStamp).LastWriteTimeUtc;
 			Assert.AreEqual (expectedXamlG, actualXamlG, $"Timestamps should match for {mainPageXamlG}.");
 			Assert.AreEqual (expectedCssG, actualCssG, $"Timestamps should match for {fooCssG}.");
-			Assert.AreNotEqual (expectedXamlC, actualXamlC, $"Timestamps should *not* match for {xamlCStamp}.");
 		}
 
 		//I believe the designer might invoke this target manually


### PR DESCRIPTION
### Description of Change ###

Some links about design-time builds:
- https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md
- https://daveaglick.com/posts/running-a-design-time-build-with-msbuild-apis

In Visual Studio 2017 (Windows), a "design-time" build is what drives
Intellisense in cases such as using `x:Name` in XAML (or
`Resource.designer.cs` in a plain Xamarin.Android app). Improving our
"design-time" build speed will improve general performance in the IDE
such as project load and how long Intellisense takes to update. Since
XamlC is not needed during a design-time build, it is an "easy-win" to
just disable it. XamlC can take a bit of time for projects with a lot
of XAML.

### Issues Resolved ###

This might also help with: https://github.com/xamarin/Xamarin.Forms/issues/3004

Although we should probably not do anything to specifically support
NCrunch; hopefully, NCrunch is running under the context of a
design-time build.

### API Changes ###

None

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

XamlC will not run during Design-Time Builds.

### PR Checklist ###

- [x] Has automated tests (Updated test)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
