### PR TITLE
[C] Allow change constraint before parenting

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/RelativeLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RelativeLayoutTests.cs
@@ -117,6 +117,30 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/2169
+		public void BoundsUpdatedIfConstraintsChangedWhileNotParented()
+		{
+			var relativeLayout = new RelativeLayout {
+				Platform = new UnitPlatform(),
+				IsPlatformEnabled = true
+			};
+
+			var child = new View {
+				IsPlatformEnabled = true
+			};
+
+			relativeLayout.Children.Add(child, Constraint.Constant(30), Constraint.Constant(20));
+			relativeLayout.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.That(child.Bounds, Is.EqualTo(new Rectangle(30,20,100,20)));
+
+			relativeLayout.Children.Remove(child);
+			relativeLayout.Children.Add(child, Constraint.Constant(50), Constraint.Constant(40));
+			Assert.That(child.Bounds, Is.EqualTo(new Rectangle(50, 40, 100, 20)));
+
+
+		}
+
+		[Test]
 		public void SimpleExpressionLayout ()
 		{
 			var relativeLayout = new RelativeLayout {

--- a/Xamarin.Forms.Core/BoundsConstraint.cs
+++ b/Xamarin.Forms.Core/BoundsConstraint.cs
@@ -13,15 +13,22 @@ namespace Xamarin.Forms
 		{
 		}
 
+		internal bool CreatedFromExpression { get; set; }
 		internal IEnumerable<View> RelativeTo { get; set; }
 
 		public static BoundsConstraint FromExpression(Expression<Func<Rectangle>> expression, IEnumerable<View> parents = null)
+		{
+			return FromExpression(expression, false, parents);
+		}
+
+		internal static BoundsConstraint FromExpression(Expression<Func<Rectangle>> expression, bool fromExpression, IEnumerable<View> parents = null)
 		{
 			Func<Rectangle> compiled = expression.Compile();
 			var result = new BoundsConstraint
 			{
 				_measureFunc = compiled,
-				RelativeTo = parents ?? ExpressionSearch.Default.FindObjects<View>(expression).ToArray() // make sure we have our own copy
+				RelativeTo = parents ?? ExpressionSearch.Default.FindObjects<View>(expression).ToArray(), // make sure we have our own copy
+				CreatedFromExpression = fromExpression
 			};
 
 			return result;

--- a/Xamarin.Forms.Core/RelativeLayout.cs
+++ b/Xamarin.Forms.Core/RelativeLayout.cs
@@ -162,7 +162,7 @@ namespace Xamarin.Forms
 		protected override void OnAdded(View view)
 		{
 			BoundsConstraint boundsConstraint = GetBoundsConstraint(view);
-			if (boundsConstraint == null)
+			if (boundsConstraint == null || !boundsConstraint.CreatedFromExpression)
 			{
 				// user probably added the view through the strict Add method.
 				CreateBoundsFromConstraints(view, GetXConstraint(view), GetYConstraint(view), GetWidthConstraint(view), GetHeightConstraint(view));
@@ -330,7 +330,7 @@ namespace Xamarin.Forms
 			{
 				if (bounds == null)
 					throw new ArgumentNullException(nameof(bounds));
-				SetBoundsConstraint(view, BoundsConstraint.FromExpression(bounds));
+				SetBoundsConstraint(view, BoundsConstraint.FromExpression(bounds, fromExpression: true));
 
 				base.Add(view);
 			}
@@ -348,7 +348,7 @@ namespace Xamarin.Forms
 				parents.AddRange(ExpressionSearch.Default.FindObjects<View>(width));
 				parents.AddRange(ExpressionSearch.Default.FindObjects<View>(height));
 
-				BoundsConstraint bounds = BoundsConstraint.FromExpression(() => new Rectangle(xCompiled(), yCompiled(), widthCompiled(), heightCompiled()), parents.Distinct().ToArray());
+				BoundsConstraint bounds = BoundsConstraint.FromExpression(() => new Rectangle(xCompiled(), yCompiled(), widthCompiled(), heightCompiled()), fromExpression: true, parents: parents.Distinct().ToArray());
 
 				SetBoundsConstraint(view, bounds);
 


### PR DESCRIPTION
### Description of Change ###

[C] Allow change constraint before parenting

Allow a constraint to be changed when the view is not parented yet.

### Issues Resolved ###

- fixes #2169

### API Changes ###

/

### Platforms Affected ###

/

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
