### PR TITLE
Fix broken 2499 test

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -24,7 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <MtouchArch>i386, x86_64</MtouchArch>
-    <MtouchLink>None</MtouchLink>
+    <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>True</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchProfiling>False</MtouchProfiling>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2499.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2499.cs
@@ -34,13 +34,20 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue2499Test ()
+		public void Issue2499Test()
 		{
-			RunningApp.Tap ("picker");
+			RunningApp.Tap("picker");
 			AppResult[] items = RunningApp.Query("cat");
 			Assert.AreNotEqual(items.Length, 0);
-
-			RunningApp.Tap ("cat");
+			RunningApp.WaitForElement(q => q.Marked("mouse"));
+			RunningApp.Tap("mouse");
+#if __IOS__
+			System.Threading.Tasks.Task.Delay(500).Wait();
+			var cancelButtonText = "Done";
+			RunningApp.WaitForElement(q => q.Marked(cancelButtonText));
+			RunningApp.Tap(q => q.Marked(cancelButtonText));
+			System.Threading.Tasks.Task.Delay(1000).Wait();
+ #endif
 			items = RunningApp.Query("cat");
 			Assert.AreEqual(items.Length, 0);
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -150,7 +150,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			Control.Hint = Element.Title;
 
-			if (Element.SelectedIndex == -1 || Element.Items == null)
+			if (Element.SelectedIndex == -1 || Element.Items == null || Element.SelectedIndex >= Element.Items.Count)
 				Control.Text = null;
 			else
 				Control.Text = Element.Items[Element.SelectedIndex];

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -180,7 +180,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			string oldText = Control.Text;
 
-			if (Element.SelectedIndex == -1 || Element.Items == null)
+			if (Element.SelectedIndex == -1 || Element.Items == null || Element.SelectedIndex >= Element.Items.Count)
 				Control.Text = null;
 			else
 				Control.Text = Element.Items[Element.SelectedIndex];

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var items = Element.Items;
 			Control.Placeholder = Element.Title;
 			var oldText = Control.Text;
-			Control.Text = selectedIndex == -1 || items == null ? "" : items[selectedIndex];
+			Control.Text = selectedIndex == -1 || items == null || selectedIndex >= items.Count ? "" : items[selectedIndex];
 			UpdatePickerNativeSize(oldText);
 			_picker.ReloadAllComponents();
 			if (items == null || items.Count == 0)


### PR DESCRIPTION
### Description of Change ###

SelectedIndex being a BP, setting it's value might be delayed, and as
both ios and android PickerRenderer do not update on individual property
changes, but have a single UpdatePicker method, some properties might be
out-of-date, causing a crash.

This doesn't attemps to fix the renderers, but only prevents a crash to
happen.

### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addesses -->

### API Changes ###

/

### Platforms Affected ###

- iOS
- Android

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
