### PR TITLE
Fine-tune the performance of VisualStateGroupList.Validate

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using NUnit.Framework;
 
 namespace Xamarin.Forms.Core.UnitTests
@@ -155,6 +157,21 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void StateNamesMustBeUniqueWithinGroupListWhenAddingGroup()
+		{
+			IList<VisualStateGroup> vsgs = CreateTestStateGroups();
+
+			// Create and add a second VisualStateGroup
+			var secondGroup = new VisualStateGroup { Name = "Foo" };
+
+			// Create a VisualState with the same name as one in another group in the list
+			var duplicate = new VisualState { Name = NormalStateName };
+			secondGroup.States.Add(duplicate);
+
+			Assert.Throws<InvalidOperationException>(() => vsgs.Add(secondGroup));
+		}
+
+		[Test]
 		public void GroupNamesMustBeUniqueWithinGroupList()
 		{
 			IList<VisualStateGroup> vsgs = CreateTestStateGroups();
@@ -261,6 +278,93 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.That(label1.Margin.Bottom, Is.EqualTo(targetBottomMargin));
 			Assert.That(label2.Margin.Bottom, Is.EqualTo(targetBottomMargin));
+		}
+
+		[Test]
+		public void CanRemoveAStateAndAddANewStateWithTheSameName()
+		{
+			var stateGroups = new VisualStateGroupList();
+			var visualStateGroup = new VisualStateGroup { Name = CommonStatesName };
+			var normalState = new VisualState { Name = NormalStateName };
+			var invalidState = new VisualState { Name = InvalidStateName };
+
+			stateGroups.Add(visualStateGroup);
+			visualStateGroup.States.Add(normalState);
+			visualStateGroup.States.Add(invalidState);
+
+			var name = visualStateGroup.States[0].Name;
+
+			visualStateGroup.States.Remove(visualStateGroup.States[0]);
+
+			visualStateGroup.States.Add(new VisualState { Name = name });
+		}
+
+		[Test]
+		public void CanRemoveAGroupAndAddANewGroupWithTheSameName()
+		{
+			var stateGroups = new VisualStateGroupList();
+			var visualStateGroup = new VisualStateGroup { Name = CommonStatesName };
+			var secondVisualStateGroup = new VisualStateGroup { Name = "Whatevs" };
+			var normalState = new VisualState { Name = NormalStateName };
+			var invalidState = new VisualState { Name = InvalidStateName };
+
+			stateGroups.Add(visualStateGroup);
+			visualStateGroup.States.Add(normalState);
+			visualStateGroup.States.Add(invalidState);
+			
+			stateGroups.Add(secondVisualStateGroup);
+
+			var name = stateGroups[0].Name;
+
+			stateGroups.Remove(stateGroups[0]);
+
+			stateGroups.Add(new VisualStateGroup { Name = name });
+		}
+
+		[Test]
+		[Explicit("This test was created to check performance characteristics; leaving it in because it may be useful again.")]
+		[TestCase(1, 10)]
+		[TestCase(1, 10000)]
+		[TestCase(10, 100)]
+		[TestCase(10, 10000)]
+		public void ValidatePerformance(int groups, int states)
+		{
+			IList<VisualStateGroup> vsgs = new VisualStateGroupList();
+
+			var groupList = new List<VisualStateGroup>();
+
+			for (int n = 0; n < groups; n++)
+			{
+				groupList.Add(new VisualStateGroup { Name = n.ToString() });
+			}
+
+			var watch = new Stopwatch();
+
+			watch.Start();
+
+			foreach (var group in groupList)
+			{
+				vsgs.Add(group);
+			}
+			
+			watch.Stop();
+
+			double iterations = states;
+			var random = new Random();
+
+			for (int n = 0; n < iterations; n++)
+			{
+				var state = new VisualState { Name = n.ToString() };
+				var group = groupList[random.Next(0, groups - 1)];
+				watch.Start();
+				group.States.Add(state);
+				watch.Stop();
+			}
+
+			var average = watch.ElapsedMilliseconds / iterations;
+
+			Debug.WriteLine($">>>>> VisualStateManagerTests ValidatePerformance: {watch.ElapsedMilliseconds}ms over {iterations} iterations; average of {average}ms");
+
 		}
 	}
 }

--- a/Xamarin.Forms.Core/VisualStateManager.cs
+++ b/Xamarin.Forms.Core/VisualStateManager.cs
@@ -103,25 +103,50 @@ namespace Xamarin.Forms
 	{
 		readonly IList<VisualStateGroup> _internalList;
 
-		static void Validate(IList<VisualStateGroup> groups)
+		// Used to check for duplicate names; we keep it around because it's cheaper to create it once and clear it
+		// than to create one every time we need to validate
+		readonly HashSet<string> _names = new HashSet<string>();
+
+		void Validate(IList<VisualStateGroup> groups)
 		{ 
-			// If we have 1 group, no need to worry about duplicate group names
-			if (groups.Count > 1)
+			var groupCount = groups.Count;
+
+			// If we only have 1 group, no need to worry about duplicate group names
+			if (groupCount > 1)
 			{
-				if (groups.GroupBy(vsg => vsg.Name).Any(g => g.Count() > 1))
+				_names.Clear();
+
+				// Using a for loop to avoid allocting an enumerator
+				for (int n = 0; n < groupCount; n++)
 				{
-					throw new InvalidOperationException("VisualStateGroup Names must be unique");
+					// HashSet will return false if the string is already in the set
+					if (!_names.Add(groups[n].Name))
+					{
+						throw new InvalidOperationException("VisualStateGroup Names must be unique");
+					}
 				}
 			}
 
-			// State names must be unique within this group list, so pull in all 
-			// the states in all the groups, group them by name, and see if we have
-			// and duplicates
-			if (groups.SelectMany(group => group.States)
-				.GroupBy(state => state.Name)
-				.Any(g => g.Count() > 1))
+			// State names must be unique within this group list, so we'll iterate over all the groups
+			// and their states and add the state names to a HashSet; we throw an exception if a duplicate shows up
+
+			_names.Clear();
+
+			// Using nested for loops to avoid allocating enumerators
+			for (int groupIndex = 0; groupIndex < groupCount; groupIndex++)
 			{
-				throw new InvalidOperationException("VisualState Names must be unique");
+				// Cache the group lookup and states count; it's ugly, but it speeds things up a lot
+				var group = groups[groupIndex];
+				var stateCount = group.States.Count;
+
+				for (int stateIndex = 0; stateIndex < stateCount; stateIndex++)
+				{
+					// HashSet will return false if the string is already in the set
+					if (!_names.Add(group.States[stateIndex].Name))
+					{
+						throw new InvalidOperationException("VisualState Names must be unique");
+					}
+				}
 			}
 		}
 
@@ -153,7 +178,13 @@ namespace Xamarin.Forms
 
 		public void Add(VisualStateGroup item)
 		{
+			if (item == null)
+			{
+				throw new ArgumentNullException(nameof(item));
+			}
+
 			_internalList.Add(item);
+
 			item.StatesChanged += ValidateAndNotify;
 		}
 
@@ -179,6 +210,11 @@ namespace Xamarin.Forms
 
 		public bool Remove(VisualStateGroup item)
 		{
+			if (item == null)
+			{
+				throw new ArgumentNullException(nameof(item));
+			}
+
 			item.StatesChanged -= ValidateAndNotify;
 			return _internalList.Remove(item);
 		}
@@ -194,6 +230,11 @@ namespace Xamarin.Forms
 
 		public void Insert(int index, VisualStateGroup item)
 		{
+			if (item == null)
+			{
+				throw new ArgumentNullException(nameof(item));
+			}
+
 			item.StatesChanged += ValidateAndNotify;
 			_internalList.Insert(index, item);
 		}

--- a/Xamarin.Forms.Core/VisualStateManager.cs
+++ b/Xamarin.Forms.Core/VisualStateManager.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Forms
 			{
 				_names.Clear();
 
-				// Using a for loop to avoid allocting an enumerator
+				// Using a for loop to avoid allocating an enumerator
 				for (int n = 0; n < groupCount; n++)
 				{
 					// HashSet will return false if the string is already in the set


### PR DESCRIPTION
### Description of Change ###

Significantly reduce the performance impact of the `Validate` method on `VisualStateGroupList`.

### Issues Resolved ###

- fixes #3033 

### API Changes ###

None

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
