### PR TITLE
[Android] Set bottom content padding on bottom of Navigation Container when bottom tab is present

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2993.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2993.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2993, "[Android] Bottom Tab Bar with a navigation page is hiding content",
+		PlatformAffected.Android)]
+	public class Issue2993 : TestTabbedPage
+	{
+		protected override void Init()
+		{
+			On<Android>().SetToolbarPlacement(PlatformConfiguration.AndroidSpecific.ToolbarPlacement.Bottom);
+			BarBackgroundColor = Color.Transparent;
+
+			Func<ContentPage> createPage = () =>
+			{
+				Grid grid = new Grid();
+				grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Star });
+				grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+				grid.Children.Add(new Label() { Text = "Top Text", BackgroundColor = Color.Purple });
+				var bottomLabel = new Label() { Text = "Bottom Text" };
+				Grid.SetRow(bottomLabel, 1);
+				grid.Children.Add(bottomLabel);
+
+				var contentPage = new ContentPage()
+				{
+					Content = grid,
+					Icon = "coffee.png"
+				};
+
+				return contentPage;
+			};
+
+			Children.Add(new NavigationPage(createPage()));
+			Children.Add((createPage()));
+			Children.Add(new ContentPage()
+			{
+				Icon = "calculator.png",
+				Content = new Button()
+				{
+					Text = "Click Me",
+					Command = new Command(() =>
+					{
+						Children.Add(new NavigationPage(createPage()));
+						Children.RemoveAt(0);
+					})
+				}
+			});
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void BottomContentVisibleWithBottomBarAndNavigationPage()
+		{
+			RunningApp.WaitForElement("Bottom Text");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -341,6 +341,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36479.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3008.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3019.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2993.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37625.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -68,7 +68,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Device.Info.PropertyChanged += DeviceInfoPropertyChanged;
 		}
 
-		internal int ContainerPadding { get; set; }
+		internal int ContainerTopPadding { get; set; }
+		internal int ContainerBottomPadding { get; set; }
 
 		Page Current
 		{
@@ -333,7 +334,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			bar.Measure(MeasureSpecFactory.MakeMeasureSpec(r - l, MeasureSpecMode.Exactly), MeasureSpecFactory.MakeMeasureSpec(barHeight, MeasureSpecMode.Exactly));
 
 			var barOffset = ToolbarVisible ? barHeight : 0;
-			int containerHeight = b - t - ContainerPadding - barOffset;
+			int containerHeight = b - t - ContainerTopPadding - barOffset - ContainerBottomPadding;
 
 			PageController.ContainerArea = new Rectangle(0, 0, Context.FromPixels(r - l), Context.FromPixels(containerHeight));
 
@@ -359,12 +360,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (childHasNavBar)
 				{
 					bar.Layout(0, 0, r - l, barHeight);
-					child.Layout(0, barHeight + ContainerPadding, r, b);
+					child.Layout(0, barHeight + ContainerTopPadding, r, b - ContainerBottomPadding);
 				}
 				else
 				{
 					bar.Layout(0, -1000, r, barHeight - 1000);
-					child.Layout(0, ContainerPadding, r, b);
+					child.Layout(0, ContainerTopPadding, r, b - ContainerBottomPadding);
 				}
 				toolbarLayoutCompleted = true;
 			}
@@ -414,7 +415,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (actionBarHeight <= 0)
 				return Device.Info.CurrentOrientation.IsPortrait() ? (int)Context.ToPixels(56) : (int)Context.ToPixels(48);
-			
+
 			if (((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentStatus) || ((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentNavigation))
 			{
 				if (_toolbar.PaddingTop == 0)
@@ -437,7 +438,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			valueAnim.Update += (s, a) => icon.Progress = (float)a.Animation.AnimatedValue;
 			valueAnim.Start();
 		}
-		
+
 		int GetStatusBarHeight()
 		{
 			if (_statusbarHeight > 0)
@@ -650,11 +651,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			_toolbar = null;
 
 			SetupToolbar();
-			
+
 			// if the old toolbar had padding from transluscentflags, set it to the new toolbar
 			if (oldToolbar.PaddingTop != 0)
 				_toolbar.SetPadding(0, oldToolbar.PaddingTop, 0, 0);
-			
+
 			RegisterToolbar();
 			UpdateToolbar();
 			UpdateMenu();

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -306,6 +306,23 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateSwipePaging();
 		}
 
+		void SetNavigationRendererPadding(int paddingTop, int paddingBottom)
+		{
+			for (var i = 0; i < PageController.InternalChildren.Count; i++)
+			{
+				var child = PageController.InternalChildren[i] as VisualElement;
+				if (child == null)
+					continue;
+				IVisualElementRenderer renderer = Android.Platform.GetRenderer(child);
+				var navigationRenderer = renderer as NavigationPageRenderer;
+				if (navigationRenderer != null)
+				{
+					navigationRenderer.ContainerTopPadding = paddingTop;
+					navigationRenderer.ContainerBottomPadding = paddingBottom;
+				}
+			}
+		}
+
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			FormsViewPager pager = _viewPager;
@@ -327,7 +344,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				if (width > 0 && height > 0)
 				{
-					PageController.ContainerArea = new Rectangle(0, 0, context.FromPixels(width), context.FromPixels(height - _bottomNavigationView.Height));
+					PageController.ContainerArea = new Rectangle(0, 0, context.FromPixels(width), context.FromPixels(height - _bottomNavigationView.MeasuredHeight));
+
+					SetNavigationRendererPadding(0, _bottomNavigationView.MeasuredHeight);
 
 					pager.Layout(0, 0, width, b);
 					// We need to measure again to ensure that the tabs show up
@@ -359,16 +378,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					PageController.ContainerArea = new Rectangle(0, context.FromPixels(tabsHeight), context.FromPixels(width), context.FromPixels(height - tabsHeight));
 
-					for (var i = 0; i < PageController.InternalChildren.Count; i++)
-					{
-						var child = PageController.InternalChildren[i] as VisualElement;
-						if (child == null)
-							continue;
-						IVisualElementRenderer renderer = Android.Platform.GetRenderer(child);
-						var navigationRenderer = renderer as NavigationPageRenderer;
-						if (navigationRenderer != null)
-							navigationRenderer.ContainerPadding = tabsHeight;
-					}
+					SetNavigationRendererPadding(tabsHeight, 0);
 
 					pager.Layout(0, 0, width, b);
 					// We need to measure again to ensure that the tabs show up


### PR DESCRIPTION
### Description of Change ###

When the Navigation Bar is on the bottom for Android the Navigation Renderer Content Area needs its bottom padding set so content doesn't show up beneath it

### Issues Resolved ###

fixes #2993

### Platforms Affected ###

- Android


### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
