### PR TITLE
Avoid infinite loop when removing refresh indicator on iOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1799.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1799.cs
@@ -1,0 +1,52 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ListView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1799, "[iOS] listView without data crash on ipad.", PlatformAffected.iOS)]
+	public class Issue1799 : TestContentPage
+	{
+		const string ListView = "ListView1799";
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var listView = new ListView { IsRefreshing = true, AutomationId = ListView, IsPullToRefreshEnabled = false };
+
+			var instructions = new Label { Text = "Pull the the ListView down and release. If the application crashes, the test has failed." };
+
+			var success = new Label { Text = Success };
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(success);
+			layout.Children.Add(listView);
+
+			Content = layout;
+		}
+
+#if UITEST
+		[Test]
+		public void ListViewWithoutDataDoesNotCrash()
+		{
+			var result = RunningApp.WaitForElement(ListView);
+			var listViewRect = result[0].Rect;
+
+			RunningApp.DragCoordinates(listViewRect.CenterX, listViewRect.Y, listViewRect.CenterX, listViewRect.Y + 50);
+
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -240,6 +240,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1799.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1931.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2767.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2499.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1103,7 +1103,14 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (_isDragging && scrollView.ContentOffset.Y < 0)
 				{
+					// If the refresh spinner is currently displayed and pull-to-refresh is not enabled,
+					// calling UpdateShowHideRefresh will remove the spinner and cause the ScrollView to shift;
+					// this will fire off this Scrolled override again and we'll be in an infinite loop (which iOS
+					// will promptly kill, and the app will close)
+					// So we temporarily flip _isDragging to false in order to prevent the loop.
+					_isDragging = false;
 					_uiTableViewController.UpdateShowHideRefresh(true);
+					_isDragging = true;
 				}
 
 				if (_isDragging && scrollView.ContentOffset.Y < -10f && _uiTableViewController._usingLargeTitles && Device.Info.CurrentOrientation.IsPortrait())


### PR DESCRIPTION
### Description of Change ###

Removing the refresh indicator when IsPullToRefreshEnabled is set to false and the ListView has no data on iOS causes the list to move enough to trigger an infinite loop in the Scrolled override. This change averts the loop.

### Issues Resolved ###

- #1799

### API Changes ###

None

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
