### PR TITLE
[Tizen] Rename EvasObjectWrapper to NativeViewWrapper

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Extensions/LayoutExtensions.cs
+++ b/Xamarin.Forms.Platform.Tizen/Extensions/LayoutExtensions.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		/// <param name="measureDelegate">Optional delegate which provides measurements for the evas object.</param>
 		public static View ToView(this EvasObject obj, MeasureDelegate measureDelegate = null)
 		{
-			return new EvasObjectWrapper(obj, measureDelegate);
+			return new NativeViewWrapper(obj, measureDelegate);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/NativeViewWrapper.cs
+++ b/Xamarin.Forms.Platform.Tizen/NativeViewWrapper.cs
@@ -3,11 +3,11 @@ using ESize = ElmSharp.Size;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
-	public delegate ESize? MeasureDelegate(EvasObjectWrapperRenderer renderer, int availableWidth, int availableHeight);
+	public delegate ESize? MeasureDelegate(NativeViewWrapperRenderer renderer, int availableWidth, int availableHeight);
 
-	public class EvasObjectWrapper : View
+	public class NativeViewWrapper : View
 	{
-		public EvasObjectWrapper(EvasObject obj, MeasureDelegate measureDelegate = null)
+		public NativeViewWrapper(EvasObject obj, MeasureDelegate measureDelegate = null)
 		{
 			EvasObject = obj;
 			MeasureDelegate = measureDelegate;

--- a/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using Xamarin.Forms.Platform.Tizen;
 [assembly: ExportRenderer(typeof(Entry), typeof(EntryRenderer))]
 [assembly: ExportRenderer(typeof(Editor), typeof(EditorRenderer))]
 [assembly: ExportRenderer(typeof(TableView), typeof(TableViewRenderer))]
-[assembly: ExportRenderer(typeof(EvasObjectWrapper), typeof(EvasObjectWrapperRenderer))]
+[assembly: ExportRenderer(typeof(NativeViewWrapper), typeof(NativeViewWrapperRenderer))]
 [assembly: ExportRenderer(typeof(WebView), typeof(WebViewRenderer))]
 
 [assembly: ExportImageSourceHandler(typeof(FileImageSource), typeof(FileImageSourceHandler))]

--- a/Xamarin.Forms.Platform.Tizen/Renderers/NativeViewWrapperRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/NativeViewWrapperRenderer.cs
@@ -1,12 +1,15 @@
+using ElmSharp;
 using ESize = ElmSharp.Size;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
-	public class EvasObjectWrapperRenderer : VisualElementRenderer<EvasObjectWrapper>
+	public class NativeViewWrapperRenderer : ViewRenderer<NativeViewWrapper, EvasObject>
 	{
-		protected override void OnElementChanged(ElementChangedEventArgs<EvasObjectWrapper> e)
+		protected override void OnElementChanged(ElementChangedEventArgs<NativeViewWrapper> e)
 		{
-			SetNativeView(Element.EvasObject);
+			if (Control == null)
+				SetNativeControl(Element.EvasObject);
+
 			base.OnElementChanged(e);
 		}
 


### PR DESCRIPTION
### Description of Change ###

`EvasObjectWrapper` is renamed to `NativeViewWrapper` for the sake of consistency. It also changed to inhert `ViewRenderer` from `VisualElementRenderer`.

### Issues Resolved ###

None

### API Changes ###

None

### Platforms Affected ###

- Tizen

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
