### PR TITLE
[UWP] Remove use of TemplatedItemsList for Cells

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2617.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2617.cs
@@ -1,0 +1,143 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2617, "Error on binding ListView with duplicated items", PlatformAffected.UWP)]
+
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue2617 : TestContentPage
+	{
+		public Label SuccessLabel { get; private set; }
+		public Button OneMillionButton { get; private set; }
+		public Button ClearItemSourceButton { get; private set; }
+		public ListView listView { get; private set; }
+		public ListView listViewIsGrouped { get; private set; }
+
+		class MyHeaderViewCell : ViewCell
+		{
+			public MyHeaderViewCell()
+			{
+				Height = 25;
+				var label = new Label { VerticalOptions = LayoutOptions.Center };
+				label.SetBinding(Label.TextProperty, nameof(GroupedItem.Name));
+				View = label;
+			}
+		}
+
+		class GroupedItem : List<string>
+		{
+			public GroupedItem()
+			{
+				AddRange(Enumerable.Range(0, 3).Select(i => "Group item"));
+			}
+			public string Name { get; set; }
+		}
+
+		protected override void Init()
+		{
+			listView = new ListView
+			{
+				ItemsSource = Enumerable.Range(0, 3).Select(x => "Item 1"),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					Label nameLabel = new Label();
+					nameLabel.SetBinding(Label.TextProperty, new Binding("."));
+					var cell = new ViewCell
+					{
+						View = new Frame()
+						{
+							Content = nameLabel
+						},
+					};
+					return cell;
+				}),
+				AutomationId = "ListViewToScroll"
+			};
+			listViewIsGrouped = new ListView
+			{
+				ItemsSource = Enumerable.Range(0, 3).Select(x => new GroupedItem() { Name = $"Group {x}" }),
+				IsGroupingEnabled = true,
+				GroupHeaderTemplate = new DataTemplate(typeof(MyHeaderViewCell)),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					Label nameLabel = new Label();
+					nameLabel.SetBinding(Label.TextProperty, new Binding("."));
+					var cell = new ViewCell
+					{
+						View = new Frame()
+						{
+							Content = nameLabel
+						},
+					};
+					return cell;
+				})
+			};
+
+			SuccessLabel = new Label() { Text = "Test Runs Automatically just wait" };
+			OneMillionButton = new Button()
+			{
+				Text = "One Million",
+				Command = new Command(() => listView.ItemsSource = Enumerable.Range(0, 1000000).Select(x => x == 999999 ? "Scroll to me" : "Item 1"))
+			};
+			ClearItemSourceButton = new Button()
+			{
+				Text = "Clear ItemsSource",
+				Command = new Command(() => listView.ItemsSource = null)
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					SuccessLabel,
+					OneMillionButton,
+					ClearItemSourceButton,
+					listView,
+					listViewIsGrouped,
+				}
+			};
+		}
+
+		protected override async void OnAppearing()
+		{
+			base.OnAppearing();
+			await Task.Delay(500);
+			ClearItemSourceButton.SendClicked();
+			await Task.Delay(500);
+			OneMillionButton.SendClicked();
+			await Task.Delay(500);
+			listViewIsGrouped.ItemsSource = null;
+			await Task.Delay(500);
+			listView.ScrollTo("Scroll to me", ScrollToPosition.Center, true);			
+			await Task.Delay(1000);
+			listView.ScrollTo("Item 1", ScrollToPosition.Start, true);
+			await Task.Delay(1000);
+			SuccessLabel.HeightRequest = 200;
+			SuccessLabel.Text = "Success";
+			SuccessLabel.HorizontalTextAlignment = TextAlignment.Center;
+			listView.ItemsSource = null;
+		}
+
+
+#if UITEST
+		[Test]
+		public async void BindingToValuesTypesAndScrollingNoCrash()
+		{
+			await Task.Delay(4000);
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3053.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3053.cs
@@ -1,0 +1,77 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3053, "Moving items around on an Observable Collection causes the last item to disappear", PlatformAffected.UWP)]
+
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue3053 : TestContentPage
+	{
+		const string _instructions = "Click me once. Item 2 should remain on bottom";
+		public class Item
+		{
+			public string Name { get; set; }
+		}
+
+		protected override void Init()
+		{
+			var listView = new ListView
+			{
+				ItemsSource = new ObservableCollection<Item>(Enumerable.Range(0, 3).Select(x => new Item() { Name = $"Item {x}" })),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					Label nameLabel = new Label();
+					nameLabel.SetBinding(Label.TextProperty, new Binding("Name"));
+					var cell = new ViewCell
+					{
+						View = new Frame()
+						{
+							Content = nameLabel
+						},
+					};
+					return cell;
+				})
+			};
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Button()
+					{
+						Text = _instructions,
+						Command = new Command(() =>
+						{
+							var collection = listView.ItemsSource as ObservableCollection<Item>;
+							collection.Add(new Item(){ Name =  Guid.NewGuid().ToString() });
+							collection.Move(3,1);
+						})
+					},
+					listView
+				}
+			};
+		}
+#if UITEST
+		[Test]
+		public void MovingItemInObservableCollectionBreaksListView()
+		{
+			RunningApp.WaitForElement(_instructions);
+			RunningApp.Tap(_instructions);
+			RunningApp.WaitForElement("Item 2");
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -242,6 +242,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1799.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1931.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3053.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2617.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2767.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2499.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />

--- a/Xamarin.Forms.Platform.UAP/CellControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CellControl.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Platform.UWP
 			_propertyChangedHandler = OnCellPropertyChanged;
 		}
 
-		public Cell Cell		
+		public Cell Cell
 		{
 			get { return (Cell)GetValue(CellProperty); }
 			set { SetValue(CellProperty, value); }
@@ -222,16 +222,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				if (template != null)
 				{
-					if (lv.IsGroupingEnabled)
-					{
-						cell = isGroupHeader 
-							? RealizeGroupedHeaderTemplate(lv.TemplatedItems, template, newContext) 
-							: RealizeGroupedItemTemplate(lv.TemplatedItems, template, newContext);
-					}
-					else
-					{
-						cell = RealizeItemTemplate(lv.TemplatedItems, template, newContext);
-					}
+					cell = template.CreateContent() as Cell;
 				}
 				else
 				{
@@ -335,44 +326,6 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 
 			this.UpdateFlowDirection(newCell.Parent as VisualElement);
-		}
-
-		static Cell RealizeGroupedHeaderTemplate(TemplatedItemsList<ItemsView<Cell>, Cell> templatedItems, 
-			ElementTemplate template, object context)
-		{
-			var index = templatedItems.GetGlobalIndexOfGroup(context);
-			if (index > -1)
-			{
-				return templatedItems[index];
-			}
-
-			return template.CreateContent() as Cell;
-		}
-
-		static Cell RealizeGroupedItemTemplate(ITemplatedItemsList<Cell> templatedItems, 
-			ElementTemplate template, object context)
-		{
-			var indices = templatedItems.GetGroupAndIndexOfItem(context);
-
-			if (indices.Item1 > -1 && indices.Item2 > -1)
-			{
-				var group = templatedItems.GetGroup(indices.Item1);
-				return group[indices.Item2];
-			}
-
-			return template.CreateContent() as Cell;
-		}
-
-		static Cell RealizeItemTemplate(ITemplatedItemsList<Cell> templatedItems, 
-			ElementTemplate template, object context)
-		{
-			var index = templatedItems.GetGlobalIndexOfItem(context);
-			if (index > -1)
-			{
-				return templatedItems[index];
-			}
-
-			return template.CreateContent() as Cell;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
Reusing templated cells on UWP breaks the UWP listview in multiple ways. This change rolls back to just creating a new cell for each row.  I tested the memory implications of this and did not see any leaks caused by this changed.   At a later point we can further test and optimize the performance but ListView2 may trump that effort

### Issues Resolved ###

- fixes #2617
- fixes #3053
- fixes #2832

### Platforms Affected ###
- UWP


### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
