### PR TITLE
[Core] Add support for internal bindable properties for F#

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -823,7 +823,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var name = $"{localName}Property";
 			FieldReference bpRef = bpOwnerType.GetField(fd => fd.Name == name &&
 														fd.IsStatic &&
-														fd.IsPublic, out declaringTypeReference);
+														(fd.IsPublic || fd.IsAssembly), out declaringTypeReference);
 			if (bpRef != null) {
 				bpRef = module.ImportReference(bpRef.ResolveGenericParameters(declaringTypeReference));
 				bpRef.FieldType = module.ImportReference(bpRef.FieldType);

--- a/Xamarin.Forms.Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					 xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.BindablePropertiesAccessModifiers">
+	<ContentPage.Content>
+		<local:AccessModifiersControl PublicFoo="{Binding Foo}"
+								      InternalBar="{Binding Bar}"
+									  x:Name="AMC"
+									  x:FieldModifier="public"/>
+	</ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml.cs
@@ -27,8 +27,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			set => SetValue(InternalBarProperty, value);
 		}
 	}
-
-	[XamlCompilation(XamlCompilationOptions.Skip)]
+	
 	public partial class BindablePropertiesAccessModifiers : ContentPage
 	{
 		class Data
@@ -66,17 +65,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TestCase(false)]
 			public void BindProperties(bool useCompiledXaml)
 			{
-				if (useCompiledXaml)
-				{
-					MockCompiler.Compile(typeof(BindablePropertiesAccessModifiers));
-				}
-				else
-				{
-					var page = new BindablePropertiesAccessModifiers();
-					page.BindingContext = new Data();
-					Assert.AreEqual("Bar", page.AMC.GetValue(AccessModifiersControl.InternalBarProperty));
-					Assert.AreEqual("Foo", page.AMC.GetValue(AccessModifiersControl.PublicFooProperty));
-				}
+				var page = new BindablePropertiesAccessModifiers(useCompiledXaml);
+				page.BindingContext = new Data();
+				Assert.AreEqual("Bar", page.AMC.GetValue(AccessModifiersControl.InternalBarProperty));
+				Assert.AreEqual("Foo", page.AMC.GetValue(AccessModifiersControl.PublicFooProperty));
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml.cs
@@ -1,0 +1,83 @@
+﻿using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class AccessModifiersControl : View
+	{
+		public static BindableProperty PublicFooProperty = BindableProperty.Create("PublicFoo",
+			typeof(string),
+			typeof(AccessModifiersControl),
+			"");
+
+		public string PublicFoo
+		{
+			get => (string)GetValue(PublicFooProperty);
+			set => SetValue(PublicFooProperty, value);
+		}
+
+		internal static BindableProperty InternalBarProperty = BindableProperty.Create("InternalBar",
+			typeof(string),
+			typeof(AccessModifiersControl),
+			"");
+
+		public string InternalBar
+		{
+			get => (string)GetValue(InternalBarProperty);
+			set => SetValue(InternalBarProperty, value);
+		}
+	}
+
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class BindablePropertiesAccessModifiers : ContentPage
+	{
+		class Data
+		{
+			public string Foo => "Foo";
+			public string Bar => "Bar";
+		}
+
+		public BindablePropertiesAccessModifiers()
+		{
+			InitializeComponent();
+		}
+
+		public BindablePropertiesAccessModifiers(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			[TestCase(false)]
+			public void BindProperties(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+				{
+					MockCompiler.Compile(typeof(BindablePropertiesAccessModifiers));
+				}
+				else
+				{
+					var page = new BindablePropertiesAccessModifiers();
+					page.BindingContext = new Data();
+					Assert.AreEqual("Bar", page.AMC.GetValue(AccessModifiersControl.InternalBarProperty));
+					Assert.AreEqual("Foo", page.AMC.GetValue(AccessModifiersControl.PublicFooProperty));
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -105,6 +105,9 @@
     <Compile Include="AutomationProperties.xaml.cs">
       <DependentUpon>AutomationProperties.xaml</DependentUpon>
     </Compile>
+    <Compile Include="BindablePropertiesAccessModifiers.xaml.cs">
+      <DependentUpon>BindablePropertiesAccessModifiers.xaml</DependentUpon>
+    </Compile>
     <Compile Include="FontConverterTests.cs" />
     <Compile Include="Issues\Bz43450.xaml.cs">
       <DependentUpon>Bz43450.xaml</DependentUpon>
@@ -1173,6 +1176,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="VisualStateManagerTests.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="BindablePropertiesAccessModifiers.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -275,8 +275,7 @@ namespace Xamarin.Forms.Xaml
 			// F# does not support public fields, so allow internal (Assembly) as well as public
 			const BindingFlags supportedFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
 			var bindableFieldInfo = elementType.GetFields(supportedFlags)
-												.Where(fi => fi.IsAssembly || fi.IsPublic)
-												.FirstOrDefault(fi => fi.Name == localName + "Property");
+												.FirstOrDefault(fi => (fi.IsAssembly || fi.IsPublic) && fi.Name == localName + "Property");
 #endif
 			Exception exception = null;
 			if (exception == null && bindableFieldInfo == null) {

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -272,7 +272,11 @@ namespace Xamarin.Forms.Xaml
 #if NETSTANDARD1_0
 			var bindableFieldInfo = elementType.GetFields().FirstOrDefault(fi => fi.Name == localName + "Property");
 #else
-			var bindableFieldInfo = elementType.GetFields(BindingFlags.Static | BindingFlags.Public|BindingFlags.FlattenHierarchy).FirstOrDefault(fi => fi.Name == localName + "Property");
+			// F# does not support public fields, so allow internal (Assembly) as well as public
+			const BindingFlags supportedFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
+			var bindableFieldInfo = elementType.GetFields(supportedFlags)
+												.Where(fi => fi.IsAssembly || fi.IsPublic)
+												.FirstOrDefault(fi => fi.Name == localName + "Property");
 #endif
 			Exception exception = null;
 			if (exception == null && bindableFieldInfo == null) {


### PR DESCRIPTION
### Description of Change ###

Changes the XAML compiler and parser to allow `internal` bindable properties on controls.

### Issues Resolved ###

- fixes #2425

### API Changes ###

None

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
