### PR TITLE
Add drag started and completed events/commands to Slider

### DIFF
--- a/Xamarin.Forms.Core/Slider.cs
+++ b/Xamarin.Forms.Core/Slider.cs
@@ -49,6 +49,10 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty ThumbImageProperty = BindableProperty.Create(nameof(ThumbImage), typeof(FileImageSource), typeof(Slider), default(FileImageSource));
 
+		public static readonly BindableProperty DragStartedCommandProperty = BindableProperty.Create(nameof(DragStartedCommand), typeof(ICommand), typeof(Slider), default(ICommand));
+
+		public static readonly BindableProperty DragCompletedCommandProperty = BindableProperty.Create(nameof(DragCompletedCommand), typeof(ICommand), typeof(Slider), default(ICommand));
+
 		readonly Lazy<PlatformConfigurationRegistry<Slider>> _platformConfigurationRegistry;
 
 		public Slider()
@@ -98,6 +102,18 @@ namespace Xamarin.Forms
 			set { SetValue(ThumbImageProperty, value); }
 		}
 
+		public ICommand DragStartedCommand
+		{
+			get { return (ICommand)GetValue(DragStartedCommandProperty); }
+			set { SetValue(DragStartedCommandProperty, value); }
+		}
+
+		public ICommand DragCompletedCommand
+		{
+			get { return (ICommand)GetValue(DragCompletedCommandProperty); }
+			set { SetValue(DragCompletedCommandProperty, value); }
+		}
+
 		public double Maximum
 		{
 			get { return (double)GetValue(MaximumProperty); }
@@ -118,9 +134,34 @@ namespace Xamarin.Forms
 
 		public event EventHandler<ValueChangedEventArgs> ValueChanged;
 
+		public event EventHandler DragStarted;
+		public event EventHandler DragCompleted;
+
 		public IPlatformElementConfiguration<T, Slider> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
+		}
+
+		public void SendDragStarted()
+		{
+			var command = DragStartedCommand;
+			if (command != null && command.CanExecute(null))
+			{
+				command.Execute(null);
+			}
+
+			DragStarted?.Invoke(this, null);
+		}
+
+		public void SendDragCompleted()
+		{
+			var command = DragCompletedCommand;
+			if (command != null && command.CanExecute(null))
+			{
+				command.Execute(null);
+			}
+
+			DragCompleted?.Invoke(this, null);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -44,11 +44,13 @@ namespace Xamarin.Forms.Platform.Android
 		void SeekBar.IOnSeekBarChangeListener.OnStartTrackingTouch(SeekBar seekBar)
 		{
 			_isTrackingChange = true;
+			Element.SendDragStarted();
 		}
 
 		void SeekBar.IOnSeekBarChangeListener.OnStopTrackingTouch(SeekBar seekBar)
 		{
 			_isTrackingChange = false;
+			Element.SendDragCompleted();
 		}
 
 		protected override SeekBar CreateNativeControl()

--- a/Xamarin.Forms.Platform.UAP/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SliderRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 
@@ -13,9 +14,19 @@ namespace Xamarin.Forms.Platform.UWP
 		Brush defaultbackgroundcolor;
 		Brush _defaultThumbColor;
 
+		PointerEventHandler _pointerPressedHandler;
+		PointerEventHandler _pointerReleasedHandler;
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Slider> e)
 		{
 			base.OnElementChanged(e);
+
+			if (e.OldElement != null)
+			{
+				Control.RemoveHandler(PointerPressedEvent, _pointerPressedHandler);
+				Control.RemoveHandler(PointerReleasedEvent, _pointerReleasedHandler);
+				Control.RemoveHandler(PointerCanceledEvent, _pointerReleasedHandler);
+			}
 
 			if (e.NewElement != null)
 			{
@@ -54,6 +65,13 @@ namespace Xamarin.Forms.Platform.UWP
 
 						slider.Margin = new Windows.UI.Xaml.Thickness(0, 7, 0, 0);
 					}
+
+					_pointerPressedHandler = new PointerEventHandler(OnPointerPressed);
+					_pointerReleasedHandler = new PointerEventHandler(OnPointerReleased);
+
+					Control.AddHandler(PointerPressedEvent, _pointerPressedHandler, true);
+					Control.AddHandler(PointerReleasedEvent, _pointerReleasedHandler, true);
+					Control.AddHandler(PointerCanceledEvent, _pointerReleasedHandler, true);
 				}
 
 				double stepping = Math.Min((e.NewElement.Maximum - e.NewElement.Minimum) / 10, 1);
@@ -179,6 +197,16 @@ namespace Xamarin.Forms.Platform.UWP
 		void OnNativeValueChanged(object sender, RangeBaseValueChangedEventArgs e)
 		{
 			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, e.NewValue);
+		}
+
+		private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+		{
+			Element.SendDragStarted();
+		}
+
+		private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+		{
+			Element.SendDragCompleted();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
@@ -28,6 +28,9 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.RemoveGestureRecognizer(_sliderTapRecognizer);
 					_sliderTapRecognizer = null;
 				}
+
+				Control.RemoveTarget(OnTouchDownControlEvent, UIControlEvent.TouchDown);
+				Control.RemoveTarget(OnTouchUpControlEvent, UIControlEvent.TouchUpInside | UIControlEvent.TouchUpOutside);
 			}
 
 			base.Dispose(disposing);
@@ -54,6 +57,9 @@ namespace Xamarin.Forms.Platform.iOS
 					// except if your not running iOS 7... then it fails...
 					if (_fitSize.Width <= 0 || _fitSize.Height <= 0)
 						_fitSize = new SizeF(22, 22); // Per the glorious documentation known as the SDK docs
+
+					Control.AddTarget(OnTouchDownControlEvent, UIControlEvent.TouchDown);
+					Control.AddTarget(OnTouchUpControlEvent, UIControlEvent.TouchUpInside | UIControlEvent.TouchUpOutside);
 				}
 
 				UpdateMaximum();
@@ -170,6 +176,16 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnControlValueChanged(object sender, EventArgs eventArgs)
 		{
 			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, Control.Value);
+		}
+
+		private void OnTouchDownControlEvent(object sender, EventArgs e)
+		{
+			Element.SendDragStarted();
+		}
+
+		private void OnTouchUpControlEvent(object sender, EventArgs e)
+		{
+			Element.SendDragCompleted();
 		}
 
 		void UpdateTapRecognizer()


### PR DESCRIPTION
### Description of Change ###

PR implementation for #1450.
Add DragStarted and DragCompleted events/commands to the Slider control.
These fire at the beginning and end of the slider drag action.

### API Changes ###

Added to `Slider`:
- EventHandler DragStarted
- EventHandler DragCompleted
 - ICommand DragStartedCommand { get; set; } // Bindable Property
 - ICommand DragCompletedCommand { get; set; } // Bindable Property
 - public void SendDragStarted()
 - public void SendDragCompleted()

### Platforms Affected ###

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

Extends behavior of `Slider` to add events/commands for drag started and completed.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard