### PR TITLE
[UWP] Allow PageControl to find its template if a NavigationPage is the app root

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1483.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1483.cs
@@ -1,0 +1,43 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1483, "Xamarin.Forms.ActivityIndicator in Forms v 2.5 doesn\'t work (UWP)", PlatformAffected.UWP)]
+	public class Issue1483 : TestNavigationPage 
+	{
+		protected override void Init()
+		{
+			PushAsync(RootPage());
+		}
+
+		ContentPage RootPage()
+		{
+			var activityIndicator = new ActivityIndicator {VerticalOptions = LayoutOptions.Center, 
+				IsRunning = true, IsVisible = true, WidthRequest = 200, HeightRequest = 100 };
+
+			var instructions = new Label { Text = "A running ActivityIndicator should be visible below." 
+												+ " If the ActivityIndicator is not visible, this test has failed." };
+
+			var page = new ContentPage();
+
+			var layout = new StackLayout { VerticalOptions = LayoutOptions.Center };
+
+			var button = new Button { Text = "Toggle" };
+			button.Clicked += (sender, args) =>
+			{
+				activityIndicator.IsVisible = !activityIndicator.IsVisible;
+				activityIndicator.IsRunning = !activityIndicator.IsRunning;
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(button);
+			layout.Children.Add(activityIndicator);
+
+			page.Content = layout;
+
+			return page;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -240,6 +240,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1483.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1799.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1931.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2767.cs" />

--- a/Xamarin.Forms.Platform.UAP/PageControl.cs
+++ b/Xamarin.Forms.Platform.UAP/PageControl.cs
@@ -42,11 +42,10 @@ namespace Xamarin.Forms.Platform.UWP
 
 		TaskCompletionSource<CommandBar> _commandBarTcs;
 		Windows.UI.Xaml.Controls.ContentPresenter _presenter;
-	    
-
-	    public PageControl()
+	    		
+		public PageControl()
 		{
-
+			DefaultStyleKey = typeof(PageControl);
 		}
 
 		public string BackButtonTitle

--- a/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
@@ -2,7 +2,10 @@
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:uwp="using:Xamarin.Forms.Platform.UWP">
-	<Style TargetType="uwp:PageControl">
+	<!-- The x:Key below looks like it's never used, but it's load-bearing.
+	For some reason, PageControl can't just find this style via the default style key type if it's the root page of the
+	application unless we also give it a key. Hopefully a wiser soul than I will someday resolve this. -->
+	<Style TargetType="uwp:PageControl" x:Key="DefaultPageControlStyle">
 		<Setter Property="ContentMargin" Value="0" />
 		<Setter Property="TitleBrush" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
 		<Setter Property="Template">


### PR DESCRIPTION
### Description of Change ###

For some reason, if a Navigation Page was the root page of a Forms application, on UWP the containing PageControl could not properly load its ControlTemplate. This had the side effect of preventing the ActivityIndicator from displaying or running.

This change allows the PageControl to find its template even when the Navigation Page is the root, which allows the ActivityIndicator to display properly.

Unfortunately, there's no good way to automate the test for this (we can't verify that the ActivityIndicator is displaying correctly, and the test app can't launch with the test page as its root).

Related to #730

### Issues Resolved ###

- fixes #1483 

### API Changes ###

None

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
