### PR TITLE
[UWP] Clean up "backButton" stuff in PageControl

### DIFF
--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -179,7 +179,6 @@ namespace Xamarin.Forms.Platform.UWP
 					_container = new PageControl();
 					_container.PointerPressed += OnPointerPressed;
 					_container.SizeChanged += OnNativeSizeChanged;
-					_container.BackClicked += OnBackClicked;
 
 					Tracker = new BackgroundTracker<PageControl>(Control.BackgroundProperty) { Element = (Page)element, Container = _container };
 
@@ -231,7 +230,6 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_container.PointerPressed -= OnPointerPressed;
 			_container.SizeChanged -= OnNativeSizeChanged;
-			_container.BackClicked -= OnBackClicked;
 			_container.Loaded -= OnLoaded;
 			_container.Unloaded -= OnUnloaded;
 

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRendererUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRendererUWP.cs
@@ -48,13 +48,13 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateBackButton()
 		{
-			bool showBackButton = Element.InternalChildren.Count > 1 && NavigationPage.GetHasBackButton(_currentPage);
-			_container.ShowBackButton = showBackButton;
-
-			if (_navManager != null)
+			if (_navManager == null)
 			{
-				_navManager.AppViewBackButtonVisibility = showBackButton ? AppViewBackButtonVisibility.Visible : AppViewBackButtonVisibility.Collapsed;
+				return;
 			}
+
+			bool showBackButton = Element.InternalChildren.Count > 1 && NavigationPage.GetHasBackButton(_currentPage);
+			_navManager.AppViewBackButtonVisibility = showBackButton ? AppViewBackButtonVisibility.Visible : AppViewBackButtonVisibility.Collapsed;
 		}
 
 		async void UpdateTitleOnParents()

--- a/Xamarin.Forms.Platform.UAP/PageControl.cs
+++ b/Xamarin.Forms.Platform.UAP/PageControl.cs
@@ -9,12 +9,6 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public sealed class PageControl : ContentControl, IToolbarProvider
 	{
-		public static readonly DependencyProperty InvisibleBackButtonCollapsedProperty = DependencyProperty.Register("InvisibleBackButtonCollapsed", typeof(bool), typeof(PageControl),
-			new PropertyMetadata(true, OnInvisibleBackButtonCollapsedChanged));
-
-		public static readonly DependencyProperty ShowBackButtonProperty = DependencyProperty.Register("ShowBackButton", typeof(bool), typeof(PageControl),
-			new PropertyMetadata(false, OnShowBackButtonChanged));
-
 		public static readonly DependencyProperty TitleVisibilityProperty = DependencyProperty.Register(nameof(TitleVisibility), typeof(Visibility), typeof(PageControl), new PropertyMetadata(Visibility.Visible));
 
 		public static readonly DependencyProperty ToolbarBackgroundProperty = DependencyProperty.Register(nameof(ToolbarBackground), typeof(Brush), typeof(PageControl),
@@ -35,7 +29,6 @@ namespace Xamarin.Forms.Platform.UWP
 
 		public static readonly DependencyProperty TitleBrushProperty = DependencyProperty.Register("TitleBrush", typeof(Brush), typeof(PageControl), new PropertyMetadata(null));
 
-		AppBarButton _backButton;
 		CommandBar _commandBar;
 		FrameworkElement _titleViewPresenter;
 
@@ -90,12 +83,6 @@ namespace Xamarin.Forms.Platform.UWP
 			get { return _presenter != null ? _presenter.ActualWidth : 0; }
 		}
 
-		public bool InvisibleBackButtonCollapsed
-		{
-			get { return (bool)GetValue(InvisibleBackButtonCollapsedProperty); }
-			set { SetValue(InvisibleBackButtonCollapsedProperty, value); }
-		}
-
 		public Brush ToolbarBackground
 		{
 			get { return (Brush)GetValue(ToolbarBackgroundProperty); }
@@ -111,12 +98,6 @@ namespace Xamarin.Forms.Platform.UWP
                 _toolbarPlacementHelper.UpdateToolbarPlacement();
             }
         }
-
-		public bool ShowBackButton
-		{
-			get { return (bool)GetValue(ShowBackButtonProperty); }
-			set { SetValue(ShowBackButtonProperty, value); }
-		}
 
 		public Visibility TitleVisibility
 		{
@@ -152,15 +133,9 @@ namespace Xamarin.Forms.Platform.UWP
 			return _commandBarTcs.Task;
 		}
 
-		public event RoutedEventHandler BackClicked;
-
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
-
-			_backButton = GetTemplateChild("backButton") as AppBarButton;
-			if (_backButton != null)
-				_backButton.Click += OnBackClicked;
 
 			_presenter = GetTemplateChild("presenter") as Windows.UI.Xaml.Controls.ContentPresenter;
 
@@ -175,65 +150,35 @@ namespace Xamarin.Forms.Platform.UWP
 		    tcs?.SetResult(_commandBar);
 		}
 
-		void OnBackClicked(object sender, RoutedEventArgs e)
-		{
-			RoutedEventHandler clicked = BackClicked;
-			if (clicked != null)
-				clicked(this, e);
+		static void OnTitleViewPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)	
+		{	
+			((PageControl)dependencyObject).UpdateTitleViewPresenter();	
+		}	
+			
+		void OnTitleViewPresenterLoaded(object sender, RoutedEventArgs e)	
+		{	
+			if (TitleView == null || _titleViewPresenter == null || _commandBar == null)	
+				return;	
+		
+			_titleViewPresenter.Width = _commandBar.ActualWidth;	
 		}
-
-		static void OnInvisibleBackButtonCollapsedChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
-		{
-			((PageControl)dependencyObject).UpdateBackButton();
+		
+		void UpdateTitleViewPresenter()	
+		{	
+			if (TitleView == null)	
+			{	
+				TitleViewVisibility = Visibility.Collapsed;	
+					
+				if (_titleViewPresenter != null)	
+					_titleViewPresenter.Loaded -= OnTitleViewPresenterLoaded;	
+			}	
+			else	
+			{	
+					TitleViewVisibility = Visibility.Visible;	
+				
+					if (_titleViewPresenter != null)	
+						_titleViewPresenter.Loaded += OnTitleViewPresenterLoaded;	
+			}	
 		}
-
-		static void OnShowBackButtonChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
-		{
-			((PageControl)dependencyObject).UpdateBackButton();
-		}
-
-		static void OnTitleViewPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
-		{
-			((PageControl)dependencyObject).UpdateTitleViewPresenter();
-		}
-
-		void OnTitleViewPresenterLoaded(object sender, RoutedEventArgs e)
-		{
-			if (TitleView == null || _titleViewPresenter == null || _commandBar == null)
-				return;
-
-			_titleViewPresenter.Width = _commandBar.ActualWidth;
-		}
-
-		void UpdateBackButton()
-		{
-			if (_backButton == null)
-				return;
-
-			if (ShowBackButton)
-				_backButton.Visibility = Visibility.Visible;
-			else
-				_backButton.Visibility = InvisibleBackButtonCollapsed ? Visibility.Collapsed : Visibility.Visible;
-
-			_backButton.Opacity = ShowBackButton ? 1 : 0;
-		}
-
-		void UpdateTitleViewPresenter()
-		{
-			if (TitleView == null)
-			{
-				TitleViewVisibility = Visibility.Collapsed;
-
-				if (_titleViewPresenter != null)
-					_titleViewPresenter.Loaded -= OnTitleViewPresenterLoaded;
-			}
-			else
-			{
-				TitleViewVisibility = Visibility.Visible;
-
-				if (_titleViewPresenter != null)
-					_titleViewPresenter.Loaded += OnTitleViewPresenterLoaded;
-			}
-		}
-	}
+    }
 }


### PR DESCRIPTION
### Description of Change ###

The UWP PageControl class contains code to manage the back button, but the back button it manages does not exist anywhere in the template. It looks like this is code left over from handling Windows 8.1 TabletResources.

No automated tests, there's literally nothing to test for.

### Issues Resolved ###

None

### API Changes ###

None

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
