### PR TITLE
[Android] Don't throw ArgumentNullException when ObservableCollection is cleared asynchronously

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1939.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1939.cs
@@ -1,0 +1,169 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1939, "ArgumentOutOfRangeException on clearing a group on a grouped ListView on Android", PlatformAffected.Android)]
+	public class Issue1939 : TestContentPage
+	{
+		ObservableCollection<GroupedData> Data { get; set; } = new ObservableCollection<GroupedData>();
+
+		readonly GroupedData _temp1 = new GroupedData() { GroupName = $"Group #1", HasHeader = true };
+		readonly GroupedData _temp2 = new GroupedData() { GroupName = $"Group #2", HasHeader = false };
+
+		protected override void Init()
+		{
+			var listView = new ListView
+			{
+				IsGroupingEnabled = true,
+				ItemTemplate = new DataTemplate(typeof(GroupItemTemplate)),
+				GroupHeaderTemplate = new MyDataTemplateSelector(),
+				ItemsSource = Data
+			};
+
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children = {
+					new Label { Text = "This test adds two groups to this list and then clears the items from one of them. If the test crashes, this test has failed." },
+					listView
+				}
+			};
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			FillResults(_temp1, 5, true);
+
+			Data.Add(_temp1);
+			Data.Add(_temp2);
+
+			FillResults(_temp2, 5, false);
+		}
+
+		async void FillResults(GroupedData results, int items, bool clear)
+		{
+			results.Clear();
+
+			await Task.Delay(200);
+
+			for (int i = 0; i < items; i++)
+			{
+				results.Add(new GroupItem { DisplayText = $"Text for ListView item {i}" });
+			}
+
+			if (!clear)
+				return;
+
+			await Task.Delay(1000);
+
+			results.Clear();
+		}
+
+		[Preserve(AllMembers = true)]
+		public class MyDataTemplateSelector : DataTemplateSelector
+		{
+			readonly DataTemplate firstGroupTemplate;
+			readonly DataTemplate secondGroupTemplate;
+
+			public MyDataTemplateSelector()
+			{
+				firstGroupTemplate = new DataTemplate(typeof(GroupNoHeaderTemplate));
+				secondGroupTemplate = new DataTemplate(typeof(GroupHeaderTemplate));
+			}
+
+			protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+			{
+				if (!(item is GroupedData model))
+				{
+					return null;
+				}
+
+				if (model.HasHeader)
+					return secondGroupTemplate;
+
+				return firstGroupTemplate;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class GroupItem
+		{
+			public string DisplayText { get; set; }
+		}
+
+		[Preserve(AllMembers = true)]
+		public class GroupedData : ObservableCollection<GroupItem>
+		{
+			public string GroupName { get; set; }
+			public bool HasHeader { get; set; }
+		}
+
+		[Preserve(AllMembers = true)]
+		public class GroupItemTemplate : ViewCell
+		{
+			public GroupItemTemplate()
+			{
+				var title = new Label() { FontSize = 14 };
+				title.SetBinding(Label.TextProperty, new Binding("DisplayText", BindingMode.OneWay));
+
+				View = new StackLayout
+				{
+					Orientation = StackOrientation.Horizontal,
+					Padding = new Thickness(8),
+					Children = { title }
+				};
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class GroupHeaderTemplate : ViewCell
+		{
+			public GroupHeaderTemplate()
+			{
+				var title = new Label { TextColor = Color.White, FontSize = 16 };
+				title.SetBinding(Label.TextProperty, new Binding("GroupName", BindingMode.OneWay));
+
+				View = new StackLayout
+				{
+					Padding = new Thickness(8, 0),
+					VerticalOptions = LayoutOptions.StartAndExpand,
+					BackgroundColor = Color.FromHex("#6D91BA"),
+					Orientation = StackOrientation.Horizontal,
+					Children = { title },
+				};
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class GroupNoHeaderTemplate : ViewCell
+		{
+			public GroupNoHeaderTemplate()
+			{
+				View = new StackLayout
+				{
+					BackgroundColor = Color.White,
+				};
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1939Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Group #1"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -453,6 +453,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2035.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2299.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2837.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1939.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -164,18 +164,29 @@ namespace Xamarin.Forms.Platform.Android
 			if (itemTemplate == null)
 				return DefaultItemTemplateId;
 
-			var selector = itemTemplate as DataTemplateSelector;
-			if (selector != null)
+			if (itemTemplate is DataTemplateSelector selector)
 			{
 				object item = null;
+
 				if (_listView.IsGroupingEnabled)
-					item = TemplatedItemsView.TemplatedItems.GetGroup(group).ListProxy[row];
+				{
+					if (TemplatedItemsView.TemplatedItems.GetGroup(group).ListProxy.Count > 0)
+						item = TemplatedItemsView.TemplatedItems.GetGroup(group).ListProxy[row];
+				}
 				else
-					item = TemplatedItemsView.TemplatedItems.ListProxy[position];
+				{
+					if (TemplatedItemsView.TemplatedItems.ListProxy.Count > 0)
+						item = TemplatedItemsView.TemplatedItems.ListProxy[position];
+				}
+
 				itemTemplate = selector.SelectTemplate(item, _listView);
 			}
-			int key;
-			if (!_templateToId.TryGetValue(itemTemplate, out key))
+
+			// check again to guard against DataTemplateSelectors that return null
+			if (itemTemplate == null)
+				return DefaultItemTemplateId;
+
+			if (!_templateToId.TryGetValue(itemTemplate, out int key))
 			{
 				_dataTemplateIncrementer++;
 				key = _dataTemplateIncrementer;


### PR DESCRIPTION
### Description of Change ###

We were attempting to get the list item from the ListProxy for the DataTemplateSelector. When the source is cleared asynchronously, the ListProxy is empty, causing the lookup to fail. No longer attempting to look up the value when there are no items in ListProxy.

### Issues Resolved ###

- fixes #1939

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
