### PR TITLE
[Controls] Support NativeView to ControlGallery.Tizen

### DIFF
--- a/Xamarin.Forms.ControlGallery.Tizen/ControlGallery.Tizen.cs
+++ b/Xamarin.Forms.ControlGallery.Tizen/ControlGallery.Tizen.cs
@@ -1,19 +1,22 @@
 using Xamarin.Forms.Platform.Tizen;
 using Xamarin.Forms.Controls;
+using ElmSharp;
 
 namespace Xamarin.Forms.ControlGallery.Tizen
 {
-	class Program : FormsApplication
+	class MainApplication : FormsApplication
 	{
+		internal static EvasObject NativeParent { get; private set; }
 		protected override void OnCreate()
 		{
 			base.OnCreate();
+			NativeParent = MainWindow;
 			LoadApplication(new App());
 		}
 
 		static void Main(string[] args)
 		{
-			var app = new Program();
+			var app = new MainApplication();
 			FormsMaps.Init("HERE", "write-your-API-key-here");
 			global::Xamarin.Forms.Platform.Tizen.Forms.Init(app);
 			app.Run(args);

--- a/Xamarin.Forms.ControlGallery.Tizen/SampleNativeControl.cs
+++ b/Xamarin.Forms.ControlGallery.Tizen/SampleNativeControl.cs
@@ -2,6 +2,7 @@
 using Xamarin.Forms.ControlGallery.Tizen;
 using Xamarin.Forms.Controls.Issues.Helpers;
 using Xamarin.Forms.Platform.Tizen;
+using ELabel = ElmSharp.Label;
 
 [assembly: Dependency(typeof(SampleNativeControl))]
 namespace Xamarin.Forms.ControlGallery.Tizen
@@ -12,7 +13,11 @@ namespace Xamarin.Forms.ControlGallery.Tizen
 		{
 			get
 			{
-				return new Label { Text = "NativeViews not supported on Tizen" };
+				var label = new ELabel(MainApplication.NativeParent)
+				{
+					Text = "Sample Native Control"
+				};
+				return label.ToView();
 			}
 		}
 	}

--- a/Xamarin.Forms.Controls/GalleryPages/XamlNativeViews.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/XamlNativeViews.xaml
@@ -5,10 +5,14 @@
 			 xmlns:androidWidget="clr-namespace:Android.Widget;assembly=Mono.Android;targetPlatform=Android"
 			 xmlns:formsandroid="clr-namespace:Xamarin.Forms;assembly=Xamarin.Forms.Platform.Android;targetPlatform=Android"
 			 xmlns:win="clr-namespace:Windows.UI.Xaml.Controls;assembly=Windows, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime;targetPlatform=Windows"
+			 xmlns:formstizen="clr-namespace:Xamarin.Forms.Platform.Tizen;assembly=Xamarin.Forms.Platform.Tizen;targetPlatform=Tizen"
+			 xmlns:tizenWidget="clr-namespace:ElmSharp;assembly=ElmSharp;targetPlatform=Tizen"
        x:Class="Xamarin.Forms.Controls.XamlNativeViews">
 	<ContentPage.Content>
 		<ios:UILabel Text="{Binding NativeText}" View.HorizontalOptions="Start"/>
 		<androidWidget:TextView Text="{Binding NativeText}" x:Arguments="{x:Static formsandroid:Forms.Context}" />
-    <win:TextBlock Text="{Binding NativeText}"/>
+		<win:TextBlock Text="{Binding NativeText}"/>
+		<tizenWidget:Label Text="{Binding NativeText}" x:Arguments="{x:Static formstizen:Forms.NativeParent}" />
+
 	</ContentPage.Content>
 </ContentPage>


### PR DESCRIPTION
### Description of Change ###

This PR adds support for `Xaml Native Views Gallery` on tizen backend. This also include `SampleNativeControl` tizen implementation coming from #2772.

<img src="https://user-images.githubusercontent.com/1029134/41571613-f35c40c2-73ae-11e8-82b4-abb66d7b4254.png" width=240><img src="https://user-images.githubusercontent.com/1029134/41571616-f4813cbe-73ae-11e8-92bb-908cfc274573.png" width=240>


### Issues Resolved ###

None

### API Changes ###

None

### Platforms Affected ###

- Tizen

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
