### PR TITLE
[C] do not crash on OneTime defaultBindingMode

### DIFF
--- a/Xamarin.Forms.Core/BindableProperty.cs
+++ b/Xamarin.Forms.Core/BindableProperty.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms
 				throw new ArgumentNullException("declaringType");
 
 			// don't use Enum.IsDefined as its redonkulously expensive for what it does
-			if (defaultBindingMode != BindingMode.Default && defaultBindingMode != BindingMode.OneWay && defaultBindingMode != BindingMode.OneWayToSource && defaultBindingMode != BindingMode.TwoWay)
+			if (defaultBindingMode != BindingMode.Default && defaultBindingMode != BindingMode.OneWay && defaultBindingMode != BindingMode.OneWayToSource && defaultBindingMode != BindingMode.TwoWay && defaultBindingMode != BindingMode.OneTime)
 				throw new ArgumentException("Not a valid type of BindingMode", "defaultBindingMode");
 			if (defaultValue == null && Nullable.GetUnderlyingType(returnType) == null && returnType.GetTypeInfo().IsValueType)
 				throw new ArgumentException("Not a valid default value", "defaultValue");


### PR DESCRIPTION
### Description of Change ###

[C] do not crash on OneTime defaultBindingMode

### Issues Resolved ###

- fixes #3071

### API Changes ###

/

### Platforms Affected ###

- Core (all platforms)

### Behavioral/Visual Changes ###

No longer crash when creating a BP with `OneTime` as default binding mode.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard