### PR TITLE
[ALL] fixes #3089 Change default TextCell to use binding

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3089.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3089.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3089, "TextCell text doesn't change when using Recycling on ListViews")]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue3089 : TestNavigationPage
+	{
+		const string reload = "reload";
+		const string success = "success";
+
+		protected override void Init()
+		{
+			var oc = new ObservableCollection<string>(new[] { $"Click {reload}","and this text should go away" });
+
+			Enumerable.Range(0, 100).ForEach(x => oc.Add(x.ToString()));
+
+			PushAsync(new MainPageCode
+			{
+				BindingContext = new MainViewModel
+				{
+					ViewModel1 = new ListViewModel
+					{
+						Items = oc
+					}
+				}
+			});
+		}
+
+		[Preserve(AllMembers = true)]
+		public partial class MainPageCode : TabbedPage
+		{
+			public MainPageCode()
+			{
+				ToolbarItems.Add(new Xamarin.Forms.ToolbarItem() { Text = "add1" });
+
+				ToolbarItems.Add(new Xamarin.Forms.ToolbarItem() { Text = "reload" });
+
+				ToolbarItems[0].SetBinding(ToolbarItem.CommandProperty, "Add1Command");
+				ToolbarItems[1].SetBinding(ToolbarItem.CommandProperty, "Add2Command");
+
+				ListPageCode page = new ListPageCode();
+				page.SetBinding(ListPageCode.BindingContextProperty, "ViewModel1");
+				Children.Add(page);
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class MainViewModel
+		{
+
+			void AddItems(ObservableCollection<string> list)
+			{
+				list.Add("new item");
+				list.Add(success);
+			}
+
+			public MainViewModel()
+			{
+				Add1Command = new Command(() => AddItems(ViewModel1.Items));
+				Add2Command = new Command(() =>
+				{
+					ViewModel1.ReloadData();
+					AddItems(ViewModel1.Items);
+				});
+			}
+
+			public ListViewModel ViewModel1 { get; set; }
+
+			public ICommand Add1Command { get; }
+			public ICommand Add2Command { get; }
+		}
+
+		[Preserve(AllMembers = true)]
+		public class ListViewModel : INotifyPropertyChanged
+		{
+			public ObservableCollection<string> Items { get; set; }
+			public bool IsVisible { get; set; } = true;
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public void ReloadData()
+			{
+				Items = new ObservableCollection<string>();
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Items)));
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public partial class ListPageCode : ContentPage
+		{
+			public ListPageCode()
+			{
+				Icon = "coffee.png";
+				ListView view = new ListView(ListViewCachingStrategy.RecycleElement);
+				Content = view;
+
+				view.SetBinding(ListView.ItemsSourceProperty, "Items");
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void ResettingItemsOnRecycledListViewKeepsOldText()
+		{
+			RunningApp.Tap(reload);
+			RunningApp.WaitForElement(success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -242,6 +242,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1799.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1931.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3089.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2767.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2499.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -75,9 +75,9 @@ namespace Xamarin.Forms
 		public ListView([Parameter("CachingStrategy")] ListViewCachingStrategy cachingStrategy) : this()
 		{
 			// null => UnitTest "platform"
-			if (Device.RuntimePlatform == null || 
-				Device.RuntimePlatform == Device.Android || 
-				Device.RuntimePlatform == Device.iOS || 
+			if (Device.RuntimePlatform == null ||
+				Device.RuntimePlatform == Device.Android ||
+				Device.RuntimePlatform == Device.iOS ||
 				Device.RuntimePlatform == Device.macOS)
 				CachingStrategy = cachingStrategy;
 		}
@@ -326,7 +326,9 @@ namespace Xamarin.Forms
 			if (item != null)
 				text = item.ToString();
 
-			return new TextCell { Text = text };
+			TextCell textCell = new TextCell();
+			textCell.SetBinding(TextCell.TextProperty, ".");
+			return textCell;
 		}
 
 		[Obsolete("OnSizeRequest is obsolete as of version 2.2.0. Please use OnMeasure instead.")]


### PR DESCRIPTION
### Description of Change ###

Changed usage of default TextCell by ListView to use Bindings to set the Text instead of just setting the text directly. This way recycled cells will correctly have their text changed when the BindingContext is changed

### Issues Resolved ###

- fixes #3089 

### Platforms Affected ###

<!-- Please list all platforms affected by these changes -->

- Core (all platforms)


### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
