### PR TITLE
[UWP] Swipe gesture not being handled in VisualElementTracker

### DIFF
--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -622,7 +622,7 @@ namespace Xamarin.Forms.Platform.UWP
 			bool hasSwipeGesture = gestures.GetGesturesFor<SwipeGestureRecognizer>().GetEnumerator().MoveNext();
 			bool hasPinchGesture = gestures.GetGesturesFor<PinchGestureRecognizer>().GetEnumerator().MoveNext();
 			bool hasPanGesture = gestures.GetGesturesFor<PanGestureRecognizer>().GetEnumerator().MoveNext();
-			if (!hasPinchGesture && !hasPanGesture)
+			if (!hasSwipeGesture && !hasPinchGesture && !hasPanGesture)
 				return;
 
 			//We can't handle ManipulationMode.Scale and System , so we don't support pinch/pan on a scrollview 


### PR DESCRIPTION
### Description of Change ###

Fixed Swipe gesture not being handled correctly in `VisualElementTracker`.
Was incorrectly returning out of the `UpdatingGestureRecognizers()` method _before_ wiring manipulation and pointer event handlers.

### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

Fixes #3097.

### API Changes ###

None

### Platforms Affected ###

<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard