### PR TITLE
[Android] fixes #3087. Move initialization of TrackDrawable  non app compat

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -25,6 +25,7 @@ using Xamarin.Forms.Controls.Issues;
 
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Effects.AttachedStateEffectLabel), typeof(AttachedStateEffectLabelRenderer))]
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.LegacyComponents.NonAppCompatSwitch), typeof(NonAppCompatSwitchRenderer))]
 [assembly: ExportRenderer(typeof(Bugzilla31395.CustomContentView), typeof(CustomContentRenderer))]
 [assembly: ExportRenderer(typeof(NativeListView), typeof(NativeListViewRenderer))]
 [assembly: ExportRenderer(typeof(NativeListView2), typeof(NativeAndroidListViewRenderer))]
@@ -47,6 +48,13 @@ using Xamarin.Forms.Controls.Issues;
 #endif
 namespace Xamarin.Forms.ControlGallery.Android
 {
+	public class NonAppCompatSwitchRenderer : Xamarin.Forms.Platform.Android.SwitchRenderer
+	{
+		public NonAppCompatSwitchRenderer(Context context) : base(context)
+		{
+		}
+	}
+
 	public class AttachedStateEffectLabelRenderer : LabelRenderer
 	{
 		public AttachedStateEffectLabelRenderer(Context context) : base(context)
@@ -55,7 +63,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 		protected override void Dispose(bool disposing)
 		{
-			foreach(var effect in Element.Effects.OfType<Controls.Effects.AttachedStateEffect>())
+			foreach (var effect in Element.Effects.OfType<Controls.Effects.AttachedStateEffect>())
 			{
 				effect.Detached(Element);
 			}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3087.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3087.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3087, "[Android] Non appcompat SwitchRenderer regression between 3.0 and 3.1",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Switch)]
+#endif
+	public class Issue3087 : TestContentPage
+	{
+		LegacyComponents.NonAppCompatSwitch legacySwitch = null;
+		Label status = new Label();
+		protected override void Init()
+		{
+			Content =
+				new StackLayout()
+				{
+					Children =
+					{
+						new Label(){ Text = "If nothing crashes this passes" },
+						status
+					}
+				};
+		}
+
+		protected async override void OnAppearing()
+		{
+			base.OnAppearing();
+			legacySwitch = new LegacyComponents.NonAppCompatSwitch() { IsToggled = true };
+			(Content as StackLayout).Children.Add(legacySwitch);
+			await Task.Delay(10);
+			legacySwitch.IsToggled = !legacySwitch.IsToggled;
+			await Task.Delay(10);
+			legacySwitch.IsToggled = !legacySwitch.IsToggled;
+			await Task.Delay(10);
+			legacySwitch.IsToggled = !legacySwitch.IsToggled;
+			status.Text = "Success";
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void NonAppCompatBasicSwitchTest()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/LegacyComponents/NonAppCompatSwitch.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/LegacyComponents/NonAppCompatSwitch.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms.Controls.LegacyComponents
+{
+    public class NonAppCompatSwitch : Switch
+    {
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -243,6 +243,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1483.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1799.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1931.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3087.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3089.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2767.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2499.cs" />
@@ -344,6 +345,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3008.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3019.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2993.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla37625.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -78,13 +78,13 @@ namespace Xamarin.Forms.Platform.Android
 					var aswitch = CreateNativeControl();
 					aswitch.SetOnCheckedChangeListener(this);
 					SetNativeControl(aswitch);
+					_defaultTrackDrawable = Control.TrackDrawable;
 				}
 				else
 					UpdateEnabled(); // Normally set by SetNativeControl, but not when the Control is reused.
 
 				e.NewElement.Toggled += HandleToggled;
 				Control.Checked = e.NewElement.IsToggled;
-				_defaultTrackDrawable = Control.TrackDrawable;
 				UpdateOnColor();
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

For non app compat Switch Renderer *OnCheckedChange* was being fired during initialization prior to the *_defaultTrackDrawable* being initialized which would cause UpdateColor to null out the *TrackDrawable* and lead to an NRE on the next check changed

### Issues Resolved ###

- fixes #3087

### Platforms Affected ###

- Android


### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
