### PR TITLE
Clear all previous animations with the same key when starting a new animation

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Dynamic;
 using System.Threading;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Dynamic;
+using System.Threading;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Animation)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2482,
+		"Animating a `View` that is currently animating will throw `System.InvalidOperationException`", 
+		PlatformAffected.All)]
+	public class Issue2482 : TestContentPage
+	{
+		Label _result;
+		int _clicks;
+
+		const string ButtonId = "SpinButton";
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label { Text = "Tap the button below twice quickly." 
+												+ " If the application crashes, this test has failed." };
+
+			_result = new Label { Text = Success, IsVisible = false };
+
+			var button = new Button
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Quickly Double Tap This Button",
+				HeightRequest = 200,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				AutomationId = ButtonId
+			};
+
+			button.Clicked += async (sender, args) =>
+			{
+				await button.RotateTo(539, 3000, Easing.CubicOut);
+				await button.RotateTo(0, 3000, Easing.CubicIn);
+
+				_clicks += 1;
+
+				if (_clicks == 2)
+				{
+					_result.IsVisible = true;
+				}
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(_result);
+			layout.Children.Add(button);
+
+			Content = layout;
+		}
+
+#if UITEST
+		[Test]
+		public void AnimationCancel()
+		{
+			RunningApp.WaitForElement(ButtonId);
+			RunningApp.DoubleTap(ButtonId);
+			RunningApp.WaitForElement(Success, timeout: TimeSpan.FromSeconds(10));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -248,6 +248,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3087.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3089.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1342.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2482.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2767.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2499.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1878.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -36,6 +36,7 @@
 		public const string Gestures = "Gestures";
 		public const string Navigation = "Navigation";
 		public const string Effects = "Effects";
+		public const string Animation = "Animation";
 
 		public const string ManualReview = "ManualReview";
 		public const string Performance = "Performance";

--- a/Xamarin.Forms.Core/AnimationExtensions.cs
+++ b/Xamarin.Forms.Core/AnimationExtensions.cs
@@ -149,18 +149,27 @@ namespace Xamarin.Forms
 
 		static void AbortAnimation(AnimatableKey key)
 		{
-			if (!s_animations.ContainsKey(key))
+			// If multiple animations on the same view with the same name (IOW, the same AnimatableKey) are invoked
+			// asynchronously (e.g., from the `[Animate]To` methods in `ViewExtensions`), it's possible to get into 
+			// a situation where after invoking the `Finished` handler below `s_animations` will have a new `Info`
+			// object in it with the same AnimatableKey. We need to continue cancelling animations until that is no
+			// longer the case; thus, the `while` loop.
+
+			// If we don't cancel all of the animations popping in with this key, `AnimateInternal` will overwrite one
+			// of them with the new `Info` object, and the overwritten animation will never complete; any `await` for
+			// it will never return.
+
+			while (s_animations.ContainsKey(key))
 			{
-				return;
+				Info info = s_animations[key];
+
+				s_animations.Remove(key);
+
+				info.Tweener.ValueUpdated -= HandleTweenerUpdated;
+				info.Tweener.Finished -= HandleTweenerFinished;
+				info.Tweener.Stop();
+				info.Finished?.Invoke(1.0f, true);
 			}
-
-			Info info = s_animations[key];
-			info.Tweener.ValueUpdated -= HandleTweenerUpdated;
-			info.Tweener.Finished -= HandleTweenerFinished;
-			info.Tweener.Stop();
-			info.Finished?.Invoke(1.0f, true);
-
-			s_animations.Remove(key);
 		}
 
 		static void AbortKinetic(AnimatableKey key)
@@ -198,7 +207,7 @@ namespace Xamarin.Forms
 			info.Finished = final;
 			info.Repeat = repeat;
 			info.Owner = new WeakReference<IAnimatable>(self);
-
+			
 			s_animations[key] = info;
 
 			info.Callback(0.0f);

--- a/Xamarin.Forms.Core/ViewExtensions.cs
+++ b/Xamarin.Forms.Core/ViewExtensions.cs
@@ -9,14 +9,13 @@ namespace Xamarin.Forms
 		{
 			if (view == null)
 				throw new ArgumentNullException(nameof(view));
-			view.AbortAnimation("LayoutTo");
-			view.AbortAnimation("TranslateTo");
-			view.AbortAnimation("RotateTo");
-			view.AbortAnimation("RotateYTo");
-			view.AbortAnimation("RotateXTo");
-			view.AbortAnimation("ScaleTo");
-			view.AbortAnimation("FadeTo");
-			view.AbortAnimation("SizeTo");
+			view.AbortAnimation(nameof(LayoutTo));
+			view.AbortAnimation(nameof(TranslateTo));
+			view.AbortAnimation(nameof(RotateTo));
+			view.AbortAnimation(nameof(RotateYTo));
+			view.AbortAnimation(nameof(RotateXTo));
+			view.AbortAnimation(nameof(ScaleTo));
+			view.AbortAnimation(nameof(FadeTo));
 		}
 
 		static Task<bool> AnimateTo(this VisualElement view, double start, double end, string name, 
@@ -47,7 +46,7 @@ namespace Xamarin.Forms
 			if (view == null)
 				throw new ArgumentNullException(nameof(view));
 
-			return AnimateTo(view, view.Opacity, opacity, "FadeTo", (v, value) => v.Opacity = value, length, easing);
+			return AnimateTo(view, view.Opacity, opacity, nameof(FadeTo), (v, value) => v.Opacity = value, length, easing);
 		}
 
 		public static Task<bool> LayoutTo(this VisualElement view, Rectangle bounds, uint length = 250, Easing easing = null)
@@ -66,7 +65,7 @@ namespace Xamarin.Forms
 				return new Rectangle(x, y, w, h);
 			};
 		
-			return AnimateTo(view, 0, 1, "LayoutTo", (v, value) => v.Layout(computeBounds(value)), length, easing);
+			return AnimateTo(view, 0, 1, nameof(LayoutTo), (v, value) => v.Layout(computeBounds(value)), length, easing);
 		}
 
 		public static Task<bool> RelRotateTo(this VisualElement view, double drotation, uint length = 250, Easing easing = null)
@@ -90,7 +89,7 @@ namespace Xamarin.Forms
 			if (view == null)
 				throw new ArgumentNullException(nameof(view));
 
-			return AnimateTo(view, view.Rotation, rotation, "RotateTo", (v, value) => v.Rotation = value, length, easing);
+			return AnimateTo(view, view.Rotation, rotation, nameof(RotateTo), (v, value) => v.Rotation = value, length, easing);
 		}
 
 		public static Task<bool> RotateXTo(this VisualElement view, double rotation, uint length = 250, Easing easing = null)
@@ -98,7 +97,7 @@ namespace Xamarin.Forms
 			if (view == null)
 				throw new ArgumentNullException(nameof(view));
 
-			return AnimateTo(view, view.RotationX, rotation, "RotateXTo", (v, value) => v.RotationX = value, length, easing);
+			return AnimateTo(view, view.RotationX, rotation, nameof(RotateXTo), (v, value) => v.RotationX = value, length, easing);
 		}
 
 		public static Task<bool> RotateYTo(this VisualElement view, double rotation, uint length = 250, Easing easing = null)
@@ -106,7 +105,7 @@ namespace Xamarin.Forms
 			if (view == null)
 				throw new ArgumentNullException(nameof(view));
 
-			return AnimateTo(view, view.RotationY, rotation, "RotateYTo", (v, value) => v.RotationY = value, length, easing);
+			return AnimateTo(view, view.RotationY, rotation, nameof(RotateYTo), (v, value) => v.RotationY = value, length, easing);
 		}
 
 		public static Task<bool> ScaleTo(this VisualElement view, double scale, uint length = 250, Easing easing = null)
@@ -114,13 +113,13 @@ namespace Xamarin.Forms
 			if (view == null)
 				throw new ArgumentNullException(nameof(view));
 
-			return AnimateTo(view, view.Scale, scale, "ScaleTo", (v, value) => v.Scale = value, length, easing);
+			return AnimateTo(view, view.Scale, scale, nameof(ScaleTo), (v, value) => v.Scale = value, length, easing);
 		}
 
 		public static Task<bool> TranslateTo(this VisualElement view, double x, double y, uint length = 250, Easing easing = null)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
+				throw new ArgumentNullException(nameof(view));
 			easing = easing ?? Easing.Linear;
 
 			var tcs = new TaskCompletionSource<bool>();
@@ -137,7 +136,7 @@ namespace Xamarin.Forms
 				if (weakView.TryGetTarget(out v))
 					v.TranslationY = f;
 			};
-			new Animation { { 0, 1, new Animation(translateX, view.TranslationX, x, easing: easing) }, { 0, 1, new Animation(translateY, view.TranslationY, y, easing:easing) } }.Commit(view, "TranslateTo", 16, length, null,
+			new Animation { { 0, 1, new Animation(translateX, view.TranslationX, x, easing: easing) }, { 0, 1, new Animation(translateY, view.TranslationY, y, easing:easing) } }.Commit(view, nameof(TranslateTo), 16, length, null,
 				(f, a) => tcs.SetResult(a));
 
 			return tcs.Task;

--- a/Xamarin.Forms.Core/ViewExtensions.cs
+++ b/Xamarin.Forms.Core/ViewExtensions.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms
 		public static void CancelAnimations(VisualElement view)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
+				throw new ArgumentNullException(nameof(view));
 			view.AbortAnimation("LayoutTo");
 			view.AbortAnimation("TranslateTo");
 			view.AbortAnimation("RotateTo");
@@ -19,35 +19,42 @@ namespace Xamarin.Forms
 			view.AbortAnimation("SizeTo");
 		}
 
-		public static Task<bool> FadeTo(this VisualElement view, double opacity, uint length = 250, Easing easing = null)
+		static Task<bool> AnimateTo(this VisualElement view, double start, double end, string name, 
+			Action<VisualElement, double> updateAction, uint length = 250, Easing easing = null)
 		{
-			if (view == null)
-				throw new ArgumentNullException("view");
 			if (easing == null)
 				easing = Easing.Linear;
 
 			var tcs = new TaskCompletionSource<bool>();
-			var weakView = new WeakReference<VisualElement>(view);
-			Action<double> fade = f =>
-			{
-				VisualElement v;
-				if (weakView.TryGetTarget(out v))
-					v.Opacity = f;
-			};
 
-			new Animation(fade, view.Opacity, opacity, easing).Commit(view, "FadeTo", 16, length, finished: (f, a) => tcs.SetResult(a));
+			var weakView = new WeakReference<VisualElement>(view);
+
+			void UpdateProperty(double f)
+			{
+				if (weakView.TryGetTarget(out VisualElement v))
+				{
+					updateAction(v, f);
+				}
+			}
+
+			new Animation(UpdateProperty, start, end, easing).Commit(view, name, 16, length, finished: (f, a) => tcs.SetResult(a));
 
 			return tcs.Task;
+		}
+
+		public static Task<bool> FadeTo(this VisualElement view, double opacity, uint length = 250, Easing easing = null)
+		{
+			if (view == null)
+				throw new ArgumentNullException(nameof(view));
+
+			return AnimateTo(view, view.Opacity, opacity, "FadeTo", (v, value) => v.Opacity = value, length, easing);
 		}
 
 		public static Task<bool> LayoutTo(this VisualElement view, Rectangle bounds, uint length = 250, Easing easing = null)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
-			if (easing == null)
-				easing = Easing.Linear;
+				throw new ArgumentNullException(nameof(view));
 
-			var tcs = new TaskCompletionSource<bool>();
 			Rectangle start = view.Bounds;
 			Func<double, Rectangle> computeBounds = progress =>
 			{
@@ -58,114 +65,56 @@ namespace Xamarin.Forms
 
 				return new Rectangle(x, y, w, h);
 			};
-			var weakView = new WeakReference<VisualElement>(view);
-			Action<double> layout = f =>
-			{
-				VisualElement v;
-				if (weakView.TryGetTarget(out v))
-					v.Layout(computeBounds(f));
-			};
-			new Animation(layout, 0, 1, easing).Commit(view, "LayoutTo", 16, length, finished: (f, a) => tcs.SetResult(a));
-
-			return tcs.Task;
+		
+			return AnimateTo(view, 0, 1, "LayoutTo", (v, value) => v.Layout(computeBounds(value)), length, easing);
 		}
 
 		public static Task<bool> RelRotateTo(this VisualElement view, double drotation, uint length = 250, Easing easing = null)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
+				throw new ArgumentNullException(nameof(view));
+
 			return view.RotateTo(view.Rotation + drotation, length, easing);
 		}
 
 		public static Task<bool> RelScaleTo(this VisualElement view, double dscale, uint length = 250, Easing easing = null)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
+				throw new ArgumentNullException(nameof(view));
+
 			return view.ScaleTo(view.Scale + dscale, length, easing);
 		}
 
 		public static Task<bool> RotateTo(this VisualElement view, double rotation, uint length = 250, Easing easing = null)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
-			if (easing == null)
-				easing = Easing.Linear;
+				throw new ArgumentNullException(nameof(view));
 
-			var tcs = new TaskCompletionSource<bool>();
-			var weakView = new WeakReference<VisualElement>(view);
-			Action<double> rotate = f =>
-			{
-				VisualElement v;
-				if (weakView.TryGetTarget(out v))
-					v.Rotation = f;
-			};
-
-			new Animation(rotate, view.Rotation, rotation, easing).Commit(view, "RotateTo", 16, length, finished: (f, a) => tcs.SetResult(a));
-
-			return tcs.Task;
+			return AnimateTo(view, view.Rotation, rotation, "RotateTo", (v, value) => v.Rotation = value, length, easing);
 		}
 
 		public static Task<bool> RotateXTo(this VisualElement view, double rotation, uint length = 250, Easing easing = null)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
-			if (easing == null)
-				easing = Easing.Linear;
+				throw new ArgumentNullException(nameof(view));
 
-			var tcs = new TaskCompletionSource<bool>();
-			var weakView = new WeakReference<VisualElement>(view);
-			Action<double> rotatex = f =>
-			{
-				VisualElement v;
-				if (weakView.TryGetTarget(out v))
-					v.RotationX = f;
-			};
-
-			new Animation(rotatex, view.RotationX, rotation, easing).Commit(view, "RotateXTo", 16, length, finished: (f, a) => tcs.SetResult(a));
-
-			return tcs.Task;
+			return AnimateTo(view, view.RotationX, rotation, "RotateXTo", (v, value) => v.RotationX = value, length, easing);
 		}
 
 		public static Task<bool> RotateYTo(this VisualElement view, double rotation, uint length = 250, Easing easing = null)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
-			if (easing == null)
-				easing = Easing.Linear;
+				throw new ArgumentNullException(nameof(view));
 
-			var tcs = new TaskCompletionSource<bool>();
-			var weakView = new WeakReference<VisualElement>(view);
-			Action<double> rotatey = f =>
-			{
-				VisualElement v;
-				if (weakView.TryGetTarget(out v))
-					v.RotationY = f;
-			};
-
-			new Animation(rotatey, view.RotationY, rotation, easing).Commit(view, "RotateYTo", 16, length, finished: (f, a) => tcs.SetResult(a));
-
-			return tcs.Task;
+			return AnimateTo(view, view.RotationY, rotation, "RotateYTo", (v, value) => v.RotationY = value, length, easing);
 		}
 
 		public static Task<bool> ScaleTo(this VisualElement view, double scale, uint length = 250, Easing easing = null)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
-			if (easing == null)
-				easing = Easing.Linear;
+				throw new ArgumentNullException(nameof(view));
 
-			var tcs = new TaskCompletionSource<bool>();
-			var weakView = new WeakReference<VisualElement>(view);
-			Action<double> _scale = f =>
-			{
-				VisualElement v;
-				if (weakView.TryGetTarget(out v))
-					v.Scale = f;
-			};
-
-			new Animation(_scale, view.Scale, scale, easing).Commit(view, "ScaleTo", 16, length, finished: (f, a) => tcs.SetResult(a));
-
-			return tcs.Task;
+			return AnimateTo(view, view.Scale, scale, "ScaleTo", (v, value) => v.Scale = value, length, easing);
 		}
 
 		public static Task<bool> TranslateTo(this VisualElement view, double x, double y, uint length = 250, Easing easing = null)


### PR DESCRIPTION
### Description of Change ###

When using the animation extensions to `VisualElement`, queueing up multiple animations can result in a race condition where an animation Task result is set multiple times (throwing an exception) and another animation's result is never set (meaning an `await` on it never returns). 

This change guarantees that all animations with the same key are cancelled before queueing up a new animation with that key, avoiding both scenarios.

### Issues Resolved ###

- fixes #2482 

### API Changes ###

None

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
