### PR TITLE
[Android] Add native ctor to PageContainer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2740.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2740.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2740, "System.NotSupportedException: Unable to activate instance of type Xamarin.Forms.Platform.Android.PageContainer from native handle", PlatformAffected.Android)]
+	public class Issue2740 : TestMasterDetailPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var page = new AddressListView();
+
+			// Initialize ui here instead of ctor
+			Master = new ContentPage
+			{
+				Content = new Label
+				{
+					Text = "Click a item on the left then the toolbar item switch"
+				},
+				Title = "2740"
+			};
+			Detail = new NavigationPage(page);
+		}
+
+		public partial class AddressListView : ContentPage
+		{
+
+			public AddressListView()
+			{
+				var listview = new ListView();
+				listview.ItemsSource = new List<string> { "1", "2" };
+				listview.ItemTapped += OnItemTapped;
+				Content = listview;
+				Title = "Unit List";
+			}
+
+			public async void OnItemTapped(object sender, ItemTappedEventArgs e)
+			{
+				var p = new UnitViolationView();
+				await Navigation.PushAsync(p);
+			}
+		}
+
+		public partial class UnitViolationView : ContentPage
+		{
+			public UnitViolationView()
+			{
+				ToolbarItems.Add(new ToolbarItem("Switch", null, MapAddressSwitch) { AutomationId = "Switch" });
+			}
+
+			async void MapAddressSwitch()
+			{
+				await Navigation.PopAsync(false);
+				(Application.Current.MainPage as MasterDetailPage).Detail = new NavigationPage(new AddressListView());
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Issue2740Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked ("1"));
+			RunningApp.Tap (q => q.Marked ("1"));
+			RunningApp.WaitForElement (q => q.Marked ("Switch"));
+			RunningApp.Tap (q => q.Marked ("Switch"));
+			RunningApp.WaitForElement (q => q.Marked ("1"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -456,6 +456,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2299.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1900.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2837.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2740.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/PageContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageContainer.cs
@@ -1,5 +1,7 @@
 using Android.Content;
+using Android.Runtime;
 using Android.Views;
+using System;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -16,6 +18,10 @@ namespace Xamarin.Forms.Platform.Android
 		public IVisualElementRenderer Child { get; set; }
 
 		public bool IsInFragment { get; set; }
+
+		protected PageContainer(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+		{
+		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{


### PR DESCRIPTION
### Description of Change ###

Add native ctor to PageContainer so it can be accessed when on a Fragment remove event

### Issues Resolved ###

- fixes #2740 

### API Changes ###

<!-- List all API changes here (or just put None), example:

Added:
 - protected PageContainer(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer) 

- Android

### Behavioral/Visual Changes ###

None, no crash when removed

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
