### PR TITLE
Use GestureDetector constructor that takes in Context 3.0

### DIFF
--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -90,7 +90,7 @@ namespace Xamarin.Forms.Platform.Android
 						return _longPressGestureDetector;
 					}
 
-					_longPressGestureDetector = new GestureDetector(new LongPressGestureListener(TriggerLongClick));
+					_longPressGestureDetector = new GestureDetector(Context, new LongPressGestureListener(TriggerLongClick));
 					return _longPressGestureDetector;
 				}
 			}


### PR DESCRIPTION
This is just to get these changes into an early branch so that once 15.8 drops we'll still be able to compile

https://github.com/xamarin/Xamarin.Forms/pull/2836