### PR TITLE
[Tizen] Add circle style dialog for watch

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/Dialog.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Dialog.cs
@@ -4,6 +4,17 @@ using EButton = ElmSharp.Button;
 
 namespace Xamarin.Forms.Platform.Tizen.Native
 {
+
+	/// <summary>
+	/// Enumerates the three valid positions of a dialog button.
+	/// </summary>
+	public enum ButtonPosition
+	{
+		Positive,
+		Neutral,
+		Negative
+	}
+
 	/// <summary>
 	/// Base class for Dialogs.
 	/// A dialog is a small window that prompts the user to make a decision or enter additional information.
@@ -15,6 +26,22 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		EButton _negativeButton;
 		EvasObject _content;
 		string _title;
+		string _message;
+
+		/// <summary>
+		///  Creates a dialog window.
+		/// </summary>
+		public static Dialog CreateDialog(EvasObject parent, bool hasAcceptButton = false)
+		{
+			if (Device.Idiom == TargetIdiom.Watch)
+			{
+				return new Watch.WatchDialog(Forms.NativeParent, hasAcceptButton);
+			}
+			else
+			{
+				return new Dialog(Forms.NativeParent);
+			}
+		}
 
 		/// <summary>
 		/// Creates a dialog window that uses the default dialog theme.
@@ -30,16 +57,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		public event EventHandler Shown;
 
 		/// <summary>
-		/// Enumerates the three valid positions of a dialog button.
-		/// </summary>
-		enum ButtonPosition
-		{
-			Positive,
-			Neutral,
-			Negative
-		}
-
-		/// <summary>
 		/// Gets or sets the title of the dialog
 		/// </summary>
 		public string Title
@@ -52,7 +69,27 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				if (_title != value)
 				{
+					_title = value;
 					ApplyTitle(value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the message to display in the dialog
+		/// </summary>
+		public string Message
+		{
+			get
+			{
+				return _message;
+			}
+			set
+			{
+				if (_message != value)
+				{
+					_message = value;
+					ApplyMessage(value);
 				}
 			}
 		}
@@ -70,6 +107,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				if (_content != value)
 				{
+					_content = value;
 					ApplyContent(value);
 				}
 			}
@@ -88,6 +126,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				if (_positiveButton != value)
 				{
+					_positiveButton = value;
 					ApplyButton(ButtonPosition.Positive, value);
 				}
 			}
@@ -106,6 +145,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				if (_neutralButton != value)
 				{
+					_neutralButton = value;
 					ApplyButton(ButtonPosition.Neutral, value);
 				}
 			}
@@ -124,6 +164,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				if (_negativeButton != value)
 				{
+					_negativeButton = value;
 					ApplyButton(ButtonPosition.Negative, value);
 				}
 			}
@@ -172,6 +213,61 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		}
 
 		/// <summary>
+		/// Changes the dialog title.
+		/// </summary>
+		/// <param name="title">New dialog title.</param>
+		protected virtual void ApplyTitle(string title)
+		{
+			SetPartText("title,text", title);
+		}
+
+		/// <summary>
+		/// Puts the button in one of the three available slots.
+		/// </summary>
+		/// <param name="position">The slot to be occupied by the button expressed as a <see cref="ButtonPosition"/></param>
+		/// <param name="button">The new button.</param>
+		protected virtual void ApplyButton(ButtonPosition position, EButton button)
+		{
+			if (button != null)
+			{
+				button.Style = "popup";
+			}
+
+			string part;
+			switch (position)
+			{
+				case ButtonPosition.Positive:
+					part = "button3";
+					break;
+
+				case ButtonPosition.Neutral:
+					part = "button2";
+					break;
+
+				case ButtonPosition.Negative:
+				default:
+					part = "button1";
+					break;
+			}
+
+			SetPartContent(part, button, true);
+		}
+
+		/// <summary>
+		/// Updates the content of the dialog.
+		/// </summary>
+		/// <param name="content">New dialog content.</param>
+		protected virtual void ApplyContent(EvasObject content)
+		{
+			SetPartContent("default", content, true);
+		}
+
+		protected virtual void ApplyMessage(string message)
+		{
+			base.Text = message;
+		}
+
+		/// <summary>
 		/// Handles the initialization process.
 		/// </summary>
 		/// <remarks>Creates handlers for vital events</remarks>
@@ -190,59 +286,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				OnShown();
 			};
-		}
-
-		/// <summary>
-		/// Changes the dialog title.
-		/// </summary>
-		/// <param name="title">New dialog title.</param>
-		void ApplyTitle(string title)
-		{
-			_title = title;
-
-			SetPartText("title,text", _title);
-		}
-
-		/// <summary>
-		/// Puts the button in one of the three available slots.
-		/// </summary>
-		/// <param name="position">The slot to be occupied by the button expressed as a <see cref="ButtonPosition"/></param>
-		/// <param name="button">The new button.</param>
-		void ApplyButton(ButtonPosition position, EButton button)
-		{
-			if (button != null)
-			{
-				button.Style = "popup";
-			}
-
-			switch (position)
-			{
-				case ButtonPosition.Positive:
-					_positiveButton = button;
-					SetPartContent("button3", _positiveButton, true);
-					break;
-
-				case ButtonPosition.Neutral:
-					_neutralButton = button;
-					SetPartContent("button2", _neutralButton, true);
-					break;
-
-				case ButtonPosition.Negative:
-					_negativeButton = button;
-					SetPartContent("button1", _negativeButton, true);
-					break;
-			}
-		}
-
-		/// <summary>
-		/// Updates the content of the dialog.
-		/// </summary>
-		/// <param name="content">New dialog content.</param>
-		void ApplyContent(EvasObject content)
-		{
-			_content = content;
-
-			SetPartContent("default", _content, true);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDialog.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDialog.cs
@@ -1,0 +1,86 @@
+using ElmSharp;
+using EButton = ElmSharp.Button;
+using ELayout = ElmSharp.Layout;
+using EColor = ElmSharp.Color;
+
+namespace Xamarin.Forms.Platform.Tizen.Native.Watch
+{
+	public class WatchDialog : Dialog
+	{
+		ELayout _popupLayout;
+		bool _hasAcceptButton = false ;
+
+		/// <summary>
+		/// Creates a dialog window for watch
+		/// </summary>
+		public WatchDialog(EvasObject parent, bool hasAcceptButton) : base(parent)
+		{
+			Style = "circle";
+
+			_popupLayout = new ELayout(this)
+			{
+				AlignmentX = -1,
+				AlignmentY = -1,
+				WeightX = 1,
+				WeightY = 1
+			};
+
+			_hasAcceptButton = hasAcceptButton;
+
+			var style = hasAcceptButton ? "content/circle/buttons2" : "content/circle";
+
+			_popupLayout.SetTheme("layout", "popup", style);
+			_popupLayout.Show();
+
+			SetContent(_popupLayout);
+		}
+
+		protected override void ApplyButton(ButtonPosition position, EButton button)
+		{
+			string style = "";
+			string part = "";
+			EColor color = EColor.Default;
+
+			switch (position)
+			{
+				case ButtonPosition.Neutral:
+					style = "popup/circle/right_check";
+					part = "button2";
+					break;
+
+				case ButtonPosition.Negative:
+					style = _hasAcceptButton ? "popup/circle/left_delete" : "bottom";
+					color = _hasAcceptButton ? EColor.Default : new EColor(0, 47, 66, 255);
+					part = "button1";
+					break;
+
+				case ButtonPosition.Positive:
+				default:
+					// Due to ux limiation, nothing to do
+					break;
+			}
+
+			if (button != null)
+			{
+				button.Style = style;
+				button.BackgroundColor = color;
+			}
+			SetPartContent(part, button);
+		}
+
+		protected override void ApplyContent(EvasObject content)
+		{
+			_popupLayout.SetContent(content);
+		}
+
+		protected override void ApplyTitle(string title)
+		{
+			_popupLayout.SetPartText("elm.text.title", title);
+		}
+
+		protected override void ApplyMessage(string message)
+		{
+			_popupLayout.SetPartText("elm.text", message);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Platform.cs
+++ b/Xamarin.Forms.Platform.Tizen/Platform.cs
@@ -2,12 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
 using ElmSharp;
 using EProgressBar = ElmSharp.ProgressBar;
 using EButton = ElmSharp.Button;
 using EColor = ElmSharp.Color;
-using System.ComponentModel;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -439,10 +440,11 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (!PageIsChildOfPlatform(sender))
 				return;
 
-			Native.Dialog alert = new Native.Dialog(Forms.NativeParent);
+			Native.Dialog alert = Native.Dialog.CreateDialog(Forms.NativeParent, (arguments.Accept != null));
+
 			alert.Title = arguments.Title;
 			var message = arguments.Message.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace(Environment.NewLine, "<br>");
-			alert.Text = message;
+			alert.Message = message;
 
 			EButton cancel = new EButton(alert) { Text = arguments.Cancel };
 			alert.NegativeButton = cancel;
@@ -480,7 +482,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (!PageIsChildOfPlatform(sender))
 				return;
 
-			Native.Dialog alert = new Native.Dialog(Forms.NativeParent);
+			Native.Dialog alert = Native.Dialog.CreateDialog(Forms.NativeParent);
 
 			alert.Title = arguments.Title;
 			Box box = new Box(alert);
@@ -490,6 +492,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				Native.Button destruction = new Native.Button(alert)
 				{
 					Text = arguments.Destruction,
+					Style = ButtonStyle.Text,
 					TextColor = EColor.Red,
 					AlignmentX = -1
 				};
@@ -507,6 +510,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				Native.Button button = new Native.Button(alert)
 				{
 					Text = buttonName,
+					Style = ButtonStyle.Text,
 					AlignmentX = -1
 				};
 				button.Clicked += (s, evt) =>


### PR DESCRIPTION
### Description of Change ###

This RR is to add circle style dialog for tizen watch

### Issues Resolved ###

None

### API Changes ###

None

### Platforms Affected ###

- Tizen

### Behavioral/Visual Changes ###

DisplayAlert 

- with a cancel button

| Before | After |
| -- | -- |
|![tw_displayalert_1_1](https://user-images.githubusercontent.com/20968023/41759747-f70c2e0c-762a-11e8-8d66-145259eb5200.png)|![tw_displayalert_1](https://user-images.githubusercontent.com/20968023/41759753-fdd68c00-762a-11e8-9d70-946606a877d0.png)|

- with an accept button and a cancel button

| Before | After |
| -- | -- |
|![tw_displayalert_2_1](https://user-images.githubusercontent.com/20968023/41759767-0de68d0c-762b-11e8-970f-31006163d56d.png)|![tw_displayalert_2](https://user-images.githubusercontent.com/20968023/41759773-140015c8-762b-11e8-8c80-4b33062bded8.png)|

DisplayActionSheet

| Before | After |
| -- | -- |
|![tw_actionsheet_1_1](https://user-images.githubusercontent.com/20968023/41759785-1b118d2e-762b-11e8-9577-13f7bf35e465.png)|![tw_actionsheet_1](https://user-images.githubusercontent.com/20968023/41759790-1f61614c-762b-11e8-8ab0-48224f0203c4.png)|



### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
