### PR TITLE
[iOS] Fix iOS WebView load url with port number

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Info.plist
+++ b/Xamarin.Forms.ControlGallery.iOS/Info.plist
@@ -118,11 +118,18 @@
 				<key>NSTemporaryExceptionMinimumTLSVersion</key>
 				<string>TLSv1.1</string>
 			</dict>
+			<key>portquiz.net</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
 		</dict>
 	</dict>
 	<key>CFBundleName</key>
 	<string>XamControl</string>
-  <key>NSPhotoLibraryUsageDescription</key>
-  <string>This app needs access to photos.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app needs access to photos.</string>
 </dict>
 </plist>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -34,6 +34,9 @@ namespace Xamarin.Forms.Controls.Issues
 			var queryButton = new Button { Text = "3:query", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "queryButton" };
 			queryButton.Clicked += (sender, args) => Load("https://www.google.com/search?q=http%3A%2F%2Fmicrosoft.com");
 
+			var portButton = new Button { Text = "4:port", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "portButton" };
+			portButton.Clicked += (sender, args) => Load("http://portquiz.net:666");
+
 			Content = new StackLayout
 			{
 				Children =
@@ -42,7 +45,7 @@ namespace Xamarin.Forms.Controls.Issues
 					new StackLayout
 					{
 						Orientation = StackOrientation.Horizontal,
-						Children = { hashButton, unicodeButton, queryButton }
+						Children = { hashButton, unicodeButton, queryButton, portButton  }
 					},
 					_webview
 				}
@@ -74,6 +77,9 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap("queryButton");
 			await Task.Delay(TimeSpan.FromSeconds(3));
 			RunningApp.Screenshot ("I didn't crash and i can see google search for http://microsoft.com");
+			RunningApp.Tap("portButton");
+			await Task.Delay(TimeSpan.FromSeconds(3));
+			RunningApp.Screenshot ("I didn't crash and i can see that i visited port 666");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue1583Test ()
 		{
+			Task.Delay(TimeSpan.FromSeconds(3)).Wait();
 			RunningApp.WaitForElement (q => q.Marked ("label"));
 			Task.Delay(TimeSpan.FromSeconds(3)).Wait();
 			RunningApp.Screenshot ("I didn't crash and i can see Skøyen");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1583, "WebView fails to load from urlwebviewsource with non-ascii characters (works with Uri)", PlatformAffected.iOS, issueTestNumber: 1)]
-	public class Issue1583 : TestContentPage
+	public class Issue1583_1 : TestContentPage
 	{
 		WebView _webview;
 		Label _label;
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 				AutomationId = "webview",
 				VerticalOptions = LayoutOptions.FillAndExpand
 			};
-			_label = new Label { AutomationId = "label" };
+			_label = new Label { AutomationId = "label", Text = "label" };
 
 			var hashButton = new Button { Text = "1:hash", HorizontalOptions = LayoutOptions.FillAndExpand, AutomationId = "hashButton" };
 			hashButton.Clicked += (sender, args) => Load("https://github.com/xamarin/Xamarin.Forms/issues/2736#issuecomment-389443737");
@@ -66,19 +66,19 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public async Task Issue1583Test ()
+		public void Issue1583Test ()
 		{
-			RunningApp.WaitForElement (q => q.Marked ("label"), "Could not find label", TimeSpan.FromSeconds(10), null, null);
-			await Task.Delay(TimeSpan.FromSeconds(3));
+			RunningApp.WaitForElement (q => q.Marked ("label"));
+			Task.Delay(TimeSpan.FromSeconds(3)).Wait();
 			RunningApp.Screenshot ("I didn't crash and i can see Skøyen");
 			RunningApp.Tap("hashButton");
-			await Task.Delay(TimeSpan.FromSeconds(3));
+			Task.Delay(TimeSpan.FromSeconds(3)).Wait();
 			RunningApp.Screenshot ("I didn't crash and i can see the GitHub comment #issuecomment-389443737");
 			RunningApp.Tap("queryButton");
-			await Task.Delay(TimeSpan.FromSeconds(3));
+			Task.Delay(TimeSpan.FromSeconds(3)).Wait();
 			RunningApp.Screenshot ("I didn't crash and i can see google search for http://microsoft.com");
 			RunningApp.Tap("portButton");
-			await Task.Delay(TimeSpan.FromSeconds(3));
+			Task.Delay(TimeSpan.FromSeconds(3)).Wait();
 			RunningApp.Screenshot ("I didn't crash and i can see that i visited port 666");
 		}
 #endif

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public void LoadUrl(string url)
 		{
 			var uri = new Uri(url);
-			var safeHostUri = new Uri($"{uri.Scheme}://{uri.IdnHost}", UriKind.Absolute);
+			var safeHostUri = new Uri($"{uri.Scheme}://{uri.Authority}", UriKind.Absolute);
 			var safeRelativeUri = new Uri($"{uri.PathAndQuery}{uri.Fragment}", UriKind.Relative);
 			LoadRequest(new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri)));
 		}


### PR DESCRIPTION
### Description of Change ###

Fixes regression loading a url with a port number

### Issues Resolved ###

- https://github.com/xamarin/Xamarin.Forms/commit/3b2be6912c35a0991ff08b26b92414a9eefb1cd0#commitcomment-29458985
-  fixes #3073

### API Changes ###

None

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###

Url with port number should now load as before

<img width="629" alt="screen shot 2018-06-22 at 12 05 46" src="https://user-images.githubusercontent.com/1235097/41774274-ded3ba62-7616-11e8-89cf-62f776f00008.png">

### PR Checklist ###

- [x] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard