### PR TITLE
[iOS] Try another fix for toolbar items layout

### DIFF
--- a/Xamarin.Forms.Controls/ControlGalleryPages/ToolbarItems.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/ToolbarItems.cs
@@ -48,7 +48,9 @@ namespace Xamarin.Forms.Controls
 			tb5.Text = "tb5";
 			tb5.Icon = "bank.png";
 			tb5.Order = ToolbarItemOrder.Secondary;
-			tb5.Command = command;
+			tb5.Command = new Command(async () => {
+				await Navigation.PushAsync(new ToolbarItems());
+			});
 			tb5.AutomationId = "toolbaritem_secondary5";
 
 			ToolbarItems.Add(tb1);

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -754,8 +754,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		class SecondaryToolbar : UIToolbar
 		{
-			nfloat _toolbarWidth;
-
 			readonly List<UIView> _lines = new List<UIView>();
 
 			public SecondaryToolbar()
@@ -783,11 +781,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			void LayoutToolbarItems(nfloat toolbarWidth, nfloat toolbarHeight, nfloat padding)
 			{
-				if (_toolbarWidth == toolbarWidth)
-					return;
-
-				_toolbarWidth = toolbarWidth;
-
 				var x = padding;
 				var y = 0;
 				var itemH = toolbarHeight;
@@ -796,6 +789,8 @@ namespace Xamarin.Forms.Platform.iOS
 				foreach (var item in Items)
 				{
 					var frame = new RectangleF(x, y, itemW, itemH);
+					if (frame == item.CustomView.Frame)
+						return;
 					item.CustomView.Frame = frame;
 					x += itemW + padding;
 				}


### PR DESCRIPTION
### Description of Change ###

Revert #2870 
Do not set frame twice as it causes the button to shift

### Issues Resolved ###

- fixes #2798 

### API Changes ###

None 

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###

Should layout buttos ok even after push and rotation 

### PR Checklist ###

- [ ] Has automated tests 
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
