### PR TITLE
[Android] NavigationPage should not push a page that has already been pushed

### DIFF
--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -29,30 +29,56 @@ namespace Xamarin.Forms.Controls
 		public App()
 		{
 			_testCloudService = DependencyService.Get<ITestCloudService>();
-			
+
 			SetMainPage(CreateDefaultMainPage());
 
-			//// Uncomment to verify that there is no gray screen displayed between the blue splash and red MasterDetailPage.
-			//SetMainPage(new Bugzilla44596SplashPage(() =>
-			//{
-			//	var newTabbedPage = new TabbedPage();
-			//	newTabbedPage.Children.Add(new ContentPage { BackgroundColor = Color.Red, Content = new Label { Text = "yay" } });
-			//	MainPage = new MasterDetailPage
-			//	{
-			//		Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
-			//		Detail = newTabbedPage
-			//	};
-			//}));
+			//TestBugzilla44596();
 
-			//// Uncomment to verify that there is no crash when switching MainPage from MDP inside NavPage
-			//SetMainPage(new Bugzilla45702());
+			//TestBugzilla45702();
+		}
+
+		protected override void OnStart()
+		{
+			//TestIssue2393();
+		}
+
+		void TestBugzilla44596()
+		{
+			// verify that there is no gray screen displayed between the blue splash and red MasterDetailPage.
+			SetMainPage(new Bugzilla44596SplashPage(() =>
+			{
+				var newTabbedPage = new TabbedPage();
+				newTabbedPage.Children.Add(new ContentPage { BackgroundColor = Color.Red, Content = new Label { Text = "yay" } });
+				MainPage = new MasterDetailPage
+				{
+					Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
+					Detail = newTabbedPage
+				};
+			}));
+		}
+
+		void TestBugzilla45702()
+		{
+			// verify that there is no crash when switching MainPage from MDP inside NavPage
+			SetMainPage(new Bugzilla45702());
+		}
+
+		void TestIssue2393()
+		{
+			MainPage = new NavigationPage();
+
+			// Hand off to website for sign in process
+			var view = new WebView { Source = new Uri("http://google.com") };
+			view.Navigated += (s, e) => MainPage.DisplayAlert("Navigated", $"If this popup appears multiple times, this test has failed", "ok"); ;
+
+			MainPage.Navigation.PushAsync(new ContentPage { Content = view, Title = "Issue 2393" });
 		}
 
 		public Page CreateDefaultMainPage()
 		{
 			var layout = new StackLayout { BackgroundColor = Color.Red };
-			layout.Children.Add(new Label { Text ="This is master Page" });
-			var master = new ContentPage { Title = "Master", Content = layout,  BackgroundColor = Color.SkyBlue };
+			layout.Children.Add(new Label { Text = "This is master Page" });
+			var master = new ContentPage { Title = "Master", Content = layout, BackgroundColor = Color.SkyBlue };
 			master.On<iOS>().SetUseSafeArea(true);
 			return new MasterDetailPage
 			{
@@ -155,7 +181,7 @@ namespace Xamarin.Forms.Controls
 				// Set up a delegate to handle the navigation to the test page
 				EventHandler toTestPage = null;
 
-				toTestPage = delegate(object sender, EventArgs e) 
+				toTestPage = delegate (object sender, EventArgs e)
 				{
 					Current.MainPage.Navigation.PushModalAsync(TestCases.GetTestCases());
 					TestCases.TestCaseScreen.PageToAction[test]();
@@ -169,7 +195,7 @@ namespace Xamarin.Forms.Controls
 
 				return true;
 			}
-			catch (Exception ex) 
+			catch (Exception ex)
 			{
 				Log.Warning("UITests", $"Error attempting to navigate directly to {test}: {ex}");
 
@@ -177,7 +203,7 @@ namespace Xamarin.Forms.Controls
 
 			return false;
 		}
-		
+
 		public void Reset()
 		{
 			SetMainPage(CreateDefaultMainPage());

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -46,8 +46,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		MasterDetailPage _masterDetailPage;
 		bool _toolbarVisible;
 		bool _isAttachedToWindow;
-		bool _didInitialPushPages;
-
 
 		// The following is based on https://android.googlesource.com/platform/frameworks/support.git/+/4a7e12af4ec095c3a53bb8481d8d92f63157c3b7/v4/java/android/support/v4/app/FragmentManager.java#677
 		// Must be overriden in a custom renderer to match durations in XML animation resource files
@@ -930,19 +928,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		
 		void PushCurrentPages()
 		{
-			if (_didInitialPushPages)
+			if (_fragmentStack.Count > 0)
 				return;
 
 			var navController = (INavigationPageController)Element;
 
 			foreach (Page page in navController.Pages)
 			{
-				if (GetPageFragment(page) != null)
-					continue;
-
 				PushViewAsync(page, false);
 			}
-			_didInitialPushPages = true;
 		}
 
 		bool IsAttachedToRoot()

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -937,6 +937,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			foreach (Page page in navController.Pages)
 			{
+				if (GetPageFragment(page) != null)
+					continue;
+
 				PushViewAsync(page, false);
 			}
 			_didInitialPushPages = true;


### PR DESCRIPTION
### Description of Change ###

If you push a page with a `WebView` onto a `NavigationPage` on `Application OnStart`, it seems to cause the `WebView` to infinitely navigate, rendering it basically useless on Android.

This is hard to reproduce in the Control Gallery, since it only happens if you do the navigation `OnStart`, so to run the test, you must uncomment the test from the `App.cs OnStart` method.

This change will ensure that a `Page` doesn't get pushed a second time `OnStart` (or `OnAttached`, in Android).



related to #1999

### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2393

### API Changes ###

None

### Platforms Affected ###

- Android


### Behavioral/Visual Changes ###

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Honestly? Probably tons. O_O



### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
