### PR TITLE
[UWP] Allow setting StepFrequency of the Slider

### DIFF
--- a/Xamarin.Forms.Platform.UAP/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SliderRenderer.cs
@@ -33,6 +33,7 @@ namespace Xamarin.Forms.Platform.UWP
 					Control.Minimum = e.NewElement.Minimum;
 					Control.Maximum = e.NewElement.Maximum;
 					Control.Value = e.NewElement.Value;
+					Control.IsThumbToolTipEnabled = false;
 
 					slider.ValueChanged += OnNativeValueChanged;
 
@@ -56,7 +57,7 @@ namespace Xamarin.Forms.Platform.UWP
 					}
 				}
 
-				double stepping = Math.Min((e.NewElement.Maximum - e.NewElement.Minimum) / 10, 1);
+				double stepping = Math.Min((e.NewElement.Maximum - e.NewElement.Minimum) / 1000, 1);
 				Control.StepFrequency = stepping;
 				Control.SmallChange = stepping;
 				UpdateFlowDirection();


### PR DESCRIPTION
### Description of Change ###

For the Slider default value of step is set to `1000` to match Android.
Also removed ToolTip with current value.

### Issues Resolved ###

- fixes #2955

### API Changes ###

None

### Platforms Affected ###

- UWP

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
