### PR TITLE
[Android] Force animations to finish immediately when power save mode is on

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1556.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1556.cs
@@ -1,19 +1,11 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
-#if UITEST
-using Xamarin.UITest;
-using NUnit.Framework;
-#endif
-
 namespace Xamarin.Forms.Controls.Issues
 {
-#if UITEST
-	[System.ComponentModel.Category(Xamarin.Forms.Core.UITests.UITestCategories.Animation)]
-#endif
-
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 1556, "Animation tasks do not complete when Battery Saver enabled", PlatformAffected.Android)]
+	[Issue(IssueTracker.Github, 1556, "Animation tasks do not complete when Battery Saver enabled", 
+		PlatformAffected.Android)]
 	public class Issue1556 : TestContentPage
 	{
 		const string FirstLabel = "Label 1";
@@ -21,8 +13,13 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			var instructions = new Label {Text = $"The label with the text '{SecondLabel}' should be visible." 
-												+ $" If the label with '{SecondLabel}' does not become visible, the test has failed." };
+			var instructions = new Label
+			{
+				Text =
+					"Once the page appears, you have 30 seconds to enable Battery Saver; enabling Battery Saver " 
+					+ "should make both labels fully visible immediately. " 
+					+ "If either label is not fully visible, this test has failed"
+			};
 
 			var label1 = new Label { Text = FirstLabel, Opacity = 0 };
 			var label2 = new Label { Text = SecondLabel, IsVisible = false };
@@ -37,17 +34,9 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Appearing += async (sender, args) =>
 			{
-				await label1.FadeTo(1);
+				await label1.FadeTo(1, 30000);
 				label2.IsVisible = true;
 			};
 		}
-
-#if UITEST
-		[Test, Explicit("This only makes sense to run if animator duration scale (in dev options) is set to 0 or low battery mode is active")]
-		public void LowBatteryAnimationTest ()
-		{
-			RunningApp.WaitForElement(SecondLabel);
-		}
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1556.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1556.cs
@@ -1,0 +1,53 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[System.ComponentModel.Category(Xamarin.Forms.Core.UITests.UITestCategories.Animation)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1556, "Animation tasks do not complete when Battery Saver enabled", PlatformAffected.Android)]
+	public class Issue1556 : TestContentPage
+	{
+		const string FirstLabel = "Label 1";
+		const string SecondLabel = "Label 2";
+
+		protected override void Init()
+		{
+			var instructions = new Label {Text = $"The label with the text '{SecondLabel}' should be visible." 
+												+ $" If the label with '{SecondLabel}' does not become visible, the test has failed." };
+
+			var label1 = new Label { Text = FirstLabel, Opacity = 0 };
+			var label2 = new Label { Text = SecondLabel, IsVisible = false };
+
+			var layout = new StackLayout();
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(label1);
+			layout.Children.Add(label2);
+
+			Content = layout;
+
+			Appearing += async (sender, args) =>
+			{
+				await label1.FadeTo(1);
+				label2.IsVisible = true;
+			};
+		}
+
+#if UITEST
+		[Test, Explicit("This only makes sense to run if animator duration scale (in dev options) is set to 0 or low battery mode is active")]
+		public void LowBatteryAnimationTest ()
+		{
+			RunningApp.WaitForElement(SecondLabel);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -241,6 +241,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Effects\AttachedStateEffectList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1483.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1556.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1799.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1931.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3087.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -4,6 +4,7 @@
 	{
 		public const string ActionSheet = "ActionSheet";
 		public const string ActivityIndicator = "ActivityIndicator";
+		public const string Animation = "Animation";
 		public const string AutomationId = "AutomationID";
 		public const string BoxView = "BoxView";
 		public const string Button = "Button";

--- a/Xamarin.Forms.Core.UnitTests/MotionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MotionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Xamarin.Forms.Internals;
 
@@ -8,13 +9,46 @@ namespace Xamarin.Forms.Core.UnitTests
 	internal class BlockingTicker : Ticker
 	{
 		bool _enabled;
-
+		
 		protected override void EnableTimer ()
 		{
 			_enabled = true;
 
 			while (_enabled) {
 				SendSignals (16);
+			}
+		}
+
+		protected override void DisableTimer ()
+		{
+			_enabled = false;
+		}
+	}
+
+	internal class AsyncTicker : Ticker
+	{
+		bool _systemEnabled = true;
+		public override bool SystemEnabled => _systemEnabled;
+
+		bool _enabled;
+
+		public void SetEnabled(bool enabled)
+		{
+			_systemEnabled = enabled;
+
+			_enabled = enabled;
+
+			OnSystemEnabledChanged();
+		}
+
+		protected override async void EnableTimer ()
+		{
+			_enabled = true;
+
+			while (_enabled)
+			{
+				SendSignals(16);
+				await Task.Delay(16);
 			}
 		}
 
@@ -114,6 +148,94 @@ namespace Xamarin.Forms.Core.UnitTests
 				finished: () => finished = true);
 
 			Assert.True (finished);
+		}
+	}
+
+	[TestFixture]
+	public class TickerSystemEnabledTests
+	{
+		[TestFixtureSetUp]
+		public void Init ()
+		{
+			Device.PlatformServices = new MockPlatformServices ();
+			Ticker.Default = new AsyncTicker(); 
+		}
+
+		[TestFixtureTearDown]
+		public void End ()
+		{
+			Device.PlatformServices = null;
+			Ticker.Default = null;
+		}
+
+		static async Task DisableTicker()
+		{
+			await Task.Delay(32);
+			((AsyncTicker)Ticker.Default).SetEnabled(false);
+		}
+
+		async Task SwapFadeViews(View view1, View view2)
+		{
+			await view1.FadeTo(0, 1000);
+			await view2.FadeTo(1, 1000);
+		}
+
+		[Test, Timeout(3000)]
+		public async Task DisablingTickerFinishesAnimationInProgress()
+		{
+			var view = new View { Opacity = 1 };
+
+			await Task.WhenAll(view.FadeTo(0, 2000), DisableTicker());
+			
+			Assert.That (view.Opacity, Is.EqualTo(0));
+		}
+
+		[Test, Timeout(3000)]
+		public async Task DisablingTickerFinishesAllAnimationsInChain()
+		{
+			var view1 = new View { Opacity = 1 };
+			var view2 = new View { Opacity = 0 };
+
+			await Task.WhenAll(SwapFadeViews(view1, view2), DisableTicker());
+
+			Assert.That(view1.Opacity, Is.EqualTo(0));
+			
+		}
+
+		static Task<bool> RepeatFade(View view)
+		{
+			var tcs = new TaskCompletionSource<bool>();
+			var fadeIn = new Animation(d => { view.Opacity = d; }, 0, 1);
+			var i = 0;
+			
+			fadeIn.Commit(view, "fadeIn", length: 2000, repeat: () => ++i < 2, finished: (d, b) =>
+			{
+				tcs.SetResult(b);
+			});
+
+			return tcs.Task;
+		}
+
+		[Test, Timeout(3000)]
+		public async Task DisablingTickerPreventsAnimationFromRepeating()
+		{
+			var view = new View { Opacity = 0 };
+			
+			await Task.WhenAll(RepeatFade(view), DisableTicker());
+
+			Assert.That(view.Opacity, Is.EqualTo(1));
+		}
+
+		[Test] 
+		public async Task NewAnimationsFinishImmediatelyWhenTickerDisabled()
+		{
+			var view = new View { Opacity = 1 };
+
+			await DisableTicker();
+
+			await view.RotateYTo(200);
+
+			Assert.That(view.RotationY, Is.EqualTo(200));
 		}
 	}
 }

--- a/Xamarin.Forms.Core/AnimationExtensions.cs
+++ b/Xamarin.Forms.Core/AnimationExtensions.cs
@@ -249,7 +249,9 @@ namespace Xamarin.Forms
 				info.Callback(tweener.Value);
 
 				var repeat = false;
-				if (info.Repeat != null)
+
+				// If the Ticker has been disabled (e.g., by power save mode), then don't repeat the animation
+				if (info.Repeat != null && Ticker.Default.SystemEnabled)
 					repeat = info.Repeat();
 
 				if (!repeat)

--- a/Xamarin.Forms.Core/Tweener.cs
+++ b/Xamarin.Forms.Core/Tweener.cs
@@ -66,13 +66,28 @@ namespace Xamarin.Forms
 			Pause();
 
 			_lastMilliseconds = 0;
+
+			if (!Ticker.Default.SystemEnabled)
+			{
+				FinishImmediately();
+				return;
+			}
+
 			_timer = Ticker.Default.Insert(step =>
 			{
-				long ms = step + _lastMilliseconds;
+				if (step == long.MaxValue)
+				{
+					// We're being forced to finish
+					Value = 1.0;
+				}
+				else
+				{
+					long ms = step + _lastMilliseconds;
 
-				Value = Math.Min(1.0f, ms / (double)Length);
+					Value = Math.Min(1.0f, ms / (double)Length);
 
-				_lastMilliseconds = ms;
+					_lastMilliseconds = ms;
+				}
 
 				ValueUpdated?.Invoke(this, EventArgs.Empty);
 
@@ -92,6 +107,15 @@ namespace Xamarin.Forms
 				}
 				return true;
 			});
+		}
+
+		void FinishImmediately()
+		{
+			Value = 1.0f;
+			ValueUpdated?.Invoke(this, EventArgs.Empty);
+			Finished?.Invoke(this, EventArgs.Empty);
+			Value = 0.0f;
+			_timer = 0;
 		}
 
 		public void Stop()

--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -29,6 +29,11 @@ namespace Xamarin.Forms.Platform.Android
 			// We can't just check ValueAnimator.AreAnimationsEnabled() because there's no event for that, and it's
 			// only supported on API >= 26
 
+			if (!Forms.IsLollipopOrNewer)
+			{
+				_systemEnabled = true;
+			}
+
 			var powerManager = (PowerManager)Forms.ApplicationContext.GetSystemService(Context.PowerService);
 
 			var powerSaveOn = powerManager.IsPowerSaveMode;

--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -1,5 +1,7 @@
 using System;
 using Android.Animation;
+using Android.Content;
+using Android.OS;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android
@@ -7,6 +9,7 @@ namespace Xamarin.Forms.Platform.Android
 	internal class AndroidTicker : Ticker, IDisposable
 	{
 		ValueAnimator _val;
+		bool _systemEnabled;
 
 		public AndroidTicker()
 		{
@@ -14,6 +17,27 @@ namespace Xamarin.Forms.Platform.Android
 			_val.SetIntValues(0, 100); // avoid crash
 			_val.RepeatCount = ValueAnimator.Infinite;
 			_val.Update += OnValOnUpdate;
+			CheckPowerSaveModeStatus();
+		}
+
+		public override bool SystemEnabled => _systemEnabled;
+
+		internal void CheckPowerSaveModeStatus()
+		{
+			// Android disables animations when it's in power save mode
+			// So we need to keep track of whether we're in that mode and handle animations accordingly
+			// We can't just check ValueAnimator.AreAnimationsEnabled() because there's no event for that, and it's
+			// only supported on API >= 26
+
+			var powerManager = (PowerManager)Forms.ApplicationContext.GetSystemService(Context.PowerService);
+
+			var powerSaveOn = powerManager.IsPowerSaveMode;
+
+			// If power saver is active, then animations will not run
+			_systemEnabled = !powerSaveOn;
+			
+			// Notify the ticker that this value has changed, so it can manage animations in progress
+			OnSystemEnabledChanged();
 		}
 
 		public void Dispose()

--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (!Forms.IsLollipopOrNewer)
 			{
 				_systemEnabled = true;
+				return;
 			}
 
 			var powerManager = (PowerManager)Forms.ApplicationContext.GetSystemService(Context.PowerService);

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Platform.Android
 		AndroidApplicationLifecycleState _currentState;
 		LinearLayout _layout;
 
+		PowerSaveModeBroadcastReceiver _powerSaveModeBroadcastReceiver;
 
 		AndroidApplicationLifecycleState _previousState;
 
@@ -126,6 +127,12 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnCreate;
 
+			if (Forms.IsLollipopOrNewer)
+			{
+				// Listen for the device going into power save mode so we can handle animations being disabled	
+				_powerSaveModeBroadcastReceiver = new PowerSaveModeBroadcastReceiver();
+			}
+
 			OnStateChanged();
 		}
 
@@ -153,6 +160,12 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnPause;
 
+			if (Forms.IsLollipopOrNewer)
+			{
+				// Don't listen for power save mode changes while we're paused
+				UnregisterReceiver(_powerSaveModeBroadcastReceiver);
+			}
+
 			OnStateChanged();
 		}
 
@@ -173,6 +186,13 @@ namespace Xamarin.Forms.Platform.Android
 
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnResume;
+
+			if (Forms.IsLollipopOrNewer)
+			{
+				// Start listening for power save mode changes
+				RegisterReceiver(_powerSaveModeBroadcastReceiver, new IntentFilter(
+					PowerManager.ActionPowerSaveModeChanged));
+			}
 
 			OnStateChanged();
 		}

--- a/Xamarin.Forms.Platform.Android/PowerSaveModeBroadcastReceiver.cs
+++ b/Xamarin.Forms.Platform.Android/PowerSaveModeBroadcastReceiver.cs
@@ -1,0 +1,14 @@
+using Android.Content;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	[BroadcastReceiver(Enabled = true, Exported = false)]
+	public class PowerSaveModeBroadcastReceiver : BroadcastReceiver
+	{
+		public override void OnReceive(Context context, Intent intent)
+		{
+			((AndroidTicker)Ticker.Default).CheckPowerSaveModeStatus();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -22,14 +22,12 @@
     <AndroidTlsProvider>
     </AndroidTlsProvider>
   </PropertyGroup>
-  
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-  </PropertyGroup>  
-  
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -175,6 +173,7 @@
     <Compile Include="PlatformConfigurationExtensions.cs" />
     <Compile Include="PlatformEffect.cs" />
     <Compile Include="LayoutExtensions.cs" />
+    <Compile Include="PowerSaveModeBroadcastReceiver.cs" />
     <Compile Include="Renderers\AHorizontalScrollView.cs" />
     <Compile Include="Renderers\ButtonDrawable.cs" />
     <Compile Include="Renderers\AlignmentExtensions.cs" />


### PR DESCRIPTION
### Description of Change ###

For Android APIs below Lollipop, this changes nothing.

For Lollipop and higher, the app will now listen for changes to the power save mode status and respond accordingly. When power save is on, animations will immediately move to their finished state. If power save becomes active while an animation is in progress, the animation will be immediately moved to its finished state.

### Issues Resolved ###

- fixes #1556

### API Changes ###

None

### Platforms Affected ###

- Core/XAML (all platforms)
- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
