### PR TITLE
[GTK] Fixed Layout calcs with NavigationBar

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
@@ -248,7 +248,9 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 current = parent;
             }
 
-            return hasParentNavigation && NavigationPage.GetHasNavigationBar(parent);
-        }
-    }
+			var hasAncestorNavigationPage = hasParentNavigation && NavigationPage.GetHasNavigationBar(current);
+
+			return hasAncestorNavigationPage;
+		}
+	}
 }


### PR DESCRIPTION
### Description of Change ###

Fixed error in page height calcs hiding the navigation bar.

On a page like this:
![imagen](https://user-images.githubusercontent.com/6755973/41933001-ee3abf7c-7982-11e8-9642-cf2b7c6f0eca.png)

The default result:
![imagen](https://user-images.githubusercontent.com/6755973/41932967-d36241a2-7982-11e8-951e-58208209e3bd.png)

Using `NavigationPage.SetHasNavigationBar(this, false);`
![imagen](https://user-images.githubusercontent.com/6755973/41932979-dc1437ce-7982-11e8-8762-a8d97fa3bb0b.png)

### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3153 

### Platforms Affected ###

<!-- Please list all platforms affected by these changes -->

- GTK

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
