### PR TITLE
[iOS] Fix NRE when child wasn't added yet to NavigationPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583.cs
@@ -3,19 +3,32 @@
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
-namespace Xamarin.Forms.Controls
+#if UITEST
+using NUnit.Framework;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
 {
-	[Preserve (AllMembers=true)]
-	[Issue (IssueTracker.Github, 1583, "NavigationPage.TitleIcon broken", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.WinPhone)]
-	public class Issue1583 : ContentPage
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1583, "NavigationPage.TitleIcon broken", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.WinPhone)]
+	public class Issue1583 : TestContentPage
 	{
-		public Issue1583 ()
+		protected override void  Init()
 		{
 			Title = "Test";
 			BackgroundColor = Color.Pink;
-			Content = new Label{Text = "Hello"};
+			Content = new Label { Text = "Hello", AutomationId ="lblHello" };
 			NavigationPage.SetTitleIcon(this, "bank.png");
 		}
+
+#if UITEST
+		[Test]
+		public void Issue1583TitleIconTest ()
+		{
+			RunningApp.WaitForElement(q => q.Marked ("lblHello"));			
+		}
+#endif
 	}
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1583, "WebView fails to load from urlwebviewsource with non-ascii characters (works with Uri)", PlatformAffected.iOS, issueTestNumber: 1)]
-	public class Issue1583 : TestContentPage
+	public class Issue1583_1 : TestContentPage
 	{
 		WebView _webview;
 		Label _label;
@@ -63,7 +63,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public async Task Issue1583Test ()
+		public async Task Issue1583_1_WebviewTest ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("label"), "Could not find label", TimeSpan.FromSeconds(10), null, null);
 			await Task.Delay(TimeSpan.FromSeconds(3));

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1341,7 +1341,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_icon != null)
 					_icon.Frame = new RectangleF(0, 0, IconWidth, Math.Min(toolbarHeight, IconHeight));
 
-				if (_child != null && _child.Element != null)
+				if (_child?.Element != null)
 					Layout.LayoutChildIntoBoundingRegion(_child.Element, new Rectangle(IconWidth, 0, Bounds.Width - IconWidth, height));
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1341,7 +1341,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_icon != null)
 					_icon.Frame = new RectangleF(0, 0, IconWidth, Math.Min(toolbarHeight, IconHeight));
 
-				if (_child.Element != null)
+				if (_child != null && _child.Element != null)
 					Layout.LayoutChildIntoBoundingRegion(_child.Element, new Rectangle(IconWidth, 0, Bounds.Width - IconWidth, height));
 			}
 


### PR DESCRIPTION
### Description of Change ###

Fix small issue introduce with TitleView, Fix NRE when child wasn't added yet to NavigationPage

### Issues Resolved ###

No link

### API Changes ###

None

### Platforms Affected ###

- iOS
### Behavioral/Visual Changes ###

No crash

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
