### PR TITLE
[UWP] Fixes hide DisplayActionSheet behind the dialog box

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3139.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3139.cs
@@ -1,0 +1,55 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3139, "DisplayActionSheet is hiding behind Dialogs", PlatformAffected.UWP)]
+	public class Issue3139 : TestContentPage
+	{
+		protected override async void Init()
+		{
+			var statusLabel = new Label()
+			{
+				FontSize = 40,
+				TextColor = Color.White
+			};
+			Content = new StackLayout()
+			{
+				Children = {
+					statusLabel,
+					new Label {
+						Text = "Pop-ups should appear on top of the dialog. And it's got any button pressed.",
+						TextColor = Color.Yellow
+					}
+				}
+			};
+
+			var alertTask = DisplayAlert("AlertDialog", "Close me", "Close");
+			await Task.Delay(200);
+			var result1 = await DisplayActionSheet("ActionSheet", "Also Yes", "Click Yes", "Yes", "Yes Yes") ?? string.Empty;
+			var result2 = await Application.Current.MainPage.DisplayActionSheet("Main page ActionSheet", "Again Yes", "Click Yes", "Yes", "Yes Yes") ?? string.Empty;
+			var testPassed = result1.Contains("Yes") && result2.Contains("Yes") && !alertTask.IsCompleted;
+			statusLabel.Text = "Test " + (testPassed ? "passed" : "failed");
+			BackgroundColor = !testPassed ? Color.DarkRed : Color.DarkGreen;
+			await alertTask;
+		}
+
+#if UITEST && __WINDOWS__
+		[Test]
+		public void Issue3139Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked ("Click Yes"));
+			RunningApp.Tap (c => c.Marked ("Yes"));
+			RunningApp.WaitForElement (q => q.Marked ("Again Yes"));
+			RunningApp.Tap (c => c.Marked ("Yes"));
+			RunningApp.WaitForElement(q => q.Marked("Test passed"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -287,6 +287,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3273.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3053.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2617.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3139.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3087.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3089.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1342.cs" />

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -10,6 +10,7 @@ using Windows.UI.Popups;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
 using NativeAutomationProperties = Windows.UI.Xaml.Automation.AutomationProperties;
 
@@ -462,7 +463,15 @@ namespace Xamarin.Forms.Platform.UWP
 					options.SetResult(null);
 			};
 
-			actionSheet.ShowAt(((Page)sender).GetOrCreateRenderer().ContainerElement);
+			try
+			{
+				actionSheet.ShowAt(((Page)sender).GetOrCreateRenderer().ContainerElement);
+			}
+			catch (ArgumentException) // if the page is not in the visual tree
+			{
+				if (Window.Current.Content is FrameworkElement mainPage)
+					actionSheet.ShowAt(mainPage);
+			}
 		}
 
 		static async void OnPageAlert(Page sender, AlertArguments options)


### PR DESCRIPTION
### Description of Change ###

In order for ActionSheet to be on top, we need to show it at the dialog box

### Issues Resolved ###

- fixes #3139 

### API Changes ###

None

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

- displaying `ActionSheet` on top, when page is the MainPage and it shows the dialog box.
- if page is not in visual tree, displaying `ActionSheet` at main window, instead Application crash.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
