### PR TITLE
[UWP] Fixes password Entry Copy/Paste/Insert/Remove behavior

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			int lengthDifference = base.Text.Length - Text.Length;
 
-			string updatedRealText = DetermineTextFromPassword(Text, base.Text);
+			string updatedRealText = DetermineTextFromPassword(Text, SelectionStart, base.Text);
 
 			if (Text == updatedRealText)
 			{
@@ -153,13 +153,13 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				// Either More than one character got added in this text change (e.g., a paste operation)
 				// Or characters were removed. Either way, we don't need to do the delayed obfuscation dance
-				newText = Obfuscate();
+				newText = Obfuscate(Text);
 			}
 			else
 			{
 				// Only one character was added; we need to leave it visible for a brief time period
 				// Obfuscate all but the last character for now
-				newText = Obfuscate(true);
+				newText = Obfuscate(Text, true);
 
 				// Leave the last character visible until a new character is added
 				// or sufficient time has passed
@@ -174,7 +174,7 @@ namespace Xamarin.Forms.Platform.UWP
 					_cts.Token.ThrowIfCancellationRequested();
 					await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 					{
-						base.Text = Obfuscate();
+						base.Text = Obfuscate(Text);
 						SelectionStart = base.Text.Length;
 					});
 				}, _cts.Token);
@@ -189,41 +189,29 @@ namespace Xamarin.Forms.Platform.UWP
 			SelectionStart = base.Text.Length;
 		}
 
-		static string DetermineTextFromPassword(string realText, string passwordText)
+		static string DetermineTextFromPassword(string realText, int start, string passwordText)
 		{
-			if (realText.Length == passwordText.Length)
-			{
-				return realText;
-			}
+			var lengthDifference = passwordText.Length - realText.Length;
+			if (lengthDifference > 0)
+				realText = realText.Insert(start - lengthDifference, new string(ObfuscationCharacter, lengthDifference));
+			else if (lengthDifference < 0)
+				realText = realText.Remove(start, -lengthDifference);
 
-			if (passwordText.Length == 0)
-			{
-				return "";
-			}
+			var sb = new System.Text.StringBuilder(passwordText.Length);
+			for (int i = 0; i < passwordText.Length; i++)
+				sb.Append(passwordText[i] == ObfuscationCharacter ? realText[i] : passwordText[i]);
 
-			if (passwordText.Length < realText.Length)
-			{
-				return realText.Substring(0, passwordText.Length);
-			}
-
-			int lengthDifference = passwordText.Length - realText.Length;
-
-			return realText + passwordText.Substring(passwordText.Length - lengthDifference, lengthDifference);
+			return sb.ToString();
 		}
 
-		string Obfuscate(bool leaveLastVisible = false)
+		string Obfuscate(string text, bool leaveLastVisible = false)
 		{
-			if (leaveLastVisible && Text.Length == 1)
-			{
-				return Text;
-			}
+			if (!leaveLastVisible)
+				return new string(ObfuscationCharacter, text.Length);
 
-			if (leaveLastVisible && Text.Length > 1)
-			{
-				return new string(ObfuscationCharacter, Text.Length - 1) + Text.Substring(Text.Length - 1, 1);
-			}
-
-			return new string(ObfuscationCharacter, Text.Length);
+			return text.Length == 1
+				? text
+				: new string(ObfuscationCharacter, text.Length - 1) + text.Substring(text.Length - 1, 1);
 		}
 
 		static void OnIsPasswordChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
@@ -296,32 +284,25 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (IsPassword)
 			{
-				// If we're not on a phone, we can just obfuscate any input
-				if (Device.Idiom != TargetIdiom.Phone)
+				// If we are on the phone, we might need to delay obfuscating the last character
+				if (Device.Idiom == TargetIdiom.Phone)
 				{
-					string updatedRealText = DetermineTextFromPassword(Text, base.Text);
-
-					if (Text == updatedRealText)
-					{
-						// Nothing to do
-						return;
-					}
-
-					Text = updatedRealText;
-
-					string updatedText = Obfuscate();
-
-					if (base.Text != updatedText)
-					{
-						base.Text = updatedText;
-						SelectionStart = base.Text.Length;
-					}
-
+					DelayObfuscation();
 					return;
 				}
 
-				// If we are on the phone, we might need to delay obfuscating the last character
-				DelayObfuscation();
+				// If we're not on a phone, we can just obfuscate any input
+				string updatedRealText = DetermineTextFromPassword(Text, SelectionStart, base.Text);
+				string updatedText = Obfuscate(updatedRealText);
+				var savedSelectionStart = SelectionStart;
+
+				if (Text != updatedRealText)
+					Text = updatedRealText;
+
+				if (base.Text != updatedText)
+					base.Text = updatedText;
+
+				SelectionStart = savedSelectionStart;
 			}
 			else if (base.Text != Text)
 			{
@@ -341,7 +322,7 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 			}
 
-			base.Text = IsPassword ? Obfuscate() : Text;
+			base.Text = IsPassword ? Obfuscate(Text) : Text;
 
 			SelectionStart = base.Text.Length;
 		}


### PR DESCRIPTION
### Description of Change ###

Fixes password Entry Copy/Paste/Insert/Remove behavior

### Issues Resolved ###

- fixes #2388

### API Changes ###

None

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

- Correct behavior copy/paste for password Entry in any position of the text cursor
- Restore cursor after insert char or string in password Entry
Screencast: http://recordit.co/fPqYn9mKXT

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
