### PR TITLE
[Android] Don't mess with the `Button.Padding` if the `Padding` property isn't set

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1702.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1702.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Text = "Reset padding",
 				Command = new Command(() =>
 				{
-					buttons.ForEach(b => b.Padding = new Thickness(0, 0, 0, 0));
+					buttons.ForEach(b => b.ClearValue(Button.PaddingProperty));
 				})
 			}, 0, 1);
 			actionGrid.AddChild(new Button()

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		ButtonBackgroundTracker _backgroundTracker;
 		TextColorSwitcher _textColorSwitcher;
 		float _defaultFontSize;
+		Thickness? _defaultPadding;
 		Typeface _defaultTypeface;
 		bool _isDisposed;
 		int _imageHeight = -1;
@@ -128,6 +129,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					_backgroundTracker = new ButtonBackgroundTracker(Element, Control);
 				else
 					_backgroundTracker.Button = e.NewElement;
+
+				_defaultFontSize = 0f;
+				_defaultPadding = null;
 
 				UpdateAll();
 			}
@@ -287,15 +291,30 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void UpdatePadding()
 		{
-			if (!Element.IsSet(Button.PaddingProperty))
+			if (Control == null)
 				return;
 
-			Control?.SetPadding(
-				(int)(Context.ToPixels(Element.Padding.Left) + _paddingDeltaPix.Left),
-				(int)(Context.ToPixels(Element.Padding.Top) + _paddingDeltaPix.Top),
-				(int)(Context.ToPixels(Element.Padding.Right) + _paddingDeltaPix.Right),
-				(int)(Context.ToPixels(Element.Padding.Bottom) + _paddingDeltaPix.Bottom)
-			);
+			if (!_defaultPadding.HasValue)
+				_defaultPadding = new Thickness(Control.PaddingLeft, Control.PaddingTop, Control.PaddingRight, Control.PaddingBottom);
+
+			if (Element.IsSet(Button.PaddingProperty))
+			{
+				Control.SetPadding(
+					(int)(Context.ToPixels(Element.Padding.Left) + _paddingDeltaPix.Left),
+					(int)(Context.ToPixels(Element.Padding.Top) + _paddingDeltaPix.Top),
+					(int)(Context.ToPixels(Element.Padding.Right) + _paddingDeltaPix.Right),
+					(int)(Context.ToPixels(Element.Padding.Bottom) + _paddingDeltaPix.Bottom)
+				);
+			}
+			else
+			{
+				Control.SetPadding(
+						(int)_defaultPadding.Value.Left,
+						(int)_defaultPadding.Value.Top,
+						(int)_defaultPadding.Value.Right,
+						(int)_defaultPadding.Value.Bottom
+					);
+			}
 		}
 
 		void UpdateContentEdge(Thickness? delta = null)

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -15,7 +15,7 @@ using static System.String;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
-    public class ButtonRenderer : ViewRenderer<Button, AppCompatButton>, AView.IOnAttachStateChangeListener
+	public class ButtonRenderer : ViewRenderer<Button, AppCompatButton>, AView.IOnAttachStateChangeListener
 	{
 		ButtonBackgroundTracker _backgroundTracker;
 		TextColorSwitcher _textColorSwitcher;
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		}
 
 		[Obsolete("This constructor is obsolete as of version 2.5. Please use ButtonRenderer(Context) instead.")]
-		public ButtonRenderer() 
+		public ButtonRenderer()
 		{
 			AutoPackage = false;
 		}
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					button.Tag = this;
 
 					var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
-					_textColorSwitcher = new TextColorSwitcher(button.TextColors, useLegacyColorManagement);  
+					_textColorSwitcher = new TextColorSwitcher(button.TextColors, useLegacyColorManagement);
 
 					SetNativeControl(button);
 					button.AddOnAttachStateChangeListener(this);
@@ -287,6 +287,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void UpdatePadding()
 		{
+			if (!Element.IsSet(Button.PaddingProperty))
+				return;
+
 			Control?.SetPadding(
 				(int)(Context.ToPixels(Element.Padding.Left) + _paddingDeltaPix.Left),
 				(int)(Context.ToPixels(Element.Padding.Top) + _paddingDeltaPix.Top),
@@ -295,9 +298,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			);
 		}
 
-		void UpdateContentEdge (Thickness? delta = null)
+		void UpdateContentEdge(Thickness? delta = null)
 		{
-			_paddingDeltaPix = delta ?? new Thickness ();
+			_paddingDeltaPix = delta ?? new Thickness();
 			UpdatePadding();
 		}
 


### PR DESCRIPTION
### Description of Change ###

#2426 added the `Button.Padding` property, but on Android, it was removing necessary padding when the value wasn't set. This checks to ensure that there is a value set before it adjusts it.

#### Before this change:
![screenshot_1530138753](https://user-images.githubusercontent.com/7827070/42003246-53382aee-7a1f-11e8-877c-81167af7d026.png)

#### After this change: (should match screenshots in #1570)
![screenshot_1530138641](https://user-images.githubusercontent.com/7827070/42003229-39886848-7a1f-11e8-97ab-76dcee7cb85b.png)

### Issues Resolved ###

unreported

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
