### PR TITLE
[Android]  Let inflight life cycle events finish up before tearing them down

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40005.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40005.cs
@@ -6,21 +6,29 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
+
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Navigation)]
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 40005, "Navigation Bar back button does not show when using InsertPageBefore")]
 	public class Bugzilla40005 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
+		public const string GoToPage2 = "Go to Page 2";
+
 		public Bugzilla40005()
 		{
-			Application.Current.MainPage = new NavigationPage(new Page1());
 		}
 
 		protected override void Init()
 		{
+			Application.Current.MainPage = new NavigationPage(new Page1());
 		}
 
 		public class Page1 : ContentPage
@@ -29,29 +37,38 @@ namespace Xamarin.Forms.Controls
 
 			public Page1()
 			{
-				Button btn = new Button() {
-					Text = "Go to Page 2"
+				Button btn = new Button()
+				{
+					Text = GoToPage2
 				};
-				btn.Clicked += async (sender, e) => {
+				btn.Clicked += async (sender, e) =>
+				{
 					await Navigation.PushAsync(new Page2());
 				};
 
-				Content = new StackLayout {
+				Content = new StackLayout
+				{
 					VerticalOptions = LayoutOptions.Center,
-					Children = {
-					new Label {
-						HorizontalTextAlignment = TextAlignment.Center,
-						Text = "Page 1"
-					},
-					btn
-				}
+					Children =
+					{
+						new Label {
+							HorizontalTextAlignment = TextAlignment.Center,
+							Text = "Page 1"
+						},
+						btn,
+						new Label {
+							HorizontalTextAlignment = TextAlignment.Center,
+							Text = $"Click {GoToPage2} and you should still see a back bar button"
+						},
+					}
 				};
 			}
 
 			protected override void OnAppearing()
 			{
 				base.OnAppearing();
-				if(!pageInserted) {
+				if (!pageInserted)
+				{
 					Navigation.InsertPageBefore(new InsertedPage(), this);
 					pageInserted = true;
 				}
@@ -69,7 +86,8 @@ namespace Xamarin.Forms.Controls
 		{
 			public InsertedPage()
 			{
-				Content = new StackLayout {
+				Content = new StackLayout
+				{
 					VerticalOptions = LayoutOptions.Center,
 					Children = {
 					new Label {
@@ -91,7 +109,8 @@ namespace Xamarin.Forms.Controls
 		{
 			public Page2()
 			{
-				Content = new StackLayout {
+				Content = new StackLayout
+				{
 					VerticalOptions = LayoutOptions.Center,
 					Children = {
 					new Label {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		// Various tests are commented out on certain platforms because
-		// they fail and there are issues already created to fix those
+		// https://github.com/xamarin/Xamarin.Forms/issues/3188
 		[Test]
 		public async Task SwapMainPageOut()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
@@ -1,0 +1,407 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Collections.Generic;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.LifeCycle)]
+	[NUnit.Framework.Category(UITestCategories.Navigation)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 2338, "Test Various Paths for Changing Main Page In Constructor")]
+	public class Issue2338 : TestNavigationPage
+	{
+		Dictionary<string, Type> tests = new Dictionary<string, Type>
+		{
+			{ "Swap Main Page right after settings Details to Navigation Page", typeof(Issue2338_MasterDetailsPage_NavigationPage)},
+			{ "Main Page right after settings Details to Content Page", typeof(Issue2338_MasterDetailsPage_ContentPage)},
+			{ "Change Page in Constructor of Page Currently being set to Main Page", typeof(Issue2338_Ctor)},
+			{ "Change Page in Constructor with some added additional changes", typeof(Issue2338_Ctor_MultipleChanges)},
+			{ "Basic change Main Page when previous page is Master Details", typeof(Issue2338_MasterDetailsPage)},
+			{ "Swap Main Page during OnAppearing", typeof(Issue2338_SwapMainPageDuringAppearing)},
+			{ "Swap out Tabbed Page", typeof(Issue2338_TabbedPage)},
+		};
+
+		protected override void Init()
+		{
+			StackLayout layout = new StackLayout();
+			layout.Children.Add(new Label() { Text = "Click each button to test a variation of Main Page Swapping. If you don't see a success page the test has failed" });
+
+			foreach (var test in tests)
+			{
+				Button testButton = new Button();
+				testButton.Text = test.Key;
+				testButton.Command = new Command(() => Navigation.PushModalAsync((Page)Activator.CreateInstance(test.Value)));
+				layout.Children.Add(testButton);
+			}
+
+			ContentPage page = new ContentPage();
+			page.Content = layout;
+			PushAsync(page);
+		}
+
+#if UITEST
+
+		public async Task TestForSuccess(IApp RunningApp, Type type)
+		{
+			var test = tests.FirstOrDefault(x => x.Value == type);
+			RunningApp.WaitForElement(test.Key);
+			RunningApp.Tap(test.Key);
+			//It takes a second for everything to settle
+			await Task.Delay(2500);
+			RunningApp.WaitForElement($"Success: {type.Name.Replace("_", " ")}");
+			RunningApp.Tap("Start Over");
+		}
+
+		// Various tests are commented out on certain platforms because
+		// they fail and there are issues already created to fix those
+		[Test]
+		public async Task SwapMainPageOut()
+		{
+			await TestForSuccess(RunningApp, typeof(Issue2338_SwapMainPageDuringAppearing));
+			await TestForSuccess(RunningApp, typeof(Issue2338_MasterDetailsPage_ContentPage));
+			await TestForSuccess(RunningApp, typeof(Issue2338_MasterDetailsPage_NavigationPage));
+
+#if !__WINDOWS__ && !__IOS__
+			await TestForSuccess(RunningApp, typeof(Issue2338_Ctor));
+#endif
+			await TestForSuccess(RunningApp, typeof(Issue2338_Ctor_MultipleChanges));
+
+#if !__WINDOWS__
+			await TestForSuccess(RunningApp, typeof(Issue2338_TabbedPage));
+#endif
+
+#if !__IOS__
+			await TestForSuccess(RunningApp, typeof(Issue2338_MasterDetailsPage));
+#endif
+
+		}
+#endif
+
+		[Preserve(AllMembers = true)]
+		public class Issue2338_Ctor : TestNavigationPage
+		{
+			public Issue2338_Ctor()
+			{
+			}
+
+			protected override void Init()
+			{
+			}
+
+			protected override void OnAppearing()
+			{
+				Navigation.PushAsync(new InternalPage());
+			}
+
+			[Preserve(AllMembers = true)]
+			public class InternalPage : ContentPage
+			{
+				public InternalPage()
+				{
+					Application.Current.MainPage = Issue2338TestHelper.CreateSuccessPage(nameof(Issue2338_Ctor));
+				}
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Issue2338_Ctor_MultipleChanges : TestNavigationPage
+		{
+			public Issue2338_Ctor_MultipleChanges()
+			{
+			}
+
+			protected override void Init()
+			{
+				PushAsync(new ContentPage());
+			}
+
+			protected override void OnAppearing()
+			{
+				Navigation.PushAsync(new InternalPage(0));
+			}
+
+			[Preserve(AllMembers = true)]
+			public class InternalPage : ContentPage
+			{
+				private readonly int _permutations;
+				public InternalPage(int permutations)
+				{
+					_permutations = permutations;
+					if (permutations > 5)
+					{
+						Device.BeginInvokeOnMainThread(() =>
+						{
+							Application.Current.MainPage = Issue2338TestHelper.CreateSuccessPage(nameof(Issue2338_Ctor_MultipleChanges));
+						});
+					}
+					else
+					{
+						Device.BeginInvokeOnMainThread(() =>
+						{
+
+							Application.Current.MainPage =
+								new NavigationPage(new InternalPage(permutations + 1) { Title = "Title 1" });
+						});
+					}
+				}
+
+				protected override void OnAppearing() => Debug.WriteLine($"OnAppearing: {_permutations}");
+				protected override void OnDisappearing() => Debug.WriteLine($"OnDisappearing: {_permutations}");
+			}
+
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Issue2338_SwapMainPageDuringAppearing : TestNavigationPage
+		{
+			protected override void Init()
+			{
+				PushAsync(new InternalPage(10));
+				PushAsync(new InternalPage(20));
+				PushAsync(new InternalPage(30));
+
+				var otherPage = new InternalPage(40);
+				PushAsync(otherPage);
+
+				otherPage.Appearing += async (object sender, EventArgs e) =>
+				{
+					await Task.Delay(1000);
+					Application.Current.MainPage = new InternalTabbedPage(this);
+
+					// this is here just to mimic the issue the user reported
+					// where additional behavior was occuring during the bindingcontext change
+					Application.Current.MainPage.BindingContext = new object();
+				};
+
+			}
+			protected override void OnAppearing() => Debug.WriteLine($"OnAppearing: Issue2338");
+			protected override void OnDisappearing() => Debug.WriteLine($"OnDisappearing: Issue2338");
+
+			[Preserve(AllMembers = true)]
+			public class InternalTabbedPage : TabbedPage
+			{
+				private readonly NavigationPage _navigationPage;
+				public InternalTabbedPage(NavigationPage navigationPage)
+				{
+					_navigationPage = navigationPage;
+					Children.Add(Issue2338TestHelper.CreateSuccessPage(nameof(Issue2338_SwapMainPageDuringAppearing)));
+				}
+
+				protected override void OnBindingContextChanged()
+				{
+					_navigationPage.PushAsync(new InternalPage(50));
+					base.OnBindingContextChanged();
+					_navigationPage.PushAsync(new InternalPage(60));
+				}
+
+
+				protected override void OnAppearing() => Debug.WriteLine($"OnAppearing: InternalTabbedPage");
+				protected override void OnDisappearing() => Debug.WriteLine($"OnDisappearing: InternalTabbedPage");
+			}
+
+			[Preserve(AllMembers = true)]
+			class InternalPage : ContentPage
+			{
+				private int v;
+
+				public InternalPage(int v)
+				{
+					this.v = v;
+					this.Content = new Label { Text = v.ToString() };
+				}
+
+				protected override void OnAppearing() => Debug.WriteLine($"OnAppearing: {v}");
+				protected override void OnDisappearing() => Debug.WriteLine($"OnDisappearing: {v}");
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Issue2338_TabbedPage : TestTabbedPage
+		{
+			public Issue2338_TabbedPage() : base()
+			{
+			}
+
+
+			protected override void Init()
+			{
+				Children.Add(new ContentPage());
+				Children.Add(new ContentPage());
+				Children.Add(new ContentPage());
+				Children.Add(new InternalPage(this));
+			}
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+				SelectedItem = Children.Last();
+			}
+
+
+			[Preserve(AllMembers = true)]
+			class InternalPage : ContentPage
+			{
+				private readonly TabbedPage _tabbedPage;
+
+				public InternalPage(TabbedPage tabbedPage)
+				{
+					_tabbedPage = tabbedPage;
+				}
+
+				protected override void OnAppearing()
+				{
+					base.OnAppearing();
+					_tabbedPage.Children.Add(new ContentPage());
+
+					Application.Current.MainPage = Issue2338TestHelper.CreateSuccessPage(nameof(Issue2338_TabbedPage));
+					_tabbedPage.Children.Add(new ContentPage());
+				}
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Issue2338_MasterDetailsPage : TestContentPage
+		{
+
+			protected override void Init()
+			{
+			}
+
+			protected override void OnAppearing()
+			{
+				Application.Current.MainPage = new InternalMasterDetailsPage();
+			}
+
+			[Preserve(AllMembers = true)]
+			class InternalMasterDetailsPage : MasterDetailPage
+			{
+				public InternalMasterDetailsPage()
+				{
+					Detail = new NavigationPage(new ContentPage() { Title = "Details" });
+					Master = new ContentPage() { Title = "Master" };
+				}
+
+				protected override async void OnAppearing()
+				{
+					base.OnAppearing();
+					await Task.Delay(500);
+					Detail.Navigation.PushAsync(new ContentPage());
+					Detail.Navigation.PushModalAsync(new NavigationPage(new ContentPage() { Title = "Details 2" }));
+
+					var navPage = new NavigationPage(new ContentPage() { Title = "Details" });
+					Detail = navPage;
+					Application.Current.MainPage = Issue2338TestHelper.CreateSuccessPage(nameof(Issue2338_MasterDetailsPage));
+					navPage.PushAsync(new ContentPage() { Title = "Details 2" });
+				}
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Issue2338_MasterDetailsPage_NavigationPage : TestContentPage
+		{
+
+			protected override void Init()
+			{
+			}
+
+			protected override void OnAppearing()
+			{
+				Application.Current.MainPage = new InternalMasterDetailsPage();
+			}
+
+			[Preserve(AllMembers = true)]
+			class InternalMasterDetailsPage : MasterDetailPage
+			{
+				public InternalMasterDetailsPage()
+				{
+					Detail = new NavigationPage(new ContentPage() { Title = "Details" });
+					Master = new ContentPage() { Title = "Master" };
+				}
+
+				protected override async void OnAppearing()
+				{
+					base.OnAppearing();
+					await Task.Delay(500);
+					var contentPage = new ContentPage();
+					Detail.Navigation.PushAsync(contentPage);
+
+					contentPage.Appearing += (_, __) =>
+					{
+						var navPage = new NavigationPage(new ContentPage() { Title = "Details" });
+						Detail = navPage;
+						Master = new ContentPage() { Title = "Master" };
+
+						Application.Current.MainPage = Issue2338TestHelper.CreateSuccessPage(nameof(Issue2338_MasterDetailsPage_NavigationPage));
+
+						navPage.PushAsync(new ContentPage() { Title = "Details 2" });
+					};
+				}
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Issue2338_MasterDetailsPage_ContentPage : TestContentPage
+		{
+
+			protected override void Init()
+			{
+			}
+
+			protected override void OnAppearing()
+			{
+				Application.Current.MainPage = new InternalMasterDetailsPage();
+			}
+
+			[Preserve(AllMembers = true)]
+			class InternalMasterDetailsPage : MasterDetailPage
+			{
+				public InternalMasterDetailsPage()
+				{
+					Detail = new ContentPage() { Title = "Details" };
+					Master = new ContentPage() { Title = "Master" };
+					Detail.Appearing += DetailAppearing;
+				}
+
+				private void DetailAppearing(object sender, EventArgs e)
+				{
+					Detail = new ContentPage() { Title = "Details" };
+					Master = new ContentPage() { Title = "Master" };
+
+					Application.Current.MainPage = Issue2338TestHelper.CreateSuccessPage(nameof(Issue2338_MasterDetailsPage_ContentPage));
+				}
+			}
+		}
+	}
+
+	public static class Issue2338TestHelper
+	{
+		public static Page CreateSuccessPage(string name)
+		{
+			return new NavigationPage(new ContentPage()
+			{
+				Title = "Title 1",
+				Content = new StackLayout()
+				{
+					Children = {
+						new Label() { Text = $"Success: {name.Replace("_", " ")}" },
+						new Button() { Text = "Start Over", Command = new Command(() =>
+						{
+							Application.Current.MainPage = new Issue2338();
+						})}
+					}
+				}
+			});
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60045.xaml.cs">
       <DependentUpon>Bugzilla60045.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
@@ -24,13 +24,12 @@ namespace Xamarin.Forms.Core.UITests
 			{
 				DesiredCapabilities appCapabilities = new DesiredCapabilities();
 				appCapabilities.SetCapability("app", "0d4424f6-1e29-4476-ac00-ba22c3789cb6_ph1m9x8skttmg!App");
-				appCapabilities.SetCapability("deviceName", "WindowsPC");
 				Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
 				Assert.IsNotNull(Session);
 				Session.Manage().Timeouts().ImplicitlyWait(TimeSpan.FromSeconds(1));
 				Reset();
 			}
-			
+
 			return new WinDriverApp(Session);
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/ILifeCycleState.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ILifeCycleState.cs
@@ -10,7 +10,7 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 
-namespace Xamarin.Forms.Internals
+namespace Xamarin.Forms.Platform.Android
 {
 	internal interface ILifeCycleState
 	{

--- a/Xamarin.Forms.Platform.Android/AppCompat/ILifeCycleState.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ILifeCycleState.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+
+namespace Xamarin.Forms.Internals
+{
+	internal interface ILifeCycleState
+	{
+		bool MarkedForDispose { get; set; }
+	}
+}

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -6,10 +6,12 @@ using Android.Support.V4.Widget;
 using Android.Views;
 using Android.Support.V4.App;
 using AView = Android.Views.View;
+using Android.OS;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
-	public class MasterDetailPageRenderer : DrawerLayout, IVisualElementRenderer, DrawerLayout.IDrawerListener, IManageFragments
+	public class MasterDetailPageRenderer : DrawerLayout, IVisualElementRenderer, DrawerLayout.IDrawerListener, IManageFragments, ILifeCycleState
 	{
 		#region Statics
 
@@ -189,6 +191,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		AView IVisualElementRenderer.View => this;
 
+		bool ILifeCycleState.MarkedForDispose { get; set; } = false;
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing && !_disposed)
@@ -367,8 +371,16 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void UpdateDetail()
 		{
-			Context.HideKeyboard(this);
-			_detailLayout.ChildView = Element.Detail;
+			if (_detailLayout.ChildView == null)
+				Update();
+			else
+				new Handler(Looper.MainLooper).Post(() => Update());
+
+			void Update()
+			{
+				Context.HideKeyboard(this);
+				_detailLayout.ChildView = Element.Detail;
+			}
 		}
 
 		void UpdateFlowDirection()
@@ -386,16 +398,26 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void UpdateMaster()
 		{
-			Android.MasterDetailContainer masterContainer = _masterLayout;
-			if (masterContainer == null)
-				return;
 
-			if (masterContainer.ChildView != null)
-				masterContainer.ChildView.PropertyChanged -= HandleMasterPropertyChanged;
+			if (_masterLayout.ChildView == null)
+				new Handler(Looper.MainLooper).Post(() => Update());
+			else
+				Update();
 
-			masterContainer.ChildView = Element.Master;
-			if (Element.Master != null)
-				Element.Master.PropertyChanged += HandleMasterPropertyChanged;
+			void Update()
+			{
+				Android.MasterDetailContainer masterContainer = _masterLayout;
+				if (masterContainer == null)
+					return;
+
+				if (masterContainer.ChildView != null)
+					masterContainer.ChildView.PropertyChanged -= HandleMasterPropertyChanged;
+
+				masterContainer.ChildView = Element.Master;
+				if (Element.Master != null)
+					Element.Master.PropertyChanged += HandleMasterPropertyChanged;
+			}
+
 		}
 
 		void UpdateSplitViewLayout()

--- a/Xamarin.Forms.Platform.Android/Extensions/FragmentManagerExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/FragmentManagerExtensions.cs
@@ -7,44 +7,44 @@ namespace Xamarin.Forms.Platform.Android
 	// This is a way to centralize all fragment modifications which makes it a lot easier to debug
 	internal static class FragmentManagerExtensions
 	{
-		public static FragmentTransaction RemoveEx(this FragmentTransaction @this, Fragment fragment)
+		public static FragmentTransaction RemoveEx(this FragmentTransaction fragmentTransaction, Fragment fragment)
 		{
-			return @this.Remove(fragment);
+			return fragmentTransaction.Remove(fragment);
 		}
 
-		public static FragmentTransaction AddEx(this FragmentTransaction @this, int containerViewId, Fragment fragment)
+		public static FragmentTransaction AddEx(this FragmentTransaction fragmentTransaction, int containerViewId, Fragment fragment)
 		{
-			return @this.Add(containerViewId, fragment);
+			return fragmentTransaction.Add(containerViewId, fragment);
 		}
 
-		public static FragmentTransaction HideEx(this FragmentTransaction @this, Fragment fragment)
+		public static FragmentTransaction HideEx(this FragmentTransaction fragmentTransaction, Fragment fragment)
 		{
-			return @this.Hide(fragment);
+			return fragmentTransaction.Hide(fragment);
 		}
 
-		public static FragmentTransaction ShowEx(this FragmentTransaction @this, Fragment fragment)
+		public static FragmentTransaction ShowEx(this FragmentTransaction fragmentTransaction, Fragment fragment)
 		{
-			return @this.Show(fragment);
+			return fragmentTransaction.Show(fragment);
 		}
 
-		public static FragmentTransaction SetTransitionEx(this FragmentTransaction @this, int transit)
+		public static FragmentTransaction SetTransitionEx(this FragmentTransaction fragmentTransaction, int transit)
 		{
-			return @this.SetTransition(transit);
+			return fragmentTransaction.SetTransition(transit);
 		}
 
-		public static int CommitAllowingStateLossEx(this FragmentTransaction @this)
+		public static int CommitAllowingStateLossEx(this FragmentTransaction fragmentTransaction)
 		{
-			return @this.CommitAllowingStateLoss();
+			return fragmentTransaction.CommitAllowingStateLoss();
 		}
 
-		public static bool ExecutePendingTransactionsEx(this FragmentManager @this)
+		public static bool ExecutePendingTransactionsEx(this FragmentManager fragmentTransaction)
 		{
-			return @this.ExecutePendingTransactions();
+			return fragmentTransaction.ExecutePendingTransactions();
 		}
 
-		public static FragmentTransaction BeginTransactionEx(this FragmentManager @this)
+		public static FragmentTransaction BeginTransactionEx(this FragmentManager fragmentTransaction)
 		{
-			return @this.BeginTransaction();
+			return fragmentTransaction.BeginTransaction();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Extensions/FragmentManagerExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/FragmentManagerExtensions.cs
@@ -1,0 +1,50 @@
+﻿using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
+using Fragment = Android.Support.V4.App.Fragment;
+using FragmentManager = Android.Support.V4.App.FragmentManager;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	// This is a way to centralize all fragment modifications which makes it a lot easier to debug
+	internal static class FragmentManagerExtensions
+	{
+		public static FragmentTransaction RemoveEx(this FragmentTransaction @this, Fragment fragment)
+		{
+			return @this.Remove(fragment);
+		}
+
+		public static FragmentTransaction AddEx(this FragmentTransaction @this, int containerViewId, Fragment fragment)
+		{
+			return @this.Add(containerViewId, fragment);
+		}
+
+		public static FragmentTransaction HideEx(this FragmentTransaction @this, Fragment fragment)
+		{
+			return @this.Hide(fragment);
+		}
+
+		public static FragmentTransaction ShowEx(this FragmentTransaction @this, Fragment fragment)
+		{
+			return @this.Show(fragment);
+		}
+
+		public static FragmentTransaction SetTransitionEx(this FragmentTransaction @this, int transit)
+		{
+			return @this.SetTransition(transit);
+		}
+
+		public static int CommitAllowingStateLossEx(this FragmentTransaction @this)
+		{
+			return @this.CommitAllowingStateLoss();
+		}
+
+		public static bool ExecutePendingTransactionsEx(this FragmentManager @this)
+		{
+			return @this.ExecutePendingTransactions();
+		}
+
+		public static FragmentTransaction BeginTransactionEx(this FragmentManager @this)
+		{
+			return @this.BeginTransaction();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
@@ -21,6 +22,35 @@ namespace Xamarin.Forms.Platform.Android
 			// or disabling the legacy color management and doing it the old-old (pre 2.0) way
 			return !element.HasVisualStateGroups()
 					&& element.OnThisPlatform().GetIsLegacyColorModeEnabled();
+		}
+
+
+		internal static bool IsAttachedToRoot(this VisualElement Element)
+		{
+			var elementRenderer = Element.GetRenderer();
+			if ((elementRenderer as ILifeCycleState)?.MarkedForDispose == true)
+				return false;
+
+			Page root = Element as Page;
+			var parent = Element.RealParent;
+			while (root == null && parent != null)
+			{
+				root = parent as Page;
+				parent = parent?.RealParent;
+			}
+
+			while (!Application.IsApplicationOrNull(root.RealParent))
+			{
+				root = (Page)root.RealParent;
+				if (root.GetRenderer() is ILifeCycleState lcs)
+				{
+					if (lcs.MarkedForDispose)
+						return false;
+				}
+			}
+
+			return root.RealParent != null &&
+				((root.GetRenderer() as ILifeCycleState)?.MarkedForDispose != true);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -109,9 +109,11 @@
     <Compile Include="AndroidApplicationLifecycleState.cs" />
     <Compile Include="AndroidTitleBarVisibility.cs" />
     <Compile Include="AppCompat\FrameRenderer.cs" />
+    <Compile Include="AppCompat\ILifeCycleState.cs" />
     <Compile Include="ButtonBackgroundTracker.cs" />
     <Compile Include="Elevation.cs" />
     <Compile Include="Extensions\EntryRendererExtensions.cs" />
+    <Compile Include="Extensions\FragmentManagerExtensions.cs" />
     <Compile Include="FastRenderers\AutomationPropertiesProvider.cs" />
     <Compile Include="AppCompat\PageExtensions.cs" />
     <Compile Include="Extensions\JavaObjectExtensions.cs" />


### PR DESCRIPTION
### Description of Change ###

OnAppearing for Android fires sometimes during *OnAttached* and sometimes during "OnResume"

- when you swapped out the MainPage it would call RemoveViews mid fragment lifecycle which would then lead to the fragment not found when FragmentManager would try to Resume the fragment

- Added an interface to allow a renderer to be declared MarkedForDeath so that things like adding more fragments or pending operations can just be halted

- Centralized on interactions with Fragments into a single Extension class because that just made it easier to break point or print debug messages for any Fragment modifications.

- Moved all the code for changing out the main page into the MainLooper call so that all "active" life cycle events will just settle before the main page does it's clean up and "realizing"

- Moved the code for when you swap out Details or Master pages it'll use MainLooper if replacing an existing page to ensure life cycle events have concluded

### Issues Resolved ###
 
- fixes #2338


### Platforms Affected ###

- Android


### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard