### PR TITLE
Fix UWP ScrollViewer Horizontal Scroll Bar Visibility when set before

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
@@ -195,6 +195,10 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateOrientation()
 		{
+			//Only update the horizontal scroll bar visibility if the user has not set a desired state.
+			if (Element.HorizontalScrollBarVisibility != ScrollBarVisibility.Default)
+				return;
+
 			if (Element.Orientation == ScrollOrientation.Horizontal || Element.Orientation == ScrollOrientation.Both)
 			{
 				Control.HorizontalScrollBarVisibility = UwpScrollBarVisibility.Auto;


### PR DESCRIPTION
### Description of Change ###

The UpdateOrientation method was resetting the horizontal scroll bar visibility when it was explicitly set by the user.  This change checks to see if the user set the value and if so respects that instead of setting it based on the Scrollview orientation. 

### Issues Resolved ###

- fixes #3193 

### API Changes ###

None

Changed:
 - object ScrollViewRenderer => UpdateOrientation

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

No change, other then to correct the behavior of Horizontal Scroll Bar Visibility. 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
