### PR TITLE
[macOS] Add basic application key shortcuts

### DIFF
--- a/Xamarin.Forms.ControlGallery.MacOS/Info.plist
+++ b/Xamarin.Forms.ControlGallery.MacOS/Info.plist
@@ -23,7 +23,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>rmarinho</string>
 	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
+	<string>FormsApplication</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcons.appiconset</string>
 	<key>LSApplicationCategoryType</key>

--- a/Xamarin.Forms.Platform.MacOS/FormsApplication.cs
+++ b/Xamarin.Forms.Platform.MacOS/FormsApplication.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using AppKit;
+using Foundation;
+
+namespace Xamarin.Forms.Platform.macOS
+{
+	[Register("FormsApplication")]
+	public class FormsApplication : NSApplication
+	{
+		public FormsApplication(NSCoder coder) : base(coder)
+		{
+		}
+
+		protected FormsApplication(NSObjectFlag t) : base(t)
+		{
+		}
+
+		protected internal FormsApplication(IntPtr handle) : base(handle)
+		{
+		}
+
+		public override void SendEvent(NSEvent theEvent)
+		{
+			if (theEvent.Type == NSEventType.KeyDown)
+			{
+				if ((theEvent.ModifierFlags & NSEventModifierMask.DeviceIndependentModifierFlagsMask) == NSEventModifierMask.CommandKeyMask)
+					switch (theEvent.KeyCode)
+					{
+						case (ushort)NSKey.V:
+							if (SendAction(new ObjCRuntime.Selector("paste:"), null, this))
+								return;
+							break;
+						case (ushort)NSKey.C:
+							if (SendAction(new ObjCRuntime.Selector("copy:"), null, this))
+								return;
+							break;
+						case (ushort)NSKey.X:
+							if (SendAction(new ObjCRuntime.Selector("cut:"), null, this))
+								return;
+							break;
+						case (ushort)NSKey.Z:
+							if (SendAction(new ObjCRuntime.Selector("undo:"), null, this))
+								return;
+							break;
+						case (ushort)NSKey.A:
+							if (SendAction(new ObjCRuntime.Selector("selectAll:"), null, this))
+								return;
+							break;
+					}
+				else if ((theEvent.ModifierFlags & NSEventModifierMask.DeviceIndependentModifierFlagsMask) == (NSEventModifierMask.ShiftKeyMask | NSEventModifierMask.CommandKeyMask))
+				{
+					switch (theEvent.KeyCode)
+					{
+						case (ushort)NSKey.Z:
+							if (SendAction(new ObjCRuntime.Selector("redo:"), null, this))
+								return;
+							break;
+					}
+				}
+			}
+
+			base.SendEvent(theEvent);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -234,10 +234,11 @@
       <Link>VisualElementRenderer.cs</Link>
     </Compile>
     <Compile Include="Extensions\NSMenuExtensions.cs" />
+    <Compile Include="FormsApplication.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj">
-      <Project>{67F9D3A8-F71E-4428-913F-C37AE82CDB24}</Project>
+      <Project>{D31A6537-ED9C-4EBD-B231-A8D4FE44126A}</Project>
       <Name>Xamarin.Forms.Platform</Name>
     </ProjectReference>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">


### PR DESCRIPTION
### Description of Change ###

A Xam.Forms standard NSApplication override is necessary to allow basic keyboard shortcuts while not using any application menus. The FormsApplication extends NSApplication while overriding the SendEvent method to be able to intercept key events to enable basic keyboard command functionality for text fields and views. The FormsApplication is used as the Principal class attribute in a project Info.plist. Until the option is added as a VS for mac item, the Info.plist file must be opened using XCode to alter the value.

No automated tests exist as each keyboard command of undo, redo, cut, copy, and paste must be run with hardware. The implementation uses hardware-independent key codes, so the "standard" key combo should work for any keyboard (https://developer.apple.com/documentation/appkit/nsevent/1534513-keycode)

### Issues Resolved ###

- fixes #1988

### API Changes ###

None

### Platforms Affected ###

- macOS

### Behavioral/Visual Changes ###

No automatic behavior changes. If the user updates their Info.plist Principal class to FormsApplication they can expect undo, redo, cut, copy, and paste keyboard commands available in all Entry and Editors.

### PR Checklist ###

- [ ] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
