### PR TITLE
[macOS] Fix standard button events

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1776.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub1776.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1776, "Button Released not being triggered", PlatformAffected.macOS)]
+	public class GitHub1776 : TestContentPage
+	{
+		Label PressedLabel;
+		int _pressedCount;
+		int PressedCount
+		{
+			get { return _pressedCount; }
+			set
+			{
+				_pressedCount = value;
+				PressedLabel.Text = $"Pressed: {_pressedCount}";
+			}
+		}
+
+		Label ReleasedLabel;
+		int _releasedCount;
+		int ReleasedCount
+		{
+			get { return _releasedCount; }
+			set
+			{
+				_releasedCount = value;
+				ReleasedLabel.Text = $"Released: {_releasedCount}";
+			}
+		}
+
+		Label ClickedLabel;
+		int _clickedCount;
+		int ClickedCount
+		{
+			get { return _clickedCount; }
+			set
+			{
+				_clickedCount = value;
+				ClickedLabel.Text = $"Clicked: {_clickedCount}";
+			}
+		}
+
+		Label CommandLabel;
+		int _commandCount;
+		int CommandCount
+		{
+			get { return _commandCount; }
+			set
+			{
+				_commandCount = value;
+				CommandLabel.Text = $"Command: {_commandCount}";
+			}
+		}
+
+		protected override void Init()
+		{
+			PressedLabel = new Label();
+			ReleasedLabel = new Label();
+			ClickedLabel = new Label();
+			CommandLabel = new Label();
+
+			var button = new Button
+			{
+				Text = "Press me!",
+				AutomationId = "TheButton"
+			};
+			button.Pressed += (s, e) =>
+			{
+				PressedCount++;
+			};
+			button.Released += (s, e) =>
+			{
+				ReleasedCount++;
+			};
+			button.Clicked += (s, e) =>
+			{
+				ClickedCount++;
+			};
+			button.Command = new Command(() =>
+			{
+				CommandCount++;
+			});
+
+			PressedCount = 0;
+			ReleasedCount = 0;
+			ClickedCount = 0;
+			CommandCount = 0;
+
+			StackLayout layout = new StackLayout();
+
+			layout.Children.Add(button);
+			layout.Children.Add(PressedLabel);
+			layout.Children.Add(ReleasedLabel);
+			layout.Children.Add(ClickedLabel);
+			layout.Children.Add(CommandLabel);
+
+			Content = layout;
+		}
+
+#if UITEST
+#if __MACOS__
+		[Test]
+		public void GitHub1776Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("TheButton"));
+			RunningApp.Tap(q => q.Marked("TheButton"));
+
+			Assert.AreEqual(1, _pressedCount, "Pressed should fire once per tap");
+			Assert.AreEqual(1, _releasedCount, "Released should fire once per tap");
+			Assert.AreEqual(1, _clickedCount, "Clicked should fire once per tap");
+			Assert.AreEqual(1, _commandCount, "Command should fire once per tap");
+		}
+#endif
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -761,6 +761,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2728.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1667.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3012.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GitHub1776.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -937,7 +938,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -2,16 +2,38 @@
 using System.ComponentModel;
 using AppKit;
 using Foundation;
-using SizeF = CoreGraphics.CGSize;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
 	public class ButtonRenderer : ViewRenderer<Button, NSButton>
 	{
+		class FormsNSButton : NSButton
+		{
+			public event Action Pressed;
+
+			public event Action Released;
+
+			public override void MouseDown(NSEvent theEvent)
+			{
+				Pressed?.Invoke();
+
+				base.MouseDown(theEvent);
+
+				Released?.Invoke();
+			}
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (Control != null)
 				Control.Activated -= OnButtonActivated;
+
+			var formsButton = Control as FormsNSButton;
+			if (formsButton != null)
+			{
+				formsButton.Pressed -= Btn_Pressed;
+				formsButton.Released -= Btn_Released;
+			}
 
 			base.Dispose(disposing);
 		}
@@ -24,8 +46,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				if (Control == null)
 				{
-					var btn = new NSButton();
+					var btn = new FormsNSButton();
 					btn.SetButtonType(NSButtonType.MomentaryPushIn);
+					btn.Pressed += Btn_Pressed;
+					btn.Released += Btn_Released;
 					SetNativeControl(btn);
 
 					Control.Activated += OnButtonActivated;
@@ -123,9 +147,20 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 			else
 			{
-				var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.Font.ToNSFont(), foregroundColor: color.ToNSColor( ), paragraphStyle: new NSMutableParagraphStyle( ) { Alignment = NSTextAlignment.Center });
+				var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.Font.ToNSFont(), foregroundColor: color.ToNSColor(), paragraphStyle: new NSMutableParagraphStyle() { Alignment = NSTextAlignment.Center });
 				Control.AttributedTitle = textWithColor;
 			}
 		}
+
+		void Btn_Pressed()
+		{
+			Element.SendPressed();
+		}
+
+		void Btn_Released()
+		{
+			Element.SendReleased();
+		}
+
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -31,8 +31,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			var formsButton = Control as FormsNSButton;
 			if (formsButton != null)
 			{
-				formsButton.Pressed -= Btn_Pressed;
-				formsButton.Released -= Btn_Released;
+				formsButton.Pressed -= HandleButtonPressed;
+				formsButton.Released -= HandleButtonReleased;
 			}
 
 			base.Dispose(disposing);
@@ -48,8 +48,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					var btn = new FormsNSButton();
 					btn.SetButtonType(NSButtonType.MomentaryPushIn);
-					btn.Pressed += Btn_Pressed;
-					btn.Released += Btn_Released;
+					btn.Pressed += HandleButtonPressed;
+					btn.Released += HandleButtonReleased;
 					SetNativeControl(btn);
 
 					Control.Activated += OnButtonActivated;
@@ -152,14 +152,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 		}
 
-		void Btn_Pressed()
+		void HandleButtonPressed()
 		{
-			Element.SendPressed();
+			Element?.SendPressed();
 		}
 
-		void Btn_Released()
+		void HandleButtonReleased()
 		{
-			Element.SendReleased();
+			Element?.SendReleased();
 		}
 
 	}


### PR DESCRIPTION
### Description of Change ###

Pressed, Released, Clicked, and Command all fire appropriately

### Issues Resolved ###

- fixes #1776 

### API Changes ###

None

### Platforms Affected ###

- macOS

### Behavioral/Visual Changes ###

The standard Button element will invoke pressed on mousedown.
The standard Button element will invoke released on mouseup, regardless of mouseup position after mousedown.
The standard Button element will invoke Clicked on mouseup if mouseup occurs in button after mousedown.
The standard Button element will execute Command on mouseup if mouseup occurs in button after mousedown.

### PR Checklist ###

- [X] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
