### PR TITLE
[UWP, Android, iOS] Added better life cycle events

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
@@ -40,16 +40,16 @@ namespace Xamarin.Forms.Controls.Issues
 
 			IsPresented = true;
 
-			var result = new List<State>();
+			var states = new List<State>();
 			var checkLabel = new Label();
 			var resultLabel = new Label { AutomationId = resultId };
 
-			var addRemoveButton = new Button
+			var goTestButton = new Button
 			{
 				Text = startTestLabel,
 				Command = new Command(async () =>
 				{
-					result.Clear();
+					states.Clear();
 					resultLabel.Text = "Let's assume that this text is not here.";
 					checkLabel.Text = "But soon everything will change.";
 
@@ -57,21 +57,21 @@ namespace Xamarin.Forms.Controls.Issues
 					{
 						Text = "Button"
 					};
-					button.Loaded += (_, __) => result.Add(State.ElementLoaded);
-					button.Unloaded += (_, __) => result.Add(State.ElementUnloaded);
-					button.BeforeAppearing += (_, __) => result.Add(State.ElementBeforeAppearing);
+					button.Loaded += (_, __) => states.Add(State.ElementLoaded);
+					button.Unloaded += (_, __) => states.Add(State.ElementUnloaded);
+					button.BeforeAppearing += (_, __) => states.Add(State.ElementBeforeAppearing);
 
 					var page = new ContentPage
 					{
 						Content = button
 					};
-					page.Loaded += (_, __) => result.Add(State.PageLoaded);
-					page.Unloaded += (_, __) => result.Add(State.PageUnloaded);
-					page.BeforeAppearing += (_, __) => result.Add(State.PageBeforeAppearing);
-					page.Appearing += (_, __) => result.Add(State.PageAppearing);
-					page.Appeared += (_, __) => result.Add(State.PageAppeared);
-					page.Disappearing += (_, __) => result.Add(State.PageDisappearing);
-					page.Disappeared += (_, __) => result.Add(State.PageDisappeared);
+					page.Loaded += (_, __) => states.Add(State.PageLoaded);
+					page.Unloaded += (_, __) => states.Add(State.PageUnloaded);
+					page.BeforeAppearing += (_, __) => states.Add(State.PageBeforeAppearing);
+					page.Appearing += (_, __) => states.Add(State.PageAppearing);
+					page.Appeared += (_, __) => states.Add(State.PageAppeared);
+					page.Disappearing += (_, __) => states.Add(State.PageDisappearing);
+					page.Disappeared += (_, __) => states.Add(State.PageDisappeared);
 
 					await Detail.Navigation.PushAsync(page);
 					// UWP not waiting for page creation
@@ -84,8 +84,8 @@ namespace Xamarin.Forms.Controls.Issues
 					await Task.Delay(200);
 
 					var sb = new StringBuilder();
-					for (int i = 0; i < result.Count; i++)
-						sb.AppendLine(result[i].ToString());
+					for (int i = 0; i < states.Count; i++)
+						sb.AppendLine(states[i].ToString());
 					resultLabel.Text = sb.ToString();
 
 					checkLabel.Text = checkLabelText;
@@ -95,11 +95,13 @@ namespace Xamarin.Forms.Controls.Issues
 			Master = new ContentPage
 			{
 				Title = "menu",
+				// on iOS the goTestButton overlaps by notch. Until this is corrected added padding-top.
+				Padding = new Thickness(5, 40, 5, 0), 
 				Content = new StackLayout
 				{
 					Children =
 					{
-						addRemoveButton,
+						goTestButton,
 						resultLabel,
 						new Button
 						{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
@@ -9,7 +9,7 @@ using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 2210, "[Enhancement] Add better life cycle events", PlatformAffected.All)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		const string startTestLabel = "GoTest";
 		const string switchButtonLabel = "Switch Legacy Events";
-		const string checkLabelText = "CheckMe";
+		const string successlText = "Success";
 		const string resultId = "Result";
 
 		public enum State
@@ -89,7 +89,42 @@ namespace Xamarin.Forms.Controls.Issues
 						sb.AppendLine(states[i].ToString());
 					resultLabel.Text = sb.ToString();
 
-					checkLabel.Text = checkLabelText;
+					bool success = false;
+
+					if (Application.Current.UseLegacyPageEvents)
+					{
+						success =
+							states.Count == 8 &&
+							states.IndexOf(State.PageAppeared) == -1 &&
+							states.IndexOf(State.PageDisappeared) == -1 &&
+							states.IndexOf(State.PageBeforeAppearing) < states.IndexOf(State.PageAppearing) &&
+							states.IndexOf(State.PageBeforeAppearing) < states.IndexOf(State.ElementBeforeAppearing) &&
+							states.IndexOf(State.PageAppearing) < states.IndexOf(State.PageDisappearing) &&
+							states.IndexOf(State.PageLoaded) < states.IndexOf(State.PageUnloaded) &&
+							states.IndexOf(State.PageLoaded) < states.IndexOf(State.PageDisappearing) &&
+							states.IndexOf(State.PageLoaded) < states.IndexOf(State.ElementUnloaded) &&
+							states.IndexOf(State.ElementBeforeAppearing) < states.IndexOf(State.ElementLoaded) &&
+							states.IndexOf(State.ElementLoaded) < states.IndexOf(State.ElementUnloaded) &&
+							states.IndexOf(State.ElementUnloaded) < states.IndexOf(State.PageUnloaded);
+					}
+					else
+					{
+						success =
+							states.Count == 10 &&
+							states.IndexOf(State.PageBeforeAppearing) < states.IndexOf(State.PageAppearing) &&
+							states.IndexOf(State.PageAppearing) < states.IndexOf(State.PageAppeared) &&
+							states.IndexOf(State.PageAppearing) < states.IndexOf(State.ElementBeforeAppearing) &&
+							states.IndexOf(State.PageAppeared) < states.IndexOf(State.PageDisappearing) &&
+							states.IndexOf(State.PageDisappearing) < states.IndexOf(State.PageDisappeared) &&
+							states.IndexOf(State.PageLoaded) < states.IndexOf(State.PageUnloaded) &&
+							states.IndexOf(State.PageLoaded) < states.IndexOf(State.PageDisappearing) &&
+							states.IndexOf(State.PageLoaded) < states.IndexOf(State.ElementUnloaded) &&
+							states.IndexOf(State.ElementBeforeAppearing) < states.IndexOf(State.ElementLoaded) &&
+							states.IndexOf(State.ElementLoaded) < states.IndexOf(State.ElementUnloaded) &&
+							states.IndexOf(State.ElementUnloaded) < states.IndexOf(State.PageUnloaded);
+					}
+
+					checkLabel.Text = success ? successlText : "Failed";
 				})
 			};
 
@@ -133,80 +168,16 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 #if UITEST
-		string[] result;
-
-		int IndexOf(State state) => result?.IndexOf(state.ToString()) ?? -1;
-
-		void GetResult()
-		{
-			var resultLabel = RunningApp.Query(c => c.Marked(resultId))[0].Text;
-			result = resultLabel.Split(new [] { '\r', '\n' }, System.StringSplitOptions.RemoveEmptyEntries);
-		}
-
 		[Test]
 		public void Issue2210_CycleEvents()
 		{
 			RunningApp.Tap(startTestLabel);
-			RunningApp.WaitForElement(checkLabelText);
-			GetResult();
-			Assert.AreEqual(10, result.Length);
-			CollectionAssert.AllItemsAreUnique(result);
-
-			var pageBeforeAppearing = IndexOf(State.PageBeforeAppearing);
-			var pageAppearing = IndexOf(State.PageAppearing);
-			var pageAppeared = IndexOf(State.PageAppeared);
-			var pageDisappearing = IndexOf(State.PageDisappearing);
-			var pageDisappeared = IndexOf(State.PageDisappeared);
-			var pageLoaded = IndexOf(State.PageLoaded);
-			var pageUnloaded = IndexOf(State.PageUnloaded);
-
-			var buttonBeforeAppearing = IndexOf(State.ElementBeforeAppearing);
-			var buttonLoaded = IndexOf(State.ElementLoaded);
-			var buttonUnloaded = IndexOf(State.ElementUnloaded);
-
-			Assert.Less(pageBeforeAppearing, pageAppearing);
-			Assert.Less(pageAppearing, pageAppeared);
-			Assert.Less(pageAppearing, buttonBeforeAppearing);
-			Assert.Less(pageAppeared, pageDisappearing);
-			Assert.Less(pageDisappearing, pageDisappeared);
-			Assert.Less(pageLoaded, pageUnloaded);
-			Assert.Less(pageLoaded, pageDisappearing);
-			Assert.Less(pageLoaded, buttonUnloaded);
-
-			Assert.Less(buttonBeforeAppearing, buttonLoaded);
-			Assert.Less(buttonLoaded, buttonUnloaded);
-			Assert.Less(buttonUnloaded, pageUnloaded);
+			RunningApp.WaitForElement(successlText);
 
 			// check legacy events
 			RunningApp.Tap(switchButtonLabel);
 			RunningApp.Tap(startTestLabel);
-			RunningApp.WaitForElement(checkLabelText);
-			GetResult();
-			Assert.AreEqual(8, result.Length);
-			CollectionAssert.AllItemsAreUnique(result);
-			CollectionAssert.DoesNotContain(result, State.PageAppeared.ToString());
-			CollectionAssert.DoesNotContain(result, State.PageDisappeared.ToString());
-
-			pageBeforeAppearing = IndexOf(State.PageBeforeAppearing);
-			pageAppearing = IndexOf(State.PageAppearing);
-			pageDisappearing = IndexOf(State.PageDisappearing);
-			pageLoaded = IndexOf(State.PageLoaded);
-			pageUnloaded = IndexOf(State.PageUnloaded);
-
-			buttonBeforeAppearing = IndexOf(State.ElementBeforeAppearing);
-			buttonLoaded = IndexOf(State.ElementLoaded);
-			buttonUnloaded = IndexOf(State.ElementUnloaded);
-
-			Assert.Less(pageBeforeAppearing, pageAppearing);
-			Assert.Less(pageBeforeAppearing, buttonBeforeAppearing);
-			Assert.Less(pageAppearing, pageDisappearing);
-			Assert.Less(pageLoaded, pageUnloaded);
-			Assert.Less(pageLoaded, pageDisappearing);
-			Assert.Less(pageLoaded, buttonUnloaded);
-
-			Assert.Less(buttonBeforeAppearing, buttonLoaded);
-			Assert.Less(buttonLoaded, buttonUnloaded);
-			Assert.Less(buttonUnloaded, pageUnloaded);
+			RunningApp.WaitForElement(successlText);
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
@@ -1,6 +1,5 @@
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -20,7 +19,6 @@ namespace Xamarin.Forms.Controls
 		const string switchButtonLabel = "Switch Legacy Events";
 		const string checkLabelText = "CheckMe";
 		const string resultId = "Result";
-		const char separator = '\n';
 
 		public enum State
 		{
@@ -87,7 +85,7 @@ namespace Xamarin.Forms.Controls
 
 					var sb = new StringBuilder();
 					for (int i = 0; i < result.Count; i++)
-						sb.Append($"{result[i]}{separator}");
+						sb.AppendLine(result[i].ToString());
 					resultLabel.Text = sb.ToString();
 
 					checkLabel.Text = checkLabelText;
@@ -139,7 +137,7 @@ namespace Xamarin.Forms.Controls
 		void GetResult()
 		{
 			var resultLabel = RunningApp.Query(c => c.Marked(resultId))[0].Text;
-			result = resultLabel.Split(new [] { separator }, System.StringSplitOptions.RemoveEmptyEntries);
+			result = resultLabel.Split(new [] { '\r', '\n' }, System.StringSplitOptions.RemoveEmptyEntries);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
@@ -1,0 +1,73 @@
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Diagnostics;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2210, "[Enhancement] Add better life cycle events", PlatformAffected.All)]
+	public class Issue2210 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var button = new Button() { Text = "Button" };
+			button.Loaded += (_, __) => Debug.WriteLine("[Button] >> loaded >>");
+			button.Unloaded += (_, __) => Debug.WriteLine("[Button] << unloaded <<");
+			button.BeforeAppearing += (_, __) => Debug.WriteLine("[Button] == BeforeAppearing ==");
+			Content = new StackLayout()
+			{
+				Children = { button }
+			};
+
+			Loaded += (_, __) => Debug.WriteLine("[Page] >> loaded >>");
+			Unloaded += (_, __) => Debug.WriteLine("[Page] << unloaded <<");
+			BeforeAppearing += (_, __) => Debug.WriteLine("[Page] == BeforeAppearing ==");
+			Appearing += (_, __) => Debug.WriteLine("[Page] ++ AppearING >>");
+			Appeared += (_, __) => Debug.WriteLine("[Page] ++ AppearED ++");
+			Disappearing += (_, __) => Debug.WriteLine("[Page] -- DisappearING >>");
+			Disappeared += (_, __) => Debug.WriteLine("[Page] -- DisappearED --");
+		}
+
+		protected override void OnLoaded()
+		{
+			Debug.WriteLine("[Page] >> loaded >>");
+			base.OnLoaded();
+		}
+
+		protected override void OnUnloaded()
+		{
+			Debug.WriteLine("[Page] << unloaded <<");
+			base.OnUnloaded();
+		}
+
+		protected override void OnBeforeAppearing()
+		{
+			Debug.WriteLine("[Page] == BeforeAppearing ==");
+			base.OnBeforeAppearing();
+		}
+
+		protected override void OnAppearing()
+		{
+			Debug.WriteLine("[Page] ++ AppearING >>");
+			base.OnAppearing();
+		}
+
+		protected override void OnAppeared()
+		{
+			Debug.WriteLine("[Page] ++ AppearED ++");
+			base.OnAppeared();
+		}
+
+		protected override void OnDisappearing()
+		{
+			Debug.WriteLine("[Page] -- DisappearING >>");
+			base.OnDisappearing();
+		}
+
+		protected override void OnDisappeared()
+		{
+			Debug.WriteLine("[Page] -- DisappearED --");
+			base.OnDisappeared();
+		}		
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2210.cs
@@ -1,73 +1,198 @@
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using System.Diagnostics;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
 
 namespace Xamarin.Forms.Controls
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 2210, "[Enhancement] Add better life cycle events", PlatformAffected.All)]
-	public class Issue2210 : TestContentPage
+	public class Issue2210 : TestMasterDetailPage
 	{
+		public enum State
+		{
+			PageLoaded,
+			PageUnloaded,
+			PageBeforeAppearing,
+			PageAppearing,
+			PageAppeared,
+			PageDisappearing,
+			PageDisappeared,
+			ElementBeforeAppearing,
+			ElementLoaded,
+			ElementUnloaded,
+		}
+
+		public List<State> Result = new List<State>();
+
+		void LogEvent(State state)
+		{
+			Result.Add(state);
+			Debug.WriteLine($"{state}");
+		}
+
+		Button addRemoveButton;
+
 		protected override void Init()
 		{
-			var button = new Button() { Text = "Button" };
-			button.Loaded += (_, __) => Debug.WriteLine("[Button] >> loaded >>");
-			button.Unloaded += (_, __) => Debug.WriteLine("[Button] << unloaded <<");
-			button.BeforeAppearing += (_, __) => Debug.WriteLine("[Button] == BeforeAppearing ==");
-			Content = new StackLayout()
+			MasterBehavior = MasterBehavior.Split;
+
+			var label = new Label();
+			var resultLabel = new Label();
+
+			addRemoveButton = new Button
 			{
-				Children = { button }
+				Text = "GoTest",
+				Command = new Command(async () =>
+				{
+					Result.Clear();
+					resultLabel.Text = "Let's assume that this text is not here.";
+					label.Text = "But soon everything will change.";
+
+					var button = new Button
+					{
+						Text = "Button"
+					};
+					button.Loaded += (_, __) => LogEvent(State.ElementLoaded);
+					button.Unloaded += (_, __) => LogEvent(State.ElementUnloaded);
+					button.BeforeAppearing += (_, __) => LogEvent(State.ElementBeforeAppearing);
+
+					var page = new ContentPage
+					{
+						Content = button
+					};
+					page.Loaded += (_, __) => LogEvent(State.PageLoaded);
+					page.Unloaded += (_, __) => LogEvent(State.PageUnloaded);
+					page.BeforeAppearing += (_, __) => LogEvent(State.PageBeforeAppearing);
+					page.Appearing += (_, __) => LogEvent(State.PageAppearing);
+					page.Appeared += (_, __) => LogEvent(State.PageAppeared);
+					page.Disappearing += (_, __) => LogEvent(State.PageDisappearing);
+					page.Disappeared += (_, __) => LogEvent(State.PageDisappeared);
+
+					await Detail.Navigation.PushAsync(page);
+					// UWP not waiting for page creation
+					await Task.Delay(800);
+					Detail.Navigation.RemovePage(page);
+
+					var eraserPage = new ContentPage();
+					await Detail.Navigation.PushAsync(eraserPage);
+					Detail.Navigation.RemovePage(eraserPage);
+					await Task.Delay(200);
+
+					var sb = new StringBuilder();
+					if (Application.Current.UseLegacyPageEvents)
+						sb.AppendLine("[!] Legacy events is enabled").AppendLine();
+					for (int i = 0; i < Result.Count; i++)
+						sb.AppendLine($"{i} {Result[i]}");
+
+					resultLabel.Text = sb.ToString();
+
+					label.Text = "CheckMe";
+				})
 			};
 
-			Loaded += (_, __) => Debug.WriteLine("[Page] >> loaded >>");
-			Unloaded += (_, __) => Debug.WriteLine("[Page] << unloaded <<");
-			BeforeAppearing += (_, __) => Debug.WriteLine("[Page] == BeforeAppearing ==");
-			Appearing += (_, __) => Debug.WriteLine("[Page] ++ AppearING >>");
-			Appeared += (_, __) => Debug.WriteLine("[Page] ++ AppearED ++");
-			Disappearing += (_, __) => Debug.WriteLine("[Page] -- DisappearING >>");
-			Disappeared += (_, __) => Debug.WriteLine("[Page] -- DisappearED --");
+			Master = new ContentPage
+			{
+				Title = "menu",
+				Content = new StackLayout
+				{
+					Children =
+					{
+						addRemoveButton,
+						resultLabel,
+						new Button
+						{
+							Text = "Swith Legacy Events",
+							Command = new Command(() => Application.Current.UseLegacyPageEvents = !Application.Current.UseLegacyPageEvents)
+						}
+					}
+				}
+			};
+
+			Detail = new NavigationPage(
+				new ContentPage
+				{
+					Content = new StackLayout
+					{
+						Children =
+						{
+							label
+						}
+					}
+				}
+			);
 		}
 
-		protected override void OnLoaded()
+#if UITEST
+		[Test]
+		public void Issue2210_CycleEvents()
 		{
-			Debug.WriteLine("[Page] >> loaded >>");
-			base.OnLoaded();
-		}
+			RunningApp.Tap("GoTest");
+			RunningApp.WaitForElement("CheckMe");
+			Assert.AreEqual(10, Result.Count);
+			CollectionAssert.AllItemsAreUnique(Result);
 
-		protected override void OnUnloaded()
-		{
-			Debug.WriteLine("[Page] << unloaded <<");
-			base.OnUnloaded();
-		}
+			var pageBeforeAppearing = Result.IndexOf(State.PageBeforeAppearing);
+			var pageAppearing = Result.IndexOf(State.PageAppearing);
+			var pageAppeared = Result.IndexOf(State.PageAppeared);
+			var pageDisappearing = Result.IndexOf(State.PageDisappearing);
+			var pageDisappeared = Result.IndexOf(State.PageDisappeared);
+			var pageLoaded = Result.IndexOf(State.PageLoaded);
+			var pageUnloaded = Result.IndexOf(State.PageUnloaded);
 
-		protected override void OnBeforeAppearing()
-		{
-			Debug.WriteLine("[Page] == BeforeAppearing ==");
-			base.OnBeforeAppearing();
-		}
+			var buttonBeforeAppearing = Result.IndexOf(State.ElementBeforeAppearing);
+			var buttonLoaded = Result.IndexOf(State.ElementLoaded);
+			var buttonUnloaded = Result.IndexOf(State.ElementUnloaded);
 
-		protected override void OnAppearing()
-		{
-			Debug.WriteLine("[Page] ++ AppearING >>");
-			base.OnAppearing();
-		}
+			Assert.Less(pageBeforeAppearing, pageAppearing);
+			Assert.Less(pageAppearing, pageAppeared);
+			Assert.Less(pageAppearing, buttonBeforeAppearing);
+			Assert.Less(pageAppeared, pageDisappearing);
+			Assert.Less(pageDisappearing, pageDisappeared);
+			Assert.Less(pageLoaded, pageUnloaded);
+			Assert.Less(pageLoaded, pageDisappearing);
+			Assert.Less(pageLoaded, buttonUnloaded);
 
-		protected override void OnAppeared()
-		{
-			Debug.WriteLine("[Page] ++ AppearED ++");
-			base.OnAppeared();
-		}
+			Assert.Less(buttonBeforeAppearing, buttonLoaded);
+			Assert.Less(buttonLoaded, buttonUnloaded);
+			Assert.Less(buttonUnloaded, pageUnloaded);
 
-		protected override void OnDisappearing()
-		{
-			Debug.WriteLine("[Page] -- DisappearING >>");
-			base.OnDisappearing();
-		}
+			// check legacy events
+			RunningApp.Tap("Swith Legacy Events");
+			RunningApp.Tap("GoTest");
+			RunningApp.WaitForElement("CheckMe");
+			Assert.AreEqual(8, Result.Count);
+			CollectionAssert.AllItemsAreUnique(Result);
+			CollectionAssert.DoesNotContain(Result, State.PageAppeared);
+			CollectionAssert.DoesNotContain(Result, State.PageDisappeared);
 
-		protected override void OnDisappeared()
-		{
-			Debug.WriteLine("[Page] -- DisappearED --");
-			base.OnDisappeared();
-		}		
+			pageBeforeAppearing = Result.IndexOf(State.PageBeforeAppearing);
+			pageAppearing = Result.IndexOf(State.PageAppearing);
+			pageDisappearing = Result.IndexOf(State.PageDisappearing);
+			pageLoaded = Result.IndexOf(State.PageLoaded);
+			pageUnloaded = Result.IndexOf(State.PageUnloaded);
+
+			buttonBeforeAppearing = Result.IndexOf(State.ElementBeforeAppearing);
+			buttonLoaded = Result.IndexOf(State.ElementLoaded);
+			buttonUnloaded = Result.IndexOf(State.ElementUnloaded);
+
+			Assert.Less(pageBeforeAppearing, pageAppearing);
+			Assert.Less(pageAppearing, buttonBeforeAppearing);
+			Assert.Less(pageLoaded, pageUnloaded);
+			Assert.Less(pageLoaded, pageDisappearing);
+			Assert.Less(pageLoaded, buttonUnloaded);
+
+			Assert.Less(buttonBeforeAppearing, buttonLoaded);
+			Assert.Less(buttonLoaded, buttonUnloaded);
+			Assert.Less(buttonUnloaded, pageUnloaded);
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -200,7 +200,7 @@ namespace Xamarin.Forms.Controls
 						// Something has failed and we're stuck in a place where we can't navigate
 						// to the test. Usually this is because we're getting network/HTTP errors 
 						// communicating with the server on the device. So we'll try restarting the app.
-						RunningApp = InitializeApp();
+						RunningApp = app = InitializeApp();
 					}
 					else
 					{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -315,6 +315,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5184.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3089.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1342.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2210.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2482.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2767.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2499.cs" />

--- a/Xamarin.Forms.Core.UnitTests/PageTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PageTests.cs
@@ -415,7 +415,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void SendApplicationPageAppearingLagacy()
+		public void SendApplicationPageAppearingLegacy()
 		{
 			var app = new PageTestApp { UseLegacyPageEvents = true };
 			var page = new ContentPage();
@@ -520,16 +520,21 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var page = new ContentPage();
 
+			int countBeforeAppearing = 0;
 			int countAppearing = 0;
 			int countAppeared = 0;
+			page.BeforeAppearing += (sender, args) => countBeforeAppearing++;
 			page.Appearing += (sender, args) => countAppearing++;
 			page.Appeared += (sender, args) => countAppeared++;
 
+			page.SendBeforeAppearing();
+			page.SendBeforeAppearing();
 			((IPageController)page).SendAppearing();
 			((IPageController)page).SendAppearing();
 			((IPageController)page).SendAppeared();
 			((IPageController)page).SendAppeared();
 
+			Assert.That(countBeforeAppearing, Is.EqualTo(1));
 			Assert.That(countAppearing, Is.EqualTo(1));
 			Assert.That(countAppeared, Is.EqualTo(1));
 		}

--- a/Xamarin.Forms.Core.UnitTests/PageTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PageTests.cs
@@ -395,7 +395,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		class PageTestApp : Application { }
 
 		[Test]
-		public void SendApplicationPageAppearing()
+		public void SendApplicationPageAppear()
 		{
 			var app = new PageTestApp();
 			var page = new ContentPage();
@@ -403,14 +403,39 @@ namespace Xamarin.Forms.Core.UnitTests
 			Page actual = null;
 			app.MainPage = page;
 			app.PageAppearing += (sender, args) => actual = args;
+			app.PageAppeared += (sender, args) => actual = args;
 
 			((IPageController)page).SendAppearing();
 
 			Assert.AreSame(page, actual);
+			actual = null;
+
+			((IPageController)page).SendAppeared();
+			Assert.AreSame(page, actual);
 		}
 
 		[Test]
-		public void SendApplicationPageDisappearing()
+		public void SendApplicationPageAppearingLagacy()
+		{
+			var app = new PageTestApp { UseLegacyPageEvents = true };
+			var page = new ContentPage();
+
+			Page actual = null;
+			app.MainPage = page;
+			app.PageAppearing += (sender, args) => actual = args;
+			app.PageAppeared += (sender, args) => actual = args;
+
+			((IPageController)page).SendAppearing();
+
+			Assert.AreSame(page, actual);
+			actual = null;
+
+			((IPageController)page).SendAppeared();
+			Assert.AreSame(actual, null);
+		}
+
+		[Test]
+		public void SendApplicationPageDisappear()
 		{
 			var app = new PageTestApp();
 			var page = new ContentPage();
@@ -418,53 +443,95 @@ namespace Xamarin.Forms.Core.UnitTests
 			Page actual = null;
 			app.MainPage = page;
 			app.PageDisappearing += (sender, args) => actual = args;
+			app.PageDisappeared += (sender, args) => actual = args;
 
 			((IPageController)page).SendAppearing();
+			((IPageController)page).SendAppeared();
 			((IPageController)page).SendDisappearing();
 
+			Assert.AreSame(page, actual);
+			actual = null;
+
+			((IPageController)page).SendDisappeared();
 			Assert.AreSame(page, actual);
 		}
 
 		[Test]
-		public void SendAppearing ()
+		public void SendApplicationPageDisappearingLegacy()
 		{
-			var page = new ContentPage ();
+			var app = new PageTestApp { UseLegacyPageEvents = true };
+			var page = new ContentPage();
+
+			Page actual = null;
+			app.MainPage = page;
+			app.PageDisappearing += (sender, args) => actual = args;
+			app.PageDisappeared += (sender, args) => actual = args;
+
+			((IPageController)page).SendAppearing();
+			((IPageController)page).SendAppeared();
+			((IPageController)page).SendDisappearing();
+
+			Assert.AreSame(page, actual);
+			actual = null;
+
+			((IPageController)page).SendDisappeared();
+			Assert.AreSame(actual, null);
+		}
+
+		[Test]
+		public void SendAppear()
+		{
+			var page = new ContentPage();
 
 			bool sent = false;
+			bool sended = false;
 			page.Appearing += (sender, args) => sent = true;
+			page.Appeared += (sender, args) => sended = sent;
 
-			((IPageController)page).SendAppearing ();
+			((IPageController)page).SendAppearing();
+			((IPageController)page).SendAppeared();
 
-			Assert.True (sent);
+			Assert.True(sent);
+			Assert.True(sended);
 		}
 
 		[Test]
-		public void SendDisappearing ()
+		public void SendDisappear()
 		{
-			var page = new ContentPage ();
+			var page = new ContentPage();
 
-			((IPageController)page).SendAppearing ();
+			((IPageController)page).SendAppearing();
+			((IPageController)page).SendAppeared();
 
 			bool sent = false;
+			bool sended = false;
 			page.Disappearing += (sender, args) => sent = true;
+			page.Disappeared += (sender, args) => sended = sent;
 
-			((IPageController)page).SendDisappearing ();
+			((IPageController)page).SendDisappearing();
+			((IPageController)page).SendDisappeared();
 
-			Assert.True (sent);
+			Assert.True(sent);
+			Assert.True(sended);
 		}
 
 		[Test]
-		public void SendAppearingDoesntGetCalledMultipleTimes ()
+		public void SendAppearDoesntGetCalledMultipleTimes()
 		{
-			var page = new ContentPage ();
+			var page = new ContentPage();
 
 			int countAppearing = 0;
+			int countAppeared = 0;
 			page.Appearing += (sender, args) => countAppearing++;
+			page.Appeared += (sender, args) => countAppeared++;
 
-			((IPageController)page).SendAppearing ();
-			((IPageController)page).SendAppearing ();
+			((IPageController)page).SendAppearing();
+			((IPageController)page).SendAppearing();
+			((IPageController)page).SendAppeared();
+			((IPageController)page).SendAppeared();
 
-			Assert.That (countAppearing, Is.EqualTo(1));
+			Assert.That(countAppearing, Is.EqualTo(1));
+			Assert.That(countAppeared, Is.EqualTo(1));
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -970,6 +970,7 @@ namespace Xamarin.Forms.Core.UITests
 				Rect = ToAppRect(windowsElement),
 				Label = windowsElement.Id, // Not entirely sure about this one
 				Description = windowsElement.Text, // or this one
+				Text = windowsElement.Text,
 				Enabled = windowsElement.Enabled,
 				Id = windowsElement.Id
 			};

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -333,6 +333,12 @@ namespace Xamarin.Forms
 		internal void OnPageDisappearing(Page page)
 			=> PageDisappearing?.Invoke(this, page);
 
+		internal void OnPageAppeared(Page page)
+			=> PageAppearing?.Invoke(this, page);
+
+		internal void OnPageDisappeared(Page page)
+			=> PageDisappearing?.Invoke(this, page);
+
 		void OnModalPopped(Page modalPage)
 			=> ModalPopped?.Invoke(this, new ModalPoppedEventArgs(modalPage));
 

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -24,6 +24,8 @@ namespace Xamarin.Forms
 
 		static SemaphoreSlim SaveSemaphore = new SemaphoreSlim(1, 1);
 
+		public static readonly BindableProperty UseLegacyPageEventsProperty = BindableProperty.Create(nameof(UseLegacyPageEvents), typeof(bool), typeof(Application), false);
+
 		[Obsolete("Assign the LogWarningsListener")]
 		public static bool LogWarningsToApplicationOutput { get; set; }
 
@@ -338,6 +340,12 @@ namespace Xamarin.Forms
 
 		internal void OnPageDisappeared(Page page)
 			=> PageDisappearing?.Invoke(this, page);
+
+		public bool UseLegacyPageEvents
+		{
+			get => (bool)GetValue(UseLegacyPageEventsProperty);
+			set => SetValue(UseLegacyPageEventsProperty, value);
+		}
 
 		void OnModalPopped(Page modalPage)
 			=> ModalPopped?.Invoke(this, new ModalPoppedEventArgs(modalPage));

--- a/Xamarin.Forms.Core/IPageController.cs
+++ b/Xamarin.Forms.Core/IPageController.cs
@@ -13,5 +13,9 @@ namespace Xamarin.Forms
 		void SendAppearing();
 
 		void SendDisappearing();
+
+		void SendAppeared();
+
+		void SendDisappeared();
 	}
 }

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -39,6 +39,7 @@ namespace Xamarin.Forms
 
 		bool _containerAreaSet;
 
+		bool _hasAppearing;
 		bool _hasAppeared;
 
 		ReadOnlyCollection<Element> _logicalChildren;
@@ -129,6 +130,10 @@ namespace Xamarin.Forms
 
 		public event EventHandler Disappearing;
 
+		public event EventHandler Appeared;
+
+		public event EventHandler Disappeared;
+
 		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons)
 		{
 			var args = new ActionSheetArguments(title, cancel, destruction, buttons);
@@ -194,6 +199,10 @@ namespace Xamarin.Forms
 		{
 		}
 
+		protected virtual void OnAppeared()
+		{
+		}
+
 		protected virtual bool OnBackButtonPressed()
 		{
 			var application = RealParent as Application;
@@ -228,6 +237,10 @@ namespace Xamarin.Forms
 		}
 
 		protected virtual void OnDisappearing()
+		{
+		}
+
+		protected virtual void OnDisappeared()
 		{
 		}
 
@@ -308,10 +321,10 @@ namespace Xamarin.Forms
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SendAppearing()
 		{
-			if (_hasAppeared)
+			if (_hasAppearing)
 				return;
 
-			_hasAppeared = true;
+			_hasAppearing = true;
 
 			if (IsBusy)
 				MessagingCenter.Send(this, BusySetSignalName, true);
@@ -328,10 +341,10 @@ namespace Xamarin.Forms
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SendDisappearing()
 		{
-			if (!_hasAppeared)
+			if (!_hasAppearing)
 				return;
 
-			_hasAppeared = false;
+			_hasAppearing = false;
 
 			if (IsBusy)
 				MessagingCenter.Send(this, BusySetSignalName, false);
@@ -343,6 +356,46 @@ namespace Xamarin.Forms
 			Disappearing?.Invoke(this, EventArgs.Empty);
 
 			FindApplication(this)?.OnPageDisappearing(this);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendAppeared()
+		{
+			if (_hasAppeared)
+				return;
+
+			_hasAppeared = true;
+
+			if (IsBusy)
+				MessagingCenter.Send(this, BusySetSignalName, true);
+
+			OnAppeared();
+			Appeared?.Invoke(this, EventArgs.Empty);
+
+			var pageContainer = this as IPageContainer<Page>;
+			pageContainer?.CurrentPage?.SendAppeared();
+
+			FindApplication(this)?.OnPageAppeared(this);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendDisappeared()
+		{
+			if (!_hasAppeared)
+				return;
+
+			_hasAppeared = false;
+
+			if (IsBusy)
+				MessagingCenter.Send(this, BusySetSignalName, false);
+
+			var pageContainer = this as IPageContainer<Page>;
+			pageContainer?.CurrentPage?.SendDisappeared();
+
+			OnDisappeared();
+			Disappeared?.Invoke(this, EventArgs.Empty);
+
+			FindApplication(this)?.OnPageDisappeared(this);
 		}
 
 		Application FindApplication(Element element)
@@ -395,7 +448,7 @@ namespace Xamarin.Forms
 
 		void OnPageBusyChanged()
 		{
-			if (!_hasAppeared)
+			if (!_hasAppearing)
 				return;
 
 			MessagingCenter.Send(this, BusySetSignalName, IsBusy);

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -361,6 +361,12 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendAppeared()
 		{
+			if (Application.Current.UseLegacyPageEvents)
+			{
+				SendAppearing();
+				return;
+			}
+
 			if (_hasAppeared)
 				return;
 
@@ -381,6 +387,12 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendDisappeared()
 		{
+			if (Application.Current.UseLegacyPageEvents)
+			{
+				SendDisappearing();
+				return;
+			}
+
 			if (!_hasAppeared)
 				return;
 

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -287,6 +287,8 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendLoaded()
 		{
+			if (Application.Current.UseLegacyPageEvents)
+				return;
 			OnLoaded();
 			Loaded?.Invoke(this, EventArgs.Empty);
 		}
@@ -294,6 +296,8 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendUnloaded()
 		{
+			if (Application.Current.UseLegacyPageEvents)
+				return;
 			OnUnloaded();
 			Unloaded?.Invoke(this, EventArgs.Empty);
 		}
@@ -301,6 +305,8 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendBeforeAppearing()
 		{
+			if (Application.Current.UseLegacyPageEvents)
+				return;
 			OnBeforeAppearing();
 			BeforeAppearing?.Invoke(this, EventArgs.Empty);
 		}

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -272,6 +272,10 @@ namespace Xamarin.Forms
 
 		public event EventHandler BeforeAppearing;
 
+		bool _hasLoaded;
+		bool _hasUnloaded;
+		bool _hasBeforeAppearing;
+
 		protected virtual void OnLoaded()
 		{
 		}
@@ -287,22 +291,40 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendLoaded()
 		{
+			if (_hasLoaded)
+				return;
+
 			OnLoaded();
 			Loaded?.Invoke(this, EventArgs.Empty);
+
+			_hasLoaded = true;
+			_hasUnloaded = false;
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendUnloaded()
 		{
+			if (_hasUnloaded)
+				return;
+
 			OnUnloaded();
 			Unloaded?.Invoke(this, EventArgs.Empty);
+
+			_hasUnloaded = true;
+			_hasBeforeAppearing = _hasLoaded = false;
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendBeforeAppearing()
 		{
+			if (_hasBeforeAppearing)
+				return;
+
 			OnBeforeAppearing();
 			BeforeAppearing?.Invoke(this, EventArgs.Empty);
+
+			_hasBeforeAppearing = true;
+			_hasUnloaded = false;
 		}
 
 		internal VisualElement()

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -287,8 +287,6 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendLoaded()
 		{
-			if (Application.Current.UseLegacyPageEvents)
-				return;
 			OnLoaded();
 			Loaded?.Invoke(this, EventArgs.Empty);
 		}
@@ -296,8 +294,6 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendUnloaded()
 		{
-			if (Application.Current.UseLegacyPageEvents)
-				return;
 			OnUnloaded();
 			Unloaded?.Invoke(this, EventArgs.Empty);
 		}
@@ -305,8 +301,6 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendBeforeAppearing()
 		{
-			if (Application.Current.UseLegacyPageEvents)
-				return;
 			OnBeforeAppearing();
 			BeforeAppearing?.Invoke(this, EventArgs.Empty);
 		}

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -266,6 +266,45 @@ namespace Xamarin.Forms
 
 		LayoutConstraint _selfConstraint;
 
+		public event EventHandler Loaded;
+
+		public event EventHandler Unloaded;
+
+		public event EventHandler BeforeAppearing;
+
+		protected virtual void OnLoaded()
+		{
+		}
+
+		protected virtual void OnUnloaded()
+		{
+		}
+
+		protected virtual void OnBeforeAppearing()
+		{
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendLoaded()
+		{
+			OnLoaded();
+			Loaded?.Invoke(this, EventArgs.Empty);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendUnloaded()
+		{
+			OnUnloaded();
+			Unloaded?.Invoke(this, EventArgs.Empty);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendBeforeAppearing()
+		{
+			OnBeforeAppearing();
+			BeforeAppearing?.Invoke(this, EventArgs.Empty);
+		}
+
 		internal VisualElement()
 		{
 			

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -63,6 +63,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnAttachedToWindow()
 		{
+			Element?.SendBeforeAppearing();
+
 			base.OnAttachedToWindow();
 
 			if (!_appearing && !Application.Current.UseLegacyPageEvents)

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -44,12 +44,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void Dispose(bool disposing)
 		{
-			if (_disposed)
-				return;
-
-			if (!Application.Current.UseLegacyPageEvents)
+			if (disposing && !_disposed)
 			{
-				if (disposing)
+				if (!Application.Current.UseLegacyPageEvents)
 				{
 					if (_appearing)
 						PageController?.SendDisappearing();
@@ -59,13 +56,13 @@ namespace Xamarin.Forms.Platform.Android
 						PageController?.SendDisappeared();
 					_appeared = false;
 				}
-			}
-			else
-			{
-				PageController?.SendDisappearing();
-			}
-			_disposed = true;
+				else
+				{
+					PageController?.SendDisappearing();
+				}
 
+				_disposed = true;
+			}
 			base.Dispose(disposing);
 		}
 
@@ -74,20 +71,19 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnAttachedToWindow();
 
 			if (!_appearing && !Application.Current.UseLegacyPageEvents)
-				PageController.SendAppearing();
+				PageController?.SendAppearing();
 			_appearing = true;
 
-			var pageContainer = Parent as PageContainer;
-			if (pageContainer != null && (pageContainer.IsInFragment || pageContainer.Visibility == ViewStates.Gone))
+			if (Parent is PageContainer pageContainer && (pageContainer.IsInFragment || pageContainer.Visibility == ViewStates.Gone))
 				return;
 
 			if (Application.Current.UseLegacyPageEvents)
-				PageController.SendAppearing();
+				PageController?.SendAppearing();
 		}
 
-		public override void OnGlobalLayout(object sender, EventArgs e)
+		protected override void OnGlobalLayout()
 		{
-			base.OnGlobalLayout(sender, e);
+			base.OnGlobalLayout();
 
 			if (!_appeared && !Application.Current.UseLegacyPageEvents)
 			{
@@ -101,20 +97,18 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnDetachedFromWindow();
 
 			if (_appeared && !Application.Current.UseLegacyPageEvents)
-				PageController.SendDisappeared();
+				PageController?.SendDisappeared();
 			_appeared = false;
 
-			var pageContainer = Parent as PageContainer;
-			if (pageContainer != null && pageContainer.IsInFragment)
+			if (Parent is PageContainer pageContainer && pageContainer.IsInFragment)
 				return;
 
 			if (Application.Current.UseLegacyPageEvents)
-				PageController.SendDisappearing();
+				PageController?.SendDisappearing();
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Page> e)
 		{
-			Page view = e.NewElement;
 			base.OnElementChanged(e);
 
 			if (Id == NoId)
@@ -218,7 +212,7 @@ namespace Xamarin.Forms.Platform.Android
 				var tabGroup = tabIndexes[idx];
 				foreach (var child in tabGroup)
 				{
-					if (child is Layout || 
+					if (child is Layout ||
 						!(
 							child is VisualElement ve && ve.IsTabStop
 							&& AutomationProperties.GetIsInAccessibleTree(ve) != false // accessible == true

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public class PageRenderer : VisualElementRenderer<Page>, IOrderedTraversalController
 	{
-		bool _appeared;
 		bool _appearing;
 		bool _disposed;
 
@@ -51,10 +50,6 @@ namespace Xamarin.Forms.Platform.Android
 					if (_appearing)
 						PageController?.SendDisappearing();
 					_appearing = false;
-
-					if (_appeared)
-						PageController?.SendDisappeared();
-					_appeared = false;
 				}
 				else
 				{
@@ -81,24 +76,9 @@ namespace Xamarin.Forms.Platform.Android
 				PageController?.SendAppearing();
 		}
 
-		protected override void OnGlobalLayout()
-		{
-			base.OnGlobalLayout();
-
-			if (!_appeared && !Application.Current.UseLegacyPageEvents)
-			{
-				PageController?.SendAppeared();
-				_appeared = true;
-			}
-		}
-
 		protected override void OnDetachedFromWindow()
 		{
 			base.OnDetachedFromWindow();
-
-			if (_appeared && !Application.Current.UseLegacyPageEvents)
-				PageController?.SendDisappeared();
-			_appeared = false;
 
 			if (Parent is PageContainer pageContainer && pageContainer.IsInFragment)
 				return;

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -271,15 +271,8 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnAttachedToWindow();
 		}
 
-		protected override void OnDetachedFromWindow()
-		{
-			base.OnDetachedFromWindow();
-			_loaded = false;
-			Element?.SendUnloaded();
-
-			if (ViewTreeObserver.IsAlive)
-				ViewTreeObserver.RemoveOnGlobalLayoutListener(this);
-		}
+		// NOTE: Adding the override OnDetachedFromWindow causes the renderers to stay alive after they've been collected by Android
+		//protected override void OnDetachedFromWindow()
 
 		protected virtual void OnGlobalLayout()
 		{
@@ -287,6 +280,9 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				Element?.SendLoaded();
 				_loaded = true;
+
+				if (ViewTreeObserver.IsAlive)
+					ViewTreeObserver.RemoveOnGlobalLayoutListener(this);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -53,8 +53,8 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				_element?.SendLoaded();
 
-				if (_element is IPageController page && !Application.Current.UseLegacyPageEvents)
-					page.SendAppeared();
+				if (!Application.Current.UseLegacyPageEvents)
+					(_element as IPageController)?.SendAppeared();
 
 				_loaded = true;
 
@@ -230,8 +230,8 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				_element?.SendUnloaded();
 
-				if (_element is IPageController page && !Application.Current.UseLegacyPageEvents)
-					page.SendDisappeared();
+				if (!Application.Current.UseLegacyPageEvents)
+					(_element as IPageController)?.SendDisappeared();
 			}
 
 			_loaded = false;
@@ -480,21 +480,11 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			public static readonly AttachTracker Instance = new AttachTracker();
 
-			public void OnViewAttachedToWindow(AView attachedView)
-			{
-				if (!(attachedView is IVisualElementRenderer renderer) || renderer.Tracker == null)
-					return;
-
-				renderer.Tracker.HandleViewAttachedToWindow();
-			}
+			public void OnViewAttachedToWindow(AView attachedView) 
+				=> (attachedView as IVisualElementRenderer)?.Tracker?.HandleViewAttachedToWindow();
 
 			public void OnViewDetachedFromWindow(AView detachedView)
-			{
-				if (!(detachedView is IVisualElementRenderer renderer) || renderer.Tracker == null)
-					return;
-
-				renderer.Tracker.HandleViewDetachedFromWindow();
-			}
+				=> (detachedView as IVisualElementRenderer)?.Tracker?.HandleViewDetachedFromWindow();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -78,13 +78,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (disposing)
 			{
-				if (_loaded)
-				{
-					_element?.SendUnloaded();
-					if (_element is IPageController page && !Application.Current.UseLegacyPageEvents)
-						page.SendDisappeared();
-				}
-
 				SetElement(_element, null);
 				if (_renderer != null)
 				{

--- a/Xamarin.Forms.Platform.UAP/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PageRenderer.cs
@@ -8,8 +8,6 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		bool _disposed;
 
-		bool _loaded;
-
 		protected override AutomationPeer OnCreateAutomationPeer()
 		{
 			// Pages need an automation peer so we can interact with them in automated tests
@@ -47,7 +45,6 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if (e.OldElement == null)
 				{
-					Loaded += OnLoaded;
 					Tracker = new BackgroundTracker<FrameworkElement>(BackgroundProperty);
 				}
 
@@ -55,29 +52,31 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					SetAutomationId(Element.AutomationId);
 				}
-
-				if (_loaded)
-					e.NewElement.SendAppearing();
 			}
 		}
 
-		void OnLoaded(object sender, RoutedEventArgs args)
+		public override void OnLoading(FrameworkElement sender, object args)
 		{
+			base.OnLoading(sender, args);
+			Element?.SendAppearing();
+		}
+
+		public override void OnLoaded(object sender, RoutedEventArgs args)
+		{
+			base.OnLoaded(sender, args);
 			var carouselPage = Element?.Parent as CarouselPage;
 			if (carouselPage != null && carouselPage.Children[0] != Element)
 			{
 				return;
 			}
-			_loaded = true;
-			Unloaded += OnUnloaded;
-			Element?.SendAppearing();
+			Element?.SendAppeared();
 		}
 
-		void OnUnloaded(object sender, RoutedEventArgs args)
+		public override void OnUnloaded(object sender, RoutedEventArgs args)
 		{
-			Unloaded -= OnUnloaded;
-			_loaded = false;
-			Element?.SendDisappearing();
+			Element?.SendDisappeared();
+
+			base.OnUnloaded(sender, args);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PageRenderer.cs
@@ -58,7 +58,8 @@ namespace Xamarin.Forms.Platform.UWP
 		public override void OnLoading(FrameworkElement sender, object args)
 		{
 			base.OnLoading(sender, args);
-			Element?.SendAppearing();
+			if (!Application.Current.UseLegacyPageEvents)
+				Element?.SendAppearing();
 		}
 
 		public override void OnLoaded(object sender, RoutedEventArgs args)
@@ -69,12 +70,18 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				return;
 			}
-			Element?.SendAppeared();
+			if (!Application.Current.UseLegacyPageEvents)
+				Element?.SendAppeared();
+			else
+				Element?.SendAppearing();
 		}
 
 		public override void OnUnloaded(object sender, RoutedEventArgs args)
 		{
-			Element?.SendDisappeared();
+			if (!Application.Current.UseLegacyPageEvents)
+				Element?.SendDisappeared();
+			else
+				Element?.SendDisappearing();
 
 			base.OnUnloaded(sender, args);
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -165,12 +165,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewWillAppear(bool animated)
 		{
-			if (Application.Current.UseLegacyPageEvents)
-			{
-				base.ViewWillAppear(animated);
-				return;
-			}
-
 			if (!_appearing && !_disposed)
 				Page.SendBeforeAppearing();
 
@@ -180,7 +174,8 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			_appearing = true;
-			Page.SendAppearing();
+			if (!Application.Current.UseLegacyPageEvents)
+				Page.SendAppearing();
 		}
 
 		public override void ViewDidAppear(bool animated)
@@ -191,7 +186,10 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			_appeared = true;
-			Page.SendAppeared();
+
+			if (!Application.Current.UseLegacyPageEvents)
+				Page.SendAppeared();
+
 			UpdateStatusBarPrefersHidden();
 			if(Forms.IsiOS11OrNewer)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
@@ -214,7 +212,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element.Parent is CarouselPage)
 				return;
 
-			Page.SendDisappeared();
+			if (!Application.Current.UseLegacyPageEvents)
+				Page.SendDisappeared();
 		}
 
 		public override void ViewDidLoad()
@@ -266,7 +265,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_appearing = false;
 
-				if (_appeared)
+				if (_appeared && !Application.Current.UseLegacyPageEvents)
 					Page.SendDisappeared();
 
 				_appeared = false;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -191,7 +191,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Page.SendAppeared();
 
 			UpdateStatusBarPrefersHidden();
-			if(Forms.IsiOS11OrNewer)
+			if (Forms.IsiOS11OrNewer)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
 			if (Element.Parent is CarouselPage)
@@ -213,7 +213,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			if (!Application.Current.UseLegacyPageEvents)
-				Page.SendDisappeared();
+				Page?.SendDisappeared();
 		}
 
 		public override void ViewDidLoad()
@@ -250,7 +250,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewWillDisappear(animated);
 			_appearing = false;
-			Page.SendDisappearing ();
+			if (!Application.Current.UseLegacyPageEvents)
+				Page?.SendDisappearing();
 			NativeView?.Window?.EndEditing(true);
 		}
 
@@ -288,7 +289,7 @@ namespace Xamarin.Forms.Platform.iOS
 					_tracker = null;
 				}
 
-				Element.SendUnloaded ();
+				Element.SendUnloaded();
 				Element = null;
 				Container?.Dispose();
 				_disposed = true;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -163,12 +163,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public UIViewController ViewController => _disposed ? null : this;
 
-		public override void ViewWillAppear (bool animated)
+		public override void ViewWillAppear(bool animated)
 		{
+			if (Application.Current.UseLegacyPageEvents)
+			{
+				base.ViewWillAppear(animated);
+				return;
+			}
+
 			if (!_appearing && !_disposed)
 				Page.SendBeforeAppearing();
 
-			base.ViewWillAppear (animated);
+			base.ViewWillAppear(animated);
 
 			if (_appearing || _disposed)
 				return;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -139,7 +139,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_disposed)
 				return;
 
-			if (Element.Parent is BaseShellItem)
+			if (Element?.Parent is BaseShellItem)
 				Element.Layout(View.Bounds.ToRectangle());
 
 			UpdateShellInsetPadding();
@@ -166,7 +166,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewWillAppear(bool animated)
 		{
 			if (!_appearing && !_disposed)
-				Page.SendBeforeAppearing();
+				Page?.SendBeforeAppearing();
 
 			base.ViewWillAppear(animated);
 
@@ -175,7 +175,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_appearing = true;
 			if (!Application.Current.UseLegacyPageEvents)
-				Page.SendAppearing();
+				Page?.SendAppearing();
 		}
 
 		public override void ViewDidAppear(bool animated)
@@ -188,16 +188,16 @@ namespace Xamarin.Forms.Platform.iOS
 			_appeared = true;
 
 			if (!Application.Current.UseLegacyPageEvents)
-				Page.SendAppeared();
+				Page?.SendAppeared();
 
 			UpdateStatusBarPrefersHidden();
 			if (Forms.IsiOS11OrNewer)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
-			if (Element.Parent is CarouselPage)
+			if (Element?.Parent is CarouselPage)
 				return;
 
-			Page.SendAppearing();
+			Page?.SendAppearing();
 		}
 
 		public override void ViewDidDisappear(bool animated)
@@ -209,7 +209,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_appeared = false;
 
-			if (Element.Parent is CarouselPage)
+			if (Element?.Parent is CarouselPage)
 				return;
 
 			if (!Application.Current.UseLegacyPageEvents)
@@ -262,12 +262,12 @@ namespace Xamarin.Forms.Platform.iOS
 				Element.PropertyChanged -= OnHandlePropertyChanged;
 				Platform.SetRenderer(Element, null);
 				if (_appearing)
-					Page.SendDisappearing();
+					Page?.SendDisappearing();
 
 				_appearing = false;
 
 				if (_appeared && !Application.Current.UseLegacyPageEvents)
-					Page.SendDisappeared();
+					Page?.SendDisappeared();
 
 				_appeared = false;
 
@@ -289,7 +289,7 @@ namespace Xamarin.Forms.Platform.iOS
 					_tracker = null;
 				}
 
-				Element.SendUnloaded();
+				Element?.SendUnloaded();
 				Element = null;
 				Container?.Dispose();
 				_disposed = true;

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -300,10 +300,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.MovedToWindow ();
 
 			if (Window != null && !_loaded) {
-				Element.SendLoaded ();
+				Element?.SendLoaded ();
 				_loaded = true;
 			} else if (Window == null && _loaded) {
-				Element.SendUnloaded ();
+				Element?.SendUnloaded ();
 				_loaded = false;
 			}
 		}
@@ -313,7 +313,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.WillMoveToWindow (window);
 
 			if (!_beforeAppearing && Element != null) {
-				Element.SendBeforeAppearing ();
+				Element?.SendBeforeAppearing ();
 				_beforeAppearing = true;
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
 using Xamarin.Forms.Internals;
+using CoreGraphics;
 
 #if __MOBILE__
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
@@ -42,6 +43,8 @@ namespace Xamarin.Forms.Platform.MacOS
 		string _defaultAccessibilityLabel;
 		string _defaultAccessibilityHint;
 		bool? _defaultIsAccessibilityElement;
+		bool _beforeAppearing;
+		bool _loaded;
 #endif
 		EventTracker _events;
 
@@ -292,6 +295,29 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 #if __MOBILE__
+		public override void MovedToWindow ()
+		{
+			base.MovedToWindow ();
+
+			if (Window != null && !_loaded) {
+				Element.SendLoaded ();
+				_loaded = true;
+			} else if (Window == null && _loaded) {
+				Element.SendUnloaded ();
+				_loaded = false;
+			}
+		}
+
+		public override void WillMoveToWindow (UIWindow window)
+		{
+			base.WillMoveToWindow (window);
+
+			if (!_beforeAppearing && Element != null) {
+				Element.SendBeforeAppearing ();
+				_beforeAppearing = true;
+			}
+		}
+
 		public override SizeF SizeThatFits(SizeF size)
 		{
 			return new SizeF(0, 0);


### PR DESCRIPTION
### Description of Change ###

Added life-cycle events, such as `Loaded`, `Unloaded`, `BeforeAppearing` for the VisualElement and `Appeared`, `Disappeared` for the Page. 
Also changed the behavior of the `Appearing` and `Disappearing` events for the Page.

### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2210

### API Changes ###

Added:
 - event VisualElement.Loaded;
 - event VisualElement.Unloaded;
 - event VisualElement.BeforeAppearing;
 - event Page.Appeared;
 - event Page.Disappeared;

Changed:
 - event Page.Appearing;
 - event Page.Disappearing;

### Platforms Affected ###

- Core (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

Event call order:

| iOS | Android  | UWP  | 
|:----------------------:|:-------------------------:|:------------------------:| 
| ![image](https://user-images.githubusercontent.com/27482193/56596674-a5891f80-65f9-11e9-9ff8-eaedb10a0c36.png) |  ![image](https://user-images.githubusercontent.com/27482193/56592956-4aa0f980-65f4-11e9-86d5-8b9e8c4d60b6.png) |  ![image](https://user-images.githubusercontent.com/27482193/56593740-c4d17e00-65f4-11e9-9d7d-2fbcd0f705f8.png) |
|  | LegacyPageEvents |  |
|  ![image](https://user-images.githubusercontent.com/27482193/56596719-bc2f7680-65f9-11e9-8d9e-7c3ee751563b.png) |  ![image](https://user-images.githubusercontent.com/27482193/56596146-aa010880-65f8-11e9-8e84-432c02f8df76.png) | ![image](https://user-images.githubusercontent.com/27482193/56595622-a456f300-65f7-11e9-9d6f-8a3efc509eaf.png) |


### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
