### PR TITLE
[Core] Add check for null _root flex item

### DIFF
--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -388,6 +388,9 @@ namespace Xamarin.Forms
 
 		protected override void LayoutChildren(double x, double y, double width, double height)
 		{
+			if (_root == null)
+				return;
+			
 			Layout(x, y, width, height);
 			foreach (var child in Children) {
 				var frame = GetFlexItem(child).GetFrame();


### PR DESCRIPTION
### Description of Change ###

This PR checks for the null reference of _root `Flex.Item` in `LayoutChildren()` before calling `Layout()` on the inner children.

### Issues Resolved ###

- fixes #3234 

### API Changes ###

None

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard

### Remarks

This is a very simplistic fix and there might be some more digging to do as whether or not the last layout cycle should be avoided upstream.
