### PR TITLE
[UWP] Fix CornerRadius rendering on Frame

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2838.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2838.cs
@@ -41,15 +41,5 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 		}
-
-#if UITEST
-		[Test]
-		public void Issue1Test ()
-		{
-			RunningApp.Screenshot ("I am at Issue 1");
-			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
-			RunningApp.Screenshot ("I see the Label");
-		}
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2838.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2838.cs
@@ -1,0 +1,55 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2838, "UWP does not render Frame CornerRadius", PlatformAffected.UWP)]
+	public class Issue2838 : TestContentPage
+	{
+		protected override void Init()
+		{
+			// Initialize ui here instead of ctor
+			Content = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				Children =
+				{
+					new Label()
+					{
+						Text ="The frame below should have its corners rounded and the background should not protrude through them.",
+						TextColor = Color.Black,
+						WidthRequest = 300,
+						LineBreakMode = LineBreakMode.WordWrap,
+						HorizontalOptions = LayoutOptions.Center,
+						Margin = new Thickness(20)
+					},
+					new Frame
+					{
+						WidthRequest = 300,
+						HeightRequest = 160,
+						HorizontalOptions = LayoutOptions.Center,
+						CornerRadius = 10,
+						BackgroundColor = Color.Red,
+						BorderColor = Color.Blue
+					}
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1Test ()
+		{
+			RunningApp.Screenshot ("I am at Issue 1");
+			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
+			RunningApp.Screenshot ("I see the Label");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2838.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2838.cs
@@ -25,9 +25,10 @@ namespace Xamarin.Forms.Controls.Issues
 						Text ="The frame below should have its corners rounded and the background should not protrude through them.",
 						TextColor = Color.Black,
 						WidthRequest = 300,
+						HeightRequest = 90,
 						LineBreakMode = LineBreakMode.WordWrap,
 						HorizontalOptions = LayoutOptions.Center,
-						Margin = new Thickness(20)
+						Margin = new Thickness(10)
 					},
 					new Frame
 					{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -474,6 +474,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2837.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2740.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1939.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2838.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
@@ -56,6 +56,25 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
+		protected override void UpdateBackgroundColor()
+		{
+			//background color change must be handled separately
+			//because the background would protrude through the border if the corners are rounded
+			//as the bakcgorund would be applied to the renderer's FrameworkElement
+			Color backgroundColor = Element.BackgroundColor;
+			if (Control != null)
+			{
+				if (!backgroundColor.IsDefault)
+				{
+					Control.Background = backgroundColor.ToBrush();
+				}
+				else
+				{
+					Control.ClearValue(BackgroundProperty);
+				}
+			}			
+		}
+
 		void PackChild()
 		{
 			if (Element.Content == null)

--- a/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			//background color change must be handled separately
 			//because the background would protrude through the border if the corners are rounded
-			//as the bakcgorund would be applied to the renderer's FrameworkElement
+			//as the background would be applied to the renderer's FrameworkElement
 			Color backgroundColor = Element.BackgroundColor;
 			if (Control != null)
 			{


### PR DESCRIPTION
### Description of Change ###

This PR fixes issue #2838 - CornerRadius rendering for Frame control on UWP. This occurs for `Frame` elements with a set background color and `CornerRadius`. In current release this causes the background to protrude through the rounded corners, which means the corners essentially remain square.

The fix provides a custom override of the `VisualElementRenderer`'s `UpdateBackgroundColor` method in UWP `FrameRenderer`.

**Before**
![image](https://user-images.githubusercontent.com/1075116/42709026-5b0831b6-86df-11e8-9410-042ceedc20ef.png)

**After**

![image](https://user-images.githubusercontent.com/1075116/42708995-3f3a7afc-86df-11e8-8e1c-b9d5dd5cab35.png)


### Issues Resolved ###

- fixes #2838 

### API Changes ###

N/A

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

`Frame` with `CornerRadius` and a background color will now render properly on UWP.

### PR Checklist ###

- [ ] Has automated tests (visual verification)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
