### PR TITLE
[Android] Improve default Button shadow & size appearance

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1436.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1436.cs
@@ -88,9 +88,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			foreach (var element in stackLayout.Descendants())
 			{
-				//TODO: if (element is Button button)
-				var button = element as Button;
-				if (button != null)
+				if (element is Button button)
 					button.On<Android>().SetUseDefaultPadding(true).SetUseDefaultShadow(true);
 			}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2664.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2664.xaml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue2664"
+			 xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
+			 xmlns:androidWidget="clr-namespace:Android.Widget;assembly=Mono.Android;targetPlatform=Android"
+			 xmlns:formsAndroid="clr-namespace:Xamarin.Forms;assembly=Xamarin.Forms.Platform.Android;targetPlatform=Android">
+	<ContentPage.Content>
+		<StackLayout>
+			<Button BackgroundColor="#d6d7d7"
+					android:Button.UseDefaultShadow="True"
+					android:Button.UseDefaultPadding="True"
+					Text="Forms BG"/>
+
+			<Button BackgroundColor="Default"
+					android:Button.UseDefaultShadow="True"
+					android:Button.UseDefaultPadding="True"
+					Text="Forms Def"/>
+
+			<androidWidget:Button x:Arguments="{x:Static formsAndroid:Forms.Context}"
+							Text="Native" />
+
+		</StackLayout>
+	</ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2664.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2664.xaml.cs
@@ -5,10 +5,15 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if APP
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2664, "", PlatformAffected.Android)]
 	[XamlCompilation(XamlCompilationOptions.Skip)]
 	public partial class Issue2664 : ContentPage
 	{
@@ -17,4 +22,5 @@ namespace Xamarin.Forms.Controls.Issues
 			InitializeComponent ();
 		}
 	}
+#endif
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2664.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2664.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Issue2664 : ContentPage
+	{
+		public Issue2664 ()
+		{
+			InitializeComponent ();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1107,7 +1107,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2664.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -299,6 +299,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1799.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1931.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1399.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2664.xaml.cs">
+      <DependentUpon>Issue2664.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue2187.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3001.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3271.cs" />
@@ -1099,6 +1103,14 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Controls\" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2664.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>

--- a/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
@@ -36,9 +36,8 @@ namespace Xamarin.Forms.Platform.Android
 			set { _paddingTop = value; }
 		}
 
-
-		double BorderWidth => Math.Max(Button.IsSet(BorderElement.BorderWidthProperty) ? BorderElement.BorderWidth : .25, 0);
-		Color BorderColor => Button.IsSet(BorderElement.BorderColorProperty) && BorderElement.BorderColor != Color.Default ? BorderElement.BorderColor : Color.FromHex("#c5c5c5");
+		double BorderWidth => Math.Max(BorderElement.IsBorderWidthSet() ? BorderElement.BorderWidth : .25, 0);
+		Color BorderColor => BorderElement.IsBorderColorSet() && BorderElement.BorderColor != Color.Default ? BorderElement.BorderColor : Color.FromHex("#c5c5c5");
 
 		public BorderDrawable(Func<double, float> convertToPixels, Color defaultColor, bool drawOutlineWithBackground)
 		{
@@ -232,7 +231,7 @@ namespace Xamarin.Forms.Platform.Android
 			using (var paint = new Paint { AntiAlias = true })
 			using (var path = new Path())
 			{
-				float borderWidth = _convertToPixels(Button.BorderWidth);
+				float borderWidth = _convertToPixels(BorderElement.BorderWidth);
 
 				// adjust border radius so outer edge of stroke is same radius as border radius of background
 				float borderRadius = Math.Max(ConvertCornerRadiusToPixels(), 0);

--- a/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		float PaddingLeft
 		{
-			get { return (_paddingLeft / 2f) + _shadowDx; }
+			get { return (_paddingLeft / 2f) + _shadowDx - _shadowRadius; }
 			set { _paddingLeft = value; }
 		}
 
@@ -35,6 +35,10 @@ namespace Xamarin.Forms.Platform.Android
 			get { return (_paddingTop / 2f) + _shadowDy; }
 			set { _paddingTop = value; }
 		}
+
+
+		double BorderWidth => Math.Max(Button.IsSet(BorderElement.BorderWidthProperty) ? BorderElement.BorderWidth : .25, 0);
+		Color BorderColor => Button.IsSet(BorderElement.BorderColorProperty) && BorderElement.BorderColor != Color.Default ? BorderElement.BorderColor : Color.FromHex("#c5c5c5");
 
 		public BorderDrawable(Func<double, float> convertToPixels, Color defaultColor, bool drawOutlineWithBackground)
 		{
@@ -184,22 +188,26 @@ namespace Xamarin.Forms.Platform.Android
 
 		void DrawBackground(Canvas canvas, int width, int height, bool pressed)
 		{
-			var paint = new Paint { AntiAlias = true };
-			var path = new Path();
+			using (var paint = new Paint { AntiAlias = true })
+			using (var path = new Path())
+			{
+				float borderRadius = ConvertCornerRadiusToPixels();
 
-			float borderRadius = ConvertCornerRadiusToPixels();
+				RectF rect = new RectF(0, 0, width, height);
 
-			RectF rect = new RectF(0, 0, width, height);
+				float borderWidth = _convertToPixels(BorderWidth);
+				float inset = borderWidth / 2;
 
-			rect.Inset(PaddingLeft, PaddingTop);
+				rect.Inset(PaddingLeft + inset, PaddingTop + inset);
 
-			path.AddRoundRect(rect, borderRadius, borderRadius, Path.Direction.Cw);
+				path.AddRoundRect(rect, borderRadius, borderRadius, Path.Direction.Cw);
 
-			paint.Color = pressed ? PressedBackgroundColor.ToAndroid() : BackgroundColor.ToAndroid();
-			paint.SetStyle(Paint.Style.Fill);
-			paint.SetShadowLayer(_shadowRadius, _shadowDx, _shadowDy, _shadowColor);
+				paint.Color = pressed ? PressedBackgroundColor.ToAndroid() : BackgroundColor.ToAndroid();
+				paint.SetStyle(Paint.Style.Fill);
+				paint.SetShadowLayer(_shadowRadius, _shadowDx, _shadowDy, _shadowColor);
 
-			canvas.DrawPath(path, paint);
+				canvas.DrawPath(path, paint);
+			}
 		}
 
 		float ConvertCornerRadiusToPixels()
@@ -221,25 +229,21 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void DrawOutline(Canvas canvas, int width, int height)
 		{
-			if (BorderElement.BorderWidth <= 0)
-				return;
-
 			using (var paint = new Paint { AntiAlias = true })
 			using (var path = new Path())
 			{
-				float borderWidth = _convertToPixels(BorderElement.BorderWidth);
-				float inset = borderWidth / 2;
+				float borderWidth = _convertToPixels(Button.BorderWidth);
 
 				// adjust border radius so outer edge of stroke is same radius as border radius of background
-				float borderRadius = Math.Max(ConvertCornerRadiusToPixels() - inset, 0);
+				float borderRadius = Math.Max(ConvertCornerRadiusToPixels(), 0);
 
 				RectF rect = new RectF(0, 0, width, height);
-				rect.Inset(inset + PaddingLeft, inset + PaddingTop);
+				rect.Inset(PaddingLeft + _shadowDx, PaddingTop + _shadowDy);
 
 				path.AddRoundRect(rect, borderRadius, borderRadius, Path.Direction.Cw);
 				paint.StrokeWidth = borderWidth;
 				paint.SetStyle(Paint.Style.Stroke);
-				paint.Color = BorderElement.BorderColor.ToAndroid();
+				paint.Color = BorderColor.ToAndroid();
 
 				canvas.DrawPath(path, paint);
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		float PaddingLeft
 		{
-			get { return (_paddingLeft / 2f) + _shadowDx - _shadowRadius; }
+			get { return (_paddingLeft / 2f) + _shadowDx; }
 			set { _paddingLeft = value; }
 		}
 
@@ -178,35 +178,12 @@ namespace Xamarin.Forms.Platform.Android
 			using (var canvas = new Canvas(bitmap))
 			{
 				DrawBackground(canvas, width, height, pressed);
+
 				if (_drawOutlineWithBackground)
 					DrawOutline(canvas, width, height);
 			}
 
 			return bitmap;
-		}
-
-		void DrawBackground(Canvas canvas, int width, int height, bool pressed)
-		{
-			using (var paint = new Paint { AntiAlias = true })
-			using (var path = new Path())
-			{
-				float borderRadius = ConvertCornerRadiusToPixels();
-
-				RectF rect = new RectF(0, 0, width, height);
-
-				float borderWidth = _convertToPixels(BorderWidth);
-				float inset = borderWidth / 2;
-
-				rect.Inset(PaddingLeft + inset, PaddingTop + inset);
-
-				path.AddRoundRect(rect, borderRadius, borderRadius, Path.Direction.Cw);
-
-				paint.Color = pressed ? PressedBackgroundColor.ToAndroid() : BackgroundColor.ToAndroid();
-				paint.SetStyle(Paint.Style.Fill);
-				paint.SetShadowLayer(_shadowRadius, _shadowDx, _shadowDy, _shadowColor);
-
-				canvas.DrawPath(path, paint);
-			}
 		}
 
 		float ConvertCornerRadiusToPixels()
@@ -226,25 +203,55 @@ namespace Xamarin.Forms.Platform.Android
 			return rect;
 		}
 
-		public void DrawOutline(Canvas canvas, int width, int height)
+		RectF createRect(int width, int height)
+		{
+			RectF rect = new RectF(0, 0, width, height);
+			rect.Inset(PaddingLeft, PaddingTop);
+			return rect;
+		}
+		RectF createRectOutline(int width, int height)
+		{
+			RectF rect = new RectF(0, 0, width, height);
+			float borderWidth = _convertToPixels(BorderWidth);
+			rect.Inset(PaddingLeft, PaddingTop);
+			rect.Inset(borderWidth / 2, borderWidth / 2);
+			return rect;
+		}
+
+		void DrawBackground(Canvas canvas, int width, int height, bool pressed)
 		{
 			using (var paint = new Paint { AntiAlias = true })
 			using (var path = new Path())
 			{
-				float borderWidth = _convertToPixels(BorderElement.BorderWidth);
-
-				// adjust border radius so outer edge of stroke is same radius as border radius of background
 				float borderRadius = Math.Max(ConvertCornerRadiusToPixels(), 0);
 
-				RectF rect = new RectF(0, 0, width, height);
-				rect.Inset(PaddingLeft + _shadowDx, PaddingTop + _shadowDy);
+				RectF rect = createRect(width, height);
+
+				float borderWidth = _convertToPixels(BorderWidth);
+				float inset = borderWidth / 2;
 
 				path.AddRoundRect(rect, borderRadius, borderRadius, Path.Direction.Cw);
+				paint.Color = pressed ? PressedBackgroundColor.ToAndroid() : BackgroundColor.ToAndroid();
+				paint.SetStyle(Paint.Style.Fill);
+				paint.SetShadowLayer(_shadowRadius, _shadowDx, _shadowDy, _shadowColor);
+				canvas.DrawPath(path, paint);
+			}
+		}
+
+		public void DrawOutline(Canvas canvas, int width, int height)
+		{
+			using (var paint = new Paint { AntiAlias = true })
+			{
+				float borderWidth = _convertToPixels(BorderElement.BorderWidth);
+				// adjust border radius so outer edge of stroke is same radius as border radius of background
+				float borderRadius = Math.Max(ConvertCornerRadiusToPixels(), 0);
+				borderRadius = (float)borderRadius - (float)borderWidth / 2.0F;
+
+				RectF rect = createRectOutline(width, height);
 				paint.StrokeWidth = borderWidth;
 				paint.SetStyle(Paint.Style.Stroke);
 				paint.Color = BorderColor.ToAndroid();
-
-				canvas.DrawPath(path, paint);
+				canvas.DrawRoundRect(rect, borderRadius, borderRadius, paint);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

When using the `DefaultPadding` and `DefaultShadow` platform specific properties, Button size and shadow now more closely match the default Android size and shadow. Note that this is not intended to be a pixel perfect match.

#### #2664 Before >> After
<img width="1676" alt="2664" src="https://user-images.githubusercontent.com/7827070/42476403-b3ad87cc-8382-11e8-963e-f0d29a84a8ee.png">

#### #1436 Before >> After
<img width="1125" alt="1436" src="https://user-images.githubusercontent.com/7827070/42476496-fece4ae8-8382-11e8-85aa-2425ea9ba629.png">

**WARNING: This is a visual breaking change from 2.5+.**

### Issues Resolved ###

- meant to fix #2664 

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

- [Android] Buttons now have a slightly different shadow radius that more closely mimics Android's default Button image. 
- [Android] Button shadow color now defaults to a light gray instead of a shade of the Button color. 
- [Android] Button border is drawn outside of the Button instead of on top of it and can increase the size of the Button. 
- [Android] Button width is slightly increased.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
