### PR TITLE
Add missing API check in ScrollViewContainer

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using Android.Content;
+using Android.OS;
 using Android.Views;
 
 namespace Xamarin.Forms.Platform.Android
@@ -50,7 +51,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnChildLayoutChanged(object sender, EventArgs e)
 		{
-			if (IsInLayout)
+			if ((int)Build.VERSION.SdkInt >= 18 && IsInLayout)
 			{
 				return;
 			}


### PR DESCRIPTION
### Description of Change ###

`ScrollViewContainer` was missing an API level check for `IsInLayout`. 

### Issues Resolved ###

- fixes #3186 

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
