### PR TITLE
[UWP] Fix NullRef. in ListViewRenderer.OnCollectionChanged after disposed...

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -154,7 +154,7 @@ namespace Xamarin.Forms.Platform.UWP
 					break;
 			}
 
-			Device.BeginInvokeOnMainThread(() => List.UpdateLayout());
+			Device.BeginInvokeOnMainThread(() => { if (!_disposed) List.UpdateLayout(); });
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
After changing from 3.0 to 3.1 some UWP pages crashes the app with a NullRef. This is because a new Async-Operation was added in ListViewRenderer.OnCollectionChanged accessing the ListView property which may be null after the ListViewRenderer was disposed.

### Platforms Affected ###

- UWP


