### PR TITLE
[UWP] store alert to local variable for thread safety

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43469.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43469.cs
@@ -14,10 +14,10 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Bugzilla, 43469, "Calling DisplayAlert twice in WinRT causes a crash", PlatformAffected.WinRT)]
 	public class Bugzilla43469 : TestContentPage
 	{
-		const string kButtonText = "Click to call DisplayAlert six times";
+		const string kButtonText = "Click to call DisplayAlert six times. Click as fast as you can to close them as they popup to ensure it doesn't crash.";
 		protected override void Init()
 		{
-			var button = new Button { Text = "Click to call DisplayAlert six times" };
+			var button = new Button { Text = kButtonText };
 
 			button.Clicked += async (sender, args) =>
 			{

--- a/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/PlatformUWP.cs
@@ -104,9 +104,11 @@ namespace Xamarin.Forms.Platform.UWP
 			if (options.Accept != null)
 				alertDialog.PrimaryButtonText = options.Accept;
 
-			while (s_currentAlert != null)
+			var currentAlert = s_currentAlert;
+			while (currentAlert != null)
 			{
-				await s_currentAlert;
+				await currentAlert;
+				currentAlert = s_currentAlert;
 			}
 
 			s_currentAlert = ShowAlert(alertDialog);


### PR DESCRIPTION
### Description of Change ###

The while loop on s_currentAlert wasn't thread safe so it could be set to null between the check and the await which meant it would be awaiting on null and throw an exception.

Added text to description but the clicking to cause the issue has to happen too quickly for the UI test to detect

### Issues Resolved ###
- fixes #3250 


### Platforms Affected ###
- UWP


### PR Checklist ###

- [ ] Has automated tests 
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
