### PR TITLE
[WPF] Fixes title in Page.DisplayActionSheet

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Themes/FormsContentDialog.xaml
+++ b/Xamarin.Forms.Platform.WPF/Themes/FormsContentDialog.xaml
@@ -9,11 +9,11 @@
 
     <DataTemplate x:Key="TitleDefaultTemplate" >
         <TextBlock DataContext="{Binding}" 
-                   Text="{Binding Converter={StaticResource ToUpperConverter}}" 
+                   Text="{Binding}"
                    FontFamily="Segoe UI"
                    FontSize="26"
                    TextOptions.TextFormattingMode="Ideal"
-                   TextTrimming="CharacterEllipsis"
+                   TextWrapping="WrapWithOverflow"
                    Foreground="Black"/>
     </DataTemplate>
 


### PR DESCRIPTION
### Description of Change ###

Fixes title at Page.DisplayActionSheet

### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3259 

### API Changes ###

None

### Platforms Affected ###

- WPF

### Behavioral/Visual Changes ###

The title in the Page.DisplayActionSheet text wraps now and the is not in uppercase.
![image](https://user-images.githubusercontent.com/27482193/42519317-7379728e-846c-11e8-9ff0-0740722aca38.png)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
