### PR TITLE
[WPF] Fix ItemTapped event in a ListView

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ListViewRenderer.cs
@@ -44,7 +44,10 @@ namespace Xamarin.Forms.Platform.WPF
 						Style = (System.Windows.Style)System.Windows.Application.Current.Resources["ListViewTemplate"]
 					};
 					SetNativeControl(listView);
-					Control.SelectionChanged += OnNativeSelectionChanged;
+					Control.MouseUp += OnNativeMouseUp;
+					Control.KeyUp += OnNativeKeyUp;
+					Control.TouchUp += OnNativeTouchUp;
+					Control.StylusUp += OnNativeStylusUp;
 				}
 				
 				// Update control property 
@@ -122,12 +125,17 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 		}
 
+		void OnNativeKeyUp(object sender, KeyEventArgs e)
+			=> Element.NotifyRowTapped(Control.SelectedIndex, cell: null);
 
-		
-		void OnNativeSelectionChanged(object sender, SelectionChangedEventArgs e)
-		{
-			Element.NotifyRowTapped(Control.SelectedIndex, cell:null);
-		}
+		void OnNativeMouseUp(object sender, MouseButtonEventArgs e)
+			=> Element.NotifyRowTapped(Control.SelectedIndex, cell: null);
+
+		void OnNativeTouchUp(object sender, TouchEventArgs e)
+			=> Element.NotifyRowTapped(Control.SelectedIndex, cell: null);
+
+		void OnNativeStylusUp(object sender, StylusEventArgs e)
+			=> Element.NotifyRowTapped(Control.SelectedIndex, cell: null);
 
 		bool _isDisposed;
 
@@ -140,7 +148,10 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				if (Control != null)
 				{
-					Control.SelectionChanged -= OnNativeSelectionChanged;
+					Control.MouseUp -= OnNativeMouseUp;
+					Control.KeyUp -= OnNativeKeyUp;
+					Control.TouchUp -= OnNativeTouchUp;
+					Control.StylusUp -= OnNativeStylusUp;
 				}
 
 				if (Element != null)


### PR DESCRIPTION
### Description of Change ###

When you tap the selected item in a ListView, ItemTapped is not raised, because it raised only when on native control changed item index. This behavior has been replaced to listening to native events `MouseUp`, `KeyUp`, `StylusUp`, `TouchUp`.

### Issues Resolved ###

- fixes #3265

### API Changes ###

<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem -->

### Platforms Affected ###

- WPF

### Behavioral/Visual Changes ###

Event `ListView.ItemTapped` is raised whether the item was selected or not.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
