### PR TITLE
CSS xf- Vendor Prefix

### DIFF
--- a/Xamarin.Forms.Core/ActivityIndicator.cs
+++ b/Xamarin.Forms.Core/ActivityIndicator.cs
@@ -1,5 +1,9 @@
 using System;
+using Xamarin.Forms;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-color", typeof(ActivityIndicator), nameof(ActivityIndicator.ColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/BoxView.cs
+++ b/Xamarin.Forms.Core/BoxView.cs
@@ -1,5 +1,9 @@
 using System;
+using Xamarin.Forms;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-color", typeof(BoxView), nameof(BoxView.ColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -2,8 +2,14 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-border-width", typeof(Button), nameof(Button.BorderWidthProperty))]
+[assembly: StyleProperty("-xf-border-color", typeof(Button), nameof(Button.BorderColorProperty))]
+[assembly: StyleProperty("-xf-corner-radius", typeof(Button), nameof(Button.CornerRadiusProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -1,7 +1,13 @@
 using System;
 using System.ComponentModel;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-color", typeof(Editor), nameof(Editor.TextColorProperty))]
+[assembly: StyleProperty("-xf-placeholder", typeof(Editor), nameof(Editor.PlaceholderProperty))]
+[assembly: StyleProperty("-xf-placeholder-color", typeof(Editor), nameof(Editor.PlaceholderColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -1,8 +1,14 @@
 using System;
 using System.ComponentModel;
 using System.Windows.Input;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-color", typeof(Entry), nameof(Entry.TextColorProperty))]
+[assembly: StyleProperty("-xf-placeholder", typeof(Entry), nameof(Entry.PlaceholderProperty))]
+[assembly: StyleProperty("-xf-placeholder-color", typeof(Entry), nameof(Entry.PlaceholderColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/Grid.cs
+++ b/Xamarin.Forms.Core/Grid.cs
@@ -3,7 +3,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-row-spacing", typeof(Grid), nameof(Grid.RowSpacingProperty))]
+[assembly: StyleProperty("-xf-column-spacing", typeof(Grid), nameof(Grid.ColumnSpacingProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/InputView.cs
+++ b/Xamarin.Forms.Core/InputView.cs
@@ -1,3 +1,8 @@
+using Xamarin.Forms;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-max-length", typeof(InputView), nameof(InputView.MaxLengthProperty))]
+
 namespace Xamarin.Forms
 {
 	public class InputView : View

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -4,8 +4,12 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-vertical-text-alignment", typeof(Label), nameof(Label.VerticalTextAlignmentProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -4,8 +4,13 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-bar-background-color", typeof(NavigationPage), nameof(NavigationPage.BarBackgroundColorProperty))]
+[assembly: StyleProperty("-xf-bar-text-color", typeof(NavigationPage), nameof(NavigationPage.BarTextColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/ProgressBar.cs
+++ b/Xamarin.Forms.Core/ProgressBar.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Threading.Tasks;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-color", typeof(ProgressBar), nameof(ProgressBar.ProgressColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/ScrollView.cs
+++ b/Xamarin.Forms.Core/ScrollView.cs
@@ -1,8 +1,14 @@
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-orientation", typeof(ScrollView), nameof(ScrollView.OrientationProperty))]
+[assembly: StyleProperty("-xf-horizontal-scroll-bar-visibility", typeof(ScrollView), nameof(ScrollView.HorizontalScrollBarVisibilityProperty))]
+[assembly: StyleProperty("-xf-vertical-scroll-bar-visibility", typeof(ScrollView), nameof(ScrollView.VerticalScrollBarVisibilityProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/SearchBar.cs
+++ b/Xamarin.Forms.Core/SearchBar.cs
@@ -1,8 +1,13 @@
 using System;
 using System.ComponentModel;
 using System.Windows.Input;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-placeholder-color", typeof(SearchBar), nameof(SearchBar.PlaceholderColorProperty))]
+[assembly: StyleProperty("-xf-cancel-button-color", typeof(SearchBar), nameof(SearchBar.CancelButtonColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/Slider.cs
+++ b/Xamarin.Forms.Core/Slider.cs
@@ -1,6 +1,12 @@
 using System;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-min-track-color", typeof(Slider), nameof(Slider.MinimumTrackColorProperty))]
+[assembly: StyleProperty("-xf-max-track-color", typeof(Slider), nameof(Slider.MaximumTrackColorProperty))]
+[assembly: StyleProperty("-xf-thumb-color", typeof(Slider), nameof(Slider.ThumbColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -1,5 +1,9 @@
 using System;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-color", typeof(Span), nameof(Span.BackgroundColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/StackLayout.cs
+++ b/Xamarin.Forms.Core/StackLayout.cs
@@ -1,6 +1,11 @@
 using System;
 using System.ComponentModel;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-spacing", typeof(StackLayout), nameof(StackLayout.SpacingProperty))]
+[assembly: StyleProperty("-xf-orientation", typeof(StackLayout), nameof(StackLayout.OrientationProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/Switch.cs
+++ b/Xamarin.Forms.Core/Switch.cs
@@ -1,5 +1,9 @@
 using System;
+using XSwitch = Xamarin.Forms.Switch;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-color", typeof(XSwitch), nameof(XSwitch.OnColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/TabbedPage.cs
+++ b/Xamarin.Forms.Core/TabbedPage.cs
@@ -1,5 +1,10 @@
 using System;
+using Xamarin.Forms;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-bar-background-color", typeof(TabbedPage), nameof(TabbedPage.BarBackgroundColorProperty))]
+[assembly: StyleProperty("-xf-bar-text-color", typeof(TabbedPage), nameof(TabbedPage.BarTextColorProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/TableView.cs
+++ b/Xamarin.Forms.Core/TableView.cs
@@ -4,6 +4,10 @@ using System.ComponentModel;
 using System.Linq;
 using Xamarin.Forms.Platform;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.StyleSheets;
+using Xamarin.Forms;
+
+[assembly: StyleProperty("-xf-row-height", typeof(TableView), nameof(TableView.RowHeightProperty))]
 
 namespace Xamarin.Forms
 {

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -1,7 +1,20 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.StyleSheets;
+
+[assembly: StyleProperty("-xf-anchor-x", typeof(VisualElement), nameof(VisualElement.AnchorXProperty))]
+[assembly: StyleProperty("-xf-anchor-y", typeof(VisualElement), nameof(VisualElement.AnchorYProperty))]
+[assembly: StyleProperty("-xf-translation-x", typeof(VisualElement), nameof(VisualElement.TranslationXProperty))]
+[assembly: StyleProperty("-xf-translation-y", typeof(VisualElement), nameof(VisualElement.TranslationYProperty))]
+[assembly: StyleProperty("-xf-rotation", typeof(VisualElement), nameof(VisualElement.RotationProperty))]
+[assembly: StyleProperty("-xf-rotation-x", typeof(VisualElement), nameof(VisualElement.RotationXProperty))]
+[assembly: StyleProperty("-xf-rotation-y", typeof(VisualElement), nameof(VisualElement.RotationYProperty))]
+[assembly: StyleProperty("-xf-scale", typeof(VisualElement), nameof(VisualElement.ScaleProperty))]
+[assembly: StyleProperty("-xf-scale-x", typeof(VisualElement), nameof(VisualElement.ScaleXProperty))]
+[assembly: StyleProperty("-xf-scale-y", typeof(VisualElement), nameof(VisualElement.ScaleYProperty))]
 
 namespace Xamarin.Forms
 {


### PR DESCRIPTION
### Description of Change ###

Add Xamarin.Forms vendor specific css properties. 

Implements #2891. 

### Issues Resolved ###

fixes #2891

### API Changes ###

See the custom attributes applied to `GreenVenderSpecificStyleSheetsAreApplied` unit test. 

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

Allows css binding to more XF BPs. 

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
