### PR TITLE
[Android] Prevent white flash when switching MainPage to new MasterDetailPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1601.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1601.cs
@@ -49,7 +49,9 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.Screenshot("Start G1601");
 			RunningApp.WaitForElement(q => q.Marked("CRASH!"));
+			RunningApp.Screenshot("I see the button");
 			RunningApp.Tap (q => q.Marked ("CRASH!"));
+			RunningApp.Screenshot("Didn't crash!");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Controls
 			SetMainPage(new Bugzilla44596SplashPage(async () =>
 			{
 				var newTabbedPage = new TabbedPage();
-				newTabbedPage.Children.Add(new ContentPage { BackgroundColor = Color.Red, Content = new Label { Text = "yay" } });
+				newTabbedPage.Children.Add(new ContentPage { BackgroundColor = Color.Red, Content = new Label { Text = "Success" } });
 				MainPage = new MasterDetailPage
 				{
 					Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
@@ -116,8 +116,7 @@ namespace Xamarin.Forms.Controls
 					string page = parts[1].Trim();
 					var pageForms = Activator.CreateInstance(Type.GetType(page));
 
-					var appLinkPageGallery = pageForms as AppLinkPageGallery;
-					if (appLinkPageGallery != null)
+					if (pageForms is AppLinkPageGallery appLinkPageGallery)
 					{
 						appLinkPageGallery.ShowLabel = true;
 						(MainPage as MasterDetailPage)?.Detail.Navigation.PushAsync((pageForms as Page));
@@ -171,8 +170,7 @@ namespace Xamarin.Forms.Controls
 
 		static async Task<string> LoadResource(string filename)
 		{
-			string assemblystring;
-			Assembly assembly = GetAssembly(out assemblystring);
+			Assembly assembly = GetAssembly(out string assemblystring);
 
 			Stream stream = assembly.GetManifestResourceStream($"{assemblystring}.{filename}");
 			string text;
@@ -191,9 +189,9 @@ namespace Xamarin.Forms.Controls
 				// Set up a delegate to handle the navigation to the test page
 				EventHandler toTestPage = null;
 
-				toTestPage = delegate (object sender, EventArgs e)
+				toTestPage = async delegate (object sender, EventArgs e)
 				{
-					Current.MainPage.Navigation.PushModalAsync(TestCases.GetTestCases());
+					await Current.MainPage.Navigation.PushModalAsync(TestCases.GetTestCases());
 					TestCases.TestCaseScreen.PageToAction[test]();
 					Current.MainPage.Appearing -= toTestPage;
 				};

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -32,9 +32,14 @@ namespace Xamarin.Forms.Controls
 
 			SetMainPage(CreateDefaultMainPage());
 
-			//TestBugzilla44596();
+			TestMainPageSwitches();
+		}
 
-			//TestBugzilla45702();
+		async Task TestMainPageSwitches()
+		{
+			await TestBugzilla45702();
+
+			await TestBugzilla44596();
 		}
 
 		protected override void OnStart()
@@ -42,10 +47,11 @@ namespace Xamarin.Forms.Controls
 			//TestIssue2393();
 		}
 
-		void TestBugzilla44596()
+		async Task TestBugzilla44596()
 		{
+			await Task.Delay(50);
 			// verify that there is no gray screen displayed between the blue splash and red MasterDetailPage.
-			SetMainPage(new Bugzilla44596SplashPage(() =>
+			SetMainPage(new Bugzilla44596SplashPage(async () =>
 			{
 				var newTabbedPage = new TabbedPage();
 				newTabbedPage.Children.Add(new ContentPage { BackgroundColor = Color.Red, Content = new Label { Text = "yay" } });
@@ -54,11 +60,15 @@ namespace Xamarin.Forms.Controls
 					Master = new ContentPage { Title = "Master", BackgroundColor = Color.Red },
 					Detail = newTabbedPage
 				};
+
+				await Task.Delay(50);
+				SetMainPage(CreateDefaultMainPage());
 			}));
 		}
 
-		void TestBugzilla45702()
+		async Task TestBugzilla45702()
 		{
+			await Task.Delay(50);
 			// verify that there is no crash when switching MainPage from MDP inside NavPage
 			SetMainPage(new Bugzilla45702());
 		}

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -32,14 +32,7 @@ namespace Xamarin.Forms.Controls
 
 			SetMainPage(CreateDefaultMainPage());
 
-			TestMainPageSwitches();
-		}
-
-		async Task TestMainPageSwitches()
-		{
-			await TestBugzilla45702();
-
-			await TestBugzilla44596();
+			//TestMainPageSwitches();
 		}
 
 		protected override void OnStart()
@@ -82,6 +75,13 @@ namespace Xamarin.Forms.Controls
 			view.Navigated += (s, e) => MainPage.DisplayAlert("Navigated", $"If this popup appears multiple times, this test has failed", "ok"); ;
 
 			MainPage.Navigation.PushAsync(new ContentPage { Content = view, Title = "Issue 2393" });
+		}
+
+		async Task TestMainPageSwitches()
+		{
+			await TestBugzilla45702();
+
+			await TestBugzilla44596();
 		}
 
 		public Page CreateDefaultMainPage()

--- a/Xamarin.Forms.Controls/Bugzilla44596SplashPage.cs
+++ b/Xamarin.Forms.Controls/Bugzilla44596SplashPage.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Controls
 		protected async override void OnAppearing()
 		{
 			base.OnAppearing();
-			await Task.Delay(2000);
+			await Task.Delay(500);
 			FinishedLoading?.Invoke();
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -116,22 +116,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				transaction.CommitAllowingStateLossEx();
 
 				_currentFragment = fragment;
-
-				new Handler(Looper.MainLooper).PostAtFrontOfQueue(() =>
-				{
-					// NOTE: If we delay ExecutePendingTransactions in any way in order to wait for the _pageContainer to be created,
-					// then we regress 44596/1373 by introducing the white screen flashing between main page changes to an MDP.
-					// However, we may need to restore this null check if we see crashes happening again.
-#if MASTERDETAILPAGECRASHES
-					if (_pageContainer == null)
-					{
-						// The view we're hosting in the fragment was never created (possibly we're already 
-						// navigating to another page?) so there's nothing to commit
-						return;
-					}
-#endif
-					FragmentManager.ExecutePendingTransactionsEx();
-				});
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -121,7 +121,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					// NOTE: If we delay ExecutePendingTransactions in any way in order to wait for the _pageContainer to be created,
 					// then we regress 44596/1373 by introducing the white screen flashing between main page changes to an MDP.
-
+					// However, we may need to restore this null check if we see crashes happening again.
+#if MASTERDETAILPAGECRASHES
+					if (_pageContainer == null)
+					{
+						// The view we're hosting in the fragment was never created (possibly we're already 
+						// navigating to another page?) so there's nothing to commit
+						return;
+					}
+#endif
 					FragmentManager.ExecutePendingTransactionsEx();
 				});
 			}

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -119,12 +119,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				new Handler(Looper.MainLooper).PostAtFrontOfQueue(() =>
 				{
-					if (_pageContainer == null)
-					{
-						// The view we're hosting in the fragment was never created (possibly we're already 
-						// navigating to another page?) so there's nothing to commit
-						return;
-					}
+					// NOTE: If we delay ExecutePendingTransactions in any way in order to wait for the _pageContainer to be created,
+					// then we regress 44596/1373 by introducing the white screen flashing between main page changes to an MDP.
 
 					FragmentManager.ExecutePendingTransactionsEx();
 				});

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -206,6 +206,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void IPlatformLayout.OnLayout(bool changed, int l, int t, int r, int b)
 		{
+			if (Page == null)
+				return;
+
 			if (changed)
 			{
 				LayoutRootPage(Page, r - l, b - t);
@@ -287,6 +290,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		}
 		void AddChild(Page page, bool layout = false)
 		{
+			if (page == null)
+				return;
+
 			if (Android.Platform.GetRenderer(page) != null)
 				return;
 


### PR DESCRIPTION
### Description of Change ###

#421 resolved this issue once, but it was regressed by #865, presumably because it was causing crashes when the MainPage was quickly swapped out because the `FragmentContainer` was not initialized properly. 

Instead of calling `ExecutePendingTransactions` to try to get the transition to happen quickly and in the proper order, we are now explicitly waiting to remove any views from the main ViewGroup until the new views have been added and are ready to display. This should eliminate that flicker and avoid any side effects from the `ExecutePendingTransactions` call altogether.

### Issues Resolved ###

- fixes #1373

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

OnAppearing and OnDisappearing events to fire in a different order when swapping out the MainPage.

This PR
```
OnAppearing: Page1
OnAppearing: Page2
OnDisappearing: Page1
```

Before PR
```
OnAppearing: Page1
OnDisappearing: Page1
OnAppearing: Page2
```

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
