### PR TITLE
[iOS] Prevent crash when a leaked cell has MenuItem with bindings

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -630,7 +630,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return null;
 		}
 
-		void SetupSelection(UITableView table)
+		static void SetupSelection(UITableView table)
 		{
 			if (table.GestureRecognizers == null)
 				return;
@@ -642,7 +642,7 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 			}
 
-			_tableView.AddGestureRecognizer(new SelectGestureRecognizer());
+			table.AddGestureRecognizer(new SelectGestureRecognizer());
 		}
 
 		class SelectGestureRecognizer : UITapGestureRecognizer

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -632,6 +632,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void SetupSelection(UITableView table)
 		{
+			if (table.GestureRecognizers == null)
+				return;
+
 			for (var i = 0; i < table.GestureRecognizers.Length; i++)
 			{
 				var r = table.GestureRecognizers[i] as SelectGestureRecognizer;


### PR DESCRIPTION
### Description of Change ###

Prevent NRE and crash when a leaked cell in ListView with Recycle mode has MenuItem with bindings and framework like Prism.Forms sets BindingContext to null after leaving the page. Leaked cells can appear as result of device orientation change plus scrolling or just ListView.ScrollTo call.

### Issues Resolved ###

- fixes the crash but not underlying cell leak, see #3275

### API Changes ###

N/A

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###

N/A

### PR Checklist ###

- [ ] Has automated tests <!-- Quite hard to reproduce, see related Issue #3275 -->
- [ x] Rebased on top of the target branch at time of PR
- [ x] Changes adhere to coding standard
