### PR TITLE
[UWP] Fix incorrect style for PageControl when not the application root

### DIFF
--- a/Xamarin.Forms.Platform.UAP/PageControl.cs
+++ b/Xamarin.Forms.Platform.UAP/PageControl.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.UWP
 	    		
 		public PageControl()
 		{
-			DefaultStyleKey = typeof(PageControl);
+			Style = Windows.UI.Xaml.Application.Current.Resources["DefaultPageControlStyle"] as Windows.UI.Xaml.Style;
 		}
 
 		public string BackButtonTitle

--- a/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
@@ -2,9 +2,7 @@
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:uwp="using:Xamarin.Forms.Platform.UWP">
-	<!-- The x:Key below looks like it's never used, but it's load-bearing.
-	For some reason, PageControl can't just find this style via the default style key type if it's the root page of the
-	application unless we also give it a key. Hopefully a wiser soul than I will someday resolve this. -->
+
 	<Style TargetType="uwp:PageControl" x:Key="DefaultPageControlStyle">
 		<Setter Property="ContentMargin" Value="0" />
 		<Setter Property="TitleBrush" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />


### PR DESCRIPTION
### Description of Change ###

The fix for issue #1483 (PR #3074) made PageControl unable to find the correct ControlTemplate when it wasn't the root page of the application. This change makes PageControl find the correct template in both situations.

No tests, for the same reason there are no tests for PR #3074.

### Issues Resolved ###

- fixes #3297

### API Changes ###

None

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
