### PR TITLE
[iOS] Implement `ForceUpdateSize` for `TableView`

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2842.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2842.cs
@@ -1,0 +1,73 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+	[Category(UITestCategories.TableView)]
+	[Category(UITestCategories.Cells)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2842, "ViewCell in TableView not adapting to changed size on iOS", PlatformAffected.iOS)]
+	public class Issue2842 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var grid = new Grid
+			{
+				Padding = 10,
+				ColumnDefinitions = { new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) } },
+				RowDefinitions = { new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) } }
+			};
+
+			grid.Children.Add(new Label { Text = "I am initially visible." }, 0, 0);
+
+			Label target = new Label { Text = "Success", AutomationId = "lblSuccess", IsVisible = false, TextColor = Color.Red };
+
+			grid.Children.Add(target, 0, 1);
+
+			var tableView = new TableView { HasUnevenRows = true, Intent = TableIntent.Settings };
+
+			ViewCell viewCell = new ViewCell { View = grid };
+			TableSection item = new TableSection
+			{
+				viewCell,
+				new ImageCell {  ImageSource = "cover1.jpg" }
+			};
+
+			tableView.Root.Add(item);
+
+			var button = new Button
+			{
+				Text = "Click me",
+				AutomationId = "btnClick",
+				Command = new Command(() =>
+				{
+					target.IsVisible = true;
+					viewCell.ForceUpdateSize();
+				})
+			};
+
+			var label = new Label { Text = "Tap the button to expand the cell. If the cell does not expand and the red text is on top of the image, this test has failed." };
+
+			Content = new StackLayout { Children = { label, button, tableView }, Margin = 20 };
+		}
+
+#if UITEST
+		[Test]
+		public void Issue2842Test() 
+		{
+			RunningApp.WaitForElement (q => q.Marked ("btnClick"));
+			RunningApp.Tap (q => q.Marked ("btnClick"));
+			RunningApp.Screenshot ("Verify that the text is not on top of the image");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -475,6 +475,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2837.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2740.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1939.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2842.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -28,6 +28,7 @@
 		public const string Slider = "Slider";
 		public const string Stepper = "Stepper";
 		public const string Switch = "Switch";
+		public const string TableView = "TableView";
 		public const string TimePicker = "TimePicker";
 		public const string ToolbarItem = "ToolbarItem";
 		public const string WebView = "WebView";

--- a/Xamarin.Forms.Core/Cells/Cell.cs
+++ b/Xamarin.Forms.Core/Cells/Cell.cs
@@ -109,7 +109,7 @@ namespace Xamarin.Forms
 			if (_nextCallToForceUpdateSizeQueued)
 				return;
 
-			if ((Parent as ListView)?.HasUnevenRows == true)
+			if ((Parent as ListView)?.HasUnevenRows == true || (Parent as TableView)?.HasUnevenRows == true)
 			{
 				_nextCallToForceUpdateSizeQueued = true;
 				OnForceUpdateSizeRequested();

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
@@ -9,6 +9,8 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		readonly Dictionary<nint, Cell> _headerCells = new Dictionary<nint, Cell>();
 
+		EventHandler _onForceUpdateSizeRequested;
+
 		protected bool HasBoundGestures;
 		protected UITableView Table;
 
@@ -32,6 +34,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var cell = View.Model.GetCell(indexPath.Section, indexPath.Row);
 
 			var nativeCell = CellTableViewCell.GetNativeCell(tableView, cell);
+
+			WireUpForceUpdateSizeRequested(cell, nativeCell, tableView);
+
 			return nativeCell;
 		}
 
@@ -98,6 +103,20 @@ namespace Xamarin.Forms.Platform.iOS
 		public override string TitleForHeader(UITableView tableView, nint section)
 		{
 			return View.Model.GetSectionTitle((int)section);
+		}
+
+		protected void WireUpForceUpdateSizeRequested(ICellController cell, UITableViewCell nativeCell, UITableView tableView)
+		{
+			cell.ForceUpdateSizeRequested -= _onForceUpdateSizeRequested;
+
+			_onForceUpdateSizeRequested = (sender, e) =>
+			{
+				var index = tableView?.IndexPathForCell(nativeCell) ?? (sender as Cell)?.GetIndexPath();
+				if (index != null)
+					tableView.ReloadRows(new[] { index }, UITableViewRowAnimation.None);
+			};
+
+			cell.ForceUpdateSizeRequested += _onForceUpdateSizeRequested;
 		}
 
 		void BindGestures(UITableView tableview)


### PR DESCRIPTION
### Description of Change ###

`TableView` cells implicitly update size on Android and UWP, but we must force them on iOS. This implements the same pattern used for `ListView`'s `ForceUpdateSize` on `TableView`.

Note that since this drastically reduces performance, you must explicitly call `ForceUpdateSize` on a cell to update its size.

### Issues Resolved ###

- fixes #2842

### API Changes ###

Added:
- iOS `TableViewModelRenderer`  `protected void WireUpForceUpdateSizeRequested`

### Platforms Affected ###

- Core (all platforms)
- iOS

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
