### PR TITLE
[UWP] Fixes throws NullReferenceException on empty NavigationPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2102.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2102.cs
@@ -1,0 +1,15 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2102, "Empty NavigationPage throws NullReferenceException", PlatformAffected.UWP)]
+	public class Issue2102 : TestTabbedPage
+	{
+		protected override void Init()
+		{
+			Children.Add(new NavigationPage { Title = "Success" });
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
       <DependentUpon>Bugzilla60787.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2102.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1588.xaml.cs">
       <DependentUpon>Issue1588.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -634,7 +634,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		async void UpdateTitleOnParents()
 		{
-			if (Element == null)
+			if (Element == null || _currentPage == null)
 				return;
 
 			ITitleProvider render = null;


### PR DESCRIPTION
### Description of Change ###

Fixes throws NullReferenceException on empty NavigationPage

### Issues Resolved ###

- fixes #2102

### Testing procedure ###

- start UITest 2102 in ControlGallery
- the application shouldn't throw an exception

### API Changes ###

/

### Platforms Affected ###

- UWP

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
