### PR TITLE
Adding index check to PageController.InternalChildren

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -600,7 +600,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (_masterDetailPage == null)
 			{
-				_masterDetailPage = PageController.InternalChildren[0] as MasterDetailPage;
+				if (PageController.InternalChildren.Count > 0)
+					_masterDetailPage = PageController.InternalChildren[0] as MasterDetailPage;
+
 				if (_masterDetailPage == null)
 					return;
 			}


### PR DESCRIPTION
If `RegisterToolbar` is called before the page has `InternalChildren` setup, an `ArgumentOutOfRange` exception will thrown when the first child is retrieved to check for a `MasterDetailPage`.

### Description of Change ###

Add count check to `PageController.InternalChildren` in `RegisterToolbar` to make sure at least one is present before getting it.

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

None.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x ] Changes adhere to coding standard
