### PR TITLE
BackButtonTitleProperty isn't used by android

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -332,8 +332,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateToolbar();
 			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName)
 				UpdateToolbar();
-			else if (e.PropertyName == NavigationPage.BackButtonTitleProperty.PropertyName)
-				UpdateToolbar();
 			else if (e.PropertyName == BarHeightProperty.PropertyName)
 				UpdateToolbar();
 		}


### PR DESCRIPTION
### Description of Change ###

BackButtonTitleProperty  isn't used by Android so when it's changed Android shouldn't call *UpdateToolBar*

### Platforms Affected ###
- Android

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
