### PR TITLE
[UWP] add null check to Listview layout update in case it's been disposed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3333.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3333.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3333, "[UWP] with ListView on page, Navigation.PopAsync() throws exception",
+		PlatformAffected.UWP)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.Navigation)]
+#endif
+	public class Issue3333 : TestNavigationPage
+	{
+		const string kSuccess = "If you're reading this the test has passed";
+		protected override void Init()
+		{
+			var testPage = new TestPage();
+			this.Navigation.PushAsync(testPage);
+		}
+
+		[Preserve(AllMembers = true)]
+		public partial class TestPage : ContentPage
+		{
+			Label content = new Label();
+			public TestPage()
+			{
+				Title = "Page 1";
+				Navigation.PushAsync(new TestPage2());
+				Content = content;
+			}
+
+			protected override void OnAppearing()
+			{
+				if (content.Text == string.Empty)
+				{
+					content.Text = "Hold Please";
+				}
+				else
+				{
+					content.Text = kSuccess;
+				}
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class TestPage2 : ContentPage
+		{
+			public List<string> Items
+			{
+				get { return new List<string> { "Test1", "Test2", "Test3" }; }
+			}
+
+			public TestPage2()
+			{
+				BindingContext = this;
+				ListView listView = new ListView();
+				listView.SetBinding(ListView.ItemsSourceProperty, "Items");
+
+				Content =
+					new StackLayout()
+					{
+						Children =
+						{
+							new ScrollView()
+							{
+								Content = listView
+							}
+						}
+					};
+
+				Device.BeginInvokeOnMainThread(async () =>
+				{
+					BindingContext = null;
+					await Navigation.PopAsync();
+				});
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void SettingBindingContextToNullBeforingPoppingPageCrashes()
+		{
+			RunningApp.WaitForElement(kSuccess);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3333.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60045.xaml.cs">
       <DependentUpon>Bugzilla60045.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -154,7 +154,7 @@ namespace Xamarin.Forms.Platform.UWP
 					break;
 			}
 
-			Device.BeginInvokeOnMainThread(() => List.UpdateLayout());
+			Device.BeginInvokeOnMainThread(() => List?.UpdateLayout());
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###
Add a null check in case the List is null

### Issues Resolved ###
- fixes #3333 

### Platforms Affected ###
- UWP

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
