### PR TITLE
[iOS] Remove iOS Platform Casts

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -136,10 +136,7 @@ namespace Xamarin.Forms.Platform.iOS
 					IVisualElementRenderer renderer;
 					if (_rendererRef != null && _rendererRef.TryGetTarget(out renderer) && renderer.Element != null)
 					{
-						var platform = renderer.Element.Platform as Platform;
-						if (platform != null)
-							platform.DisposeModelAndChildrenRenderers(renderer.Element);
-
+						renderer.Element.DisposeModalAndChildRenderers();
 						_rendererRef = null;
 					}
 
@@ -191,8 +188,8 @@ namespace Xamarin.Forms.Platform.iOS
 					{
 						//when cells are getting reused the element could be already set to another cell
 						//so we should dispose based on the renderer and not the renderer.Element
-						var platform = renderer.Element.Platform as Platform;
-						platform.DisposeRendererAndChildren(renderer);
+						renderer.DisposeRendererAndChildren();
+
 						renderer = GetNewRenderer();
 					}
 				}

--- a/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
@@ -1,0 +1,52 @@
+namespace Xamarin.Forms.Platform.iOS
+{
+	internal static class DisposeHelpers
+	{
+		internal static void DisposeModalAndChildRenderers(this Element view)
+		{
+			IVisualElementRenderer renderer;
+
+			foreach (VisualElement child in view.Descendants())
+			{
+				renderer = Platform.GetRenderer(child);
+				child.ClearValue(Platform.RendererProperty);
+
+				if (renderer != null)
+				{
+					renderer.NativeView.RemoveFromSuperview();
+					renderer.Dispose();
+				}
+			}
+
+			renderer = Platform.GetRenderer((VisualElement)view);
+			if (renderer != null)
+			{
+				if (renderer.ViewController?.ParentViewController is ModalWrapper modalWrapper)
+					modalWrapper.Dispose();
+
+				renderer.NativeView.RemoveFromSuperview();
+				renderer.Dispose();
+			}
+			view.ClearValue(Platform.RendererProperty);
+		}
+
+		internal static void DisposeRendererAndChildren(this IVisualElementRenderer rendererToRemove)
+		{
+			if (rendererToRemove == null)
+				return;
+
+			if (rendererToRemove.Element != null && Platform.GetRenderer(rendererToRemove.Element) == rendererToRemove)
+				rendererToRemove.Element.ClearValue(Platform.RendererProperty);
+
+			var subviews = rendererToRemove.NativeView.Subviews;
+			for (var i = 0; i < subviews.Length; i++)
+			{
+				if (subviews[i] is IVisualElementRenderer childRenderer)
+					DisposeRendererAndChildren(childRenderer);
+			}
+
+			rendererToRemove.NativeView.RemoveFromSuperview();
+			rendererToRemove.Dispose();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -81,9 +81,9 @@ namespace Xamarin.Forms.Platform.iOS
 			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
 			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
 
-			DisposeModelAndChildrenRenderers(Page);
+			Page.DisposeModalAndChildRenderers();
 			foreach (var modal in _modals)
-				DisposeModelAndChildrenRenderers(modal);
+				modal.DisposeModalAndChildRenderers();
 
 			_renderer.Dispose();
 		}
@@ -131,7 +131,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				await _renderer.DismissViewControllerAsync(animated);
 
-			DisposeModelAndChildrenRenderers(modal);
+			modal.DisposeModalAndChildRenderers();
 
 			return modal;
 		}
@@ -223,57 +223,6 @@ namespace Xamarin.Forms.Platform.iOS
 			_animateModals = true;
 		}
 
-		internal void DisposeModelAndChildrenRenderers(Element view)
-		{
-			IVisualElementRenderer renderer;
-			foreach (VisualElement child in view.Descendants())
-			{
-				renderer = GetRenderer(child);
-				child.ClearValue(RendererProperty);
-
-				if (renderer != null)
-				{
-					renderer.NativeView.RemoveFromSuperview();
-					renderer.Dispose();
-				}
-			}
-
-			renderer = GetRenderer((VisualElement)view);
-			if (renderer != null)
-			{
-				if (renderer.ViewController != null)
-				{
-					var modalWrapper = renderer.ViewController.ParentViewController as ModalWrapper;
-					if (modalWrapper != null)
-						modalWrapper.Dispose();
-				}
-
-				renderer.NativeView.RemoveFromSuperview();
-				renderer.Dispose();
-			}
-			view.ClearValue(RendererProperty);
-		}
-
-		internal void DisposeRendererAndChildren(IVisualElementRenderer rendererToRemove)
-		{
-			if (rendererToRemove == null)
-				return;
-
-			if (rendererToRemove.Element != null && GetRenderer(rendererToRemove.Element) == rendererToRemove)
-				rendererToRemove.Element.ClearValue(RendererProperty);
-
-			var subviews = rendererToRemove.NativeView.Subviews;
-			for (var i = 0; i < subviews.Length; i++)
-			{
-				var childRenderer = subviews[i] as IVisualElementRenderer;
-				if (childRenderer != null)
-					DisposeRendererAndChildren(childRenderer);
-			}
-
-			rendererToRemove.NativeView.RemoveFromSuperview();
-			rendererToRemove.Dispose();
-		}
-
 		internal void LayoutSubviews()
 		{
 			if (Page == null)
@@ -342,10 +291,10 @@ namespace Xamarin.Forms.Platform.iOS
 				Console.Error.WriteLine("Potential view double add");
 		}
 
-		void HandleChildRemoved(object sender, ElementEventArgs e)
+		static void HandleChildRemoved(object sender, ElementEventArgs e)
 		{
 			var view = e.Element;
-			DisposeModelAndChildrenRenderers(view);
+			view.DisposeModalAndChildRenderers();
 		}
 
 		bool PageIsChildOfPlatform(Page page)

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -294,7 +294,7 @@ namespace Xamarin.Forms.Platform.iOS
 		static void HandleChildRemoved(object sender, ElementEventArgs e)
 		{
 			var view = e.Element;
-			view.DisposeModalAndChildRenderers();
+			view?.DisposeModalAndChildRenderers();
 		}
 
 		bool PageIsChildOfPlatform(Page page)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -159,12 +159,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_headerRenderer != null)
 				{
-					_headerRenderer.Element.DisposeModalAndChildRenderers();
+					_headerRenderer.Element?.DisposeModalAndChildRenderers();
 					_headerRenderer = null;
 				}
 				if (_footerRenderer != null)
 				{
-					_footerRenderer.Element.DisposeModalAndChildRenderers();
+					_footerRenderer.Element?.DisposeModalAndChildRenderers();
 					_footerRenderer = null;
 				}
 
@@ -438,7 +438,7 @@ namespace Xamarin.Forms.Platform.iOS
 					}
 					Control.TableFooterView = null;
 					
-					_footerRenderer.Element.DisposeModalAndChildRenderers();
+					_footerRenderer.Element?.DisposeModalAndChildRenderers();
 					_footerRenderer.Dispose();
 					_footerRenderer = null;
 				}
@@ -458,7 +458,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.TableFooterView = null;
 				_footerRenderer.Element.MeasureInvalidated -= OnFooterMeasureInvalidated;
 
-				_footerRenderer.Element.DisposeModalAndChildRenderers();
+				_footerRenderer.Element?.DisposeModalAndChildRenderers();
 				_footerRenderer.Dispose();
 				_footerRenderer = null;
 			}
@@ -483,7 +483,7 @@ namespace Xamarin.Forms.Platform.iOS
 					}
 					Control.TableHeaderView = null;
 
-					_headerRenderer.Element.DisposeModalAndChildRenderers();
+					_headerRenderer.Element?.DisposeModalAndChildRenderers();
 					_headerRenderer.Dispose();
 					_headerRenderer = null;
 				}
@@ -504,7 +504,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.TableHeaderView = null;
 				_headerRenderer.Element.MeasureInvalidated -= OnHeaderMeasureInvalidated;
 
-				_headerRenderer.Element.DisposeModalAndChildRenderers();
+				_headerRenderer.Element?.DisposeModalAndChildRenderers();
 				_headerRenderer.Dispose();
 				_headerRenderer = null;
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -159,14 +159,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_headerRenderer != null)
 				{
-					var platform = _headerRenderer.Element?.Platform as Platform;
-					platform?.DisposeModelAndChildrenRenderers(_headerRenderer.Element);
+					_headerRenderer.Element.DisposeModalAndChildRenderers();
 					_headerRenderer = null;
 				}
 				if (_footerRenderer != null)
 				{
-					var platform = _footerRenderer.Element?.Platform as Platform;
-					platform?.DisposeModelAndChildrenRenderers(_footerRenderer.Element);
+					_footerRenderer.Element.DisposeModalAndChildRenderers();
 					_footerRenderer = null;
 				}
 
@@ -439,9 +437,8 @@ namespace Xamarin.Forms.Platform.iOS
 						return;
 					}
 					Control.TableFooterView = null;
-					var platform = _footerRenderer.Element.Platform as Platform;
-					if (platform != null)
-						platform.DisposeModelAndChildrenRenderers(_footerRenderer.Element);
+					
+					_footerRenderer.Element.DisposeModalAndChildRenderers();
 					_footerRenderer.Dispose();
 					_footerRenderer = null;
 				}
@@ -461,9 +458,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.TableFooterView = null;
 				_footerRenderer.Element.MeasureInvalidated -= OnFooterMeasureInvalidated;
 
-				var platform = _footerRenderer.Element.Platform as Platform;
-				if (platform != null)
-					platform.DisposeModelAndChildrenRenderers(_footerRenderer.Element);
+				_footerRenderer.Element.DisposeModalAndChildRenderers();
 				_footerRenderer.Dispose();
 				_footerRenderer = null;
 			}
@@ -487,9 +482,9 @@ namespace Xamarin.Forms.Platform.iOS
 						return;
 					}
 					Control.TableHeaderView = null;
-					var platform = _headerRenderer.Element.Platform as Platform;
-					if (platform != null)
-						platform.DisposeModelAndChildrenRenderers(_headerRenderer.Element);
+
+					_headerRenderer.Element.DisposeModalAndChildRenderers();
+					_headerRenderer.Dispose();
 					_headerRenderer = null;
 				}
 
@@ -509,9 +504,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Control.TableHeaderView = null;
 				_headerRenderer.Element.MeasureInvalidated -= OnHeaderMeasureInvalidated;
 
-				var platform = _headerRenderer.Element.Platform as Platform;
-				if (platform != null)
-					platform.DisposeModelAndChildrenRenderers(_headerRenderer.Element);
+				_headerRenderer.Element.DisposeModalAndChildRenderers();
 				_headerRenderer.Dispose();
 				_headerRenderer = null;
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1345,9 +1345,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_child == null)
 					return;
 
-				if (_child.Element.Platform is Platform platform)
-					platform.DisposeModelAndChildrenRenderers(_child.Element);
-
+				_child.Element.DisposeModalAndChildRenderers();
 				_child.NativeView.RemoveFromSuperview();
 				_child.Dispose();
 				_child = null;

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1345,7 +1345,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_child == null)
 					return;
 
-				_child.Element.DisposeModalAndChildRenderers();
+				_child.Element?.DisposeModalAndChildRenderers();
 				_child.NativeView.RemoveFromSuperview();
 				_child.Dispose();
 				_child = null;

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -110,6 +110,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CellExtensions.cs" />
     <Compile Include="CADisplayLinkTicker.cs" />
+    <Compile Include="DisposeHelpers.cs" />
     <Compile Include="EffectUtilities.cs" />
     <Compile Include="ExportCellAttribute.cs" />
     <Compile Include="ExportImageSourceHandlerAttribute.cs" />


### PR DESCRIPTION
### Description of Change ###

The iOS platform has a few places where `Element.Platform` is cast to the native iOS `Platform` to call helper methods which don't actually need anything from the native `Platform` class. 

This change makes those helper methods static and moves them to their own class. This removes the need for IPlatform in native iOS code.

### Issues Resolved ###

None; laying the groundwork for removing `Platform` from `Element`.

### API Changes ###

None

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###

None 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
