### PR TITLE
[Android] Make native Android Platforms accessible via Context

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.Android
 		AndroidApplicationLifecycleState _currentState;
 		ARelativeLayout _layout;
 
-		AppCompat.Platform _platform;
+		internal AppCompat.Platform Platform { get; private set; }
 
 		AndroidApplicationLifecycleState _previousState;
 
@@ -129,11 +129,11 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (application?.MainPage != null)
 			{
-				var iver = Platform.GetRenderer(application.MainPage);
+				var iver = Android.Platform.GetRenderer(application.MainPage);
 				if (iver != null)
 				{
 					iver.Dispose();
-					application.MainPage.ClearValue(Platform.RendererProperty);
+					application.MainPage.ClearValue(Android.Platform.RendererProperty);
 				}
 			}
 
@@ -197,7 +197,7 @@ namespace Xamarin.Forms.Platform.Android
 		protected override void OnDestroy()
 		{
 			PopupManager.Unsubscribe(this);
-			_platform?.Dispose();
+			Platform?.Dispose();
 
 			// call at the end to avoid race conditions with Platform dispose
 			base.OnDestroy();
@@ -322,19 +322,19 @@ namespace Xamarin.Forms.Platform.Android
 			if (!Forms.IsInitialized)
 				throw new InvalidOperationException("Call Forms.Init (Activity, Bundle) before this");
 
-			if (_platform != null)
+			if (Platform != null)
 			{
-				_platform.SetPage(page);
+				Platform.SetPage(page);
 				return;
 			}
 
 			PopupManager.ResetBusyCount(this);
 
-			_platform = new AppCompat.Platform(this);
+			Platform = new AppCompat.Platform(this);
 			if (_application != null)
-				_application.Platform = _platform;
-			_platform.SetPage(page);
-			_layout.AddView(_platform);
+				_application.Platform = Platform;
+			Platform.SetPage(page);
+			_layout.AddView(Platform);
 			_layout.BringToFront();
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -757,7 +757,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Current?.SendDisappearing();
 			Current = page;
 
-			Platform.NavAnimationInProgress = true;
+			if (Platform != null)
+			{
+				Platform.NavAnimationInProgress = true;
+			}
+
 			FragmentTransaction transaction = FragmentManager.BeginTransactionEx();
 
 			if (animated)
@@ -827,7 +831,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				AddTransitionTimer(tcs, fragment, FragmentManager, fragmentsToRemove, 1, true);
 
 			Context.HideKeyboard(this);
-			Platform.NavAnimationInProgress = false;
+			
+			if (Platform != null)
+			{
+				Platform.NavAnimationInProgress = false;
+			}
 
 			return tcs.Task;
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		ImageView _titleIconView;
 		ImageSource _imageSource;
 		bool _isAttachedToWindow;
+		Platform _platform;
 
 		// The following is based on https://android.googlesource.com/platform/frameworks/support.git/+/4a7e12af4ec095c3a53bb8481d8d92f63157c3b7/v4/java/android/support/v4/app/FragmentManager.java#677
 		// Must be overriden in a custom renderer to match durations in XML animation resource files
@@ -72,6 +73,22 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AutoPackage = false;
 			Id = Platform.GenerateViewId();
 			Device.Info.PropertyChanged += DeviceInfoPropertyChanged;
+		}
+
+		Platform Platform
+		{
+			get
+			{
+				if (_platform == null)
+				{
+					if (Context is FormsAppCompatActivity activity)
+					{
+						_platform = activity.Platform;
+					}
+				}
+
+				return _platform;
+			}
 		}
 
 		internal int ContainerTopPadding { get; set; }
@@ -740,7 +757,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Current?.SendDisappearing();
 			Current = page;
 
-			((Platform)Element.Platform).NavAnimationInProgress = true;
+			Platform.NavAnimationInProgress = true;
 			FragmentTransaction transaction = FragmentManager.BeginTransactionEx();
 
 			if (animated)
@@ -810,7 +827,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				AddTransitionTimer(tcs, fragment, FragmentManager, fragmentsToRemove, 1, true);
 
 			Context.HideKeyboard(this);
-			((Platform)Element.Platform).NavAnimationInProgress = false;
+			Platform.NavAnimationInProgress = false;
 
 			return tcs.Task;
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -364,24 +364,21 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					OnEnd = a =>
 					{
 						source.TrySetResult(false);
-						NavAnimationInProgress = false;
 						modalContainer = null;
 					},
 					OnCancel = a =>
 					{
 						source.TrySetResult(true);
-						NavAnimationInProgress = false;
 						modalContainer = null;
 					}
 				});
 			}
 			else
 			{
-				NavAnimationInProgress = false;
 				source.TrySetResult(true);
 			}
 
-			return source.Task;
+			return source.Task.ContinueWith(task => NavAnimationInProgress = false);
 		}
 
 		sealed class ModalContainer : ViewGroup

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -510,9 +510,17 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void ScrollToCurrentPage()
 		{
-			Platform.NavAnimationInProgress = true;
+			if (Platform != null)
+			{
+				Platform.NavAnimationInProgress = true;
+			}
+
 			_viewPager.SetCurrentItem(Element.Children.IndexOf(Element.CurrentPage), Element.OnThisPlatform().IsSmoothScrollEnabled());
-			Platform.NavAnimationInProgress = false;
+
+			if (Platform != null)
+			{
+				Platform.NavAnimationInProgress = false;
+			}
 		}
 
 		void UpdateIgnoreContainerAreas()

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		int[] _emptyStateSet = null;
 		int _defaultARGBColor = Color.Default.ToAndroid().ToArgb();
 		AColor _defaultAndroidColor = Color.Default.ToAndroid();
+		Platform _platform;
 
 		public TabbedPageRenderer(Context context) : base(context)
 		{
@@ -53,6 +54,22 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		public TabbedPageRenderer()
 		{
 			AutoPackage = false;
+		}
+
+		Platform Platform
+		{
+			get
+			{
+				if (_platform == null)
+				{
+					if (Context is FormsAppCompatActivity activity)
+					{
+						_platform = activity.Platform;
+					}
+				}
+
+				return _platform;
+			}
 		}
 
 		FragmentManager FragmentManager => _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
@@ -493,9 +510,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void ScrollToCurrentPage()
 		{
-			((Platform)Element.Platform).NavAnimationInProgress = true;
+			Platform.NavAnimationInProgress = true;
 			_viewPager.SetCurrentItem(Element.Children.IndexOf(Element.CurrentPage), Element.OnThisPlatform().IsSmoothScrollEnabled());
-			((Platform)Element.Platform).NavAnimationInProgress = false;
+			Platform.NavAnimationInProgress = false;
 		}
 
 		void UpdateIgnoreContainerAreas()

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -18,13 +18,14 @@ namespace Xamarin.Forms.Platform.Android
 		public delegate bool BackButtonPressedEventHandler(object sender, EventArgs e);
 
 		Application _application;
-		Platform _canvas;
 		AndroidApplicationLifecycleState _currentState;
 		LinearLayout _layout;
 
 		PowerSaveModeBroadcastReceiver _powerSaveModeBroadcastReceiver;
 
 		AndroidApplicationLifecycleState _previousState;
+
+		internal Platform Platform { get; private set; }
 
 		protected FormsApplicationActivity()
 		{
@@ -63,13 +64,13 @@ namespace Xamarin.Forms.Platform.Android
 		public override bool OnOptionsItemSelected(IMenuItem item)
 		{
 			if (item.ItemId == global::Android.Resource.Id.Home)
-				_canvas.SendHomeClicked();
+				Platform.SendHomeClicked();
 			return base.OnOptionsItemSelected(item);
 		}
 
 		public override bool OnPrepareOptionsMenu(IMenu menu)
 		{
-			_canvas.PrepareMenu(menu);
+			Platform.PrepareMenu(menu);
 			return base.OnPrepareOptionsMenu(menu);
 		}
 
@@ -143,8 +144,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			PopupManager.Unsubscribe(this);
 
-			if (_canvas != null)
-				((IDisposable)_canvas).Dispose();
+			if (Platform != null)
+				((IDisposable)Platform).Dispose();
 		}
 
 		protected override void OnPause()
@@ -240,19 +241,19 @@ namespace Xamarin.Forms.Platform.Android
 			if (!Forms.IsInitialized)
 				throw new InvalidOperationException("Call Forms.Init (Activity, Bundle) before this");
 
-			if (_canvas != null)
+			if (Platform != null)
 			{
-				_canvas.SetPage(page);
+				Platform.SetPage(page);
 				return;
 			}
 
 			PopupManager.ResetBusyCount(this);
 
-			_canvas = new Platform(this);
+			Platform = new Platform(this);
 			if (_application != null)
-				_application.Platform = _canvas;
-			_canvas.SetPage(page);
-			_layout.AddView(_canvas.GetViewGroup());
+				_application.Platform = Platform;
+			Platform.SetPage(page);
+			_layout.AddView(Platform.GetViewGroup());
 		}
 
 		void OnStateChanged()

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -716,24 +716,27 @@ namespace Xamarin.Forms.Platform.Android
 
 			NavAnimationInProgress = true;
 
+			SelectTab();
+
+			NavAnimationInProgress = false;
+		}
+
+		void SelectTab()
+		{
 			Page page = _currentTabbedPage.CurrentPage;
 			if (page == null)
 			{
 				ActionBar.SelectTab(null);
-				NavAnimationInProgress = false;
 				return;
 			}
 
 			int index = TabbedPage.GetIndex(page);
 			if (ActionBar.SelectedNavigationIndex == index || index >= ActionBar.NavigationItemCount)
 			{
-				NavAnimationInProgress = false;
 				return;
 			}
 
 			ActionBar.SelectTab(ActionBar.GetTabAt(index));
-
-			NavAnimationInProgress = false;
 		}
 
 		Drawable GetActionBarBackgroundDrawable()
@@ -842,6 +845,7 @@ namespace Xamarin.Forms.Platform.Android
 			_renderer.AddView(modalRenderer.View);
 
 			var source = new TaskCompletionSource<bool>();
+
 			NavAnimationInProgress = true;
 			if (animated)
 			{
@@ -853,22 +857,19 @@ namespace Xamarin.Forms.Platform.Android
 					OnEnd = a =>
 					{
 						source.TrySetResult(false);
-						NavAnimationInProgress = false;
 					},
 					OnCancel = a =>
 					{
 						source.TrySetResult(true);
-						NavAnimationInProgress = false;
 					}
 				});
 			}
 			else
 			{
-				NavAnimationInProgress = false;
 				source.TrySetResult(true);
 			}
 
-			return source.Task;
+			return source.Task.ContinueWith(task => NavAnimationInProgress = false);
 		}
 
 		void RegisterNavPageCurrent(Page page)

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Platform.Android
 		MasterDetailContainer _masterLayout;
 		MasterDetailPage _page;
 		bool _presented;
+		Platform _platform;
 
 		public MasterDetailRenderer(Context context) : base(context)
 		{
@@ -31,7 +32,23 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
-		IMasterDetailPageController MasterDetailPageController => _page as IMasterDetailPageController;
+		Platform Platform
+		{
+			get
+			{
+				if (_platform == null)
+				{
+					if (Context is FormsApplicationActivity activity)
+					{
+						_platform = activity.Platform;
+					}
+				}
+
+				return _platform;
+			}
+		}
+
+		IMasterDetailPageController MasterDetailPageController => _page;
 
 		public bool Presented
 		{
@@ -244,7 +261,7 @@ namespace Xamarin.Forms.Platform.Android
 		void HandleMasterPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Page.TitleProperty.PropertyName || e.PropertyName == Page.IconProperty.PropertyName)
-				((Platform)_page.Platform).UpdateMasterDetailToggle(true);
+				Platform?.UpdateMasterDetailToggle(true);
 		}
 
 		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -255,7 +272,7 @@ namespace Xamarin.Forms.Platform.Android
 			else if (e.PropertyName == "Detail")
 			{
 				UpdateDetail();
-				((Platform)_page.Platform).UpdateActionBar();
+				Platform?.UpdateActionBar();
 			}
 			else if (e.PropertyName == MasterDetailPage.IsPresentedProperty.PropertyName)
 			{
@@ -377,7 +394,7 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					SetScrimColor(isShowingSplit ? Color.Transparent.ToAndroid() : (int)DefaultScrimColor);
 				}
-				((Platform)_page.Platform).UpdateMasterDetailToggle();
+				Platform?.UpdateMasterDetailToggle();
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/NavigationRenderer.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		Page _current;
 		bool _disposed;
+		Platform _platform;
 
 		public NavigationRenderer(Context context) : base(context)
 		{
@@ -23,6 +24,22 @@ namespace Xamarin.Forms.Platform.Android
 		public NavigationRenderer()
 		{
 			AutoPackage = false;
+		}
+
+		Platform Platform
+		{
+			get
+			{
+				if (_platform == null)
+				{
+					if (Context is FormsApplicationActivity activity)
+					{
+						_platform = activity.Platform;
+					}
+				}
+
+				return _platform;
+			}
 		}
 
 		public Task<bool> PopToRootAsync(Page page, bool animated = true)
@@ -40,7 +57,7 @@ namespace Xamarin.Forms.Platform.Android
 			return OnPushAsync(page, animated);
 		}
 
-		IPageController PageController => Element as IPageController;
+		IPageController PageController => Element;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -146,17 +163,21 @@ namespace Xamarin.Forms.Platform.Android
 			return SwitchContentAsync(view, animated);
 		}
 
+		void UpdateActionBar()
+		{
+			Device.StartTimer(TimeSpan.FromMilliseconds(0), () => {
+				Platform?.UpdateActionBar();
+				return false;
+			});
+		}
+
 		void InsertPageBefore(Page page, Page before)
 		{
-
 			int index = PageController.InternalChildren.IndexOf(before);
 			if (index == -1)
 				throw new InvalidOperationException("This should never happen, please file a bug");
 
-			Device.StartTimer(TimeSpan.FromMilliseconds(0), () => {
-				((Platform)Element.Platform).UpdateActionBar();
-				return false;
-			});
+			UpdateActionBar();
 		}
 
 		void OnInsertPageBeforeRequested(object sender, NavigationRequestedEventArgs e)
@@ -199,11 +220,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			containerToRemove?.Dispose();
 
-			Device.StartTimer(TimeSpan.FromMilliseconds(0), () =>
-			{
-				((Platform)Element.Platform).UpdateActionBar();
-				return false;
-			});
+			UpdateActionBar();
 		}
 
 		Task<bool> SwitchContentAsync(Page view, bool animated, bool removed = false)
@@ -224,7 +241,10 @@ namespace Xamarin.Forms.Platform.Android
 
 			_current = view;
 
-			((Platform)Element.Platform).NavAnimationInProgress = true;
+			if (Platform != null)
+			{
+				Platform.NavAnimationInProgress = true;
+			}
 
 			var tcs = new TaskCompletionSource<bool>();
 
@@ -256,7 +276,6 @@ namespace Xamarin.Forms.Platform.Android
 							RemoveView(containerToRemove);
 
 							tcs.TrySetResult(true);
-							((Platform)Element.Platform).NavAnimationInProgress = false;
 
 							VisualElement removedElement = rendererToRemove.Element;
 							rendererToRemove.Dispose();
@@ -297,10 +316,6 @@ namespace Xamarin.Forms.Platform.Android
 						}
 						s_currentAnimation = null;
 						tcs.TrySetResult(true);
-						if (Element?.Platform != null)
-						{
-							((Platform)Element.Platform).NavAnimationInProgress = false;
-						}
 					} });
 				}
 			}
@@ -328,10 +343,17 @@ namespace Xamarin.Forms.Platform.Android
 
 				containerToAdd.Visibility = ViewStates.Visible;
 				tcs.SetResult(true);
-				((Platform)Element.Platform).NavAnimationInProgress = false;
 			}
 
-			return tcs.Task;
+			return tcs.Task.ContinueWith(task =>
+			{
+				if (Platform != null)
+				{
+					Platform.NavAnimationInProgress = false;
+				}
+
+				return task.Result;
+			});
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Makes the native `Platform` class accessible to the renderers which need it without having to cast `Element.IPlatfrom`. 

### Issues Resolved ###

None; this is prep work for further cleanup.

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
