### PR TITLE
[Android] Simplify subscription to context action closure messages

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					return;
 				_navAnimationInProgress = value;
 				if (value)
-					MessagingCenter.Send(this, CloseContextActionsSignalName);
+					MessagingCenter.Send(this, Android.Platform.CloseContextActionsSignalName);
 			}
 		}
 
@@ -424,8 +424,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			return canvas._renderer;
 		}
-
-		internal const string CloseContextActionsSignalName = "Xamarin.CloseContextActions";
 
 		#endregion
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -62,11 +62,8 @@ namespace Xamarin.Forms.Platform.Android
 			realListView.OnItemClickListener = this;
 			realListView.OnItemLongClickListener = this;
 
-			var platform = _listView.Platform;
-			if (platform?.GetType() == typeof(AppCompat.Platform))
-				MessagingCenter.Subscribe<AppCompat.Platform>(this, AppCompat.Platform.CloseContextActionsSignalName, p => CloseContextActions());
-			else
-				MessagingCenter.Subscribe<Platform>(this, Platform.CloseContextActionsSignalName, p => CloseContextActions());
+			MessagingCenter.Subscribe<ListViewAdapter>(this, Platform.CloseContextActionsSignalName, lva => CloseContextActions());
+
 			InvalidateCount();
 		}
 
@@ -421,11 +418,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				CloseContextActions();
 
-				var platform = _listView.Platform;
-				if (platform.GetType() == typeof(AppCompat.Platform))
-					MessagingCenter.Unsubscribe<AppCompat.Platform>(this, Platform.CloseContextActionsSignalName);
-				else
-					MessagingCenter.Unsubscribe<Platform>(this, Platform.CloseContextActionsSignalName);
+				MessagingCenter.Unsubscribe<ListViewAdapter>(this, Platform.CloseContextActionsSignalName);
 
 				_realListView.OnItemClickListener = null;
 				_realListView.OnItemLongClickListener = null;


### PR DESCRIPTION
### Description of Change ###

Android platform is doing a type check to see which version of `CloseContextActionsSignalName` to send, but both versions do the same thing. This just consolidates to a single version of the message. 

### Issues Resolved ###

None, just avoiding a _very_ minor performance hit.

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
