### PR TITLE
[WPF] Memory leak when you pop a TabbedPage

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using WControl = System.Windows.Controls.Control;
@@ -161,18 +162,29 @@ namespace Xamarin.Forms.Platform.WPF
 
 			Element.IsNativeStateConsistent = false;
 
-			Control.Loaded += (sender, e) =>
-			{
-				Element.IsNativeStateConsistent = true;
-				Appearing();
-			};
-			Control.Unloaded += (sender, e) => { Disappearing(); };
+			Control.Loaded += Control_Loaded;
+			Control.Unloaded += Control_Unloaded;
 
 			Control.GotFocus += OnGotFocus;
 			Control.LostFocus += OnLostFocus;
 
 			UpdateBackground();
 			UpdateAlignment();
+		}
+		
+		private void Control_Loaded(object sender, RoutedEventArgs e)
+		{
+			Debug.WriteLine("Control_Loaded : " + this.Control.GetType());
+			Control.Loaded -= Control_Loaded;
+			Element.IsNativeStateConsistent = true;
+			Appearing();
+		}
+
+		private void Control_Unloaded(object sender, RoutedEventArgs e)
+		{
+			Debug.WriteLine("Control_Unloaded : " + this.Control.GetType());
+			Control.Unloaded -= Control_Unloaded;
+			Disappearing();
 		}
 
 		protected virtual void Appearing()
@@ -276,7 +288,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 			if (Control != null)
 			{
-				//Console.WriteLine("Dispose : " + this.Control.GetType());
+				Debug.WriteLine("Dispose : " + this.Control.GetType());
 				Control.GotFocus -= OnGotFocus;
 				Control.LostFocus -= OnLostFocus;
 			}

--- a/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Forms.Platform.WPF
 			new List<EventHandler<VisualElementChangedEventArgs>>();
 
 		VisualElementTracker _tracker;
+		bool _disposed;
 
 		IElementController ElementController => Element as IElementController;
 
@@ -174,7 +175,6 @@ namespace Xamarin.Forms.Platform.WPF
 		
 		private void Control_Loaded(object sender, RoutedEventArgs e)
 		{
-			Debug.WriteLine("Control_Loaded : " + this.Control.GetType());
 			Control.Loaded -= Control_Loaded;
 			Element.IsNativeStateConsistent = true;
 			Appearing();
@@ -182,7 +182,6 @@ namespace Xamarin.Forms.Platform.WPF
 
 		private void Control_Unloaded(object sender, RoutedEventArgs e)
 		{
-			Debug.WriteLine("Control_Unloaded : " + this.Control.GetType());
 			Control.Unloaded -= Control_Unloaded;
 			Disappearing();
 		}
@@ -271,8 +270,6 @@ namespace Xamarin.Forms.Platform.WPF
 				Control.VerticalAlignment = view.VerticalOptions.ToNativeVerticalAlignment();
 			}
 		}
-
-		bool _disposed;
 
 		public void Dispose()
 		{

--- a/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
@@ -285,7 +285,6 @@ namespace Xamarin.Forms.Platform.WPF
 
 			if (Control != null)
 			{
-				Debug.WriteLine("Dispose : " + this.Control.GetType());
 				Control.GotFocus -= OnGotFocus;
 				Control.LostFocus -= OnLostFocus;
 			}


### PR DESCRIPTION
### Description of Change ###

This PR fix the memory leak when you pop a TabbedPage on WPF

### Issues Resolved ###

- fixes #3267

### Platforms Affected ###

- WPF

### Behavioral/Visual Changes ###


### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
