### PR TITLE
[C, Xaml] add SizeTypeConverter

### DIFF
--- a/Xamarin.Forms.Core/RectangleTypeConverter.cs
+++ b/Xamarin.Forms.Core/RectangleTypeConverter.cs
@@ -11,10 +11,12 @@ namespace Xamarin.Forms
 		{
 			if (value != null)
 			{
-				double x, y, w, h;
 				string[] xywh = value.Split(',');
-				if (xywh.Length == 4 && double.TryParse(xywh[0], NumberStyles.Number, CultureInfo.InvariantCulture, out x) && double.TryParse(xywh[1], NumberStyles.Number, CultureInfo.InvariantCulture, out y) &&
-					double.TryParse(xywh[2], NumberStyles.Number, CultureInfo.InvariantCulture, out w) && double.TryParse(xywh[3], NumberStyles.Number, CultureInfo.InvariantCulture, out h))
+				if (   xywh.Length == 4
+					&& double.TryParse(xywh[0], NumberStyles.Number, CultureInfo.InvariantCulture, out double x)
+					&& double.TryParse(xywh[1], NumberStyles.Number, CultureInfo.InvariantCulture, out double y)
+					&& double.TryParse(xywh[2], NumberStyles.Number, CultureInfo.InvariantCulture, out double w)
+					&& double.TryParse(xywh[3], NumberStyles.Number, CultureInfo.InvariantCulture, out double h))
 					return new Rectangle(x, y, w, h);
 			}
 

--- a/Xamarin.Forms.Core/Size.cs
+++ b/Xamarin.Forms.Core/Size.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 namespace Xamarin.Forms
 {
 	[DebuggerDisplay("Width={Width}, Height={Height}")]
+	[TypeConverter(typeof(SizeTypeConverter))]
 	public struct Size
 	{
 		double _width;

--- a/Xamarin.Forms.Core/SizeTypeConverter.cs
+++ b/Xamarin.Forms.Core/SizeTypeConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Globalization;
+
+namespace Xamarin.Forms
+{
+	[Xaml.TypeConversion(typeof(Size))]
+	public class SizeTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null) {
+				string[] wh = value.Split(',');
+				if (wh.Length == 2
+					&& double.TryParse(wh[0], NumberStyles.Number, CultureInfo.InvariantCulture, out double w)
+					&& double.TryParse(wh[1], NumberStyles.Number, CultureInfo.InvariantCulture, out double h))
+					return new Size(w, h);
+			}
+
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(Size)));
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3280.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3280.xaml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Gh3280" Foo="15,25">
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3280.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3280.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh3280 : ContentPage
+	{
+		public Gh3280()
+		{
+			InitializeComponent();
+		}
+
+		public Size Foo { get; set; }
+
+		public Gh3280(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void SizeHasConverter(bool useCompiledXaml)
+			{
+				Gh3280 layout = null;
+				Assert.DoesNotThrow(() => layout = new Gh3280(useCompiledXaml));
+				Assert.That(layout.Foo, Is.EqualTo(new Size(15, 25)));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -631,6 +631,9 @@
     <Compile Include="Issues\Gh3260.xaml.cs">
       <DependentUpon>Gh3260.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh3280.xaml.cs">
+      <DependentUpon>Gh3280.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('..\.nuspec\Xamarin.Forms.Build.Tasks.dll')" />
@@ -1142,6 +1145,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh3260.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh3280.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
     </EmbeddedResource>


### PR DESCRIPTION
### Description of Change ###

Add a missing TypeConverter attribute to Size struct.

### Issues Resolved ###

- fixes #3280

### API Changes ###

/

### Platforms Affected ###

<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
