### PR TITLE
[Core] Fixed computing position of children in AbsoluteLayout

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/AbsoluteLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AbsoluteLayoutTests.cs
@@ -174,7 +174,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var sizeReq = abs.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity);
 
-			Assert.AreEqual (new Size (200, 40), sizeReq.Request);
+			Assert.AreEqual (new Size (100, 20), sizeReq.Request);
 			Assert.AreEqual (new Size (0, 0), sizeReq.Minimum);
 		}
 
@@ -196,7 +196,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var sizeReq = abs.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity);
 
-			Assert.AreEqual (new Size (210, 60), sizeReq.Request);
+			Assert.AreEqual (new Size (110, 40), sizeReq.Request);
 			Assert.AreEqual (new Size (10, 20), sizeReq.Minimum);
 		}
 

--- a/Xamarin.Forms.Core/AbsoluteLayout.cs
+++ b/Xamarin.Forms.Core/AbsoluteLayout.cs
@@ -177,41 +177,29 @@ namespace Xamarin.Forms
 			double minWidth = width;
 			double minHeight = height;
 
-			if (!widthIsProportional && bounds.Width != AutoSize)
+			if (!widthIsProportional)
 			{
-				// fixed size
-				width += bounds.Width;
-				minWidth += bounds.Width;
-			}
-			else if (!widthIsProportional)
-			{
-				// auto size
-				width += sizeRequest.Value.Request.Width;
-				minWidth += sizeRequest.Value.Minimum.Width;
+				bool isFixed = bounds.Width != AutoSize;
+				width += isFixed ? bounds.Width : sizeRequest.Value.Request.Width;
+				minWidth += isFixed ? bounds.Width : sizeRequest.Value.Minimum.Width;
 			}
 			else
 			{
 				// proportional size
-				width += sizeRequest.Value.Request.Width / Math.Max(0.25, bounds.Width);
+				width += sizeRequest.Value.Request.Width;
 				//minWidth += 0;
 			}
 
-			if (!heightIsProportional && bounds.Height != AutoSize)
+			if (!heightIsProportional)
 			{
-				// fixed size
-				height += bounds.Height;
-				minHeight += bounds.Height;
-			}
-			else if (!heightIsProportional)
-			{
-				// auto size
-				height += sizeRequest.Value.Request.Height;
-				minHeight += sizeRequest.Value.Minimum.Height;
+				bool isFixed = bounds.Height != AutoSize;
+				height += isFixed ? bounds.Height : sizeRequest.Value.Request.Height;
+				minHeight += isFixed ? bounds.Height : sizeRequest.Value.Minimum.Height;
 			}
 			else
 			{
 				// proportional size
-				height += sizeRequest.Value.Request.Height / Math.Max(0.25, bounds.Height);
+				height += sizeRequest.Value.Request.Height;
 				//minHeight += 0;
 			}
 


### PR DESCRIPTION
### Description of Change ###

When fired `OnMeasure` in `AbsoluteLayout` with a proportional bounds original size of children divides on the bounds. It was wrong, because all manipulation with `bounds` already have in the function `LayoutChildren`.
If bounds is equals 1 this issue is not noticeable, but if bounds is far from the standard values it may happen that the boundaries of child will be incorrectly calculated.

### Issues Resolved ###

- fixes #2368

### API Changes ###

/

### Platforms Affected ###

- Core (all platforms)

### Visual Changes ###


Screencasts: 
UWP: http://recordit.co/Mz9KRVoAGa
Android: http://recordit.co/RP7NpKLEnK

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
