### PR TITLE
[Android] BoxView should fall back to BackgroundColor

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3342.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3342.cs
@@ -1,0 +1,59 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3342, "[Android] BoxView BackgroundColor not working on 3.2.0-pre1", PlatformAffected.Android)]
+	public class Issue3342 : TestContentPage 
+	{
+		protected override void Init()
+		{
+			var instructions = new Label
+			{
+				Text = "You should see a green BoxView. You should not see the text that says FAIL."
+			};
+
+			var hiddenLabel = new Label
+			{
+				Text = "FAIL"
+			};
+
+			var target = new BoxView
+			{
+				HeightRequest = 200,
+				WidthRequest = 200,
+				BackgroundColor = Color.Green,
+				CornerRadius = new CornerRadius(3)
+			};
+
+			var grid = new Grid
+			{
+				ColumnDefinitions = { new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) } },
+				RowDefinitions = {  new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+									new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }}
+			};
+
+			grid.Children.Add(instructions);
+			grid.Children.Add(hiddenLabel, 0, 1);
+			grid.Children.Add(target, 0, 1);
+
+			Content = grid;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue342Test ()
+		{
+			RunningApp.Screenshot ("I am at Issue 3342");
+			RunningApp.WaitForNoElement (q => q.Marked ("FAIL"));
+			RunningApp.Screenshot ("I see the green box");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -475,6 +475,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2837.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2740.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1939.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3342.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -56,6 +56,9 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Color colorToSet = Element.Color;
 
+			if (colorToSet == Color.Default)
+				colorToSet = Element.BackgroundColor;
+
 			if (_backgroundDrawable == null)
 				_backgroundDrawable = new GradientDrawable();
 


### PR DESCRIPTION
### Description of Change ###

#1998 added CornerRadius to the BoxView, but when the UpdateBackground method was updated to use a GradientDrawable, the fallback to BackgroundColor was missed. This restores it.

### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3342

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
