### PR TITLE
[XamlC] Resolve generic base type on GetProperty

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -799,7 +799,6 @@ namespace Xamarin.Forms.Build.Tasks
 			var localName = propertyName.LocalName;
 			bool attached;
 			var bpRef = GetBindablePropertyReference(parent, propertyName.NamespaceURI, ref localName, out attached, context, lineInfo);
-			TypeReference _;
 
 			//If it's a BP, GetValue ()
 			if (CanGetValue(parent, bpRef, attached, lineInfo, context, out _))
@@ -1181,8 +1180,7 @@ namespace Xamarin.Forms.Build.Tasks
 		static IEnumerable<Instruction> Get(VariableDefinition parent, string localName, IXmlLineInfo iXmlLineInfo, ILContext context, out TypeReference propertyType)
 		{
 			var module = context.Body.Method.Module;
-			TypeReference declaringTypeReference;
-			var property = parent.VariableType.GetProperty(pd => pd.Name == localName, out declaringTypeReference);
+			var property = parent.VariableType.GetProperty(pd => pd.Name == localName, out var declaringTypeReference);
 			var propertyGetter = property.GetMethod;
 
 			module.ImportReference(parent.VariableType.ResolveCached());

--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Build.Tasks
 				return properties.Single();
 			if (typeDef.BaseType == null || typeDef.BaseType.FullName == "System.Object")
 				return null;
-			return typeDef.BaseType.GetProperty(predicate, out declaringTypeRef);
+			return typeDef.BaseType.ResolveGenericParameters(typeRef).GetProperty(predicate, out declaringTypeRef);
 		}
 
 		public static EventDefinition GetEvent(this TypeReference typeRef, Func<EventDefinition, bool> predicate,
@@ -85,7 +85,7 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 			if (typeDef.BaseType == null || typeDef.BaseType.FullName == "System.Object")
 				return null;
-			return typeDef.BaseType.GetEvent(predicate, out declaringTypeRef);
+			return typeDef.BaseType.ResolveGenericParameters(typeRef).GetEvent(predicate, out declaringTypeRef);
 		}
 
 		//this resolves generic eventargs (https://bugzilla.xamarin.com/show_bug.cgi?id=57574)
@@ -120,8 +120,7 @@ namespace Xamarin.Forms.Build.Tasks
 				return bp.Single();
 			if (typeDef.BaseType == null || typeDef.BaseType.FullName == "System.Object")
 				return null;
-			var basetype = typeDef.BaseType.ResolveGenericParameters(typeRef);
-			return basetype.GetField(predicate, out declaringTypeRef);
+			return typeDef.BaseType.ResolveGenericParameters(typeRef).GetField(predicate, out declaringTypeRef);
 		}
 
 		public static bool ImplementsInterface(this TypeReference typeRef, TypeReference @interface)

--- a/Xamarin.Forms.Core/ContentPropertyAttribute.cs
+++ b/Xamarin.Forms.Core/ContentPropertyAttribute.cs
@@ -11,7 +11,7 @@ using System;
 
 namespace Xamarin.Forms
 {
-	[AttributeUsage(AttributeTargets.Class)]
+	[AttributeUsage(AttributeTargets.Class, Inherited = true)]
 	public sealed class ContentPropertyAttribute : Attribute
 	{
 		internal static string[] ContentPropertyTypes = { "Xamarin.Forms.ContentPropertyAttribute", "System.Windows.Markup.ContentPropertyAttribute" };
@@ -21,6 +21,6 @@ namespace Xamarin.Forms
 			Name = name;
 		}
 
-		public string Name { get; private set; }
+		public string Name { get; }
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3260.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3260.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Gh3260">
+    <ContentPage.Content>
+        <local:Gh3260MyLayout x:Name="mylayout">
+            <Label x:Name="label"/>
+        </local:Gh3260MyLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3260.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3260.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public abstract class Gh3260MyGLayout<T> : Layout<T> where T : View
+	{
+		protected override void LayoutChildren(double x, double y, double width, double height)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	public class Gh3260MyLayout : Gh3260MyGLayout<View>
+	{
+		protected override void LayoutChildren(double x, double y, double width, double height)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	public partial class Gh3260 : ContentPage
+	{
+		public Gh3260()
+		{
+			InitializeComponent();
+		}
+
+		public Gh3260(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void AssignContentWithNoContentAttributeDoesNotThrow(bool useCompiledXaml)
+			{
+				var layout = new Gh3260(useCompiledXaml);
+				Assert.That(layout.mylayout.Children.Count, Is.EqualTo(1));
+				Assert.That(layout.mylayout.Children[0], Is.EqualTo(layout.label));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -628,6 +628,9 @@
     <Compile Include="Issues\Gh3082.xaml.cs">
       <DependentUpon>Gh3082.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh3260.xaml.cs">
+      <DependentUpon>Gh3260.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('..\.nuspec\Xamarin.Forms.Build.Tasks.dll')" />
@@ -1137,6 +1140,10 @@
     <EmbeddedResource Include="Issues\Gh3082.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh3260.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

GetMethod, GetField, ... were already correctly resolving generic base
types. GetProperty or GetEvent were not, causing NRE later on.

### Issues Resolved ###

- fixes #3260

### API Changes ###

/

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
