### PR TITLE
[Android,iOS,UWP] Allow Entry CursorPosition/SelectionLength to be set in ctor

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3343.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3343.cs
@@ -1,0 +1,88 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3343, "[Android] Cursor position in entry and selection length not working on 3.2.0-pre1", PlatformAffected.Android | PlatformAffected.iOS)]
+	public class Issue3343 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Entry entry = new Entry()
+			{
+				Text = "Initialized",
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.StartAndExpand,
+				WidthRequest = 150
+			};
+
+			entry.CursorPosition = 4;
+			entry.SelectionLength = entry.Text.Length;
+
+			Label entryLabel = new Label { VerticalOptions = LayoutOptions.Center, FontSize = 8 };
+			entryLabel.SetBinding(Label.TextProperty, new Binding(nameof(Entry.CursorPosition), stringFormat: "CursorPostion: {0}", source: entry));
+
+			Label entryLabel2 = new Label { VerticalOptions = LayoutOptions.Center, FontSize = 8 };
+			entryLabel2.SetBinding(Label.TextProperty, new Binding(nameof(Entry.SelectionLength), stringFormat: "SelectionLength: {0}", source: entry));
+
+			Entry entry2 = new Entry()
+			{
+				Text = "Click Button",
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.StartAndExpand,
+				WidthRequest = 150
+			};
+
+			Label entry2Label = new Label { VerticalOptions = LayoutOptions.Center, FontSize = 8 };
+			entry2Label.SetBinding(Label.TextProperty, new Binding(nameof(Entry.CursorPosition), stringFormat: "CursorPostion: {0}", source: entry2));
+
+			Label entry2Label2 = new Label { VerticalOptions = LayoutOptions.Center, FontSize = 8 };
+			entry2Label2.SetBinding(Label.TextProperty, new Binding(nameof(Entry.SelectionLength), stringFormat: "SelectionLength: {0}", source: entry2));
+
+			// When the Entry is in a NavPage, the Entry doesn't get first focus on UWP
+			string uwp_instructions = Device.RuntimePlatform == Device.UWP ? "Press Tab to focus the first entry. " : "";
+
+			Content = new StackLayout()
+			{
+				Padding = 20,
+				Children =
+						{
+							new StackLayout{ Children = { entry, entryLabel, entryLabel2  }, Orientation = StackOrientation.Horizontal },
+							new StackLayout{ Children = { entry2, entry2Label, entry2Label2 }, Orientation = StackOrientation.Horizontal },
+							new Button()
+							{
+								Text = "Click Me",
+								Command = new Command(() =>
+								{
+									entry2.CursorPosition = 4;
+									entry2.SelectionLength = entry2.Text.Length;
+								})
+							},
+							new Button()
+							{
+								Text = "Click Me After",
+								Command = new Command(() =>
+								{
+									entry2.CursorPosition = 2;
+								})
+							},
+							new Button()
+							{
+								Text = "Click Me Last",
+								Command = new Command(async () =>
+								{
+									entry2.ClearValue(Entry.SelectionLengthProperty);
+
+									await Task.Delay(500);
+
+									entry2.ClearValue(Entry.CursorPositionProperty);
+								})
+							},
+							new Label{ Text = $"{uwp_instructions}The first Entry should have all text selected starting at character 4. Click the first button to trigger the same selection in the second Entry. Click the second button to move the cursor position but keep the selection length to the end. Click the third button to clear the selection length and then the cursor position." }
+						}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3343.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3343.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Controls.Issues
 			entry.SelectionLength = entry.Text.Length;
 
 			Label entryLabel = new Label { VerticalOptions = LayoutOptions.Center, FontSize = 8 };
-			entryLabel.SetBinding(Label.TextProperty, new Binding(nameof(Entry.CursorPosition), stringFormat: "CursorPostion: {0}", source: entry));
+			entryLabel.SetBinding(Label.TextProperty, new Binding(nameof(Entry.CursorPosition), stringFormat: "CursorPosition: {0}", source: entry));
 
 			Label entryLabel2 = new Label { VerticalOptions = LayoutOptions.Center, FontSize = 8 };
 			entryLabel2.SetBinding(Label.TextProperty, new Binding(nameof(Entry.SelectionLength), stringFormat: "SelectionLength: {0}", source: entry));
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 
 			Label entry2Label = new Label { VerticalOptions = LayoutOptions.Center, FontSize = 8 };
-			entry2Label.SetBinding(Label.TextProperty, new Binding(nameof(Entry.CursorPosition), stringFormat: "CursorPostion: {0}", source: entry2));
+			entry2Label.SetBinding(Label.TextProperty, new Binding(nameof(Entry.CursorPosition), stringFormat: "CursorPosition: {0}", source: entry2));
 
 			Label entry2Label2 = new Label { VerticalOptions = LayoutOptions.Center, FontSize = 8 };
 			entry2Label2.SetBinding(Label.TextProperty, new Binding(nameof(Entry.SelectionLength), stringFormat: "SelectionLength: {0}", source: entry2));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -480,6 +480,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2837.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2740.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1939.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3343.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3342.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3415.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3049.cs" />

--- a/Xamarin.Forms.Core.UnitTests/EntryUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/EntryUnitTests.cs
@@ -15,22 +15,24 @@ namespace Xamarin.Forms.Core.UnitTests
 			const string value = "Foo";
 
 			bool signaled = false;
-			entry.TextChanged += (sender, args) => {
+			entry.TextChanged += (sender, args) =>
+			{
 				signaled = true;
-				Assert.AreEqual (value, args.NewTextValue);
+				Assert.AreEqual(value, args.NewTextValue);
 			};
 
-			entry.SetValue (Entry.TextProperty, value);
+			entry.SetValue(Entry.TextProperty, value);
 
-			Assert.IsTrue (signaled, "ValueChanged did not fire");
+			Assert.IsTrue(signaled, "ValueChanged did not fire");
 		}
 
-		[TestCase (null, "foo")]
-		[TestCase ("foo", "bar")]
-		[TestCase ("foo", null)]
-		public void ValueChangedArgs (string initial, string final)
+		[TestCase(null, "foo")]
+		[TestCase("foo", "bar")]
+		[TestCase("foo", null)]
+		public void ValueChangedArgs(string initial, string final)
 		{
-			var entry = new Entry {
+			var entry = new Entry
+			{
 				Text = initial
 			};
 
@@ -39,7 +41,8 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Entry entryFromSender = null;
 
-			entry.TextChanged += (s, e) => {
+			entry.TextChanged += (s, e) =>
+			{
 				entryFromSender = (Entry)s;
 				oldValue = e.OldTextValue;
 				newValue = e.NewTextValue;
@@ -47,9 +50,64 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			entry.Text = final;
 
-			Assert.AreEqual (entry, entryFromSender);
-			Assert.AreEqual (initial, oldValue);
-			Assert.AreEqual (final, newValue);
+			Assert.AreEqual(entry, entryFromSender);
+			Assert.AreEqual(initial, oldValue);
+			Assert.AreEqual(final, newValue);
+		}
+
+
+		[TestCase(1)]
+		[TestCase(0)]
+		[TestCase(9999)]
+		public void CursorPositionValid(int val)
+		{
+			var entry = new Entry
+			{
+				CursorPosition = val
+			};
+
+			var target = entry.CursorPosition;
+
+			Assert.AreEqual(target, val);
+		}
+
+		[Test]
+		public void CursorPositionInvalid()
+		{
+			Assert.Throws<System.ArgumentException>(() =>
+			{
+				var entry = new Entry
+				{
+					CursorPosition = -1
+				};
+			});
+		}
+
+		[TestCase(1)]
+		[TestCase(0)]
+		[TestCase(9999)]
+		public void SelectionLengthValid(int val)
+		{
+			var entry = new Entry
+			{
+				SelectionLength = val
+			};
+
+			var target = entry.SelectionLength;
+
+			Assert.AreEqual(target, val);
+		}
+
+		[Test]
+		public void SelectionLengthInvalid()
+		{
+			Assert.Throws<System.ArgumentException>(() =>
+			{
+				var entry = new Entry
+				{
+					SelectionLength = -1
+				};
+			});
 		}
 
 		[TestCase(true)]
@@ -63,8 +121,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			bool result = false;
 
-			var bindingContext = new
-			{
+			var bindingContext = new {
 				Command = new Command(() => { result = true; }, () => true)
 			};
 
@@ -86,10 +143,11 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 
 			bool result = false;
-		
+
 			entry.SetBinding(Entry.ReturnCommandProperty, "Command");
 			entry.BindingContext = null;
-			entry.Completed += (s, e) => {
+			entry.Completed += (s, e) =>
+			{
 				result = true;
 			};
 			entry.SendCompleted();

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -35,9 +35,9 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Entry), true, BindingMode.OneTime);
 
-		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(Entry), 0);
+		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(Entry), 0, validateValue: (b, v) => (int)v >= 0);
 
-		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(Entry), 0);
+		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(Entry), 0, validateValue: (b, v) => (int)v >= 0);
 
 		readonly Lazy<PlatformConfigurationRegistry<Entry>> _platformConfigurationRegistry;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -349,14 +349,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		int GetSelectionEnd(int start)
 		{
-			int end;
-			bool selectionLengthSet = Element.IsSet(Entry.SelectionLengthProperty);
+			int end = start;
 			int selectionLength = Element.SelectionLength;
 
-			if (selectionLengthSet)
+			if (Element.IsSet(Entry.SelectionLengthProperty))
 				end = System.Math.Max(start, System.Math.Min(Control.Length(), start + selectionLength));
-			else
-				end = start;
 
 			int newSelectionLength = System.Math.Max(0, end - start);
 			if (newSelectionLength != selectionLength)
@@ -371,14 +368,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		int GetSelectionStart()
 		{
-			int start;
-			bool cursorPositionSet = Element.IsSet(Entry.CursorPositionProperty);
+			int start = Control.Length();
 			int cursorPosition = Element.CursorPosition;
 
-			if (cursorPositionSet)
+			if (Element.IsSet(Entry.CursorPositionProperty))
 				start = System.Math.Min(Control.Text.Length, cursorPosition);
-			else
-				start = Control.Length();
 
 			if (start != cursorPosition)
 			{

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -343,15 +343,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (Control.Focus(FocusState.Programmatic))
 			{
-				int selectionLength;
+				int selectionLength = 0;
 				int elemSelectionLength = Element.SelectionLength;
 
 				if (Element.IsSet(Entry.SelectionLengthProperty))
-				{
 					selectionLength = Math.Max(0, Math.Min(Control.Text.Length - Element.CursorPosition, elemSelectionLength));
-				}
-				else
-					selectionLength = 0;
 
 				if (elemSelectionLength != selectionLength)
 				{
@@ -373,13 +369,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (Control.Focus(FocusState.Programmatic))
 			{
-				int start;
+				int start = Control.Text.Length;
 				int cursorPosition = Element.CursorPosition;
 
 				if (Element.IsSet(Entry.CursorPositionProperty))
-					start = Math.Min(Control.Text.Length, cursorPosition);
-				else
-					start = Control.Text.Length;
+					start = Math.Min(start, cursorPosition);
 
 				if (start != cursorPosition)
 				{

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -18,6 +19,10 @@ namespace Xamarin.Forms.Platform.UWP
 		Brush _textDefaultBrush;
 		Brush _defaultTextColorFocusBrush;
 		Brush _defaultPlaceholderColorFocusBrush;
+		bool _cursorPositionChangePending;
+		bool _selectionLengthChangePending;
+		bool _nativeSelectionIsUpdating;
+
 		IElementController ElementController => Element as IElementController;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
@@ -34,11 +39,17 @@ namespace Xamarin.Forms.Platform.UWP
 					textBox.TextChanged += OnNativeTextChanged;
 					textBox.KeyUp += TextBoxOnKeyUp;
 					textBox.SelectionChanged += SelectionChanged;
+					textBox.GotFocus += TextBoxGotFocus;
 					// If the Forms VisualStateManager is in play or the user wants to disable the Forms legacy
 					// color stuff, then the underlying textbox should just use the Forms VSM states
 					textBox.UseFormsVsm = e.NewElement.HasVisualStateGroups()
 						|| !e.NewElement.OnThisPlatform().GetIsLegacyColorModeEnabled();
 				}
+
+				// When we set the control text, it triggers the SelectionChanged event, which updates CursorPosition and SelectionLength;
+				// These one-time-use variables will let us initialize a CursorPosition and SelectionLength via ctor/xaml/etc.
+				_cursorPositionChangePending = Element.IsSet(Entry.CursorPositionProperty);
+				_selectionLengthChangePending = Element.IsSet(Entry.SelectionLengthProperty);
 
 				UpdateIsPassword();
 				UpdateText();
@@ -51,9 +62,27 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateMaxLength();
 				UpdateDetectReadingOrderFromContent();
 				UpdateReturnType();
-				UpdateCursorPosition();
-				UpdateSelectionLength();
+
+				if (_cursorPositionChangePending)
+					UpdateCursorPosition();
+
+				if (_selectionLengthChangePending)
+					UpdateSelectionLength();
 			}
+		}
+
+		void TextBoxGotFocus(object sender, RoutedEventArgs e)
+		{
+			if (_cursorPositionChangePending)
+				UpdateCursorPosition();
+
+			if (_selectionLengthChangePending)
+				UpdateSelectionLength();
+
+			_nativeSelectionIsUpdating = true;
+			ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, Control.SelectionStart);
+			ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, Control.SelectionLength);
+			_nativeSelectionIsUpdating = false;
 		}
 
 		protected override void Dispose(bool disposing)
@@ -63,6 +92,7 @@ namespace Xamarin.Forms.Platform.UWP
 				Control.TextChanged -= OnNativeTextChanged;
 				Control.KeyUp -= TextBoxOnKeyUp;
 				Control.SelectionChanged -= SelectionChanged;
+				Control.GotFocus -= TextBoxGotFocus;
 			}
 
 			base.Dispose(disposing);
@@ -183,8 +213,7 @@ namespace Xamarin.Forms.Platform.UWP
 		void UpdateInputScope()
 		{
 			Entry entry = Element;
-			var custom = entry.Keyboard as CustomKeyboard;
-			if (custom != null)
+			if (entry.Keyboard is CustomKeyboard custom)
 			{
 				Control.IsTextPredictionEnabled = (custom.Flags & KeyboardFlags.Suggestions) != 0;
 				Control.IsSpellCheckEnabled = (custom.Flags & KeyboardFlags.Spellcheck) != 0;
@@ -276,51 +305,95 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void SelectionChanged(object sender, RoutedEventArgs e)
 		{
-			var control = Control;
-			if (control == null || Element == null)
+			if (_nativeSelectionIsUpdating || Control == null || Element == null)
 				return;
 
-			var start = Element.CursorPosition;
+			int cursorPosition = Element.CursorPosition;
 
-			if (control.SelectionStart != start)
-				ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, control.SelectionStart);
+			if (!_cursorPositionChangePending)
+			{
+				var start = cursorPosition;
+				int selectionStart = Control.SelectionStart;
+				if (selectionStart != start)
+				{
+					_nativeSelectionIsUpdating = true;
+					ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, selectionStart);
+				}
+			}
 
-			var selectionLength = control.SelectionLength;
-			if (selectionLength != Element.SelectionLength)
-				ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+			if (!_selectionLengthChangePending)
+			{
+				int elementSelectionLength = Math.Min(Control.Text.Length - cursorPosition, Element.SelectionLength);
+
+				int controlSelectionLength = Control.SelectionLength;
+				if (controlSelectionLength != elementSelectionLength)
+				{
+					_nativeSelectionIsUpdating = true;
+					ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, controlSelectionLength);
+				}
+			}
+
+			_nativeSelectionIsUpdating = false;
 		}
 
 		void UpdateSelectionLength()
 		{
-			var control = Control;
-			if (control == null || Element == null)
+			if (_nativeSelectionIsUpdating || Control == null || Element == null)
 				return;
 
-			if (Element.IsSet(Entry.SelectionLengthProperty))
+			if (Control.Focus(FocusState.Programmatic))
 			{
-				var selectionLength = Element.SelectionLength;
-				if (selectionLength != control.SelectionLength)
+				int selectionLength;
+				int elemSelectionLength = Element.SelectionLength;
+
+				if (Element.IsSet(Entry.SelectionLengthProperty))
 				{
-					control.SelectionLength = selectionLength;
-					control.Focus(FocusState.Programmatic);
+					selectionLength = Math.Max(0, Math.Min(Control.Text.Length - Element.CursorPosition, elemSelectionLength));
 				}
+				else
+					selectionLength = 0;
+
+				if (elemSelectionLength != selectionLength)
+				{
+					_nativeSelectionIsUpdating = true;
+					ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+					_nativeSelectionIsUpdating = false;
+				}
+
+				Control.SelectionLength = selectionLength;
+
+				_selectionLengthChangePending = false;
 			}
 		}
 
 		void UpdateCursorPosition()
 		{
-			var control = Control;
-			if (control == null || Element == null)
+			if (_nativeSelectionIsUpdating || Control == null || Element == null)
 				return;
 
-			if (Element.IsSet(Entry.CursorPositionProperty))
+			if (Control.Focus(FocusState.Programmatic))
 			{
-				var start = Element.CursorPosition;
-				if (start != control.SelectionStart)
+				int start;
+				int cursorPosition = Element.CursorPosition;
+
+				if (Element.IsSet(Entry.CursorPositionProperty))
+					start = Math.Min(Control.Text.Length, cursorPosition);
+				else
+					start = Control.Text.Length;
+
+				if (start != cursorPosition)
 				{
-					control.SelectionStart = start;
-					control.Focus(FocusState.Programmatic);
+					_nativeSelectionIsUpdating = true;
+					ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, start);
+					_nativeSelectionIsUpdating = false;
 				}
+
+				Control.SelectionStart = start;
+
+				// Length is dependent on start, so we'll need to update it
+				UpdateSelectionLength();
+
+				_cursorPositionChangePending = false;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -22,17 +22,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 		bool _disposed;
 		IDisposable _selectedTextRangeObserver;
-		bool _selectedTextRangeIsUpdating;
+		bool _nativeSelectionIsUpdating;
+
+		bool _cursorPositionChangePending;
+		bool _selectionLengthChangePending;
 
 		static readonly int baseHeight = 30;
 		static CGSize initialSize = CGSize.Empty;
 
-		public EntryRenderer() 
+		public EntryRenderer()
 		{
 			Frame = new RectangleF(0, 20, 320, 40);
 		}
 
-		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint) 
+		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			var baseResult = base.GetDesiredSize(widthConstraint, heightConstraint);
 
@@ -66,7 +69,7 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.EditingDidBegin -= OnEditingBegan;
 					Control.EditingChanged -= OnEditingChanged;
 					Control.EditingDidEnd -= OnEditingEnded;
-                    Control.ShouldChangeCharacters -= ShouldChangeCharacters;
+					Control.ShouldChangeCharacters -= ShouldChangeCharacters;
 					_selectedTextRangeObserver?.Dispose();
 				}
 			}
@@ -99,9 +102,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 				textField.EditingDidBegin += OnEditingBegan;
 				textField.EditingDidEnd += OnEditingEnded;
-                textField.ShouldChangeCharacters += ShouldChangeCharacters;
+				textField.ShouldChangeCharacters += ShouldChangeCharacters;
 				_selectedTextRangeObserver = textField.AddObserver("selectedTextRange", NSKeyValueObservingOptions.New, UpdateCursorFromControl);
 			}
+
+			// When we set the control text, it triggers the UpdateCursorFromControl event, which updates CursorPosition and SelectionLength;
+			// These one-time-use variables will let us initialize a CursorPosition and SelectionLength via ctor/xaml/etc.
+			_cursorPositionChangePending = Element.IsSet(Entry.CursorPositionProperty);
+			_selectionLengthChangePending = Element.IsSet(Entry.SelectionLengthProperty);
 
 			UpdatePlaceholder();
 			UpdatePassword();
@@ -113,7 +121,10 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateAdjustsFontSizeToFitWidth();
 			UpdateMaxLength();
 			UpdateReturnType();
-			UpdateCursorSelection();
+
+			if (_cursorPositionChangePending || _selectionLengthChangePending)
+				UpdateCursorSelection();
+
 			UpdateCursorColor();
 		}
 
@@ -146,7 +157,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateColor();
 				UpdatePlaceholder();
 			}
-			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Entry.AdjustsFontSizeToFitWidthProperty.PropertyName)
+			else if (e.PropertyName == Specifics.AdjustsFontSizeToFitWidthProperty.PropertyName)
 				UpdateAdjustsFontSizeToFitWidth();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateAlignment();
@@ -154,7 +165,9 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateMaxLength();
 			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
 				UpdateReturnType();
-			else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName || e.PropertyName == Entry.SelectionLengthProperty.PropertyName)
+			else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName)
+				UpdateCursorSelection();
+			else if (e.PropertyName == Entry.SelectionLengthProperty.PropertyName)
 				UpdateCursorSelection();
 			else if (e.PropertyName == Specifics.CursorColorProperty.PropertyName)
 				UpdateCursorColor();
@@ -164,6 +177,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnEditingBegan(object sender, EventArgs e)
 		{
+			UpdateCursorSelection();
+
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 		}
 
@@ -315,42 +330,104 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateCursorFromControl(NSObservedChange obj)
 		{
-			var control = Control;
-			if (_selectedTextRangeIsUpdating || control == null || Element == null)
+			if (_nativeSelectionIsUpdating || Control == null || Element == null)
 				return;
 
-			var currentSelection = control.SelectedTextRange;
-			int selectionLength = (int)control.GetOffsetFromPosition(currentSelection.Start, currentSelection.End);
-			int newCursorPosition = (int)control.GetOffsetFromPosition(control.BeginningOfDocument, currentSelection.Start);
+			var currentSelection = Control.SelectedTextRange;
+			if (currentSelection != null)
+			{
+				if (!_cursorPositionChangePending)
+				{
+					int newCursorPosition = (int)Control.GetOffsetFromPosition(Control.BeginningOfDocument, currentSelection.Start);
+					if (newCursorPosition != Element.CursorPosition)
+					{
+						_nativeSelectionIsUpdating = true;
+						ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, newCursorPosition);
+					}
+				}
 
-			_selectedTextRangeIsUpdating = true;
-			if (newCursorPosition != Element.CursorPosition)
-				ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, newCursorPosition);
+				if (!_selectionLengthChangePending)
+				{
+					int selectionLength = (int)Control.GetOffsetFromPosition(currentSelection.Start, currentSelection.End);
 
-			if (selectionLength != Element.SelectionLength)
-				ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
-			_selectedTextRangeIsUpdating = false;
+					if (selectionLength != Element.SelectionLength)
+					{
+						_nativeSelectionIsUpdating = true;
+						ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+					}
+				}
+			}
+
+			_nativeSelectionIsUpdating = false;
 		}
 
 		void UpdateCursorSelection()
 		{
-			var control = Control;
-			if (_selectedTextRangeIsUpdating || control == null || Element == null)
+			if (_nativeSelectionIsUpdating || Control == null || Element == null)
 				return;
 
-			if (Element.IsSet(Entry.CursorPositionProperty) || Element.IsSet(Entry.SelectionLengthProperty)) {
+			// If this is run from the ctor, the control is likely too early in its lifecycle to be first responder yet. 
+			// Anything done here will have no effect, so we'll skip this work until later.
+			// We'll try again when the control does become first responder later OnEditingBegan
+			if (Control.BecomeFirstResponder())
+			{
+				int cursorPosition = Element.CursorPosition;
 
-				control.BecomeFirstResponder();
-				var start = control.GetPosition(control.BeginningOfDocument, Element.CursorPosition);
-				var end = control.GetPosition(start, System.Math.Min(control.Text.Length - Element.CursorPosition, Element.SelectionLength));
-				var currentSelection = control.SelectedTextRange;
-				if (currentSelection.Start != start || currentSelection.End != end)
-				{
-					_selectedTextRangeIsUpdating = true;
-					control.SelectedTextRange = control.GetTextRange(start, end);
-					_selectedTextRangeIsUpdating = false;
-				}
+				UITextPosition start = GetSelectionStart(cursorPosition, out int startOffset);
+				UITextPosition end = GetSelectionEnd(cursorPosition, start, startOffset);
+
+				Control.SelectedTextRange = Control.GetTextRange(start, end);
+
+				_cursorPositionChangePending = _selectionLengthChangePending = false;
 			}
+		}
+
+		UITextPosition GetSelectionEnd(int cursorPosition, UITextPosition start, int startOffset)
+		{
+			UITextPosition end;
+			int endOffset = startOffset;
+			int selectionLength = Element.SelectionLength;
+
+			if (Element.IsSet(Entry.SelectionLengthProperty))
+			{
+				end = Control.GetPosition(start, Math.Max(startOffset, Math.Min(Control.Text.Length - cursorPosition, selectionLength))) ?? start;
+				endOffset = Math.Max(startOffset, (int)Control.GetOffsetFromPosition(Control.BeginningOfDocument, end));
+			}
+			else
+				end = start;
+
+			int newSelectionLength = Math.Max(0, endOffset - startOffset);
+			if (newSelectionLength != selectionLength)
+			{
+				_nativeSelectionIsUpdating = true;
+				ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, newSelectionLength);
+				_nativeSelectionIsUpdating = false;
+			}
+
+			return end;
+		}
+
+		UITextPosition GetSelectionStart(int cursorPosition, out int startOffset)
+		{
+			UITextPosition start;
+			startOffset = 0;
+
+			if (Element.IsSet(Entry.CursorPositionProperty))
+			{
+				start = Control.GetPosition(Control.BeginningOfDocument, cursorPosition) ?? Control.EndOfDocument;
+				startOffset = Math.Max(0, (int)Control.GetOffsetFromPosition(Control.BeginningOfDocument, start));
+			}
+			else
+				start = Control.EndOfDocument;
+
+			if (startOffset != cursorPosition)
+			{
+				_nativeSelectionIsUpdating = true;
+				ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, startOffset);
+				_nativeSelectionIsUpdating = false;
+			}
+
+			return start;
 		}
 
 		void UpdateCursorColor()
@@ -369,6 +446,4 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 	}
-
-
 }


### PR DESCRIPTION
### Description of Change ###

#2539 added the ability to set `CursorPosition` and `SelectionLength` on `Entry`. It was set up to allow these properties to be set during construction, but that was thwarted by the initial `Text` triggering a `SelectionChanged`, which reverted the `CursorPosition` and `SelectionLength` to default values. This change established a one-time-use bool that will skip the initial `SelectionChanged` work.

Also resolved issue where clearing the set values of CursorPosition/SelectionLength did nothing.

### Issues Resolved ###

- fixes #3343 
- fixes #3633

### API Changes ###

None

### Platforms Affected ###

- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Testing procedure ###

1. Open test case 3343.
2. First Entry should have selection. CursorPositon: 4 SelectionLength: 7.
3. Second Entry should have no selection. CursorPostion: 0 SelectionLength: 0.
4. Tap in second Entry. Make selection. CursorPosition and SelectionLength should update accordingly. Note: iOS will snap to end on first click, tap and hold to move the cursor.
5. Tap quickly between the two entries. Should not crash.
6. Tap Click Me button. 
7. Second Entry should have selection. CursorPosition: 4. SelectionLength: 8.
8. Tap Click Me After.
9. Second Entry should have selection. CursorPosition: 2 SelectionLength 8.
10. Tap Click Me Last. Watch the second entry.
11. Second Entry selection should disappear. CursorPosition: 2 SelectionLength 0. 
12. Second Entry CursorPostion should snap to end. CursorPostion: 12 SelectionLength 0.
13. Clear the text in the second Entry. CursorPosition: 0 SelectionLength: 0
14. Tap Click Me. Should not crash. CursorPosition: 0 SelectionLength: 0
15. Type three characters in the second Entry. CursorPosition: 3 SelectionLength: 0
16. Tap Click Me. Should not crash. CursorPosition: 3 SelectionLength: 0
17. Tap Click Me After. Should not crash. CursorPosition: 2 SelectionLength: 0
18. Repeat 15-17 with varying text lengths.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
