### PR TITLE
[UWP] Remove old appbar code in Platform

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -500,5 +500,14 @@ namespace Xamarin.Forms.Platform.UWP
 
 			return result == ContentDialogResult.Primary;
 		}
+
+		void OnBackRequested(object sender, BackRequestedEventArgs e)
+		{
+			Application app = Application.Current;
+			Page page = app?.MainPage;
+			if (page == null)
+				return;
+			e.Handled = BackButtonPressed();
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -147,19 +147,6 @@
 	<SolidColorBrush x:Key="TabButtonPointerOverBackgroundBrush" Color="#44888888" />
 	<SolidColorBrush x:Key="TabButtonBackgroundBrush" Color="#29888888" />
 
-	<Style x:Key="TitleToolbar" TargetType="uwp:FormsCommandBar">
-		<Setter Property="ContentTemplate">
-			<Setter.Value>
-				<DataTemplate>
-					<Grid Background="{Binding ToolbarBackground}">
-						<TextBlock Text="{Binding}" Margin="10,0,0,0" VerticalAlignment="Center" Style="{ThemeResource TitleTextBlockStyle}" Foreground="{Binding ToolbarForeground}" />
-					</Grid>
-				</DataTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
-
-
 	<Style x:Key="FormsListViewItem" TargetType="ListViewItem">
 		<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
 		<Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />


### PR DESCRIPTION
### Description of Change ###

Before the various IToolBarProvider implemenations (MasterDetail, Tabbed, Navigation) implemented their own command bars as part of their control templates, Platform could add a command bar to any page which needed it. 

Now that each of the providers ... er, provides their own command bar, this capability is no longer necessary or in use. This change removes the unused code.

### Issues Resolved ###

None, just cleaning out unused code.

### API Changes ###

None

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
