### PR TITLE
[macOS] ScrollViewRenderer.PackContent is not called when ScrollView.Content is set after same delay

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2875.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2875.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Linq.Expressions;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2875, "[macOS] ScrollViewRenderer.PackContent is not called when ScrollView.Content is set after same delay", PlatformAffected.macOS)]
+	public class Issue2875 : TestContentPage
+	{
+		const string ButtonId = "ChangeButton";
+		const string Label1Id = "Label1";
+		const string Label2Id = "Label2";
+
+		protected override void Init()
+		{
+			var sl = new StackLayout();
+			var sv = new ScrollView
+			{
+				Content = new Label
+				{
+					Text = "Label 1",
+					AutomationId = Label1Id
+				}
+			};
+			sl.Children.Add(sv);
+			sl.Children.Add(new Button
+			{
+				Text = "Change",
+				AutomationId = ButtonId,
+				Command = new Command(() =>
+					sv.Content = new Label
+					{
+						Text = "Label 2",
+						AutomationId = Label2Id
+					}
+				)
+			});
+
+			Content = sl;
+		}
+
+#if UITEST
+#if __MACOS__
+		[Test]
+		public void Issue2875Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked(Label1Id));
+			RunningApp.WaitForElement(q => q.Marked(ButtonId));
+			RunningApp.Tap(q => q.Marked(ButtonId));
+
+			RunningApp.WaitForElement(q => q.Marked(Label2Id));
+		}
+#endif
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -247,6 +247,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1556.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1799.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1931.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2875.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3053.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2617.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3087.cs" />


### PR DESCRIPTION
### Description of Change ###

ScrollView.Content changes are monitored in the same way as on iOS platform. The original code did not update the view after Content change.

### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2875

### API Changes ###

None
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem -->

### Platforms Affected ###

<!-- Please list all platforms affected by these changes -->

- macOS

### Behavioral/Visual Changes ###

Changes of ScrollView.Content are reflected on the view.

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
