### PR TITLE
[Tizen] Fix Page.IsBusy Appearance

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Platform.cs
+++ b/Xamarin.Forms.Platform.Tizen/Platform.cs
@@ -402,13 +402,18 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				_pageBusyDialog = new Native.Dialog(Forms.NativeParent)
 				{
-					Orientation = PopupOrientation.Top,
+					Orientation = PopupOrientation.Center,
+					BackgroundColor = EColor.Transparent
 				};
 
-				if (Device.Idiom == TargetIdiom.Watch)
+				if (Device.Idiom == TargetIdiom.Phone)
+				{
+					_pageBusyDialog.SetPartColor("bg_title", EColor.Transparent);
+					_pageBusyDialog.SetPartColor("bg_content", EColor.Transparent);
+				}
+				else if (Device.Idiom == TargetIdiom.Watch)
 				{
 					_pageBusyDialog.Style = "circle";
-					_pageBusyDialog.BackgroundColor = EColor.Transparent;
 				}
 
 				var activity = new EProgressBar(_pageBusyDialog)


### PR DESCRIPTION
### Description of Change ###

This change is about fixing the appearance of `Page.IsBusy` on Tizen.
- Inappropriate white color background of popup is removed
- Busy mark is moved to the center of a screen

![isbusyontv](https://user-images.githubusercontent.com/14328614/43307051-1cfadb6a-91b8-11e8-93e5-c36cd3ac509d.gif)

![isbusyonmobile](https://user-images.githubusercontent.com/14328614/43307053-1fa09102-91b8-11e8-893f-92e6941ccc3b.gif)



### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###

- None

### Platforms Affected ###

- Tizen

### Behavioral/Visual Changes ###

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->
Unwanted white background color is removed, and busy mark is shown as expected.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
