### PR TITLE
[CSS] allow mapping css prop to multiple BPs

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/StyleSheets/IStylableTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/StyleSheets/IStylableTest.cs
@@ -41,6 +41,14 @@ namespace Xamarin.Forms.StyleSheets.UnitTests
 		}
 
 		[TestCase]
+		public void GetPropertyDefinedOnType3()
+		{
+			var indicator = new ActivityIndicator();
+			var bp = ((IStylable)indicator).GetProperty("color", false);
+			Assert.AreSame(ActivityIndicator.ColorProperty, bp);
+		}
+
+		[TestCase]
 		public void GetInvalidPropertyForType()
 		{
 			var grid = new Grid();
@@ -63,6 +71,5 @@ namespace Xamarin.Forms.StyleSheets.UnitTests
 			var bp = ((IStylable)label).GetProperty("margin-right", false);
 			Assert.That(bp, Is.SameAs(View.MarginRightProperty));
 		}
-
 	}
 }

--- a/Xamarin.Forms.Core/ActivityIndicator.cs
+++ b/Xamarin.Forms.Core/ActivityIndicator.cs
@@ -4,11 +4,11 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_ActivityIndicatorRenderer))]
-	public class ActivityIndicator : View, IElementConfiguration<ActivityIndicator>
+	public class ActivityIndicator : View, IColorElement, IElementConfiguration<ActivityIndicator>
 	{
 		public static readonly BindableProperty IsRunningProperty = BindableProperty.Create("IsRunning", typeof(bool), typeof(ActivityIndicator), default(bool));
 
-		public static readonly BindableProperty ColorProperty = BindableProperty.Create("Color", typeof(Color), typeof(ActivityIndicator), Color.Default);
+		public static readonly BindableProperty ColorProperty = ColorElement.ColorProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<ActivityIndicator>> _platformConfigurationRegistry;
 
@@ -19,8 +19,8 @@ namespace Xamarin.Forms
 
 		public Color Color
 		{
-			get { return (Color)GetValue(ColorProperty); }
-			set { SetValue(ColorProperty, value); }
+			get { return (Color)GetValue(ColorElement.ColorProperty); }
+			set { SetValue(ColorElement.ColorProperty, value); }
 		}
 
 		public bool IsRunning

--- a/Xamarin.Forms.Core/ColorElement.cs
+++ b/Xamarin.Forms.Core/ColorElement.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.Forms
+{
+	static class ColorElement
+	{
+		public static readonly BindableProperty ColorProperty =
+			BindableProperty.Create(nameof(IColorElement.Color), typeof(Color), typeof(IColorElement), Color.Default);
+	}
+}

--- a/Xamarin.Forms.Core/IColorElement.cs
+++ b/Xamarin.Forms.Core/IColorElement.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.Forms
+{
+	interface IColorElement
+	{
+		//note to implementor: implement this property publicly
+		Color Color { get; }
+	}
+}

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -40,6 +40,7 @@ using Xamarin.Forms.StyleSheets;
 [assembly: StyleProperty("border-color", typeof(IBorderElement), nameof(BorderElement.BorderColorProperty))]
 [assembly: StyleProperty("border-radius", typeof(ICornerElement), nameof(CornerElement.CornerRadiusProperty))]
 [assembly: StyleProperty("border-width", typeof(Button), nameof(Button.BorderWidthProperty))]
+[assembly: StyleProperty("color", typeof(IColorElement), nameof(ColorElement.ColorProperty), Inherited = true)]
 [assembly: StyleProperty("color", typeof(ITextElement), nameof(TextElement.TextColorProperty), Inherited = true)]
 [assembly: StyleProperty("direction", typeof(VisualElement), nameof(VisualElement.FlowDirectionProperty), Inherited = true)]
 [assembly: StyleProperty("font-family", typeof(IFontElement), nameof(FontElement.FontFamilyProperty), Inherited = true)]

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -183,7 +183,7 @@ namespace Xamarin.Forms.Internals
 		}
 
 		internal static Dictionary<string, Type> Effects { get; } = new Dictionary<string, Type>();
-		internal static Dictionary<string, StyleSheets.StylePropertyAttribute> StyleProperties { get; } = new Dictionary<string, StyleSheets.StylePropertyAttribute>();
+		internal static Dictionary<string, IList<StyleSheets.StylePropertyAttribute>> StyleProperties { get; } = new Dictionary<string, IList<StyleSheets.StylePropertyAttribute>>();
 
 		public static IEnumerable<Assembly> ExtraAssemblies { get; set; }
 
@@ -248,7 +248,10 @@ namespace Xamarin.Forms.Internals
 				for (var i = 0; i < stylePropertiesLength; i++)
 				{
 					var attribute = (StyleSheets.StylePropertyAttribute)styleAttributes[i];
-					StyleProperties[attribute.CssPropertyName] = attribute;
+					if (StyleProperties.TryGetValue(attribute.CssPropertyName, out var attrList))
+						attrList.Add(attribute);
+					else
+						StyleProperties[attribute.CssPropertyName] = new List<StyleSheets.StylePropertyAttribute> { attribute };
 				}
 			}
 

--- a/Xamarin.Forms.Core/VisualElement_StyleSheet.cs
+++ b/Xamarin.Forms.Core/VisualElement_StyleSheet.cs
@@ -13,11 +13,18 @@ namespace Xamarin.Forms
 
 		BindableProperty IStylable.GetProperty(string key, bool inheriting)
 		{
-			StylePropertyAttribute styleAttribute;
-			if (!Internals.Registrar.StyleProperties.TryGetValue(key, out styleAttribute))
+			if (!Internals.Registrar.StyleProperties.TryGetValue(key, out var attrList))
 				return null;
 
-			if (!styleAttribute.TargetType.GetTypeInfo().IsAssignableFrom(GetType().GetTypeInfo()))
+			StylePropertyAttribute styleAttribute = null;
+			for (int i = 0; i < attrList.Count; i++) {
+				styleAttribute = attrList[i];
+				if (styleAttribute.TargetType.GetTypeInfo().IsAssignableFrom(GetType().GetTypeInfo()))
+					break;
+				styleAttribute = null;
+			}
+
+			if (styleAttribute == null)
 				return null;
 
 			//do not inherit non-inherited properties


### PR DESCRIPTION
### Description of Change ###

To allow mapping a single CSS property to multiple controls, we so far
relied on extracting the BindableProperties to static helper classes,
and implementing an interface for accessors, and eventually change
handlers.

That extraction works well, and is actually a good pattern, as long as:
 - the extracted BPs share the same PropertyName,
 - default value, and
 - return type, obiously

As the CSS `color` property has to map to both `TextColor` and `Color`
BPs, the property extraction wasn't possible.

This change adds the capability to map a single CSS property to
multiples BPS, when extraction isn't possible. Whenever the extraction
to an interface is possible, that behavior is strongly encouraged.

### Issues Resolved ###

/

### API Changes ###

/

### Platforms Affected ###

<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
