### PR TITLE
[C] abstract the Style property in an interface

### DIFF
--- a/Xamarin.Forms.Core/IStyleElement.cs
+++ b/Xamarin.Forms.Core/IStyleElement.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.Forms
+{
+	interface IStyleElement
+	{
+		//note to implementor: implement this property publicly
+		Style Style { get; }
+	}
+}

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms
 {
 	[ContentProperty("Text")]
-	public sealed class Span : GestureElement, IFontElement, ITextElement, ILineHeightElement
+	public sealed class Span : GestureElement, IFontElement, IStyleElement, ITextElement, ILineHeightElement
 	{
 		internal readonly MergedStyle _mergedStyle;
 

--- a/Xamarin.Forms.Core/Style.cs
+++ b/Xamarin.Forms.Core/Style.cs
@@ -157,7 +157,7 @@ namespace Xamarin.Forms
 
 		static void OnBasedOnResourceChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			Style style = (bindable as VisualElement).Style;
+			Style style = (bindable as IStyleElement).Style;
 			if (style == null)
 				return;
 			style.UnApplyCore(bindable, (Style)oldValue);

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	public partial class VisualElement : Element, IAnimatable, IVisualElementController, IResourcesProvider, IFlowDirectionController
+	public partial class VisualElement : Element, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController
 	{
 		internal static readonly BindablePropertyKey NavigationPropertyKey = BindableProperty.CreateReadOnly("Navigation", typeof(INavigation), typeof(VisualElement), default(INavigation));
 
@@ -290,7 +290,6 @@ namespace Xamarin.Forms
 			get { return (Style)GetValue(StyleProperty); }
 			set { SetValue(StyleProperty, value); }
 		}
-
 
 		[TypeConverter(typeof(ListStringTypeConverter))]
 		public IList<string> StyleClass


### PR DESCRIPTION
### Description of Change ###

[C] abstract the Style property in an interface

so it's shared between VisualElement and span, and retrieving the
property is easier.

<!-- Describe your changes here. -->

### Issues Resolved ###

- fixes #3314

### API Changes ###

/

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
