### PR TITLE
[UWP] Fixed freezing UI when scrolling the listview

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3367.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3367.cs
@@ -48,6 +48,8 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Children =
 				{
+					new Label { Text = "As the list views scrolls, click around and try to select rows in the ListView. " +
+						"The UI should remain responsive as you click and as the ListView continues to scrolls." },
 					startStopButton,
 					lstMessages
 				}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3367.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3367.cs
@@ -1,0 +1,57 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System.Threading;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers = true)]
+	[Issue (IssueTracker.Github, 3367, "The ScrollTo method freezes UI", PlatformAffected.UWP)]
+	public class Issue3367 : TestContentPage 
+	{
+		bool simulateMessages = false;
+		bool simulatedThreadEnabled = true;
+
+		protected override void Init ()
+		{
+			var collection = new ObservableCollection<string>();
+			int itemId = 0;
+			for (int i = 0; i < 100; i++)
+				collection.Add($"message {++itemId}");
+			BindingContext = collection;
+			var lstMessages = new ListView();
+			lstMessages.SetBinding(ListView.ItemsSourceProperty, ".");
+
+			new Thread(() =>
+			{
+				while (simulatedThreadEnabled)
+				{
+					Thread.Sleep(500);
+					if (!simulateMessages)
+						continue;
+
+					var newItem = $"added message {++itemId}";
+					collection.Add(newItem);
+					Device.BeginInvokeOnMainThread(() => lstMessages.ScrollTo(newItem, ScrollToPosition.Start, false));
+				}
+			}).Start();
+			
+			this.Disappearing += (_, __) => simulatedThreadEnabled = false;
+
+			var startStopButton = new Button()
+			{
+				Text = "Start/stop simulate",
+				Command = new Command(() => simulateMessages = !simulateMessages)
+			};
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					startStopButton,
+					lstMessages
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -361,6 +361,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3008.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3019.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2993.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3367.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -457,37 +457,42 @@ namespace Xamarin.Forms.Platform.UWP
 
 			var semanticLocation = new SemanticZoomLocation { Item = c };
 
-			switch (toPosition)
+			// async scrolling
+			await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
 			{
-				case ScrollToPosition.Start:
-					{
-						List.ScrollIntoView(c, ScrollIntoViewAlignment.Leading);
-						return;
-					}
+				switch (toPosition)
+				{
+					case ScrollToPosition.Start:
+						{
 
-				case ScrollToPosition.MakeVisible:
-					{
-						List.ScrollIntoView(c, ScrollIntoViewAlignment.Default);
-						return;
-					}
+							List.ScrollIntoView(c, ScrollIntoViewAlignment.Leading);
+							return;
+						}
 
-				case ScrollToPosition.End:
-				case ScrollToPosition.Center:
-					{
-						var content = (FrameworkElement)List.ItemTemplate.LoadContent();
-						content.DataContext = c;
-						content.Measure(new Windows.Foundation.Size(viewer.ActualWidth, double.PositiveInfinity));
+					case ScrollToPosition.MakeVisible:
+						{
+							List.ScrollIntoView(c, ScrollIntoViewAlignment.Default);
+							return;
+						}
 
-						double tHeight = content.DesiredSize.Height;
+					case ScrollToPosition.End:
+					case ScrollToPosition.Center:
+						{
+							var content = (FrameworkElement)List.ItemTemplate.LoadContent();
+							content.DataContext = c;
+							content.Measure(new Windows.Foundation.Size(viewer.ActualWidth, double.PositiveInfinity));
 
-						if (toPosition == ScrollToPosition.Center)
-							semanticLocation.Bounds = new Rect(0, viewportHeight / 2 - tHeight / 2, 0, 0);
-						else
-							semanticLocation.Bounds = new Rect(0, viewportHeight - tHeight, 0, 0);
+							double tHeight = content.DesiredSize.Height;
 
-						break;
-					}
-			}
+							if (toPosition == ScrollToPosition.Center)
+								semanticLocation.Bounds = new Rect(0, viewportHeight / 2 - tHeight / 2, 0, 0);
+							else
+								semanticLocation.Bounds = new Rect(0, viewportHeight - tHeight, 0, 0);
+
+							break;
+						}
+				}
+			});
 
 			// Waiting for loaded doesn't seem to be enough anymore; the ScrollViewer does not appear until after Loaded.
 			// Even if the ScrollViewer is present, an invoke at low priority fails (E_FAIL) presumably because the items are


### PR DESCRIPTION
### Description of Change ###

`ListView` scrolls asynchronously so as not to freeze the UI thread.
**Screencast:** http://recordit.co/f2RIEyQdTG

### Issues Resolved ###

- fixes #3367 

### API Changes ###

/

### Platforms Affected ###

- UWP

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
