### PR TITLE
[Core] Fixed setting CornerRadius of button to 5

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3390.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3390.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Controls.Issues
 			btn.Command = new Command(async () => {
 				btn.CornerRadius = 5;
 				await Task.Delay(200);
-				btn.Text = btn.CornerRadius == 5 ? "Success" : "Faled";
+				btn.Text = btn.CornerRadius == 5 ? "Success" : "Failed";
 			});
 
 			Content = new StackLayout()
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Controls.Issues
 					{
 						Text = $"When you click on the button, it will change the corner radius.{Environment.NewLine}" +
 							$"[UWP] Application does not crash.{Environment.NewLine}" +
-							$"[All] Сorner radius must be equal 5.{Environment.NewLine}"
+							$"[All] Сorner radius must be equal 5."
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3390.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3390.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3390, "Crash/incorrect behavior with corner radius 5", PlatformAffected.All)]
+	public class Issue3390 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var btn = new Button()
+			{
+				Text = "Click me",
+				WidthRequest = 50,
+				HeightRequest = 50,
+				CornerRadius = 25,
+			};
+
+			btn.Command = new Command(async () => {
+				btn.CornerRadius = 5;
+				await Task.Delay(200);
+				btn.Text = btn.CornerRadius == 5 ? "Success" : "Faled";
+			});
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					btn,
+					new Label
+					{
+						Text = $"When you click on the button, it will change the corner radius.{Environment.NewLine}" +
+							$"[UWP] Application does not crash.{Environment.NewLine}" +
+							$"[All] Сorner radius must be equal 5.{Environment.NewLine}"
+					}
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void Issue3390Test()
+		{
+			RunningApp.Tap("Click me");
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -247,6 +247,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1556.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1799.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1931.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3390.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3000.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3053.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2617.cs" />

--- a/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
@@ -305,7 +305,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void ButtonBorderRadiusSetMinisOne()
+		public void ButtonBorderRadiusSetMinusOne()
 		{
 			var button = new Button { Platform = new UnitPlatform() };
 

--- a/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/ButtonUnitTest.cs
@@ -292,6 +292,30 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual((int)Button.CornerRadiusProperty.DefaultValue, button.CornerRadius);
 		}
 
+		[Test]
+		public void ButtonCornerRadiusSetToFive()
+		{
+			var button = new Button { Platform = new UnitPlatform() };
+
+			button.CornerRadius = 25;
+			Assert.AreEqual(25, button.CornerRadius);
+
+			button.CornerRadius = 5;
+			Assert.AreEqual(5, button.CornerRadius);
+		}
+
+		[Test]
+		public void ButtonBorderRadiusSetMinisOne()
+		{
+			var button = new Button { Platform = new UnitPlatform() };
+
+			button.BorderRadius = 25;
+			Assert.AreEqual(25, button.BorderRadius);
+
+			button.BorderRadius = -1;
+			Assert.AreEqual(-1, button.BorderRadius);
+		}
+
 		private void AssertButtonContentLayoutsEqual(Button.ButtonContentLayout layout1, object layout2)
 		{
 			var bcl = (Button.ButtonContentLayout)layout2;

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -281,13 +281,19 @@ namespace Xamarin.Forms
 				oldvalue.SourceChanged -= OnSourceChanged;
 		}
 
+		/// <summary>
+		/// Flag to prevent overwriting the value of CornerRadius
+		/// </summary>
+		bool cornerOrBorderRadiusSetting = false;
+
 		static void BorderRadiusPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
 		{
 			if (newvalue == oldvalue)
 				return;
 
+			var button = (Button)bindable;
 			var val = (int)newvalue;
-			if (val == DefaultBorderRadius)
+			if (val == DefaultBorderRadius && !button.cornerOrBorderRadiusSetting)
 				val = DefaultCornerRadius;
 
 			var oldVal = (int)bindable.GetValue(Button.CornerRadiusProperty);
@@ -295,7 +301,9 @@ namespace Xamarin.Forms
 			if (oldVal == val)
 				return;
 
+			button.cornerOrBorderRadiusSetting = true;
 			bindable.SetValue(Button.CornerRadiusProperty, val);
+			button.cornerOrBorderRadiusSetting = false;
 		}
 
 		static void CornerRadiusPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
@@ -303,8 +311,9 @@ namespace Xamarin.Forms
 			if (newvalue == oldvalue)
 				return;
 
+			var button = (Button)bindable;
 			var val = (int)newvalue;
-			if (val == DefaultCornerRadius)
+			if (val == DefaultCornerRadius && !button.cornerOrBorderRadiusSetting)
 				val = DefaultBorderRadius;
 
 #pragma warning disable 0618 // retain until BorderRadiusProperty removed
@@ -315,7 +324,9 @@ namespace Xamarin.Forms
 				return;
 
 #pragma warning disable 0618 // retain until BorderRadiusProperty removed
+			button.cornerOrBorderRadiusSetting = true;
 			bindable.SetValue(Button.BorderRadiusProperty, val);
+			button.cornerOrBorderRadiusSetting = false;
 #pragma warning restore
 		}
 


### PR DESCRIPTION
### Description of Change ###

If you change the `CornerRadius` to 5 has replaced it by -1, and If you change the `BorderRadius` when set to -1 has replaced it by 5. This happened because there was no verification conflicts.
These two properties change each other and the default property may not be applied correctly in this process. 
This PR adds a check that the property is already in the process of changing. And no need to change value to default.

### Issues Resolved ###

- fixes #3390

### API Changes ###

/

### Platforms Affected ###

- Core (all platforms)

### Behavioral/Visual Changes ###

Correct setting `CornerRadius` of button to 5.
Correct setting `BorderRadius` of button to -1.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
