### PR TITLE
[UWP] Remove Platform casts

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -61,7 +61,6 @@ namespace Xamarin.Forms
 			IsInitialized = true;
 			s_state = launchActivatedEventArgs.PreviousExecutionState;
 
-			SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
 			Platform.UWP.Platform.SubscribeAlertsAndActionSheets();
 		}
 
@@ -90,23 +89,6 @@ namespace Xamarin.Forms
 			return new Windows.UI.Xaml.ResourceDictionary {
 				Source = new Uri("ms-appx:///Xamarin.Forms.Platform.UAP/Resources.xbf")
 			};
-		}
-
-		static void OnBackRequested(object sender, BackRequestedEventArgs e)
-		{
-			Application app = Application.Current;
-			if (app == null)
-				return;
-
-			Page page = app.MainPage;
-			if (page == null)
-				return;
-
-			var platform = page.Platform as Platform.UWP.Platform;
-			if (platform == null)
-				return;
-
-			e.Handled = platform.BackButtonPressed();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -35,6 +35,9 @@ namespace Xamarin.Forms.Platform.UWP
 		WImageSource _titleIcon;
 		VisualElementTracker<Page, PageControl> _tracker;
 		EntranceThemeTransition _transition;
+		Platform _platform;
+
+		Platform Platform => _platform ?? (_platform = Platform.Current);
 
 		public NavigationPage Element { get; private set; }
 
@@ -633,10 +636,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (_showTitle || (render != null && render.ShowTitle))
 			{
-				var platform = Element.Platform as Platform;
-				if (platform != null)
+				if (Platform != null)
 				{
-					await platform.UpdateToolbarItems();
+					await Platform.UpdateToolbarItems();
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -46,6 +46,16 @@ namespace Xamarin.Forms.Platform.UWP
 			return renderer;
 		}
 
+		internal static Platform Current
+		{
+			get
+			{
+				var frame = Window.Current?.Content as Windows.UI.Xaml.Controls.Frame;
+				var wbp = frame?.Content as WindowsBasePage;
+				return wbp?.Platform;
+			}
+		}
+
 		internal Platform(Windows.UI.Xaml.Controls.Page page)
 		{
 			if (page == null)

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.Foundation.Metadata;
 using Windows.UI;
+using Windows.UI.Core;
 using Windows.UI.Popups;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
@@ -72,6 +73,8 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdateBounds();
 
 			InitializeStatusBar();
+
+			SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
 		}
 
 		internal void SetPage(Page newRoot)
@@ -564,6 +567,17 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				return _commandBar;
 			}
+		}
+
+		void OnBackRequested(object sender, BackRequestedEventArgs e)
+		{
+			Application app = Application.Current;
+
+			Page page = app?.MainPage;
+			if (page == null)
+				return;
+
+			e.Handled = BackButtonPressed();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePage.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePage.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		protected Platform Platform { get; private set; }
+		internal Platform Platform { get; private set; }
 
 		protected abstract Platform CreatePlatform();
 


### PR DESCRIPTION
### Description of Change ###

Fix the two places where UWP is relying on casting Element.Platform to UWP.Platform (for handling back button presses and for toolbar updates).

### Issues Resolved ###

None, prepping for further cleanup.

### API Changes ###

None

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
