### PR TITLE
[Android] Prevent duplicate events from SwipeGestureRecognizer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3415.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3415.cs
@@ -1,11 +1,6 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
-#if UITEST
-using Xamarin.UITest;
-using NUnit.Framework;
-#endif
-
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
@@ -54,15 +49,5 @@ namespace Xamarin.Forms.Controls.Issues
 					})
 				});
 		}
-
-#if UITEST
-		[Test]
-		public void Issue3415Test ()
-		{
-			RunningApp.Screenshot ("I am at Issue 1");
-			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
-			RunningApp.Screenshot ("I see the Label");
-		}
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3415.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3415.cs
@@ -1,0 +1,68 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3415, "[Android] Swipe Command fires twice on Android for each swipe action", PlatformAffected.Android)]
+	public class Issue3415 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Label rightSwipeFired = new Label();
+			Label leftSwipeFired = new Label();
+
+			Content = new StackLayout()
+			{
+				Children = {
+						new Label(){ Text = "Swipe Anywhere on the Screen. Android fires swipe events twice"},
+						rightSwipeFired,
+						leftSwipeFired
+					},
+				BackgroundColor = Color.Green
+			};
+
+			int right = 0;
+			int left = 0;
+
+			Content
+				.GestureRecognizers
+				.Add(new SwipeGestureRecognizer()
+				{
+					Direction = SwipeDirection.Right,
+					Command = new Command(() =>
+					{
+						right++;
+						rightSwipeFired.Text = $"Right Swipe: {right}";
+					})
+				});
+
+			Content
+				.GestureRecognizers
+				.Add(new SwipeGestureRecognizer()
+				{
+					Direction = SwipeDirection.Left,
+					Command = new Command(() =>
+					{
+						left++;
+						leftSwipeFired.Text = $"Left Swipe: {left}";
+					})
+				});
+		}
+
+#if UITEST
+		[Test]
+		public void Issue3415Test ()
+		{
+			RunningApp.Screenshot ("I am at Issue 1");
+			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
+			RunningApp.Screenshot ("I see the Label");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -477,6 +477,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2837.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2740.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1939.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3415.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Core/SwipeGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/SwipeGestureRecognizer.cs
@@ -55,22 +55,22 @@ namespace Xamarin.Forms
 			var detected = false;
 			var threshold = Threshold;
 
-			if (direction.HasFlag(SwipeDirection.Left))
+			if (direction.IsLeft())
 			{
 				detected |= _totalX < -threshold;
 			}
 
-			if (direction.HasFlag(SwipeDirection.Right))
+			if (direction.IsRight())
 			{
 				detected |= _totalX > threshold;
 			}
 
-			if (direction.HasFlag(SwipeDirection.Down))
+			if (direction.IsDown())
 			{
 				detected |= _totalY > threshold;
 			}
 
-			if (direction.HasFlag(SwipeDirection.Up))
+			if (direction.IsUp())
 			{
 				detected |= _totalY < -threshold;
 			}
@@ -90,6 +90,26 @@ namespace Xamarin.Forms
 				cmd.Execute(CommandParameter);
 
 			Swiped?.Invoke(sender, new SwipedEventArgs(CommandParameter, direction));
+		}
+	}
+
+	static class SwipeDirectionExtensions
+	{
+		public static bool IsLeft(this SwipeDirection self)
+		{
+			return (self & SwipeDirection.Left) == SwipeDirection.Left;
+		}
+		public static bool IsRight(this SwipeDirection self)
+		{
+			return (self & SwipeDirection.Right) == SwipeDirection.Right;
+		}
+		public static bool IsUp(this SwipeDirection self)
+		{
+			return (self & SwipeDirection.Up) == SwipeDirection.Up;
+		}
+		public static bool IsDown(this SwipeDirection self)
+		{
+			return (self & SwipeDirection.Down) == SwipeDirection.Down;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
+++ b/Xamarin.Forms.Platform.Android/InnerGestureListener.cs
@@ -217,7 +217,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (_isScrolling && _scrollCompleteDelegate != null)
 				_scrollCompleteDelegate();
-			if (_swipeCompletedDelegate != null)
+
+			if (_isScrolling && _swipeCompletedDelegate != null)
 				_swipeCompletedDelegate();
 
 			_isScrolling = false;


### PR DESCRIPTION
### Description of Change ###

#2727 added a SwipeGestureRecognizer for all platforms. On Android, the command was firing twice because the `EndScrolling` delegate is called twice. Now checking the same `isScrolling` bool that prevents the duplicate call for the `PanGestureRecognizer`.

Also removed the `HasFlag` calls in favor of bitwise checks for performance.



### Issues Resolved ###

- fixes #3415 

### API Changes ###

None

### Platforms Affected ###

- Core/XAML (all platforms)
- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
