### PR TITLE
[Android] check if bitmaps have been GC'd

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2004.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2004.cs
@@ -1,0 +1,301 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2004, "[Android] Xamarin caused by: android.runtime.JavaProxyThrowable: System.ObjectDisposedException: Cannot access a disposed object",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.LifeCycle)]
+#endif
+	public class Issue2004 : TestContentPage
+	{
+		static internal NavigationPage settingsPage = new NavigationPage(new SettingsView());
+		static internal NavigationPage addressesPage = new NavigationPage(new AddressListView());
+		static internal NavigationPage associationsPage = new NavigationPage(new ContentPage());
+		static MasterDetailPage RootPage;
+		protected override void Init()
+		{
+			MasterDetailPage testPage = new MasterDetailPage();
+			RootPage = testPage;
+			testPage.Master = new ContentPage
+			{
+				Title = "M",
+			};
+
+			testPage.Detail = new SettingsView();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			Application.Current.MainPage = RootPage;
+		}
+
+		static void SetPage(Page page)
+		{
+			RootPage.Detail = page;
+		}
+
+		static async Task UI(int delay)
+		{
+			await Task.Delay(delay);
+		}
+
+		public static INavigation NavigationPage => RootPage.Detail.Navigation;
+
+		public static async Task DisposedBitmapTest()
+		{
+			SetPage(Issue2004.associationsPage);
+			await UI(999);
+			SetPage(Issue2004.addressesPage);
+			await UI(999);
+
+			SetPage(Issue2004.associationsPage);
+
+			await UI(999);
+			SetPage(Issue2004.addressesPage);
+			await UI(999);
+
+			await NavigationPage.PushAsync(new ContentPage());
+			await UI(999);
+			await NavigationPage.PopAsync();
+			await UI(999);
+
+			SetPage(Issue2004.associationsPage);
+			await UI(999);
+
+			SetPage(Issue2004.addressesPage);
+			await UI(999);
+			SetPage(new ContentPage() { Content = new Label() { Text = "Success" } });
+		}
+
+
+		[Preserve(AllMembers = true)]
+		public class AddressListItemView : Grid
+		{
+			public AddressListItemView()
+			{
+				this.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+				this.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+				this.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+				this.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+				this.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+
+				this.Children.Add(new Button() { Text = "qwe", BackgroundColor = Color.Transparent }, 0, 0);
+				this.Children.Add(new Button() { Text = "qwe", BackgroundColor = Color.Transparent }, 1, 0);
+				this.Children.Add(new Button() { Text = "qwe", BackgroundColor = Color.Transparent }, 2, 0);
+				this.Children.Add(new Button() { Text = "qwe", BackgroundColor = Color.Transparent }, 3, 0);
+
+				this.Children.Add(new StackLayout()
+				{
+					Children =
+					{
+						new Label{ Text = "Address", LineBreakMode = LineBreakMode.TailTruncation},
+						new Label{ Text = "Owner", LineBreakMode = LineBreakMode.TailTruncation},
+						new Label{ Text = "ViolationCount"},
+					}
+
+				}, 4, 0);
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class AddressListView : ContentPage
+		{
+			public AddressListView()
+			{
+				ListView listView = new ListView() { RowHeight = 75 };
+
+				listView.SetBinding(ListView.ItemsSourceProperty, "UnitList");
+
+				listView.ItemTemplate = new DataTemplate(() =>
+				{
+					ViewCell cell = new ViewCell();
+					cell.View = new AddressListItemView();
+					return cell;
+				});
+
+				Content = new StackLayout()
+				{
+
+					Children =
+					{
+						new StackLayout()
+						{
+							Orientation = StackOrientation.Horizontal,
+							Padding = 4,
+							Children =
+							{
+								new StackLayout()
+								{
+									Children =
+									{
+										new Label()
+										{
+											Text = "SortText",
+											HorizontalOptions = LayoutOptions.Center
+										}
+									}
+								}
+							}
+						},
+						listView
+					}
+				};
+
+				BindingContext = this;
+			}
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+				UnitList = null;
+				NotifyPropertyChanged(() => UnitList);
+				SelectedAddress = null;
+				LoadAddresses();
+			}
+
+			string _selectedAddress;
+			public string SelectedAddress
+			{
+				get => _selectedAddress;
+				set
+				{
+					if (_selectedAddress != value)
+					{
+						_selectedAddress = value;
+						NotifyPropertyChanged(() => SelectedAddress);
+						if (SelectedAddress != null)
+						{
+							LoadUnitsByAddress(_selectedAddress);
+							NotifyPropertyChanged(() => UnitList);
+						}
+					}
+				}
+			}
+
+			List<string> _streeAddresses;
+			private List<string> _unitList;
+
+			public List<string> StreetAddresses
+			{
+				get { return _streeAddresses; }
+				set
+				{
+					_streeAddresses = value;
+					NotifyPropertyChanged();
+				}
+			}
+
+			public void LoadAddresses()
+			{
+				StreetAddresses = Enumerable.Range(1, 10).Select(x => x.ToString()).ToList();
+				SelectedAddress = StreetAddresses.First();
+			}
+
+			public void LoadUnitsByAddress(string address)
+			{
+				if (string.IsNullOrEmpty(address))
+				{
+					UnitList?.Clear();
+					return;
+				}
+				UnitList = Enumerable.Range(1, 10).Select(x => x.ToString()).ToList();
+			}
+
+			public List<string> UnitList
+			{
+				get { return _unitList; }
+				set { _unitList = value; }
+			}
+
+			public virtual void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
+			{
+				OnPropertyChanged(propertyName);
+			}
+
+			protected virtual void NotifyPropertyChanged<T>(Expression<Func<T>> propertyExpression)
+			{
+				string propertyName = GetPropertyName(propertyExpression);
+				OnPropertyChanged(propertyName);
+			}
+
+			private string GetPropertyName<T>(Expression<Func<T>> propertyExpression)
+			{
+				if (propertyExpression == null)
+				{
+					throw new ArgumentNullException("propertyExpression");
+				}
+
+				if (propertyExpression.Body.NodeType != ExpressionType.MemberAccess)
+				{
+					throw new ArgumentException("Should be a member access lambda expression", "propertyExpression");
+				}
+
+				var memberExpression = (MemberExpression)propertyExpression.Body;
+				return memberExpression.Member.Name;
+			}
+		}
+
+
+		[Preserve(AllMembers = true)]
+		public class SettingsView : ContentPage
+		{
+			public Command AutoTest => new Command(async () =>
+			{
+				await Issue2004.DisposedBitmapTest();
+			});
+
+
+			protected async override void OnAppearing()
+			{
+				base.OnAppearing();
+				await Task.Delay(1000);
+				AutoTest.Execute(null);
+
+			}
+			public SettingsView()
+			{
+				BindingContext = this;
+				Content = new ScrollView()
+				{
+					Content = new StackLayout()
+					{
+						Children =
+						{
+							new Label()
+							{
+								Text = "Auto Test",
+								HorizontalOptions = LayoutOptions.Start
+							}
+						}
+					}
+				};
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void NoCrashFromDisposedBitmapWhenSwitchingPages()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2004.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3333.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60045.xaml.cs">

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -46,6 +46,9 @@ namespace Xamarin.Forms.Controls
 
 			//// Uncomment to verify that there is no crash when switching MainPage from MDP inside NavPage
 			//SetMainPage(new Bugzilla45702());
+
+			//// Uncomment to verify that there is no crash when rapidly switching pages that contain lots of buttons
+			//SetMainPage(new Issues.Issue2004());
 		}
 
 		public Page CreateDefaultMainPage()

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -162,7 +162,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (Element == null || Control == null)
 				return;
 
-			_backgroundTracker?.UpdateBackgroundColor();
+			_backgroundTracker?.UpdateDrawable();
 		}
 
 		void UpdateAll()

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -173,16 +173,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			UpdateTextColor();
 			UpdateEnabled();
 			UpdateBackgroundColor();
-			UpdateDrawable();
 			UpdatePadding();
-		}
-
-		void UpdateDrawable()
-		{
-			if (Element == null || Control == null)
-				return;
-
-			_backgroundTracker?.UpdateDrawable();
 		}
 
 		void UpdateBitmap()

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -95,6 +95,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					_textColorSwitcher = null;
 				}
 				_backgroundTracker?.Dispose();
+				_backgroundTracker = null;
 			}
 
 			base.Dispose(disposing);

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -1072,12 +1072,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (shouldUpdateToolbar)
 					UpdateToolbar();
 
-				FragmentTransaction fragmentTransaction = fragmentManager.BeginTransactionEx();
+				if (fragmentsToRemove.Count > 0)
+				{
+					FragmentTransaction fragmentTransaction = fragmentManager.BeginTransactionEx();
 
-				foreach (Fragment frag in fragmentsToRemove)
-					fragmentTransaction.RemoveEx(frag);
+					foreach (Fragment frag in fragmentsToRemove)
+						fragmentTransaction.RemoveEx(frag);
 
-				fragmentTransaction.CommitAllowingStateLossEx();
+					fragmentTransaction.CommitAllowingStateLossEx();
+				}
 
 				return false;
 			});

--- a/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
@@ -120,11 +120,6 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		public void UpdateBackgroundColor()
-		{
-			UpdateDrawable();
-		}
-
 		public void Dispose()
 		{
 			Dispose(true);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -198,6 +198,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				_tracker?.Dispose();
 
 				_backgroundTracker?.Dispose();
+				_backgroundTracker = null;
 
 				if (Element != null)
 				{

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			_automationPropertiesProvider = new AutomationPropertiesProvider(this);
 			_effectControlProvider = new EffectControlProvider(this);
-			
+
 			Initialize();
 		}
 
@@ -244,7 +244,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				UpdateIsEnabled();
 				UpdateInputTransparent();
 				UpdateBackgroundColor();
-				UpdateDrawable();
 				UpdatePadding();
 
 				ElevationHelper.SetElevation(this, e.NewElement);
@@ -321,7 +320,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		void UpdateBackgroundColor()
 		{
-			_backgroundTracker?.UpdateBackgroundColor();
+			_backgroundTracker?.UpdateDrawable();
 		}
 
 		internal void OnNativeFocusChanged(bool hasFocus)
@@ -484,7 +483,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			_textColorSwitcher.Value.UpdateTextColor(this, Button.TextColor);
 		}
 
-		void UpdatePadding ()
+		void UpdatePadding()
 		{
 			SetPadding(
 				(int)(Context.ToPixels(Button.Padding.Left) + _paddingDeltaPix.Left),
@@ -494,15 +493,10 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			);
 		}
 
-		void UpdateContentEdge (Thickness? delta = null)
+		void UpdateContentEdge(Thickness? delta = null)
 		{
-			_paddingDeltaPix = delta ?? new Thickness ();
-			UpdatePadding ();
-		}
-
-		void UpdateDrawable()
-		{
-			_backgroundTracker?.UpdateDrawable();
+			_paddingDeltaPix = delta ?? new Thickness();
+			UpdatePadding();
 		}
 
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonDrawable.cs
@@ -63,15 +63,25 @@ namespace Xamarin.Forms.Platform.Android
 			if (width <= 0 || height <= 0)
 				return;
 
-			if (_normalBitmap == null || _normalBitmap.Height != height || _normalBitmap.Width != width)
-			{
+			if (_normalBitmap == null ||
+				_normalBitmap?.IsDisposed() == true ||
+				_pressedBitmap?.IsDisposed() == true ||
+				_normalBitmap.Height != height ||
+				_normalBitmap.Width != width)
 				Reset();
 
-				_normalBitmap = CreateBitmap(false, width, height);
-				_pressedBitmap = CreateBitmap(true, width, height);
+			Bitmap bitmap = null;
+			if (GetState().Contains(global::Android.Resource.Attribute.StatePressed))
+			{
+				_pressedBitmap = _pressedBitmap ?? CreateBitmap(true, width, height);
+				bitmap = _pressedBitmap;
+			}
+			else
+			{
+				_normalBitmap = _normalBitmap ?? CreateBitmap(false, width, height);
+				bitmap = _normalBitmap;
 			}
 
-			Bitmap bitmap = GetState().Contains(global::Android.Resource.Attribute.StatePressed) ? _pressedBitmap : _normalBitmap;
 			canvas.DrawBitmap(bitmap, 0, 0, new Paint());
 		}
 
@@ -95,15 +105,21 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (_normalBitmap != null)
 			{
-				_normalBitmap.Recycle();
-				_normalBitmap.Dispose();
+				if (!_normalBitmap.IsDisposed())
+				{
+					_normalBitmap.Recycle();
+					_normalBitmap.Dispose();
+				}
 				_normalBitmap = null;
 			}
 
 			if (_pressedBitmap != null)
 			{
-				_pressedBitmap.Recycle();
-				_pressedBitmap.Dispose();
+				if (!_pressedBitmap.IsDisposed())
+				{
+					_pressedBitmap.Recycle();
+					_pressedBitmap.Dispose();
+				}
 				_pressedBitmap = null;
 			}
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -147,7 +147,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element == null || Control == null)
 				return;
 
-			_backgroundTracker?.UpdateBackgroundColor();
+			_backgroundTracker?.UpdateDrawable();
 		}
 
 		void UpdateAll()
@@ -157,7 +157,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateBitmap();
 			UpdateTextColor();
 			UpdateEnabled();
-			UpdateDrawable();
+			UpdateBackgroundColor();
 			UpdatePadding();
 		}
 
@@ -217,11 +217,6 @@ namespace Xamarin.Forms.Platform.Android
 			image?.Dispose();
 		}
 
-		void UpdateDrawable()
-		{
-			_backgroundTracker.UpdateDrawable();
-		}
-
 		void UpdateEnabled()
 		{
 			Control.Enabled = Element.IsEnabled;
@@ -270,7 +265,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdatePadding()
 		{
-			Control?.SetPadding (
+			Control?.SetPadding(
 				(int)(Context.ToPixels(Element.Padding.Left) + _paddingDeltaPix.Left),
 				(int)(Context.ToPixels(Element.Padding.Top) + _paddingDeltaPix.Top),
 				(int)(Context.ToPixels(Element.Padding.Right) + _paddingDeltaPix.Right),
@@ -278,9 +273,9 @@ namespace Xamarin.Forms.Platform.Android
 			);
 		}
 
-		void UpdateContentEdge (Thickness? delta = null)
+		void UpdateContentEdge(Thickness? delta = null)
 		{
-			_paddingDeltaPix = delta ?? new Thickness ();
+			_paddingDeltaPix = delta ?? new Thickness();
 			UpdatePadding();
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (disposing)
 			{
 				_backgroundTracker?.Dispose();
+				_backgroundTracker = null;
 			}
 
 			base.Dispose(disposing);


### PR DESCRIPTION
### Description of Change ###
From what I can tell the set of operations that causes this to happen go as follows

- Main Page set to a page with a ListView that has lots of buttons with background set
- Set Main Page to something else
- Main Page set to a page with a ListView that has lots of buttons with background set
  - At this point the ListView gets LayedOut twice. From what I can tell this is caused from a race condition with fragments.  Two commits occur when the page is swapped out. One from the DetailsContainer on the MasterDetails and then one from the Internal navigation page. Sometimes a layout happens between the two commits which means it'll happen a second time after the second commit
  - Between the first and second layout (on low end devices) the GC runs which causes the bitmaps that are stored inside *ButtonDrawable* to be collected.
  - Now that they are disposed the second layout tries to access the disposed bitmaps when it re-draws the ButtonDrawables

Getting this to crash required a really specific set of conditions
- I can't get it to crash when running the issue through the control gallery, but it does consistently crash if you initially set the Main Page to the Issue
- It never crashes for me on higher end devices.  For testing I've been using a Moto-E
- Everything I tried to simplify the sample down caused it to stop crashing so I just left it as is. Even if I modified the await times

- I also removed the call to *UpdateDrawable* because all it was accomplishing was the same thing that *UpdateBackgroundColor* was

### Issues Resolved ###
- fixes #2004

### Platforms Affected ###
- Android

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
