### PR TITLE
Add assembly version to XF.Core

### DIFF
--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@ using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.StyleSheets;
 
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
+
 [assembly: InternalsVisibleTo("iOSUnitTests")]
 [assembly: InternalsVisibleTo("Xamarin.Forms.Controls")]
 [assembly: InternalsVisibleTo("Xamarin.Forms.Core.Design")]

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;


### PR DESCRIPTION
### Description of Change ###

Per: https://github.com/xamarin/Xamarin.Forms/issues/3354#issuecomment-406725306

Adding ```[assembly: AssemblyVersion("2.0.0.0")]
[assembly: AssemblyFileVersion("2.0.0.0")]``` to Xamarin.Forms.Core `AssemblyInfo` after it was removed from the `GlobalAssemblyInfo` in #3118 

### Issues Resolved ###

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3354

### API Changes ###

None

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
