### PR TITLE
[C] fix TargetNullValue Bindings

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2222,7 +2222,19 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void TargetNullValue()
+		//https://github.com/xamarin/Xamarin.Forms/issues/3467
+		public void TargetNullValueIgnoredWhenBindingIsResolved()
+		{
+			var bindable = new MockBindable();
+			var property = BindableProperty.Create("Foo", typeof(string), typeof(MockBindable), "default");
+			bindable.SetBinding(property, new Binding("Text") { TargetNullValue = "fallback" });
+			Assert.That(bindable.GetValue(property), Is.EqualTo("default"));
+			bindable.BindingContext = new MockViewModel { Text="Foo"};
+			Assert.That(bindable.GetValue(property), Is.EqualTo("Foo"));
+		}
+
+		[Test]
+		public void TargetNullValueFallback()
 		{
 			var bindable = new MockBindable();
 			var property = BindableProperty.Create("Foo", typeof(string), typeof(MockBindable), "default");

--- a/Xamarin.Forms.Core/BindingBase.cs
+++ b/Xamarin.Forms.Core/BindingBase.cs
@@ -107,7 +107,7 @@ namespace Xamarin.Forms
 
 		internal virtual object GetSourceValue(object value, Type targetPropertyType)
 		{
-			if (TargetNullValue != null)
+			if (value == null && TargetNullValue != null)
 				return TargetNullValue;
 
 			if (StringFormat != null)


### PR DESCRIPTION
### Description of Change ###

Due to a flux in the matrix, Bindings with a TargetNullValue assigned
were always returning that value. It had the advantage of being right
sometimes, but the inconvenient for being wrong, most of the times.

By properly aligning the bits of the register with the sun at beer time,
we can avoid that side effect, and actually returns a value when the
binding is succesful, and the TargetNullValue whem the Binding returns
null.

### Issues Resolved ###

- fixes #3467

### API Changes ###

/

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
