### PR TITLE
[Android] Improve error message when not calling base.OnCreate

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected void LoadApplication(Application application)
 		{
-		        if(!_activityCreated)
+			if(!_activityCreated)
 			{
 			    throw new InvalidOperationException("Activity OnCreate was not called prior to loading the application. Did you forget a base.OnCreate call?");
 			}
@@ -148,7 +148,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnCreate(Bundle savedInstanceState)
 		{
-		        _activityCreated = true;
+			_activityCreated = true;
 			if (!AllowFragmentRestore)
 			{
 				// Remove the automatically persisted fragment structure; we don't need them

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 		AndroidApplicationLifecycleState _previousState;
 
 		bool _renderersAdded;
+		bool _activityCreated;
 		PowerSaveModeBroadcastReceiver _powerSaveModeBroadcastReceiver;
 
 		// Override this if you want to handle the default Android behavior of restoring fragments on an application restart
@@ -85,6 +86,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected void LoadApplication(Application application)
 		{
+		        if(!_activityCreated)
+			{
+			    throw new InvalidOperationException("Activity OnCreate was not called prior to loading the application. Did you forget a base.OnCreate call?");
+			}
+			
 			if (!_renderersAdded)
 			{
 				RegisterHandlerForDefaultRenderer(typeof(NavigationPage), typeof(NavigationPageRenderer), typeof(NavigationRenderer));
@@ -142,6 +148,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnCreate(Bundle savedInstanceState)
 		{
+		        _activityCreated = true;
 			if (!AllowFragmentRestore)
 			{
 				// Remove the automatically persisted fragment structure; we don't need them


### PR DESCRIPTION
### Description of Change ###

This change detects that OnCreate was called prior to calling LoadApplication and throws a better error message to help the developer.

### Issues Resolved ###

NullReferenceException with no information is thrown if you don't call `base.OnCreate(bundle)` in your subclass. It took quite a long time to figure this oversight out - a proper error message would have gotten me to move a lot faster.
I found lots of forum issues with people reporting the same thing. 

### API Changes ###

None

### Platforms Affected ###

Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
