### PR TITLE
[Tizen] Fix minor bugs on CarouselPage and ActivityIndicator

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ActivityIndicatorRenderer.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateIsRunning()
 		{
-			if (Element.IsRunning)
+			if (Element.IsRunning && Element.IsEnabled)
 			{
 				Control.PlayPulse();
 			}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/CarouselPageRenderer.cs
@@ -182,6 +182,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		void UpdateCarouselContent()
 		{
 			_innerContainer.UnPackAll();
+			_layoutBound = new ESize(0, 0);
 			foreach (var page in Element.Children)
 			{
 				EvasObject nativeView = Platform.GetOrCreateRenderer(page).NativeView;


### PR DESCRIPTION
### Description of Change ###

1. Fixed `CarouselPage` 
- Fixed the issue of `CarouselPage`, The current page is not chagned when `CarouselPage` have one page and another page is added after.
- When children of `CarouselPage` is changed, the layout bound should be reset. Because inner container is temporarily empty by `UnPackAll` method of inner container.

2. Fixed ActivityIndicator.IsRunning condition
- Update `IsRunning` property when the `IsEnabled` property is updated.
![ai-tv](https://user-images.githubusercontent.com/10704816/43625471-2bb58d7e-9728-11e8-8dcf-6272618b5452.gif)
![ai-mobile](https://user-images.githubusercontent.com/10704816/43625475-2eedfc42-9728-11e8-87cd-2f0a70d48abc.gif)


### Platforms Affected ###

Tizen

### Behavioral/Visual Changes ###

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
