### PR TITLE
[Android] Add ClearTop and NewTask flags when using Device.OpenUri

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -520,6 +520,8 @@ namespace Xamarin.Forms
 			{
 				global::Android.Net.Uri aUri = global::Android.Net.Uri.Parse(uri.ToString());
 				var intent = new Intent(Intent.ActionView, aUri);
+				intent.SetFlags(ActivityFlags.ClearTop);
+				intent.SetFlags(ActivityFlags.NewTask);
 
 				// This seems to work fine even if the context has been destroyed (while another activity is in the
 				// foreground). If we run into a situation where that's not the case, we'll have to do some work to


### PR DESCRIPTION
### Description of Change ###

Added `ClearTop` and `NewTask` flags when using `Device.OpenUri` to prevent crash in API 21-23.

Use test cases Bugzilla29247 and Bugzilla60691 for verification.

### Issues Resolved ###

- fixes #3477

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
