### PR TITLE
[UWP] ScrollView will not crash when it has null Content

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3507.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3507.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3507, "[UWP] Scrollview with null content crashes on UWP",
+		PlatformAffected.UWP)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue3507 : TestContentPage
+	{
+		Label label;
+		ScrollView scrollView;
+		protected override void Init()
+		{
+			scrollView = new ScrollView();
+			label = new Label();
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					label,
+					scrollView
+				}
+			};
+		}
+
+		protected override async void OnAppearing()
+		{
+			base.OnAppearing();
+			await Task.Delay(500);
+			scrollView.Content = new StackLayout();
+			await Task.Delay(500);
+			scrollView.Content = null;
+			await Task.Delay(500);
+			label.Text = "Success";
+		}
+
+#if UITEST
+		[Test]
+		public void NullContentOnScrollViewDoesntCrash()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -363,6 +363,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3008.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3019.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2993.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3507.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />

--- a/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Forms.Platform.UWP
 			Control.Content = renderer != null ? renderer.ContainerElement : null;
 
 			UpdateMargins();
-			if(renderer.ContainerElement != null)
+			if (renderer?.ContainerElement != null)
 				renderer.ContainerElement.LayoutUpdated += SetInitialRtlPosition;
 		}
 
@@ -175,7 +175,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 			Element.SendScrollFinished();
 		}
-				
+
 		void SetInitialRtlPosition(object sender, object e)
 		{
 			if (Control == null) return;
@@ -200,8 +200,7 @@ namespace Xamarin.Forms.Platform.UWP
 		void ClearRtlScrollCheck()
 		{
 			_checkedForRtlScroll = true;
-			var element = (Control.Content as FrameworkElement);
-			if (element != null)
+			if (Control.Content is FrameworkElement element)
 				element.LayoutUpdated -= SetInitialRtlPosition;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Check if the Content View or Renderer for the content on the ScrollView is null to avoid an NRE when wiring up 

### Issues Resolved ###

- fixes #3507 


### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###


### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
