### PR TITLE
[MacOS] Fix NRE when checking for existing MainMenu, fixes #3353

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -944,7 +944,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.MacOS/FormsApplicationDelegate.cs
+++ b/Xamarin.Forms.Platform.MacOS/FormsApplicationDelegate.cs
@@ -29,7 +29,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			Application.SetCurrentApplication(application);
 			_application = application;
-			_storyboardMainMenuCount = (int)NSApplication.SharedApplication.MainMenu.Count;
+
+			if(NSApplication.SharedApplication.MainMenu != null)
+				_storyboardMainMenuCount = (int)NSApplication.SharedApplication.MainMenu.Count;
 
 			application.PropertyChanged += ApplicationOnPropertyChanged;
 		}


### PR DESCRIPTION
### Description of Change ###

Fixes a change made to check existing MenuItems. IF using the old way of not specify a Storyboard wasn+t take in account.

To test one should use the old method of setup the macOS app : 

`Edit info.plist and remove the source entry (NSMainStoryboardFile)`

and On Main.cs 

```
NSApplication.Init();
NSApplication.SharedApplication.Delegate = new AppDelegate();
NSApplication.Main(args);
```
### Issues Resolved ###

- fixes #3353 

### Platforms Affected ###

- macOS


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard