### PR TITLE
[UWP] Fixes crash app when create navigation/tabbed page without children

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsPresenter.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsPresenter.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.UWP
 			Unloaded += FormsPresenter_Unloaded;
 			SizeChanged += (s, e) =>
 			{
-				if (ActualWidth > 0 && ActualHeight > 0)
+				if (ActualWidth > 0 && ActualHeight > 0 && DataContext != null)
 				{
 					var page = (Page)DataContext;
 					((Page)page.RealParent).ContainerArea = new Rectangle(0, 0, ActualWidth, ActualHeight);
@@ -21,15 +21,9 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 		void FormsPresenter_Loaded(object sender, RoutedEventArgs e)
-		{
-			var page = (Page)DataContext;
-			page.SendAppearing();
-		}
+			=> (DataContext as Page)?.SendAppearing();
 
 		void FormsPresenter_Unloaded(object sender, RoutedEventArgs e)
-		{
-			var page = (Page)DataContext;
-			page.SendDisappearing();
-		}
+			=> (DataContext as Page)?.SendDisappearing();
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -598,7 +598,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateBackButton()
 		{
-			if (_navManager == null)
+			if (_navManager == null || _currentPage == null)
 			{
 				return;
 			}


### PR DESCRIPTION
### Description of Change ###

When initializing navigation / tabbed pages, the user can not add any child pages. Check it did not exist and threw NullReferenceException.

You can run UITest 2338 for testing.

### Issues Resolved ###

- fixes #3188

### API Changes ###

/

### Platforms Affected ###

- UWP

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
