### PR TITLE
[iOS] Fix sizing issue on MDP 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -944,7 +944,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls/ControlGalleryPages/FlowDirectionGallery.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/FlowDirectionGallery.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Forms.Controls
 		{
 			FlowDirection = direction;
 			Master = new FlowDirectionGalleryCP(direction) { Title = "Master", BackgroundColor = Color.Red };
-			Detail = new FlowDirectionGalleryCP(direction) { Title = "Detail" };
+			Detail = new NavigationPage(new FlowDirectionGalleryCP(direction) { Title = "Detail" });
 			IsPresented = true;
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -47,11 +47,8 @@ namespace Xamarin.Forms.Platform.iOS
 		InnerDelegate _innerDelegate;
 		nfloat _masterWidth = 0;
 		EventedViewController _masterController;
-
 		MasterDetailPage _masterDetailPage;
-
 		bool _masterVisible;
-
 		VisualElementTracker _tracker;
 
 		Page PageController => Element as Page;
@@ -186,7 +183,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_masterWidth = (nfloat)Math.Max(_masterWidth, masterBounds.Width);
 
 			if (!masterBounds.IsEmpty)
-				MasterDetailPage.MasterBounds = new Rectangle(_masterWidth, 0, _masterWidth, masterBounds.Height);
+				MasterDetailPage.MasterBounds = new Rectangle(0, 0, _masterWidth, masterBounds.Height);
 
 			if (!detailsBounds.IsEmpty)
 				MasterDetailPage.DetailBounds = new Rectangle(0, 0, detailsBounds.Width, detailsBounds.Height);


### PR DESCRIPTION
### Description of Change ###

Reverting some changes done on #1222  .

Start portrait , rotate to landscape , rotate portrait and rotate to landscape again.

Before:
![simulator screen shot - ipad 5th generation - 2018-08-09 at 15 52 16](https://user-images.githubusercontent.com/1235097/43906921-4e52001a-9bec-11e8-98b9-7074eb7f84fd.png)

After: 
![simulator screen shot - ipad 5th generation - 2018-08-09 at 15 36 05](https://user-images.githubusercontent.com/1235097/43907027-826138f8-9bec-11e8-8dee-b1bf12bc1c52.png)


### Issues Resolved ###

- fixes #3458 

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###

After several rotations on iPad the Master page on MDP should always be visible 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard