### PR TITLE
 [iOS] Unsubscribe CellPropertyChanged when SwitchCellRenderer is disposed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
@@ -1,0 +1,868 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Xamarin.Forms;
+using static Xamarin.Forms.Controls.Issues.Issue3408;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3408, "System.ObjectDisposedException: from SwitchCellRenderer when changing ItemSource", PlatformAffected.iOS)]
+	public class Issue3408 : TestContentPage
+	{
+		public static List<Recommendation> GetRecommendations(object e)
+		{
+			switch (e)
+			{
+				case List<RecommendationsViewModel> pc: return pc.First().Recommendations;
+				case List<RecommendationsViewModel2> pc: return pc.First().Recommendations;
+				default: return null;
+			}
+		}
+		protected override void Init()
+		{
+
+			var grd = new Grid();
+
+			var aacountListView = new RepeaterSwipeView();
+			aacountListView.ItemTemplate = new AccountDetailsDataTemplateSelector();
+			aacountListView.BindingContext = new List<RecommendationsViewModel> { new RecommendationsViewModel() };
+
+			aacountListView.SetBinding(RepeaterSwipeView.ItemsSourceProperty, ".");
+			var btn = new Button
+			{
+				Text = "Change Source",
+				AutomationId = "btn1",
+				Command = new Command(() =>
+				{
+					aacountListView.BindingContext = new List<RecommendationsViewModel2> { new RecommendationsViewModel2() };
+				})
+			};
+			var btn2 = new Button
+			{
+				Text = "Change Property",
+				AutomationId = "btn2",
+				Command = new Command(() =>
+				{
+
+					foreach (var item in GetRecommendations(aacountListView.BindingContext))
+					{
+						item.Name = "New Item Name";
+						item.IsBusy = !item.IsBusy;
+					}
+
+				})
+			};
+			grd.Children.Add(aacountListView);
+			Grid.SetRow(aacountListView, 0);
+			grd.Children.Add(btn);
+			Grid.SetRow(btn, 1);
+			grd.Children.Add(btn2);
+			Grid.SetRow(btn2, 2);
+			Content = grd;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue3408Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked ("btn1"));
+			RunningApp.WaitForElement (q => q.Marked ("Click to Change"));
+			RunningApp.Tap(q => q.Marked("btn1"));
+			RunningApp.WaitForElement(q => q.Marked("This should have changed"));
+			RunningApp.Tap(q => q.Marked("btn2"));
+			RunningApp.WaitForElement(q => q.Marked("New Item Name"));
+		}
+#endif
+
+		[Preserve(AllMembers = true)]
+		public class RecommendationsBaseViewModel : ViewModelBase
+		{
+			public string AccountName => $"";
+			public List<Recommendation> Recommendations { get; set; }
+		}
+
+		[Preserve(AllMembers = true)]
+		public class RecommendationsViewModel : RecommendationsBaseViewModel
+		{
+			public string AccountName => $"Recommendations";
+
+			public RecommendationsViewModel()
+			{
+				Recommendations = new List<Recommendation>()
+			{
+					new Recommendation(){ Name = "Click to Change"},
+					new Recommendation(){ Name = "Recommendations"},
+					new Recommendation(){ Name = "Recommendations"},
+			};
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class RecommendationsViewModel2 : RecommendationsBaseViewModel
+		{
+			public string AccountName => $"Recommendations 2";
+			public RecommendationsViewModel2()
+			{
+				Recommendations = new List<Recommendation>()
+			{
+					new Recommendation(){ Name = "This should have changed"},
+					new Recommendation(){ Name = "Recommendations 2"},
+					new Recommendation(){ Name = "Recommendations 2", IsBusy = true },
+			};
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Recommendation : ViewModelBase
+		{
+			string _name;
+			public string Name
+			{
+				get { return _name; }
+				set
+				{
+					if (_name == value)
+						return;
+					_name = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class RepeaterView : StackLayout
+		{
+			public RepeaterView()
+			{
+				Dictionary<Element, IDisposable> activatedViews
+					= new Dictionary<Element, IDisposable>();
+			}
+
+			public static readonly BindableProperty ItemsSourceProperty =
+				BindableProperty.Create(
+					"ItemsSource",
+					typeof(IEnumerable),
+					typeof(RepeaterView),
+					defaultValue: null,
+					defaultBindingMode: BindingMode.OneWay,
+					propertyChanged: ItemsChanged);
+
+
+			public static readonly BindableProperty ItemTemplateProperty =
+				BindableProperty.Create(
+					"ViewModel",
+					typeof(DataTemplate),
+					typeof(RepeaterView),
+					defaultValue: null,
+					defaultBindingMode: BindingMode.OneWay);
+
+
+			bool waitingForBindingContext = false;
+			public event RepeaterViewItemAddedEventHandler ItemCreated;
+
+			public IEnumerable ItemsSource
+			{
+				get { return (IEnumerable)GetValue(ItemsSourceProperty); }
+				set { SetValue(ItemsSourceProperty, value); }
+			}
+
+			public DataTemplate ItemTemplate
+			{
+				get { return (DataTemplate)GetValue(ItemTemplateProperty); }
+				set { SetValue(ItemTemplateProperty, value); }
+			}
+
+
+			protected override void OnBindingContextChanged()
+			{
+				base.OnBindingContextChanged();
+
+				if (BindingContext != null && waitingForBindingContext && ItemsSource != null)
+				{
+					ItemsChanged(this, null, ItemsSource);
+				}
+			}
+
+			static void ItemsChanged(BindableObject bindable, object old, object newVal)
+			{
+				IEnumerable oldValue = old as IEnumerable;
+				IEnumerable newValue = newVal as IEnumerable;
+
+				var control = (RepeaterView)bindable;
+
+				var oldObservableCollection = oldValue as INotifyCollectionChanged;
+
+				if (oldObservableCollection != null)
+				{
+					oldObservableCollection.CollectionChanged -= control.OnItemsSourceCollectionChanged;
+				}
+
+				//HACK:SHANE
+				if (control.BindingContext == null)
+				{
+					control.waitingForBindingContext = true;
+					//this means this control has been removed from the visual tree
+					//so don't update it other wise you get random null reference exceptions
+					return;
+				}
+
+				control.waitingForBindingContext = false;
+
+				var newObservableCollection = newValue as INotifyCollectionChanged;
+
+				if (newObservableCollection != null)
+				{
+					newObservableCollection.CollectionChanged += control.OnItemsSourceCollectionChanged;
+				}
+
+				try
+				{
+					control.Children.Clear();
+
+					if (newValue != null)
+					{
+						foreach (var item in newValue)
+						{
+							var view = control.CreateChildViewFor(item);
+							control.Children.Add(view);
+							control.OnItemCreated(view);
+						}
+					}
+
+					control.UpdateChildrenLayout();
+					control.InvalidateLayout();
+				}
+				catch (NullReferenceException)
+				{
+					try
+					{
+						Debug.WriteLine(
+							String.Format($"RepeaterView: NullReferenceException Parent:{control.Parent} ParentView:{control.Parent} IsVisible:{control.IsVisible}")
+						);
+					}
+					catch (Exception exc)
+					{
+						Debug.WriteLine($"NullReferenceException Logging Failed {exc}");
+					}
+				}
+			}
+
+			protected virtual void OnItemCreated(View view)
+			{
+
+				if (this.ItemCreated != null)
+				{
+					ItemCreated.Invoke(this, new RepeaterViewItemAddedEventArgs(view, view.BindingContext));
+				}
+
+
+			}
+
+			void OnItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+			{
+				try
+				{
+					var invalidate = false;
+
+					List<View> createdViews = new List<View>();
+					if (e.Action == NotifyCollectionChangedAction.Reset)
+					{
+						var list = sender as IEnumerable;
+
+
+						this.Children.SyncList(
+							list,
+							(item) =>
+							{
+								var view = this.CreateChildViewFor(item);
+								createdViews.Add(view);
+								return view;
+							}, (item, view) => view.BindingContext == item,
+							null);
+
+						foreach (View view in createdViews)
+						{
+							OnItemCreated(view);
+						}
+
+						invalidate = true;
+					}
+
+					if (e.OldItems != null)
+					{
+						this.Children.RemoveAt(e.OldStartingIndex);
+						invalidate = true;
+					}
+
+					if (e.NewItems != null)
+					{
+						for (var i = 0; i < e.NewItems.Count; ++i)
+						{
+							var item = e.NewItems[i];
+							var view = this.CreateChildViewFor(item);
+
+							this.Children.Insert(i + e.NewStartingIndex, view);
+							OnItemCreated(view);
+						}
+
+						invalidate = true;
+					}
+
+					if (invalidate)
+					{
+						this.UpdateChildrenLayout();
+						this.InvalidateLayout();
+					}
+				}
+				catch (NullReferenceException)
+				{
+					try
+					{
+						Debug.WriteLine(
+							$"RepeaterView.OnItemsSourceCollectionChanged: NullReferenceException Parent:{Parent} ParentView:{Parent} IsVisible:{IsVisible} BindingContext: {BindingContext}"
+						);
+					}
+					catch (Exception exc)
+					{
+						Debug.WriteLine($"OnItemsSourceCollectionChanged: NullReferenceException Logging Failed {exc}");
+					}
+				}
+			}
+
+			View CreateChildViewFor(object item)
+			{
+				this.ItemTemplate.SetValue(BindableObject.BindingContextProperty, item);
+
+				if (this.ItemTemplate is DataTemplateSelector)
+				{
+					var dts = (DataTemplateSelector)this.ItemTemplate;
+					return (View)dts.SelectTemplate(item, null).CreateContent();
+				}
+				else
+				{
+					return (View)this.ItemTemplate.CreateContent();
+				}
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public delegate void RepeaterViewItemAddedEventHandler(object sender, RepeaterViewItemAddedEventArgs args);
+		[Preserve(AllMembers = true)]
+		public class RepeaterSwipeView : StackLayout
+		{
+			public event EventHandler SelectedIndexChanged;
+			public int SelectedIndex
+			{
+				get { return _selectedIndex; }
+				private set { _selectedIndex = value; SelectedIndexChanged?.Invoke(this, EventArgs.Empty); }
+			}
+
+			public RepeaterSwipeView()
+			{
+				Dictionary<Element, IDisposable> activatedViews
+					= new Dictionary<Element, IDisposable>();
+
+				Orientation = StackOrientation.Horizontal;
+				Padding = new Thickness(0);
+				Margin = new Thickness(0);
+				if (Device.RuntimePlatform == Device.iOS)
+					AddSwipeGestures();
+			}
+
+			public void RemoveSwipeGestures()
+			{
+				if (Device.RuntimePlatform == Device.iOS)
+					return;
+
+				this.GestureRecognizers.Clear();
+			}
+
+
+			public async void MoveForward()
+			{
+				var view = Children[SelectedIndex];
+				if (this.Children.LastOrDefault() == view)
+					return;
+
+				RemoveSwipeGestures();
+				SelectedIndex++;
+				await this.TranslateTo(-this.Width, this.Y);
+				await this.TranslateTo(0, this.Y, 0);
+				this.UpdateChildrenLayout();
+				this.InvalidateLayout();
+			}
+
+			public async void MoveBackwards()
+			{
+				var view = Children[SelectedIndex];
+				if (this.Children.FirstOrDefault() == view)
+					return;
+
+				RemoveSwipeGestures();
+				SelectedIndex--;
+				await this.TranslateTo(Width, Y);
+				await this.TranslateTo(0, Y, 0);
+				this.UpdateChildrenLayout();
+				this.InvalidateLayout();
+			}
+
+			public void AddSwipeGestures()
+			{
+				if (Device.RuntimePlatform == Device.iOS && this.GestureRecognizers.Any())
+					return;
+
+				RemoveSwipeGestures();
+				var control = this;
+
+				this.GestureRecognizers.Add(new SwipeGestureRecognizer()
+				{
+					Command = new Command(MoveBackwards),
+					Direction = SwipeDirection.Right
+				});
+
+				this.GestureRecognizers.Add(new SwipeGestureRecognizer()
+				{
+					Command = new Command(MoveForward),
+					Direction = SwipeDirection.Left
+				});
+
+			}
+
+			public static readonly BindableProperty ItemsSourceProperty =
+				BindableProperty.Create(
+					"ItemsSource",
+					typeof(IEnumerable),
+					typeof(RepeaterSwipeView),
+					defaultValue: null,
+					defaultBindingMode: BindingMode.OneWay,
+					propertyChanged: ItemsChanged);
+
+
+			public static readonly BindableProperty ItemTemplateProperty =
+				BindableProperty.Create(
+					"ViewModel",
+					typeof(DataTemplate),
+					typeof(RepeaterSwipeView),
+					defaultValue: null,
+					defaultBindingMode: BindingMode.OneWay);
+
+
+			bool waitingForBindingContext = false;
+			private int _selectedIndex = 0;
+
+			public event RepeaterViewItemAddedEventHandler ItemCreated;
+
+			public IEnumerable ItemsSource
+			{
+				get { return (IEnumerable)GetValue(ItemsSourceProperty); }
+				set { SetValue(ItemsSourceProperty, value); }
+			}
+
+			public DataTemplate ItemTemplate
+			{
+				get { return (DataTemplate)GetValue(ItemTemplateProperty); }
+				set { SetValue(ItemTemplateProperty, value); }
+			}
+
+
+			protected override void OnBindingContextChanged()
+			{
+				base.OnBindingContextChanged();
+
+				if (BindingContext != null && waitingForBindingContext && ItemsSource != null)
+				{
+					ItemsChanged(this, null, ItemsSource);
+				}
+			}
+
+			private static void ItemsChanged(BindableObject bindable, object old, object newVal)
+			{
+				IEnumerable oldValue = old as IEnumerable;
+				IEnumerable newValue = newVal as IEnumerable;
+
+				var control = (RepeaterSwipeView)bindable;
+
+				var oldObservableCollection = oldValue as INotifyCollectionChanged;
+
+				if (oldObservableCollection != null)
+				{
+					oldObservableCollection.CollectionChanged -= control.OnItemsSourceCollectionChanged;
+				}
+
+				//HACK:SHANE
+				if (control.BindingContext == null)
+				{
+					control.waitingForBindingContext = true;
+					//this means this control has been removed from the visual tree
+					//so don't update it other wise you get random null reference exceptions
+					return;
+				}
+
+				control.waitingForBindingContext = false;
+
+				var newObservableCollection = newValue as INotifyCollectionChanged;
+
+				if (newObservableCollection != null)
+				{
+					newObservableCollection.CollectionChanged += control.OnItemsSourceCollectionChanged;
+				}
+
+				try
+				{
+					control.Children.Clear();
+
+					if (newValue != null)
+					{
+						foreach (var item in newValue)
+						{
+							var view = control.CreateChildViewFor(item);
+							view.WidthRequest = Application.Current.MainPage?.Width ?? 360.0;
+							control.Children.Add(view);
+							control.OnItemCreated(view);
+
+						}
+					}
+
+					control.UpdateChildrenLayout();
+					control.InvalidateLayout();
+				}
+				catch (NullReferenceException)
+				{
+					try
+					{
+						Debug.WriteLine(
+							String.Format($"RepeaterView: NullReferenceException Parent:{control.Parent} ParentView:{control.Parent} IsVisible:{control.IsVisible}")
+						);
+					}
+					catch (Exception exc)
+					{
+						Debug.WriteLine($"NullReferenceException Logging Failed {exc}");
+					}
+				}
+			}
+
+			public double GetTotalChildrenWidth()
+			{
+				double total = 0;
+				foreach (var child in Children)
+				{
+					total += Application.Current.MainPage?.Width ?? 360.0;
+				}
+
+				return total;
+			}
+
+			public double GetDesiredOffset()
+			{
+				double total = 0;
+				foreach (var child in Children)
+				{
+					if (Children.IndexOf(child) >= SelectedIndex)
+						break;
+
+					total += Application.Current.MainPage?.Width ?? 360.0;
+				}
+
+				return total;
+			}
+
+
+			protected override void LayoutChildren(double x, double y, double width, double height)
+			{
+				//TranslationX = 0;
+				base.LayoutChildren(-GetDesiredOffset(), y, GetTotalChildrenWidth(), height);
+				AddSwipeGestures();
+			}
+
+			protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
+			{
+				return base.OnMeasure(widthConstraint, heightConstraint);
+			}
+
+
+			protected virtual void OnItemCreated(View view)
+			{
+				if (this.ItemCreated != null)
+				{
+					ItemCreated.Invoke(this, new RepeaterViewItemAddedEventArgs(view, view.BindingContext));
+				}
+			}
+
+			private void OnItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+			{
+				try
+				{
+					var invalidate = false;
+
+					List<View> createdViews = new List<View>();
+					if (e.Action == NotifyCollectionChangedAction.Reset)
+					{
+						var list = sender as IEnumerable;
+
+
+						this.Children.SyncList(
+							list,
+							(item) =>
+							{
+								var view = this.CreateChildViewFor(item);
+								createdViews.Add(view);
+								return view;
+							}, (item, view) => view.BindingContext == item,
+							null);
+
+						foreach (View view in createdViews)
+						{
+							OnItemCreated(view);
+						}
+
+						invalidate = true;
+					}
+
+					if (e.OldItems != null)
+					{
+						this.Children.RemoveAt(e.OldStartingIndex);
+						invalidate = true;
+					}
+
+					if (e.NewItems != null)
+					{
+						for (var i = 0; i < e.NewItems.Count; ++i)
+						{
+							var item = e.NewItems[i];
+							var view = this.CreateChildViewFor(item);
+
+							this.Children.Insert(i + e.NewStartingIndex, view);
+							OnItemCreated(view);
+						}
+
+						invalidate = true;
+					}
+
+					if (invalidate)
+					{
+						this.UpdateChildrenLayout();
+						this.InvalidateLayout();
+					}
+				}
+				catch (NullReferenceException)
+				{
+					try
+					{
+						Debug.WriteLine(
+							$"RepeaterView.OnItemsSourceCollectionChanged: NullReferenceException Parent:{Parent} ParentView:{Parent} IsVisible:{IsVisible} BindingContext: {BindingContext}"
+						);
+					}
+					catch (Exception exc)
+					{
+						Debug.WriteLine($"OnItemsSourceCollectionChanged: NullReferenceException Logging Failed {exc}");
+					}
+				}
+			}
+
+			private View CreateChildViewFor(object item)
+			{
+				this.ItemTemplate.SetValue(BindableObject.BindingContextProperty, item);
+
+				if (this.ItemTemplate is DataTemplateSelector)
+				{
+					var dts = (DataTemplateSelector)this.ItemTemplate;
+					return (View)dts.SelectTemplate(item, null).CreateContent();
+				}
+				else
+				{
+					return (View)this.ItemTemplate.CreateContent();
+				}
+			}
+		}
+	}
+	[Preserve(AllMembers = true)]
+	public class RepeaterViewItemAddedEventArgs : EventArgs
+	{
+		private readonly View view;
+		private readonly object model;
+
+		public RepeaterViewItemAddedEventArgs(View view, object model)
+		{
+			this.view = view;
+			this.model = model;
+		}
+
+		public View View { get { return view; } }
+
+		public object Model { get { return model; } }
+	}
+	[Preserve(AllMembers = true)]
+	public class RecommendationsView : ContentView
+	{
+		public RecommendationsView()
+		{
+			Grid grd = new Grid();
+			var lst = new ListView
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var swittch = new SwitchCell();
+					swittch.SetBinding(SwitchCell.TextProperty, new Binding("Name"));
+					swittch.SetBinding(SwitchCell.OnProperty, new Binding("IsBusy"));
+					//swittch.Text = new Binding("Text");
+					return swittch;
+				})
+
+			};
+			lst.SetBinding(ListView.ItemsSourceProperty, new Binding("Recommendations"));
+			grd.Children.Add(lst);
+			Content = grd;
+		}
+	}
+	[Preserve(AllMembers = true)]
+	public class AccountDetailsDataTemplateSelector : DataTemplateSelector
+	{
+		public Lazy<DataTemplate> ConsumptionDetailsViewDataTemplate { get; }
+		public Lazy<DataTemplate> AfkCurrentWorkLoadsViewDataTemplate { get; }
+		public Lazy<DataTemplate> RecommendationsViewDataTemplate { get; }
+		public Lazy<DataTemplate> AccountDetailsViewDataTemplate { get; }
+
+
+		public Lazy<View> RecommendationsView { get; } = new Lazy<View>(() => new RecommendationsView());
+
+
+		public AccountDetailsDataTemplateSelector()
+		{
+			RecommendationsViewDataTemplate = new Lazy<DataTemplate>(() => new DataTemplate(() => RecommendationsView.Value));
+		}
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			if (item is RecommendationsViewModel)
+			{
+				RecommendationsView.Value.BindingContext = item;
+				return RecommendationsViewDataTemplate.Value;
+			}
+
+			if (item is RecommendationsViewModel2)
+			{
+				RecommendationsView.Value.BindingContext = item;
+				return RecommendationsViewDataTemplate.Value;
+			}
+
+			throw new ArgumentException("Invalid ViewModel Type");
+		}
+	}
+	[Preserve(AllMembers = true)]
+	public static class IListMixIns
+	{
+
+		public static void SyncList<T>(
+			this IList<T> This,
+			IEnumerable<T> sourceList)
+		{
+			This.SyncList<T, T>(sourceList, x => x, (x, y) => x.Equals(y), null);
+		}
+
+
+		public static void SyncList<T>(
+			this IList<T> This,
+			IEnumerable sourceList,
+			Func<object, T> selector,
+			Func<object, T, bool> areEqual,
+			Action<object, T> updateExisting,
+			bool dontRemove = false)
+		{
+			var sourceListEnum = sourceList.OfType<Object>().ToList();
+
+			//passengers
+			foreach (T dest in This.ToList())
+			{
+				var match = sourceListEnum.FirstOrDefault(p => areEqual(p, dest));
+				if (match != null)
+				{
+					if (updateExisting != null)
+						updateExisting(match, dest);
+				}
+				else if (!dontRemove)
+				{
+					This.Remove(dest);
+				}
+			}
+
+			sourceListEnum.Where(x => !This.Any(p => areEqual(x, p)))
+				.ToList().ForEach(p =>
+				{
+					if (This.Count >= sourceListEnum.IndexOf(p))
+						This.Insert(sourceListEnum.IndexOf(p), selector(p));
+					else
+					{
+						var result = selector(p);
+						if (!EqualityComparer<T>.Default.Equals(result, default(T)))
+							This.Add(result);
+					}
+				});
+		}
+
+		public static bool IsEmpty<T>(this IEnumerable<T> list)
+		{
+			return !list.Any();
+		}
+
+		public static bool IsEmpty<T>(this Array list)
+		{
+			return list.Length == 0;
+		}
+
+		public static bool IsEmpty<T>(this List<T> list)
+		{
+			return list.Count == 0;
+		}
+
+		public static void ForEach<T>(this IEnumerable<T> list, Action<T> doMe)
+		{
+			foreach (var item in list)
+			{
+				doMe(item);
+			}
+		}
+
+		public static void SyncList<T, Source>(
+			this IList<T> This,
+			IEnumerable<Source> sourceList,
+			Func<Source, T> selector,
+			Func<Source, T, bool> areEqual,
+			Action<Source, T> updateExisting,
+			bool dontRemove = false)
+		{
+			//passengers
+			foreach (T dest in This.ToList())
+			{
+				var match = sourceList.FirstOrDefault(p => areEqual(p, dest));
+				if (!EqualityComparer<Source>.Default.Equals(match, default(Source)))
+				{
+					updateExisting?.Invoke(match, dest);
+				}
+				else if (!dontRemove)
+				{
+					This.Remove(dest);
+				}
+			}
+
+			sourceList.Where(x => !This.Any(p => areEqual(x, p)))
+				.ToList().ForEach(p =>
+				{
+					var result = selector(p);
+					if (!EqualityComparer<T>.Default.Equals(result, default(T)))
+						This.Add(result);
+				});
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
@@ -162,6 +162,8 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = grd;
 		}
 
+		// This work around exists because of this issue
+		// https://github.com/xamarin/Xamarin.Forms/issues/3602
 		object context = null;
 		protected override void OnBindingContextChanged()
 		{
@@ -194,6 +196,11 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
 		{
+			if (item == null)
+			{
+				return null;
+			}
+
 			if (item is RecommendationsViewModel)
 			{
 				RecommendationsView.Value.BindingContext = item;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
@@ -1,13 +1,8 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using Xamarin.Forms;
 using static Xamarin.Forms.Controls.Issues.Issue3408;
 
 #if UITEST
@@ -35,11 +30,12 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var grd = new Grid();
 
-			var aacountListView = new RepeaterSwipeView();
+			var aacountListView = new ListView();
+			aacountListView.HasUnevenRows = true;
 			aacountListView.ItemTemplate = new AccountDetailsDataTemplateSelector();
 			aacountListView.BindingContext = new List<RecommendationsViewModel> { new RecommendationsViewModel() };
 
-			aacountListView.SetBinding(RepeaterSwipeView.ItemsSourceProperty, ".");
+			aacountListView.SetBinding(ListView.ItemsSourceProperty, ".");
 			var btn = new Button
 			{
 				Text = "Change Source",
@@ -102,9 +98,9 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Recommendations = new List<Recommendation>()
 			{
-					new Recommendation(){ Name = "Click to Change"},
-					new Recommendation(){ Name = "Recommendations"},
-					new Recommendation(){ Name = "Recommendations"},
+					new Recommendation(){ Name = "Click to Change"} ,
+					new Recommendation(){ Name = "Recommendations"} ,
+					new Recommendation(){ Name = "Recommendations"} ,
 			};
 			}
 		}
@@ -117,9 +113,9 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Recommendations = new List<Recommendation>()
 			{
-					new Recommendation(){ Name = "This should have changed"},
-					new Recommendation(){ Name = "Recommendations 2"},
-					new Recommendation(){ Name = "Recommendations 2", IsBusy = true },
+					new Recommendation(){ Name = "This should have changed"} ,
+					new Recommendation(){ Name = "Recommendations 2"} ,
+					new Recommendation(){ Name = "Recommendations 2", IsBusy = true } ,
 			};
 			}
 		}
@@ -141,568 +137,8 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-		[Preserve(AllMembers = true)]
-		public class RepeaterView : StackLayout
-		{
-			public RepeaterView()
-			{
-				Dictionary<Element, IDisposable> activatedViews
-					= new Dictionary<Element, IDisposable>();
-			}
-
-			public static readonly BindableProperty ItemsSourceProperty =
-				BindableProperty.Create(
-					"ItemsSource",
-					typeof(IEnumerable),
-					typeof(RepeaterView),
-					defaultValue: null,
-					defaultBindingMode: BindingMode.OneWay,
-					propertyChanged: ItemsChanged);
-
-
-			public static readonly BindableProperty ItemTemplateProperty =
-				BindableProperty.Create(
-					"ViewModel",
-					typeof(DataTemplate),
-					typeof(RepeaterView),
-					defaultValue: null,
-					defaultBindingMode: BindingMode.OneWay);
-
-
-			bool waitingForBindingContext = false;
-			public event RepeaterViewItemAddedEventHandler ItemCreated;
-
-			public IEnumerable ItemsSource
-			{
-				get { return (IEnumerable)GetValue(ItemsSourceProperty); }
-				set { SetValue(ItemsSourceProperty, value); }
-			}
-
-			public DataTemplate ItemTemplate
-			{
-				get { return (DataTemplate)GetValue(ItemTemplateProperty); }
-				set { SetValue(ItemTemplateProperty, value); }
-			}
-
-
-			protected override void OnBindingContextChanged()
-			{
-				base.OnBindingContextChanged();
-
-				if (BindingContext != null && waitingForBindingContext && ItemsSource != null)
-				{
-					ItemsChanged(this, null, ItemsSource);
-				}
-			}
-
-			static void ItemsChanged(BindableObject bindable, object old, object newVal)
-			{
-				IEnumerable oldValue = old as IEnumerable;
-				IEnumerable newValue = newVal as IEnumerable;
-
-				var control = (RepeaterView)bindable;
-
-				var oldObservableCollection = oldValue as INotifyCollectionChanged;
-
-				if (oldObservableCollection != null)
-				{
-					oldObservableCollection.CollectionChanged -= control.OnItemsSourceCollectionChanged;
-				}
-
-				//HACK:SHANE
-				if (control.BindingContext == null)
-				{
-					control.waitingForBindingContext = true;
-					//this means this control has been removed from the visual tree
-					//so don't update it other wise you get random null reference exceptions
-					return;
-				}
-
-				control.waitingForBindingContext = false;
-
-				var newObservableCollection = newValue as INotifyCollectionChanged;
-
-				if (newObservableCollection != null)
-				{
-					newObservableCollection.CollectionChanged += control.OnItemsSourceCollectionChanged;
-				}
-
-				try
-				{
-					control.Children.Clear();
-
-					if (newValue != null)
-					{
-						foreach (var item in newValue)
-						{
-							var view = control.CreateChildViewFor(item);
-							control.Children.Add(view);
-							control.OnItemCreated(view);
-						}
-					}
-
-					control.UpdateChildrenLayout();
-					control.InvalidateLayout();
-				}
-				catch (NullReferenceException)
-				{
-					try
-					{
-						Debug.WriteLine(
-							String.Format($"RepeaterView: NullReferenceException Parent:{control.Parent} ParentView:{control.Parent} IsVisible:{control.IsVisible}")
-						);
-					}
-					catch (Exception exc)
-					{
-						Debug.WriteLine($"NullReferenceException Logging Failed {exc}");
-					}
-				}
-			}
-
-			protected virtual void OnItemCreated(View view)
-			{
-
-				if (this.ItemCreated != null)
-				{
-					ItemCreated.Invoke(this, new RepeaterViewItemAddedEventArgs(view, view.BindingContext));
-				}
-
-
-			}
-
-			void OnItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-			{
-				try
-				{
-					var invalidate = false;
-
-					List<View> createdViews = new List<View>();
-					if (e.Action == NotifyCollectionChangedAction.Reset)
-					{
-						var list = sender as IEnumerable;
-
-
-						this.Children.SyncList(
-							list,
-							(item) =>
-							{
-								var view = this.CreateChildViewFor(item);
-								createdViews.Add(view);
-								return view;
-							}, (item, view) => view.BindingContext == item,
-							null);
-
-						foreach (View view in createdViews)
-						{
-							OnItemCreated(view);
-						}
-
-						invalidate = true;
-					}
-
-					if (e.OldItems != null)
-					{
-						this.Children.RemoveAt(e.OldStartingIndex);
-						invalidate = true;
-					}
-
-					if (e.NewItems != null)
-					{
-						for (var i = 0; i < e.NewItems.Count; ++i)
-						{
-							var item = e.NewItems[i];
-							var view = this.CreateChildViewFor(item);
-
-							this.Children.Insert(i + e.NewStartingIndex, view);
-							OnItemCreated(view);
-						}
-
-						invalidate = true;
-					}
-
-					if (invalidate)
-					{
-						this.UpdateChildrenLayout();
-						this.InvalidateLayout();
-					}
-				}
-				catch (NullReferenceException)
-				{
-					try
-					{
-						Debug.WriteLine(
-							$"RepeaterView.OnItemsSourceCollectionChanged: NullReferenceException Parent:{Parent} ParentView:{Parent} IsVisible:{IsVisible} BindingContext: {BindingContext}"
-						);
-					}
-					catch (Exception exc)
-					{
-						Debug.WriteLine($"OnItemsSourceCollectionChanged: NullReferenceException Logging Failed {exc}");
-					}
-				}
-			}
-
-			View CreateChildViewFor(object item)
-			{
-				this.ItemTemplate.SetValue(BindableObject.BindingContextProperty, item);
-
-				if (this.ItemTemplate is DataTemplateSelector)
-				{
-					var dts = (DataTemplateSelector)this.ItemTemplate;
-					return (View)dts.SelectTemplate(item, null).CreateContent();
-				}
-				else
-				{
-					return (View)this.ItemTemplate.CreateContent();
-				}
-			}
-		}
-
-		[Preserve(AllMembers = true)]
-		public delegate void RepeaterViewItemAddedEventHandler(object sender, RepeaterViewItemAddedEventArgs args);
-		[Preserve(AllMembers = true)]
-		public class RepeaterSwipeView : StackLayout
-		{
-			public event EventHandler SelectedIndexChanged;
-			public int SelectedIndex
-			{
-				get { return _selectedIndex; }
-				private set { _selectedIndex = value; SelectedIndexChanged?.Invoke(this, EventArgs.Empty); }
-			}
-
-			public RepeaterSwipeView()
-			{
-				Dictionary<Element, IDisposable> activatedViews
-					= new Dictionary<Element, IDisposable>();
-
-				Orientation = StackOrientation.Horizontal;
-				Padding = new Thickness(0);
-				Margin = new Thickness(0);
-				if (Device.RuntimePlatform == Device.iOS)
-					AddSwipeGestures();
-			}
-
-			public void RemoveSwipeGestures()
-			{
-				if (Device.RuntimePlatform == Device.iOS)
-					return;
-
-				this.GestureRecognizers.Clear();
-			}
-
-
-			public async void MoveForward()
-			{
-				var view = Children[SelectedIndex];
-				if (this.Children.LastOrDefault() == view)
-					return;
-
-				RemoveSwipeGestures();
-				SelectedIndex++;
-				await this.TranslateTo(-this.Width, this.Y);
-				await this.TranslateTo(0, this.Y, 0);
-				this.UpdateChildrenLayout();
-				this.InvalidateLayout();
-			}
-
-			public async void MoveBackwards()
-			{
-				var view = Children[SelectedIndex];
-				if (this.Children.FirstOrDefault() == view)
-					return;
-
-				RemoveSwipeGestures();
-				SelectedIndex--;
-				await this.TranslateTo(Width, Y);
-				await this.TranslateTo(0, Y, 0);
-				this.UpdateChildrenLayout();
-				this.InvalidateLayout();
-			}
-
-			public void AddSwipeGestures()
-			{
-				if (Device.RuntimePlatform == Device.iOS && this.GestureRecognizers.Any())
-					return;
-
-				RemoveSwipeGestures();
-				var control = this;
-
-				this.GestureRecognizers.Add(new SwipeGestureRecognizer()
-				{
-					Command = new Command(MoveBackwards),
-					Direction = SwipeDirection.Right
-				});
-
-				this.GestureRecognizers.Add(new SwipeGestureRecognizer()
-				{
-					Command = new Command(MoveForward),
-					Direction = SwipeDirection.Left
-				});
-
-			}
-
-			public static readonly BindableProperty ItemsSourceProperty =
-				BindableProperty.Create(
-					"ItemsSource",
-					typeof(IEnumerable),
-					typeof(RepeaterSwipeView),
-					defaultValue: null,
-					defaultBindingMode: BindingMode.OneWay,
-					propertyChanged: ItemsChanged);
-
-
-			public static readonly BindableProperty ItemTemplateProperty =
-				BindableProperty.Create(
-					"ViewModel",
-					typeof(DataTemplate),
-					typeof(RepeaterSwipeView),
-					defaultValue: null,
-					defaultBindingMode: BindingMode.OneWay);
-
-
-			bool waitingForBindingContext = false;
-			private int _selectedIndex = 0;
-
-			public event RepeaterViewItemAddedEventHandler ItemCreated;
-
-			public IEnumerable ItemsSource
-			{
-				get { return (IEnumerable)GetValue(ItemsSourceProperty); }
-				set { SetValue(ItemsSourceProperty, value); }
-			}
-
-			public DataTemplate ItemTemplate
-			{
-				get { return (DataTemplate)GetValue(ItemTemplateProperty); }
-				set { SetValue(ItemTemplateProperty, value); }
-			}
-
-
-			protected override void OnBindingContextChanged()
-			{
-				base.OnBindingContextChanged();
-
-				if (BindingContext != null && waitingForBindingContext && ItemsSource != null)
-				{
-					ItemsChanged(this, null, ItemsSource);
-				}
-			}
-
-			private static void ItemsChanged(BindableObject bindable, object old, object newVal)
-			{
-				IEnumerable oldValue = old as IEnumerable;
-				IEnumerable newValue = newVal as IEnumerable;
-
-				var control = (RepeaterSwipeView)bindable;
-
-				var oldObservableCollection = oldValue as INotifyCollectionChanged;
-
-				if (oldObservableCollection != null)
-				{
-					oldObservableCollection.CollectionChanged -= control.OnItemsSourceCollectionChanged;
-				}
-
-				//HACK:SHANE
-				if (control.BindingContext == null)
-				{
-					control.waitingForBindingContext = true;
-					//this means this control has been removed from the visual tree
-					//so don't update it other wise you get random null reference exceptions
-					return;
-				}
-
-				control.waitingForBindingContext = false;
-
-				var newObservableCollection = newValue as INotifyCollectionChanged;
-
-				if (newObservableCollection != null)
-				{
-					newObservableCollection.CollectionChanged += control.OnItemsSourceCollectionChanged;
-				}
-
-				try
-				{
-					control.Children.Clear();
-
-					if (newValue != null)
-					{
-						foreach (var item in newValue)
-						{
-							var view = control.CreateChildViewFor(item);
-							view.WidthRequest = Application.Current.MainPage?.Width ?? 360.0;
-							control.Children.Add(view);
-							control.OnItemCreated(view);
-
-						}
-					}
-
-					control.UpdateChildrenLayout();
-					control.InvalidateLayout();
-				}
-				catch (NullReferenceException)
-				{
-					try
-					{
-						Debug.WriteLine(
-							String.Format($"RepeaterView: NullReferenceException Parent:{control.Parent} ParentView:{control.Parent} IsVisible:{control.IsVisible}")
-						);
-					}
-					catch (Exception exc)
-					{
-						Debug.WriteLine($"NullReferenceException Logging Failed {exc}");
-					}
-				}
-			}
-
-			public double GetTotalChildrenWidth()
-			{
-				double total = 0;
-				foreach (var child in Children)
-				{
-					total += Application.Current.MainPage?.Width ?? 360.0;
-				}
-
-				return total;
-			}
-
-			public double GetDesiredOffset()
-			{
-				double total = 0;
-				foreach (var child in Children)
-				{
-					if (Children.IndexOf(child) >= SelectedIndex)
-						break;
-
-					total += Application.Current.MainPage?.Width ?? 360.0;
-				}
-
-				return total;
-			}
-
-
-			protected override void LayoutChildren(double x, double y, double width, double height)
-			{
-				//TranslationX = 0;
-				base.LayoutChildren(-GetDesiredOffset(), y, GetTotalChildrenWidth(), height);
-				AddSwipeGestures();
-			}
-
-			protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
-			{
-				return base.OnMeasure(widthConstraint, heightConstraint);
-			}
-
-
-			protected virtual void OnItemCreated(View view)
-			{
-				if (this.ItemCreated != null)
-				{
-					ItemCreated.Invoke(this, new RepeaterViewItemAddedEventArgs(view, view.BindingContext));
-				}
-			}
-
-			private void OnItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-			{
-				try
-				{
-					var invalidate = false;
-
-					List<View> createdViews = new List<View>();
-					if (e.Action == NotifyCollectionChangedAction.Reset)
-					{
-						var list = sender as IEnumerable;
-
-
-						this.Children.SyncList(
-							list,
-							(item) =>
-							{
-								var view = this.CreateChildViewFor(item);
-								createdViews.Add(view);
-								return view;
-							}, (item, view) => view.BindingContext == item,
-							null);
-
-						foreach (View view in createdViews)
-						{
-							OnItemCreated(view);
-						}
-
-						invalidate = true;
-					}
-
-					if (e.OldItems != null)
-					{
-						this.Children.RemoveAt(e.OldStartingIndex);
-						invalidate = true;
-					}
-
-					if (e.NewItems != null)
-					{
-						for (var i = 0; i < e.NewItems.Count; ++i)
-						{
-							var item = e.NewItems[i];
-							var view = this.CreateChildViewFor(item);
-
-							this.Children.Insert(i + e.NewStartingIndex, view);
-							OnItemCreated(view);
-						}
-
-						invalidate = true;
-					}
-
-					if (invalidate)
-					{
-						this.UpdateChildrenLayout();
-						this.InvalidateLayout();
-					}
-				}
-				catch (NullReferenceException)
-				{
-					try
-					{
-						Debug.WriteLine(
-							$"RepeaterView.OnItemsSourceCollectionChanged: NullReferenceException Parent:{Parent} ParentView:{Parent} IsVisible:{IsVisible} BindingContext: {BindingContext}"
-						);
-					}
-					catch (Exception exc)
-					{
-						Debug.WriteLine($"OnItemsSourceCollectionChanged: NullReferenceException Logging Failed {exc}");
-					}
-				}
-			}
-
-			private View CreateChildViewFor(object item)
-			{
-				this.ItemTemplate.SetValue(BindableObject.BindingContextProperty, item);
-
-				if (this.ItemTemplate is DataTemplateSelector)
-				{
-					var dts = (DataTemplateSelector)this.ItemTemplate;
-					return (View)dts.SelectTemplate(item, null).CreateContent();
-				}
-				else
-				{
-					return (View)this.ItemTemplate.CreateContent();
-				}
-			}
-		}
 	}
-	[Preserve(AllMembers = true)]
-	public class RepeaterViewItemAddedEventArgs : EventArgs
-	{
-		private readonly View view;
-		private readonly object model;
 
-		public RepeaterViewItemAddedEventArgs(View view, object model)
-		{
-			this.view = view;
-			this.model = model;
-		}
-
-		public View View { get { return view; } }
-
-		public object Model { get { return model; } }
-	}
 	[Preserve(AllMembers = true)]
 	public class RecommendationsView : ContentView
 	{
@@ -721,26 +157,40 @@ namespace Xamarin.Forms.Controls.Issues
 				})
 
 			};
+
 			lst.SetBinding(ListView.ItemsSourceProperty, new Binding("Recommendations"));
 			grd.Children.Add(lst);
 			Content = grd;
 		}
+
+		object context = null;
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+			if (BindingContext == null)
+				Device.BeginInvokeOnMainThread(() => BindingContext = context);
+			else
+				context = BindingContext;
+		}
 	}
+
 	[Preserve(AllMembers = true)]
 	public class AccountDetailsDataTemplateSelector : DataTemplateSelector
 	{
-		public Lazy<DataTemplate> ConsumptionDetailsViewDataTemplate { get; }
-		public Lazy<DataTemplate> AfkCurrentWorkLoadsViewDataTemplate { get; }
 		public Lazy<DataTemplate> RecommendationsViewDataTemplate { get; }
-		public Lazy<DataTemplate> AccountDetailsViewDataTemplate { get; }
+		public Lazy<ViewCell> RecommendationsView { get; }
 
-
-		public Lazy<View> RecommendationsView { get; } = new Lazy<View>(() => new RecommendationsView());
-
+		public Lazy<DataTemplate> RecommendationsViewDataTemplate2 { get; }
+		public Lazy<ViewCell> RecommendationsView2 { get; }
 
 		public AccountDetailsDataTemplateSelector()
 		{
+			RecommendationsView = new Lazy<ViewCell>(() => new ViewCell() { View = new RecommendationsView() });
 			RecommendationsViewDataTemplate = new Lazy<DataTemplate>(() => new DataTemplate(() => RecommendationsView.Value));
+
+
+			RecommendationsView2 = new Lazy<ViewCell>(() => new ViewCell() { View = new RecommendationsView() });
+			RecommendationsViewDataTemplate2 = new Lazy<DataTemplate>(() => new DataTemplate(() => RecommendationsView2.Value));
 		}
 
 		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
@@ -753,116 +203,11 @@ namespace Xamarin.Forms.Controls.Issues
 
 			if (item is RecommendationsViewModel2)
 			{
-				RecommendationsView.Value.BindingContext = item;
-				return RecommendationsViewDataTemplate.Value;
+				RecommendationsView2.Value.BindingContext = item;
+				return RecommendationsViewDataTemplate2.Value;
 			}
 
 			throw new ArgumentException("Invalid ViewModel Type");
-		}
-	}
-	[Preserve(AllMembers = true)]
-	public static class IListMixIns
-	{
-
-		public static void SyncList<T>(
-			this IList<T> This,
-			IEnumerable<T> sourceList)
-		{
-			This.SyncList<T, T>(sourceList, x => x, (x, y) => x.Equals(y), null);
-		}
-
-
-		public static void SyncList<T>(
-			this IList<T> This,
-			IEnumerable sourceList,
-			Func<object, T> selector,
-			Func<object, T, bool> areEqual,
-			Action<object, T> updateExisting,
-			bool dontRemove = false)
-		{
-			var sourceListEnum = sourceList.OfType<Object>().ToList();
-
-			//passengers
-			foreach (T dest in This.ToList())
-			{
-				var match = sourceListEnum.FirstOrDefault(p => areEqual(p, dest));
-				if (match != null)
-				{
-					if (updateExisting != null)
-						updateExisting(match, dest);
-				}
-				else if (!dontRemove)
-				{
-					This.Remove(dest);
-				}
-			}
-
-			sourceListEnum.Where(x => !This.Any(p => areEqual(x, p)))
-				.ToList().ForEach(p =>
-				{
-					if (This.Count >= sourceListEnum.IndexOf(p))
-						This.Insert(sourceListEnum.IndexOf(p), selector(p));
-					else
-					{
-						var result = selector(p);
-						if (!EqualityComparer<T>.Default.Equals(result, default(T)))
-							This.Add(result);
-					}
-				});
-		}
-
-		public static bool IsEmpty<T>(this IEnumerable<T> list)
-		{
-			return !list.Any();
-		}
-
-		public static bool IsEmpty<T>(this Array list)
-		{
-			return list.Length == 0;
-		}
-
-		public static bool IsEmpty<T>(this List<T> list)
-		{
-			return list.Count == 0;
-		}
-
-		public static void ForEach<T>(this IEnumerable<T> list, Action<T> doMe)
-		{
-			foreach (var item in list)
-			{
-				doMe(item);
-			}
-		}
-
-		public static void SyncList<T, Source>(
-			this IList<T> This,
-			IEnumerable<Source> sourceList,
-			Func<Source, T> selector,
-			Func<Source, T, bool> areEqual,
-			Action<Source, T> updateExisting,
-			bool dontRemove = false)
-		{
-			//passengers
-			foreach (T dest in This.ToList())
-			{
-				var match = sourceList.FirstOrDefault(p => areEqual(p, dest));
-				if (!EqualityComparer<Source>.Default.Equals(match, default(Source)))
-				{
-					updateExisting?.Invoke(match, dest);
-				}
-				else if (!dontRemove)
-				{
-					This.Remove(dest);
-				}
-			}
-
-			sourceList.Where(x => !This.Any(p => areEqual(x, p)))
-				.ToList().ForEach(p =>
-				{
-					var result = selector(p);
-					if (!EqualityComparer<T>.Default.Equals(result, default(T)))
-						This.Add(result);
-				});
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
@@ -12,6 +12,8 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+	// This may crash for you on Android if you click too many buttons
+	// https://github.com/xamarin/Xamarin.Forms/issues/3603
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 3408, "System.ObjectDisposedException: from SwitchCellRenderer when changing ItemSource", PlatformAffected.iOS)]
 	public class Issue3408 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
@@ -152,7 +152,6 @@ namespace Xamarin.Forms.Controls.Issues
 					var swittch = new SwitchCell();
 					swittch.SetBinding(SwitchCell.TextProperty, new Binding("Name"));
 					swittch.SetBinding(SwitchCell.OnProperty, new Binding("IsBusy"));
-					//swittch.Text = new Binding("Text");
 					return swittch;
 				})
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -768,6 +768,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2728.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1667.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3012.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3408.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -944,7 +945,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Platform.iOS
 			get { return _cell; }
 			set
 			{
-				if (this._cell == value)
+				if (_cell == value)
 					return;
 
 				if (_cell != null)
@@ -29,7 +29,6 @@ namespace Xamarin.Forms.Platform.iOS
 					_cell.PropertyChanged -= HandlePropertyChanged;
 					Device.BeginInvokeOnMainThread(_cell.SendDisappearing);
 				}
-				this._cell = value;
 				_cell = value;
 
 				if (_cell != null)
@@ -42,10 +41,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public Element Element => Cell;
 
-		public void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
-		{
-			PropertyChanged?.Invoke(sender, e);
-		}
+		public void HandlePropertyChanged(object sender, PropertyChangedEventArgs e) => PropertyChanged?.Invoke(sender, e);
 
 		internal static UITableViewCell GetNativeCell(UITableView tableView, Cell cell, bool recycleCells = false, string templateId = "")
 		{

--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -23,13 +23,18 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 
 				if (_cell != null)
+				{
+					_cell.PropertyChanged -= HandlePropertyChanged;
 					Device.BeginInvokeOnMainThread(_cell.SendDisappearing);
-
+				}
 				this._cell = value;
 				_cell = value;
 
 				if (_cell != null)
+				{
+					_cell.PropertyChanged += HandlePropertyChanged;
 					Device.BeginInvokeOnMainThread(_cell.SendAppearing);
+				}
 			}
 		}
 
@@ -37,8 +42,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (PropertyChanged != null)
-				PropertyChanged(this, e);
+			PropertyChanged?.Invoke(sender, e);
 		}
 
 		internal static UITableViewCell GetNativeCell(UITableView tableView, Cell cell, bool recycleCells = false, string templateId = "")
@@ -102,6 +106,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (disposing)
 			{
 				PropertyChanged = null;
+				if (_cell != null)
+				{
+					_cell.PropertyChanged -= HandlePropertyChanged;
+				}
 				_cell = null;
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -7,7 +7,9 @@ namespace Xamarin.Forms.Platform.iOS
 	public class CellTableViewCell : UITableViewCell, INativeElementView
 	{
 		Cell _cell;
-		public Action<object, PropertyChangedEventArgs> CellPropertyChanged;
+
+		public Action<object, PropertyChangedEventArgs> PropertyChanged;
+
 		bool _disposed;
 
 		public CellTableViewCell(UITableViewCellStyle style, string key) : base(style, key)
@@ -24,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_cell != null)
 				{
-					_cell.PropertyChanged -= HandleCellPropertyChanged;
+					_cell.PropertyChanged -= HandlePropertyChanged;
 					Device.BeginInvokeOnMainThread(_cell.SendDisappearing);
 				}
 				this._cell = value;
@@ -32,7 +34,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_cell != null)
 				{
-					_cell.PropertyChanged += HandleCellPropertyChanged;
+					_cell.PropertyChanged += HandlePropertyChanged;
 					Device.BeginInvokeOnMainThread(_cell.SendAppearing);
 				}
 			}
@@ -40,9 +42,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public Element Element => Cell;
 
-		public void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs e)
+		public void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			CellPropertyChanged?.Invoke(sender, e);
+			PropertyChanged?.Invoke(sender, e);
 		}
 
 		internal static UITableViewCell GetNativeCell(UITableView tableView, Cell cell, bool recycleCells = false, string templateId = "")
@@ -105,10 +107,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
-				CellPropertyChanged = null;
+				PropertyChanged = null;
+
 				if (_cell != null)
 				{
-					_cell.PropertyChanged -= HandleCellPropertyChanged;
+					_cell.PropertyChanged -= HandlePropertyChanged;
 				}
 				_cell = null;
 			}

--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -8,7 +8,6 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		Cell _cell;
 		public Action<object, PropertyChangedEventArgs> CellPropertyChanged;
-		public Action<object, PropertyChangedEventArgs> PropertyChanged;
 		bool _disposed;
 
 		public CellTableViewCell(UITableViewCellStyle style, string key) : base(style, key)
@@ -44,11 +43,6 @@ namespace Xamarin.Forms.Platform.iOS
 		public void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			CellPropertyChanged?.Invoke(sender, e);
-		}
-
-		public void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
-		{
-			PropertyChanged?.Invoke(this, e);
 		}
 
 		internal static UITableViewCell GetNativeCell(UITableView tableView, Cell cell, bool recycleCells = false, string templateId = "")
@@ -111,7 +105,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
-				PropertyChanged = null;
 				CellPropertyChanged = null;
 				if (_cell != null)
 				{

--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -7,6 +7,7 @@ namespace Xamarin.Forms.Platform.iOS
 	public class CellTableViewCell : UITableViewCell, INativeElementView
 	{
 		Cell _cell;
+		public Action<object, PropertyChangedEventArgs> CellPropertyChanged;
 		public Action<object, PropertyChangedEventArgs> PropertyChanged;
 		bool _disposed;
 
@@ -24,7 +25,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_cell != null)
 				{
-					_cell.PropertyChanged -= HandlePropertyChanged;
+					_cell.PropertyChanged -= HandleCellPropertyChanged;
 					Device.BeginInvokeOnMainThread(_cell.SendDisappearing);
 				}
 				this._cell = value;
@@ -32,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_cell != null)
 				{
-					_cell.PropertyChanged += HandlePropertyChanged;
+					_cell.PropertyChanged += HandleCellPropertyChanged;
 					Device.BeginInvokeOnMainThread(_cell.SendAppearing);
 				}
 			}
@@ -40,9 +41,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public Element Element => Cell;
 
+		public void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			CellPropertyChanged?.Invoke(sender, e);
+		}
+
 		public void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			PropertyChanged?.Invoke(sender, e);
+			PropertyChanged?.Invoke(this, e);
 		}
 
 		internal static UITableViewCell GetNativeCell(UITableView tableView, Cell cell, bool recycleCells = false, string templateId = "")
@@ -106,9 +112,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (disposing)
 			{
 				PropertyChanged = null;
+				CellPropertyChanged = null;
 				if (_cell != null)
 				{
-					_cell.PropertyChanged -= HandlePropertyChanged;
+					_cell.PropertyChanged -= HandleCellPropertyChanged;
 				}
 				_cell = null;
 			}

--- a/Xamarin.Forms.Platform.iOS/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/EntryCellRenderer.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.iOS
 				tvc = new EntryCellTableViewCell(item.GetType().FullName);
 			else
 			{
-				tvc.CellPropertyChanged -= OnCellPropertyChanged;
+				tvc.PropertyChanged -= HandlePropertyChanged;
 				tvc.TextFieldTextChanged -= OnTextFieldTextChanged;
 				tvc.KeyboardDoneButtonPressed -= OnKeyBoardDoneButtonPressed;
 			}
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 			SetRealCell(item, tvc);
 
 			tvc.Cell = item;
-			tvc.CellPropertyChanged += OnCellPropertyChanged;
+			tvc.PropertyChanged += HandlePropertyChanged;
 			tvc.TextFieldTextChanged += OnTextFieldTextChanged;
 			tvc.KeyboardDoneButtonPressed += OnKeyBoardDoneButtonPressed;
 
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return tvc;
 		}
 
-		static void OnCellPropertyChanged(object sender, PropertyChangedEventArgs e)
+		static void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			var entryCell = (EntryCell)sender;
 			var realCell = (EntryCellTableViewCell)GetRealCell(entryCell);

--- a/Xamarin.Forms.Platform.iOS/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/EntryCellRenderer.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.iOS
 				tvc = new EntryCellTableViewCell(item.GetType().FullName);
 			else
 			{
-				tvc.Cell.PropertyChanged -= OnCellPropertyChanged;
+				tvc.CellPropertyChanged -= OnCellPropertyChanged;
 				tvc.TextFieldTextChanged -= OnTextFieldTextChanged;
 				tvc.KeyboardDoneButtonPressed -= OnKeyBoardDoneButtonPressed;
 			}
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 			SetRealCell(item, tvc);
 
 			tvc.Cell = item;
-			tvc.Cell.PropertyChanged += OnCellPropertyChanged;
+			tvc.CellPropertyChanged += OnCellPropertyChanged;
 			tvc.TextFieldTextChanged += OnTextFieldTextChanged;
 			tvc.KeyboardDoneButtonPressed += OnKeyBoardDoneButtonPressed;
 

--- a/Xamarin.Forms.Platform.iOS/Cells/ImageCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ImageCellRenderer.cs
@@ -20,12 +20,12 @@ namespace Xamarin.Forms.Platform.iOS
 			return result;
 		}
 
-		protected override void HandlePropertyChanged(object sender, PropertyChangedEventArgs args)
+		protected override void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
-			var tvc = (CellTableViewCell)sender;
-			var imageCell = (ImageCell)tvc.Cell;
+			var imageCell = (ImageCell)sender;
+			var tvc = (CellTableViewCell)GetRealCell(imageCell);
 
-			base.HandlePropertyChanged(sender, args);
+			base.HandleCellPropertyChanged(sender, args);
 
 			if (args.PropertyName == ImageCell.ImageSourceProperty.PropertyName)
 				SetImage(imageCell, tvc);

--- a/Xamarin.Forms.Platform.iOS/Cells/ImageCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ImageCellRenderer.cs
@@ -20,12 +20,12 @@ namespace Xamarin.Forms.Platform.iOS
 			return result;
 		}
 
-		protected override void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs args)
+		protected override void HandlePropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
 			var imageCell = (ImageCell)sender;
 			var tvc = (CellTableViewCell)GetRealCell(imageCell);
 
-			base.HandleCellPropertyChanged(sender, args);
+			base.HandlePropertyChanged(sender, args);
 
 			if (args.PropertyName == ImageCell.ImageSourceProperty.PropertyName)
 				SetImage(imageCell, tvc);

--- a/Xamarin.Forms.Platform.iOS/Cells/ImageCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ImageCellRenderer.cs
@@ -20,12 +20,12 @@ namespace Xamarin.Forms.Platform.iOS
 			return result;
 		}
 
-		protected override void HandlePropertyChanged(object sender, PropertyChangedEventArgs args)
+		protected override void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
 			var imageCell = (ImageCell)sender;
 			var tvc = (CellTableViewCell)GetRealCell(imageCell);
 
-			base.HandlePropertyChanged(sender, args);
+			base.HandleCellPropertyChanged(sender, args);
 
 			if (args.PropertyName == ImageCell.ImageSourceProperty.PropertyName)
 				SetImage(imageCell, tvc);

--- a/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				uiSwitch = tvc.AccessoryView as UISwitch;
-				tvc.CellPropertyChanged -= OnCellPropertyChanged;
+				tvc.PropertyChanged -= HandlePropertyChanged;
 			}
 
 			SetRealCell(item, tvc);
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var boolCell = (SwitchCell)item;
 
 			tvc.Cell = item;
-			tvc.CellPropertyChanged += OnCellPropertyChanged;
+			tvc.PropertyChanged += HandlePropertyChanged;
 			tvc.AccessoryView = uiSwitch;
 			tvc.TextLabel.Text = boolCell.Text;
 
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return tvc;
 		}
 
-		void OnCellPropertyChanged(object sender, PropertyChangedEventArgs e)
+		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			var boolCell = (SwitchCell)sender;
 			var realCell = (CellTableViewCell)GetRealCell(boolCell);

--- a/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				uiSwitch = tvc.AccessoryView as UISwitch;
-				tvc.Cell.PropertyChanged -= OnCellPropertyChanged;
+				tvc.PropertyChanged -= OnCellPropertyChanged;
 			}
 
 			SetRealCell(item, tvc);
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var boolCell = (SwitchCell)item;
 
 			tvc.Cell = item;
-			tvc.Cell.PropertyChanged += OnCellPropertyChanged;
+			tvc.PropertyChanged += OnCellPropertyChanged;
 			tvc.AccessoryView = uiSwitch;
 			tvc.TextLabel.Text = boolCell.Text;
 

--- a/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				uiSwitch = tvc.AccessoryView as UISwitch;
-				tvc.PropertyChanged -= OnCellPropertyChanged;
+				tvc.CellPropertyChanged -= OnCellPropertyChanged;
 			}
 
 			SetRealCell(item, tvc);
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var boolCell = (SwitchCell)item;
 
 			tvc.Cell = item;
-			tvc.PropertyChanged += OnCellPropertyChanged;
+			tvc.CellPropertyChanged += OnCellPropertyChanged;
 			tvc.AccessoryView = uiSwitch;
 			tvc.TextLabel.Text = boolCell.Text;
 

--- a/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
@@ -63,7 +63,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void HandlePropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
-			//keeping this method for backwards compatability as the the sender here is a CellTableViewCell
+			//keeping this method for backwards compatibility 
+			//as the the sender for this method is a CellTableViewCell
 		}
 
 		static void UpdateIsEnabled(CellTableViewCell cell, TextCell entryCell)

--- a/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
@@ -16,12 +16,12 @@ namespace Xamarin.Forms.Platform.iOS
 			if (tvc == null)
 				tvc = new CellTableViewCell(UITableViewCellStyle.Subtitle, item.GetType().FullName);
 			else
-				tvc.CellPropertyChanged -= HandleCellPropertyChanged;
+				tvc.PropertyChanged -= HandlePropertyChanged;
 
 			SetRealCell(item, tvc);
 
 			tvc.Cell = textCell;
-			tvc.CellPropertyChanged = HandleCellPropertyChanged;
+			tvc.PropertyChanged = HandlePropertyChanged;
 
 			tvc.TextLabel.Text = textCell.Text;
 			tvc.DetailTextLabel.Text = textCell.Detail;
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return tvc;
 		}
 
-		protected virtual void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs args)
+		protected virtual void HandlePropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
 			var textCell = (TextCell)sender;
 			var tvc = (CellTableViewCell)GetRealCell(textCell);

--- a/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
@@ -16,11 +16,12 @@ namespace Xamarin.Forms.Platform.iOS
 			if (tvc == null)
 				tvc = new CellTableViewCell(UITableViewCellStyle.Subtitle, item.GetType().FullName);
 			else
-				tvc.Cell.PropertyChanged -= tvc.HandlePropertyChanged;
+				tvc.CellPropertyChanged -= HandleCellPropertyChanged;
+
+			SetRealCell(item, tvc);
 
 			tvc.Cell = textCell;
-			textCell.PropertyChanged += tvc.HandlePropertyChanged;
-			tvc.PropertyChanged = HandlePropertyChanged;
+			tvc.CellPropertyChanged = HandleCellPropertyChanged;
 
 			tvc.TextLabel.Text = textCell.Text;
 			tvc.DetailTextLabel.Text = textCell.Detail;
@@ -36,10 +37,11 @@ namespace Xamarin.Forms.Platform.iOS
 			return tvc;
 		}
 
-		protected virtual void HandlePropertyChanged(object sender, PropertyChangedEventArgs args)
+		protected virtual void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
-			var tvc = (CellTableViewCell)sender;
-			var textCell = (TextCell)tvc.Cell;
+			var textCell = (TextCell)sender;
+			var tvc = (CellTableViewCell)GetRealCell(textCell);
+
 			if (args.PropertyName == TextCell.TextProperty.PropertyName)
 			{
 				tvc.TextLabel.Text = ((TextCell)tvc.Cell).Text;

--- a/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
@@ -12,16 +12,15 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var textCell = (TextCell)item;
 
-			var tvc = reusableCell as CellTableViewCell;
-			if (tvc == null)
+			if (!(reusableCell is CellTableViewCell tvc))
 				tvc = new CellTableViewCell(UITableViewCellStyle.Subtitle, item.GetType().FullName);
 			else
-				tvc.PropertyChanged -= HandlePropertyChanged;
+				tvc.PropertyChanged -= HandleCellPropertyChanged;
 
 			SetRealCell(item, tvc);
 
 			tvc.Cell = textCell;
-			tvc.PropertyChanged = HandlePropertyChanged;
+			tvc.PropertyChanged = HandleCellPropertyChanged;
 
 			tvc.TextLabel.Text = textCell.Text;
 			tvc.DetailTextLabel.Text = textCell.Detail;
@@ -37,7 +36,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return tvc;
 		}
 
-		protected virtual void HandlePropertyChanged(object sender, PropertyChangedEventArgs args)
+		protected virtual void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
 			var textCell = (TextCell)sender;
 			var tvc = (CellTableViewCell)GetRealCell(textCell);
@@ -58,6 +57,13 @@ namespace Xamarin.Forms.Platform.iOS
 				tvc.DetailTextLabel.TextColor = textCell.DetailColor.ToUIColor(DefaultTextColor);
 			else if (args.PropertyName == Cell.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled(tvc, textCell);
+
+			HandlePropertyChanged(tvc, args);
+		}
+
+		protected virtual void HandlePropertyChanged(object sender, PropertyChangedEventArgs args)
+		{
+			//keeping this method for backwards compatability as the the sender here is a CellTableViewCell
 		}
 
 		static void UpdateIsEnabled(CellTableViewCell cell, TextCell entryCell)


### PR DESCRIPTION
### Description of Change ###

SwitchCellRenderer wasn't unsubscribing when disposed. 
The best way would be to just use the event exposed by our `CellTableViewCell` 

We should use this in other cell renderers, this will allow to control the unsubscribing  when cell's are dispose and reused. 

### Issues Resolved ###

- fixes #3408 

### API Changes ###

Changes to `CellTableViewCell`

Add:

`public void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs e)`

`public Action<object, PropertyChangedEventArgs> CellPropertyChanged`

Remove: 

`public Action<object, PropertyChangedEventArgs> PropertyChanged`

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###

Doesn't crash when SwitchCells go away (are disposed) 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard