### PR TITLE
[Tizen] Support the TitleView of NavigationPage

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/TitleViewPage.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/TitleViewPage.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using ElmSharp;
+
+namespace Xamarin.Forms.Platform.Tizen.Native
+{
+	public class TitleViewPage : Native.Box
+	{
+		Native.Page _page = null;
+		View _titleView = null;
+		bool _hasNavigationBar = true;
+
+		public TitleViewPage(EvasObject parent, Xamarin.Forms.Page page, View titleView) : base(parent)
+		{
+			_page = Platform.GetOrCreateRenderer(page).NativeView as Native.Page;
+			_titleView = titleView;
+			if (_titleView != null)
+			{
+				var renderer = Platform.GetOrCreateRenderer(_titleView);
+				(renderer as LayoutRenderer)?.RegisterOnLayoutUpdated();
+
+				this.PackEnd(renderer.NativeView);
+			}
+			this.PackEnd(_page);
+			this.LayoutUpdated += OnLayoutUpdated;
+		}
+
+		public bool HasNavigationBar
+		{
+			get
+			{
+				return _hasNavigationBar;
+			}
+			set
+			{
+				if (_hasNavigationBar != value)
+				{
+					_hasNavigationBar = value;
+					UpdatPageLayout(this, new LayoutEventArgs() { Geometry = this.Geometry });
+				}
+
+			}
+		}
+
+		void OnLayoutUpdated(object sender, LayoutEventArgs e)
+		{
+			UpdatPageLayout(sender, e);
+		}
+
+		void UpdatPageLayout(object sender, LayoutEventArgs e)
+		{
+			double dHeight = _titleView.Measure(Forms.ConvertToScaledDP(e.Geometry.Width), Forms.ConvertToScaledDP(e.Geometry.Height)).Request.Height;
+			int height = 0;
+			if (_hasNavigationBar)
+			{
+				height = Forms.ConvertToScaledPixel(dHeight);
+			}
+
+			var renderer = Platform.GetOrCreateRenderer(_titleView);
+			renderer.NativeView.Move(e.Geometry.X, e.Geometry.Y);
+			renderer.NativeView.Resize(e.Geometry.Width, height);
+
+			_page.Move(e.Geometry.X, e.Geometry.Y + height);
+			_page.Resize(e.Geometry.Width, e.Geometry.Height - height);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###
This change is about supporting the `TitleView` of `NavigationPage` on Tizen

![titleview_mobile](https://user-images.githubusercontent.com/20967778/43946415-2e52dcd8-9cc0-11e8-983d-6c2e8e016494.gif)


### Issues Resolved ###
None

### API Changes ###
None

### Platforms Affected ###
- Tizen

### Behavioral/Visual Changes ###
If you set any `View` of Xamarin.Forms to the navigation bar of a `NavigationPage`, `TitleView` would be shown on top of `Page`.
However,  If pages are pushed before the `TitleView` is set, these pages can not display the `TitleView` due to the platform limitation. 
It is recommend to set the `TitleView` before pushing a `Page`.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
