### PR TITLE
[XamlC] Throws on duplicate x:Key

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3512.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3512.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Gh3512">
+	<ContentPage.Resources>
+		<Style x:Key="foo" TargetType="Label"/>
+		<Style x:Key="foo" TargetType="Label"/>
+	</ContentPage.Resources>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3512.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3512.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh3512 : ContentPage
+	{
+		public Gh3512()
+		{
+			InitializeComponent();
+		}
+
+		public Gh3512(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false), TestCase(true)]
+			public void ThrowsOnDuplicateXKey(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<XamlParseException>(() => MockCompiler.Compile(typeof(Gh3512)));
+				else
+					Assert.Throws<ArgumentException>(() => new Gh3512(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -634,6 +634,9 @@
     <Compile Include="Issues\Gh3280.xaml.cs">
       <DependentUpon>Gh3280.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh3512.xaml.cs">
+      <DependentUpon>Gh3512.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('..\.nuspec\Xamarin.Forms.Build.Tasks.dll')" />
@@ -1151,6 +1154,10 @@
     <EmbeddedResource Include="Issues\Gh3280.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh3512.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Throws a XamlParseException on duplicate x:Key on RDs. This will find
duplicate in xaml, but duplicates can still happen if the RD is modified
in code. Those dupes are already detected at runtime.

### Issues Resolved ###

- helps, but doesn't fixes, #3512

### API Changes ###

/

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
