### PR TITLE
[XamlC] Fix binding compilation for value types

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -540,7 +540,7 @@ namespace Xamarin.Forms.Build.Tasks
 		static IEnumerable<Instruction> CompiledBindingGetSetter(TypeReference tSourceRef, TypeReference tPropertyRef, IList<Tuple<PropertyDefinition, string>> properties, ElementNode node, ILContext context)
 		{
 			if (properties == null || properties.Count == 0) {
-				yield return Instruction.Create(OpCodes.Ldnull);
+				yield return Create(Ldnull);
 				yield break;
 			}
 
@@ -573,7 +573,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var lastProperty = properties.LastOrDefault();
 			var setterRef = lastProperty?.Item1.SetMethod;
 			if (setterRef == null) {
-				yield return Instruction.Create(OpCodes.Ldnull); //throw or not ?
+				yield return Create(Ldnull); //throw or not ?
 				yield break;
 			}
 
@@ -586,12 +586,12 @@ namespace Xamarin.Forms.Build.Tasks
 				var indexerArg = properties[i].Item2;
 				if (indexerArg != null) {
 					if (property.GetMethod.Parameters [0].ParameterType == module.TypeSystem.String)
-						il.Emit(OpCodes.Ldstr, indexerArg);
+						il.Emit(Ldstr, indexerArg);
 					else if (property.GetMethod.Parameters [0].ParameterType == module.TypeSystem.Int32) {
 						int index;
 						if (!int.TryParse(indexerArg, out index))
 							throw new XamlParseException($"Binding: {indexerArg} could not be parsed as an index for a {property.Name}", node as IXmlLineInfo);
-						il.Emit(OpCodes.Ldc_I4, index);
+						il.Emit(Ldc_I4, index);
 					}
 				}
 				if (property.GetMethod.IsVirtual)
@@ -603,25 +603,23 @@ namespace Xamarin.Forms.Build.Tasks
 			var indexer = properties.Last().Item2;
 			if (indexer != null) {
 				if (lastProperty.Item1.GetMethod.Parameters [0].ParameterType == module.TypeSystem.String)
-					il.Emit(OpCodes.Ldstr, indexer);
+					il.Emit(Ldstr, indexer);
 				else if (lastProperty.Item1.GetMethod.Parameters [0].ParameterType == module.TypeSystem.Int32) {
 					int index;
 					if (!int.TryParse(indexer, out index))
 						throw new XamlParseException($"Binding: {indexer} could not be parsed as an index for a {lastProperty.Item1.Name}", node as IXmlLineInfo);
-					il.Emit(OpCodes.Ldc_I4, index);
+					il.Emit(Ldc_I4, index);
 				}
 			}
-			if (tPropertyRef.IsValueType)
-				il.Emit(Ldarga_S, (byte)1);
-			else
-				il.Emit(Ldarg_1);
+
+			il.Emit(Ldarg_1);
 
 			if (setterRef.IsVirtual)
 				il.Emit(Callvirt, module.ImportReference(setterRef));
 			else
 				il.Emit(Call, module.ImportReference(setterRef));
 
-			il.Emit(OpCodes.Ret);
+			il.Emit(Ret);
 
 			context.Body.Method.DeclaringType.Methods.Add(setter);
 

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3539.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3539.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Xamarin.Forms.Xaml.UnitTests.Gh3539"
+			 xmlns:local="using:Xamarin.Forms.Xaml.UnitTests">
+	<StackLayout x:DataType="local:Gh3539ViewModel">
+        <StackLayout.BindingContext>
+            <local:Gh3539ViewModel Color="Sienna" />
+        </StackLayout.BindingContext>
+        <BoxView Color="{Binding Color}"
+                 VerticalOptions="FillAndExpand" />
+        <StackLayout Margin="10, 0">
+            <Label Text="{Binding Name}" />
+            <Slider Value="{Binding Hue}" />
+            <Label Text="{Binding Hue, StringFormat='Hue = {0:F2}'}" />
+            <Slider Value="{Binding Saturation}" />
+            <Label Text="{Binding Saturation, StringFormat='Saturation = {0:F2}'}" />
+            <Slider Value="{Binding Luminosity}" />
+            <Label Text="{Binding Luminosity, StringFormat='Luminosity = {0:F2}'}" />
+        </StackLayout>
+    </StackLayout> 
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3539.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3539.xaml.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+using System.Text;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh3539ViewModel : INotifyPropertyChanged
+	{
+		Color color;
+		string name;
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public double Hue {
+			set {
+				if (color.Hue != value) {
+					Color = Color.FromHsla(value, color.Saturation, color.Luminosity);
+				}
+			}
+			get {
+				return color.Hue;
+			}
+		}
+
+		public double Saturation {
+			set {
+				if (color.Saturation != value) {
+					Color = Color.FromHsla(color.Hue, value, color.Luminosity);
+				}
+			}
+			get {
+				return color.Saturation;
+			}
+		}
+
+		public double Luminosity {
+			set {
+				if (color.Luminosity != value) {
+					Color = Color.FromHsla(color.Hue, color.Saturation, value);
+				}
+			}
+			get {
+				return color.Luminosity;
+			}
+		}
+
+		public Color Color {
+			set {
+				if (color != value) {
+					color = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Hue"));
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Saturation"));
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Luminosity"));
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Color"));
+
+					Name = Gh3539NamedColor.GetNearestColorName(color);
+				}
+			}
+			get {
+				return color;
+			}
+		}
+
+		public string Name {
+			private set {
+				if (name != value) {
+					name = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Name"));
+				}
+			}
+			get {
+				return name;
+			}
+		}
+	}
+
+	public class Gh3539NamedColor : IEquatable<Gh3539NamedColor>, IComparable<Gh3539NamedColor>
+	{
+		// Instance members
+		private Gh3539NamedColor()
+		{
+		}
+
+		public string Name { private set; get; }
+
+		public string FriendlyName { private set; get; }
+
+		public Color Color { private set; get; }
+
+		public string RgbDisplay { private set; get; }
+
+		public bool Equals(Gh3539NamedColor other)
+		{
+			return Name.Equals(other.Name);
+		}
+
+		public int CompareTo(Gh3539NamedColor other)
+		{
+			return Name.CompareTo(other.Name);
+		}
+
+		// Static members
+		static Gh3539NamedColor()
+		{
+			List<Gh3539NamedColor> all = new List<Gh3539NamedColor>();
+			StringBuilder stringBuilder = new StringBuilder();
+
+			// Loop through the public static fields of the Color structure.
+			foreach (FieldInfo fieldInfo in typeof(Color).GetRuntimeFields()) {
+				if (fieldInfo.IsPublic &&
+					fieldInfo.IsStatic &&
+					fieldInfo.FieldType == typeof(Color)) {
+					// Convert the name to a friendly name.
+					string name = fieldInfo.Name;
+					stringBuilder.Clear();
+					int index = 0;
+
+					foreach (char ch in name) {
+						if (index != 0 && Char.IsUpper(ch)) {
+							stringBuilder.Append(' ');
+						}
+						stringBuilder.Append(ch);
+						index++;
+					}
+
+					// Instantiate a NamedColor object.
+					Color color = (Color)fieldInfo.GetValue(null);
+
+					Gh3539NamedColor namedColor = new Gh3539NamedColor {
+						Name = name,
+						FriendlyName = stringBuilder.ToString(),
+						Color = color,
+						RgbDisplay = String.Format("{0:X2}-{1:X2}-{2:X2}",
+												   (int)(255 * color.R),
+												   (int)(255 * color.G),
+												   (int)(255 * color.B))
+					};
+
+					// Add it to the collection.
+					all.Add(namedColor);
+				}
+			}
+			all.TrimExcess();
+			all.Sort();
+			All = all;
+		}
+
+		public static IList<Gh3539NamedColor> All { private set; get; }
+
+		public static Gh3539NamedColor Find(string name)
+		{
+			return ((List<Gh3539NamedColor>)All).Find(nc => nc.Name == name);
+		}
+
+		public static string GetNearestColorName(Color color)
+		{
+			double shortestDistance = 1000;
+			Gh3539NamedColor closestColor = null;
+
+			foreach (Gh3539NamedColor namedColor in Gh3539NamedColor.All) {
+				double distance = Math.Sqrt(Math.Pow(color.R - namedColor.Color.R, 2) +
+											Math.Pow(color.G - namedColor.Color.G, 2) +
+											Math.Pow(color.B - namedColor.Color.B, 2));
+
+				if (distance < shortestDistance) {
+					shortestDistance = distance;
+					closestColor = namedColor;
+				}
+			}
+			return closestColor.Name;
+		}
+	}
+
+	public partial class Gh3539 : ContentPage
+	{
+		public Gh3539()
+		{
+			InitializeComponent();
+		}
+
+		public Gh3539(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			public void CompiledBindingCodeIsValid(bool useCompiledXaml)
+			{
+				var layout = new Gh3539(useCompiledXaml);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -637,6 +637,9 @@
     <Compile Include="Issues\Gh3512.xaml.cs">
       <DependentUpon>Gh3512.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh3539.xaml.cs">
+      <DependentUpon>Gh3280.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('..\.nuspec\Xamarin.Forms.Build.Tasks.dll')" />
@@ -1158,6 +1161,10 @@
     <EmbeddedResource Include="Issues\Gh3512.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh3539.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

[XamlC] Fix binding compilation fo value types

properly load valuetype arguments of generated setters, using ldarg,
instead of ldarga.

### Issues Resolved ###

- fixes #3539

### API Changes ###

/

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard