### PR TITLE
Implementation of BottomNavigationView.IOnNavigationItemReselectedListener for Bottom Tabbed Bar

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -21,9 +21,9 @@ using AColor = Android.Graphics.Color;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
-	public class TabbedPageRenderer : VisualElementRenderer<TabbedPage>, TabLayout.IOnTabSelectedListener, ViewPager.IOnPageChangeListener, IManageFragments, BottomNavigationView.IOnNavigationItemSelectedListener
-	{
-		Drawable _backgroundDrawable;
+	public class TabbedPageRenderer : VisualElementRenderer<TabbedPage>, TabLayout.IOnTabSelectedListener, ViewPager.IOnPageChangeListener, IManageFragments, BottomNavigationView.IOnNavigationItemSelectedListener, BottomNavigationView.IOnNavigationItemReselectedListener
+    {
+        Drawable _backgroundDrawable;
 		Drawable _wrappedBackgroundDrawable;
 		ColorStateList _originalTabTextColors;
 		ColorStateList _orignalTabIconColors;
@@ -113,6 +113,18 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			SetIconColorFilter(tab, false);
 		}
 
+        void BottomNavigationView.IOnNavigationItemReselectedListener.OnNavigationItemReselected(IMenuItem item)
+        {
+            if (Element == null)
+                return;
+
+			OnNavigationItemReselected(item);
+        }
+
+		protected virtual void OnNavigationItemReselected(IMenuItem item)
+		{
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing && !_disposed)
@@ -148,7 +160,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (_bottomNavigationView != null)
 				{
 					_bottomNavigationView.SetOnNavigationItemSelectedListener(null);
-					_bottomNavigationView.Dispose();
+                    _bottomNavigationView.SetOnNavigationItemReselectedListener(null);
+                    _bottomNavigationView.Dispose();
 					_bottomNavigationView = null;
 				}
 
@@ -203,7 +216,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 						{
 							_relativeLayout.RemoveView(_bottomNavigationView);
 							_bottomNavigationView.SetOnNavigationItemSelectedListener(null);
-						}
+                            _bottomNavigationView.SetOnNavigationItemReselectedListener(null);
+                        }
 
 						var bottomNavigationViewLayoutParams = new AWidget.RelativeLayout.LayoutParams(
 							LayoutParams.MatchParent,
@@ -400,7 +414,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					SetupBottomNavigationView(e);
 					UpdateBottomNavigationViewIcons();
 					bottomNavigationView.SetOnNavigationItemSelectedListener(this);
-				}
+                    bottomNavigationView.SetOnNavigationItemReselectedListener(this);
+                }
 
 				UpdateIgnoreContainerAreas();
 			}

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -113,13 +113,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			SetIconColorFilter(tab, false);
 		}
 
-        void BottomNavigationView.IOnNavigationItemReselectedListener.OnNavigationItemReselected(IMenuItem item)
+		void BottomNavigationView.IOnNavigationItemReselectedListener.OnNavigationItemReselected(IMenuItem item)
 		{
 			if (Element == null)
 				return;
 
 			OnNavigationItemReselected(item);
-        }
+		}
 
 		protected virtual void OnNavigationItemReselected(IMenuItem item)
 		{

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -22,8 +22,8 @@ using AColor = Android.Graphics.Color;
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
 	public class TabbedPageRenderer : VisualElementRenderer<TabbedPage>, TabLayout.IOnTabSelectedListener, ViewPager.IOnPageChangeListener, IManageFragments, BottomNavigationView.IOnNavigationItemSelectedListener, BottomNavigationView.IOnNavigationItemReselectedListener
-    {
-        Drawable _backgroundDrawable;
+	{
+		Drawable _backgroundDrawable;
 		Drawable _wrappedBackgroundDrawable;
 		ColorStateList _originalTabTextColors;
 		ColorStateList _orignalTabIconColors;
@@ -114,9 +114,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		}
 
         void BottomNavigationView.IOnNavigationItemReselectedListener.OnNavigationItemReselected(IMenuItem item)
-        {
-            if (Element == null)
-                return;
+		{
+			if (Element == null)
+				return;
 
 			OnNavigationItemReselected(item);
         }
@@ -160,7 +160,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (_bottomNavigationView != null)
 				{
 					_bottomNavigationView.SetOnNavigationItemSelectedListener(null);
-                    _bottomNavigationView.SetOnNavigationItemReselectedListener(null);
+					_bottomNavigationView.SetOnNavigationItemReselectedListener(null);
                     _bottomNavigationView.Dispose();
 					_bottomNavigationView = null;
 				}
@@ -216,8 +216,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 						{
 							_relativeLayout.RemoveView(_bottomNavigationView);
 							_bottomNavigationView.SetOnNavigationItemSelectedListener(null);
-                            _bottomNavigationView.SetOnNavigationItemReselectedListener(null);
-                        }
+							_bottomNavigationView.SetOnNavigationItemReselectedListener(null);
+						}
 
 						var bottomNavigationViewLayoutParams = new AWidget.RelativeLayout.LayoutParams(
 							LayoutParams.MatchParent,


### PR DESCRIPTION
Implementation of BottomNavigationView.IOnNavigationItemReselectedListener for Bottom Tabbed Bar

### Description of Change ###

Ability for developers using bottom tabs to know, on Android, that a tab previously selected has been tapped again.
There are no automated tests currently (not sure it's really needed for that case).

### Issues Resolved ###

- fixes #3552

### API Changes ###

Added:
 - protected virtual void OnNavigationItemReselected(IMenuItem item)

Changed:
 - public class TabbedPageRenderer : VisualElementRenderer<TabbedPage>, TabLayout.IOnTabSelectedListener, ViewPager.IOnPageChangeListener, IManageFragments, BottomNavigationView.IOnNavigationItemSelectedListener => public class TabbedPageRenderer : VisualElementRenderer<TabbedPage>, TabLayout.IOnTabSelectedListener, ViewPager.IOnPageChangeListener, IManageFragments, BottomNavigationView.IOnNavigationItemSelectedListener, BottomNavigationView.IOnNavigationItemReselectedListener

### Platforms Affected ###
- Android

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
