### PR TITLE
[Android] Support multiple clipping settings in single layout

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MultipleClipToBounds.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MultipleClipToBounds.cs
@@ -1,0 +1,101 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 8088, "Mixing IsClippedToBounds settings in a single layout", PlatformAffected.Android)]
+	public class MultipleClipToBounds : TestContentPage
+	{
+		Label _label1;
+		Label _label2;
+		ContentView _layout1;
+		ContentView _layout2;
+
+		Button _button1;
+		Button _button2;
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Text = "Toggle the IsClippedToBounds settings below. Toggling the settings "
+						+ "for the first layout should not affect the second layout " 
+						+ "(and vice versa). If toggling the settings for one layout affects" 
+						+ " the other layout, this test has failed."
+			};
+
+			var box1 = new BoxView { BackgroundColor = Color.Coral, TranslationX = -10, TranslationY = -10 };
+			var box2 = new BoxView { BackgroundColor = Color.LightGreen, TranslationX = -10, TranslationY = -10 };
+
+			_layout1 = new ContentView
+			{
+				BackgroundColor = Color.RosyBrown,
+				Margin = new Thickness(50),
+				Content = box1
+			};
+
+			_label1 = new Label();
+
+			_layout2 = new ContentView
+			{
+				BackgroundColor = Color.RosyBrown,
+				Margin = new Thickness(50),
+				Content = box2
+			};
+
+			_label2 = new Label();
+
+			_button1 = new Button();
+
+			_button2 = new Button();
+
+			_button1.Clicked += (sender, args) =>
+			{
+				_layout1.IsClippedToBounds = !_layout1.IsClippedToBounds;
+				UpdateLabels();
+			};
+
+			_button2.Clicked += (sender, args) =>
+			{
+				_layout2.IsClippedToBounds = !_layout2.IsClippedToBounds;
+				UpdateLabels();
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(_button1);
+			layout.Children.Add(_button2);
+			layout.Children.Add(_layout1);
+			layout.Children.Add(_label1);
+			layout.Children.Add(_layout2);
+			layout.Children.Add(_label2);
+
+			UpdateLabels();
+
+			Content = layout;
+		}
+
+		void UpdateLabels()
+		{
+			_label1.Text =
+				$"The coral Box above {(_layout1.IsClippedToBounds ? "should" : "should not")} be clipped by the brown container.";
+
+			_label2.Text =
+				$"The green Box above {(_layout2.IsClippedToBounds ? "should" : "should not")} be clipped by the brown container.";
+
+			_button1.Text = $"Toggle L1 (currently {_layout1.IsClippedToBounds})";
+			_button2.Text = $"Toggle L2 (currently {_layout2.IsClippedToBounds})";
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -386,6 +386,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39829.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MultipleClipToBounds.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PerformanceGallery\PerformanceDataManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PerformanceGallery\PerformanceGallery.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PerformanceGallery\PerformanceScenario.cs" />


### PR DESCRIPTION
### Description of Change ###

The bounds clipping settings for Layouts on Android modify the parent's ClipChildren property; this means that if a Layout contains multiple child Layouts, the clipping setting is effectively the IsClippedToBounds property of the last layout to be processed by the VisualElementTracker; mixed IsClippedToBounds settings among siblings are impossible.

This fix uses the ClipBounds property on the actual Layout (as opposed to the parent) to handle bounds clipping, avoiding the conflict.

This fix only applies to API 18+. The necessary methods don't exist for earlier APIs, so 15-17 will still have the buggy behavior.

This change includes a manual test; can't currently think of a way to automate this test.

### Issues Resolved ###

- https://bugzilla.xamarin.com/show_bug.cgi?id=36121

### API Changes ###

None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
