### PR TITLE
add project-wide properties as ext block

### DIFF
--- a/AndroidNative/FormsViewGroup/build.gradle
+++ b/AndroidNative/FormsViewGroup/build.gradle
@@ -1,12 +1,21 @@
 apply plugin: 'com.android.library'
 
+ext {
+    buildToolsVersion = "27.0.3"
+    minSdkVersion = 21
+    compileSdkVersion = 27
+    targetSdkVersion = 27
+    supportLibVersion = "27.1.1"
+}
+
+
 android {
-    compileSdkVersion 20
-    buildToolsVersion "25.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 15
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
     }
 
     buildTypes {


### PR DESCRIPTION
### Description of Change ###

ref: https://developer.android.com/studio/build/
add better way to get the Gradle based values.
Aslo upgrade to SDK 27

### Issues Resolved ###

additionally, changed the SDK values to 27 as per new changes coming.

Android Target API Level 26 will be required in August 2018.
https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html


