### PR TITLE
[UWP] Fixed double set margins in Layouts

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41418.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41418.cs
@@ -1,4 +1,6 @@
-﻿using Xamarin.Forms.CustomAttributes;
+﻿using System;
+using System.Threading;
+using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
 #if UITEST
@@ -14,17 +16,54 @@ namespace Xamarin.Forms.Controls
 	{
 		protected override void Init()
 		{
-			Content = new ScrollView()
+			var box = new BoxView
 			{
-				BackgroundColor = Color.Yellow,
-				Content = new BoxView
-				{
-					Margin = 100,
-					WidthRequest = 500,
-					HeightRequest = 800,
-					BackgroundColor = Color.Red
+				Margin = 100,
+				WidthRequest = 500,
+				HeightRequest = 800,
+				BackgroundColor = Color.Red
+			};
+			var description = "The red rectangle with margins is nested in the yellow rectangle. " +
+				$"This margins should be visible as yellow Indents and will change in separate thread until the test is closed.{Environment.NewLine}" +
+				"Margins = ";
+			var desc = new Label
+			{
+				BackgroundColor = Color.Azure,
+				Text = $"{description}{box.Margin.Top}"
+			};
+			Content = new StackLayout
+			{
+				Children = {
+					desc,
+					new ScrollView
+					{
+						BackgroundColor = Color.Yellow,
+						Content = box
+					}
 				}
 			};
+
+			var disappeared = false;
+
+			// change margin of box after the first rendering
+			new Thread(() => {
+				while (true)
+				{
+					for (int margin = 20; margin < 160; margin += 20)
+					{
+						Thread.Sleep(1000);
+						if (disappeared)
+							return;
+						Device.BeginInvokeOnMainThread(() =>
+						{
+							box.Margin = margin;
+							desc.Text = $"{description}{margin}";
+						});
+					}
+				};
+			}).Start();
+
+			Disappearing += (_, __) => disappeared = true;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3398.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3398.cs
@@ -1,0 +1,39 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3398, "Labels not always rendering in a StackLayout", PlatformAffected.UWP)]
+	public class Issue3398 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Margin = new Thickness(20),
+				Children = {
+					new Label {
+						Margin = new Thickness(0, 10),
+						FontSize = 20,
+						Text = "Should be seen 2 labels. Above and below the page." ,
+						BackgroundColor = Color.OrangeRed
+					},
+					new BoxView
+					{
+						BackgroundColor = Color.Teal,
+						WidthRequest = 300,
+						HeightRequest = 300,
+						HorizontalOptions = LayoutOptions.Center,
+						VerticalOptions = LayoutOptions.CenterAndExpand
+					},
+					new Label {
+						Text = "Label 2",
+						BackgroundColor = Color.Aqua,
+						FontSize = 20
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -365,7 +365,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3019.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2993.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3507.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue3367.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3398.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -365,6 +365,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3019.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2993.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3507.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3367.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3398.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />

--- a/Xamarin.Forms.Platform.UAP/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ViewRenderer.cs
@@ -18,7 +18,6 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateBackgroundColor();
 				UpdateFlowDirection();
-				UpdateMargins();
 			}
 		}
 
@@ -130,11 +129,6 @@ namespace Xamarin.Forms.Platform.UWP
 		void UpdateFlowDirection()
 		{
 			Control.UpdateFlowDirection(Element);
-		}
-
-		void UpdateMargins()
-		{
-			Margin = new Windows.UI.Xaml.Thickness(Element.Margin.Left, Element.Margin.Top, Element.Margin.Right, Element.Margin.Bottom);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

In PR https://github.com/xamarin/Xamarin.Forms/pull/2515 there was a mistake due to which all `Margin` properties inside `StackLayout` / `AbsoluteLayout` were applied twice.

### Issues Resolved ###

- fixes #3398 
- fixes #3616

### API Changes ###

<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem -->

### Platforms Affected ###

- UWP

### Behavioral/Visual Changes ###

Labels and other elements with `Margin` property are correctly displayed inside in layouts.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
