### PR TITLE
[C] VisibilityConverter Trims input

### DIFF
--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -920,13 +920,14 @@ namespace Xamarin.Forms
 		{
 			public override object ConvertFromInvariantString(string value)
 			{
-				if (value != null)
+				value = value?.Trim();
+				if (!string.IsNullOrEmpty(value))
 				{
-					if (value.Equals("true", StringComparison.OrdinalIgnoreCase))
+					if (value.Equals(Boolean.TrueString, StringComparison.OrdinalIgnoreCase))
 						return true;
 					if (value.Equals("visible", StringComparison.OrdinalIgnoreCase))
 						return true;
-					if (value.Equals("false", StringComparison.OrdinalIgnoreCase))
+					if (value.Equals(Boolean.FalseString, StringComparison.OrdinalIgnoreCase))
 						return false;
 					if (value.Equals("hidden", StringComparison.OrdinalIgnoreCase))
 						return false;


### PR DESCRIPTION
### Description of Change ###

For CSS purposes, the VisibilityConverter was added, and actually
replaced the `Boolean.Parse(str)` call for parsing Visibility.
`Boolean.Parse()` trims input, and the converter was not, so this was a
regression.
This changes Trim() the input, to be fully backward compatible.

### Issues Resolved ###

- fixes #3554

### API Changes ###

/

### Platforms Affected ###

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

/

### PR Checklist ###

- [ ] Has automated tests: none. I was lazy
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
