### PR TITLE
Ensure ConstructorCountId and TimeId elements are available before querying them

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56896.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56896.cs
@@ -214,6 +214,8 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Bugzilla56896Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Instructions));
+			RunningApp.WaitForElement(q => q.Marked(ConstructorCountId));
+			RunningApp.WaitForElement(q => q.Marked(TimeId));
 			var count = int.Parse(RunningApp.Query(q => q.Marked(ConstructorCountId))[0].Text);
 			Assert.IsTrue(count < 100); // Failing test makes ~15000 constructor calls
 			var time = int.Parse(RunningApp.Query(q => q.Marked(TimeId))[0].Text);


### PR DESCRIPTION
### Description of Change ###

The test for Bugzilla56896 is failing intermittently with a `System.IndexOutOfRangeException`; this _might_ be an issue where the UITest query for ConstructorCountId and TimeId is occurring before the elements are actually available to be found by UITest. This change adds a WaitForElement for each of those elements to ensure that they are available before running the queries.

