### PR TITLE
Issue #3589 - revised View.EndEditing logic for TableView

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewModelRenderer.cs
@@ -84,6 +84,8 @@ namespace Xamarin.Forms.Platform.iOS
 			View.Model.RowSelected(indexPath.Section, indexPath.Row);
 			if (AutomaticallyDeselect)
 				tableView.DeselectRow(indexPath, true);
+
+			tableView.EndEditing(true);
 		}
 
 		public override nint RowsInSection(UITableView tableview, nint section)
@@ -121,6 +123,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void Tap(UITapGestureRecognizer gesture)
 		{
+			// if the gesture point is in the view and maps to a table index, do not end editing
+			// this forces the keyboard to close, adjusting the screen and changing the index on RowSelected
+			// the keyboard should close after RowSelected is complete
+
+			var point = gesture.LocationInView(Table);
+			var indexPath = Table.IndexPathForRowAtPoint(point);
+			if (indexPath != null)
+				return;
+
 			gesture.View.EndEditing(true);
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

If tap occurs within view on a row, will not EndEditing
At the completion of RowSelected is when EndEditing will be called

No unit tests available to reproduce UI issue cause by keyboard opening/closing

### Issues Resolved ###

- fixes #3589 

### API Changes ###

None

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###

Proper ordering of keyboard closed and TableView.RowSelected events to ensure proper Row Index is selected.

### PR Checklist ###

- [ ] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
