### PR TITLE
[UWP] update test nugets and establish baseline for current passing UWP tests

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/MainPage.xaml.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/MainPage.xaml.cs
@@ -30,7 +30,14 @@ namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 		{
 			InitializeComponent();
 
-			
+			// some tests need to window to be large enough to click on things
+			// can we make this only open to window size for UI Tests?
+			//var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
+			//var scaleFactor = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+			//var size = new Windows.Foundation.Size(bounds.Width * scaleFactor, bounds.Height * scaleFactor);
+			//ApplicationView.PreferredLaunchViewSize = size;
+			//ApplicationView.PreferredLaunchWindowingMode = ApplicationViewWindowingMode.PreferredLaunchViewSize;
+
 
 			_app = new Controls.App();
 
@@ -43,6 +50,7 @@ namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 			LoadApplication(_app);
 
 			CoreWindow.GetForCurrentThread().KeyDown += OnKeyDown;
+
 		}
 
 		void OnKeyDown(CoreWindow coreWindow, KeyEventArgs args)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/BottomTabbedPageTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/BottomTabbedPageTests.cs
@@ -10,12 +10,14 @@ using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using System.Collections.Specialized;
 
 #if UITEST
+using Xamarin.Forms.Core.UITests;
 using NUnit.Framework;
 using Xamarin.UITest;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1675, "Bottom Tabbed Page Basic Test", PlatformAffected.All)]
 	public class BottomTabbedPageTests : TestTabbedPage
@@ -246,7 +248,7 @@ namespace Xamarin.Forms.Controls.Issues
 			pageCountLabel.Text = $"{Children.Count} Pages";
 		}
 
-#if UITEST
+#if UITEST && __ANDROID__
 		[Test]
 		public async Task AddAndRemovePages()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26171.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26171.cs
@@ -7,10 +7,15 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 26171, "Xamarin.Forms.Maps is not updating VisibleRegion property when layout is changed")]
 	public class Bugzilla26171 : TestContentPage // or TestMasterDetailPage, etc ...

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26501.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26501.cs
@@ -5,6 +5,7 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using NUnit.Framework;
 using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
@@ -78,6 +79,10 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 	}
 
+#if UITEST
+	[Category(UITestCategories.InputTransparent)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Bugzilla, 26501, "BindingSource / Context action issue", PlatformAffected.iOS)]
 	public class Bugzilla26501 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
@@ -10,6 +10,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 26993, "https://bugzilla.xamarin.com/show_bug.cgi?id=26993")]
 	public class Bugzilla26993 : TestContentPage // or TestMasterDetailPage, etc ...

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29247.cs
@@ -5,12 +5,18 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params", PlatformAffected.iOS, issueTestNumber: 1)]
+#if UITEST
+	// this doesn't fail on Uwp but it leaves a browser window open and breaks later tests
+	[Category(UITestCategories.UwpIgnore)]
+#endif
 	public class Bugzilla29247 : TestContentPage
 	{
 		protected override void Init()
@@ -45,8 +51,14 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 #endif
 	}
+
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params 2", PlatformAffected.iOS, issueTestNumber: 2)]
+#if UITEST
+	// This one isn't failing on UWP but it opens a browser window
+	// and causes the rest to fail
+	[Category(UITestCategories.UwpIgnore)]
+#endif
 	public class Bugzilla29247_2 : TestContentPage
 	{
 		protected override void Init()
@@ -82,6 +94,12 @@ namespace Xamarin.Forms.Controls.Issues
 
 #endif
 	}
+
+#if UITEST
+	// This one isn't failing on UWP but it opens a browser window
+	// and causes the rest to fail
+	[Category(UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 29247, "iOS Device.OpenUri breaks with encoded params 3", PlatformAffected.iOS, issueTestNumber: 3)]
 	public class Bugzilla29247_3 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
@@ -6,12 +6,16 @@ using Xamarin.Forms.Internals;
 using Xamarin.UITest.iOS;
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 30353, "MasterDetailPage.IsPresentedChanged is not raised")]
+#if UITEST
+	[Category(UITestCategories.UwpIgnore)]
+#endif
 	public class Bugzilla30353 : TestMasterDetailPage
 	{
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32040.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32040.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.Cells)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 
 	[Preserve (AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35472.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35472.cs
@@ -12,6 +12,9 @@ using Xamarin.UITest;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 35472, "PopAsync during ScrollToAsync throws NullReferenceException")]
 	public class Bugzilla35472 : TestNavigationPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35733.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35733.cs
@@ -6,6 +6,7 @@ using Xamarin.Forms.Internals;
 
 #if UITEST
 using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
 using NUnit.Framework;
 #endif
 
@@ -13,6 +14,10 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 35733, "iOS WebView crashes when loading an URL with encoded parameters", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.WebView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	public class Bugzilla35733 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
 		protected override void Init ()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39489.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 #if UITEST
 	[Category(UITestCategories.Maps)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 	[Issue(IssueTracker.Bugzilla, 39489, "Memory leak when using NavigationPage with Maps", PlatformAffected.Android | PlatformAffected.iOS)]
 	public class Bugzilla39489 : TestNavigationPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39530.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39530.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.Gestures)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 
 	[Preserve (AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39821.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39821.cs
@@ -12,6 +12,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 39821, "ViewExtension.TranslateTo cannot be invoked on Main thread")]
 	public class Bugzilla39821 : TestContentPage 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39963.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39963.cs
@@ -10,6 +10,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 39963, "iOS WebView has wrong scrolling size when loading local html content with images")]
 	public class Bugzilla39963 : TestContentPage 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40173.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40173.cs
@@ -13,8 +13,8 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[Category(UITestCategories.BoxView)]
 	[Category(UITestCategories.InputTransparent)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
-
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 40173, "Android BoxView/Frame not clickthrough in ListView")]
 	public class Bugzilla40173 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41153.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41153.cs
@@ -11,6 +11,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 41153, "jobject must not be IntPtr.Zero with TabbedPage and ToolbarItems")]
 	public class Bugzilla41153 : TestTabbedPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44176.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44176.cs
@@ -11,8 +11,8 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.InputTransparent)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
-
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 44176, "InputTransparent fails if BackgroundColor not explicitly set on Android", PlatformAffected.Android)]
 	public class Bugzilla44176 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44886.cs
@@ -11,6 +11,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 44886, "UWP Listview ItemSelected event triggered twice for each selection", PlatformAffected.UWP)]
 	public class Bugzilla44886 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45125.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45125.cs
@@ -11,6 +11,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 45125, "ListView lacks a way to get information about visible elements (such as FirstVisibleItem) to restore visual positions of elements", PlatformAffected.iOS)]
 	public class Bugzilla45125 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45722.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45722.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45722Xaml0.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45722Xaml0.xaml.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56896.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56896.cs
@@ -13,6 +13,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 56896, "ListViews for lists with many elements regressed in performance on iOS", PlatformAffected.iOS)]
 	public class Bugzilla56896 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57114.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57114.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.Gestures)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57515.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57515.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 	[Category(UITestCategories.Gestures)]
 #endif 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59863_0.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59863_0.cs
@@ -11,8 +11,8 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.Gestures)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
-
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 59863, "TapGestureRecognizer extremely finicky", PlatformAffected.Android)]
 	public class Bugzilla59863_0 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59863_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59863_1.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.Gestures)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59863_2.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59863_2.cs
@@ -10,6 +10,7 @@ using Xamarin.Forms.Core.UITests;
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 	[Category(UITestCategories.Gestures)]
 #endif
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60691.cs
@@ -5,12 +5,17 @@ using System.Threading.Tasks;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 60691, "Device.OpenUri(new Uri(\"tel: 123 456\")) crashes the app (space in phone number)", PlatformAffected.iOS)]
+#if UITEST
+	// this doesn't fail on Uwp but it leaves a browser window open and breaks later tests
+	[Category(UITestCategories.UwpIgnore)]
+#endif
 	public class Bugzilla60691 : TestContentPage
 	{
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CarouselAsync.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CarouselAsync.cs
@@ -12,6 +12,9 @@ using Xamarin.UITest;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.None, 0, "Carousel Async Add Page Issue", PlatformAffected.All, NavigationBehavior.PushModalAsync)]
 	public class CarouselAsync : TestCarouselPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
@@ -159,6 +159,10 @@ namespace Xamarin.Forms.Controls.Issues
 					from Layout element in layout.InternalChildren
 					from Button button in element.InternalChildren
 					let text = button.Text
+					// UwpIgnore
+#if __WINDOWS__
+					where text != "Stepper" && text != "Entry"
+#endif
 					select new object[]
 					{
 						text,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.InputTransparent)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/IsInvokeRequiredRaceCondition.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/IsInvokeRequiredRaceCondition.cs
@@ -11,6 +11,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 0, "Device.IsInvokeRequired race condition causes crash")]
 	public class IsInvokeRequiredRaceCondition : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1342.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1342.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Controls.Issues
 		PlatformAffected.iOS)]
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 	public class Issue1342 : TestNavigationPage
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1355.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1355.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.Navigation)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1355, "Setting Main Page in quick succession causes crash on Android",

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1414.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1414.cs
@@ -12,6 +12,9 @@ using Xamarin.Forms.Core.UITests;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1414, "InvalidCastException when scrolling and refreshing TableView", PlatformAffected.iOS)]
 	public class Issue1414 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1733.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1733.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.Editor)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1733, "Autoresizable Editor")]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1799.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1799.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1799, "[iOS] listView without data crash on ipad.", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1900.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1900.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ListView)] 
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1900, "Xamarin ios ListView ObservableCollection<myClass>. Collection.Add() throwing 'Index # is greater than the number of rows #' exception", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1905.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1905.cs
@@ -11,12 +11,16 @@ using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 #if UITEST
 using NUnit.Framework;
 using Xamarin.UITest;
-
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 
+#if UITEST
+	[Category(UITestCategories.DisplayAlert)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1905, "AlertView doesn't scroll when text is to large", PlatformAffected.iOS | PlatformAffected.Android)]
 	public class Issue1905 : ContentPage
@@ -44,6 +48,10 @@ namespace Xamarin.Forms.Controls.Issues
 	}
 
 
+#if UITEST
+	[Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1905, "Pull to refresh doesn't work if iOS 11 large titles is enabled", PlatformAffected.iOS, NavigationBehavior.PushModalAsync, issueTestNumber: 1)]
 	public class Issue1905LargeTitles : TestNavigationPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue198.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue198.cs
@@ -8,6 +8,9 @@ using Xamarin.UITest;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 198, "TabbedPage shouldn't proxy content of NavigationPage", PlatformAffected.iOS)]
 	public class Issue198 : TestTabbedPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue206.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue206.cs
@@ -12,6 +12,9 @@ using Xamarin.UITest;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 206, "ViewCell with Label's text does not resize when value is changed", PlatformAffected.iOS)]
 	public class Issue206 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2272.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2272.cs
@@ -12,6 +12,9 @@ using Xamarin.UITest.Android;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 2272, "Entry text updating set focus on the beginning of text not the end of it", PlatformAffected.Android)]
 	public class Issue2272 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2357.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2357.xaml.cs
@@ -10,12 +10,21 @@ using System.ComponentModel;
 using System.Text;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 #if APP
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2357, "Webview waits to load the content until webviews on previous pages are loaded", PlatformAffected.iOS | PlatformAffected.Android)]
+#if UITEST
+	// this doesn't fail on Uwp but it leaves a browser window open and breaks later tests
+	[Category(UITestCategories.UwpIgnore)]
+#endif
 	public partial class Issue2357 : MasterDetailPage
 	{
 		public Issue2357 ()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2411.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2411.cs
@@ -15,7 +15,10 @@ using Xamarin.UITest;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-    [Preserve(AllMembers = true)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
+	[Preserve(AllMembers = true)]
     [Issue(IssueTracker.Github, 2411, "ListView.ScrollTo not working in TabbedPage", PlatformAffected.Android)]
     public class Issue2411 : TestTabbedPage
     {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue264.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue264.cs
@@ -11,6 +11,9 @@ using Xamarin.UITest;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 264, "PopModal NRE", PlatformAffected.Android | PlatformAffected.iOS)]
 	public class Issue264 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2767.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2767.cs
@@ -4,10 +4,14 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST 
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 2767, "ArgumentException: NaN not valid for height", PlatformAffected.All)]
 	public class Issue2767 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2809.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2809.cs
@@ -6,10 +6,15 @@ using Xamarin.Forms.Internals;
 using NUnit.Framework;
 using Xamarin.UITest;
 using Xamarin.UITest.Android;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[Category(UITestCategories.DisplayAlert)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 2809, "Secondary ToolbarItems cause app to hang during PushAsync", PlatformAffected.iOS)]
 	public class Issue2809: TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2883.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2883.cs
@@ -13,6 +13,9 @@ using Xamarin.UITest.iOS;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2883, "ViewCell IsEnabled set to false does not disable a cell in a TableView")]
 	public class Issue2883 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
@@ -14,6 +14,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2951, "On Android, button background is not updated when color changes ")]
 	public partial class Issue2951 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2963.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2963.cs
@@ -10,6 +10,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 2963, "Disabling Editor in iOS does not disable entry of text")]
 	public class Issue2963 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3089.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3089.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 3089, "TextCell text doesn't change when using Recycling on ListViews")]
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 	public class Issue3089 : TestNavigationPage
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3292.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3292.cs
@@ -13,6 +13,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 3292, "TableSection.Title property binding fails in XAML")]
 	public class Issue3292 : TestContentPage 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue416.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue416.cs
@@ -7,10 +7,15 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using NUnit.Framework;
 using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+	[NUnit.Framework.Category(UITestCategories.Navigation)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 416, "NavigationPage in PushModal does not show NavigationBar", PlatformAffected.Android, NavigationBehavior.PushModalAsync)]
 	public class Issue416 : TestNavigationPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue417.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue417.cs
@@ -9,10 +9,15 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using NUnit.Framework;
 using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+	[NUnit.Framework.Category(UITestCategories.Navigation)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Github, 417, "Navigation.PopToRootAsync does nothing", PlatformAffected.Android)]
 	public class Issue417 : TestNavigationPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue55555.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue55555.cs
@@ -10,6 +10,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 55555, "Header problem")]
 	public class Issue55555 : TestContentPage // or TestMasterDetailPage, etc ...

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue935.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue935.cs
@@ -9,6 +9,7 @@ using Xamarin.UITest;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+	[Preserve(AllMembers = true)]
 	public class Person 
 	{
 		public string Name { get; set; }
@@ -20,6 +21,7 @@ namespace Xamarin.Forms.Controls.Issues
 	}
 
 
+	[Preserve(AllMembers = true)]
 	public class CustomViewCell : ViewCell 
 	{
 
@@ -41,7 +43,9 @@ namespace Xamarin.Forms.Controls.Issues
 			View = label;
 		}
 	}
-
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 935, "ViewCell.ItemTapped only fires once for ListView.SelectedItem", PlatformAffected.Android)]
 	public class Issue935 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MapsModalCrash.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/MapsModalCrash.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[Category(UITestCategories.Maps)]
 	[Category(UITestCategories.ManualReview)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
@@ -16,9 +16,9 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
-	[Category(Xamarin.Forms.Core.UITests.UITestCategories.Performance)]
+	[Category(Xamarin.Forms.Core.UITests.UITestCategories.Performance)] 
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
-
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 0, "Performance Testing")]
 	public class PerformanceGallery : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollViewIsEnabled.cs
@@ -11,8 +11,8 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.IsEnabled)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
-
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 0112358, "ScrollView set to disabled will still allow scrolling", PlatformAffected.All)]
 	public class ScrollViewIsEnabled : TestNavigationPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/SwipeBackNavCrash.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/SwipeBackNavCrash.cs
@@ -17,6 +17,10 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.None, 0, "Swipe back nav crash", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Navigation)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	public class SwipeBackNavCrash : TestNavigationPage
 	{
 		protected override void Init ()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TabbedPageTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TabbedPageTests.cs
@@ -9,10 +9,14 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using NUnit.Framework;
 using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.None, 0,"TabbedPage nav tests", PlatformAffected.All)]
 	public class TabbedPageTests : TestTabbedPage

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/AutomationIDUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/AutomationIDUITests.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.Core.UITests
 {
 	[TestFixture]
 	[Category(UITestCategories.AutomationId)]
+	[Category(UITestCategories.UwpIgnore)]
 	internal class AutomationIDUITests : BaseTestFixture
 	{
 		protected override void NavigateToGallery ()

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ButtonUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ButtonUITests.cs
@@ -80,6 +80,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[UiTest(typeof(Button), "Clicked")]
+		[Category(UITestCategories.UwpIgnore)]
 		public void Clicked()
 		{
 			var remote = new EventViewContainerRemote(App, Test.Button.Clicked, PlatformViewType);
@@ -110,6 +111,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[UiTest(typeof(Button), "Font")]
+		[Category(UITestCategories.UwpIgnore)]
 		public void Font()
 		{
 			//TODO iOS
@@ -139,6 +141,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[UiTest(typeof(Button), "Text")]
+		[Category(UITestCategories.UwpIgnore)]
 		public void Text()
 		{
 			var remote = new ViewContainerRemote(App, Test.Button.Text, PlatformViewType);

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Forms.Core.UITests
 		// Implement control specific ui tests
 		[Test]
 		[UiTest(typeof(Entry), "Completed")]
+		[Category(UITestCategories.UwpIgnore)]
 		public void Completed()
 		{
 			var remote = new EventViewContainerRemote(App, Test.Entry.Completed, PlatformViewType);

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-CellsUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-CellsUITests.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Core.UITests
 #endif
 	[TestFixture]
 	[Category(UITestCategories.Cells)]
+	[Category(UITestCategories.UwpIgnore)]
 	internal class CellsGalleryTests : BaseTestFixture
 	{
 		public const string CellTestContainerId = "CellTestContainer";

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/StepperUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/StepperUITests.cs
@@ -37,6 +37,19 @@ namespace Xamarin.Forms.Core.UITests
 		{
 		}
 
+		[Category(UITestCategories.UwpIgnore)]
+		public override void _IsEnabled()
+		{
+			base._IsEnabled();
+		} 
+
+		 
+		[Category(UITestCategories.UwpIgnore)] 
+		public override void _IsVisible()
+		{
+			base._IsVisible();
+		}
+
 		// TODO
 		// Implement control specific ui tests
 		protected override void FixtureTeardown()

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Forms.Core.UITests
 {
 	[TestFixture]
 	[Category(UITestCategories.ToolbarItem)]
+	[Category(UITestCategories.UwpIgnore)]
 	internal class ToolbarItemTests : BaseTestFixture
 	{
 		string btn1Id = "tb1";

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ViewUITests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Net.Configuration;
 
 using NUnit.Framework;
-
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.UITest.Android;
 using Xamarin.UITest.iOS;
@@ -98,12 +98,12 @@ namespace Xamarin.Forms.Core.UITests
 
 			remote.TapStateButton ();
 
-			var isEnabled = remote.GetStateLabel ().Text;
+			var isEnabled = remote.GetStateLabel ().ReadText();
 			Assert.AreEqual ("True", isEnabled);
 
 			remote.TapStateButton ();
 
-			var isDisabled = remote.GetStateLabel ().Text;
+			var isDisabled = remote.GetStateLabel ().ReadText();
 			Assert.AreEqual ("False", isDisabled);
 		}
 

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -18,6 +18,7 @@
 		public const string Image = "Image";
 		public const string Label = "Label";
 		public const string ListView = "ListView";
+		public const string UwpIgnore = "UwpIgnore";
 		public const string LifeCycle = "Lifecycle";
 		public const string MasterDetailPage = "MasterDetailPage";
 		public const string Picker = "Picker";

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -30,7 +30,8 @@ namespace Xamarin.Forms.Core.UITests
 
 		readonly Dictionary<string, string> _translatePropertyAccessor = new Dictionary<string, string>
 		{
-			{ "getAlpha", "Opacity" }
+			{ "getAlpha", "Opacity" },
+			{ "isEnabled", "IsEnabled" }
 		};
 
 		int _scrollBarOffset = 5;
@@ -240,7 +241,12 @@ namespace Xamarin.Forms.Core.UITests
 			// Now that we have them in text form, we can reinterpret them for Windows
 			WinQuery winQuery = WinQuery.FromRaw(selector);
 			// TODO hartez 2017/07/19 17:08:44 Make this a bit more resilient if the translation isn't there	
-			string attribute = _translatePropertyAccessor[invoke.Substring(8).Replace("\")", "")];
+			var translationKey = invoke.Substring(8).Replace("\")", "");
+
+			if (!_translatePropertyAccessor.ContainsKey(translationKey))
+				throw new Exception($"{translationKey} not found please add to _translatePropertyAccessor");
+
+			string attribute = _translatePropertyAccessor[translationKey];
 
 			ReadOnlyCollection<WindowsElement> elements = QueryWindows(winQuery);
 
@@ -270,7 +276,7 @@ namespace Xamarin.Forms.Core.UITests
 			string filename = $"{title}.png";
 
 			Screenshot screenshot = _session.GetScreenshot();
-			screenshot.SaveAsFile(filename, ImageFormat.Png);
+			screenshot.SaveAsFile(filename, ScreenshotImageFormat.Png);
 			return new FileInfo(filename);
 		}
 

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Remote;
 using Xamarin.UITest;
 using Xamarin.UITest.Queries;
@@ -110,17 +111,21 @@ namespace Xamarin.Forms.Core.UITests
 
 		public void EnterText(string text)
 		{
-			_session.Keyboard.SendKeys(text);
+			new Actions(_session)
+					.SendKeys(text)
+					.Perform();
 		}
 
 		public void EnterText(Func<AppQuery, AppQuery> query, string text)
 		{
-			QueryWindows(query).First().SendKeys(text);
+			var result = QueryWindows(query).First();
+			result.SendKeys(text);
 		}
 
 		public void EnterText(string marked, string text)
 		{
-			QueryWindows(marked).First().SendKeys(text);
+			var results = QueryWindows(marked).First();
+			results.SendKeys(text);
 		}
 
 		public void EnterText(Func<AppQuery, AppWebQuery> query, string text)
@@ -189,7 +194,9 @@ namespace Xamarin.Forms.Core.UITests
 
 		public void PressEnter()
 		{
-			_session.Keyboard.PressKey(Keys.Enter);
+			new Actions(_session)
+					   .SendKeys(Keys.Enter)
+					   .Perform();
 		}
 
 		public void PressVolumeDown()
@@ -594,21 +601,25 @@ namespace Xamarin.Forms.Core.UITests
 			WindowsElement viewPort = GetViewPort();
 			int xOffset = viewPort.Coordinates.LocationInViewport.X;
 			int yOffset = viewPort.Coordinates.LocationInViewport.Y;
-			_session.Mouse.MouseMove(viewPort.Coordinates, (int)x - xOffset, (int)y - yOffset);
+
+			var actions = new Actions(_session)
+					   .MoveToElement(viewPort, (int)x - xOffset, (int)y - yOffset);
 
 			switch (clickType)
 			{
 				case ClickType.DoubleClick:
-					_session.Mouse.DoubleClick(null);
+					actions.DoubleClick();
 					break;
 				case ClickType.ContextClick:
-					_session.Mouse.ContextClick(null);
+					actions.ContextClick();					
 					break;
 				case ClickType.SingleClick:
 				default:
-					_session.Mouse.Click(null);
+					actions.Click();					
 					break;
 			}
+
+			actions.Perform();
 		}
 
 		void ClickOrTapElement(WindowsElement element)
@@ -784,7 +795,7 @@ namespace Xamarin.Forms.Core.UITests
 			WindowsElement viewPort = GetViewPort();
 			int xOffset = viewPort.Coordinates.LocationInViewport.X;
 			int yOffset = viewPort.Coordinates.LocationInViewport.Y;
-			_session.Mouse.MouseMove(viewPort.Coordinates, xOffset, yOffset);
+			new Actions(_session).MoveToElement(viewPort, xOffset, yOffset);
 		}
 
 		ReadOnlyCollection<WindowsElement> QueryWindows(WinQuery query)

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
@@ -24,9 +24,10 @@ namespace Xamarin.Forms.Core.UITests
 			{
 				DesiredCapabilities appCapabilities = new DesiredCapabilities();
 				appCapabilities.SetCapability("app", "0d4424f6-1e29-4476-ac00-ba22c3789cb6_ph1m9x8skttmg!App");
+				appCapabilities.SetCapability("deviceName", "DESKTOP-PTAUA2P");
 				Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
 				Assert.IsNotNull(Session);
-				Session.Manage().Timeouts().ImplicitlyWait(TimeSpan.FromSeconds(1));
+				Session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1);
 				Reset();
 			}
 

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
@@ -10,6 +10,11 @@ using OpenQA.Selenium.Interactions.Internal;
 using OpenQA.Selenium.Remote;
 using Xamarin.Forms.Xaml;
 using Xamarin.UITest;
+using OpenQA.Selenium.Appium;
+using System.Collections.Generic;
+using OpenQA.Selenium.Interactions;
+using OpenQA.Selenium.Appium.Windows.Enums;
+using System.Windows.Input;
 
 namespace Xamarin.Forms.Core.UITests
 {
@@ -22,10 +27,9 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			if (Session == null)
 			{
-				DesiredCapabilities appCapabilities = new DesiredCapabilities();
-				appCapabilities.SetCapability("app", "0d4424f6-1e29-4476-ac00-ba22c3789cb6_ph1m9x8skttmg!App");
-				appCapabilities.SetCapability("deviceName", "DESKTOP-PTAUA2P");
-				Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+				AppiumOptions options = new AppiumOptions();
+				options.AddAdditionalCapability("app", "0d4424f6-1e29-4476-ac00-ba22c3789cb6_ph1m9x8skttmg!App");
+				Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), options);
 				Assert.IsNotNull(Session);
 				Session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1);
 				Reset();
@@ -46,7 +50,9 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			try
 			{
-				Session?.Keyboard?.PressKey(Keys.Escape);
+				new Actions(Session)
+					.SendKeys(Keys.Escape)
+					.Perform();
 			}
 			catch (Exception ex)
 			{

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -35,16 +35,14 @@
     <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="appium-dotnet-driver, Version=3.0.0.2, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Appium.WebDriver.3.0.0.2\lib\net45\appium-dotnet-driver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="appium-dotnet-driver, Version=4.0.0.4, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Appium.WebDriver.4.0.0.4-beta\lib\net45\appium-dotnet-driver.dll</HintPath>
     </Reference>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -56,7 +54,11 @@
     <Reference Include="Plugin.DeviceInfo.Abstractions, Version=3.0.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xam.Plugin.DeviceInfo.3.0.2\lib\netstandard1.0\Plugin.DeviceInfo.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="SeleniumExtras.PageObjects, Version=3.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetSeleniumExtras.PageObjects.3.11.0\lib\net45\SeleniumExtras.PageObjects.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
@@ -65,11 +67,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebDriver, Version=3.11.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.3.11.2\lib\net45\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.14.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.14.0\lib\net45\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=3.11.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.3.11.2\lib\net45\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.14.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.14.0\lib\net45\WebDriver.Support.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.UITest, Version=2.2.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xamarin.UITest.2.2.6\lib\net45\Xamarin.UITest.dll</HintPath>

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -65,13 +65,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebDriver, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.3.0.1\lib\net40\WebDriver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver, Version=3.11.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.11.2\lib\net45\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.3.0.1\lib\net40\WebDriver.Support.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver.Support, Version=3.11.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.11.2\lib\net45\WebDriver.Support.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.UITest, Version=2.2.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xamarin.UITest.2.2.6\lib\net45\Xamarin.UITest.dll</HintPath>
@@ -86,7 +84,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/Xamarin.Forms.Core.Windows.UITests/packages.config
+++ b/Xamarin.Forms.Core.Windows.UITests/packages.config
@@ -4,8 +4,8 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net47" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Selenium.Support" version="3.0.1" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="3.0.1" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.11.2" targetFramework="net47" />
+  <package id="Selenium.WebDriver" version="3.11.2" targetFramework="net47" />
   <package id="Xam.Plugin.DeviceInfo" version="3.0.2" targetFramework="net47" />
   <package id="Xamarin.UITest" version="2.2.6" targetFramework="net47" />
 </packages>

--- a/Xamarin.Forms.Core.Windows.UITests/packages.config
+++ b/Xamarin.Forms.Core.Windows.UITests/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Appium.WebDriver" version="3.0.0.2" targetFramework="net45" />
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net47" />
+  <package id="Appium.WebDriver" version="4.0.0.4-beta" targetFramework="net47" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net47" />
+  <package id="DotNetSeleniumExtras.PageObjects" version="3.11.0" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Selenium.Support" version="3.11.2" targetFramework="net47" />
-  <package id="Selenium.WebDriver" version="3.11.2" targetFramework="net47" />
+  <package id="Selenium.Support" version="3.14.0" targetFramework="net47" />
+  <package id="Selenium.WebDriver" version="3.14.0" targetFramework="net47" />
   <package id="Xam.Plugin.DeviceInfo" version="3.0.2" targetFramework="net47" />
   <package id="Xamarin.UITest" version="2.2.6" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
### Description of Change ##
Initial work done to tag UWP tests that are currently causing UI test issues.   These failing tests don't represent actual UWP issues there are just nuances to getting them to run in an automated fashion.  

The purpose of this PR is to add a category to these so that we can more easily track issues that do break because of regressions.



### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
