### PR TITLE
[GTK] Add a new forms view to wrap existing GTK+ widgets

### DIFF
--- a/Xamarin.Forms.Platform.GTK/GtkWidgetWrapper.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkWidgetWrapper.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Gtk;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Platform.GTK
+{
+	/// <summary>
+	/// Convenience helper to wrap an existing Gtk+ <see cref="Widget"/> in a forms <see cref="View"/>.
+	/// It can be used to reuse existing Gtk+ <see cref="Widget"/> and ease porting of Gtk+ applications.
+	/// </summary>
+	public class GtkWidgetWrapper : View
+	{
+		Widget nativeWidget;
+
+		public static readonly BindableProperty WidgetTypeProperty = BindableProperty.Create(
+			propertyName: "WidgetType", returnType: typeof(Type), declaringType: typeof(GtkWidgetWrapper), defaultValue: null,
+			defaultBindingMode: BindingMode.OneWay);
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Xamarin.Forms.Platform.GTK.GtkWidgetWrapper"/> class.
+		/// </summary>
+		public GtkWidgetWrapper()
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Xamarin.Forms.Platform.GTK.GtkWidgetWrapper"/> class
+		/// with an instance of the <see cref="Widget"/> to wrap.
+		/// </summary>
+		/// <param name="widget">Widget.</param>
+		public GtkWidgetWrapper(Widget widget)
+		{
+			Widget = widget;
+		}
+
+		/// <summary>
+		/// Gets the <see cref="Widget"/> wrapped.
+		/// </summary>
+		/// <value>The native widget.</value>
+		public Widget Widget
+		{
+			get
+			{
+				return nativeWidget;
+			}
+			internal set
+			{
+				nativeWidget = value;
+				OnPropertyChanged(nameof(Widget));
+			}
+		}
+
+		/// <summary>
+		/// Gets the type of the <see cref="Widget"/>.
+		/// </summary>
+		/// <value>The type of the widget.</value>
+		public Type WidgetType
+		{
+			set
+			{
+				if (!typeof(Widget).IsAssignableFrom(value))
+				{
+					throw new InvalidCastException($"The input type {value} must inherit from {typeof(Widget)}");
+				}
+				SetValue(WidgetTypeProperty, value);
+			}
+			get
+			{
+				return (Type)GetValue(WidgetTypeProperty);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Renderers/GtkWidgetWrapperRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/GtkWidgetWrapperRenderer.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Gtk;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.GTK;
+using Xamarin.Forms.Platform.GTK.Renderers;
+
+[assembly: ExportRenderer(typeof(GtkWidgetWrapper), typeof(GtkWidgetWrapperRenderer))]
+namespace Xamarin.Forms.Platform.GTK.Renderers
+{
+	public class GtkWidgetWrapperRenderer : ViewRenderer<GtkWidgetWrapper, Widget>
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<GtkWidgetWrapper> e)
+		{
+			if (e.NewElement != null)
+			{
+				if (Control == null)
+				{
+					if (e.NewElement.Widget == null)
+					{
+						if (e.NewElement.WidgetType != null)
+						{
+							var widget = (Widget)Activator.CreateInstance(e.NewElement.WidgetType);
+							e.NewElement.Widget = widget;
+						}
+						else
+						{
+							throw new InvalidOperationException("No widget instance or widget type was defined to create the Control");
+						}
+					}
+					SetNativeControl(e.NewElement.Widget);
+				}
+			}
+			base.OnElementChanged(e);
+		}
+
+		protected override void SetNativeControl(Widget view)
+		{
+			if (view.Parent != null)
+			{
+				view.Unparent();
+			}
+			base.SetNativeControl(view);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
+++ b/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
@@ -211,6 +211,8 @@
     <Compile Include="ViewRenderer.cs" />
     <Compile Include="VisualElementRenderer.cs" />
     <Compile Include="VisualElementTracker.cs" />
+    <Compile Include="Renderers\GtkWidgetWrapperRenderer.cs" />
+    <Compile Include="GtkWidgetWrapper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">


### PR DESCRIPTION

### Description of Change ###

A convenience wrapper that allows embedding an Gtk Widget into a
Forms view to ease porting of GTK+ applications and reuse
existing GTK+ widgets.

### Issues Resolved ###

### API Changes ###
 - Added GtkWidgetWrapper class.
### Platforms Affected ###

- Gtk+

### Behavioral/Visual Changes ###

### PR Checklist ###

- [] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [] Rebased on top of the target branch at time of PR
- [] Changes adhere to coding standard
