### PR TITLE
[Android] API check for Shadow properties on Button

### DIFF
--- a/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonBackgroundTracker.cs
@@ -77,10 +77,27 @@ namespace Xamarin.Forms.Platform.Android
 
 				var useDefaultShadow = _button.OnThisPlatform().UseDefaultShadow();
 
-				float shadowRadius = useDefaultShadow ? 2 : _nativeButton.ShadowRadius;
-				float shadowDx = useDefaultShadow ? 0 : _nativeButton.ShadowDx;
-				float shadowDy = useDefaultShadow ? 4 : _nativeButton.ShadowDy;
-				AColor shadowColor = useDefaultShadow ? _backgroundDrawable.PressedBackgroundColor.ToAndroid() : _nativeButton.ShadowColor;
+				// Use no shadow by default for API < 16
+				float shadowRadius = 0;
+				float shadowDy = 0;
+				float shadowDx = 0;
+				AColor shadowColor = Color.Transparent.ToAndroid();
+				// Add Android's default material shadow if we want it
+				if (useDefaultShadow)
+				{
+					shadowRadius = 2;
+					shadowDy = 0;
+					shadowDx = 4;
+					shadowColor = _backgroundDrawable.PressedBackgroundColor.ToAndroid();
+				}
+				// Otherwise get values from the control (but only for supported APIs)
+				else if ((int)Build.VERSION.SdkInt >= 16)
+				{
+					shadowRadius = _nativeButton.ShadowRadius;
+					shadowDy = _nativeButton.ShadowDy;
+					shadowDx = _nativeButton.ShadowDx;
+					shadowColor = _nativeButton.ShadowColor;
+				}
 
 				_backgroundDrawable.SetPadding(paddingTop, paddingLeft)
 								   .SetShadow(shadowDy, shadowDx, shadowColor, shadowRadius);


### PR DESCRIPTION
### Description of Change ###

#1935 added a shadow to Android Buttons. The `Shadow...` properties on `TextView` were added in API 16, so this caused crashes in API 15. This change will add an API check before calling those properties.

No new tests added, since this would affect any page with a Button, including the basic Control Gallery.

### Issues Resolved ###

- fixes #2702

### API Changes ###

None

### Platforms Affected ###

- Android


### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
