### PR TITLE
[iOS] Specify a default size for UISearchBar width if needed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3413.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3413.cs
@@ -1,0 +1,66 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3413, "[iOS] Searchbar in Horizontal Stacklayout doesn't render", PlatformAffected.iOS)]
+	public class Issue3413 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Padding = new Thickness(20);
+
+			var layout = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical
+			};
+
+			var searchBar = new SearchBar
+			{
+				BackgroundColor = Color.Yellow,
+				Text = "i m on a vertical stacklayout",
+				AutomationId = "srb_vertical"
+			};
+			layout.Children.Add(new Label { Text = "Vertical" });
+			layout.Children.Add(searchBar);
+
+			var layout1 = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var searchBar1 = new SearchBar
+			{
+				BackgroundColor = Color.Yellow,
+				Text = "i m on a horizontal stacklayout",
+				AutomationId = "srb_horizontal"
+			};
+
+			layout1.Children.Add(new Label { Text = "Horizontal" });
+			layout1.Children.Add(searchBar1);
+
+			var grid = new Grid();
+			grid.Children.Add(layout);
+			Grid.SetRow(layout, 0);
+			grid.Children.Add(layout1);
+			Grid.SetRow(layout1, 1);
+			Content = grid;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue3413Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked ("srb_vertical"));
+			RunningApp.WaitForElement (q => q.Marked ("srb_horizontal"));
+			RunningApp.Screenshot ("Please verify we have 2 SearchBar's. One below the label, other side by side with the label");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3413.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3413.cs
@@ -4,6 +4,7 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
@@ -55,11 +56,12 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[Category(UITestCategories.ManualReview)]
 		public void Issue3413Test ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("srb_vertical"));
 			RunningApp.WaitForElement (q => q.Marked ("srb_horizontal"));
-			RunningApp.Screenshot ("Please verify we have 2 SearchBar's. One below the label, other side by side with the label");
+			RunningApp.Screenshot ("Please verify we have 2 SearchBars. One below the label, other side by side with the label");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3413.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3413.cs
@@ -46,11 +46,21 @@ namespace Xamarin.Forms.Controls.Issues
 			layout1.Children.Add(new Label { Text = "Horizontal" });
 			layout1.Children.Add(searchBar1);
 
+			var searchBar2 = new SearchBar
+			{
+				BackgroundColor = Color.Blue,
+				Text = "i m with expand",
+				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				AutomationId = "srb_grid"
+			};
+
 			var grid = new Grid();
 			grid.Children.Add(layout);
 			Grid.SetRow(layout, 0);
 			grid.Children.Add(layout1);
 			Grid.SetRow(layout1, 1);
+			grid.Children.Add(searchBar2);
+			Grid.SetRow(searchBar2, 2);
 			Content = grid;
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -768,6 +768,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2728.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1667.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3012.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3413.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -130,8 +130,8 @@ namespace Xamarin.Forms.Platform.iOS
 		public override CoreGraphics.CGSize SizeThatFits(CoreGraphics.CGSize size)
 		{
 			if (nfloat.IsInfinity(size.Width) && Forms.IsiOS11OrNewer)
-				size.Width = nfloat.MaxValue;
-			
+				size.Width = (nfloat)(Element?.Parent is VisualElement parent ? parent.Width : Device.Info.ScaledScreenSize.Width);
+
 			return base.SizeThatFits(size);
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -129,10 +129,21 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override CoreGraphics.CGSize SizeThatFits(CoreGraphics.CGSize size)
 		{
-			if (nfloat.IsInfinity(size.Width) && Forms.IsiOS11OrNewer)
-				size.Width = (nfloat)(Element?.Parent is VisualElement parent ? parent.Width : Device.Info.ScaledScreenSize.Width);
+			if (!nfloat.IsInfinity(size.Width))
+				return base.SizeThatFits(size);
 
-			return base.SizeThatFits(size);
+			if (Forms.IsiOS11OrNewer)
+			{
+				size.Width = (nfloat)(Element?.Parent is VisualElement parent ? parent.Width : Device.Info.ScaledScreenSize.Width);
+				return base.SizeThatFits(size);
+			}
+
+			//iOS10 hack because SizeThatFits always returns a width of 0
+			var sizeThatFits = Control.SizeThatFits(size);
+			if (sizeThatFits.Width == 0)
+				sizeThatFits.Width = (nfloat)(Element?.Parent is VisualElement parent ? parent.Width : Device.Info.ScaledScreenSize.Width);
+
+			return sizeThatFits;
 		}
 
 		void OnCancelClicked(object sender, EventArgs args)

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -129,18 +129,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override CoreGraphics.CGSize SizeThatFits(CoreGraphics.CGSize size)
 		{
-			if (!nfloat.IsInfinity(size.Width))
-				return base.SizeThatFits(size);
+			if (nfloat.IsInfinity(size.Width))
+				size.Width = (nfloat)(Element?.Parent is VisualElement parent ? parent.Width : Device.Info.ScaledScreenSize.Width);
 
-			size.Width = (nfloat)(Element?.Parent is VisualElement parent ? parent.Width : Device.Info.ScaledScreenSize.Width);
+			var sizeThatFits = Control.SizeThatFits(size);
 
 			if (Forms.IsiOS11OrNewer)
-				return base.SizeThatFits(size);
+				return sizeThatFits;
 
-			//iOS10 hack because SizeThatFits always returns a width of 0
-			var sizeThatFits = Control.SizeThatFits(size);
-			if (sizeThatFits.Width == 0)
-				sizeThatFits.Width = size.Width;
+			////iOS10 hack because SizeThatFits always returns a width of 0
+			sizeThatFits.Width = (nfloat)Math.Max(sizeThatFits.Width, size.Width);
 
 			return sizeThatFits;
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -132,16 +132,15 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!nfloat.IsInfinity(size.Width))
 				return base.SizeThatFits(size);
 
+			size.Width = (nfloat)(Element?.Parent is VisualElement parent ? parent.Width : Device.Info.ScaledScreenSize.Width);
+
 			if (Forms.IsiOS11OrNewer)
-			{
-				size.Width = (nfloat)(Element?.Parent is VisualElement parent ? parent.Width : Device.Info.ScaledScreenSize.Width);
 				return base.SizeThatFits(size);
-			}
 
 			//iOS10 hack because SizeThatFits always returns a width of 0
 			var sizeThatFits = Control.SizeThatFits(size);
 			if (sizeThatFits.Width == 0)
-				sizeThatFits.Width = (nfloat)(Element?.Parent is VisualElement parent ? parent.Width : Device.Info.ScaledScreenSize.Width);
+				sizeThatFits.Width = size.Width;
 
 			return sizeThatFits;
 		}


### PR DESCRIPTION
### Description of Change ###

As of latest versions of iOS11.3 seems that passing the max value to the UISearchBar for sizing breaks.
This only happens when we don't specify any Width request for the SearchBar and the SearchBar is requested to stretch itself. 
We could try to pass a enormous value but I figure this was a best call. 

At the same time we found out iOS10 also wasn't rendering , the issue that is SizeThatFits always is retiring a 0 Width , we override the call and set the width. 

### Issues Resolved ###

- fixes #3413 
- fixes #2139  

### API Changes ###

None

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###

Should show the Searchbar inside a horizontal StackLayout and blue SearchBar Expanding

Before:

It crashed  and didn't renderer the blue SearchBar with CenterAndExpand

After:

IOS 10
![simulator screen shot - iphone 5 - 2018-08-29 at 12 38 38](https://user-images.githubusercontent.com/1235097/44786344-b88f4100-ab8b-11e8-982b-f49f0ff96098.png)
![simulator screen shot - iphone 5 - 2018-08-29 at 12 38 46](https://user-images.githubusercontent.com/1235097/44786347-b927d780-ab8b-11e8-8c52-5b5af68dcd63.png)

iOS11
![simulator screen shot - iphone x - 2018-08-29 at 12 20 30](https://user-images.githubusercontent.com/1235097/44786348-b927d780-ab8b-11e8-9742-7749febf409a.png)
![simulator screen shot - iphone x - 2018-08-29 at 12 20 44](https://user-images.githubusercontent.com/1235097/44786349-b927d780-ab8b-11e8-8d51-34d370952729.png)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard