### PR TITLE
[iOS] iPad ActionSheet should always have a Cancel method

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3049.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3049.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST && __IOS__
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3049, "DisplayActionSheet freezes app in iOS custom renderer (iPad only)", PlatformAffected.iOS)]
+	public class Issue3049 : TestContentPage
+	{
+		const string Button1Id = "button1";
+		const string Button2Id = "button2";
+		const string LabelId = "label";
+		const string Success = "Success";
+		const string Action1 = "Don't click me";
+		const string Skip = "skip";
+
+		protected override void Init()
+		{
+			Label instructions = new Label { Text = "Click the first button to open an ActionSheet. Click anywhere outside of the ActionSheet to close it. Then click the second button. If nothing happens (and the app is basically frozen), this test has failed.", AutomationId = LabelId };
+
+			Label skip = new Label { Text = "Skip this test -- this is not an iPad, so this is not relevant.", AutomationId = Skip };
+
+			Button button = new Button { Text = "Click me first", AutomationId = Button1Id };
+			button.Clicked += async (s, e) =>
+			{
+				string action = await DisplayActionSheet(null, null, null, Action1, "Click outside ActionSheet instead");
+				System.Diagnostics.Debug.WriteLine("## " + action);
+			};
+
+			Button button2 = new Button { Text = "Click me second", AutomationId = Button2Id };
+			button2.Clicked += (s, e) =>
+			{
+				instructions.Text = Success;
+			};
+
+			StackLayout stackLayout = new StackLayout
+			{
+				Children = {
+					instructions,
+					button,
+					button2
+				}
+			};
+
+			if (Device.Idiom != TargetIdiom.Tablet || Device.RuntimePlatform != Device.iOS)
+				stackLayout.Children.Insert(0, skip);
+
+			Content = stackLayout;
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void Issue3049Test ()
+		{
+			RunningApp.WaitForElement (q => q.Marked (Button1Id));
+
+			if (RunningApp.Query(q => q.Marked(Skip)).Length > 0)
+				Assert.Pass("Test ignored, not relevant on phone");
+			else
+			{
+				RunningApp.Tap (q => q.Marked (Button1Id));
+
+				RunningApp.WaitForElement (q => q.Marked (Action1));
+
+				// tap outside ActionSheet to dismiss it
+				RunningApp.Tap (q => q.Marked (LabelId));
+
+				RunningApp.WaitForElement (q => q.Marked (Button2Id));
+				RunningApp.Tap (q => q.Marked (Button2Id));
+
+				RunningApp.WaitForElement (q => q.Marked (Success));
+			}
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -481,6 +481,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1939.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3342.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3415.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3049.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -395,9 +395,10 @@ namespace Xamarin.Forms.Platform.iOS
 			var alert = UIAlertController.Create(arguments.Title, null, UIAlertControllerStyle.ActionSheet);
 			var window = new UIWindow { BackgroundColor = Color.Transparent.ToUIColor() };
 
-			if (arguments.Cancel != null)
+			// Clicking outside of an ActionSheet is an implicit cancel on iPads. If we don't handle it, it freezes the app.
+			if (arguments.Cancel != null || UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
 			{
-				alert.AddAction(CreateActionWithWindowHide(arguments.Cancel, UIAlertActionStyle.Cancel, () => arguments.SetResult(arguments.Cancel), window));
+				alert.AddAction(CreateActionWithWindowHide(arguments.Cancel ?? "", UIAlertActionStyle.Cancel, () => arguments.SetResult(arguments.Cancel), window));
 			}
 
 			if (arguments.Destruction != null)


### PR DESCRIPTION
### Description of Change ###

The iPad ActionSheet has an implicit cancel when you click outside of the ActionSheet. However, if the user did not supply a text for the Cancel button (which is only relevant for phone), then we did not handle the cancel event. This caused the app to hang on iPad while it waited for the cancel result.

Now adding a cancel event to an ActionSheet whether text is defined or not if the device is an iPad.

### Issues Resolved ###
- fixes #3049

### API Changes ###

None

### Platforms Affected ###

- iOS (iPad only)

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
