### PR TITLE
[Android] Use height when determining ScaledScreenSize on Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -282,7 +282,7 @@ namespace Xamarin.Forms
 				{
 					_scalingFactor = display.Density;
 					_pixelScreenSize = new Size(display.WidthPixels, display.HeightPixels);
-					ScaledScreenSize = new Size(_pixelScreenSize.Width / _scalingFactor, _pixelScreenSize.Width / _scalingFactor);
+					ScaledScreenSize = new Size(_pixelScreenSize.Width / _scalingFactor, _pixelScreenSize.Height / _scalingFactor);
 				}
 
 				CheckOrientationChanged(formsActivity.Resources.Configuration.Orientation);


### PR DESCRIPTION
### Description of Change ###

Android `ScaledScreenSize` is using the screen width to calculate the height. This change uses the height instead.

### Issues Resolved ### 

- fixes #3609 

### API Changes ###

 None

### Platforms Affected ### 

- Android


