### PR TITLE
[iOS, UWP] fixes #2894 - Gestures collection changes weren't correctly propagating

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2894.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2894.cs
@@ -1,0 +1,252 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2894, "Gesture Recognizers added to Span after it's been set to FormattedText don't work and can cause an NRE")]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Gestures)]
+#endif
+	public class Issue2894 : TestContentPage
+	{
+		Label label = null;
+		Label gestureLabel1 = null;
+		Label gestureLabel2 = null;
+		int i1 = 0;
+		int i2 = 0;
+		const string kGesture1 = "Sentence 1: ";
+		const string kGesture2 = "Sentence 2: ";
+
+		const string kClickSentence1 = "I will fire when clicked. ";
+		const string kClickSentence2 = "I should also fire when clicked.";
+
+		const string kClickSentenceAutomationId1 = "Spanning1";
+		const string kClickSentenceAutomationId2 = "Spanning2";
+
+		const string kLabelAutomationId = "kLabelAutomationId";
+
+		GestureRecognizer CreateRecognizer1() => new TapGestureRecognizer()
+		{
+			Command = new Command(() =>
+			{
+				i1++;
+				gestureLabel1.Text = $"{kGesture1}{i1}";
+			})
+		};
+
+		GestureRecognizer CreateRecognizer2() => new TapGestureRecognizer()
+		{
+			Command = new Command(() =>
+			{
+				i2++;
+				gestureLabel2.Text = $"{kGesture2}{i2}";
+			})
+		};
+
+		void AddRemoveSpan(bool includeRecognizers = true)
+		{
+			if (label.FormattedText != null)
+			{
+				label.FormattedText = null;
+				return;
+			}
+
+			FormattedString s = new FormattedString();
+
+			var span = new Span
+			{
+				Text = kClickSentence1,
+				FontAttributes = FontAttributes.Bold,
+				AutomationId = kClickSentenceAutomationId1
+			};
+
+			var span2 = new Span
+			{
+				Text = kClickSentence2,
+				FontAttributes = FontAttributes.Bold,
+				AutomationId = kClickSentenceAutomationId2
+			};
+
+			if (includeRecognizers)
+				span.GestureRecognizers.Add(CreateRecognizer1());
+
+			s.Spans.Add(span);
+			s.Spans.Add(span2);
+
+			label.FormattedText = s;
+
+			if (includeRecognizers)
+				span2.GestureRecognizers.Add(CreateRecognizer2());
+		}
+
+
+		Label GetLabel() =>
+			new Label()
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				AutomationId = kLabelAutomationId
+			};
+
+		protected override void Init()
+		{
+			BindingContext = this;
+
+			label = GetLabel();
+			gestureLabel1 = new Label() { HorizontalOptions = LayoutOptions.Center };
+			gestureLabel2 = new Label() { HorizontalOptions = LayoutOptions.Center };
+
+			gestureLabel1.Text = $"{kGesture1}{i1}";
+			gestureLabel2.Text = $"{kGesture2}{i2}";
+
+			AddRemoveSpan();
+			StackLayout stackLayout = null;
+			stackLayout = new StackLayout()
+			{
+				Children =
+					{
+						label,
+						gestureLabel1,
+						gestureLabel2,
+						new Label(){Text = "Each sentence above has a separate Gesture Recognizer. Click each button below once then test that each Gesture Recognizer fires separately. If the sentence wraps make sure to click on the wrapped text as well."},
+						// test removing then adding span back
+						new Button()
+						{
+							Text = "Add and Remove Spans",
+							AutomationId = "TestSpan1",
+							Command = new Command(async () =>
+							{
+								if(label.FormattedText != null)
+									AddRemoveSpan();
+
+								await Task.Delay(100);
+								AddRemoveSpan();
+							})
+						},
+						// test removing and adding same span back
+						new Button()
+						{
+							Text = "Null FormattedText then set again",
+							AutomationId = "TestSpan2",
+							Command = new Command(async () =>
+							{
+								if(label.FormattedText == null)
+									AddRemoveSpan();
+
+								var span = label.FormattedText;
+								await Task.Delay(100);
+								label.FormattedText = null;
+								await Task.Delay(100);
+								label.FormattedText = span;
+							})
+						},
+						new Button()
+						{
+							Text = "Remove Gestures then add again",
+							AutomationId = "TestSpan3",
+							Command = new Command(async () =>
+							{
+								if(label.FormattedText == null)
+									AddRemoveSpan();
+
+								if(label.FormattedText.Spans[0].GestureRecognizers.Count > 0)
+								{
+									label.FormattedText.Spans[0].GestureRecognizers.Clear();
+									label.FormattedText.Spans[1].GestureRecognizers.Clear();
+								}
+
+								await Task.Delay(100);
+
+								label.FormattedText.Spans[0].GestureRecognizers.Add(CreateRecognizer1());
+								label.FormattedText.Spans[1].GestureRecognizers.Add(CreateRecognizer2());
+							})
+						},
+						new Button()
+						{
+							Text = "Add Gestures after rendering",
+							AutomationId = "TestSpan4",
+							Command = new Command(async () =>
+							{
+								stackLayout.Children.Remove(label);
+								await Task.Delay(50);
+								label = GetLabel();
+								stackLayout.Children.Insert(0, label);
+								await Task.Delay(50);
+								AddRemoveSpan(false);
+								await Task.Delay(50);
+								label.FormattedText.Spans[0].GestureRecognizers.Add(CreateRecognizer1());
+								label.FormattedText.Spans[1].GestureRecognizers.Add(CreateRecognizer2());
+							})
+						},
+						new Label()
+						{
+							Text = "This Button should remove all gestures"
+						},
+						new Button()
+						{
+							Text = "Remove All Gestures",
+							AutomationId = "TestSpan5",
+							Command = new Command(() =>
+							{
+								if(label.FormattedText == null)
+									return;
+
+								label.FormattedText.Spans[0].GestureRecognizers.Clear();
+								label.FormattedText.Spans[1].GestureRecognizers.Clear();
+							})
+						}
+					},
+				Padding = 40
+			};
+
+			Content = new ContentView()
+			{
+				Content = stackLayout
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void VariousSpanGesturePermutation()
+		{
+			RunningApp.WaitForElement($"{kGesture1}0");
+			RunningApp.WaitForElement($"{kGesture2}0");
+			var labelId = RunningApp.WaitForElement(kLabelAutomationId);
+			var target = labelId.First().Rect;
+
+
+			for (int i = 1; i < 5; i++)
+			{
+				RunningApp.Tap($"TestSpan{i}");
+				RunningApp.TapCoordinates(target.X + 5, target.Y + 5);
+				RunningApp.TapCoordinates(target.X + target.CenterX, target.Y + 2);
+
+
+				RunningApp.WaitForElement($"{kGesture1}{i}");
+				RunningApp.WaitForElement($"{kGesture2}{i}");
+			}
+
+
+			RunningApp.Tap($"TestSpan5");
+			RunningApp.TapCoordinates(target.X + 5, target.Y + 5);
+			RunningApp.TapCoordinates(target.X + target.CenterX, target.Y + 2);
+
+			RunningApp.WaitForElement($"{kGesture1}4");
+			RunningApp.WaitForElement($"{kGesture2}4");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -8,7 +8,8 @@
   <PropertyGroup Label="Configuration">
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
-  <ItemGroup>    
+  <ItemGroup>
+	<Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2004.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3333.cs" />

--- a/Xamarin.Forms.Core/FormattedString.cs
+++ b/Xamarin.Forms.Core/FormattedString.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms
 	public class FormattedString : Element
 	{
 		readonly SpanCollection _spans = new SpanCollection();
+		internal event NotifyCollectionChangedEventHandler SpansCollectionChanged;
 
 		public FormattedString()
 		{
@@ -69,6 +70,7 @@ namespace Xamarin.Forms
 			}
 
 			OnPropertyChanged(nameof(Spans));
+			SpansCollectionChanged?.Invoke(sender, e);
 		}
 
 		void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Core/GestureElement.cs
+++ b/Xamarin.Forms.Core/GestureElement.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms
 	public class GestureElement : Element, ISpatialElement
 	{
 		readonly GestureRecognizerCollection _gestureRecognizers = new GestureRecognizerCollection();
-		internal event NotifyCollectionChangedEventHandler SpansCollectionChanged;
+		internal event NotifyCollectionChangedEventHandler GestureRecognizersCollectionChanged;
 
 		public GestureElement()
 		{
@@ -48,7 +48,7 @@ namespace Xamarin.Forms
 						break;
 				}
 
-				SpansCollectionChanged?.Invoke(sender, args);
+				GestureRecognizersCollectionChanged?.Invoke(sender, args);
 			};
 		}
 

--- a/Xamarin.Forms.Core/GestureElement.cs
+++ b/Xamarin.Forms.Core/GestureElement.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms
 	public class GestureElement : Element, ISpatialElement
 	{
 		readonly GestureRecognizerCollection _gestureRecognizers = new GestureRecognizerCollection();
+		internal event NotifyCollectionChangedEventHandler SpansCollectionChanged;
 
 		public GestureElement()
 		{
@@ -46,6 +47,8 @@ namespace Xamarin.Forms
 							item.Parent = this;
 						break;
 				}
+
+				SpansCollectionChanged?.Invoke(sender, args);
 			};
 		}
 

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -42,35 +42,32 @@ namespace Xamarin.Forms
 				if (oldvalue != null)
 				{
 					var formattedString = ((FormattedString)oldvalue);
+					var label = ((Label)bindable);
 
-					// Remove spans here, to ensure all collection watching, removes necessary event hooks.
-					for (int i = formattedString.Spans.Count - 1; i >= 0; i--)
-						formattedString.Spans.RemoveAt(i);
-
-					((ObservableCollection<Span>)formattedString.Spans).CollectionChanged -= ((Label)bindable).Span_CollectionChanged;
-					formattedString.PropertyChanged -= ((Label)bindable).OnFormattedTextChanged;
+					formattedString.SpansCollectionChanged -= label.Span_CollectionChanged;
+					formattedString.PropertyChanged -= label.OnFormattedTextChanged;
 					formattedString.Parent = null;
 				}
 			}, propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
+				var label = ((Label)bindable);
+
 				if (newvalue != null)
 				{
-					var label = ((Label)bindable);
 					var formattedString = (FormattedString)newvalue;
 					formattedString.Parent = label;
 					formattedString.PropertyChanged += label.OnFormattedTextChanged;
 
-					((ObservableCollection<Span>)formattedString.Spans).CollectionChanged += label.Span_CollectionChanged;
+					formattedString.SpansCollectionChanged += label.Span_CollectionChanged;
 
 					// Initial Load of FormattedText could come preloaded with spans
 					for (int i = 0; i < formattedString.Spans.Count; i++)
-						for (int j = 0; j < formattedString.Spans[i].GestureRecognizers.Count; j++)
-							((IGestureController)label).CompositeGestureRecognizers.Add(new ChildGestureRecognizer() { GestureRecognizer = formattedString.Spans[i].GestureRecognizers[j] });
+						label.SetupSpanGestureRecognizers(formattedString.Spans[i], label);
 				}
 
-				((Label)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+				label.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 				if (newvalue != null)
-					((Label)bindable).Text = null;
+					label.Text = null;
 			});
 
 		public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(Label), LineBreakMode.WordWrap,
@@ -197,6 +194,22 @@ namespace Xamarin.Forms
 			OnPropertyChanged("FormattedText");
 		}
 
+		void SetupSpanGestureRecognizers(Span span, IGestureController gestureController)
+		{
+			span.SpansCollectionChanged += Span_GestureRecognizer_CollectionChanged;
+			for (int j = 0; j < span.GestureRecognizers.Count; j++)
+				gestureController.CompositeGestureRecognizers.Add(new ChildGestureRecognizer() { GestureRecognizer = span.GestureRecognizers[j] });
+		}
+
+
+		void TearDownSpanGestureRecognizers(Span span)
+		{
+			for (int i = span.GestureRecognizers.Count - 1; i >= 0; i--)
+				span.GestureRecognizers.RemoveAt(i);
+
+			span.SpansCollectionChanged -= Span_GestureRecognizer_CollectionChanged;
+		}
+
 		void Span_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			switch (e.Action)
@@ -218,24 +231,14 @@ namespace Xamarin.Forms
 
 			void AddItems()
 			{
-				foreach (GestureElement span in e.NewItems)
-				{
-					((ObservableCollection<IGestureRecognizer>)span.GestureRecognizers).CollectionChanged += Span_GestureRecognizer_CollectionChanged;
-					// span could be preloaded with GestureRecognizers
-					for (int i = 0; i < span.GestureRecognizers.Count; i++)
-						((IGestureController)this).CompositeGestureRecognizers.Add(new ChildGestureRecognizer() { GestureRecognizer = span.GestureRecognizers[i] });
-				}
+				for (int i = 0; i < e.NewItems.Count; i++)
+					SetupSpanGestureRecognizers((Span)e.NewItems[i], this);
 			}
 
 			void RemoveItems()
 			{
-				foreach (GestureElement span in e.OldItems)
-				{
-					for (int i = span.GestureRecognizers.Count - 1; i >= 0; i--)
-						span.GestureRecognizers.RemoveAt(i);
-
-					((ObservableCollection<IGestureRecognizer>)span.GestureRecognizers).CollectionChanged -= Span_GestureRecognizer_CollectionChanged;
-				}
+				for (int i = 0; i < e.OldItems.Count; i++)
+					TearDownSpanGestureRecognizers((Span)e.OldItems[i]);
 			}
 		}
 
@@ -254,7 +257,7 @@ namespace Xamarin.Forms
 			{
 				for (int i = 0; i < e.OldItems.Count; i++)
 					foreach (var spanRecognizer in GestureController.CompositeGestureRecognizers.ToList())
-						if (spanRecognizer is ChildGestureRecognizer && spanRecognizer == e.OldItems[i])
+						if (spanRecognizer is ChildGestureRecognizer childGestureRecognizer && childGestureRecognizer.GestureRecognizer == e.OldItems[i])
 							GestureController.CompositeGestureRecognizers.Remove(spanRecognizer);
 			}
 
@@ -318,11 +321,16 @@ namespace Xamarin.Forms
 				return null;
 
 			var spans = new List<GestureElement>();
-			foreach (var span in FormattedText.Spans)
+			for (int i = 0; i < FormattedText.Spans.Count; i++)
+			{
+				Span span = FormattedText.Spans[i];
+				var text = span.Text;
+				var region = ((ISpatialElement)span).Region;
 				if (span.GestureRecognizers.Count > 0 && (((ISpatialElement)span).Region.Contains(point) || point.IsEmpty))
 					spans.Add(span);
+			}
 
-			if (spans.Count > 1) // More than 2 elements overlapping, deflate to see which one is actually hit.
+			if (!point.IsEmpty && spans.Count > 1) // More than 2 elements overlapping, deflate to see which one is actually hit.
 				for (var i = spans.Count - 1; i >= 0; i--)
 					if (!((ISpatialElement)spans[i]).Region.Deflate().Contains(point))
 						spans.RemoveAt(i);

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -132,12 +132,16 @@ namespace Xamarin.Forms
 
 		internal override void ValidateGesture(IGestureRecognizer gesture)
 		{
-			if (gesture == null)
-				return;
-			if (gesture is PanGestureRecognizer)
-				throw new InvalidOperationException($"{nameof(PanGestureRecognizer)} is not supported on a {nameof(Span)}");
-			if (gesture is PinchGestureRecognizer)
-				throw new InvalidOperationException($"{nameof(PinchGestureRecognizer)} is not supported on a {nameof(Span)}");
+			switch (gesture)
+			{
+				case ClickGestureRecognizer click:
+				case TapGestureRecognizer tap:
+				case null:
+					break;
+				default:
+					throw new InvalidOperationException($"{gesture.GetType().Name} is not supported on a {nameof(Span)}");
+
+			}
 		}
 
 		void ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue)

--- a/Xamarin.Forms.Platform.Android/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormattedStringExtensions.cs
@@ -17,8 +17,9 @@ namespace Xamarin.Forms.Platform.Android
 				return null;
 
 			var builder = new StringBuilder();
-			foreach (Span span in formattedString.Spans)
+			for (int i = 0; i < formattedString.Spans.Count; i++)
 			{
+				Span span = formattedString.Spans[i];
 				var text = span.Text;
 				if (text == null)
 					continue;
@@ -29,8 +30,9 @@ namespace Xamarin.Forms.Platform.Android
 			var spannable = new SpannableString(builder.ToString());
 
 			var c = 0;
-			foreach (Span span in formattedString.Spans)
+			for (int i = 0; i < formattedString.Spans.Count; i++)
 			{
+				Span span = formattedString.Spans[i];
 				var text = span.Text;
 				if (text == null)
 					continue;

--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -95,6 +95,7 @@ namespace Xamarin.Forms.Platform.UWP
 					{
 						var oldRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
 						oldRecognizers.CollectionChanged -= _collectionChangedHandler;
+						((view as IGestureController)?.CompositeGestureRecognizers as ObservableCollection<IGestureRecognizer>).CollectionChanged -= _collectionChangedHandler;
 					}
 				}
 
@@ -110,6 +111,7 @@ namespace Xamarin.Forms.Platform.UWP
 					{
 						var newRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
 						newRecognizers.CollectionChanged += _collectionChangedHandler;
+						((view as IGestureController)?.CompositeGestureRecognizers as ObservableCollection<IGestureRecognizer>).CollectionChanged += _collectionChangedHandler;
 					}
 				}
 
@@ -592,7 +594,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			var children = (view as IGestureController)?.GetChildElements(Point.Zero);
 			IList<TapGestureRecognizer> childGestures = children?.GetChildGesturesFor<TapGestureRecognizer>().ToList();
-			
+
 			if (gestures.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any()
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any() == true)
 			{
@@ -608,7 +610,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (gestures.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2).Any()
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2).Any() == true)
-			{ 
+			{
 				_container.DoubleTapped += OnDoubleTap;
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -125,8 +125,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				var eventTracker = weakEventTracker.Target as EventTracker;
 				var view = eventTracker?._renderer?.Element as View;
 				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, eventTracker, view);
-				if (childGestures == null) return;
-
+				
 				if (childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfClicksRequired).Count() > 0)
 					return;
 
@@ -142,8 +141,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				var eventTracker = weakEventTracker.Target as EventTracker;
 				var view = eventTracker?._renderer?.Element as View;
 				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, eventTracker, view);
-				if (childGestures == null) return;
-
+				
 				var clickGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as ClickGestureRecognizer;
 				var recognizers = childGestures?.GetChildGesturesFor<ClickGestureRecognizer>(x => x.NumberOfClicksRequired == (int)sender.NumberOfClicksRequired);
 
@@ -163,7 +161,6 @@ namespace Xamarin.Forms.Platform.MacOS
 				View view = eventTracker?._renderer?.Element as View;
 
 				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, eventTracker, view);
-				if (childGestures == null) return;
 
 				if (childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfTapsRequired).Count() > 0)
 					return;
@@ -181,10 +178,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				var view = eventTracker?._renderer?.Element as View;
 
 				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, eventTracker, view);
-				if (childGestures == null) return;
 
 				var recognizers = childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfTapsRequired);
-
 
 				var tapGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as TapGestureRecognizer;
 				foreach (var item in recognizers)

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			get
 			{
 				return ((_renderer?.Element as IGestureController)
-							?.CompositeGestureRecognizers as ObservableCollection<IGestureRecognizer>);				
+							?.CompositeGestureRecognizers as ObservableCollection<IGestureRecognizer>);
 			}
 		}
 
@@ -67,6 +67,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			foreach (var kvp in _gestureRecognizers)
 			{
 				_handler.RemoveGestureRecognizer(kvp.Value);
+#if __MOBILE__
+				kvp.Value.ShouldReceiveTouch = null;
+#endif
 				kvp.Value.Dispose();
 			}
 
@@ -87,6 +90,33 @@ namespace Xamarin.Forms.Platform.MacOS
 			OnElementChanged(this, new VisualElementChangedEventArgs(null, _renderer.Element));
 		}
 
+		static IList<GestureElement> GetChildGestures(
+
+#if __MOBILE__
+			UIGestureRecognizer sender,
+#else
+			NSGestureRecognizer sender,
+#endif
+			WeakReference weakEventTracker, WeakReference weakRecognizer, EventTracker eventTracker, View view)
+		{
+			if (!weakRecognizer.IsAlive)
+				return null;
+
+			if (eventTracker._disposed || view == null)
+				return null;
+
+#if __MOBILE__
+			var originPoint = sender.LocationInView(null);
+			originPoint = UIApplication.SharedApplication.KeyWindow.ConvertPointToView(originPoint, eventTracker._renderer.NativeView);
+#else
+			var originPoint = sender.LocationInView(null);
+			originPoint = NSApplication.SharedApplication.KeyWindow.ContentView.ConvertPointToView(originPoint, eventTracker._renderer.NativeView);
+#endif
+
+			var childGestures = view.GetChildElements(new Point(originPoint.X, originPoint.Y));
+			return childGestures;
+		}
+
 #if !__MOBILE__
 		Action<NSClickGestureRecognizer> CreateRecognizerHandler(WeakReference weakEventTracker, WeakReference weakRecognizer, ClickGestureRecognizer clickRecognizer)
 		{
@@ -94,11 +124,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				var eventTracker = weakEventTracker.Target as EventTracker;
 				var view = eventTracker?._renderer?.Element as View;
-
-				var originPoint = sender.LocationInView(null);
-				originPoint = NSApplication.SharedApplication.KeyWindow.ContentView.ConvertPointToView(originPoint, eventTracker._renderer.NativeView);
-
-				var childGestures = view.GetChildElements(new Point(originPoint.X, originPoint.Y));
+				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, eventTracker, view);
+				if (childGestures == null) return;
 
 				if (childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfClicksRequired).Count() > 0)
 					return;
@@ -112,14 +139,12 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			return new Action<NSClickGestureRecognizer>((sender) =>
 			{
-				var clickGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as ClickGestureRecognizer;
 				var eventTracker = weakEventTracker.Target as EventTracker;
 				var view = eventTracker?._renderer?.Element as View;
+				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, eventTracker, view);
+				if (childGestures == null) return;
 
-				var originPoint = sender.LocationInView(null);
-				originPoint = NSApplication.SharedApplication.KeyWindow.ContentView.ConvertPointToView(originPoint, eventTracker._renderer.NativeView);
-
-				var childGestures = view.GetChildElements(new Point(originPoint.X, originPoint.Y));
+				var clickGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as ClickGestureRecognizer;
 				var recognizers = childGestures?.GetChildGesturesFor<ClickGestureRecognizer>(x => x.NumberOfClicksRequired == (int)sender.NumberOfClicksRequired);
 
 				foreach (var item in recognizers)
@@ -129,17 +154,16 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		}
 #else
+
 		Action<UITapGestureRecognizer> CreateRecognizerHandler(WeakReference weakEventTracker, WeakReference weakRecognizer, TapGestureRecognizer clickRecognizer)
 		{
 			return new Action<UITapGestureRecognizer>((sender) =>
 			{
-				var eventTracker = weakEventTracker.Target as EventTracker;
-				var view = eventTracker?._renderer?.Element as View;
+				EventTracker eventTracker = weakEventTracker.Target as EventTracker;
+				View view = eventTracker?._renderer?.Element as View;
 
-				var originPoint = sender.LocationInView(null);
-				originPoint = UIApplication.SharedApplication.KeyWindow.ConvertPointToView(originPoint, eventTracker._renderer.NativeView);
-
-				var childGestures = view.GetChildElements(new Point(originPoint.X, originPoint.Y));
+				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, eventTracker, view);
+				if (childGestures == null) return;
 
 				if (childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfTapsRequired).Count() > 0)
 					return;
@@ -153,16 +177,16 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			return new Action<UITapGestureRecognizer>((sender) =>
 			{
-				var tapGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as TapGestureRecognizer;
 				var eventTracker = weakEventTracker.Target as EventTracker;
 				var view = eventTracker?._renderer?.Element as View;
 
-				var originPoint = sender.LocationInView(null);
-				originPoint = UIApplication.SharedApplication.KeyWindow.ConvertPointToView(originPoint, eventTracker._renderer.NativeView);
+				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, eventTracker, view);
+				if (childGestures == null) return;
 
-				var childGestures = view.GetChildElements(new Point(originPoint.X, originPoint.Y));
 				var recognizers = childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfTapsRequired);
 
+
+				var tapGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as TapGestureRecognizer;
 				foreach (var item in recognizers)
 					if (item == tapGestureRecognizer && view != null)
 						tapGestureRecognizer.SendTapped(view);
@@ -511,8 +535,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 #endif
 
-			foreach (var recognizer in ElementGestureRecognizers)
+			for (int i = 0; i < ElementGestureRecognizers.Count; i++)
 			{
+				IGestureRecognizer recognizer = ElementGestureRecognizers[i];
 				if (_gestureRecognizers.ContainsKey(recognizer))
 					continue;
 
@@ -529,8 +554,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 
 			var toRemove = _gestureRecognizers.Keys.Where(key => !ElementGestureRecognizers.Contains(key)).ToArray();
-			foreach (var gestureRecognizer in toRemove)
+
+			for (int i = 0; i < toRemove.Length; i++)
 			{
+				IGestureRecognizer gestureRecognizer = toRemove[i];
 				var uiRecognizer = _gestureRecognizers[gestureRecognizer];
 				_gestureRecognizers.Remove(gestureRecognizer);
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
@@ -42,8 +42,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (formattedString == null)
 				return null;
 			var attributed = new NSMutableAttributedString();
-			foreach (var span in formattedString.Spans)
+			for (int i = 0; i < formattedString.Spans.Count; i++)
 			{
+				Span span = formattedString.Spans[i];
 				if (span.Text == null)
 					continue;
 
@@ -109,8 +110,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				return null;
 			var attributed = new NSMutableAttributedString();
 
-			foreach (var span in formattedString.Spans)
+			for (int i = 0; i < formattedString.Spans.Count; i++)
 			{
+				Span span = formattedString.Spans[i];
 				var attributedString = span.ToAttributed(owner, defaultForegroundColor, lineHeight);
 				if (attributedString == null)
 					continue;


### PR DESCRIPTION
### Description of Change ###

[UWP] - When Multiple gestures were attached to different spans the initial gestures wouldn't wire up, changes to span gestures weren't propagating

[iOS] - condensed some code and fixed issue where changes to Span Gesture Collections weren't propagating. Fixed an issue where clicking really fast in the control gallery would cause an exception because the MainPage gets swapped out after 5 clicks which would dispose of the underlying views prior to the uitouch getting dispatched

iOS testing note - Clicking on the span in iOS will probably be a little quirky but there's already an issue for that that I'm currently working on 

### Issues Resolved ### 
- fixes #2894 

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
