### PR TITLE
[GTK] Fix navigation bar visibility updates

### DIFF
--- a/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
@@ -145,6 +145,7 @@ namespace Xamarin.Forms.Platform.GTK
         {
             if (e.PropertyName.Equals(NavigationPage.BarTextColorProperty.PropertyName) ||
                 e.PropertyName.Equals(NavigationPage.BarBackgroundColorProperty.PropertyName) ||
+                e.PropertyName.Equals(NavigationPage.HasNavigationBarProperty.PropertyName) ||
                 e.PropertyName.Equals(Page.TitleProperty.PropertyName) ||
                 e.PropertyName.Equals(Page.IconProperty.PropertyName))
                 UpdateToolBar();

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -199,6 +199,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 UpdateBackButtonIcon();
             else if (e.PropertyName == NavigationPage.CurrentPageProperty.PropertyName)
                 UpdateCurrentPage();
+            else if (e.PropertyName == NavigationPage.HasNavigationBarProperty.PropertyName)
+                UpdateToolBar();
         }
 
         private void Init()


### PR DESCRIPTION
### Description of Change ###
Calling NavigationPage.SetHasNavigationBar after the page is loaded does not update the visibility of the navigation bar correctly

### Platforms Affected ### 
- GTK
