### PR TITLE
[Android] Update Forms to remove API28 deprecated API

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/ColorPicker.cs
+++ b/Xamarin.Forms.ControlGallery.Android/ColorPicker.cs
@@ -34,19 +34,20 @@ namespace Xamarin.Forms.ControlGallery.Android
 			SetMinimumWidth(minWidth);
 
 			imageViewPallete = new ImageView(context);
-#pragma warning disable 618
-			imageViewPallete.DrawingCacheEnabled = true;
-#pragma warning restore 618
 			imageViewPallete.Background = new Droid.Graphics.Drawables.GradientDrawable(Droid.Graphics.Drawables.GradientDrawable.Orientation.LeftRight, COLORS);
 
 			imageViewPallete.Touch += (object sender, TouchEventArgs e) =>
 			{
 				if (e.Event.Action == MotionEventActions.Down || e.Event.Action == MotionEventActions.Move)
 				{
-					currentPoint = new Droid.Graphics.Point((int)e.Event.GetX(), (int)e.Event.GetY());
-#pragma warning disable 618
-					previewColor = GetCurrentColor(imageViewPallete.GetDrawingCache(false), (int)e.Event.GetX(), (int)e.Event.GetY());
-#pragma warning restore 618
+					using (Droid.Graphics.Bitmap bitmap = Droid.Graphics.Bitmap.CreateBitmap(imageViewPallete.Width, imageViewPallete.Height, Droid.Graphics.Bitmap.Config.Argb8888))
+					{
+						Droid.Graphics.Canvas canvas = new Droid.Graphics.Canvas(bitmap);
+						imageViewPallete.Background.Draw(canvas);
+
+						currentPoint = new Droid.Graphics.Point((int)e.Event.GetX(), (int)e.Event.GetY());
+						previewColor = GetCurrentColor(bitmap, (int)e.Event.GetX(), (int)e.Event.GetY());
+					}
 				}
 				if (e.Event.Action == MotionEventActions.Up)
 				{

--- a/Xamarin.Forms.ControlGallery.Android/ColorPicker.cs
+++ b/Xamarin.Forms.ControlGallery.Android/ColorPicker.cs
@@ -34,7 +34,9 @@ namespace Xamarin.Forms.ControlGallery.Android
 			SetMinimumWidth(minWidth);
 
 			imageViewPallete = new ImageView(context);
-			//imageViewPallete.DrawingCacheEnabled = true;
+#pragma warning disable 618
+			imageViewPallete.DrawingCacheEnabled = true;
+#pragma warning restore 618
 			imageViewPallete.Background = new Droid.Graphics.Drawables.GradientDrawable(Droid.Graphics.Drawables.GradientDrawable.Orientation.LeftRight, COLORS);
 
 			imageViewPallete.Touch += (object sender, TouchEventArgs e) =>
@@ -42,8 +44,9 @@ namespace Xamarin.Forms.ControlGallery.Android
 				if (e.Event.Action == MotionEventActions.Down || e.Event.Action == MotionEventActions.Move)
 				{
 					currentPoint = new Droid.Graphics.Point((int)e.Event.GetX(), (int)e.Event.GetY());
-
-					previewColor = GetCurrentColor(null, (int)e.Event.GetX(), (int)e.Event.GetY());
+#pragma warning disable 618
+					previewColor = GetCurrentColor(imageViewPallete.GetDrawingCache(false), (int)e.Event.GetX(), (int)e.Event.GetY());
+#pragma warning restore 618
 				}
 				if (e.Event.Action == MotionEventActions.Up)
 				{

--- a/Xamarin.Forms.ControlGallery.Android/ColorPicker.cs
+++ b/Xamarin.Forms.ControlGallery.Android/ColorPicker.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 			SetMinimumWidth(minWidth);
 
 			imageViewPallete = new ImageView(context);
-			imageViewPallete.DrawingCacheEnabled = true;
+			//imageViewPallete.DrawingCacheEnabled = true;
 			imageViewPallete.Background = new Droid.Graphics.Drawables.GradientDrawable(Droid.Graphics.Drawables.GradientDrawable.Orientation.LeftRight, COLORS);
 
 			imageViewPallete.Touch += (object sender, TouchEventArgs e) =>
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 				{
 					currentPoint = new Droid.Graphics.Point((int)e.Event.GetX(), (int)e.Event.GetY());
 
-					previewColor = GetCurrentColor(imageViewPallete.GetDrawingCache(false), (int)e.Event.GetX(), (int)e.Event.GetY());
+					previewColor = GetCurrentColor(null, (int)e.Event.GetX(), (int)e.Event.GetY());
 				}
 				if (e.Event.Action == MotionEventActions.Up)
 				{

--- a/Xamarin.Forms.Platform.Android/AppCompat/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PageExtensions.cs
@@ -8,25 +8,67 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public static class PageExtensions
 	{
-		//public static Fragment CreateFragment(this ContentPage view, Context context)
-		//{
+#pragma warning disable 618
+		[Obsolete("ContentPage.CreateFragment() is obsolete as of version 3.2. Please use ContentPage.CreateSupportFragment() instead.")]
+		public static Fragment CreateFragment(this ContentPage view, Context context)
+		{
+			if (!Forms.IsInitialized)
+				throw new InvalidOperationException("call Forms.Init() before this");
 
-		//	if (!Forms.IsInitialized)
-		//		throw new InvalidOperationException("call Forms.Init() before this");
+			if (!(view.RealParent is Application))
+			{
+				Application app = new DefaultApplication();
+				app.MainPage = view;
+			}
 
-		//	if (!(view.RealParent is Application))
-		//	{
-		//		Application app = new DefaultApplication();
-		//		app.MainPage = view;
-		//	}
+			var platform = new Platform(context, true);
+			platform.SetPage(view);
 
-		//	var platform = new Platform(context, true);
-		//	platform.SetPage(view);
+			var vg = platform.GetViewGroup();
 
-		//	var vg = platform.GetViewGroup();
+			return new EmbeddedFragment(vg, platform);
+		}
 
-		//	return new EmbeddedFragment(vg, platform);
-		//}
+		class EmbeddedFragment : Fragment
+		{
+			readonly ViewGroup _content;
+			readonly Platform _platform;
+			bool _disposed;
+
+			// ReSharper disable once UnusedMember.Local (Android uses this on configuration change
+			public EmbeddedFragment()
+			{
+			}
+
+			public EmbeddedFragment(ViewGroup content, Platform platform)
+			{
+				_content = content;
+				_platform = platform;
+			}
+
+			public override global::Android.Views.View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+			{
+				return _content;
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_disposed = true;
+
+				if (disposing)
+				{
+					(_platform as IDisposable)?.Dispose();
+				}
+
+				base.Dispose(disposing);
+			}
+		}
+#pragma warning restore 618
 
 		public static global::Android.Support.V4.App.Fragment CreateSupportFragment(this ContentPage view, Context context)
 		{
@@ -50,46 +92,6 @@ namespace Xamarin.Forms.Platform.Android
 		class DefaultApplication : Application
 		{
 		}
-
-		//class EmbeddedFragment :  Android.Support.V4.App.Fragment
-		//{
-		//	readonly ViewGroup _content;
-		//	readonly Platform _platform;
-		//	bool _disposed;
-
-		//	// ReSharper disable once UnusedMember.Local (Android uses this on configuration change
-		//	public EmbeddedFragment()
-		//	{
-		//	}
-
-		//	public EmbeddedFragment(ViewGroup content, Platform platform)
-		//	{
-		//		_content = content;
-		//		_platform = platform;
-		//	}
-
-		//	public override global::Android.Views.View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
-		//	{
-		//		return _content;
-		//	}
-
-		//	protected override void Dispose(bool disposing)
-		//	{
-		//		if (_disposed)
-		//		{
-		//			return;
-		//		}
-
-		//		_disposed = true;
-
-		//		if (disposing)
-		//		{
-		//			(_platform as IDisposable)?.Dispose();
-		//		}
-
-		//		base.Dispose(disposing);
-		//	}
-		//}
 
 		class EmbeddedSupportFragment : global::Android.Support.V4.App.Fragment
 		{

--- a/Xamarin.Forms.Platform.Android/AppCompat/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PageExtensions.cs
@@ -8,24 +8,25 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public static class PageExtensions
 	{
-		public static Fragment CreateFragment(this ContentPage view, Context context)
-		{
-			if (!Forms.IsInitialized)
-				throw new InvalidOperationException("call Forms.Init() before this");
+		//public static Fragment CreateFragment(this ContentPage view, Context context)
+		//{
 
-			if (!(view.RealParent is Application))
-			{
-				Application app = new DefaultApplication();
-				app.MainPage = view;
-			}
+		//	if (!Forms.IsInitialized)
+		//		throw new InvalidOperationException("call Forms.Init() before this");
 
-			var platform = new Platform(context, true);
-			platform.SetPage(view);
+		//	if (!(view.RealParent is Application))
+		//	{
+		//		Application app = new DefaultApplication();
+		//		app.MainPage = view;
+		//	}
 
-			var vg = platform.GetViewGroup();
+		//	var platform = new Platform(context, true);
+		//	platform.SetPage(view);
 
-			return new EmbeddedFragment(vg, platform);
-		}
+		//	var vg = platform.GetViewGroup();
+
+		//	return new EmbeddedFragment(vg, platform);
+		//}
 
 		public static global::Android.Support.V4.App.Fragment CreateSupportFragment(this ContentPage view, Context context)
 		{
@@ -50,45 +51,45 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
-		class EmbeddedFragment : Fragment
-		{
-			readonly ViewGroup _content;
-			readonly Platform _platform;
-			bool _disposed;
+		//class EmbeddedFragment :  Android.Support.V4.App.Fragment
+		//{
+		//	readonly ViewGroup _content;
+		//	readonly Platform _platform;
+		//	bool _disposed;
 
-			// ReSharper disable once UnusedMember.Local (Android uses this on configuration change
-			public EmbeddedFragment()
-			{
-			}
+		//	// ReSharper disable once UnusedMember.Local (Android uses this on configuration change
+		//	public EmbeddedFragment()
+		//	{
+		//	}
 
-			public EmbeddedFragment(ViewGroup content, Platform platform)
-			{
-				_content = content;
-				_platform = platform;
-			}
+		//	public EmbeddedFragment(ViewGroup content, Platform platform)
+		//	{
+		//		_content = content;
+		//		_platform = platform;
+		//	}
 
-			public override global::Android.Views.View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
-			{
-				return _content;
-			}
+		//	public override global::Android.Views.View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+		//	{
+		//		return _content;
+		//	}
 
-			protected override void Dispose(bool disposing)
-			{
-				if (_disposed)
-				{
-					return;
-				}
+		//	protected override void Dispose(bool disposing)
+		//	{
+		//		if (_disposed)
+		//		{
+		//			return;
+		//		}
 
-				_disposed = true;
+		//		_disposed = true;
 
-				if (disposing)
-				{
-					(_platform as IDisposable)?.Dispose();
-				}
+		//		if (disposing)
+		//		{
+		//			(_platform as IDisposable)?.Dispose();
+		//		}
 
-				base.Dispose(disposing);
-			}
-		}
+		//		base.Dispose(disposing);
+		//	}
+		//}
 
 		class EmbeddedSupportFragment : global::Android.Support.V4.App.Fragment
 		{

--- a/Xamarin.Forms.Platform.Android/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/EntryCellRenderer.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Android.Content;
+using Android.Support.V4.Content;
 using Android.Text;
 using Android.Text.Method;
 using Android.Views;
@@ -9,11 +10,9 @@ namespace Xamarin.Forms.Platform.Android
 	public class EntryCellRenderer : CellRenderer
 	{
 		EntryCellView _view;
-		Context _context;
 
 		protected override global::Android.Views.View GetCellCore(Cell item, global::Android.Views.View convertView, ViewGroup parent, Context context)
 		{
-			_context = context;
 			if ((_view = convertView as EntryCellView) == null)
 				_view = new EntryCellView(context, item);
 			else
@@ -122,7 +121,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateLabelColor()
 		{
-			_view.SetLabelTextColor(((EntryCell)Cell).LabelColor, global::Android.Resource.Color.PrimaryTextDark);
+			_view.SetLabelTextColor(((EntryCell)Cell).LabelColor, Forms.DefaultTextColor);
 		}
 
 		void UpdateFlowDirection()

--- a/Xamarin.Forms.Platform.Android/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/EntryCellRenderer.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Android.Content;
-using Android.Support.V4.Content;
 using Android.Text;
 using Android.Text.Method;
 using Android.Views;
@@ -121,7 +120,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateLabelColor()
 		{
-			_view.SetLabelTextColor(((EntryCell)Cell).LabelColor, Forms.DefaultTextColor);
+			_view.SetLabelTextColor(((EntryCell)Cell).LabelColor, global::Android.Resource.Attribute.TextColor);
 		}
 
 		void UpdateFlowDirection()

--- a/Xamarin.Forms.Platform.Android/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/EntryCellRenderer.cs
@@ -122,10 +122,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateLabelColor()
 		{
-			global::Android.Util.TypedValue attributeValue  = new global::Android.Util.TypedValue();
-			_context.Theme.ResolveAttribute(global::Android.Resource.Attribute.TextColorPrimary, attributeValue, true);
-			var textColor = ((global::Android.Graphics.Drawables.ColorDrawable)_context.GetDrawable(attributeValue.ResourceId)).Color;
-			_view.SetLabelTextColor(((EntryCell)Cell).LabelColor, textColor);
+			_view.SetLabelTextColor(((EntryCell)Cell).LabelColor, global::Android.Resource.Color.PrimaryTextDark);
 		}
 
 		void UpdateFlowDirection()

--- a/Xamarin.Forms.Platform.Android/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/EntryCellRenderer.cs
@@ -9,9 +9,11 @@ namespace Xamarin.Forms.Platform.Android
 	public class EntryCellRenderer : CellRenderer
 	{
 		EntryCellView _view;
+		Context _context;
 
 		protected override global::Android.Views.View GetCellCore(Cell item, global::Android.Views.View convertView, ViewGroup parent, Context context)
 		{
+			_context = context;
 			if ((_view = convertView as EntryCellView) == null)
 				_view = new EntryCellView(context, item);
 			else
@@ -120,7 +122,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateLabelColor()
 		{
-			_view.SetLabelTextColor(((EntryCell)Cell).LabelColor, global::Android.Resource.Color.PrimaryTextDark);
+			global::Android.Util.TypedValue attributeValue  = new global::Android.Util.TypedValue();
+			_context.Theme.ResolveAttribute(global::Android.Resource.Attribute.TextColorPrimary, attributeValue, true);
+			var textColor = ((global::Android.Graphics.Drawables.ColorDrawable)_context.GetDrawable(attributeValue.ResourceId)).Color;
+			_view.SetLabelTextColor(((EntryCell)Cell).LabelColor, textColor);
 		}
 
 		void UpdateFlowDirection()

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -30,10 +30,6 @@ namespace Xamarin.Forms
 
 		static bool? s_isLollipopOrNewer;
 
-		static global::Android.Graphics.Color s_defaultThemeTextColor = global::Android.Graphics.Color.Black;
-		static bool s_defaultColorInitialized = false;
-
-
 		[Obsolete("Context is obsolete as of version 2.5. Please use a local context instead.")]
 		public static Context Context { get; internal set; }
 
@@ -47,7 +43,6 @@ namespace Xamarin.Forms
 		static Color _ColorButtonNormal = Color.Default;
 		public static Color ColorButtonNormalOverride { get; set; }
 
-		internal static global::Android.Graphics.Color DefaultTextColor => GetDefaultTextColor(ApplicationContext);
 		internal static bool IsLollipopOrNewer
 		{
 			get
@@ -146,7 +141,6 @@ namespace Xamarin.Forms
 				ResourceManager.Init(resourceAssembly);
 			}
 
-			GetDefaultTextColor(activity);
 			// We want this to be updated when we have a new activity (e.g. on a configuration change)
 			// This could change if the UI mode changes (e.g., if night mode is enabled)
 			Color.SetAccent(GetAccentColor(activity));
@@ -271,19 +265,6 @@ namespace Xamarin.Forms
 				}
 			}
 			return rc;
-		}
-
-		static global::Android.Graphics.Color GetDefaultTextColor(Context context)
-		{
-			if (!s_defaultColorInitialized)
-			{
-				var themeTextColorValue = new TypedValue();
-				context.Theme.ResolveAttribute(Resource.Attribute.TextColor, themeTextColorValue, true);
-				s_defaultThemeTextColor = new global::Android.Graphics.Color(themeTextColorValue.Data);
-				s_defaultColorInitialized = true;
-			}
-
-			return s_defaultThemeTextColor;
 		}
 
 		class AndroidDeviceInfo : DeviceInfo

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -30,6 +30,10 @@ namespace Xamarin.Forms
 
 		static bool? s_isLollipopOrNewer;
 
+		static global::Android.Graphics.Color s_defaultThemeTextColor = global::Android.Graphics.Color.Black;
+		static bool s_defaultColorInitialized = false;
+
+
 		[Obsolete("Context is obsolete as of version 2.5. Please use a local context instead.")]
 		public static Context Context { get; internal set; }
 
@@ -43,6 +47,7 @@ namespace Xamarin.Forms
 		static Color _ColorButtonNormal = Color.Default;
 		public static Color ColorButtonNormalOverride { get; set; }
 
+		internal static global::Android.Graphics.Color DefaultTextColor => GetDefaultTextColor(ApplicationContext);
 		internal static bool IsLollipopOrNewer
 		{
 			get
@@ -141,6 +146,7 @@ namespace Xamarin.Forms
 				ResourceManager.Init(resourceAssembly);
 			}
 
+			GetDefaultTextColor(activity);
 			// We want this to be updated when we have a new activity (e.g. on a configuration change)
 			// This could change if the UI mode changes (e.g., if night mode is enabled)
 			Color.SetAccent(GetAccentColor(activity));
@@ -265,6 +271,19 @@ namespace Xamarin.Forms
 				}
 			}
 			return rc;
+		}
+
+		static global::Android.Graphics.Color GetDefaultTextColor(Context context)
+		{
+			if (!s_defaultColorInitialized)
+			{
+				var themeTextColorValue = new TypedValue();
+				context.Theme.ResolveAttribute(Resource.Attribute.TextColor, themeTextColorValue, true);
+				s_defaultThemeTextColor = new global::Android.Graphics.Color(themeTextColorValue.Data);
+				s_defaultColorInitialized = true;
+			}
+
+			return s_defaultThemeTextColor;
 		}
 
 		class AndroidDeviceInfo : DeviceInfo


### PR DESCRIPTION
### Description of Change ###

Ignore warning our extension method throws since is returning a deprecated android  api App.Fragment. 
Fix usage of default text color that is also deprecated on API28 SDK

Update provisioning for 15.8

### Issues Resolved ### 
 
Build issues with API28
- fixes #2128
- fixes #3629 

### API Changes ###

Obsolete:

`[Obsolete("ContentPage.CreateFragment() is obsolete as of version 3.2. Please use ContentPage.CreateSupportFragment() instead.")]`
 - public static global::Android.Support.V4.App.Fragment CreateFragment(this ContentPage view, Context context)
 		

### Platforms Affected ### 

- Android


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard