### PR TITLE
[WPF] Fix DisplayAlert has no Text Wrapping

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Themes/FormsContentDialog.xaml
+++ b/Xamarin.Forms.Platform.WPF/Themes/FormsContentDialog.xaml
@@ -52,7 +52,7 @@
                                                        FontFamily="Segoe UI"
                                                        FontSize="16"
                                                        TextOptions.TextFormattingMode="Ideal"
-                                                       TextTrimming="CharacterEllipsis" 
+                                                       TextWrapping="Wrap"
                                                        Foreground="Black"/>
                                     </DataTemplate>
                                 </ContentPresenter.Resources>


### PR DESCRIPTION
### Description of Change ###

Fix DisplayAlert has no Text Wrapping issue

### Issues Resolved ### 

- fixes #3634 

### Platforms Affected ### 

- WPF

### After Screenshot ### 

![image](https://user-images.githubusercontent.com/25939826/44684357-2e3ec400-aa49-11e8-802d-39c21e1a856d.png)

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
