### PR TITLE
[Android] Set initial ScrollView Scroll values when RTL

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -252,8 +252,13 @@ namespace Xamarin.Forms.Platform.Android
 				_container?.RequestLayout();
 
 			// if the target sdk >= 17 then setting the LayoutDirection on the scroll view natively takes care of the scroll
-			if (Context.TargetSdkVersion() < 17 && !_checkedForRtlScroll && _hScrollView != null && Element is IVisualElementController controller && controller.EffectiveFlowDirection.IsRightToLeft())
-				_hScrollView.ScrollX = _container.MeasuredWidth - _hScrollView.MeasuredWidth - _hScrollView.ScrollX;
+			if (!_checkedForRtlScroll && _hScrollView != null && Element is IVisualElementController controller && controller.EffectiveFlowDirection.IsRightToLeft())
+			{
+				if (Context.TargetSdkVersion() < 17)
+					_hScrollView.ScrollX = _container.MeasuredWidth - _hScrollView.MeasuredWidth - _hScrollView.ScrollX;
+				else
+					Device.BeginInvokeOnMainThread(() => UpdateScrollPosition(_hScrollView.ScrollX, ScrollY));
+			}
 
 			_checkedForRtlScroll = true;
 		}


### PR DESCRIPTION
### Description of Change ###
On the initial layout of a scroll view that is set to RTL the ScrollX position needs to be propagated to the cross platform control. Android will just start the Horizontal scroll all the way to the right without through a scrolled event so the value was never propagating to our control

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3675 


### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
When set to RTL the ScrollChanged event will now fire once on load to indicate its non zero X position. This brings it in line when running below API 17 as well

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
