### PR TITLE
[UWP] fixed `MinimumDate` and `MaximumDate` properties of DatePicker

### DIFF
--- a/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
@@ -103,7 +103,15 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (Element.Date.CompareTo(e.NewDate.Date) != 0)
 			{
-				Element.Date = e.NewDate.Date;
+				var date = e.NewDate.Date.Clamp(Element.MinimumDate, Element.MaximumDate);
+				Element.Date = date;
+
+				// set the control date-time to clamped value, if it exceeded the limits at the time of installation.
+				if (date != e.NewDate.Date)
+				{
+					UpdateDate(date);
+					Control.UpdateLayout();
+				}
 				((IVisualElementController)Element).InvalidateMeasure(InvalidationTrigger.SizeRequestChanged);
 			}
 		}

--- a/Xamarin.Forms.Platform.UAP/Extensions.cs
+++ b/Xamarin.Forms.Platform.UAP/Extensions.cs
@@ -83,5 +83,14 @@ namespace Xamarin.Forms.Platform.UWP
 
 			return inputScope;
 		}
+
+		public static T Clamp<T>(this T value, T min, T max) where T : IComparable<T>
+		{
+			if (value.CompareTo(min) < 0)
+				return min;
+			if (value.CompareTo(max) > 0)
+				return max;
+			return value;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Native `DatePicker` control allows you to limit only a year. This fix add clamp DateTime after change and updates the visual element if the DateTime is out of limits.

### Issues Resolved ### 

- fixes #3331

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

`DatePicker` cannot show date outside the limits

### Before/After Screenshots ### 

<details>
  <summary>Before</summary>

  ![Before](http://g.recordit.co/dyiQMa4J1s.gif)
</details>

<details>
  <summary>After</summary>

![After](http://g.recordit.co/nD8J0vMXl5.gif)
</details>

### Testing Procedure ###
- run DatePicker Gallery
- select page `MinimumDate View`
- select on `DatePicker` date less than September 13th 1987
- again select on `DatePicker` date less than September 13th 1987
- check result
- select page `MaximumDate View`
- select on `DatePicker` date over September 13th 2087
- again select on `DatePicker` date over September 13th 2087
- check result

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
