### PR TITLE
[Core] Fixes conversion binding a DateTime to a string if the locale is not the US

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2049.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2049.cs
@@ -20,13 +20,30 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			public DateTime TheDate { get; set; }
 			public float FloatValue { get; set; }
+
+			decimal _decimal;
+			public decimal Decimal
+			{
+				get
+				{
+					return _decimal;
+				}
+				set
+				{
+					_decimal = value;
+					DecimalChange?.Invoke(value);
+				}
+			}
+
+			public static Action<decimal> DecimalChange;
 		}
 
 		DateTime testDate = DateTime.ParseExact("2077-12-31T13:55:56", "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
 		int _localeIndex = 0;
 		string[] _localeIds = new[] { "en-US", "ru-RU", "en-AU", "zh-Hans" };
 		string _instuctions = $"When you change the locale, the date format must change.{Environment.NewLine}Current locale: ";
-		Label descLabel = new Label(); 
+		Label descLabel = new Label();
+		Label decimalResult = new Label();
 
 		protected override void Init()
 		{
@@ -34,9 +51,16 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var label = new Label();
 			label.SetBinding(Label.TextProperty, nameof(Model.TheDate));
-
 			var labelFloat = new Label();
-			labelFloat.SetBinding(Label.TextProperty, nameof(Model.FloatValue));
+			labelFloat.SetBinding(Label.TextProperty, nameof(Model.Decimal));
+			var entry = new Entry
+			{
+				Keyboard = Keyboard.Numeric
+			};
+			entry.SetBinding(Entry.TextProperty, nameof(Model.Decimal));
+			Model.DecimalChange = (v) => {
+				decimalResult.Text = v.ToString(CultureInfo.CurrentCulture);
+			};
 
 			UpdateDescLabel();
 
@@ -50,7 +74,9 @@ namespace Xamarin.Forms.Controls.Issues
 						Command = new Command(() => ChangeLocale())
 					},
 					label,
-					labelFloat
+					labelFloat,
+					entry,
+					decimalResult
 				}
 			};
 
@@ -62,7 +88,8 @@ namespace Xamarin.Forms.Controls.Issues
 			BindingContext = new Model
 			{
 				TheDate = DateTime.ParseExact("2077-12-31T13:55:56", "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture),
-				FloatValue = 123.456f // in some locales, the decimal symbol may not be a dot.
+				FloatValue = 123.456f, // in some locales, the decimal symbol may not be a dot.
+				Decimal = 456.789m
 			};
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2049.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2049.cs
@@ -15,32 +15,9 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 2049, "Bound DateTimes Display in en-US Format Not Local Format", PlatformAffected.All)]
 	public class Issue2049 : TestContentPage
 	{
-		[Preserve(AllMembers = true)]
-		public class Model
-		{
-			public DateTime TheDate { get; set; }
-			public float FloatValue { get; set; }
-
-			decimal _decimal;
-			public decimal Decimal
-			{
-				get
-				{
-					return _decimal;
-				}
-				set
-				{
-					_decimal = value;
-					DecimalChange?.Invoke(value);
-				}
-			}
-
-			public static Action<decimal> DecimalChange;
-		}
-
-		DateTime testDate = DateTime.ParseExact("2077-12-31T13:55:56", "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
+		DateTime _testDate = DateTime.ParseExact("2077-12-31T13:55:56", "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
 		int _localeIndex = 0;
-		string[] _localeIds = new[] { "en-US", "ru-RU", "en-AU", "zh-Hans" };
+		string[] _localeIds = new[] { "en-US", "pt-PT", "ru-RU", "en-AU", "zh-Hans" };
 		string _instuctions = $"When you change the locale, the date format must change.{Environment.NewLine}Current locale: ";
 		Label descLabel = new Label();
 		Label decimalResult = new Label();
@@ -52,7 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var label = new Label();
 			label.SetBinding(Label.TextProperty, nameof(Model.TheDate));
 			var labelFloat = new Label();
-			labelFloat.SetBinding(Label.TextProperty, nameof(Model.Decimal));
+			labelFloat.SetBinding(Label.TextProperty, nameof(Model.Float));
 			var entry = new Entry
 			{
 				Keyboard = Keyboard.Numeric
@@ -88,7 +65,7 @@ namespace Xamarin.Forms.Controls.Issues
 			BindingContext = new Model
 			{
 				TheDate = DateTime.ParseExact("2077-12-31T13:55:56", "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture),
-				FloatValue = 123.456f, // in some locales, the decimal symbol may not be a dot.
+				Float = 123.456f, // in some locales, the decimal symbol may not be a dot.
 				Decimal = 456.789m
 			};
 		}
@@ -104,6 +81,30 @@ namespace Xamarin.Forms.Controls.Issues
 			UpdateContext();
 		}
 
+		[Preserve(AllMembers = true)]
+		public class Model
+		{
+			public DateTime TheDate { get; set; }
+
+			public float Float { get; set; }
+
+			decimal _decimal;
+			public decimal Decimal
+			{
+				get
+				{
+					return _decimal;
+				}
+				set
+				{
+					_decimal = value;
+					DecimalChange?.Invoke(value);
+				}
+			}
+
+			public static Action<decimal> DecimalChange;
+		}
+
 		void UpdateDescLabel() => descLabel.Text = $"{_instuctions}{Thread.CurrentThread.CurrentCulture.DisplayName}";
 
 #if UITEST
@@ -112,7 +113,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			foreach (var locale in _localeIds)
 			{
-				if (RunningApp.Query(query => query.Text(testDate.ToString(new CultureInfo(locale)))).Length != 1)
+				if (RunningApp.Query(query => query.Text(_testDate.ToString(new CultureInfo(locale)))).Length != 1)
 					Assert.Fail();
 				RunningApp.Tap("Change Locale");
 			}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2049.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2049.cs
@@ -1,0 +1,95 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Threading;
+using System.Globalization;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2049, "Bound DateTimes Display in en-US Format Not Local Format", PlatformAffected.All)]
+	public class Issue2049 : TestContentPage
+	{
+		[Preserve(AllMembers = true)]
+		public class Model
+		{
+			public DateTime TheDate { get; set; }
+			public float FloatValue { get; set; }
+		}
+
+		DateTime testDate = DateTime.ParseExact("2077-12-31T13:55:56", "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
+		int _localeIndex = 0;
+		string[] _localeIds = new[] { "en-US", "ru-RU", "en-AU", "zh-Hans" };
+		string _instuctions = $"When you change the locale, the date format must change.{Environment.NewLine}Current locale: ";
+		Label descLabel = new Label(); 
+
+		protected override void Init()
+		{
+			UpdateContext();
+
+			var label = new Label();
+			label.SetBinding(Label.TextProperty, nameof(Model.TheDate));
+
+			var labelFloat = new Label();
+			labelFloat.SetBinding(Label.TextProperty, nameof(Model.FloatValue));
+
+			UpdateDescLabel();
+
+			var layout = new StackLayout
+			{
+				Children = {
+					descLabel,
+					new Button()
+					{
+						Text = "Change Locale",
+						Command = new Command(() => ChangeLocale())
+					},
+					label,
+					labelFloat
+				}
+			};
+
+			Content = layout;
+		}
+
+		void UpdateContext()
+		{
+			BindingContext = new Model
+			{
+				TheDate = DateTime.ParseExact("2077-12-31T13:55:56", "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture),
+				FloatValue = 123.456f // in some locales, the decimal symbol may not be a dot.
+			};
+		}
+
+		void ChangeLocale()
+		{
+			if (++_localeIndex > _localeIds.Length - 1)
+				_localeIndex = 0;
+			var locale = _localeIds[_localeIndex];
+
+			Thread.CurrentThread.CurrentCulture = new CultureInfo(locale);
+			UpdateDescLabel();
+			UpdateContext();
+		}
+
+		void UpdateDescLabel() => descLabel.Text = $"{_instuctions}{Thread.CurrentThread.CurrentCulture.DisplayName}";
+
+#if UITEST
+		[Test]
+		public void Issue2049Test ()
+		{
+			foreach (var locale in _localeIds)
+			{
+				if (RunningApp.Query(query => query.Text(testDate.ToString(new CultureInfo(locale)))).Length != 1)
+					Assert.Fail();
+				RunningApp.Tap("Change Locale");
+			}
+		} 
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2049.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2049.cs
@@ -18,13 +18,16 @@ namespace Xamarin.Forms.Controls.Issues
 		DateTime _testDate = DateTime.ParseExact("2077-12-31T13:55:56", "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
 		int _localeIndex = 0;
 		string[] _localeIds = new[] { "en-US", "pt-PT", "ru-RU", "en-AU", "zh-Hans" };
-		string _instuctions = $"When you change the locale, the date format must change.{Environment.NewLine}Current locale: ";
-		Label descLabel = new Label();
+		readonly string _instructions = $"When you change the locale, the date format must change.{Environment.NewLine}Current locale: ";
+		Label descLabel = new Label { MaxLines = 3 };
 		Label decimalResult = new Label();
 
 		protected override void Init()
 		{
 			UpdateContext();
+
+			Label.TextProperty.UseCurrentCulture = true;
+			Entry.TextProperty.UseCurrentCulture = true;
 
 			var label = new Label();
 			label.SetBinding(Label.TextProperty, nameof(Model.TheDate));
@@ -105,7 +108,7 @@ namespace Xamarin.Forms.Controls.Issues
 			public static Action<decimal> DecimalChange;
 		}
 
-		void UpdateDescLabel() => descLabel.Text = $"{_instuctions}{Thread.CurrentThread.CurrentCulture.DisplayName}";
+		void UpdateDescLabel() => descLabel.Text = $"{_instructions}{Thread.CurrentThread.CurrentCulture.DisplayName}";
 
 #if UITEST
 		[Test]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -90,6 +90,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36014.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36649.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36559.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2049.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36171.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36780.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla36651.cs" />

--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -1897,13 +1897,30 @@ namespace Xamarin.Forms.Core.UnitTests
 			slider.Value = 0.9;
 
 			Assert.That (vm.Text, Is.EqualTo ("0.9"));
-
-			// people write numbers using the separator accepted in their locale
-			var ds = System.Threading.Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator;
-			vm.Text = $"0{ds}7";
-			Assert.That(slider.Value, Is.EqualTo(0.7));
 		}
-		#endif
+
+		[TestCase("pt-PT"), TestCase("ru-RU")]
+		public void ConvertIsCommaCulture(string culture)
+		{
+			var locale = System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
+
+			Slider.ValueProperty.UseCurrentCulture = true;
+			var slider = new Slider();
+			var dot = locale.NumberFormat.NumberDecimalSeparator;
+			var vm = new MockViewModel { Text = $"0{dot}5" };
+			slider.BindingContext = vm;
+			slider.SetBinding(Slider.ValueProperty, "Text", BindingMode.TwoWay);
+
+			Assert.That(slider.Value, Is.EqualTo(0.5));
+
+			// old "excepted" behavior
+			Slider.ValueProperty.UseCurrentCulture = false;
+			vm.Text = $"0{dot}7";
+			Assert.AreNotEqual(slider.Value, 0.7);
+			vm.Text = $"0.8";
+			Assert.AreEqual(slider.Value, 0.8);
+		}
+#endif
 
 		[Test]
 		public void FailToConvert ()

--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -1897,6 +1897,11 @@ namespace Xamarin.Forms.Core.UnitTests
 			slider.Value = 0.9;
 
 			Assert.That (vm.Text, Is.EqualTo ("0.9"));
+
+			// people write numbers using the separator accepted in their locale
+			var ds = System.Threading.Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+			vm.Text = $"0{ds}7";
+			Assert.That(slider.Value, Is.EqualTo(0.7));
 		}
 		#endif
 

--- a/Xamarin.Forms.Core/BindableProperty.cs
+++ b/Xamarin.Forms.Core/BindableProperty.cs
@@ -51,7 +51,8 @@ namespace Xamarin.Forms
 			{ typeof(long), new[] { typeof(string), typeof(float), typeof(double), typeof(decimal) } },
 			{ typeof(char), new[] { typeof(string), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) } },
 			{ typeof(float), new[] { typeof(string), typeof(double) } },
-			{ typeof(ulong), new[] { typeof(string), typeof(float), typeof(double), typeof(decimal) } }
+			{ typeof(ulong), new[] { typeof(string), typeof(float), typeof(double), typeof(decimal) } },
+			{ typeof(DateTime), new[] { typeof(string) } }
 		};
 
 		BindableProperty(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode = BindingMode.OneWay,
@@ -317,7 +318,7 @@ namespace Xamarin.Forms
 			TypeConverter typeConverterTo;
 			if (SimpleConvertTypes.TryGetValue(valueType, out convertableTo) && Array.IndexOf(convertableTo, type) != -1)
 			{
-				value = Convert.ChangeType(value, type);
+				value = Convert.ChangeType(value, type, System.Globalization.CultureInfo.CurrentCulture);
 			}
 			else if (WellKnownConvertTypes.TryGetValue(type, out typeConverterTo) && typeConverterTo.CanConvertFrom(valueType))
 			{

--- a/Xamarin.Forms.Core/BindableProperty.cs
+++ b/Xamarin.Forms.Core/BindableProperty.cs
@@ -106,6 +106,8 @@ namespace Xamarin.Forms
 
 		public Type ReturnType { get; }
 
+		public bool UseCurrentCulture { get; set; } = false;
+
 		internal BindablePropertyBindingChanging BindingChanging { get; private set; }
 
 		internal CoerceValueDelegate CoerceValue { get; private set; }
@@ -318,7 +320,7 @@ namespace Xamarin.Forms
 			TypeConverter typeConverterTo;
 			if (SimpleConvertTypes.TryGetValue(valueType, out convertableTo) && Array.IndexOf(convertableTo, type) != -1)
 			{
-				value = Convert.ChangeType(value, type, System.Globalization.CultureInfo.CurrentCulture);
+				value = Convert.ChangeType(value, type, UseCurrentCulture ? System.Globalization.CultureInfo.CurrentCulture : System.Globalization.CultureInfo.InvariantCulture);
 			}
 			else if (WellKnownConvertTypes.TryGetValue(type, out typeConverterTo) && typeConverterTo.CanConvertFrom(valueType))
 			{

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -439,7 +439,9 @@ namespace Xamarin.Forms
 					if (stringValue == "-0")
 						throw new FormatException();
 
-					locale = CultureInfo.CurrentCulture;
+					// to change locale if stringValue contains decimal separator for that locale
+					if (stringValue.IndexOf(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator) != -1)
+						locale = CultureInfo.CurrentCulture;
 				}
 
 				value = Convert.ChangeType(value, convertTo, locale);

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -423,19 +423,26 @@ namespace Xamarin.Forms
 				return true;
 
 			object original = value;
+			var locale = CultureInfo.InvariantCulture;
 			try
 			{
 				var stringValue = value as string ?? string.Empty;
-				// see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
-				// do not canonicalize "*.[.]"; "1." should not update bound BindableProperty
-				if (stringValue.EndsWith(".") && DecimalTypes.Contains(convertTo))
-					throw new FormatException();
 
-				// do not canonicalize "-0"; user will likely enter a period after "-0"
-				if (stringValue == "-0" && DecimalTypes.Contains(convertTo))
-					throw new FormatException();
+				if (DecimalTypes.Contains(convertTo))
+				{
+					// see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
+					// do not canonicalize "*.[.]"; "1." should not update bound BindableProperty
+					if (stringValue.EndsWith("."))
+						throw new FormatException();
 
-				value = Convert.ChangeType(value, convertTo, CultureInfo.InvariantCulture);
+					// do not canonicalize "-0"; user will likely enter a period after "-0"
+					if (stringValue == "-0")
+						throw new FormatException();
+
+					locale = CultureInfo.CurrentCulture;
+				}
+
+				value = Convert.ChangeType(value, convertTo, locale);
 				return true;
 			}
 			catch (InvalidCastException)


### PR DESCRIPTION
### Description of Change ###

Fixed converting the date without regard to the installed locale.
You can install the locale using the following code:
```C#
Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("eu-AU");
```

### Issues Resolved ### 

- fixes #2049

### API Changes ###
 
 None

### Platforms Affected ### 

- Core (all platforms)

### Behavioral/Visual Changes ###

Simple types correctly converts to a string from binding context.

### Before/After Screenshots ### 

**Before**
![screenshot_3](https://user-images.githubusercontent.com/27482193/45030000-25ef1600-b053-11e8-8a5d-6f09f5d3c601.png)

**After**
![screenshot_2](https://user-images.githubusercontent.com/27482193/45029886-c8f36000-b052-11e8-9c64-39b5f14e9f1b.png)

### Testing Procedure ###
- run UItest 2049
- click on button "Change locale"
- check result
- click on button "Change locale" ...

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
