### PR TITLE
[Android] Fixed TimePicker to support 24H mode

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		AlertDialog _dialog;
 		TextColorSwitcher _textColorSwitcher;
-		protected bool _is24HourFormat;
+		 
 
 		bool Is24HourView
 		{
@@ -110,7 +110,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual TimePickerDialog CreateTimePickerDialog(int hours, int minutes)
 		{
-			var dialog = new TimePickerDialog(Context, this, hours, minutes, _is24HourFormat);
+			var dialog = new TimePickerDialog(Context, this, hours, minutes, Is24HourView);
 
 			if (Forms.IsLollipopOrNewer)
 				dialog.CancelEvent += OnCancelButtonClicked;


### PR DESCRIPTION
The 24h mode for the pickerdialog was not working.

Version 3.1 was working fine. 

Here is an updated file.

### Platforms Affected ### 
- Android
