### PR TITLE
[UWP] uncomment tests that are now passing for 3188

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
@@ -73,14 +73,11 @@ namespace Xamarin.Forms.Controls.Issues
 			await TestForSuccess(RunningApp, typeof(Issue2338_MasterDetailsPage_ContentPage));
 			await TestForSuccess(RunningApp, typeof(Issue2338_MasterDetailsPage_NavigationPage));
 
-#if !__WINDOWS__ && !__IOS__
+#if !__IOS__
 			await TestForSuccess(RunningApp, typeof(Issue2338_Ctor));
 #endif
 			await TestForSuccess(RunningApp, typeof(Issue2338_Ctor_MultipleChanges));
-
-#if !__WINDOWS__
 			await TestForSuccess(RunningApp, typeof(Issue2338_TabbedPage));
-#endif
 
 #if !__IOS__
 			await TestForSuccess(RunningApp, typeof(Issue2338_MasterDetailsPage));


### PR DESCRIPTION
### Description of Change ###

Remove if defs for UWP that are no longer valid because of https://github.com/xamarin/Xamarin.Forms/pull/3514


### Platforms Affected ### 

- UWP


### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
