### PR TITLE
[Android] Revert bad merge

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -7,6 +7,7 @@ using Android.OS;
 using Android.Views;
 using Android.Views.Animations;
 using ARelativeLayout = Android.Widget.RelativeLayout;
+using AView = Android.Views.View;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
@@ -218,7 +219,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			for (var i = 0; i < _renderer.ChildCount; i++)
 			{
-				global::Android.Views.View child = _renderer.GetChildAt(i);
+				AView child = _renderer.GetChildAt(i);
 				if (child is ModalContainer)
 				{
 					child.Measure(MeasureSpecFactory.MakeMeasureSpec(r - l, MeasureSpecMode.Exactly), MeasureSpecFactory.MakeMeasureSpec(t - b, MeasureSpecMode.Exactly));
@@ -265,7 +266,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			var layout = false;
 
-			var viewsToRemove = new List<global::Android.Views.View>();
+			var viewsToRemove = new List<AView>();
 			var renderersToDispose = new List<IVisualElementRenderer>();
 
 			if (Page != null)
@@ -273,10 +274,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				for (int i = 0; i < _renderer.ChildCount; i++)
 					viewsToRemove.Add(_renderer.GetChildAt(i));
 
-				foreach (IVisualElementRenderer rootRenderer in _navModel.Roots.Select(Android.Platform.GetRenderer))
-				{
-					rootRenderer?.Dispose();
-				}
+				foreach (var root in _navModel.Roots)
+					renderersToDispose.Add(Android.Platform.GetRenderer(root));
 
 				_navModel = new NavigationModel();
 
@@ -300,13 +299,19 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			Application.Current.NavigationProxy.Inner = this;
 		}
 
-		void Cleanup(List<global::Android.Views.View> viewsToRemove, List<IVisualElementRenderer> renderersToDispose)
+		void Cleanup(List<AView> viewsToRemove, List<IVisualElementRenderer> renderersToDispose)
 		{
-			foreach (var view in viewsToRemove)
+			for (int i = 0; i < viewsToRemove.Count; i++)
+			{
+				AView view = viewsToRemove[i];
 				_renderer?.RemoveView(view);
+			}
 
-			foreach (IVisualElementRenderer rootRenderer in renderersToDispose)
+			for (int i = 0; i < renderersToDispose.Count; i++)
+			{
+				IVisualElementRenderer rootRenderer = renderersToDispose[i];
 				rootRenderer?.Dispose();
+			}
 		}
 
 		void AddChild(Page page, bool layout = false)
@@ -381,7 +386,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		sealed class ModalContainer : ViewGroup
 		{
-			global::Android.Views.View _backgroundView;
+			AView _backgroundView;
 			bool _disposed;
 			Page _modal;
 			IVisualElementRenderer _renderer;
@@ -390,7 +395,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				_modal = modal;
 
-				_backgroundView = new global::Android.Views.View(context);
+				_backgroundView = new AView(context);
 				_backgroundView.SetWindowBackground();
 				AddView(_backgroundView);
 


### PR DESCRIPTION
### Description of Change ###

#3283 was built on top of #3187 to incorporate the great changes made there in my tests, but I targeted #3283 to master while #3187 was targeted to 3.1.0. When #3187 was merged down to master in a94074463efe263cfe3056f6e1c65e65c2fac86f, the change [here](https://github.com/xamarin/Xamarin.Forms/pull/3187/files#diff-c986fa1fa0e47f337a0dcc0ec16b5d05R269) was taken. We actually needed to keep the changes that were already in master [here](https://github.com/xamarin/Xamarin.Forms/pull/3283/files#diff-c986fa1fa0e47f337a0dcc0ec16b5d05R276). This was an absolutely confusing merge to do, and I doubt I will do such a silly thing again.

While I was in there, I fixed the ugly `global::` namespaces and converted the `foreach`s to `for`s as previously requested in #3283.

### Issues Resolved ### 

- fixes #3705

### API Changes ###

 None

### Platforms Affected ### 

- Android


### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
1. Open Control Gallery
2. Click "Swap Page - [whatever]".
3. Should not crash! Huzzah!

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
