### PR TITLE
[Android Maps] Make markers available to subclasses

### DIFF
--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -250,7 +250,7 @@ namespace Xamarin.Forms.Maps.Android
 		void PinOnPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			Pin pin = (Pin)sender;
-			Marker marker = _markers.FirstOrDefault(m => m.Id == (string)pin.Id);
+			Marker marker = GetMarkerForPin(pin);
 
 			if (marker == null)
 			{
@@ -269,6 +269,11 @@ namespace Xamarin.Forms.Maps.Android
 			{
 				marker.Position = new LatLng(pin.Position.Latitude, pin.Position.Longitude);
 			}
+		}
+
+        protected GetMarkerForPin(Pin pin)
+        {
+            return _markers?.FirstOrDefault(m => m.Id == (string)pin.Id);
 		}
 
 		void MapOnMarkerClick(object sender, GoogleMap.InfoWindowClickEventArgs eventArgs)
@@ -373,7 +378,7 @@ namespace Xamarin.Forms.Maps.Android
 			foreach (Pin p in pins)
 			{
 				p.PropertyChanged -= PinOnPropertyChanged;
-				var marker = _markers.FirstOrDefault(m => m.Id == (string)p.Id);
+				var marker = GetMarkerForPin(pin);
 
 				if (marker == null)
 				{

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -271,9 +271,9 @@ namespace Xamarin.Forms.Maps.Android
 			}
 		}
 
-        protected GetMarkerForPin(Pin pin)
-        {
-            return _markers?.FirstOrDefault(m => m.Id == (string)pin.Id);
+		protected Marker GetMarkerForPin(Pin pin)
+		{
+			return _markers?.FirstOrDefault(m => m.Id == (string)pin.Id);
 		}
 
 		void MapOnMarkerClick(object sender, GoogleMap.InfoWindowClickEventArgs eventArgs)
@@ -378,7 +378,7 @@ namespace Xamarin.Forms.Maps.Android
 			foreach (Pin p in pins)
 			{
 				p.PropertyChanged -= PinOnPropertyChanged;
-				var marker = GetMarkerForPin(pin);
+				var marker = GetMarkerForPin(p);
 
 				if (marker == null)
 				{

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -273,7 +273,7 @@ namespace Xamarin.Forms.Maps.Android
 
 		protected Marker GetMarkerForPin(Pin pin)
 		{
-			return _markers?.FirstOrDefault(m => m.Id == (string)pin.Id);
+			return _markers?.Find(m => m.Id == (string)pin.Id);
 		}
 
 		void MapOnMarkerClick(object sender, GoogleMap.InfoWindowClickEventArgs eventArgs)


### PR DESCRIPTION
### Description of Change ###
Add method to retrieve native Marker from a pin in Android MapRenderer.  No tests added as it is a simple Extract Method refactoring.

### Issues Resolved ### 
Eases subclassing of MapRenderer to extend pins.  Needed to build a Skia Maps extension Nuget.

### API Changes ###

Added:
protected Marker GetMarkerForPin(Pin pin)

Changed:
N/A
 
 Removed:
N/A
 
### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
N/A

### Testing Procedure ###
N/A

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
