### PR TITLE
WPF - Fix Local store not persistant when restarting App

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3541.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3541.cs
@@ -1,0 +1,58 @@
+﻿using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3541, "[WPF] Fix Local store not persistant when restarting App", PlatformAffected.WPF)]
+	public class Issue3541 : TestContentPage
+	{
+		Entry _entry;
+
+		protected override void Init()
+		{
+			var stack = new StackLayout();
+
+			_entry = new Entry
+			{
+				Placeholder = "Enter a text then click on save",
+				Text = GetText()
+			};
+
+			Button saveButton = new Button
+			{
+				Text = "Save"
+			};
+			saveButton.Clicked += SaveButton_Clicked;
+			
+			stack.Children.Add(_entry);
+			stack.Children.Add(saveButton);
+			Content = stack;
+		}
+
+		private void SaveButton_Clicked(object sender, System.EventArgs e)
+		{
+			this.Save(_entry.Text);
+		}
+
+		private async void Save(string text)
+		{
+			Application.Current.Properties[nameof(Issue3541)] = text;
+			await Application.Current.SavePropertiesAsync();
+		}
+
+		private string GetText()
+		{
+			if (Application.Current.Properties.ContainsKey(nameof(Issue3541)))
+				return Application.Current.Properties[nameof(Issue3541)] as string;
+
+			return null;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,7 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-	  <Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2004.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3333.cs" />
@@ -376,6 +376,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3507.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3367.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3398.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3541.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />

--- a/Xamarin.Forms.Platform.WPF/Deserializer.cs
+++ b/Xamarin.Forms.Platform.WPF/Deserializer.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				IsolatedStorageFile isoStore = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Assembly, null, null);
 
-				using (IsolatedStorageFileStream stream = new IsolatedStorageFileStream(PropertyStoreFile, FileMode.OpenOrCreate, isoStore))
+				using (IsolatedStorageFileStream stream = new IsolatedStorageFileStream(PropertyStoreFile, FileMode.Create, isoStore))
 				{
 					var serializer = new DataContractSerializer(typeof(IDictionary<string, object>));
 					serializer.WriteObject(stream, properties);


### PR DESCRIPTION
### Description of Change ###

Fix : Local store not persistant when restarting App in Xamarin Forms WPF

### Issues Resolved ### 

- fixes #3541