### PR TITLE
WPF - Fix Binding Icon in ToolbarItem in TabbedPage doesn't refresh

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Converters/IconConveter.cs
+++ b/Xamarin.Forms.Platform.WPF/Converters/IconConveter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Windows.Media;
+using Xamarin.Forms.Platform.WPF.Controls;
+using Xamarin.Forms.Platform.WPF.Enums;
+
+namespace Xamarin.Forms.Platform.WPF.Converters
+{
+	public class IconConveter : System.Windows.Data.IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is FileImageSource imageSource)
+			{
+				if (Enum.TryParse(imageSource.File, true, out Symbol symbol))
+					return new FormsSymbolIcon() { Symbol = symbol };
+				else if (TryParseGeometry(imageSource.File, out Geometry geometry))
+					return new FormsPathIcon() { Data = geometry };
+				else if (Path.GetExtension(imageSource.File) != null)
+					return new FormsBitmapIcon() { UriSource = new Uri(imageSource.File, UriKind.RelativeOrAbsolute) };
+			}
+
+			return null;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+
+		private bool TryParseGeometry(string value, out Geometry geometry)
+		{
+			geometry = null;
+			try
+			{
+				geometry = Geometry.Parse(value);
+				return true;
+			}
+			catch (Exception)
+			{
+				return false;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
+++ b/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Converters\CollapseWhenEmptyConverter.cs" />
     <Compile Include="Converters\ColorConverter.cs" />
     <Compile Include="Converters\HeightConverter.cs" />
+    <Compile Include="Converters\IconConveter.cs" />
     <Compile Include="Converters\ImageConverter.cs" />
     <Compile Include="Converters\SymbolToValueConverter.cs" />
     <Compile Include="Converters\ToUpperConverter.cs" />


### PR DESCRIPTION
### Description of Change ###

FIX : Binding an icon in a ToolbarItem in a TabbedPage doesn't refresh when the binding changes. Even changing the icon directly doesn't work. Only way is to remove the ToolbarItem, change it and add it again.

### Issues Resolved ### 

- fixes #3756

### Platforms Affected ### 

- WPF