### PR TITLE
Added a disabled look to Android Toolbar Item images.

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -33,6 +33,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 {
 	public class NavigationPageRenderer : VisualElementRenderer<NavigationPage>, IManageFragments, IOnClickListener, ILifeCycleState
 	{
+		const int DefaultDisabledToolbarAlpha = 127;
+	
 		readonly List<Fragment> _fragmentStack = new List<Fragment>();
 
 		Drawable _backgroundDrawable;
@@ -879,7 +881,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					if (!menuItem.IsEnabled)
 					{
-						iconDrawable.Mutate().SetAlpha(127);
+						iconDrawable.Mutate().SetAlpha(DefaultDisabledToolbarAlpha);
 					}
 
 					menuItem.SetIcon(iconDrawable);

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -18,6 +18,7 @@ using Android.Views;
 using Xamarin.Forms.Internals;
 using ActionBarDrawerToggle = Android.Support.V7.App.ActionBarDrawerToggle;
 using AView = Android.Views.View;
+using AColor = Android.Graphics.Color;
 using AToolbar = Android.Support.V7.Widget.Toolbar;
 using Fragment = Android.Support.V4.App.Fragment;
 using FragmentManager = Android.Support.V4.App.FragmentManager;
@@ -860,8 +861,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else
 				{
 					IMenuItem menuItem = menu.Add(item.Text);
-					UpdateMenuItemIcon(context, menuItem, item);
 					menuItem.SetEnabled(controller.IsEnabled);
+					UpdateMenuItemIcon(context, menuItem, item);
 					menuItem.SetShowAsAction(ShowAsAction.Always);
 					menuItem.SetOnMenuItemClickListener(new GenericMenuClickListener(controller.Activate));
 				}
@@ -876,6 +877,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				Drawable iconDrawable = context.GetFormsDrawable(icon);
 				if (iconDrawable != null)
 				{
+					if (!menuItem.IsEnabled)
+					{
+						iconDrawable.Mutate().SetAlpha(127);
+					}
+
 					menuItem.SetIcon(iconDrawable);
 					iconDrawable.Dispose();
 				}


### PR DESCRIPTION
### Description of Change ###

Toolbar Items on Android do not appear disabled when they are an icon that is not in the overflow menu. There is no visual change between enabled and disabled.

iOS and UWP make changes when disabled.

This change makes them appear with a 50% alpha, similar to disabled text toolbar items.

### Issues Resolved ### 
Fixes #3628 

### API Changes ###

None
 
### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###

If the user disables a Toolbar Item with an icon, it will now have a disabled look on Android.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before:

![image](https://user-images.githubusercontent.com/6599983/45451977-4a29a300-b6a2-11e8-97c4-5ec7e2d9b3a2.png)

After:

![image](https://user-images.githubusercontent.com/6599983/45451865-fcad3600-b6a1-11e8-9632-e3ae8fc8e921.png)

### Testing Procedure ###
Go to the ToolbarItems Gallery page. Observe the disabled icon appearance.

I can sure write a test page if someone tells me where they want it and what exactly you would like on it.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR (not sure, I just pulled master and wrote this in an hour or two, let me know if I need to do something)
- [x] Changes adhere to coding standard
