### PR TITLE
[iOS] Add ability to turn off updates to native controls from another thread

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Application.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Application.cs
@@ -4,6 +4,7 @@
 
 	public static class Application
 	{
+		#region PanGestureRecognizerShouldRecognizeSimultaneously
 		public static readonly BindableProperty PanGestureRecognizerShouldRecognizeSimultaneouslyProperty = BindableProperty.Create("PanGestureRecognizerShouldRecognizeSimultaneously", typeof(bool), typeof(Application), false);
 
 		public static bool GetPanGestureRecognizerShouldRecognizeSimultaneously(BindableObject element)
@@ -26,5 +27,31 @@
 			SetPanGestureRecognizerShouldRecognizeSimultaneously(config.Element, value);
 			return config;
 		}
+		#endregion
+
+		#region HandleControlUpdatesOnMainThread
+		public static readonly BindableProperty HandleControlUpdatesOnMainThreadProperty = BindableProperty.Create("HandleControlUpdatesOnMainThread", typeof(bool), typeof(Application), false);
+
+		public static bool GetHandleControlUpdatesOnMainThread(BindableObject element)
+		{
+			return (bool)element.GetValue(HandleControlUpdatesOnMainThreadProperty);
+		}
+
+		public static void SetHandleControlUpdatesOnMainThread(BindableObject element, bool value)
+		{
+			element.SetValue(HandleControlUpdatesOnMainThreadProperty, value);
+		}
+
+		public static bool GetHandleControlUpdatesOnMainThread(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetHandleControlUpdatesOnMainThread(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetHandleControlUpdatesOnMainThread(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		{
+			SetHandleControlUpdatesOnMainThread(config.Element, value);
+			return config;
+		}
+		#endregion
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using CoreAnimation;
 using Xamarin.Forms.Internals;
 #if __MOBILE__
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms.Platform.iOS
 #else
@@ -32,14 +33,12 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public VisualElementTracker(IVisualElementRenderer renderer)
 		{
-			if (renderer == null)
-				throw new ArgumentNullException("renderer");
+			Renderer = renderer ?? throw new ArgumentNullException("renderer");
 
 			_propertyChangedHandler = HandlePropertyChanged;
 			_sizeChangedEventHandler = HandleSizeChanged;
 			_batchCommittedHandler = HandleRedrawNeeded;
 
-			Renderer = renderer;
 			renderer.ElementChanged += OnRendererElementChanged;
 			SetElement(null, renderer.Element);
 		}
@@ -143,9 +142,9 @@ namespace Xamarin.Forms.Platform.MacOS
 #if !__MOBILE__
 			var viewParent = view.RealParent as VisualElement;
 			var parentBoundsChanged = _lastParentBounds != (viewParent == null ? Rectangle.Zero : viewParent.Bounds);
+#else
+			var thread = Application.Current?.OnThisPlatform()?.GetHandleControlUpdatesOnMainThread() == false && !boundsChanged && !caLayer.Frame.IsEmpty;
 #endif
-			var thread = !boundsChanged && !caLayer.Frame.IsEmpty;
-
 			var anchorX = (float)view.AnchorX;
 			var anchorY = (float)view.AnchorY;
 			var translationX = (float)view.TranslationX;
@@ -165,7 +164,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			var updateTarget = Interlocked.Increment(ref _updateCount);
 
-			Action update = () =>
+			void update()
 			{
 				if (updateTarget != _updateCount)
 					return;
@@ -262,7 +261,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				transform = transform.Rotate(rotation * (float)Math.PI / 180.0f, 0.0f, 0.0f, 1.0f);
 				caLayer.Transform = transform;
-			};
+			}
 
 #if __MOBILE__
 			if (thread)

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -143,7 +143,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			var viewParent = view.RealParent as VisualElement;
 			var parentBoundsChanged = _lastParentBounds != (viewParent == null ? Rectangle.Zero : viewParent.Bounds);
 #else
-			var thread = Application.Current?.OnThisPlatform()?.GetHandleControlUpdatesOnMainThread() == false && !boundsChanged && !caLayer.Frame.IsEmpty;
+			var thread = !boundsChanged && !caLayer.Frame.IsEmpty && Application.Current?.OnThisPlatform()?.GetHandleControlUpdatesOnMainThread() == false;
 #endif
 			var anchorX = (float)view.AnchorX;
 			var anchorY = (float)view.AnchorY;


### PR DESCRIPTION
### Description of Change ###

Added a platform specific property to iOS that allows you to direct all control layout/rendering updates to the main thread instead of to a background thread. This should be rarely needed, but in some cases, it may prevent crashes.

### Issues Resolved ### 

- fixes #1755

### API Changes ###

Added:
 - `void On<iOS>().GetHandleControlUpdatesOnMainThread() //Platform Specific`
 - `bool On<iOS>().SetHandleControlUpdatesOnMainThread(true/false) //Platform Specific`

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Since SkiaSharp.Views.Forms doesn't play well with our ControlGallery, you'll need to use the sample project provided in #1755 and the nuget package produced by the build.

1. Get project from #1755 (CADError).
2. Run project. Verify crash.
3. Update Xamarin.Forms nuget package to the package created by this build.
4. In `App.xaml.cs`, add `using Xamarin.Forms.PlatformConfiguration.iOSSpecific;` at the top of the file and add `On<Xamarin.Forms.PlatformConfiguration.iOS>().SetHandleControlUpdatesOnMainThread(true);` to the end of the ctor.
5. Verify no crash.

Note that if your connection to the remote simulator is particularly slow, you may not see the crash. I verified the crash on my device very quickly (within 10 seconds).

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
