### PR TITLE
[Android] Fix WebView.Navigating event, make WebViewClient inheritable

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.Graphics;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Webkit;
+using Android.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	public class FormsWebViewClient : WebViewClient
+	{
+		WebNavigationResult _navigationResult = WebNavigationResult.Success;
+		WebViewRenderer _renderer;
+
+		public FormsWebViewClient(WebViewRenderer renderer)
+		{
+			if (renderer == null)
+				throw new ArgumentNullException("renderer");
+			_renderer = renderer;
+		}
+
+		public override void OnPageStarted(global::Android.Webkit.WebView view, string url, Bitmap favicon)
+		{
+			if (_renderer.Element == null || url == WebViewRenderer.AssetBaseUrl)
+				return;
+
+			var args = new WebNavigatingEventArgs(WebNavigationEvent.NewPage, new UrlWebViewSource { Url = url }, url);
+
+			_renderer.ElementController.SendNavigating(args);
+			_navigationResult = WebNavigationResult.Success;
+
+			_renderer.UpdateCanGoBackForward();
+
+			if (args.Cancel)
+			{
+				_renderer.Control.StopLoading();
+			}
+			else
+			{
+				base.OnPageStarted(view, url, favicon);
+			}
+		}
+
+		public override void OnPageFinished(global::Android.Webkit.WebView view, string url)
+		{
+			if (_renderer.Element == null || url == WebViewRenderer.AssetBaseUrl)
+				return;
+
+			var source = new UrlWebViewSource { Url = url };
+			_renderer.IgnoreSourceChanges = true;
+			_renderer.ElementController.SetValueFromRenderer(WebView.SourceProperty, source);
+			_renderer.IgnoreSourceChanges = false;
+
+			var args = new WebNavigatedEventArgs(WebNavigationEvent.NewPage, source, url, _navigationResult);
+
+			_renderer.ElementController.SendNavigated(args);
+
+			_renderer.UpdateCanGoBackForward();
+
+			base.OnPageFinished(view, url);
+		}
+
+		[Obsolete("OnReceivedError is obsolete as of version 2.3.0. This method was deprecated in API level 23.")]
+		public override void OnReceivedError(global::Android.Webkit.WebView view, ClientError errorCode, string description, string failingUrl)
+		{
+			_navigationResult = WebNavigationResult.Failure;
+			if (errorCode == ClientError.Timeout)
+				_navigationResult = WebNavigationResult.Timeout;
+#pragma warning disable 618
+			base.OnReceivedError(view, errorCode, description, failingUrl);
+#pragma warning restore 618
+		}
+
+		public override void OnReceivedError(global::Android.Webkit.WebView view, IWebResourceRequest request, WebResourceError error)
+		{
+			_navigationResult = WebNavigationResult.Failure;
+			if (error.ErrorCode == ClientError.Timeout)
+				_navigationResult = WebNavigationResult.Timeout;
+			base.OnReceivedError(view, request, error);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+			if (disposing)
+				_renderer = null;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
@@ -26,9 +26,14 @@ namespace Xamarin.Forms.Platform.Android
 			_renderer = renderer;
 		}
 
+		protected FormsWebViewClient(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+		{
+
+		}
+
 		public override void OnPageStarted(global::Android.Webkit.WebView view, string url, Bitmap favicon)
 		{
-			if (_renderer.Element == null || url == WebViewRenderer.AssetBaseUrl)
+			if (_renderer?.Element == null || url == WebViewRenderer.AssetBaseUrl)
 				return;
 
 			var args = new WebNavigatingEventArgs(WebNavigationEvent.NewPage, new UrlWebViewSource { Url = url }, url);
@@ -50,7 +55,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override void OnPageFinished(global::Android.Webkit.WebView view, string url)
 		{
-			if (_renderer.Element == null || url == WebViewRenderer.AssetBaseUrl)
+			if (_renderer?.Element == null || url == WebViewRenderer.AssetBaseUrl)
 				return;
 
 			var source = new UrlWebViewSource { Url = url };

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		public const string AssetBaseUrl = "file:///android_asset/";
 
-		FormsWebViewClient _webViewClient;
+		WebViewClient _webViewClient;
 		FormsWebChromeClient _webChromeClient;
 
 		public IWebViewController ElementController => Element;
@@ -64,7 +64,7 @@ namespace Xamarin.Forms.Platform.Android
 			base.Dispose(disposing);
 		}
 
-		protected virtual FormsWebViewClient GetFormsWebViewClient()
+		protected virtual WebViewClient GetWebViewClient()
 		{
 			return new FormsWebViewClient(this);
 		}
@@ -95,7 +95,7 @@ namespace Xamarin.Forms.Platform.Android
 				webView.LayoutParameters = new global::Android.Widget.AbsoluteLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, 0, 0);
 #pragma warning restore 618
 
-				_webViewClient = GetFormsWebViewClient();
+				_webViewClient = GetWebViewClient();
 				webView.SetWebViewClient(_webViewClient);
 
 				_webChromeClient = GetFormsWebChromeClient();

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -20,8 +20,8 @@ namespace Xamarin.Forms.Platform.Android
 		WebViewClient _webViewClient;
 		FormsWebChromeClient _webChromeClient;
 
-		public IWebViewController ElementController => Element;
-		public bool IgnoreSourceChanges { get; set; }
+		protected internal IWebViewController ElementController => Element;
+		protected internal bool IgnoreSourceChanges { get; set; }
 
 		public WebViewRenderer(Context context) : base(context)
 		{
@@ -185,7 +185,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateCanGoBackForward();
 		}
 
-		public void UpdateCanGoBackForward()
+		protected internal void UpdateCanGoBackForward()
 		{
 			if (Element == null || Control == null)
 				return;

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -15,10 +15,13 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public class WebViewRenderer : ViewRenderer<WebView, AWebView>, IWebViewDelegate
 	{
-		bool _ignoreSourceChanges;
+		public const string AssetBaseUrl = "file:///android_asset/";
+
+		FormsWebViewClient _webViewClient;
 		FormsWebChromeClient _webChromeClient;
 
-		IWebViewController ElementController => Element;
+		public IWebViewController ElementController => Element;
+		public bool IgnoreSourceChanges { get; set; }
 
 		public WebViewRenderer(Context context) : base(context)
 		{
@@ -33,7 +36,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void LoadHtml(string html, string baseUrl)
 		{
-			Control.LoadDataWithBaseURL(baseUrl == null ? "file:///android_asset/" : baseUrl, html, "text/html", "UTF-8", null);
+			Control.LoadDataWithBaseURL(baseUrl ?? AssetBaseUrl, html, "text/html", "UTF-8", null);
 		}
 
 		public void LoadUrl(string url)
@@ -47,17 +50,23 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (Element != null)
 				{
-					if (Control != null)
-						Control.StopLoading();
+					Control?.StopLoading();
+
 					ElementController.EvalRequested -= OnEvalRequested;
 					ElementController.GoBackRequested -= OnGoBackRequested;
 					ElementController.GoForwardRequested -= OnGoForwardRequested;
 
+					_webViewClient?.Dispose();
 					_webChromeClient?.Dispose();
 				}
 			}
 
 			base.Dispose(disposing);
+		}
+
+		protected virtual FormsWebViewClient GetFormsWebViewClient()
+		{
+			return new FormsWebViewClient(this);
 		}
 
 		protected virtual FormsWebChromeClient GetFormsWebChromeClient()
@@ -85,7 +94,9 @@ namespace Xamarin.Forms.Platform.Android
 #pragma warning disable 618 // This can probably be replaced with LinearLayout(LayoutParams.MatchParent, LayoutParams.MatchParent); just need to test that theory
 				webView.LayoutParameters = new global::Android.Widget.AbsoluteLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, 0, 0);
 #pragma warning restore 618
-				webView.SetWebViewClient(new WebClient(this));
+
+				_webViewClient = GetFormsWebViewClient();
+				webView.SetWebViewClient(_webViewClient);
 
 				_webChromeClient = GetFormsWebChromeClient();
 				_webChromeClient.SetContext(Context as Activity);
@@ -136,11 +147,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		void Load()
 		{
-			if (_ignoreSourceChanges)
+			if (IgnoreSourceChanges)
 				return;
 
-			if (Element.Source != null)
-				Element.Source.Load(this);
+			Element.Source?.Load(this);
 
 			UpdateCanGoBackForward();
 		}
@@ -175,7 +185,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateCanGoBackForward();
 		}
 
-		void UpdateCanGoBackForward()
+		public void UpdateCanGoBackForward()
 		{
 			if (Element == null || Control == null)
 				return;
@@ -188,79 +198,6 @@ namespace Xamarin.Forms.Platform.Android
 			if (Control != null && ((int)Build.VERSION.SdkInt >= 21))
 			{
 				Control.Settings.MixedContentMode = (MixedContentHandling)Element.OnThisPlatform().MixedContentMode();
-			}
-		}
-
-		class WebClient : WebViewClient
-		{
-			WebNavigationResult _navigationResult = WebNavigationResult.Success;
-			WebViewRenderer _renderer;
-
-			public WebClient(WebViewRenderer renderer)
-			{
-				if (renderer == null)
-					throw new ArgumentNullException("renderer");
-				_renderer = renderer;
-			}
-
-			public override void OnPageFinished(AWebView view, string url)
-			{
-				if (_renderer.Element == null || url == "file:///android_asset/")
-					return;
-
-				var source = new UrlWebViewSource { Url = url };
-				_renderer._ignoreSourceChanges = true;
-				_renderer.ElementController.SetValueFromRenderer(WebView.SourceProperty, source);
-				_renderer._ignoreSourceChanges = false;
-
-				var args = new WebNavigatedEventArgs(WebNavigationEvent.NewPage, source, url, _navigationResult);
-
-				_renderer.ElementController.SendNavigated(args);
-
-				_renderer.UpdateCanGoBackForward();
-
-				base.OnPageFinished(view, url);
-			}
-
-			[Obsolete("OnReceivedError is obsolete as of version 2.3.0. This method was deprecated in API level 23.")]
-			public override void OnReceivedError(AWebView view, ClientError errorCode, string description, string failingUrl)
-			{
-				_navigationResult = WebNavigationResult.Failure;
-				if (errorCode == ClientError.Timeout)
-					_navigationResult = WebNavigationResult.Timeout;
-#pragma warning disable 618
-				base.OnReceivedError(view, errorCode, description, failingUrl);
-#pragma warning restore 618
-			}
-
-			public override void OnReceivedError(AWebView view, IWebResourceRequest request, WebResourceError error)
-			{
-				_navigationResult = WebNavigationResult.Failure;
-				if (error.ErrorCode == ClientError.Timeout)
-					_navigationResult = WebNavigationResult.Timeout;
-				base.OnReceivedError(view, request, error);
-			}
-
-			[Obsolete]
-			public override bool ShouldOverrideUrlLoading(AWebView view, string url)
-			{
-				if (_renderer.Element == null)
-					return true;
-
-				var args = new WebNavigatingEventArgs(WebNavigationEvent.NewPage, new UrlWebViewSource { Url = url }, url);
-
-				_renderer.ElementController.SendNavigating(args);
-				_navigationResult = WebNavigationResult.Success;
-
-				_renderer.UpdateCanGoBackForward();
-				return args.Cancel;
-			}
-
-			protected override void Dispose(bool disposing)
-			{
-				base.Dispose(disposing);
-				if (disposing)
-					_renderer = null;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -160,6 +160,7 @@
     <Compile Include="GetDesiredSizeDelegate.cs" />
     <Compile Include="IDeviceInfoProvider.cs" />
     <Compile Include="ITabStop.cs" />
+    <Compile Include="Renderers\FormsWebViewClient.cs" />
     <Compile Include="Renderers\IImageViewHandler.cs" />
     <Compile Include="InnerGestureListener.cs" />
     <Compile Include="InnerScaleListener.cs" />


### PR DESCRIPTION
### Description of Change ###

- Extracted WebViewRenderer.WebClient to FormsWebViewClient so that it can be inherited from and overwritten when custom renderers require a custom WebViewClient
- Moved firing of WebView.Navigating event from ShouldOverrideUrlLoading to OnPageStarted in FormsWebViewClient so that it is consistently fired every time a URL is navigated to including initial load

### Issues Resolved ### 

- fixes #3778 

### API Changes ###

Added:
 - public override void FormsWebViewClient.OnPageStarted(WebView view, string url, Bitmap favicon)
 - public const string WebViewRenderer.AssetBaseUrl = "file:///android_asset/"
 - protected virtual FormsWebViewClient WebViewRenderer.GetFormsWebViewClient()
 - FormsWebViewClient WebViewRenderer._webViewClient 

Changed:
 - class WebViewRenderer.WebClient => public class FormsWebViewClient
 - bool WebViewRenderer._ignoreSourceChanges => public bool WebViewRenderer.IgnoreSourceChanges { get; set; }
 - IWebViewController WebViewRenderer.ElementController => public IWebViewController WebViewRenderer.ElementController
 - void WebViewRenderer.UpdateCanGoBackForward() => public void WebViewRenderer.UpdateCanGoBackForward()  
 
 Removed:
 - WebClient.ShouldOverrideUrlLoading(WebView view, string url)

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

WebView.Navigating will be fired for the initial URL load in addition to redirects and subsequent navigations.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

 - In the WebViewCoreGalleryPage, add a listener to the element's Navigating event in InitializeElement(). 
 - Change the source URL from http://xamarin.com/ (which gets redirected to https://visualstudio.microsoft.com/xamarin/) to https://www.google.com (which will not be redirected). 
- Run the ControlGallery and verify that the Navigating event is fired for https://www.google.com

### PR Checklist ###

- [ ] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
