### PR TITLE
[A] do not draw gradient for empty CornerRadius

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -59,15 +59,20 @@ namespace Xamarin.Forms.Platform.Android
 			if (colorToSet == Color.Default)
 				colorToSet = Element.BackgroundColor;
 
-			if (_backgroundDrawable == null)
-				_backgroundDrawable = new GradientDrawable();
+			if (_backgroundDrawable != null) {
 
-			if (colorToSet != Color.Default)
-				_backgroundDrawable.SetColor(colorToSet.ToAndroid());
-			else
-				_backgroundDrawable.SetColor(colorToSet.ToAndroid(Color.Transparent));
+				if (colorToSet != Color.Default)
+					_backgroundDrawable.SetColor(colorToSet.ToAndroid());
+				else
+					_backgroundDrawable.SetColor(colorToSet.ToAndroid(Color.Transparent));
 
-			this.SetBackground(_backgroundDrawable);
+				this.SetBackground(_backgroundDrawable);
+			}
+			else {
+				if (colorToSet == Color.Default)
+					colorToSet = Element.BackgroundColor;
+				SetBackgroundColor(colorToSet.ToAndroid(Color.Transparent));
+			}
 		}
 
 		protected override void Dispose(bool disposing)
@@ -101,26 +106,32 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateCornerRadius()
 		{
 			var cornerRadius = Element.CornerRadius;
-
-			if (Background is GradientDrawable backgroundGradient)
-			{
-				var cornerRadii = new[]
-				{
-					(float)(cornerRadius.TopLeft),
-					(float)(cornerRadius.TopLeft),
-
-					(float)(cornerRadius.TopRight),
-					(float)(cornerRadius.TopRight),
-
-					(float)(cornerRadius.BottomRight),
-					(float)(cornerRadius.BottomRight),
-
-					(float)(cornerRadius.BottomLeft),
-					(float)(cornerRadius.BottomLeft)
-				};
-
-				backgroundGradient.SetCornerRadii(cornerRadii);
+			if (cornerRadius == new CornerRadius(0d)) {
+				_backgroundDrawable?.Dispose();
+				_backgroundDrawable = null;
 			}
+			else {
+				this.SetBackground(_backgroundDrawable = new GradientDrawable());
+				if (Background is GradientDrawable backgroundGradient) {
+					var cornerRadii = new[] {
+						(float)(cornerRadius.TopLeft),
+						(float)(cornerRadius.TopLeft),
+
+						(float)(cornerRadius.TopRight),
+						(float)(cornerRadius.TopRight),
+
+						(float)(cornerRadius.BottomRight),
+						(float)(cornerRadius.BottomRight),
+
+						(float)(cornerRadius.BottomLeft),
+						(float)(cornerRadius.BottomLeft)
+					};
+
+					backgroundGradient.SetCornerRadii(cornerRadii);
+				}
+			}
+
+			UpdateBackgroundColor();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Drawing CornerRadius (introduced by #1998) when the CornerRadii are
actually 0 causes scaling artifacts on API < 25.

This fixes the regression when no CornerRadius is set. Expect blurry
border scaling with CornerRadius not empty and API < 25

### Issues Resolved ### 

- fixes #3781

### API Changes ###

None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
