### PR TITLE
[UITests] wait for element before querying for it

### DIFF
--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -33,5 +33,20 @@ namespace Xamarin.Forms.Core.UITests
 			app.Tap (q => q.Raw (goToTestButtonQuery));
 			app.WaitForNoElement (o => o.Raw (goToTestButtonQuery), "Timed out waiting for Go To Test button to disappear", TimeSpan.FromMinutes(2));
 		}
+
+
+		public static AppResult[] QueryNTimes(this IApp app, Func<AppQuery, AppQuery> elementQuery, int numberOfTries, Action onFail)
+		{
+			int tryCount = 0;
+			var elements = app.Query(elementQuery);
+			while (elements.Length == 0 && tryCount < numberOfTries)
+			{
+				elements = app.Query(elementQuery);
+				tryCount++;
+				if (elements.Length == 0 && onFail != null) onFail();
+			}
+
+			return elements;
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/Gestures.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/Gestures.cs
@@ -7,128 +7,85 @@ namespace Xamarin.Forms.Core.UITests
 {
 	internal static class Gestures
 	{
-		static AppRect GetAppRect(this IApp app, Func<AppQuery, AppQuery> elementQuery)
+		public static bool ScrollForElement(this IApp app, string query, Drag drag, int maxSteps = 25)
 		{
-			int tryCount = 0;
-			var elements = app.Query(elementQuery);
-			while (elements.Count() == 0 && tryCount < 10)
-			{
-				elements = app.WaitForElement(elementQuery);
-				tryCount++;
-			}
-
-			if(elements.Count() == 0)
-			{
-				throw new Exception("Failed to Retreive Element from elementQuery");
-			}
-
-			return elements.First().Rect;
-		}
-			
-		public static bool ScrollForElement (this IApp app, string query, Drag drag, int maxSteps = 25)
-		{
-			Func<AppQuery, AppQuery> elementQuery = q => q.Raw (query);
-
-			int count = 0;
+			Func<AppQuery, AppQuery> elementQuery = q => q.Raw(query);
 
 			int centerTolerance = 50;
+			var appResults = app.QueryNTimes(elementQuery, 10, null);
 
 			// Visible elements
-			if (app.Query (elementQuery).Length > 1) {
-				throw new UITestQueryMultipleResultsException (query);
-			}
+			if (appResults.Length > 1)
+				throw new UITestQueryMultipleResultsException(query);
 
-			// check to see if the element is visible already
-			if (app.Query (elementQuery).Length == 1) {
+			appResults = app.QueryNTimes(elementQuery, maxSteps, () => app.DragCoordinates(drag.XStart, drag.YStart, drag.XEnd, drag.YEnd));
+			if (appResults.Length > 0)
+			{
 				// centering an element whos CenterX is close to the bounding rectangle's center X can sometime register the swipe as a tap
-				float elementDistanceToDragCenter = Math.Abs (app.GetAppRect(elementQuery).CenterY - drag.DragBounds.CenterY);
- 				if (elementDistanceToDragCenter > centerTolerance)
-					app.CenterElementInView (elementQuery, drag.DragBounds, drag.DragDirection);
-				return true;
-			}
-
-			// loop until element is seen
-			while (app.Query (elementQuery).Length == 0 && count < maxSteps) {
-				app.DragCoordinates (drag.XStart, drag.YStart, drag.XEnd, drag.YEnd);
-				count++;
-			}
-
-			if (count != maxSteps) {
-				var elements = app.Query(elementQuery);
-				while (elements.Count() == 0)
-				{
-					app.WaitForElement(elementQuery);
-					elements = app.Query(elementQuery);
-				}
-
-				// centering an element whos CenterX is close to the bounding rectangle's center X can sometime register the swipe as a tap
-				float elementDistanceToDragCenter = Math.Abs (app.GetAppRect(elementQuery).CenterY - drag.DragBounds.CenterY);
+				float elementDistanceToDragCenter = Math.Abs(appResults.First().Rect.CenterY - drag.DragBounds.CenterY);
 				if (elementDistanceToDragCenter > centerTolerance)
-					app.CenterElementInView (elementQuery, drag.DragBounds, drag.DragDirection);
+					app.CenterElementInView(appResults.First().Rect, drag.DragBounds, drag.DragDirection);
 				return true;
 			}
 
-			count = 0;
 			drag.DragDirection = drag.OppositeDirection;
+			appResults = app.QueryNTimes(elementQuery, maxSteps, () => app.DragCoordinates(drag.XStart, drag.YStart, drag.XEnd, drag.YEnd));
 
-			while (app.Query (elementQuery).Length == 0 && count < maxSteps) {
-				app.DragCoordinates (drag.XStart, drag.YStart, drag.XEnd, drag.YEnd);
-				count++;
-			}
-
-			if (count != maxSteps) {
-				app.CenterElementInView (elementQuery, drag.DragBounds, drag.DragDirection);
+			if (appResults.Length > 0)
+			{
+				app.CenterElementInView(appResults.First().Rect, drag.DragBounds, drag.DragDirection);
 				return true;
 			}
 
 			return false;
 		}
-			
-		static void CenterElementInView (this IApp app, Func<AppQuery, AppQuery> element, AppRect containingView, Drag.Direction direction)
+
+		static void CenterElementInView(this IApp app, AppRect elementBounds, AppRect containingView, Drag.Direction direction)
 		{
 			// TODO Implement horizontal centering
 
-			if (direction == Drag.Direction.BottomToTop || direction == Drag.Direction.TopToBottom) {
-
-				var elementBounds = app.GetAppRect(element);
-
+			if (direction == Drag.Direction.BottomToTop || direction == Drag.Direction.TopToBottom)
+			{
 				bool elementCenterBelowContainerCenter = elementBounds.CenterY > containingView.CenterY;
 				bool elementCenterAboveContainerCenter = elementBounds.CenterY < containingView.CenterY;
 
-				var displacementToCenter = Math.Abs (elementBounds.CenterY - containingView.CenterY) / 2;
+				var displacementToCenter = Math.Abs(elementBounds.CenterY - containingView.CenterY) / 2;
 
 				// avoid drag as touch
 				if (displacementToCenter < 50)
 					return;
 
-				if (elementCenterBelowContainerCenter) {
-			
-					var drag = new Drag (
+				if (elementCenterBelowContainerCenter)
+				{
+
+					var drag = new Drag(
 						containingView,
 						containingView.CenterX, containingView.CenterY + displacementToCenter,
 						containingView.CenterX, containingView.CenterY - displacementToCenter,
 						Drag.Direction.BottomToTop
 						);
 
-					app.DragCoordinates (drag.XStart, drag.YStart, drag.XEnd, drag.YEnd);
+					app.DragCoordinates(drag.XStart, drag.YStart, drag.XEnd, drag.YEnd);
 
-				} else if (elementCenterAboveContainerCenter) {
+				}
+				else if (elementCenterAboveContainerCenter)
+				{
 
-					var drag = new Drag (
+					var drag = new Drag(
 						containingView,
 						containingView.CenterX, containingView.CenterY - displacementToCenter,
 						containingView.CenterX, containingView.CenterY + displacementToCenter,
 						Drag.Direction.TopToBottom
 						);
 
-					app.DragCoordinates (drag.XStart, drag.YStart, drag.XEnd, drag.YEnd);
+					app.DragCoordinates(drag.XStart, drag.YStart, drag.XEnd, drag.YEnd);
 				}
-			} 
+			}
 		}
 
-		public static void Pan (this IApp app, Drag drag)
+		public static void Pan(this IApp app, Drag drag)
 		{
-			app.DragCoordinates (drag.XStart, drag.YStart, drag.XEnd, drag.YEnd);
+			app.DragCoordinates(drag.XStart, drag.YStart, drag.XEnd, drag.YEnd);
 		}
 
 		public static void ActivateContextMenu(this IApp app, string target)


### PR DESCRIPTION
### Description of Change ###
When attempting to scroll during UI Tests, occasionally the timing of the scroll and querying for an element don't match up. This attempts to query a few times before failing.

### Issues Resolved ### 
This attempts to resolve random failures with calls to *App.ScrollForElement*

### Platforms Affected ### 
UI TESTS

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
