### PR TITLE
[UWP] implement Replace without reloading ListView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3788.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3788.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3788, "[UWP] ListView with observable collection always seems to refresh the entire list",
+		PlatformAffected.UWP)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue3788 : TestContentPage
+	{
+		const string _replaceMe = "Replace Me";
+		const string _last = "Last";
+		const string _buttonText = "Scroll down and click me";
+
+		protected override void Init()
+		{
+			ChangingList data =
+				new ChangingList(Enumerable.Range(0, 1000).Select(_ => new TestModel()));
+
+			data.Add(new TestModel() { Text = _replaceMe });
+			ListView view = new ListView();
+
+			view.ItemTemplate = new DataTemplate(() =>
+			{
+				ViewCell cell = new ViewCell();
+				Label label = new Label();
+				label.SetBinding(Label.TextProperty, "Text");
+				cell.View = label;
+				return cell;
+			});
+
+			view.ItemsSource = data;
+			view.VerticalOptions = LayoutOptions.StartAndExpand;
+			view.ScrollTo(data.Last(), ScrollToPosition.End, false);
+			Content = new StackLayout()
+			{
+				Children =
+					{
+						view,
+						new Button()
+						{
+							Text = _buttonText,
+							Command = new Command(() =>
+							{
+								data.Test();
+							})
+						}
+					}
+			};
+		}
+
+		[Preserve(AllMembers = true)]
+		public class ChangingList : List<TestModel>, INotifyCollectionChanged
+		{
+			public ChangingList(IEnumerable<TestModel> collection) : base(collection)
+			{
+			}
+
+			public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+			public void Test()
+			{
+				var oldItem = this[this.Count - 1];
+				this[this.Count - 1] = new TestModel() { Text = _last };
+				CollectionChanged?.Invoke(this,
+					new NotifyCollectionChangedEventArgs(
+							NotifyCollectionChangedAction.Replace,
+							this[this.Count - 1], oldItem, this.Count - 1
+						));
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class TestModel
+		{
+			public string Text { get; set; } = Guid.NewGuid().ToString();
+			public override string ToString()
+			{
+				return Text;
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void ReplaceItemScrollsListToTop()
+		{
+			RunningApp.WaitForElement(_replaceMe);
+			RunningApp.Tap(_buttonText);
+			RunningApp.WaitForElement(_last);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,7 +9,8 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-	  <Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3788.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2004.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3333.cs" />

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -153,7 +153,7 @@ namespace Xamarin.Forms.Platform.UWP
 						break;
 					case NotifyCollectionChangedAction.Move:
 						{
-							var collection = ((ObservableCollection<object>)_collection);
+							var collection = (ObservableCollection<object>)_collection;
 							for (var i = 0; i < e.OldItems.Count; i++)
 							{
 								var oldi = e.OldStartingIndex;
@@ -171,12 +171,12 @@ namespace Xamarin.Forms.Platform.UWP
 						break;
 					case NotifyCollectionChangedAction.Replace:
 						{
-							var collection = ((ObservableCollection<object>)_collection);
+							var collection = (ObservableCollection<object>)_collection;
 							var newi = e.NewStartingIndex;
 							for (var i = 0; i < e.NewItems.Count; i++)
 							{
 								newi += i;
-								collection[newi] = e.NewItems[i];
+								collection[newi] = (e.NewItems[i] as BindableObject).BindingContext;
 							}
 						}
 						break;

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Forms.Platform.UWP
 						GroupStyleSelector = (GroupStyleSelector)WApp.Current.Resources["ListViewGroupSelector"]
 					};
 
-					List.SelectionChanged += OnControlSelectionChanged;	
+					List.SelectionChanged += OnControlSelectionChanged;
 				}
 
 				ReloadData();
@@ -117,7 +117,7 @@ namespace Xamarin.Forms.Platform.UWP
 				Source = _collection,
 				IsSourceGrouped = Element.IsGroupingEnabled
 			};
-			
+
 			List.ItemsSource = _collectionViewSource.View;
 		}
 
@@ -152,22 +152,34 @@ namespace Xamarin.Forms.Platform.UWP
 							_collection.RemoveAt(e.OldStartingIndex);
 						break;
 					case NotifyCollectionChangedAction.Move:
-						for (var i = 0; i < e.OldItems.Count; i++)
 						{
-							var oldi = e.OldStartingIndex;
-							var newi = e.NewStartingIndex;
-
-							if (e.NewStartingIndex < e.OldStartingIndex)
+							var collection = ((ObservableCollection<object>)_collection);
+							for (var i = 0; i < e.OldItems.Count; i++)
 							{
-								oldi += i;
-								newi += i;
-							}
+								var oldi = e.OldStartingIndex;
+								var newi = e.NewStartingIndex;
 
-							// we know that wrapped collection is an ObservableCollection<object>
-							((ObservableCollection<object>)_collection).Move(oldi, newi);
+								if (e.NewStartingIndex < e.OldStartingIndex)
+								{
+									oldi += i;
+									newi += i;
+								}
+
+								collection.Move(oldi, newi);
+							}
 						}
 						break;
 					case NotifyCollectionChangedAction.Replace:
+						{
+							var collection = ((ObservableCollection<object>)_collection);
+							var newi = e.NewStartingIndex;
+							for (var i = 0; i < e.NewItems.Count; i++)
+							{
+								newi += i;
+								collection[newi] = e.NewItems[i];
+							}
+						}
+						break;
 					case NotifyCollectionChangedAction.Reset:
 					default:
 						ClearSizeEstimate();


### PR DESCRIPTION
### Description of Change ###
Currently when replacing an item in an ObservableCollection it causes the entire list to reload and scroll to the top.  This change correctly implements Replace opposed to just reloading the entire list

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3788 

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP


### Testing Procedure ###
1) Run Issue3788 in the control gallery
2) click the button 
3) this should replace the last item on the list and the list shouldn't scroll to the top

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
