### PR TITLE
Fixes failed activation of ListViewAdapter when using nested ListViews and DataTemplateSelector

### DIFF
--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -10,6 +10,7 @@ using AView = Android.Views.View;
 using AListView = Android.Widget.ListView;
 using Android.Graphics.Drawables;
 using Android.Support.V7.App;
+using Android.Runtime;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -23,6 +24,10 @@ namespace Xamarin.Forms.Platform.Android
 		bool _actionModeNeedsUpdates;
 		AView _contextView;
 		global::Android.Support.V7.View.ActionMode _supportActionMode;
+
+		protected CellAdapter(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+		{
+		}
 
 		protected CellAdapter(Context context)
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -10,6 +10,7 @@ using AView = Android.Views.View;
 using AListView = Android.Widget.ListView;
 using Xamarin.Forms.Internals;
 using System.Collections;
+using Android.Runtime;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -43,6 +44,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		IListViewController Controller => _listView;
 		protected ITemplatedItemsView<Cell> TemplatedItemsView => _listView;
+
+		internal ListViewAdapter(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+		{
+			throw new Exception("Unexpected ListViewAdapter ressurection.");
+		}
 
 		public ListViewAdapter(Context context, AListView realListView, ListView listView) : base(context)
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal ListViewAdapter(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
 		{
-			throw new Exception("Unexpected ListViewAdapter ressurection.");
+			throw new Exception("Unexpected ListViewAdapter resurrection.");
 		}
 
 		public ListViewAdapter(Context context, AListView realListView, ListView listView) : base(context)

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -9,6 +9,7 @@ using Xamarin.Forms.Internals;
 using System;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Android.Widget;
+using Android.Runtime;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -26,6 +27,10 @@ namespace Xamarin.Forms.Platform.Android
 		SwipeRefreshLayout _refresh;
 		IListViewController Controller => Element;
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
+
+		internal ListViewRenderer(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+		{
+		}
 
 		public ListViewRenderer(Context context) : base(context)
 		{
@@ -106,7 +111,8 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnDetachedFromWindow();
 
 			_isAttached = false;
-			_adapter.IsAttachedToWindow = _isAttached;
+			if (_adapter != null)
+				_adapter.IsAttachedToWindow = _isAttached;
 		}
 
 		protected override AListView CreateNativeControl()
@@ -150,10 +156,10 @@ namespace Xamarin.Forms.Platform.Android
 				((IListViewController)e.NewElement).ScrollToRequested += OnScrollToRequested;
 
 				nativeListView.DividerHeight = 0;
+				nativeListView.Adapter = _adapter = e.NewElement.IsGroupingEnabled && e.NewElement.OnThisPlatform().IsFastScrollEnabled() ? new GroupedListViewAdapter(Context, nativeListView, e.NewElement) : new ListViewAdapter(Context, nativeListView, e.NewElement);
 				nativeListView.Focusable = false;
 				nativeListView.DescendantFocusability = DescendantFocusability.AfterDescendants;
 				nativeListView.OnFocusChangeListener = this;
-				nativeListView.Adapter = _adapter = e.NewElement.IsGroupingEnabled && e.NewElement.OnThisPlatform().IsFastScrollEnabled() ? new GroupedListViewAdapter(Context, nativeListView, e.NewElement) : new ListViewAdapter(Context, nativeListView, e.NewElement);
 				_adapter.HeaderView = _headerView;
 				_adapter.FooterView = _footerView;
 				_adapter.IsAttachedToWindow = _isAttached;

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -6,6 +6,7 @@ using Android.OS;
 using Android.Views;
 using AView = Android.Views.View;
 using Xamarin.Forms.Platform.Android.FastRenderers;
+using Android.Runtime;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -28,6 +29,11 @@ namespace Xamarin.Forms.Platform.Android
 
 	public abstract class ViewRenderer<TView, TNativeView> : VisualElementRenderer<TView>, IViewRenderer, ITabStop, AView.IOnFocusChangeListener where TView : View where TNativeView : AView
 	{
+
+		internal ViewRenderer(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+		{
+		}
+
 		protected ViewRenderer(Context context) : base(context)
 		{
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -27,6 +27,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		readonly GestureManager _gestureManager;
 
+		internal VisualElementRenderer(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+		{
+		}
+
 		protected VisualElementRenderer(Context context) : base(context)
 		{
 			_gestureManager = new GestureManager(this);


### PR DESCRIPTION
### Description of Change ###

There is precedent in Xamarin.Forms for allowing Android to temporarily "resurrect" an object in C# simply to call it's dispose methods. While I'm not entirely sure why this happens, its seems innocuous if all that happens is invocation of the dispose function which then does nothing. 

### Issues Resolved ### 

- fixes #3603

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

As described in resolved issue.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
