### PR TITLE
Only set the Page Padding via SafeAreaInset on iOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
@@ -1,0 +1,127 @@
+﻿using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3809, "SetUseSafeArea is wiping out Page Padding ")]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue3809 : TestMasterDetailPage
+	{
+		const string _setPagePadding = "Set Page Padding";
+		const string _safeAreaText = "Safe Area Enabled: ";
+		const string _paddingLabel = "paddingLabel";
+		const string _safeAreaAutomationId = "SafeAreaAutomation";
+
+		Label label = null;
+		protected override void Init()
+		{
+			label = new Label()
+			{
+				AutomationId = _paddingLabel
+			};
+
+			Master = new ContentPage() { Title = "Master" };
+			Button button = null;
+			button = new Button()
+			{
+				Text = $"{_safeAreaText} true",
+				AutomationId = _safeAreaAutomationId,
+				Command = new Command(() =>
+				{
+					bool safeArea = !Detail.On<Xamarin.Forms.PlatformConfiguration.iOS>().UsingSafeArea();
+					Detail.On<Xamarin.Forms.PlatformConfiguration.iOS>().SetUseSafeArea(safeArea);
+					button.Text = $"{_safeAreaText} {safeArea}";
+					Device.BeginInvokeOnMainThread(() =>
+					{
+						label.Text = $"{Detail.Padding.Left}, {Detail.Padding.Top}, {Detail.Padding.Right}, {Detail.Padding.Bottom}";
+					});
+				})
+			};
+
+			Detail = new ContentPage()
+			{
+				Title = "Details",
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new ListView(ListViewCachingStrategy.RecycleElement)
+						{
+							ItemsSource = Enumerable.Range(0,200).Select(x=> x.ToString()).ToList()
+						},
+						label,
+						button,
+						new Button()
+						{
+							Text = _setPagePadding,
+							Command = new Command(() =>
+							{
+								Detail.Padding = new Thickness(25, 25, 25, 25);
+							})
+						}
+					}
+				}
+			};
+
+			Detail.Padding = new Thickness(25, 25, 25, 25);
+			Detail.On<Xamarin.Forms.PlatformConfiguration.iOS>().SetUseSafeArea(true);
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			label.Text = $"{Detail.Padding.Left}, {Detail.Padding.Top}, {Detail.Padding.Right}, {Detail.Padding.Bottom}";
+		}
+
+#if UITEST
+		[Test]
+		public void SafeAreaInsetsBreaksAndroidPadding()
+		{
+			// ensure initial paddings are honored
+			var element = RunningApp.WaitForElement(_paddingLabel).First();
+			Assert.AreNotEqual(element.Text, "0, 0, 0, 0");
+#if !__IOS__
+			Assert.AreEqual(element.Text, "25, 25, 25, 25");
+#endif
+
+			// disable Safe Area Insets
+			RunningApp.Tap(_safeAreaAutomationId);
+			element = RunningApp.WaitForElement(_paddingLabel).First();
+
+#if __IOS__
+			Assert.AreEqual(element.Text, "0, 0, 0, 0");
+#else
+			Assert.AreEqual(element.Text, "25, 25, 25, 25");
+#endif
+
+			// enable Safe Area insets
+			RunningApp.Tap(_safeAreaAutomationId);
+			element = RunningApp.WaitForElement(_paddingLabel).First();
+			Assert.AreNotEqual(element.Text, "0, 0, 0, 0");
+#if !__IOS__
+			Assert.AreEqual(element.Text, "25, 25, 25, 25");
+#endif
+
+
+			// Set Padding and then disable safe area insets
+			RunningApp.Tap(_setPagePadding);
+			RunningApp.Tap(_safeAreaAutomationId);
+			element = RunningApp.WaitForElement(_paddingLabel).First();
+			Assert.AreEqual(element.Text, "25, 25, 25, 25");
+
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
@@ -36,13 +36,13 @@ namespace Xamarin.Forms.Controls.Issues
 			Button button = null;
 			button = new Button()
 			{
-				Text = $"{_safeAreaText} true",
+				Text = $"{_safeAreaText}{true}",
 				AutomationId = _safeAreaAutomationId,
 				Command = new Command(() =>
 				{
 					bool safeArea = !Detail.On<Xamarin.Forms.PlatformConfiguration.iOS>().UsingSafeArea();
 					Detail.On<Xamarin.Forms.PlatformConfiguration.iOS>().SetUseSafeArea(safeArea);
-					button.Text = $"{_safeAreaText} {safeArea}";
+					button.Text = $"{_safeAreaText}{safeArea}";
 					Device.BeginInvokeOnMainThread(() =>
 					{
 						label.Text = $"{Detail.Padding.Left}, {Detail.Padding.Top}, {Detail.Padding.Right}, {Detail.Padding.Bottom}";
@@ -90,6 +90,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public void SafeAreaInsetsBreaksAndroidPadding()
 		{
 			// ensure initial paddings are honored
+			RunningApp.WaitForElement($"{_safeAreaText}{true}");
 			var element = RunningApp.WaitForElement(_paddingLabel).First();
 			Assert.AreNotEqual(element.Text, "0, 0, 0, 0");
 #if !__IOS__
@@ -98,6 +99,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// disable Safe Area Insets
 			RunningApp.Tap(_safeAreaAutomationId);
+			RunningApp.WaitForElement($"{_safeAreaText}{false}");
 			element = RunningApp.WaitForElement(_paddingLabel).First();
 
 #if __IOS__
@@ -108,6 +110,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// enable Safe Area insets
 			RunningApp.Tap(_safeAreaAutomationId);
+			RunningApp.WaitForElement($"{_safeAreaText}{true}");
 			element = RunningApp.WaitForElement(_paddingLabel).First();
 			Assert.AreNotEqual(element.Text, "0, 0, 0, 0");
 #if !__IOS__
@@ -118,6 +121,7 @@ namespace Xamarin.Forms.Controls.Issues
 			// Set Padding and then disable safe area insets
 			RunningApp.Tap(_setPagePadding);
 			RunningApp.Tap(_safeAreaAutomationId);
+			RunningApp.WaitForElement($"{_safeAreaText}{false}");
 			element = RunningApp.WaitForElement(_paddingLabel).First();
 			Assert.AreEqual(element.Text, "25, 25, 25, 25");
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
@@ -14,9 +14,6 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 3809, "SetUseSafeArea is wiping out Page Padding ")]
-#if UITEST
-	[NUnit.Framework.Category(UITestCategories.ListView)]
-#endif
 	public class Issue3809 : TestMasterDetailPage
 	{
 		const string _setPagePadding = "Set Page Padding";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
@@ -37,13 +37,10 @@ namespace Xamarin.Forms.Controls.Issues
 				AutomationId = _safeAreaAutomationId,
 				Command = new Command(() =>
 				{
-					bool safeArea = !Detail.On<Xamarin.Forms.PlatformConfiguration.iOS>().UsingSafeArea();
-					Detail.On<Xamarin.Forms.PlatformConfiguration.iOS>().SetUseSafeArea(safeArea);
+					bool safeArea = !Detail.On<PlatformConfiguration.iOS>().UsingSafeArea();
+					Detail.On<PlatformConfiguration.iOS>().SetUseSafeArea(safeArea);
 					button.Text = $"{_safeAreaText}{safeArea}";
-					Device.BeginInvokeOnMainThread(() =>
-					{
-						label.Text = $"{Detail.Padding.Left}, {Detail.Padding.Top}, {Detail.Padding.Right}, {Detail.Padding.Bottom}";
-					});
+					Device.BeginInvokeOnMainThread(() => label.Text = $"{Detail.Padding.Left}, {Detail.Padding.Top}, {Detail.Padding.Right}, {Detail.Padding.Bottom}");
 				})
 			};
 
@@ -66,6 +63,7 @@ namespace Xamarin.Forms.Controls.Issues
 							Command = new Command(() =>
 							{
 								Detail.Padding = new Thickness(25, 25, 25, 25);
+								Device.BeginInvokeOnMainThread(() => label.Text = $"{Detail.Padding.Left}, {Detail.Padding.Top}, {Detail.Padding.Right}, {Detail.Padding.Bottom}");
 							})
 						}
 					}
@@ -89,30 +87,33 @@ namespace Xamarin.Forms.Controls.Issues
 			// ensure initial paddings are honored
 			RunningApp.WaitForElement($"{_safeAreaText}{true}");
 			var element = RunningApp.WaitForElement(_paddingLabel).First();
+
+			bool usesSafeAreaInsets = false;
+			if (element.Text != "25, 25, 25, 25")
+				usesSafeAreaInsets = true;
+
 			Assert.AreNotEqual(element.Text, "0, 0, 0, 0");
-#if !__IOS__
-			Assert.AreEqual(element.Text, "25, 25, 25, 25");
-#endif
+			if (!usesSafeAreaInsets)
+				Assert.AreEqual(element.Text, "25, 25, 25, 25");
 
 			// disable Safe Area Insets
 			RunningApp.Tap(_safeAreaAutomationId);
 			RunningApp.WaitForElement($"{_safeAreaText}{false}");
 			element = RunningApp.WaitForElement(_paddingLabel).First();
 
-#if __IOS__
-			Assert.AreEqual(element.Text, "0, 0, 0, 0");
-#else
-			Assert.AreEqual(element.Text, "25, 25, 25, 25");
-#endif
+			if (usesSafeAreaInsets)
+				Assert.AreEqual(element.Text, "0, 0, 0, 0");
+			else
+				Assert.AreEqual(element.Text, "25, 25, 25, 25");
 
 			// enable Safe Area insets
 			RunningApp.Tap(_safeAreaAutomationId);
 			RunningApp.WaitForElement($"{_safeAreaText}{true}");
 			element = RunningApp.WaitForElement(_paddingLabel).First();
 			Assert.AreNotEqual(element.Text, "0, 0, 0, 0");
-#if !__IOS__
-			Assert.AreEqual(element.Text, "25, 25, 25, 25");
-#endif
+
+			if (!usesSafeAreaInsets)
+				Assert.AreEqual(element.Text, "25, 25, 25, 25");
 
 
 			// Set Padding and then disable safe area insets

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3809.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2004.cs" />

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -60,10 +60,14 @@
 
 		public static readonly BindableProperty UseSafeAreaProperty = BindableProperty.Create("UseSafeArea", typeof(bool), typeof(Page), false, propertyChanged: (bindable, oldValue, newValue) =>
 		{
+			if (Device.RuntimePlatform != Device.iOS) return;
+
 			var page = bindable as Xamarin.Forms.Page;
 			if ((bool)oldValue && !(bool)newValue)
 			{
-				page.Padding = default(Thickness);
+				var safeAreaInsets = GetSafeAreaInsets(page);
+				if (safeAreaInsets == page.Padding)
+					page.Padding = default(Thickness);
 			}
 			else
 			{

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -58,22 +58,7 @@
 			return config;
 		}
 
-		public static readonly BindableProperty UseSafeAreaProperty = BindableProperty.Create("UseSafeArea", typeof(bool), typeof(Page), false, propertyChanged: (bindable, oldValue, newValue) =>
-		{
-			if (Device.RuntimePlatform != Device.iOS) return;
-
-			var page = bindable as Xamarin.Forms.Page;
-			if ((bool)oldValue && !(bool)newValue)
-			{
-				var safeAreaInsets = GetSafeAreaInsets(page);
-				if (safeAreaInsets == page.Padding)
-					page.Padding = default(Thickness);
-			}
-			else
-			{
-				UpdatePadding(GetSafeAreaInsets(page), page);
-			}
-		});
+		public static readonly BindableProperty UseSafeAreaProperty = BindableProperty.Create("UseSafeArea", typeof(bool), typeof(Page), false);
 
 		public static bool GetUseSafeArea(BindableObject element)
 		{
@@ -119,17 +104,7 @@
 			return config;
 		}
 
-		static readonly BindablePropertyKey SafeAreaInsetsPropertyKey = BindableProperty.CreateReadOnly(nameof(SafeAreaInsets), typeof(Thickness), typeof(Page), default(Thickness), propertyChanged: (bindable, oldValue, newValue) =>
-		{
-			var page = bindable as Xamarin.Forms.Page;
-			UpdatePadding((Thickness)newValue, page);
-		});
-
-		static void UpdatePadding(Thickness thickness, FormsElement page)
-		{
-			if (page.On<iOS>().UsingSafeArea())
-				page.Padding = thickness;
-		}
+		static readonly BindablePropertyKey SafeAreaInsetsPropertyKey = BindableProperty.CreateReadOnly(nameof(SafeAreaInsets), typeof(Thickness), typeof(Page), default(Thickness));
 
 		public static readonly BindableProperty SafeAreaInsetsProperty = SafeAreaInsetsPropertyKey.BindableProperty;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -18,6 +18,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		Page Page => Element as Page;
 
+		bool UsingSafeArea => (Forms.IsiOS11OrNewer) ? Page.On<PlatformConfiguration.iOS>().UsingSafeArea() : false;
+		Thickness SafeAreaInsets => Page.On<PlatformConfiguration.iOS>().SafeAreaInsets();
+
 		public PageRenderer()
 		{
 		}
@@ -70,13 +73,14 @@ namespace Xamarin.Forms.Platform.iOS
 			if (page != null && Forms.IsiOS11OrNewer)
 			{
 				var insets = NativeView.SafeAreaInsets;
-				if(page.Parent is TabbedPage)
+				if (page.Parent is TabbedPage)
 				{
 					insets.Bottom = 0;
 				}
 				page.On<PlatformConfiguration.iOS>().SetSafeAreaInsets(new Thickness(insets.Left, insets.Top, insets.Right, insets.Bottom));
-			
+
 			}
+
 			base.ViewSafeAreaInsetsDidChange();
 		}
 
@@ -195,6 +199,10 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateTitle();
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty.PropertyName)
 				UpdateStatusBarPrefersHidden();
+			else if (Forms.IsiOS11OrNewer && e.PropertyName == PlatformConfiguration.iOSSpecific.Page.UseSafeAreaProperty.PropertyName)
+				UpdateUseSafeArea();
+			else if (Forms.IsiOS11OrNewer && e.PropertyName == PlatformConfiguration.iOSSpecific.Page.SafeAreaInsetsProperty.PropertyName)
+				UpdateUseSafeArea();
 		}
 
 		public override UIKit.UIStatusBarAnimation PreferredStatusBarUpdateAnimation
@@ -212,6 +220,22 @@ namespace Xamarin.Forms.Platform.iOS
 					default:
 						return UIKit.UIStatusBarAnimation.None;
 				}
+			}
+		}
+
+		void UpdateUseSafeArea()
+		{
+			if (!Forms.IsiOS11OrNewer) return;
+
+			if (!UsingSafeArea)
+			{
+				var safeAreaInsets = SafeAreaInsets;
+				if (safeAreaInsets == Page.Padding)
+					Page.Padding = default(Thickness);
+			}
+			else
+			{
+				Page.Padding = SafeAreaInsets;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###
-If platform isn't iOS then don't do anything when the user changes the SafeAreaPadding setting
-Check to see if the user has changed the padding when setting SafeAreaPadding to false so it doesn't overwrite what the user used.  



### Issues Resolved ### 
- fixes #3809 
- fixes #3866

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
-For the issue created click the two buttons provided to set the padding and change whether Safe Area has been enabled. Ensure that the page padding reacts as you'd expect it to 

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
