### PR TITLE
[iOS] Use UIApperance default color for UISwitch

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -154,6 +154,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 
 		public override bool FinishedLaunching(UIApplication uiApplication, NSDictionary launchOptions)
 		{
+			UISwitch.Appearance.OnTintColor = UIColor.Red;
 			var versionPart = UIDevice.CurrentDevice.SystemVersion.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
 			App.IOSVersion = int.Parse(versionPart[0]);
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwitchRenderer.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.ValueChanged += OnControlValueChanged;
 				}
 
-				_defaultOnColor = Control.OnTintColor;
+				_defaultOnColor = UISwitch.Appearance.OnTintColor;
 				Control.On = Element.IsToggled;
 				e.NewElement.Toggled += OnElementToggled;
 				UpdateOnColor();


### PR DESCRIPTION
### Description of Change ###

Use default UIApperance tint color 

### Issues Resolved ### 
- fixes #3111 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

Default color should be respect if set via UIAppereance 

Before
![simulator screen shot - iphone xr - 2018-09-18 at 11 48 30](https://user-images.githubusercontent.com/1235097/45682736-213d5e00-bb39-11e8-9dce-e57aaa573d82.png)

After

![simulator screen shot - iphone xr - 2018-09-18 at 11 50 48](https://user-images.githubusercontent.com/1235097/45682747-29959900-bb39-11e8-9768-d2cd3bde4452.png)

### Testing Procedure ###

Go to Switch cell gallery on iOS and check the default color for the switch is Red

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
