### PR TITLE
Ensure that the ListViewAdapter is no longer being used by the ListVi…

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 {
 	internal class ListViewAdapter : CellAdapter
 	{
+		bool _disposed;
 		static readonly object DefaultItemTypeOrDataTemplate = new object();
 		const int DefaultGroupHeaderTemplateId = 0;
 		const int DefaultItemTemplateId = 1;
@@ -417,6 +418,13 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
 			if (disposing)
 			{
 				CloseContextActions();

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -75,6 +75,12 @@ namespace Xamarin.Forms.Platform.Android
 				_footerView?.Dispose();
 				_footerView = null;
 
+				// Unhook the adapter from the ListView before disposing of it
+				if (Control != null)
+				{
+					Control.Adapter = null;
+				}
+
 				if (_adapter != null)
 				{
 					_adapter.Dispose();
@@ -124,6 +130,12 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (_adapter != null)
 				{
+					// Unhook the adapter from the ListView before disposing of it
+					if (Control != null)
+					{
+						Control.Adapter = null;
+					}
+
 					_adapter.Dispose();
 					_adapter = null;
 				}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -238,8 +238,6 @@ namespace Xamarin.Forms.Platform.Android
 					}
 				}
 
-				RemoveAllViews();
-
 				if (Element != null)
 				{
 					Element.PropertyChanged -= _propertyChangeHandler;


### PR DESCRIPTION
### Description of Change ###

When a `ListViewRenderer` is re-used with a new `ListView` element, the old `ListViewAdapter` is disposed of. But the `ListView` still holds a reference to it and attempts to use it, resulting in a Disposed object access exception.

This change unhooks the `ListViewAdapter` from the `ListView` before disposing of it.

This change also fixes potential double-disposal issues with `ListViewAdapter`.

### Issues Resolved ### 

- fixes problem with the UI Test for 3408 crashing
- fixes #3603 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run UI Test 3408. Push a lot of buttons. If the application doesn't crash, there's a chance the bug is fixed.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
