### PR TITLE
[Core] Moving Command's CanExecuteChanged to use the WeakEventManager

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/WeakEventManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/WeakEventManagerTests.cs
@@ -13,6 +13,32 @@ namespace Xamarin.Forms.Core.UnitTests
 			s_count++;
 		}
 
+		internal class TestSource
+		{
+			public int Count = 0;
+			public TestEventSource EventSource { get; set; }
+			public TestSource()
+			{
+				EventSource = new TestEventSource();
+				EventSource.TestEvent += EventSource_TestEvent;
+			}
+			public void Clean()
+			{
+				EventSource.TestEvent -= EventSource_TestEvent;
+			}
+
+			public void Fire()
+			{
+				EventSource.FireTestEvent();
+			}
+
+
+			void EventSource_TestEvent(object sender, EventArgs e)
+			{
+				Count++;
+			}
+		}
+
 		internal class TestEventSource
 		{
 			readonly WeakEventManager _weakEventManager;
@@ -71,6 +97,19 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var wem = new WeakEventManager();
 			Assert.Throws<ArgumentNullException>(() => wem.AddEventHandler(null, (sender, args) => { }));
+		}
+
+		[Test]
+		public void CanRemoveEventHandler()
+		{
+			var source = new TestSource();
+			int beforeRun = source.Count;
+			source.Fire();
+
+			Assert.IsTrue(source.Count == 1);
+			source.Clean();
+			source.Fire();
+			Assert.IsTrue(source.Count == 1);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -61,6 +61,7 @@ namespace Xamarin.Forms
 	{
 		readonly Func<object, bool> _canExecute;
 		readonly Action<object> _execute;
+		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 
 		public Command(Action<object> execute)
 		{
@@ -100,7 +101,11 @@ namespace Xamarin.Forms
 			return true;
 		}
 
-		public event EventHandler CanExecuteChanged;
+		public event EventHandler CanExecuteChanged
+		{
+			add { _weakEventManager.AddEventHandler(nameof(CanExecuteChanged), value); }
+			remove { _weakEventManager.RemoveEventHandler(nameof(CanExecuteChanged), value); }
+		}
 
 		public void Execute(object parameter)
 		{
@@ -109,8 +114,7 @@ namespace Xamarin.Forms
 
 		public void ChangeCanExecute()
 		{
-			EventHandler changed = CanExecuteChanged;
-			changed?.Invoke(this, EventArgs.Empty);
+			_weakEventManager.HandleEvent(this, EventArgs.Empty, nameof(CanExecuteChanged));
 		}
 	}
 }

--- a/Xamarin.Forms.Core/WeakEventManager.cs
+++ b/Xamarin.Forms.Core/WeakEventManager.cs
@@ -146,7 +146,7 @@ namespace Xamarin.Forms
 			{
 				Subscription current = subscriptions[n - 1];
 
-				if (current.Subscriber != handlerTarget
+				if (current.Subscriber?.Target != handlerTarget
 				    || current.Handler.Name != methodInfo.Name)
 				{
 					continue;


### PR DESCRIPTION
### Description of Change ###

Moving Command's CanExecuteChanged to use the WeakEventManager may reduce the number of memory leaks caused by this pattern.
Fix issue with removing handler from WeakEventManager.

### Issues Resolved ### 

- fixes #3656 

### API Changes ###

 None

### Platforms Affected ### 
- Core/XAML 
### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 
<Not applicable


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
