### PR TITLE
[All] Added preserve attribute to the view model class of UI test 39378

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml.cs
@@ -27,6 +27,7 @@ namespace Xamarin.Forms.Controls.Issues
 			BindingContext = new ImageController();
 		}
 
+		[Preserve(AllMembers = true)]
 		class ImageController : ViewModelBase
 		{
 			


### PR DESCRIPTION
### Description of Change ###

Added missing `Preserve` attribute to the existing test so the class members can be loaded properly. The issue was not just with the image source but also the background color of the containing grid.

### Issues Resolved ### 

- fixes #2306

### API Changes ###

 None



### Behavioral/Visual Changes ###

None


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run UI test 39378

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
