### PR TITLE
[Android] Convert corner radius with correct pixel density

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3884.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3884.cs
@@ -40,8 +40,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue3884Test() 
 		{
-			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
-			RunningApp.Screenshot ("I am at Issue 1");
+			RunningApp.Screenshot ("I see a blue circle");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3884.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3884.cs
@@ -1,0 +1,48 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3884, "BoxView corner radius", PlatformAffected.Android)]
+	public class Issue3884 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var label = new Label { Text = "You should see a blue circle" };
+			var box = new BoxView
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				BackgroundColor = Color.Blue,
+				HeightRequest = 100,
+				WidthRequest = 100,
+				CornerRadius = 50
+			};
+
+			Content = new StackLayout
+			{
+				Children = { label,box}
+			};
+		}
+
+#if UITEST
+		[Test]
+		[Category(UITestCategories.ManualReview)]
+		public void Issue3884Test() 
+		{
+			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
+			RunningApp.Screenshot ("I am at Issue 1");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -802,6 +802,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3413.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3525.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3275.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3884.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -106,25 +106,28 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateCornerRadius()
 		{
 			var cornerRadius = Element.CornerRadius;
-			if (cornerRadius == new CornerRadius(0d)) {
+			if (cornerRadius == new CornerRadius(0d))
+			{
 				_backgroundDrawable?.Dispose();
 				_backgroundDrawable = null;
 			}
-			else {
+			else
+			{
 				this.SetBackground(_backgroundDrawable = new GradientDrawable());
-				if (Background is GradientDrawable backgroundGradient) {
+				if (Background is GradientDrawable backgroundGradient)
+				{
 					var cornerRadii = new[] {
-						(float)(cornerRadius.TopLeft),
-						(float)(cornerRadius.TopLeft),
+						(float)(Context.ToPixels(cornerRadius.TopLeft)),
+						(float)(Context.ToPixels(cornerRadius.TopLeft)),
 
-						(float)(cornerRadius.TopRight),
-						(float)(cornerRadius.TopRight),
+						(float)(Context.ToPixels(cornerRadius.TopRight)),
+						(float)(Context.ToPixels(cornerRadius.TopRight)),
 
-						(float)(cornerRadius.BottomRight),
-						(float)(cornerRadius.BottomRight),
+						(float)(Context.ToPixels(cornerRadius.BottomRight)),
+						(float)(Context.ToPixels(cornerRadius.BottomRight)),
 
-						(float)(cornerRadius.BottomLeft),
-						(float)(cornerRadius.BottomLeft)
+						(float)(Context.ToPixels(cornerRadius.BottomLeft)),
+						(float)(Context.ToPixels(cornerRadius.BottomLeft))
 					};
 
 					backgroundGradient.SetCornerRadii(cornerRadii);


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 

- fixes #3884 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
Corner radius should look correct on Android

### Before/After Screenshots ### 

Before
![screenshot_1537870754](https://user-images.githubusercontent.com/1235097/46008508-dda4a000-c0b4-11e8-891f-a0896e22e56c.png)

After
![screenshot_1537870645](https://user-images.githubusercontent.com/1235097/46008454-b64dd300-c0b4-11e8-9480-4efdab3ef22d.png)


### Testing Procedure ###
Just go to test 3884 and make sure you see a circle

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
