### PR TITLE
[UWP] fixes tabstops of TimePicker, DatePiker. SearchBar, Stepper

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3872.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3872.cs
@@ -1,0 +1,25 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3872, "TabStop additions cause a non interactive TabStop on Time Picker...", PlatformAffected.UWP)]
+	public class GitHub3872 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout()
+			{
+				Children = {
+					new Entry(),
+					new TimePicker(),
+					new DatePicker(),
+					new SearchBar(),
+					new Stepper(),
+					new Entry()
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -790,6 +790,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2728.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1667.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3012.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3872.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1650.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub3216.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub1776.cs" />

--- a/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
 
@@ -13,6 +14,7 @@ namespace Xamarin.Forms.Platform.UWP
 		Brush _defaultBrush;
 		bool _fontApplied;
 		FontFamily _defaultFontFamily;
+		FocusNavigationDirection focusDirection;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -20,6 +22,8 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				Control.DateChanged -= OnControlDateChanged;
 				Control.Loaded -= ControlOnLoaded;
+				Control.GotFocus -= OnGotFocus;
+				Control.GettingFocus -= OnGettingFocus;
 			}
 
 			base.Dispose(disposing);
@@ -35,6 +39,8 @@ namespace Xamarin.Forms.Platform.UWP
 					SetNativeControl(picker);
 					Control.Loaded += ControlOnLoaded;
 					Control.DateChanged += OnControlDateChanged;
+					Control.GotFocus += OnGotFocus;
+					Control.GettingFocus += OnGettingFocus;
 				}
 				else
 				{
@@ -48,6 +54,20 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			base.OnElementChanged(e);
+		}
+
+		protected override void UpdateTabStop()
+		{
+			base.UpdateTabStop();
+			Control?.GetChildren<Control>().ForEach(c => c.IsTabStop = Element.IsTabStop);
+		}
+
+		void OnGettingFocus(UIElement sender, GettingFocusEventArgs args) => focusDirection = args.Direction;
+
+		void OnGotFocus(object sender, RoutedEventArgs e)
+		{
+			if (e.OriginalSource == Control)
+				FocusManager.TryMoveFocus(focusDirection);
 		}
 
 		void ControlOnLoaded(object sender, RoutedEventArgs routedEventArgs)

--- a/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
@@ -3,18 +3,16 @@ using System.ComponentModel;
 using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class DatePickerRenderer : ViewRenderer<DatePicker, Windows.UI.Xaml.Controls.DatePicker>
+	public class DatePickerRenderer : ViewRenderer<DatePicker, Windows.UI.Xaml.Controls.DatePicker>, ITabStopOnDescenants
 	{
 		Brush _defaultBrush;
 		bool _fontApplied;
 		FontFamily _defaultFontFamily;
-		FocusNavigationDirection focusDirection;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -22,8 +20,6 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				Control.DateChanged -= OnControlDateChanged;
 				Control.Loaded -= ControlOnLoaded;
-				Control.GotFocus -= OnGotFocus;
-				Control.GettingFocus -= OnGettingFocus;
 			}
 
 			base.Dispose(disposing);
@@ -39,8 +35,6 @@ namespace Xamarin.Forms.Platform.UWP
 					SetNativeControl(picker);
 					Control.Loaded += ControlOnLoaded;
 					Control.DateChanged += OnControlDateChanged;
-					Control.GotFocus += OnGotFocus;
-					Control.GettingFocus += OnGettingFocus;
 				}
 				else
 				{
@@ -54,20 +48,6 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			base.OnElementChanged(e);
-		}
-
-		protected override void UpdateTabStop()
-		{
-			base.UpdateTabStop();
-			Control?.GetChildren<Control>().ForEach(c => c.IsTabStop = Element.IsTabStop);
-		}
-
-		void OnGettingFocus(UIElement sender, GettingFocusEventArgs args) => focusDirection = args.Direction;
-
-		void OnGotFocus(object sender, RoutedEventArgs e)
-		{
-			if (e.OriginalSource == Control)
-				FocusManager.TryMoveFocus(focusDirection);
 		}
 
 		void ControlOnLoaded(object sender, RoutedEventArgs routedEventArgs)

--- a/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
@@ -8,7 +8,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class DatePickerRenderer : ViewRenderer<DatePicker, Windows.UI.Xaml.Controls.DatePicker>, ITabStopOnDescenants
+	public class DatePickerRenderer : ViewRenderer<DatePicker, Windows.UI.Xaml.Controls.DatePicker>, ITabStopOnDescendants
 	{
 		Brush _defaultBrush;
 		bool _fontApplied;

--- a/Xamarin.Forms.Platform.UAP/ITabStopOnDescenants.cs
+++ b/Xamarin.Forms.Platform.UAP/ITabStopOnDescenants.cs
@@ -1,0 +1,6 @@
+﻿namespace Xamarin.Forms.Platform.UWP
+{
+	public interface ITabStopOnDescenants
+	{
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/ITabStopOnDescendants.cs
+++ b/Xamarin.Forms.Platform.UAP/ITabStopOnDescendants.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.Platform.UWP
 {
-	public interface ITabStopOnDescenants
+	public interface ITabStopOnDescendants
 	{
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
@@ -7,7 +7,7 @@ using Specifics = Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class SearchBarRenderer : ViewRenderer<SearchBar, AutoSuggestBox>, ITabStopOnDescenants
+	public class SearchBarRenderer : ViewRenderer<SearchBar, AutoSuggestBox>, ITabStopOnDescendants
 	{
 		Brush _defaultPlaceholderColorBrush;
 		Brush _defaultPlaceholderColorFocusBrush;

--- a/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SearchBarRenderer.cs
@@ -4,12 +4,10 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 using Specifics = Xamarin.Forms.PlatformConfiguration.WindowsSpecific.SearchBar;
-using Xamarin.Forms.Internals;
-using Windows.UI.Xaml.Input;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class SearchBarRenderer : ViewRenderer<SearchBar, AutoSuggestBox>
+	public class SearchBarRenderer : ViewRenderer<SearchBar, AutoSuggestBox>, ITabStopOnDescenants
 	{
 		Brush _defaultPlaceholderColorBrush;
 		Brush _defaultPlaceholderColorFocusBrush;
@@ -23,19 +21,6 @@ namespace Xamarin.Forms.Platform.UWP
 		Brush _defaultDeleteButtonForegroundColorBrush;
 		Brush _defaultDeleteButtonBackgroundColorBrush;
 
-		FocusNavigationDirection focusDirection;
-
-		protected override void Dispose(bool disposing)
-		{
-			if (disposing && Control != null)
-			{
-				Control.GotFocus -= OnGotFocus;
-				Control.GettingFocus -= OnGettingFocus;
-			}
-
-			base.Dispose(disposing);
-		}
-
 		protected override void OnElementChanged(ElementChangedEventArgs<SearchBar> e)
 		{
 			if (e.NewElement != null)
@@ -47,8 +32,6 @@ namespace Xamarin.Forms.Platform.UWP
 					Control.TextChanged += OnTextChanged;
 					Control.Loaded += OnControlLoaded;
 					Control.AutoMaximizeSuggestionArea = false;
-					Control.GotFocus += OnGotFocus;
-					Control.GettingFocus += OnGettingFocus;
 				}
 
 				UpdateText();
@@ -62,20 +45,6 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			base.OnElementChanged(e);
-		}
-
-		protected override void UpdateTabStop()
-		{
-			base.UpdateTabStop();
-			Control?.GetChildren<Control>().ForEach(c => c.IsTabStop = Element.IsTabStop);
-		}
-
-		void OnGettingFocus(UIElement sender, GettingFocusEventArgs args) => focusDirection = args.Direction;
-
-		void OnGotFocus(object sender, RoutedEventArgs e)
-		{
-			if (e.OriginalSource == Control)
-				FocusManager.TryMoveFocus(focusDirection);
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.UAP/StepperRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/StepperRenderer.cs
@@ -1,10 +1,27 @@
 ﻿using System;
 using System.ComponentModel;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Xamarin.Forms.Internals;
+using Windows.UI.Xaml.Input;
 
 namespace Xamarin.Forms.Platform.UWP
 {
 	public class StepperRenderer : ViewRenderer<Stepper, StepperControl>
 	{
+		FocusNavigationDirection focusDirection;
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && Control != null)
+			{
+				Control.GotFocus -= OnGotFocus;
+				Control.GettingFocus -= OnGettingFocus;
+			}
+
+			base.Dispose(disposing);
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Stepper> e)
 		{
 			base.OnElementChanged(e);
@@ -15,6 +32,8 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					SetNativeControl(new StepperControl());
 					Control.ValueChanged += OnControlValue;
+					Control.GettingFocus += OnGettingFocus;
+					Control.GotFocus += OnGotFocus;
 				}
 
 				UpdateMaximum();
@@ -41,6 +60,20 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateBackgroundColor();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
+		}
+
+		protected override void UpdateTabStop()
+		{
+			base.UpdateTabStop();
+			Control?.GetChildren<Control>().ForEach(c => c.IsTabStop = Element.IsTabStop);
+		}
+
+		void OnGettingFocus(UIElement sender, GettingFocusEventArgs args) => focusDirection = args.Direction;
+
+		void OnGotFocus(object sender, RoutedEventArgs e)
+		{
+			if (e.OriginalSource == Control)
+				FocusManager.TryMoveFocus(focusDirection);
 		}
 
 		protected override void UpdateBackgroundColor()

--- a/Xamarin.Forms.Platform.UAP/StepperRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/StepperRenderer.cs
@@ -1,27 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Xamarin.Forms.Internals;
-using Windows.UI.Xaml.Input;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class StepperRenderer : ViewRenderer<Stepper, StepperControl>
+	public class StepperRenderer : ViewRenderer<Stepper, StepperControl>, ITabStopOnDescenants
 	{
-		FocusNavigationDirection focusDirection;
-
-		protected override void Dispose(bool disposing)
-		{
-			if (disposing && Control != null)
-			{
-				Control.GotFocus -= OnGotFocus;
-				Control.GettingFocus -= OnGettingFocus;
-			}
-
-			base.Dispose(disposing);
-		}
-
 		protected override void OnElementChanged(ElementChangedEventArgs<Stepper> e)
 		{
 			base.OnElementChanged(e);
@@ -32,8 +15,6 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					SetNativeControl(new StepperControl());
 					Control.ValueChanged += OnControlValue;
-					Control.GettingFocus += OnGettingFocus;
-					Control.GotFocus += OnGotFocus;
 				}
 
 				UpdateMaximum();
@@ -60,20 +41,6 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateBackgroundColor();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
-		}
-
-		protected override void UpdateTabStop()
-		{
-			base.UpdateTabStop();
-			Control?.GetChildren<Control>().ForEach(c => c.IsTabStop = Element.IsTabStop);
-		}
-
-		void OnGettingFocus(UIElement sender, GettingFocusEventArgs args) => focusDirection = args.Direction;
-
-		void OnGotFocus(object sender, RoutedEventArgs e)
-		{
-			if (e.OriginalSource == Control)
-				FocusManager.TryMoveFocus(focusDirection);
 		}
 
 		protected override void UpdateBackgroundColor()

--- a/Xamarin.Forms.Platform.UAP/StepperRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/StepperRenderer.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class StepperRenderer : ViewRenderer<Stepper, StepperControl>, ITabStopOnDescenants
+	public class StepperRenderer : ViewRenderer<Stepper, StepperControl>, ITabStopOnDescendants
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<Stepper> e)
 		{

--- a/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
 
@@ -13,6 +15,7 @@ namespace Xamarin.Forms.Platform.UWP
 		Brush _defaultBrush;
 		bool _fontApplied;
 		FontFamily _defaultFontFamily;
+		FocusNavigationDirection focusDirection;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -20,6 +23,8 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				Control.TimeChanged -= OnControlTimeChanged;
 				Control.Loaded -= ControlOnLoaded;
+				Control.GotFocus -= OnGotFocus;
+				Control.GettingFocus -= OnGettingFocus;
 			}
 
 			base.Dispose(disposing);
@@ -39,6 +44,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 					Control.TimeChanged += OnControlTimeChanged;
 					Control.Loaded += ControlOnLoaded;
+					Control.GotFocus += OnGotFocus;
+					Control.GettingFocus += OnGettingFocus;
 				}
 				else
 				{
@@ -48,6 +55,20 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTime();
 				UpdateFlowDirection();
 			}
+		}
+
+		protected override void UpdateTabStop()
+		{
+			base.UpdateTabStop();
+			Control?.GetChildren<Control>().ForEach(c => c.IsTabStop = Element.IsTabStop);
+		}
+
+		void OnGettingFocus(UIElement sender, GettingFocusEventArgs args) => focusDirection = args.Direction;
+
+		void OnGotFocus(object sender, RoutedEventArgs e)
+		{
+			if (e.OriginalSource == Control)
+				FocusManager.TryMoveFocus(focusDirection);
 		}
 
 		void ControlOnLoaded(object sender, RoutedEventArgs routedEventArgs)

--- a/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
@@ -1,21 +1,18 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class TimePickerRenderer : ViewRenderer<TimePicker, Windows.UI.Xaml.Controls.TimePicker>
+	public class TimePickerRenderer : ViewRenderer<TimePicker, Windows.UI.Xaml.Controls.TimePicker>, ITabStopOnDescenants
 	{
 		Brush _defaultBrush;
 		bool _fontApplied;
 		FontFamily _defaultFontFamily;
-		FocusNavigationDirection focusDirection;
 
 		protected override void Dispose(bool disposing)
 		{
@@ -23,8 +20,6 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				Control.TimeChanged -= OnControlTimeChanged;
 				Control.Loaded -= ControlOnLoaded;
-				Control.GotFocus -= OnGotFocus;
-				Control.GettingFocus -= OnGettingFocus;
 			}
 
 			base.Dispose(disposing);
@@ -44,8 +39,6 @@ namespace Xamarin.Forms.Platform.UWP
 
 					Control.TimeChanged += OnControlTimeChanged;
 					Control.Loaded += ControlOnLoaded;
-					Control.GotFocus += OnGotFocus;
-					Control.GettingFocus += OnGettingFocus;
 				}
 				else
 				{
@@ -55,20 +48,6 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTime();
 				UpdateFlowDirection();
 			}
-		}
-
-		protected override void UpdateTabStop()
-		{
-			base.UpdateTabStop();
-			Control?.GetChildren<Control>().ForEach(c => c.IsTabStop = Element.IsTabStop);
-		}
-
-		void OnGettingFocus(UIElement sender, GettingFocusEventArgs args) => focusDirection = args.Direction;
-
-		void OnGotFocus(object sender, RoutedEventArgs e)
-		{
-			if (e.OriginalSource == Control)
-				FocusManager.TryMoveFocus(focusDirection);
 		}
 
 		void ControlOnLoaded(object sender, RoutedEventArgs routedEventArgs)

--- a/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
@@ -8,7 +8,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class TimePickerRenderer : ViewRenderer<TimePicker, Windows.UI.Xaml.Controls.TimePicker>, ITabStopOnDescenants
+	public class TimePickerRenderer : ViewRenderer<TimePicker, Windows.UI.Xaml.Controls.TimePicker>, ITabStopOnDescendants
 	{
 		Brush _defaultBrush;
 		bool _fontApplied;

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -297,16 +297,10 @@ namespace Xamarin.Forms.Platform.UWP
 				changed(this, e);
 		}
 
-		protected void UpdateTabStop()
+		protected virtual void UpdateTabStop()
 		{
-			if (_control == null)
-				return;
-			_control.IsTabStop = Element.IsTabStop;
-
-			// update TabStop of children for complex controls (like as DatePicker, TimePicker, SearchBar and Stepper)
-			var children = FrameworkElementExtensions.GetChildren<Control>(_control);
-			foreach (var child in children)
-				child.IsTabStop = _control.IsTabStop;
+			if (_control != null)
+				_control.IsTabStop = Element.IsTabStop;
 		}
 
 		protected void UpdateTabIndex()

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -152,7 +152,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			OnElementChanged(new ElementChangedEventArgs<TElement>(oldElement, Element));
 
-			if (_control != null && this is ITabStopOnDescenants)
+			if (_control != null && this is ITabStopOnDescendants)
 			{
 				_control.GotFocus += OnGotFocus;
 				_control.GettingFocus += OnGettingFocus;
@@ -323,7 +323,7 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 			_control.IsTabStop = Element.IsTabStop;
 
-			if (this is ITabStopOnDescenants)
+			if (this is ITabStopOnDescendants)
 				_control?.GetChildren<Control>().ForEach(c => c.IsTabStop = Element.IsTabStop);
 		}
 

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -7,6 +7,8 @@ using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Specifics = Xamarin.Forms.PlatformConfiguration.WindowsSpecific.VisualElement;
+using Xamarin.Forms.Internals;
+using Windows.UI.Xaml.Input;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -18,6 +20,7 @@ namespace Xamarin.Forms.Platform.UWP
 		string _defaultAutomationPropertiesHelpText;
 		UIElement _defaultAutomationPropertiesLabeledBy;
 		bool _disposed;
+		FocusNavigationDirection focusDirection;
 		EventHandler<VisualElementChangedEventArgs> _elementChangedHandlers;
 		VisualElementTracker<TElement, TNativeElement> _tracker;
 		Windows.UI.Xaml.Controls.Page _containingPage; // Cache of containing page used for unfocusing
@@ -149,6 +152,12 @@ namespace Xamarin.Forms.Platform.UWP
 
 			OnElementChanged(new ElementChangedEventArgs<TElement>(oldElement, Element));
 
+			if (_control != null && this is ITabStopOnDescenants)
+			{
+				_control.GotFocus += OnGotFocus;
+				_control.GettingFocus += OnGettingFocus;
+			}
+
 			var controller = (IElementController)oldElement;
 			if (controller != null && controller.EffectControlProvider == this)
 			{
@@ -160,7 +169,13 @@ namespace Xamarin.Forms.Platform.UWP
 				controller.EffectControlProvider = this;
 		}
 
-		
+		void OnGettingFocus(UIElement sender, GettingFocusEventArgs args) => focusDirection = args.Direction;
+
+		void OnGotFocus(object sender, RoutedEventArgs e)
+		{
+			if (e.OriginalSource == Control)
+				FocusManager.TryMoveFocus(focusDirection);
+		}
 
 		public event EventHandler<ElementChangedEventArgs<TElement>> ElementChanged;
 
@@ -242,6 +257,11 @@ namespace Xamarin.Forms.Platform.UWP
 			Packager?.Dispose();
 			Packager = null;
 
+			if (_control != null)
+			{
+				_control.GotFocus -= OnGotFocus;
+				_control.GettingFocus -= OnGettingFocus;
+			}
 			SetNativeControl(null);
 			SetElement(null);
 		}
@@ -297,10 +317,14 @@ namespace Xamarin.Forms.Platform.UWP
 				changed(this, e);
 		}
 
-		protected virtual void UpdateTabStop()
+		protected void UpdateTabStop()
 		{
-			if (_control != null)
-				_control.IsTabStop = Element.IsTabStop;
+			if (_control == null)
+				return;
+			_control.IsTabStop = Element.IsTabStop;
+
+			if (this is ITabStopOnDescenants)
+				_control?.GetChildren<Control>().ForEach(c => c.IsTabStop = Element.IsTabStop);
 		}
 
 		protected void UpdateTabIndex()

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -54,6 +54,7 @@
     <Compile Include="FormsSlider.cs" />
     <Compile Include="FormsTextBox.cs" />
     <Compile Include="FormsComboBox.cs" />
+    <Compile Include="ITabStopOnDescenants.cs" />
     <Compile Include="InterceptVisualStateManager.cs" />
     <Compile Include="HorizontalTextAlignmentConverter.cs" />
     <Compile Include="ITitleIconProvider.cs" />

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -54,7 +54,7 @@
     <Compile Include="FormsSlider.cs" />
     <Compile Include="FormsTextBox.cs" />
     <Compile Include="FormsComboBox.cs" />
-    <Compile Include="ITabStopOnDescenants.cs" />
+    <Compile Include="ITabStopOnDescendants.cs" />
     <Compile Include="InterceptVisualStateManager.cs" />
     <Compile Include="HorizontalTextAlignmentConverter.cs" />
     <Compile Include="ITitleIconProvider.cs" />


### PR DESCRIPTION
### Description of Change ###

Complex controls when receive focus send it further to descendant or previous element.

### Issues Resolved ### 

- fixes #3872

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

When press `Tab` button or `Shift-Tab` controls immediately getting focus on interactive control.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
- run UI test 3872
- press Tab key few times.
- check switching focus control. They should switch the next interactive control on a single click.
- press Shift-Tab keys few times.
- check switching focus control in reverse order. They should switch the next interactive control on a single click.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
