### PR TITLE
[Android] Prevent double time/date picker dialogs on Android when setting focus

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -170,6 +170,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnTextFieldClicked()
 		{
+			if (_dialog != null && _dialog.IsShowing)
+			{
+				return;
+			}
+
 			DatePicker view = Element;
 			((IElementController)view).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 

--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -145,6 +145,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnClick()
 		{
+			if (_dialog != null && _dialog.IsShowing)
+			{
+				return;
+			}
+
 			TimePicker view = Element;
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 


### PR DESCRIPTION
### Description of Change ###

If the Android Date- or TimePicker controls get a focus request while the picker dialog is visible, they launch a second picker dialog which covers the first. 

This change verifies that the picker dialog is not already visible before launching a new one.

### Issues Resolved ### 

- Breaking UI tests 42074/41424 (and following tests, as the dialogs do not dismiss properly).

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run UI tests 42074 and 41424; in each one, tap the "Click to focus X" button. Then tap the hardware back button. Without this change, a picker dialog will still be visible. With this change, there will be no picker dialog visible.

### PR Checklist ###

- [X] Has automated tests 
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
