### PR TITLE
[Android]Fix for frame renderer's bug (bugzilla 60787).

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -48,10 +48,19 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnElementChanged(e);
 
+			if (e.OldElement != null)
+			{
+				e.OldElement.PropertyChanged -= Element_PropertyChanged;
+			}
+			if (e.NewElement != null)
+			{
+				e.NewElement.PropertyChanged += Element_PropertyChanged;
+			}
+
+
 			if (e.NewElement != null && e.OldElement == null)
 			{
 				UpdateBackground();
-				UpdateCornerRadius();
 				_motionEventHelper.UpdateElement(e.NewElement);
 			}
 		}
@@ -61,9 +70,9 @@ namespace Xamarin.Forms.Platform.Android
 			this.SetBackground(new FrameDrawable(Element, Context.ToPixels));
 		}
 
-		void UpdateCornerRadius()
+		void Element_PropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			this.SetBackground(new FrameDrawable(Element, Context.ToPixels));
+			UpdateBackground();
 		}
 
 		class FrameDrawable : Drawable


### PR DESCRIPTION
### Description of Change ###

This change forces FrameRenderer on Android to rerender of its background Drawable without losing the corner radius..

### Issues Resolved ### 

- fixes #3902

### API Changes ###

Added:
 - void FrameRenderer.Element_PropertyChanged(object sender, PropertyChangedEventArgs e);

Changed:
 - void Xamarin.Forms.Platform.Android.FrameRenderer.OnElementChanged => now it subscribes and unsubscribe to events.
 
 Removed:
 - void Xamarin.Forms.Platform.Android.FrameRenderer.UpdateCornerRadius=> it had a redundant code lines, same as UpdateBackground.
 

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

After dynamic background color change, the corner radius should stay the same before.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
