### PR TITLE
[GTK] Fix visibility in modal pages

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/Page.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Page.cs
@@ -1,6 +1,7 @@
 ﻿using Gdk;
 using Gtk;
 using System;
+using System.Linq;
 using Xamarin.Forms.Platform.GTK.Extensions;
 
 namespace Xamarin.Forms.Platform.GTK.Controls
@@ -91,6 +92,22 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			{
 				Internals.Log.Warning("Page BackgroundImage", "Could not load background image: {0}", ex);
 			}
+		}
+
+		public void PushModal(Widget modal)
+		{
+			Children.Last().Hide();
+			Attach(modal, 0, 1, 0, 1);
+			modal.ShowAll();
+		}
+
+		public void PopModal(Widget modal)
+		{
+			if (Children.Length > 0)
+			{
+				Remove(modal);
+			}
+			Children.Last().Show();
 		}
 
 		public override void Dispose()

--- a/Xamarin.Forms.Platform.GTK/Platform.cs
+++ b/Xamarin.Forms.Platform.GTK/Platform.cs
@@ -181,28 +181,7 @@ namespace Xamarin.Forms.Platform.GTK
 
 			Device.BeginInvokeOnMainThread(() =>
 			{
-				if (pageControl != null)
-				{
-					var page = pageControl.Control;
-
-					if (page != null)
-					{
-						if (page.Children.Length > 0)
-						{
-							page.Remove(modalPage);
-						}
-
-						if (page.Children != null)
-						{
-							foreach (var child in page.Children)
-							{
-								child.ShowAll();
-							}
-
-							page.ShowAll();
-						}
-					}
-				}
+				pageControl?.Control?.PopModal(modalPage);
 
 				DisposeModelAndChildrenRenderers(modal);
 			});
@@ -258,17 +237,7 @@ namespace Xamarin.Forms.Platform.GTK
 
 					if (page != null)
 					{
-						page.Attach(modalRenderer.Container, 0, 1, 0, 1);
-
-						if (page.Children != null)
-						{
-							foreach (var child in page.Children)
-							{
-								child.ShowAll();
-							}
-
-							page.ShowAll();
-						}
+						page.PushModal(modalRenderer.Container);
 					}
 				}
 			});

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -330,7 +330,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			if (oldPage != null && Platform.GetRenderer(oldPage) != null)
 			{
 				var oldPageRenderer = Platform.GetRenderer(oldPage);
-				oldPageRenderer.Container.Sensitive = false;
+				oldPageRenderer.Container.Visible = false;
 			}
 
 			return true;
@@ -343,7 +343,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			if (oldPage != null && Platform.GetRenderer(oldPage) != null)
 			{
 				var oldPageRenderer = Platform.GetRenderer(oldPage);
-				oldPageRenderer.Container.Sensitive = true;
+				oldPageRenderer.Container.Visible = true;
 			}
 
 			(page as IPageController)?.SendDisappearing();


### PR DESCRIPTION

### Description of Change ###

A modal navigation stacks the new page in the Page's control without hiding the current page or the previous stacked page, so those are still taken in account for redraws and resizes. This change hides the current visible page before showing the new one. Also, the current implementation is iterating over all children and calling ShowAll when the modal is poped, changing the visibility state of the page that's under the modal.
Example:
1. A page has a label that's hidden
2. A modal navigation hide the page and shows the new page
3. The modal is poped, showing again the page with the label
4. The label must remain hidden

### Issues Resolved ### 

### API Changes ###
 None

### Platforms Affected ### 
- Gtk

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
