### PR TITLE
[Android] Update ClipBounds when View bounds changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ViewClipBoundsShouldUpdate.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ViewClipBoundsShouldUpdate.cs
@@ -1,0 +1,49 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 888888, "Bounds clipping does not update when View bounds change", PlatformAffected.Android)]
+	public class ViewClipBoundsShouldUpdate : TestContentPage
+	{
+		const string Success = "Success";
+
+		class TestContentView : ContentView
+		{
+			public TestContentView()
+			{
+				Content = new Label { Text = Success };
+
+				IsClippedToBounds = true;
+			}
+		}
+
+		protected override void Init()
+		{
+			var layout = new StackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = $"If '{Success}' displays below then this test has passed."
+					},
+					new TestContentView()
+				}
+			};
+
+			Content = layout;
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -502,6 +502,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3342.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3415.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3049.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ViewClipBoundsShouldUpdate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -104,6 +104,13 @@ namespace Xamarin.Forms.Platform.Android
 				Performance.Stop(reference, "MeasureAndLayout");
 			}
 
+			// If we're running sufficiently new Android, we have to make sure to update the ClipBounds to
+			// match the new size of the ViewGroup
+			if ((int)Build.VERSION.SdkInt >= 18)
+			{
+				UpdateClipToBounds();
+			}
+
 			Performance.Stop(reference);
 
 			//On Width or Height changes, the anchors needs to be updated


### PR DESCRIPTION
### Description of Change ###

The ClipBounds for Layouts is not being updated when the size of the Layout changes. This change fixes that issue.

### Issues Resolved ### 

- Clipped layouts disappearing entirely if IsClippedToBounds set before they are sized
- Clipped layouts being clipped at the wrong dimensions after rotation/resizing
- fixes #3717

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
