### PR TITLE
Fix StartTimer and Ticker for UWP

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1937.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1937.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1937, "[UWP] Choppy animation", PlatformAffected.UWP)]
+	public class Issue1937 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var description = new Label
+			{
+				Text = "Fast timer have interval 20ms. Slow timer have interval 100ms. Both timers work for 1000ms. Start timer and check timer ticks."
+			};
+			var finishFlag = new Label();
+			var resultDesription = new Label()
+			{
+				Text = "Timer ticks:"
+			};
+			var resultContainer = new Label()
+			{
+				AutomationId = "RESULT"
+			};
+
+			var fastTimerStartButton = new Button
+			{
+				Text = "FAST_TIMER"
+			};
+
+			fastTimerStartButton.Clicked += (_, __) =>
+			{
+				finishFlag.Text = "";
+				var timerTicks = 0;
+				var stopwatch = new Stopwatch();
+				stopwatch.Start();
+				Device.StartTimer(TimeSpan.FromMilliseconds(20), () =>
+				{
+					timerTicks++;
+					if (stopwatch.ElapsedMilliseconds < 1000)
+						return true;
+					resultContainer.Text = timerTicks.ToString();
+					finishFlag.Text = "COMPLETE";
+					return false;
+				});
+			};
+
+			var slowTimerStartButton = new Button
+			{
+				Text = "SLOW_TIMER"
+			};
+
+			slowTimerStartButton.Clicked += (_, __) =>
+			{
+				finishFlag.Text = "";
+				var timerTicks = 0;
+				var stopwatch = new Stopwatch();
+				stopwatch.Start();
+				Device.StartTimer(TimeSpan.FromMilliseconds(100), () =>
+				{
+					timerTicks++;
+					if (stopwatch.ElapsedMilliseconds < 1000)
+						return true;
+					resultContainer.Text = timerTicks.ToString();
+					finishFlag.Text = "COMPLETE";
+					return false;
+				});
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					description,
+					fastTimerStartButton,
+					slowTimerStartButton,
+					finishFlag,
+					resultDesription,
+					resultContainer
+				}
+			};
+		}
+
+#if UITEST && __WINDOWS__
+		[Test]
+		public void Issue1937Test ()
+		{
+			RunningApp.Tap(q => q.Marked("FAST_TIMER"));
+			RunningApp.WaitForElement(q => q.Marked("COMPLETE"), timeout:TimeSpan.FromSeconds(2));
+			var result = RunningApp.WaitForElement(q => q.Marked("RESULT"))[0];
+			var timerTicks = int.Parse(result.Text);
+			//If fps > 50 then result must be 50. For small fps we use comparing with 35.
+			Assert.IsTrue(timerTicks > 35, $"Expected timer ticks are greater than 35. Actual: {timerTicks}");
+
+			RunningApp.Tap(q => q.Marked("SLOW_TIMER"));
+			RunningApp.WaitForElement(q => q.Marked("COMPLETE"), timeout:TimeSpan.FromSeconds(2));
+			result = RunningApp.WaitForElement(q => q.Marked("RESULT"))[0];
+			timerTicks = int.Parse(result.Text);
+			Assert.IsTrue(timerTicks < 11, $"Expected timer ticks are less than 11. Actual: {timerTicks}");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -14,6 +14,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Github3856.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1937.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3308.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3788.cs" />

--- a/Xamarin.Forms.Platform.UAP/WindowsTicker.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsTicker.cs
@@ -1,27 +1,23 @@
-﻿using System;
-using Windows.UI.Xaml;
+﻿using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.UWP
 {
 	internal class WindowsTicker : Ticker
 	{
-		readonly DispatcherTimer _timer;
-
-		public WindowsTicker()
-		{
-			_timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(15) };
-			_timer.Tick += (sender, args) => SendSignals();
-		}
-
 		protected override void DisableTimer()
 		{
-			_timer.Stop();
+			CompositionTarget.Rendering -= RenderingFrameEventHandler;
 		}
 
 		protected override void EnableTimer()
 		{
-			_timer.Start();
+			CompositionTarget.Rendering += RenderingFrameEventHandler;
+		}
+
+		void RenderingFrameEventHandler(object sender, object args)
+		{
+			SendSignals();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Replace ```DispatcherTimer ``` to ```CompositionTarget.Rendering``` event in ```WindowsTicker``` and ```WindowsBasePlatformServices``` . 

### Issues Resolved ### 

- fixes #1937

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

These changes would improve animation smoothness.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
I checked only on _ScaleTo_ animation and wrote ```Issue1937Test ``` for ```Device.StartTimer```.

### PR Checklist ###

- [ ] Has automated tests 
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
