### PR TITLE
[C] catch AmbiguousMatchException on GetProps

### DIFF
--- a/Xamarin.Forms.Core/Interactivity/PropertyCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/PropertyCondition.cs
@@ -33,7 +33,14 @@ namespace Xamarin.Forms
 				//convert the value
 				if (_property != null && s_valueConverter != null)
 				{
-					Func<MemberInfo> minforetriever = () => Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
+					Func<MemberInfo> minforetriever = () =>
+					{
+						try {
+							return Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
+						} catch (AmbiguousMatchException e) {
+							throw new XamlParseException($"Multiple properties with name '{Property.DeclaringType}.{Property.PropertyName}' found.", new XmlLineInfo(), innerException: e);
+						}
+					};
 					Value = s_valueConverter.Convert(Value, Property.ReturnType, minforetriever, null);
 				}
 			}
@@ -52,7 +59,14 @@ namespace Xamarin.Forms
 				//convert the value
 				if (_property != null && s_valueConverter != null)
 				{
-					Func<MemberInfo> minforetriever = () => Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
+					Func<MemberInfo> minforetriever = () =>
+					{
+						try {
+							return Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
+						} catch (AmbiguousMatchException e) {
+							throw new XamlParseException($"Multiple properties with name '{Property.DeclaringType}.{Property.PropertyName}' found.", new XmlLineInfo(), innerException: e);
+						}
+					};
 					value = s_valueConverter.Convert(value, Property.ReturnType, minforetriever, null);
 				}
 				_triggerValue = value;

--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -22,15 +22,30 @@ namespace Xamarin.Forms
 		{
 			if (Property == null)
 			{
-				var lineInfoProvider = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) as IXmlLineInfoProvider;
-				IXmlLineInfo lineInfo = lineInfoProvider != null ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+				IXmlLineInfo lineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
 				throw new XamlParseException("Property not set", lineInfo);
 			}
 			var valueconverter = serviceProvider.GetService(typeof(IValueConverterProvider)) as IValueConverterProvider;
 
 			Func<MemberInfo> minforetriever =
 				() =>
-				(MemberInfo)Property.DeclaringType.GetRuntimeProperty(Property.PropertyName) ?? (MemberInfo)Property.DeclaringType.GetRuntimeMethod("Get" + Property.PropertyName, new[] { typeof(BindableObject) });
+				{
+					MemberInfo minfo = null;
+					try {
+						minfo = Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
+					} catch (AmbiguousMatchException e) {
+						IXmlLineInfo lineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+						throw new XamlParseException($"Multiple properties with name '{Property.DeclaringType}.{Property.PropertyName}' found.", lineInfo, innerException: e);
+					}
+					if (minfo != null)
+						return minfo;
+					try {
+						return Property.DeclaringType.GetRuntimeMethod("Get" + Property.PropertyName, new[] { typeof(BindableObject) });
+					} catch (AmbiguousMatchException e) {
+						IXmlLineInfo lineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+						throw new XamlParseException($"Multiple methods with name '{Property.DeclaringType}.Get{Property.PropertyName}' found.", lineInfo, innerException: e);
+					}
+				};
 
 			object value = valueconverter.Convert(Value, Property.ReturnType, minforetriever, serviceProvider);
 			Value = value;
@@ -40,7 +55,7 @@ namespace Xamarin.Forms
 		internal void Apply(BindableObject target, bool fromStyle = false)
 		{
 			if (target == null)
-				throw new ArgumentNullException("target");
+				throw new ArgumentNullException(nameof(target));
 			if (Property == null)
 				return;
 

--- a/Xamarin.Forms.Core/StyleSheets/Style.cs
+++ b/Xamarin.Forms.Core/StyleSheets/Style.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Xml;
 using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.StyleSheets
@@ -84,9 +85,26 @@ namespace Xamarin.Forms.StyleSheets
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		static object Convert(object target, object value, BindableProperty property)
 		{
-			Func<MemberInfo> minforetriever = () =>    property.DeclaringType.GetRuntimeProperty(property.PropertyName) as MemberInfo
-													?? property.DeclaringType.GetRuntimeMethod("Get" + property.PropertyName, new[] { typeof(BindableObject) }) as MemberInfo;
 			var serviceProvider = new StyleSheetServiceProvider(target, property);
+			Func<MemberInfo> minforetriever =
+				() =>
+				{
+					MemberInfo minfo = null;
+					try {
+						minfo = property.DeclaringType.GetRuntimeProperty(property.PropertyName);
+					} catch (AmbiguousMatchException e) {
+						IXmlLineInfo lineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+						throw new XamlParseException($"Multiple properties with name '{property.DeclaringType}.{property.PropertyName}' found.", lineInfo, innerException: e);
+					}
+					if (minfo != null)
+						return minfo;
+					try {
+						return property.DeclaringType.GetRuntimeMethod("Get" + property.PropertyName, new[] { typeof(BindableObject) });
+					} catch (AmbiguousMatchException e) {
+						IXmlLineInfo lineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+						throw new XamlParseException($"Multiple methods with name '{property.DeclaringType}.Get{property.PropertyName}' found.", lineInfo, innerException: e);
+					}
+				};
 			return value.ConvertTo(property.ReturnType, minforetriever, serviceProvider);
 		}
 


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->
As, most of the time, the property passed to Get[Runtime](Method|Property) is provided by user code, validate that it doesn't throw AME, as AME message is mostly useless

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3870

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
