### PR TITLE
WPF - Fix TimePicker with short time pattern shows verbose time

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3306.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3306.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3306, "[WPF] TimePicker with short time pattern shows verbose time", PlatformAffected.WPF)]
+	public class Issue3306 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var stack = new StackLayout();
+
+			TimePicker timePicker = new TimePicker();
+			timePicker.Time = DateTime.Now.TimeOfDay;
+			
+			TimePicker timePicker2 = new TimePicker();
+			timePicker2.Time = DateTime.Now.TimeOfDay;
+			timePicker2.Format = "t";
+
+			stack.Children.Add(timePicker);
+			stack.Children.Add(timePicker2);
+			Content = stack;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -15,6 +15,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Github3856.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3306.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3308.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3788.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3524.cs" />

--- a/Xamarin.Forms.Platform.WPF/FormsTimePicker.cs
+++ b/Xamarin.Forms.Platform.WPF/FormsTimePicker.cs
@@ -48,7 +48,9 @@ namespace Xamarin.Forms.Platform.WPF
 				Text = null;
 			else
 			{
-				String text = Time.Value.ToString(String.IsNullOrWhiteSpace(TimeFormat) ? @"hh\:mm" : TimeFormat.ToLower());
+				var dateTime = new DateTime(Time.Value.Ticks);
+				
+				String text = dateTime.ToString(String.IsNullOrWhiteSpace(TimeFormat) ? @"hh\:mm" : TimeFormat.ToLower());
 				if (text.CompareTo(Text) != 0)
 					Text = text;
 			}
@@ -56,15 +58,15 @@ namespace Xamarin.Forms.Platform.WPF
 
 		private void SetTime()
 		{
-			TimeSpan timeSpan = TimeSpan.MinValue;
+			DateTime dateTime = DateTime.MinValue;
 			String timeFormat = String.IsNullOrWhiteSpace(TimeFormat) ? @"hh\:mm" : TimeFormat.ToLower();
 
-			if (TimeSpan.TryParseExact(Text, timeFormat, null, out timeSpan))
+			if (DateTime.TryParseExact(Text, timeFormat, null, System.Globalization.DateTimeStyles.None, out dateTime))
 			{
-				if ((Time == null) || (Time != null && Time.Value.CompareTo(timeSpan) != 0))
+				if ((Time == null) || (Time != null && Time.Value.CompareTo(dateTime.TimeOfDay) != 0))
 				{
-					if (timeSpan < TimeSpan.FromHours(24) && timeSpan > TimeSpan.Zero)
-						Time = timeSpan;
+					if (dateTime.TimeOfDay < TimeSpan.FromHours(24) && dateTime.TimeOfDay > TimeSpan.Zero)
+						Time = dateTime.TimeOfDay;
 					else
 						SetText();
 				}


### PR DESCRIPTION
### Description of Change ###

 Fix TimePicker with short time pattern shows verbose time

### Issues Resolved ### 

- fixes #3306

### Platforms Affected ### 

- WPF