### PR TITLE
Fix UI test 39378

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml
@@ -2,7 +2,8 @@
 <local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Controls.Issues.Bugzilla39378" xmlns:local="clr-namespace:Xamarin.Forms.Controls">
     <local:TestContentPage.Content>
         <Grid BackgroundColor="{Binding BackgroundColor}" Margin="20" Padding="20">
-            <Image AutomationId="image1">
+			<Label Text="Verify that the background color for the container is beige and an image can be seen below this text. This is primarily testing that the binding for the URI image source works." LineBreakMode="WordWrap" MaxLines="4" VerticalTextAlignment="Start"/>
+			<Image AutomationId="image1" HorizontalOptions="Center" VerticalOptions="Center">
                 <Image.Source>
                     <UriImageSource Uri="{Binding HomeImage}" />
                 </Image.Source>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39378.xaml.cs
@@ -1,13 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using Xamarin.Forms;
-using Xamarin.Forms.CustomAttributes;
+﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-#if UITEST
-using Xamarin.UITest;
-using NUnit.Framework;
-#endif
-
 
 namespace Xamarin.Forms.Controls.Issues
 {
@@ -24,18 +16,17 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			BindingContext = new ImageController();
+			BindingContext = new ImageController39378();
 		}
 
 		[Preserve(AllMembers = true)]
-		class ImageController : ViewModelBase
+		class ImageController39378 : ViewModelBase
 		{
 			
-			public ImageController()
+			public ImageController39378()
 			{
-				HomeImage = "http://xamarin.com/content/images/pages/forms/example-app.png";
-				LocalBackgroundImage = "Default-568h@2x.png";
-				BackgroundColor = "#00FF00";
+				HomeImage = "https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/banner.png";
+				BackgroundColor = "#f5f5dc";
 			}
 
 			public string BackgroundColor
@@ -66,33 +57,8 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			}
 
-			public string LocalBackgroundImage
-			{
-				get
-				{ 
-					return _localBackgroundImage;
-				}
-
-				set
-				{
-					_localBackgroundImage = value;
-					OnPropertyChanged();
-				}
-			}
-
-
 			string _backgroundColor;
 			string _homeImage;
-			string _localBackgroundImage;
 		}
-
-#if UITEST
-		[Test]
-		public void ImageIsPresent()
-		{
-			RunningApp.WaitForElement(q => q.Marked("image1"));
-			Assert.Inconclusive("Please verify image is present");
-		}
-#endif
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Removed automated test
Added on-screen instructions
Switched to using another URL for the image
@hartez wanted to see `ManualReview` category added, but this category is set when `#if UITEST` is true. Why set it if the test is not automated? Should this still be added?

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2305

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
