### PR TITLE
Fix bugzilla60787

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
@@ -1,0 +1,21 @@
+﻿<local:TestContentPage 
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Xamarin.Forms.Controls"
+	x:Class=" Xamarin.Forms.Controls.Issues.Bugzilla60787"
+	x:Name="This"
+	BindingContext="{x:Reference This}">
+	<StackLayout>
+
+		<Frame x:Name="frmNoChange" BackgroundColor="CornflowerBlue" CornerRadius="10">
+			<Label Text="This one doesn't change colour and keeps its corner radius" />
+		</Frame>
+
+		<Frame x:Name="frmDoesChange" BackgroundColor="Red" CornerRadius="10">
+			<Label Text="This one changes colour and loses the corner radius" />
+		</Frame>
+
+		<Button x:Name="btnChangeColour" Text="Change colour" />
+
+	</StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
@@ -1,21 +1,20 @@
-﻿<local:TestContentPage 
-	xmlns="http://xamarin.com/schemas/2014/forms"
-	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-	xmlns:local="clr-namespace:Xamarin.Forms.Controls"
-	x:Class=" Xamarin.Forms.Controls.Issues.Bugzilla60787"
-	x:Name="This"
-	BindingContext="{x:Reference This}">
-	<StackLayout>
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.Bugzilla60787">
+    <ContentPage.Content>
+	    <StackLayout>
 
-		<Frame x:Name="frmNoChange" BackgroundColor="CornflowerBlue" CornerRadius="10">
-			<Label Text="This one doesn't change colour and keeps its corner radius" />
-		</Frame>
+		    <Frame x:Name="frmNoChange" BackgroundColor="CornflowerBlue" CornerRadius="10">
+			    <Label Text="This one doesn't change colour and keeps its corner radius" />
+		    </Frame>
 
-		<Frame x:Name="frmDoesChange" BackgroundColor="Red" CornerRadius="10">
-			<Label Text="This one changes colour and loses the corner radius" />
-		</Frame>
+		    <Frame x:Name="frmDoesChange" BackgroundColor="Red" CornerRadius="10">
+			    <Label Text="This one changes colour and loses the corner radius" />
+		    </Frame>
 
-		<Button x:Name="btnChangeColour" Text="Change colour" />
+		    <Button x:Name="btnChangeColour" Text="Change colour" />
 
-	</StackLayout>
-</local:TestContentPage>
+	    </StackLayout>
+	</ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.Forms.Controls.Issues.Bugzilla60787">
+             x:Class="Xamarin.Forms.Controls.Bugzilla60787">
     <ContentPage.Content>
 	    <StackLayout>
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 60787, "Frames with border radius preset have this radius reset when their background color is changed.",
 		PlatformAffected.Android, issueTestNumber: 1)]
-	public partial class Bugzilla60787 : TestContentPage
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Bugzilla60787 : ContentPage
 	{
 		bool _colourIndicator;
 
@@ -25,5 +27,4 @@ namespace Xamarin.Forms.Controls.Issues
 			_colourIndicator = !_colourIndicator;
 		}
 	}
-
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml.cs
@@ -3,12 +3,12 @@ using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml;
 
-namespace Xamarin.Forms.Controls.Issues
+namespace Xamarin.Forms.Controls
 {
+#if APP
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 60787, "Frames with border radius preset have this radius reset when their background color is changed.",
 		PlatformAffected.Android, issueTestNumber: 1)]
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class Bugzilla60787 : ContentPage
 	{
 		bool _colourIndicator;
@@ -27,4 +27,5 @@ namespace Xamarin.Forms.Controls.Issues
 			_colourIndicator = !_colourIndicator;
 		}
 	}
+#endif
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 60787, "Frames with border radius preset have this radius reset when their background color is changed.",
+		PlatformAffected.Android, issueTestNumber: 1)]
+	public partial class Bugzilla60787 : TestContentPage
+	{
+		bool _colourIndicator;
+
+		public Bugzilla60787()
+		{
+			InitializeComponent();
+
+			this.btnChangeColour.Clicked += btnChangeColour_Click;
+		}
+
+		void btnChangeColour_Click(object sender, EventArgs e)
+		{
+			this.frmDoesChange.BackgroundColor = _colourIndicator ? Color.LightBlue : Color.LightGoldenrodYellow;
+
+			_colourIndicator = !_colourIndicator;
+		}
+	}
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml.cs">
       <DependentUpon>Bugzilla60787.xaml</DependentUpon>
+      <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue1588.xaml.cs">
       <DependentUpon>Issue1588.xaml</DependentUpon>
@@ -992,9 +993,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Page Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml">
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
-    </Page>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,9 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml.cs">
+      <DependentUpon>Bugzilla60787.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue1588.xaml.cs">
       <DependentUpon>Issue1588.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -987,5 +990,11 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -48,10 +48,19 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnElementChanged(e);
 
+			if (e.OldElement != null)
+			{
+				e.OldElement.PropertyChanged -= Element_PropertyChanged;
+			}
+			if (e.NewElement != null)
+			{
+				e.NewElement.PropertyChanged += Element_PropertyChanged;
+			}
+
+
 			if (e.NewElement != null && e.OldElement == null)
 			{
 				UpdateBackground();
-				UpdateCornerRadius();
 				_motionEventHelper.UpdateElement(e.NewElement);
 			}
 		}
@@ -61,9 +70,9 @@ namespace Xamarin.Forms.Platform.Android
 			this.SetBackground(new FrameDrawable(Element, Context.ToPixels));
 		}
 
-		void UpdateCornerRadius()
+		void Element_PropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			this.SetBackground(new FrameDrawable(Element, Context.ToPixels));
+			UpdateBackground();
 		}
 
 		class FrameDrawable : Drawable

--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -48,16 +48,6 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnElementChanged(e);
 
-			if (e.OldElement != null)
-			{
-				e.OldElement.PropertyChanged -= Element_PropertyChanged;
-			}
-			if (e.NewElement != null)
-			{
-				e.NewElement.PropertyChanged += Element_PropertyChanged;
-			}
-
-
 			if (e.NewElement != null && e.OldElement == null)
 			{
 				UpdateBackground();
@@ -65,14 +55,18 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
+			{
+				UpdateBackground();
+			}
+		}
+
 		void UpdateBackground()
 		{
 			this.SetBackground(new FrameDrawable(Element, Context.ToPixels));
-		}
-
-		void Element_PropertyChanged(object sender, PropertyChangedEventArgs e)
-		{
-			UpdateBackground();
 		}
 
 		class FrameDrawable : Drawable


### PR DESCRIPTION
### Description of Change ###

This change forces FrameRenderer on Android to rerender of its background Drawable without losing the corner radius..

### Issues Resolved ### 

- fixes #3902 
- [https://bugzilla.xamarin.com/show_bug.cgi?id=60787](https://bugzilla.xamarin.com/show_bug.cgi?id=60787)

### API Changes ###

Added:
 - void FrameRenderer.Element_PropertyChanged(object sender, PropertyChangedEventArgs e);

Changed:
 - void Xamarin.Forms.Platform.Android.FrameRenderer.OnElementChanged => now it subscribes and unsubscribe to events.
 
 Removed:
 - void Xamarin.Forms.Platform.Android.FrameRenderer.UpdateCornerRadius=> it had a redundant code lines, same as UpdateBackground.
 

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

After dynamic background color change, the corner radius should stay the same before.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

[Before](https://drive.google.com/file/d/1ONs_F7AF2MweJvgjn7Zr8ejZy-NX_yRG/view)
[After](https://drive.google.com/open?id=1Z9AvR2ScUsGAkNu77OqSan_tAZ2jfXSt)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
