### PR TITLE
[Android] If MaxLines is not explicitly set, let LineBreakMode handle it

### DIFF
--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 			var lineBreakMode = label.LineBreakMode;
 
 			int maxLines = Int32.MaxValue;
+			bool singleLine = false;
 
 			switch (lineBreakMode)
 			{
@@ -53,6 +54,7 @@ namespace Xamarin.Forms.Platform.Android
 					break;
 				case LineBreakMode.HeadTruncation:
 					maxLines = 1;
+					singleLine = true; // Workaround for bug in older Android API versions (https://bugzilla.xamarin.com/show_bug.cgi?id=49069)
 					textView.Ellipsize = TextUtils.TruncateAt.Start;
 					break;
 				case LineBreakMode.TailTruncation:
@@ -61,10 +63,12 @@ namespace Xamarin.Forms.Platform.Android
 					break;
 				case LineBreakMode.MiddleTruncation:
 					maxLines = 1;
+					singleLine = true; // Workaround for bug in older Android API versions (https://bugzilla.xamarin.com/show_bug.cgi?id=49069)
 					textView.Ellipsize = TextUtils.TruncateAt.Middle;
 					break;
 			}
 
+			textView.SetSingleLine(singleLine);
 			textView.SetMaxLines(label, maxLines);
 		}
 

--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -46,11 +46,9 @@ namespace Xamarin.Forms.Platform.Android
 					break;
 				case LineBreakMode.WordWrap:
 					textView.Ellipsize = null;
-					maxLines = int.MaxValue;
 					break;
 				case LineBreakMode.CharacterWrap:
 					textView.Ellipsize = null;
-					maxLines = int.MaxValue;
 					break;
 				case LineBreakMode.HeadTruncation:
 					maxLines = 1;

--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -14,11 +14,12 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (maxLines == (int)Label.MaxLinesProperty.DefaultValue)
 			{
-				// MaxLines has not been explicitly set, so just let it be whatever was set by LineBreakMode
+				// MaxLines is not explicitly set, so just let it be whatever gets set by LineBreakMode
+				textView.SetLineBreakMode(label);
 				return;
 			}
 
-			textView.SetMaxLines(maxLines);	
+			textView.SetMaxLines(maxLines);
 		}
 
 		static void SetMaxLines(this TextView textView, Label label, int lines)

--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Android.Text;
+﻿using System;
+using Android.Text;
 using Android.Widget;
 using System.Collections.Generic;
 using Xamarin.Forms.Internals;
@@ -7,41 +8,65 @@ namespace Xamarin.Forms.Platform.Android
 {
 	internal static class TextViewExtensions
 	{
-		public static void SetLineBreakMode(this TextView textView, LineBreakMode lineBreakMode)
+		public static void SetMaxLines(this TextView textView, Label label)
 		{
+			var maxLines = label.MaxLines;
+
+			if (maxLines == (int)Label.MaxLinesProperty.DefaultValue)
+			{
+				// MaxLines has not been explicitly set, so just let it be whatever was set by LineBreakMode
+				return;
+			}
+
+			textView.SetMaxLines(maxLines);	
+		}
+
+		static void SetMaxLines(this TextView textView, Label label, int lines)
+		{
+			// If the Label's MaxLines has been explicitly set, we should not set it here
+			if (label.MaxLines != (int)Label.MaxLinesProperty.DefaultValue)
+			{
+				return;
+			}
+
+			textView.SetMaxLines(lines);
+		}
+
+		public static void SetLineBreakMode(this TextView textView, Label label)
+		{
+			var lineBreakMode = label.LineBreakMode;
+
+			int maxLines = Int32.MaxValue;
+
 			switch (lineBreakMode)
 			{
 				case LineBreakMode.NoWrap:
-					textView.SetMaxLines(1);
-					textView.SetSingleLine(true);
+					maxLines = 1;
 					textView.Ellipsize = null;
 					break;
 				case LineBreakMode.WordWrap:
 					textView.Ellipsize = null;
-					textView.SetMaxLines(100);
-					textView.SetSingleLine(false);
+					maxLines = int.MaxValue;
 					break;
 				case LineBreakMode.CharacterWrap:
 					textView.Ellipsize = null;
-					textView.SetMaxLines(100);
-					textView.SetSingleLine(false);
+					maxLines = int.MaxValue;
 					break;
 				case LineBreakMode.HeadTruncation:
-					textView.SetMaxLines(1);
-					textView.SetSingleLine(true);
+					maxLines = 1;
 					textView.Ellipsize = TextUtils.TruncateAt.Start;
 					break;
 				case LineBreakMode.TailTruncation:
-					textView.SetMaxLines(1);
-					textView.SetSingleLine(true);
+					maxLines = 1;
 					textView.Ellipsize = TextUtils.TruncateAt.End;
 					break;
 				case LineBreakMode.MiddleTruncation:
-					textView.SetMaxLines(1);
-					textView.SetSingleLine(true);
+					maxLines = 1;
 					textView.Ellipsize = TextUtils.TruncateAt.Middle;
 					break;
 			}
+
+			textView.SetMaxLines(label, maxLines);
 		}
 
 		public static void RecalculateSpanPositions(this TextView textView, Label element, SpannableString spannableString, SizeRequest finalSize)

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -317,14 +317,13 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		void UpdateLineBreakMode()
 		{
-			this.SetLineBreakMode(Element.LineBreakMode);
+			this.SetLineBreakMode(Element);
 			_lastSizeRequest = null;
 		}
 
 		void UpdateMaxLines()
 		{
-			SetSingleLine(Element.MaxLines == 1);
-			SetMaxLines(Element.MaxLines > 0 ? Element.MaxLines : 1);
+			this.SetMaxLines(Element);
 		}
 
 		void UpdateText()

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -211,7 +211,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateLineBreakMode()
 		{
-			_view.SetLineBreakMode(Element.LineBreakMode);
+			_view.SetLineBreakMode(Element);
 			_lastSizeRequest = null;
 		}
 
@@ -226,8 +226,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateMaxLines()
 		{
-			Control.SetSingleLine(Element.MaxLines == 1);
-			Control.SetMaxLines(Element.MaxLines > 0 ? Element.MaxLines : 1);
+			Control.SetMaxLines(Element);	
 		}
 
 		void UpdateText()


### PR DESCRIPTION
### Description of Change ###

MaxLines handling on Android is currently blowing away the settings from LineBreakMode, causing CharacterWrap and WordWrap to fail.

This change addresses that by doing the following:

- If MaxLines is not explicitly set, it is ignored and the values from LineBreakMode handle the native maxLines value.

- If MaxLines is explicitly set, the MaxLines setting wins. 

This change also uses a more reasonable default for native maxLines when handling it via LineBreakMode (the Android default of MaxValue rather than an arbitrary 100). This change also consolidates MaxLines handling code between legacy and fast renderers for less duplication and removes unnecessary calls to SetSingleLine (which only applies to input).

### Issues Resolved ### 

- fixes #3772 
- fixes broken LineBreakMode on Android when using WordWrap and CharacterWrap

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
