### PR TITLE
[GTK] Changes in TableView to allow refresh the content (updating/removing TableSections)

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/TableView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/TableView.cs
@@ -28,11 +28,8 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			}
 			set
 			{
-				if (_source != value)
-				{
-					_source = value;
-					RefreshSource(_source);
-				}
+				_source = value;
+				RefreshSource(_source);
 			}
 		}
 
@@ -59,7 +56,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			}
 		}
 
-		private int GetUnevenRowCellHeight(Gtk.Container cell)
+		int GetUnevenRowCellHeight(Container cell)
 		{
 			int height = -1;
 
@@ -73,7 +70,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			return height;
 		}
 
-		private Cell GetXamarinFormsCell(Container cell)
+		Cell GetXamarinFormsCell(Container cell)
 		{
 			try
 			{
@@ -90,7 +87,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			}
 		}
 
-		private void BuildTableView()
+		void BuildTableView()
 		{
 			CanFocus = true;
 			ShadowType = ShadowType.None;
@@ -100,8 +97,11 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
 			_root = new VBox(false, 0);
 
-			Viewport viewPort = new Viewport();
-			viewPort.ShadowType = ShadowType.None;
+			Viewport viewPort = new Viewport
+			{
+				ShadowType = ShadowType.None
+			};
+
 			viewPort.Add(_root);
 
 			Add(viewPort);
@@ -109,11 +109,19 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			_cells = new List<Container>();
 		}
 
-		private void RefreshSource(TableRoot source)
+		void RefreshSource(TableRoot source)
 		{
+			// Clear
+			_cells.Clear();
+
+			foreach (var child in _root.AllChildren)
+			{
+				_root.RemoveFromContainer((Widget)child);
+			}
+
+			// Add Title
 			if (!string.IsNullOrEmpty(source.Title))
 			{
-				// Add Title
 				var titleSpan = new Span()
 				{
 					FontSize = 16,
@@ -129,9 +137,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			// Add Table Section
 			for (int i = 0; i < source.Count; i++)
 			{
-				var tableSection = source[i] as TableSection;
-
-				if (tableSection != null)
+				if (source[i] is TableSection tableSection)
 				{
 					var tableSectionSpan = new Span()
 					{
@@ -146,8 +152,11 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 					_root.PackStart(sectionTitle, false, false, 0);
 
 					// Table Section Separator
-					EventBox separator = new EventBox();
-					separator.HeightRequest = 1;
+					EventBox separator = new EventBox
+					{
+						HeightRequest = 1
+					};
+
 					separator.ModifyBg(StateType.Normal, Color.Black.ToGtkColor());
 					_root.PackStart(separator, false, false, 0);
 
@@ -166,9 +175,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 						{
 							nativeCell.ButtonPressEvent += (sender, args) =>
 							{
-								var gtkCell = sender as CellBase;
-
-								if (gtkCell != null && gtkCell.Cell != null)
+								if (sender is CellBase gtkCell && gtkCell.Cell != null)
 								{
 									var selectedCell = gtkCell.Cell;
 
@@ -184,6 +191,9 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 						_root.PackStart(cell, false, false, 0);
 					}
 				}
+
+				// Refresh
+				_root.ShowAll();
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.GTK/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/TableViewRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Xamarin.Forms.Platform.GTK.Extensions;
 
 namespace Xamarin.Forms.Platform.GTK.Renderers
@@ -34,6 +35,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 		protected override void OnElementChanged(ElementChangedEventArgs<TableView> e)
 		{
+			if (e.OldElement != null)
+			{
+				e.OldElement.ModelChanged -= OnModelChanged;
+			}
+
 			if (e.NewElement != null)
 			{
 				if (Control == null)
@@ -49,6 +55,9 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				UpdateRowHeight();
 				UpdateHasUnevenRows();
 				UpdateBackgroundView();
+
+				e.NewElement.ModelChanged += OnModelChanged;
+				OnModelChanged(e.NewElement, EventArgs.Empty);
 			}
 
 			base.OnElementChanged(e);
@@ -67,12 +76,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			}
 		}
 
-		private void SetSource()
+		void SetSource()
 		{
 			Control.Root = Element.Root;
 		}
 
-		private void UpdateRowHeight()
+		void UpdateRowHeight()
 		{
 			var hasUnevenRows = Element.HasUnevenRows;
 
@@ -86,7 +95,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			Control.SetRowHeight(rowHeight > 0 ? rowHeight : DefaultRowHeight);
 		}
 
-		private void UpdateHasUnevenRows()
+		void UpdateHasUnevenRows()
 		{
 			var hasUnevenRows = Element.HasUnevenRows;
 
@@ -100,7 +109,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			}
 		}
 
-		private void UpdateBackgroundView()
+		void UpdateBackgroundView()
 		{
 			if (Element.BackgroundColor.IsDefault)
 			{
@@ -111,20 +120,23 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			Control.SetBackgroundColor(backgroundColor);
 		}
 
-		private void OnItemTapped(object sender, Controls.ItemTappedEventArgs args)
+		void OnItemTapped(object sender, Controls.ItemTappedEventArgs args)
 		{
 			if (Element == null)
 				return;
 
-			var cell = args.Item as Cell;
-
-			if (cell != null)
+			if (args.Item is Cell cell)
 			{
 				if (cell.IsEnabled)
 				{
 					Element.Model.RowSelected(cell);
 				}
 			}
+		}
+
+		void OnModelChanged(object sender, EventArgs e)
+		{
+			SetSource();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Changes in TableView GTK Control and TableViewRenderer to allow refresh the content (updating/removing TableSections).

![3725](https://user-images.githubusercontent.com/6755973/46245139-7571f900-c3e9-11e8-80d7-6e1877e7d399.gif)

### Issues Resolved ### 
- fixes #3725 

### Platforms Affected ### 
- GTK

### Behavioral/Visual Changes ###
Now, the TableView refresh the content adding or removing TableSections, etc.

### Testing Procedure ###
When running the Xamarin Forms Control Gallery for GTK the test cases screen doesn't appear to update it's view as you try to filter down issues.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
