### PR TITLE
[Core] Added IsVisible property to ToolbarItem

### DIFF
--- a/Xamarin.Forms.Controls/ControlGalleryPages/ToolbarItems.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/ToolbarItems.cs
@@ -1,8 +1,4 @@
-﻿using System;
-
-using Xamarin.Forms;
-
-namespace Xamarin.Forms.Controls
+﻿namespace Xamarin.Forms.Controls
 {
 	public class ToolbarItems : ContentPage
 	{
@@ -48,7 +44,8 @@ namespace Xamarin.Forms.Controls
 			tb5.Text = "tb5";
 			tb5.Icon = "bank.png";
 			tb5.Order = ToolbarItemOrder.Secondary;
-			tb5.Command = new Command(async () => {
+			tb5.Command = new Command(async () =>
+			{
 				await Navigation.PushAsync(new ToolbarItems());
 			});
 			tb5.AutomationId = "toolbaritem_secondary5";
@@ -59,10 +56,19 @@ namespace Xamarin.Forms.Controls
 			ToolbarItems.Add(tb4);
 			ToolbarItems.Add(tb5);
 
+
+			var button = new Button { Text = "Change tb2 visibility" };
+
+			button.Clicked += (sender, args) =>
+			{
+				tb2.IsVisible = !tb2.IsVisible;
+			};
+
 			Content = new StackLayout
 			{
 				Children = {
-					label
+					label,
+					button
 				}
 			};
 		}

--- a/Xamarin.Forms.Core/ToolbarItem.cs
+++ b/Xamarin.Forms.Core/ToolbarItem.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms
 
 			if (item != null)
 			{
-				var items = ((ContentPage)item.Parent).ToolbarItems;
+				var items = ((Page)item.Parent).ToolbarItems;
 
 				if ((bool)newvalue && !items.Contains(item))
 				{

--- a/Xamarin.Forms.Core/ToolbarItem.cs
+++ b/Xamarin.Forms.Core/ToolbarItem.cs
@@ -16,11 +16,11 @@ namespace Xamarin.Forms
 		{
 			var item = bindable as ToolbarItem;
 
-			if (item != null && item.Parent == null)
-				return;
-
 			if (item != null)
 			{
+				if (item.Parent == null)
+					return;
+
 				var items = ((Page)item.Parent).ToolbarItems;
 
 				if ((bool)newvalue && !items.Contains(item))

--- a/Xamarin.Forms.Core/ToolbarItem.cs
+++ b/Xamarin.Forms.Core/ToolbarItem.cs
@@ -25,11 +25,11 @@ namespace Xamarin.Forms
 
 				if ((bool)newvalue && !items.Contains(item))
 				{
-					items.Add(item);
+					Device.BeginInvokeOnMainThread(() => { items.Add(item); });
 				}
 				else if (!(bool)newvalue && items.Contains(item))
 				{
-					items.Remove(item);
+					Device.BeginInvokeOnMainThread(() => { items.Remove(item); });
 				}
 			}
 		});

--- a/Xamarin.Forms.Core/ToolbarItem.cs
+++ b/Xamarin.Forms.Core/ToolbarItem.cs
@@ -12,11 +12,34 @@ namespace Xamarin.Forms
 
 		static readonly BindableProperty PriorityProperty = BindableProperty.Create("Priority", typeof(int), typeof(ToolbarItem), 0);
 
+		public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create("IsVisible", typeof(bool), typeof(ToolbarItem), true, BindingMode.TwoWay, propertyChanged: (bindable, oldvalue, newvalue) =>
+		{
+			var item = bindable as ToolbarItem;
+
+			if (item != null && item.Parent == null)
+				return;
+
+			if (item != null)
+			{
+				var items = ((ContentPage)item.Parent).ToolbarItems;
+
+				if ((bool)newvalue && !items.Contains(item))
+				{
+					items.Add(item);
+				}
+				else if (!(bool)newvalue && items.Contains(item))
+				{
+					items.Remove(item);
+				}
+			}
+		});
+
 		public ToolbarItem()
 		{
+	
 		}
 
-		public ToolbarItem(string name, string icon, Action activated, ToolbarItemOrder order = ToolbarItemOrder.Default, int priority = 0)
+		public ToolbarItem(string name, string icon, Action activated, ToolbarItemOrder order = ToolbarItemOrder.Default, int priority = 0, bool isVisible = true)
 		{
 			if (activated == null)
 				throw new ArgumentNullException("activated");
@@ -26,6 +49,7 @@ namespace Xamarin.Forms
 			Clicked += (s, e) => activated();
 			Order = order;
 			Priority = priority;
+			IsVisible = isVisible;
 		}
 
 		[Obsolete("Name is obsolete as of version 1.3.0. Please use Text instead.")]
@@ -45,6 +69,12 @@ namespace Xamarin.Forms
 		{
 			get { return (int)GetValue(PriorityProperty); }
 			set { SetValue(PriorityProperty, value); }
+		}
+
+		public bool IsVisible
+		{
+			get { return (bool)GetValue(IsVisibleProperty); }
+			set { SetValue(IsVisibleProperty, value); }
 		}
 
 		[Obsolete("Activated is obsolete as of version 1.3.0. Please use Clicked instead.")]

--- a/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
@@ -35,9 +35,9 @@ namespace Xamarin.Forms.Platform.GTK
 			_toolbarTracker.CollectionChanged += ToolbarTrackerOnCollectionChanged;
 		}
 
-		public HBox Toolbar
+		public ToolbarTracker Tracker
 		{
-			get { return _toolbar; }
+			get { return _toolbarTracker; }
 		}
 
 		public NavigationPage Navigation

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -238,6 +238,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			}
 
 			_currentPage = Page.CurrentPage;
+			NativeToolbarTracker.Tracker.Target = _currentPage;
 
 			if (_currentPage != null)
 			{


### PR DESCRIPTION
### Description of Change ###

Added IsVisible property to ToolbarItem.

### Issues Resolved ### 

- fixes #3838 

### API Changes ###

Added:
 - bool ToolbarItem.IsVisible{ get; set; } //Bindable Property

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core
- iOS
- Android
- UWP
- macOS
- WPF
- GTK
- Tizen

### Behavioral/Visual Changes ###

Some screenshots:

GTK
![3838-gtk](https://user-images.githubusercontent.com/6755973/46256305-2d1a1000-c4a9-11e8-8512-705b0ddb8914.gif)

WPF
![3838-wpf](https://user-images.githubusercontent.com/6755973/46256306-2ee3d380-c4a9-11e8-9ab0-493e09c4a783.gif)

**NOTE**: In other platforms, the behaviors is the same.

### Testing Procedure ###
Using Core Gallery, open the ToolbarItems sample and press the "Change tb2 visibiltiy" button. Must change the visiblity of the "tb2" ToolbarItem.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
