### PR TITLE
[iOS, Android, macOS] fixes accessibility of Picker. Support accessibility for macOS,

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3454.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3454.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3454, "Picker accessibility text is wrong", PlatformAffected.macOS)]
+	public class Issue3454 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var picker = new Picker();
+			var picker2 = new Picker();
+#if !UITEST
+			picker.SetAutomationPropertiesName("pi pi picker");
+			picker.SetAutomationPropertiesHelpText("double tap to edit");
+#endif
+			picker.ItemsSource = picker2.ItemsSource = Enumerable.Range(1, 10).Select(i => $"item {i}").ToList();
+
+			Content = new StackLayout
+			{
+				Children = {
+					new Label { Text = "↓ Picker with setted AutomationProperties ↓" },
+					picker,
+					new Label { Text = "↓ Default picker ↓" },
+					picker2
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -34,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3809.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3306.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3454.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3308.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3788.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1724.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -1,6 +1,7 @@
 using Android.App;
 using Android.Util;
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
@@ -9,6 +10,8 @@ using Android.Widget;
 using AColor = Android.Graphics.Color;
 using Android.Text;
 using Android.Text.Style;
+using Android.Views;
+using Android.Views.Accessibility;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -18,6 +21,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		bool _disposed;
 		TextColorSwitcher _textColorSwitcher;
 		int _originalHintTextColor;
+		PickerAccessibilityDelegate _pickerAccessibilityDelegate;
+
+		HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
+			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
+		});
 
 		public PickerRenderer(Context context) : base(context)
 		{
@@ -59,6 +67,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (Control == null)
 				{
 					var textField = CreateNativeControl();
+
+					_pickerAccessibilityDelegate = new PickerAccessibilityDelegate();
+					textField.SetAccessibilityDelegate(_pickerAccessibilityDelegate);
+					if (e.NewElement.GetValue(AutomationProperties.NameProperty) == null && e.NewElement.GetValue(AutomationProperties.HelpTextProperty) == null)
+						e.NewElement.SetValue(AutomationProperties.NameProperty, nameof(Picker));
 
 					var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors, useLegacyColorManagement);
@@ -168,11 +181,25 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				Control.Text = null;
 			else
 				Control.Text = Element.Items[Element.SelectedIndex];
+
+			_pickerAccessibilityDelegate.ValueText = Control.Text;
 		}
 
 		void UpdateTextColor()
 		{
 			_textColorSwitcher?.UpdateTextColor(Control, Element.TextColor);
+		}
+
+		class PickerAccessibilityDelegate : AccessibilityDelegate
+		{
+			public string ValueText { get; set; }
+
+			public override void OnInitializeAccessibilityNodeInfo(global::Android.Views.View host, AccessibilityNodeInfo info)
+			{
+				base.OnInitializeAccessibilityNodeInfo(host, info);
+				info.ClassName = "android.widget.Button";
+				info.Text = ValueText;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -71,8 +71,9 @@ namespace Xamarin.Forms.Platform.iOS
 					entry.InputAccessoryView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
 
 					_defaultTextColor = entry.TextColor;
-					
+
 					_useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
+					entry.AccessibilityLabel = nameof(Button);
 
 					SetNativeControl(entry);
 				}
@@ -87,6 +88,27 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			base.OnElementChanged(e);
+		}
+
+		protected override void SetAccessibilityLabel()
+		{
+			base.SetAccessibilityLabel();
+			if (Control != null && _picker != null)
+				_picker.AccessibilityLabel = Control.AccessibilityLabel;
+		}
+
+		protected override void SetAccessibilityHint()
+		{
+			base.SetAccessibilityHint();
+			if (Control != null && _picker != null)
+				_picker.AccessibilityHint = Control.AccessibilityHint;
+		}
+
+		protected override void SetIsAccessibilityElement()
+		{
+			base.SetIsAccessibilityElement();
+			if (Control != null && _picker != null)
+				_picker.IsAccessibilityElement = Control.IsAccessibilityElement;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -188,6 +210,7 @@ namespace Xamarin.Forms.Platform.iOS
 			source.SelectedIndex = formsIndex;
 			source.SelectedItem = formsIndex >= 0 ? Element.Items[formsIndex] : null;
 			_picker.Select(Math.Max(formsIndex, 0), 0, true);
+			_picker.AccessibilityValue = Control.Text;
 		}
 
 		void UpdateTextColor()

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -30,10 +30,34 @@ namespace Xamarin.Forms.Platform.MacOS
 	public abstract class ViewRenderer<TView, TNativeView> : VisualElementRenderer<TView>, IVisualNativeElementRenderer, ITabStop where TView : View where TNativeView : NativeView
 	{
 #if __MOBILE__
-		string _defaultAccessibilityLabel;
-		string _defaultAccessibilityHint;
-		bool? _defaultIsAccessibilityElement;
+		string ControlAccessibilityHint
+		{
+			get => Control.AccessibilityHint;
+			set => Control.AccessibilityHint = value;
+		}
+		bool ControlAccessibilityElement
+		{
+			get => Control.IsAccessibilityElement;
+			set => Control.IsAccessibilityElement = value;
+		}
+#else
+		string ControlAccessibilityHint
+		{
+			get => Control.AccessibilityTitle;
+			set => Control.AccessibilityTitle = value;
+		}
+		bool ControlAccessibilityElement
+		{
+			get => Control.AccessibilityElement;
+			set => Control.AccessibilityElement = value;
+		}
 #endif
+		string ControlAccessibilityLabel
+		{
+			get => Control.AccessibilityLabel;
+			set => Control.AccessibilityLabel = value;
+		}
+
 		NativeColor _defaultColor;
 
 		event EventHandler<PropertyChangedEventArgs> _elementPropertyChanged;
@@ -158,23 +182,21 @@ namespace Xamarin.Forms.Platform.MacOS
 			effect.SetControl(Control);
 		}
 
-#if __MOBILE__
 		protected override void SetAccessibilityHint()
 		{
-			_defaultAccessibilityHint = Control.SetAccessibilityHint(Element, _defaultAccessibilityHint);
+			ControlAccessibilityHint = (string)Element.GetValue(AutomationProperties.HelpTextProperty) ?? ControlAccessibilityHint;
 		}
 
 		protected override void SetAccessibilityLabel()
 		{
-			_defaultAccessibilityLabel = Control.SetAccessibilityLabel(Element, _defaultAccessibilityLabel);
+			ControlAccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? ControlAccessibilityLabel;
 		}
 
 		protected override void SetIsAccessibilityElement()
 		{
-			_defaultIsAccessibilityElement = Control.SetIsAccessibilityElement(Element, _defaultIsAccessibilityElement);
+			ControlAccessibilityElement = (bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? ControlAccessibilityElement;
 		}
-	
-#endif
+
 		protected override void SetAutomationId(string id)
 		{
 			if (Control == null)

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -38,11 +38,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		readonly List<EventHandler<VisualElementChangedEventArgs>> _elementChangedHandlers = new List<EventHandler<VisualElementChangedEventArgs>>();
 
 		readonly PropertyChangedEventHandler _propertyChangedHandler;
-#if __MOBILE__
-		string _defaultAccessibilityLabel;
-		string _defaultAccessibilityHint;
-		bool? _defaultIsAccessibilityElement;
-#endif
+
 		EventTracker _events;
 
 		VisualElementRendererFlags _flags = VisualElementRendererFlags.AutoPackage | VisualElementRendererFlags.AutoTrack;
@@ -53,7 +49,34 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __MOBILE__
 		UIVisualEffectView _blur;
 		BlurEffectStyle _previousBlur;
+
+		string ControlAccessibilityHint
+		{
+			get => AccessibilityHint;
+			set => AccessibilityHint = value;
+		}
+		bool ControlAccessibilityElement
+		{
+			get => IsAccessibilityElement;
+			set => IsAccessibilityElement = value;
+		}
+#else
+		string ControlAccessibilityHint
+		{
+			get => AccessibilityTitle;
+			set => AccessibilityTitle = value;
+		}
+		bool ControlAccessibilityElement
+		{
+			get => AccessibilityElement;
+			set => AccessibilityElement = value;
+		}
 #endif
+		string ControlAccessibilityLabel
+		{
+			get => AccessibilityLabel;
+			set => AccessibilityLabel = value;
+		}
 
 		protected VisualElementRenderer() : base(RectangleF.Empty)
 		{
@@ -270,11 +293,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (Element != null && !string.IsNullOrEmpty(Element.AutomationId))
 				SetAutomationId(Element.AutomationId);
-#if __MOBILE__
 			SetAccessibilityLabel();
 			SetAccessibilityHint();
 			SetIsAccessibilityElement();
-#endif
 			Performance.Stop(reference);
 		}
 
@@ -308,7 +329,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			var menu = Xamarin.Forms.Element.GetMenu(Element);
 			if (menu != null && NativeView != null)
 				NSMenu.PopUpContextMenu(menu.ToNSMenu(), theEvent, NativeView);
-		
+
 			base.RightMouseUp(theEvent);
 		}
 #endif
@@ -374,14 +395,13 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __MOBILE__
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.VisualElement.BlurEffectProperty.PropertyName)
 				SetBlur((BlurEffectStyle)Element.GetValue(PlatformConfiguration.iOSSpecific.VisualElement.BlurEffectProperty));
+#endif
 			else if (e.PropertyName == AutomationProperties.HelpTextProperty.PropertyName)
 				SetAccessibilityHint();
 			else if (e.PropertyName == AutomationProperties.NameProperty.PropertyName)
 				SetAccessibilityLabel();
 			else if (e.PropertyName == AutomationProperties.IsInAccessibleTreeProperty.PropertyName)
 				SetIsAccessibilityElement();
-#endif
-
 		}
 
 		protected virtual void OnRegisterEffect(PlatformEffect effect)
@@ -389,22 +409,21 @@ namespace Xamarin.Forms.Platform.MacOS
 			effect.SetContainer(this);
 		}
 
-#if __MOBILE__
 		protected virtual void SetAccessibilityHint()
 		{
-			_defaultAccessibilityHint = this.SetAccessibilityHint(Element, _defaultAccessibilityHint);
+			ControlAccessibilityHint = (string)Element.GetValue(AutomationProperties.HelpTextProperty) ?? ControlAccessibilityHint;
 		}
 
 		protected virtual void SetAccessibilityLabel()
 		{
-			_defaultAccessibilityLabel = this.SetAccessibilityLabel(Element, _defaultAccessibilityLabel);
+			ControlAccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? ControlAccessibilityLabel;
 		}
 
 		protected virtual void SetIsAccessibilityElement()
 		{
-			_defaultIsAccessibilityElement = this.SetIsAccessibilityElement(Element, _defaultIsAccessibilityElement);
+			ControlAccessibilityElement = (bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? ControlAccessibilityElement;
 		}
-#endif
+
 		protected virtual void SetAutomationId(string id)
 		{
 			AccessibilityIdentifier = id;


### PR DESCRIPTION
### Description of Change ###

[Android, iOS] Changed accessibility of Picker. Now it reads like a `button`. If something is selected in it, this item is also read.
[Mac ] Added support AutomationProperty.

### Issues Resolved ### 

- fixes #3454

### API Changes ###
 
 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Before
![before](https://user-images.githubusercontent.com/27482193/46279337-8188c280-c571-11e8-95a2-bd57145883c8.png)

After
![after](https://user-images.githubusercontent.com/27482193/46279361-906f7500-c571-11e8-853f-fe0cdad539b3.png)
iOS
![iOS](https://user-images.githubusercontent.com/27482193/46354341-0bff1e00-c667-11e8-8687-5a30176b283b.png)


### Testing Procedure ###
- Run UI test 3454 on macOS
- Check accessibility on picker

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
