### PR TITLE
Fixed NotImplementedException refreshing items in WPF ListView

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ListViewRenderer.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Input;
-using System.Windows.Media;
-using Xamarin.Forms.Internals;
 using WList = System.Windows.Controls.ListView;
 
 namespace Xamarin.Forms.Platform.WPF
@@ -28,14 +20,14 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			if (e.OldElement != null) // Clear old element event
 			{
-				var templatedItems = ((ITemplatedItemsView<Cell>)e.OldElement).TemplatedItems;
-				templatedItems.CollectionChanged -= TemplatedItems_GroupedCollectionChanged;
-				templatedItems.GroupedCollectionChanged -= TemplatedItems_GroupedCollectionChanged;
+				var templatedItems = TemplatedItemsView.TemplatedItems;
+				templatedItems.CollectionChanged -= OnCollectionChanged;
+				templatedItems.GroupedCollectionChanged -= OnGroupedCollectionChanged;
 			}
 
 			if (e.NewElement != null)
 			{
-				if (Control == null) // construct and SetNativeControl and suscribe control event
+				if (Control == null) // Construct and SetNativeControl and suscribe control event
 				{
 					var listView = new WList
 					{
@@ -43,59 +35,35 @@ namespace Xamarin.Forms.Platform.WPF
 						ItemTemplate = (System.Windows.DataTemplate)System.Windows.Application.Current.Resources["CellTemplate"],
 						Style = (System.Windows.Style)System.Windows.Application.Current.Resources["ListViewTemplate"]
 					};
+
 					SetNativeControl(listView);
+
 					Control.MouseUp += OnNativeMouseUp;
 					Control.KeyUp += OnNativeKeyUp;
 					Control.TouchUp += OnNativeTouchUp;
 					Control.StylusUp += OnNativeStylusUp;
 				}
-				
-				// Update control property 
+
+				// Update control properties
 				UpdateItemSource();
 
-				//UpdateHeader();
-				//UpdateFooter();
-				//UpdateJumpList();
-
 				// Suscribe element event
-				TemplatedItemsView.TemplatedItems.CollectionChanged += TemplatedItems_GroupedCollectionChanged;
-				TemplatedItemsView.TemplatedItems.GroupedCollectionChanged += TemplatedItems_GroupedCollectionChanged;
+				TemplatedItemsView.TemplatedItems.CollectionChanged += OnCollectionChanged;
+				TemplatedItemsView.TemplatedItems.GroupedCollectionChanged += OnGroupedCollectionChanged;
 			}
 
 			base.OnElementChanged(e);
-		}
-		
-		private void TemplatedItems_GroupedCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			UpdateItemSource();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-
-			if (e.PropertyName == ListView.IsGroupingEnabledProperty.PropertyName)
-			{
-				//UpdateGrouping();
-			}
-
-
-			/*if (e.PropertyName == ListView.SelectedItemProperty.PropertyName)
-				OnItemSelected(Element.SelectedItem);
-			else if (e.PropertyName == "HeaderElement")
-				UpdateHeader();
-			else if (e.PropertyName == "FooterElement")
-				UpdateFooter();
-			else if ((e.PropertyName == ListView.IsRefreshingProperty.PropertyName) || (e.PropertyName == ListView.IsPullToRefreshEnabledProperty.PropertyName) || (e.PropertyName == "CanRefresh"))
-				UpdateIsRefreshing();
-			else if (e.PropertyName == "GroupShortNameBinding")
-				UpdateJumpList();*/
 		}
 
-		
 		void UpdateItemSource()
 		{
 			List<object> items = new List<object>();
+
 			if (Element.IsGroupingEnabled)
 			{
 				int index = 0;
@@ -107,16 +75,12 @@ namespace Xamarin.Forms.Platform.WPF
 					{
 						items.Add(group.HeaderContent);
 
-						/*if (HasHeader(group))
-							_cells.Add(GetCell(group.HeaderContent));
-						else
-							_cells.Add(CreateEmptyHeader());*/
-
 						items.AddRange(group);
 					}
 
 					index++;
 				}
+
 				Control.ItemsSource = items;
 			}
 			else
@@ -156,13 +120,22 @@ namespace Xamarin.Forms.Platform.WPF
 
 				if (Element != null)
 				{
-					TemplatedItemsView.TemplatedItems.CollectionChanged -= TemplatedItems_GroupedCollectionChanged;
-					TemplatedItemsView.TemplatedItems.GroupedCollectionChanged -= TemplatedItems_GroupedCollectionChanged;
+					TemplatedItemsView.TemplatedItems.CollectionChanged -= OnCollectionChanged;
+					TemplatedItemsView.TemplatedItems.GroupedCollectionChanged -= OnGroupedCollectionChanged;
 				}
 			}
 
 			_isDisposed = true;
 			base.Dispose(disposing);
+		}
+
+		void OnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			UpdateItemSource();
+		}
+		void OnGroupedCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			UpdateItemSource();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ListViewRenderer.cs
@@ -43,13 +43,14 @@ namespace Xamarin.Forms.Platform.WPF
 					Control.TouchUp += OnNativeTouchUp;
 					Control.StylusUp += OnNativeStylusUp;
 				}
+				
+				// Suscribe element event
+				var templatedItems = TemplatedItemsView.TemplatedItems;
+				templatedItems.CollectionChanged += OnCollectionChanged;
+				templatedItems.GroupedCollectionChanged += OnGroupedCollectionChanged;
 
 				// Update control properties
 				UpdateItemSource();
-
-				// Suscribe element event
-				TemplatedItemsView.TemplatedItems.CollectionChanged += OnCollectionChanged;
-				TemplatedItemsView.TemplatedItems.GroupedCollectionChanged += OnGroupedCollectionChanged;
 			}
 
 			base.OnElementChanged(e);
@@ -85,7 +86,12 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 			else
 			{
-				Control.ItemsSource = Element.TemplatedItems;
+				foreach (var item in TemplatedItemsView.TemplatedItems)
+				{
+					items.Add(item);
+				}
+
+				Control.ItemsSource = items;
 			}
 		}
 
@@ -133,6 +139,7 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			UpdateItemSource();
 		}
+
 		void OnGroupedCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
 			UpdateItemSource();


### PR DESCRIPTION
### Description of Change ###

Fixed NotImplementedException refreshing items (addin, clear) in WPF ListView.

### Issues Resolved ### 
- fixes #3309 
- fixes #3737 
- fixes #3648 

### Platforms Affected ### 
- WPF

### Behavioral/Visual Changes ###
Now, can clear or change items in WPF ListView.

### Before/After Screenshots ### 

Before
![wrong-3309](https://user-images.githubusercontent.com/6755973/46307347-f16d6c00-c5b6-11e8-85cb-e9b0942d667f.gif)

After
![3309](https://user-images.githubusercontent.com/6755973/46307274-c551eb00-c5b6-11e8-80eb-a904b55fad9f.gif)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
