### PR TITLE
InternalsVisibleTo attributes in preparation for CollectionView preview packages

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core.UnitTests/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using System.Runtime.CompilerServices;
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
 
+[assembly: InternalsVisibleTo ("Xamarin.Forms.CollectionView.Tests")]

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -104,3 +104,5 @@ using Xamarin.Forms.StyleSheets;
 [assembly: StyleProperty("-xf-thumb-color", typeof(Slider), nameof(Slider.ThumbColorProperty))]
 [assembly: StyleProperty("-xf-spacing", typeof(StackLayout), nameof(StackLayout.SpacingProperty))]
 [assembly: StyleProperty("-xf-orientation", typeof(StackLayout), nameof(StackLayout.OrientationProperty))]
+
+[assembly: InternalsVisibleTo("Xamarin.Forms.CollectionView")]

--- a/Xamarin.Forms.Platform.Android/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.Android/Properties/AssemblyInfo.cs
@@ -68,3 +68,5 @@ using Xamarin.Forms.Platform.Android;
 [assembly: Preserve]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
+
+[assembly: InternalsVisibleTo("Xamarin.Forms.CollectionView.Android")]

--- a/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
@@ -1,9 +1,10 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.UWP;
 
 
-[assembly: Dependency(typeof(WindowsSerializer))]
+[assembly: Xamarin.Forms.Dependency(typeof(WindowsSerializer))]
 
 // Views
 
@@ -49,9 +50,11 @@ using Xamarin.Forms.Platform.UWP;
 [assembly: ExportCell(typeof(EntryCell), typeof(EntryCellRenderer))]
 [assembly: ExportCell(typeof(SwitchCell), typeof(SwitchCellRenderer))]
 [assembly: ExportCell(typeof(ViewCell), typeof(ViewCellRenderer))]
-[assembly: Dependency(typeof(WindowsResourcesProvider))]
+[assembly: Xamarin.Forms.Dependency(typeof(WindowsResourcesProvider))]
 [assembly: ExportRenderer(typeof(SearchBar), typeof(SearchBarRenderer))]
 [assembly: ExportRenderer(typeof(TabbedPage), typeof(TabbedPageRenderer))]
 
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
+
+[assembly: InternalsVisibleTo("Xamarin.Forms.CollectionView.UWP")]

--- a/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
@@ -70,3 +70,5 @@ using UIKit;
 [assembly: Preserve]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
+
+[assembly: InternalsVisibleTo("Xamarin.Forms.CollectionView.iOS")]


### PR DESCRIPTION
Adding the necessary InternalsVisibleTo attributes to allow the CollectionView preview packages to work with 3.3.0 and up while it's in the preview stage.