### PR TITLE
[Android] Make GetIconDrawable virtual

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -655,7 +655,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 
-		Drawable GetIconDrawable(FileImageSource icon) =>
+		protected virtual Drawable GetIconDrawable(FileImageSource icon) =>
 			Context.GetDrawable(icon);
 
 		protected virtual void SetTabIcon(TabLayout.Tab tab, FileImageSource icon)


### PR DESCRIPTION
By making GetIconDrawable virtual for the Android TabbedPageRenderer it allows for the icon to come from other sources (like glyph fonts). This will work for both top and bottom tabs.

### Description of Change ###

Changed TabbedPageRenderer.GetIconDrawable to virtual.

### Issues Resolved ### 

- fixes #

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
