### PR TITLE
[XamlC] avoid multiple subscription

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
@@ -1547,7 +1547,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Ignore]
 		public void SpeedTestSetBC()
 		{
-
 			var property = BindableProperty.Create("Foo", typeof(string), typeof(MockBindable));
 			var vm0 = new MockViewModel { Text = "Foo" };
 			var vm1 = new MockViewModel { Text = "Bar" };
@@ -1609,6 +1608,67 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("Bar", bindable.GetValue(property));
 
 			Assert.Fail($"Setting BC for {it} Typedbindings\t\t\t: {swtb.ElapsedMilliseconds}ms.\nSetting BC for {it} Typedbindings (without INPC)\t: {swtbh.ElapsedMilliseconds}ms.\nSetting BC for {it} Bindings\t\t\t\t: {swb.ElapsedMilliseconds}ms.\nSetting  {it} values\t\t\t\t\t: {swsv.ElapsedMilliseconds}ms.");
+		}
+
+		class VM3650 : INotifyPropertyChanged
+		{
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public int Count { get; set; }
+
+			string _title = "default";
+			public string Title
+			{
+				get {
+					Count++;
+					return _title;
+				}
+				set {
+					_title = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Title"));
+				}
+			}
+		}
+
+		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/3650
+		//https://github.com/xamarin/Xamarin.Forms/issues/3613
+		public void TypedBindingsShouldNotHang()
+		{
+			var typedBinding = new TypedBinding<VM3650, string>(
+				vm => vm.Title,
+				(vm, s) => vm.Title = s,
+				new Tuple<Func<VM3650, object>, string>[] {
+					new Tuple<Func<VM3650, object>, string>(vm=>vm, "Title")
+				});
+			var vm3650 = new VM3650();
+			var label = new Label();
+			label.SetBinding(Label.TextProperty, typedBinding);
+			label.BindingContext = vm3650;
+
+			Assert.That(label.Text, Is.EqualTo("default"));
+			Assert.That(vm3650.Count, Is.EqualTo(1));
+
+			vm3650.Count = 0;
+			vm3650.Title = "foo";
+			Assert.That(label.Text, Is.EqualTo("foo"));
+			Assert.That(vm3650.Count, Is.EqualTo(1));
+
+			vm3650.Count = 0;
+			vm3650.Title = "bar";
+			Assert.That(label.Text, Is.EqualTo("bar"));
+			Assert.That(vm3650.Count, Is.EqualTo(1));
+
+			vm3650.Count = 0;
+			vm3650.Title = "baz";
+			Assert.That(label.Text, Is.EqualTo("baz"));
+			Assert.That(vm3650.Count, Is.EqualTo(1));
+
+			vm3650.Count = 0;
+			vm3650.Title = "qux";
+			Assert.That(label.Text, Is.EqualTo("qux"));
+			Assert.That(vm3650.Count, Is.EqualTo(1));
+
 		}
 	}
 }

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -63,10 +63,7 @@ namespace Xamarin.Forms.Internals
 
 		public TypedBinding(Func<TSource, TProperty> getter, Action<TSource, TProperty> setter, Tuple<Func<TSource, object>, string> [] handlers)
 		{
-			if (getter == null)
-				throw new ArgumentNullException(nameof(getter));
-
-			_getter = getter;
+			_getter = getter ?? throw new ArgumentNullException(nameof(getter));
 			_setter = setter;
 
 			if (handlers == null)
@@ -258,6 +255,13 @@ namespace Xamarin.Forms.Internals
 					return null;
 				} 
 				set {
+					if (Listener != null && Listener.Source.TryGetTarget(out var source) && ReferenceEquals(value, source))
+						//Already subscribed
+						return;
+
+					//clear out previous subscription
+					Listener?.Unsubscribe();
+
 					_weakPart.SetTarget(value);
 					Listener.SubscribeTo(value, handler);
 				}


### PR DESCRIPTION
### Description of Change ###

Avoid multiple subscription to PropertyChanged on TypedBindings

### Issues Resolved ### 

- fixes #3613
- fixes #3650

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
