### PR TITLE
[Xaml[C]] resolve Extensions first

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XmlTypeExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/XmlTypeExtensions.cs
@@ -16,8 +16,8 @@ namespace Xamarin.Forms.Build.Tasks
 		{
 			//this could be extended to look for [XmlnsDefinition] in all assemblies
 			var assemblies = new [] {
-				typeof(View).Assembly,
 				typeof(XamlLoader).Assembly,
+				typeof(View).Assembly,
 			};
 
 			s_xmlnsDefinitions = new List<XmlnsDefinitionAttribute>();
@@ -85,8 +85,8 @@ namespace Xamarin.Forms.Build.Tasks
 					});
 			}
 
-			lookupNames.Add(elementName);
 			lookupNames.Add(elementName + "Extension");
+			lookupNames.Add(elementName);
 
 			for (var i = 0; i < lookupNames.Count; i++)
 			{

--- a/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 
 using Xamarin.Forms.Core.UnitTests;
+using Xamarin.Forms.Build.Tasks;
+using Mono.Cecil;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -805,6 +807,18 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</Label>";
 			var label = new Label ();
 			Assert.Throws (new XamlParseExceptionConstraint (4, 8), () => label.LoadFromXaml (xaml));
+		}
+
+		[Test]
+		public void BindingIsResolvedAsBindingExtension()
+		// https://github.com/xamarin/Xamarin.Forms/issues/3606#issuecomment-422377338
+		{
+			var bindingType = XamlParser.GetElementType(new XmlType("http://xamarin.com/schemas/2014/forms", "Binding", null), null, null, out var ex);
+			Assert.That(ex, Is.Null);
+			Assert.That(bindingType, Is.EqualTo(typeof(BindingExtension)));
+
+			var bindingTypeRef = new XmlType("http://xamarin.com/schemas/2014/forms", "Binding", null).GetTypeReference(ModuleDefinition.CreateModule("foo", ModuleKind.Dll), null);
+			Assert.That(bindingType.FullName, Is.EqualTo("Xamarin.Forms.Xaml.BindingExtension"));
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -313,8 +313,8 @@ namespace Xamarin.Forms.Xaml
 		{
 			//this could be extended to look for [XmlnsDefinition] in all assemblies
 			var assemblies = new [] {
-				typeof(View).GetTypeInfo().Assembly,
 				typeof(XamlLoader).GetTypeInfo().Assembly,
+				typeof(View).GetTypeInfo().Assembly,
 			};
 
 			s_xmlnsDefinitions = new List<XmlnsDefinitionAttribute>();
@@ -354,8 +354,8 @@ namespace Xamarin.Forms.Xaml
 				});
 			}
 
-			lookupNames.Add(elementName);
 			lookupNames.Add(elementName + "Extension");
+			lookupNames.Add(elementName);
 
 			for (var i = 0; i < lookupNames.Count; i++)
 			{


### PR DESCRIPTION
### Description of Change ###

XamlLoader should first look for type with the Extension suffix. It used
to be the case, but somehow regressed.

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes issue describe in comment https://github.com/xamarin/Xamarin.Forms/issues/3606#issuecomment-422377338

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
