### PR TITLE
[XamlC] don't compile bindings with Source

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -283,7 +283,9 @@ namespace Xamarin.Forms.Build.Tasks
 				out markupExtension, out genericArguments))
 			{
 				var acceptEmptyServiceProvider = vardefref.VariableDefinition.VariableType.GetCustomAttribute(module, ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "AcceptEmptyServiceProviderAttribute")) != null;
-				if (vardefref.VariableDefinition.VariableType.FullName == "Xamarin.Forms.Xaml.BindingExtension")
+				if (   vardefref.VariableDefinition.VariableType.FullName == "Xamarin.Forms.Xaml.BindingExtension"
+				    && (   node.Properties == null
+				        || !node.Properties.ContainsKey(new XmlName("", "Source"))))
 					foreach (var instruction in CompileBindingPath(node, context, vardefref.VariableDefinition))
 						yield return instruction;
 

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3606.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3606.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Gh3606" x:Name="page">
+	<StackLayout x:DataType="x:String">
+        <Label Text="{Binding Content, Source={x:Reference page}}" />
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3606.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3606.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh3606 : ContentPage
+	{
+		public Gh3606()
+		{
+			InitializeComponent();
+		}
+
+		public Gh3606(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true)]
+			public void BindingsWithSourceArentCompiled(bool useCompiledXaml)
+			{
+				new Gh3606(useCompiledXaml);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -640,6 +640,9 @@
     <Compile Include="Issues\Gh3539.xaml.cs">
       <DependentUpon>Gh3280.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh3606.xaml.cs">
+      <DependentUpon>Gh3606.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('..\.nuspec\Xamarin.Forms.Build.Tasks.dll')" />
@@ -1165,6 +1168,10 @@
     <EmbeddedResource Include="Issues\Gh3539.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh3606.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

Sources are usually x:reference that can't be resolved at compilation
time.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3606

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
