### PR TITLE
[UWP] Fix TitleView Width and MDP rendering quirks

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml
@@ -9,7 +9,6 @@
 			<Label Text="I can be a subtitle" />
 		</StackLayout>
 	</NavigationPage.TitleView>
-
 	<ScrollView>
 		<StackLayout BackgroundColor="Pink">
 			<Button Clicked="masterDetailsPage_Clicked" Text="Master Details Page"></Button>
@@ -22,6 +21,7 @@
 			<Button Clicked="toggleSecondaryToolBarItem_Clicked" Text="Toggle Secondary Tool Bar Item" ></Button>
 			<Button Clicked="toggleLargeTitles_Clicked" Text="Toggle Large Titles" ></Button>
 			<Button Clicked="changeTitleView_Clicked" Text="Toggle Different Title Views"></Button>
+			<Button Clicked="swapDetails_Page" Text="Swap Details Page"></Button>
 			<Button x:Name="btnToggleBackButtonTitle" Clicked="toggleBackButtonText_Clicked" Text="Toggle Back Button Title Text"></Button>
 			<Button Clicked="backToGallery_Clicked" Text="Back to Gallery"></Button>
 		</StackLayout>

--- a/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml.cs
@@ -24,18 +24,27 @@ namespace Xamarin.Forms.Controls.GalleryPages
 			}
 		}
 
-		NavigationPage CreateNavigationPage()
+		static NavigationPage CreateNavigationPage()
 		{
-			return new NavigationPage(new TitleView(false) { Title = "Nav Title" });
+			var page = new TitleView(false) { Title = "Nav Title" };
+			return new NavigationPage(page);
 		}
 
-		public Page GetPage()
+		public static Page GetPage()
 		{
 			return new MasterDetailPage()
 			{
 				Detail = CreateNavigationPage(),
 				Master = new ContentPage() { Title = "Master" }
 			};
+		}
+
+		void swapDetails_Page(object sender, EventArgs e)
+		{
+			if (App.Current.MainPage is MasterDetailPage mdp)
+			{
+				mdp.Detail = CreateNavigationPage();
+			}
 		}
 
 		void masterDetailsPage_Clicked(object sender, EventArgs e)
@@ -125,12 +134,12 @@ namespace Xamarin.Forms.Controls.GalleryPages
 			Navigation.PushAsync(page);
 		}
 
-		View createSearchBarView()
+		static View createSearchBarView()
 		{
 			return new SearchBar { BackgroundColor = Color.Cornsilk, HorizontalOptions = LayoutOptions.FillAndExpand, Margin = new Thickness(10, 0) };
 		}
 
-		View createGrid()
+		static View createGrid()
 		{
 			var grid = new Grid
 			{
@@ -157,13 +166,18 @@ namespace Xamarin.Forms.Controls.GalleryPages
 
 		void titleIcon_Clicked(object sender, EventArgs e)
 		{
-			var titleIcon = NavigationPage.GetTitleIcon(this);
+			toggleTitleIcon(this);
+
+		}
+
+		static void toggleTitleIcon(Page page)
+		{
+			var titleIcon = NavigationPage.GetTitleIcon(page);
 
 			if (titleIcon == null)
-				NavigationPage.SetTitleIcon(this, "coffee.png");
+				NavigationPage.SetTitleIcon(page, "coffee.png");
 			else
-				NavigationPage.SetTitleIcon(this, null);
-
+				NavigationPage.SetTitleIcon(page, null);
 		}
 
 		void masterDetailsPageIcon_Clicked(object sender, EventArgs e)
@@ -188,9 +202,10 @@ namespace Xamarin.Forms.Controls.GalleryPages
 			(App.Current as App).Reset();
 		}
 
-		void toggleToolBarItem_Clicked(object sender, EventArgs e)
+		void toggleToolBarItem_Clicked(object sender, EventArgs e) => toggleToolBarItem(Navigation.NavigationStack.Last());
+
+		static void toggleToolBarItem(Page page)
 		{
-			var page = Navigation.NavigationStack.Last();
 			var items = page.ToolbarItems.Where(x => x.Order == ToolbarItemOrder.Primary).ToList();
 
 			if (items.Any())
@@ -215,14 +230,19 @@ namespace Xamarin.Forms.Controls.GalleryPages
 
 		void changeTitleView_Clicked(object sender, EventArgs e)
 		{
-			var currentView = NavigationPage.GetTitleView(Navigation.NavigationStack.Last());
+			changeTitleView(Navigation.NavigationStack.Last());
+		}
+
+		static void changeTitleView(Page page)
+		{
+			var currentView = NavigationPage.GetTitleView(page);
 
 			if (currentView is Grid)
-				NavigationPage.SetTitleView(Navigation.NavigationStack.Last(), createSearchBarView());
+				NavigationPage.SetTitleView(page, createSearchBarView());
 			else if (currentView is SearchBar)
-				NavigationPage.SetTitleView(Navigation.NavigationStack.Last(), null);
+				NavigationPage.SetTitleView(page, null);
 			else
-				NavigationPage.SetTitleView(Navigation.NavigationStack.Last(), createGrid());
+				NavigationPage.SetTitleView(page, createGrid());
 
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/ITitleViewRendererController.cs
+++ b/Xamarin.Forms.Platform.UAP/ITitleViewRendererController.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	internal interface ITitleViewRendererController
+	{
+		View TitleView { get; }
+		FrameworkElement TitleViewPresenter { get; }
+		Visibility TitleViewVisibility { get; set; }
+		CommandBar CommandBar { get; }
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.UWP
 		bool _showTitle;
 
 		VisualElementTracker<Page, FrameworkElement> _tracker;
-		
+
 		public MasterDetailControl Control { get; private set; }
 
 		public MasterDetailPage Element { get; private set; }
@@ -185,10 +185,10 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (e.PropertyName == "Detail")
 				UpdateDetail();
 			else if (e.PropertyName == nameof(MasterDetailControl.ShouldShowSplitMode)
-			         || e.PropertyName == Specifics.CollapseStyleProperty.PropertyName
-			         || e.PropertyName == Specifics.CollapsedPaneWidthProperty.PropertyName)
+					 || e.PropertyName == Specifics.CollapseStyleProperty.PropertyName
+					 || e.PropertyName == Specifics.CollapsedPaneWidthProperty.PropertyName)
 				UpdateMode();
-			else if(e.PropertyName ==  PlatformConfiguration.WindowsSpecific.Page.ToolbarPlacementProperty.PropertyName)
+			else if (e.PropertyName == PlatformConfiguration.WindowsSpecific.Page.ToolbarPlacementProperty.PropertyName)
 				UpdateToolbarPlacement();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
@@ -255,7 +255,6 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateDetailTitle();
 				UpdateDetailTitleIcon();
-				UpdateDetailTitleView();
 			}
 		}
 
@@ -313,7 +312,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_detail == null)
 				return;
 
-			Control.DetailTitle = (_detail as NavigationPage)?.CurrentPage?.Title ?? _detail.Title ?? Element?.Title;
+			Control.DetailTitle = GetCurrentPage().Title ?? Element?.Title;
 			(this as ITitleProvider).ShowTitle = !string.IsNullOrEmpty(Control.DetailTitle);
 		}
 
@@ -322,7 +321,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_detail == null)
 				return;
 
-			Control.DetailTitleIcon = await NavigationPage.GetTitleIcon(_detail).ToWindowsImageSource();
+			Control.DetailTitleIcon = await NavigationPage.GetTitleIcon(GetCurrentPage()).ToWindowsImageSource();
 			Control.InvalidateMeasure();
 		}
 
@@ -331,7 +330,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_detail == null)
 				return;
 
-			Control.DetailTitleView = NavigationPage.GetTitleView(_detail) as View;
+			Control.DetailTitleView = NavigationPage.GetTitleView(GetCurrentPage()) as View;
 			Control.InvalidateMeasure();
 		}
 
@@ -389,9 +388,9 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			// Enforce consistency rules on toolbar
 			Control.ShouldShowToolbar = _detail is NavigationPage || _master is NavigationPage;
-			if(_detail is NavigationPage _detailNav)
+			if (_detail is NavigationPage _detailNav)
 				Control.ShouldShowNavigationBar = NavigationPage.GetHasNavigationBar(_detailNav.CurrentPage);
-			
+
 		}
 
 		public void BindForegroundColor(AppBar appBar)
@@ -408,6 +407,14 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			element.SetBinding(Windows.UI.Xaml.Controls.Control.ForegroundProperty,
 				new Windows.UI.Xaml.Data.Binding { Path = new PropertyPath("Control.ToolbarForeground"), Source = this, RelativeSource = new RelativeSource { Mode = RelativeSourceMode.TemplatedParent } });
+		}
+
+		Page GetCurrentPage()
+		{
+			if (_detail is NavigationPage page)
+				return page.CurrentPage;
+
+			return _detail;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -304,10 +304,6 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdateShowTitle();
 
 			UpdateTitleOnParents();
-
-			UpdateTitleIcon();
-
-			UpdateTitleView();
 		}
 
 		void MultiPagePropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -377,6 +373,12 @@ namespace Xamarin.Forms.Platform.UWP
 			Element.SendAppearing();
 			UpdateBackButton();
 			UpdateTitleOnParents();
+
+			if (_parentMasterDetailPage != null)
+			{
+				UpdateTitleView();
+				UpdateTitleIcon();
+			}
 		}
 
 		void OnNativeSizeChanged(object sender, SizeChangedEventArgs e)
@@ -460,8 +462,6 @@ namespace Xamarin.Forms.Platform.UWP
 
 			UpdateTitleVisible();
 			UpdateTitleOnParents();
-			UpdateTitleIcon();
-			UpdateTitleView();
 
 			if (isAnimated && _transition == null)
 			{
@@ -546,10 +546,16 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_currentPage == null)
 				return;
 
-			_container.TitleView = TitleView;
-
+			// If the container TitleView gets initialized before the MDP TitleView it causes the 
+			// MDP TitleView to not render correctly
 			if (_parentMasterDetailPage != null && Platform.GetRenderer(_parentMasterDetailPage) is ITitleViewProvider parent)
+			{
+				_container.TitleView = null;
 				parent.TitleView = TitleView;
+			}
+			else if (_parentMasterDetailPage == null)
+				_container.TitleView = TitleView;
+
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/PageControl.cs
+++ b/Xamarin.Forms.Platform.UAP/PageControl.cs
@@ -7,7 +7,7 @@ using WImageSource = Windows.UI.Xaml.Media.ImageSource;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public sealed class PageControl : ContentControl, IToolbarProvider
+	public sealed class PageControl : ContentControl, IToolbarProvider, ITitleViewRendererController
 	{
 		public static readonly DependencyProperty TitleVisibilityProperty = DependencyProperty.Register(nameof(TitleVisibility), typeof(Visibility), typeof(PageControl), new PropertyMetadata(Visibility.Visible));
 
@@ -55,7 +55,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		TaskCompletionSource<CommandBar> _commandBarTcs;
 		Windows.UI.Xaml.Controls.ContentPresenter _presenter;
-	    		
+		TitleViewManager _titleViewManager;
+
 		public PageControl()
 		{
 			Style = Windows.UI.Xaml.Application.Current.Resources["DefaultPageControlStyle"] as Windows.UI.Xaml.Style;
@@ -123,6 +124,9 @@ namespace Xamarin.Forms.Platform.UWP
 			set { SetValue(TitleInsetProperty, value); }
 		}
 
+		FrameworkElement ITitleViewRendererController.TitleViewPresenter => _titleViewPresenter;
+		CommandBar ITitleViewRendererController.CommandBar => _commandBar;
+
 		Task<CommandBar> IToolbarProvider.GetCommandBarAsync()
 		{
 			if (_commandBar != null)
@@ -143,6 +147,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_commandBar = GetTemplateChild("CommandBar") as CommandBar;
 
+			_titleViewManager = new TitleViewManager(this);
 
 			_toolbarPlacementHelper.Initialize(_commandBar, () => ToolbarPlacement, GetTemplateChild);
 
@@ -152,33 +157,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static void OnTitleViewPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)	
 		{	
-			((PageControl)dependencyObject).UpdateTitleViewPresenter();	
-		}	
-			
-		void OnTitleViewPresenterLoaded(object sender, RoutedEventArgs e)	
-		{	
-			if (TitleView == null || _titleViewPresenter == null || _commandBar == null)	
-				return;	
-		
-			_titleViewPresenter.Width = _commandBar.ActualWidth;	
+			((PageControl)dependencyObject)._titleViewManager?.OnTitleViewPropertyChanged();	
 		}
-		
-		void UpdateTitleViewPresenter()	
-		{	
-			if (TitleView == null)	
-			{	
-				TitleViewVisibility = Visibility.Collapsed;	
-					
-				if (_titleViewPresenter != null)	
-					_titleViewPresenter.Loaded -= OnTitleViewPresenterLoaded;	
-			}	
-			else	
-			{	
-					TitleViewVisibility = Visibility.Visible;	
-				
-					if (_titleViewPresenter != null)	
-						_titleViewPresenter.Loaded += OnTitleViewPresenterLoaded;	
-			}	
-		}
-    }
+	}
 }

--- a/Xamarin.Forms.Platform.UAP/TitleViewManager.cs
+++ b/Xamarin.Forms.Platform.UAP/TitleViewManager.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	internal class TitleViewManager
+	{
+		readonly ITitleViewRendererController _titleViewRendererController;
+
+		View TitleView => _titleViewRendererController.TitleView;
+		CommandBar CommandBar =>  _titleViewRendererController.CommandBar;
+		FrameworkElement TitleViewPresenter => _titleViewRendererController.TitleViewPresenter;
+
+		public TitleViewManager(ITitleViewRendererController titleViewRendererController)
+		{
+			_titleViewRendererController = titleViewRendererController;
+			_titleViewRendererController.TitleViewPresenter.Loaded += OnTitleViewPresenterLoaded;
+			CommandBar.LayoutUpdated += commandLayoutUpdated;
+			CommandBar.Unloaded += commandBarUnloaded;
+		}
+
+		internal void OnTitleViewPropertyChanged()
+		{
+			UpdateTitleViewWidth();
+		}
+
+		void OnTitleViewPresenterLoaded(object sender, RoutedEventArgs e)
+		{
+			UpdateTitleViewWidth();
+			TitleViewPresenter.Loaded -= OnTitleViewPresenterLoaded;
+		}
+
+		void commandBarUnloaded(object sender, RoutedEventArgs e)
+		{
+			CommandBar.LayoutUpdated -= commandLayoutUpdated;
+			CommandBar.Unloaded -= commandBarUnloaded;
+		}
+
+		void commandLayoutUpdated(object sender, object e)
+		{
+			UpdateTitleViewWidth();
+		}
+
+		void UpdateTitleViewWidth()
+		{
+			if (TitleView == null || TitleViewPresenter == null || CommandBar == null)
+				return;
+
+			if (CommandBar.ActualWidth <= 0) return;
+
+			double buttonWidth = 0;
+			foreach (var item in CommandBar.GetDescendantsByName<Windows.UI.Xaml.Controls.Button>("MoreButton"))
+				if (item.Visibility == Visibility.Visible)
+					buttonWidth += item.ActualWidth;
+
+			if (!CommandBar.IsDynamicOverflowEnabled)
+				foreach (var item in CommandBar.GetDescendantsByName<ItemsControl>("PrimaryItemsControl"))
+					buttonWidth += item.ActualWidth;
+
+			TitleViewPresenter.Width = CommandBar.ActualWidth - buttonWidth;
+			UpdateVisibility();
+		}
+
+		void UpdateVisibility()
+		{
+			if (TitleView == null)
+				_titleViewRendererController.TitleViewVisibility = Visibility.Collapsed;
+			else
+				_titleViewRendererController.TitleViewVisibility = Visibility.Visible;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -59,6 +59,7 @@
     <Compile Include="ITitleIconProvider.cs" />
     <Compile Include="ITitleProvider.cs" />
     <Compile Include="ITitleViewProvider.cs" />
+    <Compile Include="ITitleViewRendererController.cs" />
     <Compile Include="IToolbarProvider.cs" />
     <Compile Include="NativeBindingExtensions.cs" />
     <Compile Include="NativeEventWrapper.cs" />
@@ -69,6 +70,7 @@
     <Compile Include="PlatformConfigurationExtensions.cs" />
     <Compile Include="PlatformEffect.cs" />
     <Compile Include="TextBlockExtensions.cs" />
+    <Compile Include="TitleViewManager.cs" />
     <Compile Include="UriImageSourceHandler.cs" />
     <Compile Include="ViewExtensions.cs" />
     <Compile Include="LayoutExtensions.cs" />


### PR DESCRIPTION
### Description of Change ###

Fixed issues where TitleView would sometimes not render and the width would be variable. 

Currently the TitleView on UWP will take the entire width thus pushing primary items into the secondary window. The main reason this happens is due to this setting [IsDynamicOverflowEnabled](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.commandbar.isdynamicoverflowenabled#Windows_UI_Xaml_Controls_CommandBar_IsDynamicOverflowEnabled) being set to true by default. I added code so that if it gets set to false it will account for that width and measure correctly but currently that will just have to be done via Custom Renderer or a platform specific down the road

### Issues Resolved ### 

- fixes #3828
- fixes #3834


### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Go to the Title View Control Gallery and try the various buttons. Make sure it acts how you would expect it to in each case.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
