### PR TITLE
Adds Placeholder and PlaceholderColor to Picker

### DIFF
--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -35,7 +35,11 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
-		
+
+		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
+
+		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
+
 		readonly Lazy<PlatformConfigurationRegistry<Picker>> _platformConfigurationRegistry;
 
 		public Picker()
@@ -105,6 +109,18 @@ namespace Xamarin.Forms
 		public string Title {
 			get { return (string)GetValue(TitleProperty); }
 			set { SetValue(TitleProperty, value); }
+		}
+
+		public string Placeholder
+		{
+			get { return (string)GetValue(PlaceholderProperty); }
+			set { SetValue(PlaceholderProperty, value); }
+		}
+
+		public Color PlaceholderColor
+		{
+			get { return (Color)GetValue(PlaceholderColorProperty); }
+			set { SetValue(PlaceholderColorProperty, value); }
 		}
 
 		BindingBase _itemDisplayBinding;

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -11,7 +11,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_PickerRenderer))]
-	public class Picker : View, IFontElement, ITextElement, IElementConfiguration<Picker>
+	public class Picker : View, IFontElement, ITextElement, IPlaceholderElement, IElementConfiguration<Picker>
 	{
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -148,8 +148,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					builder.SetTitle(model.Title ?? "");
 					string[] items = model.Items.ToArray();
-					//builder.SetItems(items, (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
-					builder.SetSingleChoiceItems(items, (int)Element.GetValue(Picker.SelectedIndexProperty), (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
+					builder.SetItems(items, (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
 
 					builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) => { });
 					

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -118,9 +118,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateTextColor();
 			else if (e.PropertyName == Picker.FontAttributesProperty.PropertyName || e.PropertyName == Picker.FontFamilyProperty.PropertyName || e.PropertyName == Picker.FontSizeProperty.PropertyName)
 				UpdateFont();
-			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
+			else if (e.PropertyName == Picker.PlaceholderColorProperty.PropertyName)
 				UpdatePlaceholderColor();
-			else if (e.PropertyName == Entry.PlaceholderProperty.PropertyName)
+			else if (e.PropertyName == Picker.PlaceholderProperty.PropertyName)
 				Control.Hint = Element.Placeholder;
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -197,7 +197,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void UpdatePlaceholderColor()
 		{
-			_hintColorSwitcher.UpdateTextColor(Control, Element.PlaceholderColor, Control.SetHintTextColor);
+			_hintColorSwitcher?.UpdateTextColor(Control, Element.PlaceholderColor, Control.SetHintTextColor);
 		}
 
 		class PickerListener : Object, IOnClickListener

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		AlertDialog _dialog;
 		bool _disposed;
 		TextColorSwitcher _textColorSwitcher;
+		TextColorSwitcher _hintColorSwitcher;
 
 		HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
 			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
@@ -70,15 +71,18 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					textField.InputType = InputTypes.Null;
 					textField.KeyPress += TextFieldKeyPress;
 					textField.SetOnClickListener(PickerListener.Instance);
+					textField.Hint = Element.Placeholder;
 
 					var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors, useLegacyColorManagement);
-					
+					_hintColorSwitcher = new TextColorSwitcher(textField.HintTextColors, useLegacyColorManagement);
+
 					SetNativeControl(textField);
 				}
 				UpdateFont();
 				UpdatePicker();
 				UpdateTextColor();
+				UpdatePlaceholderColor();
 			}
 
 			base.OnElementChanged(e);
@@ -114,6 +118,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateTextColor();
 			else if (e.PropertyName == Picker.FontAttributesProperty.PropertyName || e.PropertyName == Picker.FontFamilyProperty.PropertyName || e.PropertyName == Picker.FontSizeProperty.PropertyName)
 				UpdateFont();
+			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
+				UpdatePlaceholderColor();
+			else if (e.PropertyName == Entry.PlaceholderProperty.PropertyName)
+				Control.Hint = Element.Placeholder;
 		}
 
 		internal override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
@@ -140,7 +148,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					builder.SetTitle(model.Title ?? "");
 					string[] items = model.Items.ToArray();
-					builder.SetItems(items, (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
+					//builder.SetItems(items, (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
+					builder.SetSingleChoiceItems(items, (int)Element.GetValue(Picker.SelectedIndexProperty), (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
 
 					builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) => { });
 					
@@ -184,6 +193,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdateTextColor()
 		{
 			_textColorSwitcher?.UpdateTextColor(Control, Element.TextColor);
+		}
+
+		void UpdatePlaceholderColor()
+		{
+			_hintColorSwitcher.UpdateTextColor(Control, Element.PlaceholderColor, Control.SetHintTextColor);
 		}
 
 		class PickerListener : Object, IOnClickListener

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 		AlertDialog _dialog;
 		bool _isDisposed;
 		TextColorSwitcher _textColorSwitcher;
+		TextColorSwitcher _hintColorSwitcher;
 
 		HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
 			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
@@ -71,9 +72,11 @@ namespace Xamarin.Forms.Platform.Android
 					textField.SetOnClickListener(PickerListener.Instance);
 					textField.InputType = InputTypes.Null;
 					textField.KeyPress += TextFieldKeyPress;
+					textField.Hint = Element.Placeholder;
 
 					var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors, useLegacyColorManagement);
+					_hintColorSwitcher = new TextColorSwitcher(textField.HintTextColors, useLegacyColorManagement);
 
 					SetNativeControl(textField);
 				}
@@ -81,6 +84,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateFont();
 				UpdatePicker();
 				UpdateTextColor();
+				UpdatePlaceholderColor();
 			}
 
 			base.OnElementChanged(e);
@@ -116,6 +120,10 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateTextColor();
 			else if (e.PropertyName == Picker.FontAttributesProperty.PropertyName || e.PropertyName == Picker.FontFamilyProperty.PropertyName || e.PropertyName == Picker.FontSizeProperty.PropertyName)
 				UpdateFont();
+			else if (e.PropertyName == Picker.PlaceholderColorProperty.PropertyName)
+				UpdatePlaceholderColor();
+			else if (e.PropertyName == Picker.PlaceholderProperty.PropertyName)
+				Control.Hint = Element.Placeholder;
 		}
 
 		internal override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
@@ -211,6 +219,11 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateTextColor()
 		{
 			_textColorSwitcher?.UpdateTextColor(Control, Element.TextColor);
+		}
+
+		void UpdatePlaceholderColor()
+		{
+			_hintColorSwitcher?.UpdateTextColor(Control, Element.PlaceholderColor, Control.SetHintTextColor);
 		}
 
 		class PickerListener : Object, IOnClickListener

--- a/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
@@ -16,6 +16,9 @@ namespace Xamarin.Forms.Platform.UWP
 		Brush _defaultBrush;
 		FontFamily _defaultFontFamily;
 
+		Brush _placeholderDefaultBrush;
+		Brush _defaultPlaceholderColorFocusBrush;
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
@@ -57,6 +60,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 				UpdateTitle();
 				UpdateSelectedIndex();
+				UpdatePlaceholder();
+				UpdatePlaceholderColor();
 			}
 
 			base.OnElementChanged(e);
@@ -74,6 +79,10 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTextColor();
 			else if (e.PropertyName == Picker.FontAttributesProperty.PropertyName || e.PropertyName == Picker.FontFamilyProperty.PropertyName || e.PropertyName == Picker.FontSizeProperty.PropertyName)
 				UpdateFont();
+			else if (e.PropertyName == Picker.PlaceholderColorProperty.PropertyName)
+				UpdatePlaceholderColor();
+			else if (e.PropertyName == Picker.PlaceholderProperty.PropertyName)
+				UpdatePlaceholder();
 		}
 
 		void ControlOnLoaded(object sender, RoutedEventArgs routedEventArgs)
@@ -211,6 +220,22 @@ namespace Xamarin.Forms.Platform.UWP
 		void UpdateTitle()
 		{
 			Control.Header = Element.Title;
+		}
+
+		void UpdatePlaceholder()
+		{
+			Control.PlaceholderText = Element.Placeholder ?? "";
+		}
+
+		void UpdatePlaceholderColor()
+		{
+			Color placeholderColor = Element.PlaceholderColor;
+
+			BrushHelpers.UpdateColor(placeholderColor, ref _placeholderDefaultBrush,
+				() => Control.PlaceholderForeground, brush => Control.PlaceholderForeground = brush);
+
+			BrushHelpers.UpdateColor(placeholderColor, ref _defaultPlaceholderColorFocusBrush,
+				() => Control.PlaceholderForeground, brush => Control.PlaceholderForeground = brush);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Forms.Platform.iOS
 		UIColor _defaultTextColor;
 		bool _disposed;
 		bool _useLegacyColorManagement;
+		readonly Color _defaultPlaceholderColor = ColorExtensions.SeventyPercentGrey.ToColor();
 
 		IElementController ElementController => Element as IElementController;
 
@@ -82,6 +83,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateFont();
 				UpdatePicker();
 				UpdateTextColor();
+				UpdatePlaceholder();
 
 				((INotifyCollectionChanged)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
 			}
@@ -100,6 +102,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateTextColor();
 			else if (e.PropertyName == Picker.FontAttributesProperty.PropertyName || e.PropertyName == Picker.FontFamilyProperty.PropertyName || e.PropertyName == Picker.FontSizeProperty.PropertyName)
 				UpdateFont();
+			else if (e.PropertyName == Picker.PlaceholderProperty.PropertyName || e.PropertyName == Picker.PlaceholderColorProperty.PropertyName)
+				UpdatePlaceholder();
 		}
 
 		void OnEditing(object sender, EventArgs eventArgs)
@@ -188,6 +192,28 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// HACK This forces the color to update; there's probably a more elegant way to make this happen
 			Control.Text = Control.Text;
+		}
+
+		void UpdatePlaceholder()
+		{
+			var formatted = (FormattedString)Element.Placeholder;
+
+			if (formatted == null)
+				return;
+
+			var targetColor = Element.PlaceholderColor;
+
+			if (_useLegacyColorManagement)
+			{
+				var color = targetColor.IsDefault || !Element.IsEnabled ? _defaultPlaceholderColor : targetColor;
+				Control.AttributedPlaceholder = formatted.ToAttributed(Element, color);
+			}
+			else
+			{
+				// Using VSM color management; take whatever is in Element.PlaceholderColor
+				var color = targetColor.IsDefault ? _defaultPlaceholderColor : targetColor;
+				Control.AttributedPlaceholder = formatted.ToAttributed(Element, color);
+			}
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

Adds Placeholder and PlaceholderColor to Picker

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3935

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string Picker.Placeholder { get; set; } //Bindable Property
 - Color Picker.PlaceholderColor { get; set; } // Bindable Property
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

Placeholder and PlaceholderColor were not present before

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
