### PR TITLE
[Sample] [Android] Fixed PagesGallery.Droid build

### DIFF
--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -178,7 +178,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Stubs\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android %28Forwarders%29.csproj">
-      <Project>{6E53FEB1-1100-46AE-8013-17BBA35CC197}</Project>
+      <Project>{6e53feb1-1100-46ae-8013-17bba35cc197}</Project>
       <Name>Xamarin.Forms.Platform.Android (Forwarders)</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -177,6 +177,10 @@
     <None Include="Properties\AndroidManifest.xml" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Stubs\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android %28Forwarders%29.csproj">
+      <Project>{6E53FEB1-1100-46AE-8013-17BBA35CC197}</Project>
+      <Name>Xamarin.Forms.Platform.Android (Forwarders)</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
       <Project>{57b8b73d-c3b5-4c42-869e-7b2f17d354ac}</Project>
       <Name>Xamarin.Forms.Core</Name>
@@ -204,10 +208,6 @@
     <ProjectReference Include="..\PagesGallery\PagesGallery.csproj">
       <Name>PagesGallery</Name>
       <Project>{7B5F9E6A-6334-4C74-9B77-A55B3DA60E41}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Stubs\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android %28Forwarders%29.csproj">
-      <Project>{6E53FEB1-1100-46AE-8013-17BBA35CC197}</Project>
-      <Name>Xamarin.Forms.Platform.Android (Forwarders)</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -177,10 +177,6 @@
     <None Include="Properties\AndroidManifest.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Stubs\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android %28Forwarders%29.csproj">
-      <Project>{6e53feb1-1100-46ae-8013-17bba35cc197}</Project>
-      <Name>Xamarin.Forms.Platform.Android %28Forwarders%29</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
       <Project>{57b8b73d-c3b5-4c42-869e-7b2f17d354ac}</Project>
       <Name>Xamarin.Forms.Core</Name>
@@ -208,6 +204,10 @@
     <ProjectReference Include="..\PagesGallery\PagesGallery.csproj">
       <Name>PagesGallery</Name>
       <Project>{7B5F9E6A-6334-4C74-9B77-A55B3DA60E41}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Stubs\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android %28Forwarders%29.csproj">
+      <Project>{6E53FEB1-1100-46AE-8013-17BBA35CC197}</Project>
+      <Name>Xamarin.Forms.Platform.Android (Forwarders)</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Hi, I noticed an issue with PagesGallery.Droid
I couldn't build it on my Mac

Really, I don't know, whether there is such problem on Windows, but it occurs on VS for mac
After these changes I'm able to build PagesGallery.Droid again

### API Changes ###

Changed:
 - object ListView.SelectedItem => One of ref. in PagesGallery.Droid.csproj

### Platforms Affected ### 
Only sample project, Android

### Before/After Screenshots ### 
[BEFORE]
<img width="739" alt="1" src="https://user-images.githubusercontent.com/10124814/46503761-816c1980-c834-11e8-9e8b-8645878a47d8.png">

[AFTER]
![image](https://user-images.githubusercontent.com/10124814/46509969-ae2d2a80-c84e-11e8-995f-1a27c5e4c051.png)


### Testing Procedure ###
Try to build PagesGallery.Droid project on Mac