### PR TITLE
[iOS] Fixed editor placeholder font

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -195,7 +195,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateFont()
 		{
-			Control.Font = Element.ToUIFont();
+			var font = Element.ToUIFont();
+			Control.Font = font;
+			_placeholderLabel.Font = font;
 		}
 
 		void UpdateKeyboard()


### PR DESCRIPTION
### Description of Change ###

Fixed iOS editor placeholder font (Size/Family)

### Issues Resolved ### 
- fixes #4004

### API Changes ###

Changed: private UpdateFont method in iOS EditorRenderer

### Platforms Affected ### 
**iOS**

### Behavioral/Visual Changes ###
FontFamily/FontSize is applied for Placeholder as well

### Before/After Screenshots ### 
[BEFORE]
<img width="454" alt="1" src="https://user-images.githubusercontent.com/10124814/46525516-7ea11100-c894-11e8-83da-8b558f9af59c.png">

[AFTER]
<img width="394" alt="2" src="https://user-images.githubusercontent.com/10124814/46525524-8365c500-c894-11e8-8ef3-be8b59a5930f.png">

### Testing Procedure ###

Run test sample on iOS and see, that FontSize and FontFamily is applied for Placeholder as well as for Text

```csharp
                public App ()
		{
			InitializeComponent ();

			MainPage = new ContentPage
			{
				Content = new StackLayout
				{
					Children = {
						new Editor
						{
							Placeholder = "Test Text",
							FontSize = 50,
							WidthRequest = 200,
							VerticalOptions = LayoutOptions.CenterAndExpand,
							HorizontalOptions = LayoutOptions.CenterAndExpand
						}
					}
				}
			};
		}
```
