### PR TITLE
Add Editor.IsTextPredictionEnabled property

### DIFF
--- a/.Xamarin.forms.sln
+++ b/.Xamarin.forms.sln
@@ -142,7 +142,6 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{0a39a74b-6f7a-4d41-84f2-b0ccdce899df}*SharedItemsImports = 4
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{0a39a74b-6f7a-4d41-84f2-b0ccdce899df}*SharedItemsImports = 4
-		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{0f0db9cc-ea65-429c-9363-38624bf8f49c}*SharedItemsImports = 13
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{a34ebe01-25bf-4e69-a2dc-2288dc625541}*SharedItemsImports = 4
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{a34ebe01-25bf-4e69-a2dc-2288dc625541}*SharedItemsImports = 4
 		Xamarin.Flex\Xamarin.Flex.projitems*{a6703c7d-d362-452a-a7a5-73771194d38c}*SharedItemsImports = 13

--- a/.Xamarin.forms.sln
+++ b/.Xamarin.forms.sln
@@ -142,6 +142,7 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{0a39a74b-6f7a-4d41-84f2-b0ccdce899df}*SharedItemsImports = 4
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{0a39a74b-6f7a-4d41-84f2-b0ccdce899df}*SharedItemsImports = 4
+		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{0f0db9cc-ea65-429c-9363-38624bf8f49c}*SharedItemsImports = 13
 		Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Xamarin.Forms.Controls.Issues.Shared.projitems*{a34ebe01-25bf-4e69-a2dc-2288dc625541}*SharedItemsImports = 4
 		Xamarin.Forms.Core.UITests.Shared\Xamarin.Forms.Core.UITests.projitems*{a34ebe01-25bf-4e69-a2dc-2288dc625541}*SharedItemsImports = 4
 		Xamarin.Flex\Xamarin.Flex.projitems*{a6703c7d-d362-452a-a7a5-73771194d38c}*SharedItemsImports = 13

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3555.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3555.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 3555, "[Enhancement] Editor: Control over text-prediction", PlatformAffected.All)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3555.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3555.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3555, "[Enhancement] Editor: Control over text-prediction", PlatformAffected.All)]
+	public class Issue3555
+		: TestContentPage
+	{
+		protected override void Init()
+		{
+			var editorDefaults = new Editor();
+			var editorFull = new Editor();
+			editorFull.Keyboard = Keyboard.Create(KeyboardFlags.All);
+			var editorNoTextPrediction = new Editor { IsTextPredictionEnabled = false };
+			// IsTextPredictionEnabled should be ignored for email in Editor
+			var editorEmail = new Editor { Text = "moses@example.com", Keyboard = Keyboard.Email, IsTextPredictionEnabled = true };
+			// IsTextPredictionEnabled should be ignored for numeric Editor
+			var editorNumeric = new Editor { Text = "01234", Keyboard = Keyboard.Numeric, IsTextPredictionEnabled = true };
+			// On Android disabling either spell checking or text prediction both turn off text suggestions so this Editor
+			// should behave the same as editorNoTextPrediction above
+			var editorNoSpellChecking = new Editor { IsSpellCheckEnabled = false };
+			var stackLayout = new StackLayout();
+			stackLayout.Children.Add(new Label { Text = "Defaults" });
+			stackLayout.Children.Add(editorDefaults);
+			stackLayout.Children.Add(new Label { Text = "Text prediction disabled" });
+			stackLayout.Children.Add(editorNoTextPrediction);
+			stackLayout.Children.Add(new Label { Text = "Spell checking disabled" });
+			stackLayout.Children.Add(editorNoSpellChecking);
+			stackLayout.Children.Add(new Label { Text = "Email" });
+			stackLayout.Children.Add(editorEmail);
+			stackLayout.Children.Add(new Label { Text = "Numeric" });
+			stackLayout.Children.Add(editorNumeric);
+			stackLayout.Children.Add(new Label { Text = "Full" });
+			stackLayout.Children.Add(editorFull);
+			stackLayout.Padding = new Thickness(0, 20, 0, 0);
+			Content = stackLayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3509.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Github3856.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1937.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3555.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3843.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4053.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3809.cs" />

--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -23,6 +23,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
 
+		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Editor), true, BindingMode.OneTime);
+
 		public static readonly BindableProperty AutoSizeProperty = BindableProperty.Create(nameof(AutoSize), typeof(EditorAutoSizeOption), typeof(Editor), defaultValue: EditorAutoSizeOption.Disabled, propertyChanged: (bindable, oldValue, newValue)
 			=> ((Editor)bindable)?.InvalidateMeasure());
 
@@ -60,6 +62,12 @@ namespace Xamarin.Forms
 		{
 			get { return (FontAttributes)GetValue(FontAttributesProperty); }
 			set { SetValue(FontAttributesProperty, value); }
+		}
+
+		public bool IsTextPredictionEnabled
+		{
+			get { return (bool)GetValue(IsTextPredictionEnabledProperty); }
+			set { SetValue(IsTextPredictionEnabledProperty, value); }
 		}
 
 		public string FontFamily

--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
 
-		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Editor), true, BindingMode.OneTime);
+		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Editor), true, BindingMode.Default);
 
 		public static readonly BindableProperty AutoSizeProperty = BindableProperty.Create(nameof(AutoSize), typeof(EditorAutoSizeOption), typeof(Editor), defaultValue: EditorAutoSizeOption.Disabled, propertyChanged: (bindable, oldValue, newValue)
 			=> ((Editor)bindable)?.InvalidateMeasure());

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -100,6 +100,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateInputType();
 			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
 				UpdateInputType();
+			else if (e.PropertyName == Editor.IsTextPredictionEnabledProperty.PropertyName)
+				UpdateInputType();
 			else if (e.PropertyName == Editor.TextColorProperty.PropertyName)
 				UpdateTextColor();
 			else if (e.PropertyName == Editor.FontAttributesProperty.PropertyName)
@@ -165,12 +167,23 @@ namespace Xamarin.Forms.Platform.Android
 			var keyboard = model.Keyboard;
 
 			edit.InputType = keyboard.ToInputType() | InputTypes.TextFlagMultiLine;
-			if (!(keyboard is Internals.CustomKeyboard) && model.IsSet(InputView.IsSpellCheckEnabledProperty))
+			if (!(keyboard is Internals.CustomKeyboard))
 			{
-				if ((edit.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+				if (model.IsSet(InputView.IsSpellCheckEnabledProperty))
 				{
-					if (!model.IsSpellCheckEnabled)
-						edit.InputType = edit.InputType | InputTypes.TextFlagNoSuggestions;
+					if ((edit.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsSpellCheckEnabled)
+							edit.InputType = edit.InputType | InputTypes.TextFlagNoSuggestions;
+					}
+				}
+				if (model.IsSet(Editor.IsTextPredictionEnabledProperty))
+				{
+					if ((edit.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsTextPredictionEnabled)
+							edit.InputType = edit.InputType | InputTypes.TextFlagNoSuggestions;
+					}
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -171,19 +171,13 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (model.IsSet(InputView.IsSpellCheckEnabledProperty))
 				{
-					if ((edit.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
-					{
-						if (!model.IsSpellCheckEnabled)
-							edit.InputType = edit.InputType | InputTypes.TextFlagNoSuggestions;
-					}
+					if (!model.IsSpellCheckEnabled)
+						edit.InputType = edit.InputType | InputTypes.TextFlagNoSuggestions;					
 				}
 				if (model.IsSet(Editor.IsTextPredictionEnabledProperty))
 				{
-					if ((edit.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
-					{
-						if (!model.IsTextPredictionEnabled)
-							edit.InputType = edit.InputType | InputTypes.TextFlagNoSuggestions;
-					}
+					if (!model.IsTextPredictionEnabled)
+						edit.InputType = edit.InputType | InputTypes.TextFlagNoSuggestions;					
 				}
 			}
 

--- a/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EditorRenderer.cs
@@ -94,6 +94,10 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateInputScope();
 			}
+			else if (e.PropertyName == Editor.IsTextPredictionEnabledProperty.PropertyName)
+			{
+				UpdateInputScope();
+			}
 			else if (e.PropertyName == Editor.FontAttributesProperty.PropertyName)
 			{
 				UpdateFont();
@@ -282,7 +286,10 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 			else
 			{
-				Control.ClearValue(TextBox.IsTextPredictionEnabledProperty);
+				if (editor.IsSet(Editor.IsTextPredictionEnabledProperty))
+					Control.IsTextPredictionEnabled = editor.IsTextPredictionEnabled;
+				else
+					Control.ClearValue(TextBox.IsTextPredictionEnabledProperty);
 				if (editor.IsSet(InputView.IsSpellCheckEnabledProperty))
 					Control.IsSpellCheckEnabled = editor.IsSpellCheckEnabled;
 				else

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -132,6 +132,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateKeyboard();
 			else if (e.PropertyName == Xamarin.Forms.InputView.IsSpellCheckEnabledProperty.PropertyName)
 				UpdateKeyboard();
+			else if (e.PropertyName == Editor.IsTextPredictionEnabledProperty.PropertyName)
+				UpdateKeyboard();
 			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateEditable();
 			else if (e.PropertyName == Editor.TextColorProperty.PropertyName)
@@ -202,12 +204,23 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateKeyboard()
 		{
-			Control.ApplyKeyboard(Element.Keyboard);
-			if (!(Element.Keyboard is Internals.CustomKeyboard) && Element.IsSet(Xamarin.Forms.InputView.IsSpellCheckEnabledProperty))
+			var keyboard = Element.Keyboard;
+			Control.ApplyKeyboard(keyboard);
+			if (!(keyboard is Internals.CustomKeyboard))
 			{
-				if (!Element.IsSpellCheckEnabled)
+				if (Element.IsSet(Xamarin.Forms.InputView.IsSpellCheckEnabledProperty))
 				{
-					Control.SpellCheckingType = UITextSpellCheckingType.No;
+					if (!Element.IsSpellCheckEnabled)
+					{
+						Control.SpellCheckingType = UITextSpellCheckingType.No;
+					}
+				}
+				if (Element.IsSet(Editor.IsTextPredictionEnabledProperty))
+				{
+					if (!Element.IsTextPredictionEnabled)
+					{
+						Control.AutocorrectionType = UITextAutocorrectionType.No;
+					}
 				}
 			}
 			Control.ReloadInputViews();


### PR DESCRIPTION
Fixes #3555
### Description of Change ###
Added the `Editor.IsTextPredictionEnabledProperty` field and `Editor.IsTextPredictionEnabled` property. Modified `EditorRenderer.OnElementPropertyChanged()` for Android, iOS and UWP to react to changes to the new `IsTextPredictionEnabled` property.

On Android setting `IsTextPredictionEnabled to false sets the `InputTypes.TextFlagNoSuggestions` flag on the native control's `InputType`.

On UWP the native control's `IsTextPredictionEnabled` will be set to the value of the `Editor.IsTextPredictionEnabled` property.

On iOS the native control's `AutocorrectionType` property will be set to `No` when `Editor.IsTextPredictionEnabled` is `false`.

### Issues Resolved ### 

- Fixes #3555

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
*`bool Editor.IsTextPredictionEnabled { get; set; }`
### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Please note #2038

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
