### PR TITLE
Removing LineBreakMode support from WindowsResourcesProvider

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3979.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3979.xaml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+			 xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+	         xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue3979">
+	<ContentPage.Content>
+		<StackLayout>
+			<Label LineBreakMode="WordWrap">Clicking the button sets one of the spans in the following label to Device.Styles.BodyStyle. This test succeeds if clicking the button does not cause exception.</Label>
+			<Label>
+				<Label.FormattedText>
+					<FormattedString>
+						<Span Text="Red Bold, " TextColor="Red" FontAttributes="Bold" />
+						<Span Text="default, " x:Name="TargetSpan">
+							<Span.GestureRecognizers>
+								<TapGestureRecognizer Command="{Binding TapCommand}" />
+							</Span.GestureRecognizers>
+						</Span>
+						<Span Text="italic small." FontAttributes="Italic" FontSize="Small" />
+					</FormattedString>
+				</Label.FormattedText>
+			</Label>
+			<Button Clicked="Button_OnClicked" Text="Set style" />
+		</StackLayout>
+	</ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3979.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3979.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3979, "Issue Description", PlatformAffected.UWP)]
+	public partial class Issue3979 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		public Issue3979()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+
+		private void Button_OnClicked(object sender, EventArgs e)
+		{
+			TargetSpan.Style = Device.Styles.BodyStyle;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -395,6 +395,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3541.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3840.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3913.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3979.xaml.cs">
+      <DependentUpon>Issue3979.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />
@@ -1003,6 +1007,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue3979.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.UAP/WindowsResourcesProvider.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsResourcesProvider.cs
@@ -34,8 +34,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			formsStyle.Setters.Add(Label.FontSizeProperty, prototype.FontSize);
 			formsStyle.Setters.Add(Label.FontFamilyProperty, prototype.FontFamily.Source);
-			formsStyle.Setters.Add(Label.FontAttributesProperty, ToAttributes(prototype.FontWeight));
-			formsStyle.Setters.Add(Label.LineBreakModeProperty, ToLineBreakMode(prototype.TextWrapping));
+			formsStyle.Setters.Add(Label.FontAttributesProperty, ToAttributes(prototype.FontWeight));			
 
 			return formsStyle;
 		}
@@ -49,20 +48,6 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			return FontAttributes.None;
-		}
-
-		static LineBreakMode ToLineBreakMode(TextWrapping value)
-		{
-			switch (value)
-			{
-				case TextWrapping.Wrap:
-					return LineBreakMode.CharacterWrap;
-				case TextWrapping.WrapWholeWords:
-					return LineBreakMode.WordWrap;
-				default:
-				case TextWrapping.NoWrap:
-					return LineBreakMode.NoWrap;
-			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

`WindowsResourcesProvider.GetStyle` method previously set the `LineBreakMode` setter of the style. This was inconsistent with all other platforms (including WPF) and caused exceptions when one of the default styles was set to a `Span`.

### Issues Resolved ### 

- fixes #3979 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

The `LineBreakMode` is no longer set on UWP's default Device styles (`TitleStyle`, `SubtitleStyle`, `BodyStyle`, `ListItemTextStyle`, `ListItemDetailTesxtStyle`, `CaptionStyle`). The Windows default was `CharacterWrap` whereas the `Label` default (and other platforms default) is `WordWrap`.

Looking into UWP `LabelRenderer` there is only a slight difference between how these two modes are handled:

```
case LineBreakMode.WordWrap:
	textBlock.TextTrimming = TextTrimming.None;
	textBlock.TextWrapping = TextWrapping.Wrap;
	break;
case LineBreakMode.CharacterWrap:
	textBlock.TextTrimming = TextTrimming.WordEllipsis;
	textBlock.TextWrapping = TextWrapping.Wrap;
	break;
```

This means for overflowing text the original style performed word ellipsis, but now it will overflow.

It could be discussed if `TextTrimming` should be set to `WordEllipsis` in case of `WordWrap` as well, but that would again be inconsistent with other platforms.

### Before/After Screenshots ### 

**Default UWP `BodyStyle` behavior before change**
![image](https://user-images.githubusercontent.com/1075116/46578769-ed9e7700-ca06-11e8-814e-79d5ce0c9123.png)

**Default UWP `BodyStyle` behavior after change**
![46578827-73babd80-ca07-11e8-8254-291071281fed](https://user-images.githubusercontent.com/1075116/46579181-8edbfc00-ca0c-11e8-8425-a9eb3749f404.png)

**Default Android `BodyStyle` behavior for reference**
![screenshot_20181007-083710 13880](https://user-images.githubusercontent.com/1075116/46579176-70760080-ca0c-11e8-85d6-dd22900dd166.jpg)

### Testing Procedure ###

Added `Issue3979` repro page to the Controls Gallery.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
