### PR TITLE
Upgrading OnIdiom<T>

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4006.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4006.xaml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="clr-namespace:Xamarin.Forms.Controls"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue4006">
+    <ContentPage.Content>
+        <StackLayout>
+			<Label Text="The following rectangle should be blue on phone only, otherwise red" />
+			<BoxView WidthRequest="100" HeightRequest="100">
+				<BoxView.BackgroundColor>
+					<OnIdiom x:TypeArguments="Color" Default="Red">
+						<OnIdiomSetting Idiom="Phone" Value="Blue" />
+					</OnIdiom>
+				</BoxView.BackgroundColor>
+			</BoxView>
+		</StackLayout>
+    </ContentPage.Content>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4006.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4006.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4006, "OnIdiom default value")]
+	public partial class Issue4006 : TestContentPage
+	{
+		public Issue4006()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+			
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -398,6 +398,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3541.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3840.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3913.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4006.xaml.cs">
+      <DependentUpon>Issue4006.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue3979.xaml.cs">
       <DependentUpon>Issue3979.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -1023,6 +1027,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue3979.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4006.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core.UnitTests/OnIdiomTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/OnIdiomTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class OnIdiomTests : BaseTestFixture
+	{
+		[Test]
+		public void OnIdiomReturnsAppropriateValue()
+		{
+			OnIdiom<int> onIdiom = new OnIdiom<int>();
+			onIdiom.Idioms.Add(new OnIdiomSetting() { Idiom = new[] { "Phone", "Desktop" }, Value = 1 });
+			onIdiom.Idioms.Add(new OnIdiomSetting() { Idiom = new[] { "Watch", "TV" }, Value = 2 });
+			
+			Device.Idiom = TargetIdiom.TV;
+			Assert.AreEqual(2, onIdiom);
+			Device.Idiom = TargetIdiom.Desktop;
+			Assert.AreEqual(1, onIdiom);
+			Device.Idiom = TargetIdiom.Watch;
+			Assert.AreEqual(2, onIdiom);
+			Device.Idiom = TargetIdiom.Unsupported;
+			Assert.AreEqual(default(int), onIdiom);
+		}
+
+		[Test]
+		public void OnIdiomFallsBackToLegacyGracefully()
+		{
+			OnIdiom<int> onIdiom = new OnIdiom<int>();
+			onIdiom.Idioms.Add(new OnIdiomSetting() { Idiom = new[] { "Desktop" }, Value = 1 });
+			onIdiom.Idioms.Add(new OnIdiomSetting() { Idiom = new[] { "Watch", "TV" }, Value = 2 });
+			onIdiom.Phone = 3;
+
+			Device.Idiom = TargetIdiom.Phone;
+			Assert.AreEqual(3, onIdiom);
+			Device.Idiom = TargetIdiom.TV;
+			Assert.AreEqual(2, onIdiom);
+		}
+
+		[Test]
+		public void DefaultValueIsSupportedOnLegacySyntax()
+		{
+			OnIdiom<int> onIdiom = new OnIdiom<int>();
+			onIdiom.Phone = 1;
+			onIdiom.Default = 3;
+			Device.Idiom = TargetIdiom.TV;
+			Assert.AreEqual(3, onIdiom);
+		}
+
+		[Test]
+		public void DefaultValueIsSupported()
+		{
+			OnIdiom<int> onIdiom = new OnIdiom<int>();
+			onIdiom.Idioms.Add(new OnIdiomSetting() { Idiom = new[] { "Desktop" }, Value = 1 });
+			onIdiom.Idioms.Add(new OnIdiomSetting() { Idiom = new[] { "Watch", "Phone" }, Value = 2 });
+			onIdiom.Default = 6;
+			Device.Idiom = TargetIdiom.TV;
+			Assert.AreEqual(6, onIdiom);
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="FlowDirectionTests.cs" />
     <Compile Include="LayoutChildIntoBoundingRegionTests.cs" />
     <Compile Include="MenuUnitTests.cs" />
+    <Compile Include="OnIdiomTests.cs" />
     <Compile Include="RegionTests.cs" />
     <Compile Include="SpanTests.cs" />
     <Compile Include="TitleViewUnitTests.cs" />

--- a/Xamarin.Forms.Core/OnIdiom.cs
+++ b/Xamarin.Forms.Core/OnIdiom.cs
@@ -1,33 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms.Xaml;
+
 namespace Xamarin.Forms
 {
+	[ContentProperty("Idioms")]
 	public class OnIdiom<T>
 	{
-		public T Phone { get; set; }
+		readonly Dictionary<TargetIdiom, T> _legacyValues = new Dictionary<TargetIdiom, T>();
 
-		public T Tablet { get; set; }
+		bool _hasDefault;		
+
+		T _default;
 		
-		public T Desktop { get; set; }
 
-		public T TV { get; set; }
+		public OnIdiom()
+		{
+			Idioms = new List<OnIdiomSetting>();
+		}
 
-		public T Watch { get; set; }
+		public T Phone
+		{
+			get => GetLegacyValue(TargetIdiom.Phone);
+			set => SetLegacyValue(TargetIdiom.Phone, value);
+		}
+
+		public T Tablet
+		{
+			get => GetLegacyValue(TargetIdiom.Tablet);
+			set => SetLegacyValue(TargetIdiom.Tablet, value);
+		}
+
+		public T Desktop
+		{
+			get => GetLegacyValue(TargetIdiom.Desktop);
+			set => SetLegacyValue(TargetIdiom.Desktop, value);
+		}
+
+		public T TV
+		{
+			get => GetLegacyValue(TargetIdiom.TV);
+			set => SetLegacyValue(TargetIdiom.TV, value);
+		}
+
+		public T Watch
+		{
+			get => GetLegacyValue(TargetIdiom.Watch);
+			set => SetLegacyValue(TargetIdiom.Watch, value);
+		}
+
+		public T Default
+		{
+			get { return _default; }
+			set
+			{
+				_hasDefault = true;
+				_default = value;
+			}
+		}
+
+		public IList<OnIdiomSetting> Idioms { get; private set; }
+
+#pragma warning disable RECS0108 // Warns about static fields in generic types
+		static readonly IValueConverterProvider s_valueConverter = DependencyService.Get<IValueConverterProvider>();
+#pragma warning restore RECS0108 // Warns about static fields in generic types
 
 		public static implicit operator T(OnIdiom<T> onIdiom)
 		{
-			switch (Device.Idiom)
+			var currentIdiom = Device.Idiom.ToString("G");
+			foreach (var idiomSetting in onIdiom.Idioms)
 			{
-				default:
-				case TargetIdiom.Phone:
-					return onIdiom.Phone;
-				case TargetIdiom.Tablet:
-					return onIdiom.Tablet;
-				case TargetIdiom.Desktop:
-					return onIdiom.Desktop;
-				case TargetIdiom.TV:
-					return onIdiom.TV;
-				case TargetIdiom.Watch:
-					return onIdiom.Watch;
+				if (idiomSetting.Idiom?.FirstOrDefault(idiom =>
+					    idiom.Equals(currentIdiom, StringComparison.OrdinalIgnoreCase)) == null)
+					continue;
+				if (s_valueConverter == null)
+					continue;
+				return (T)s_valueConverter.Convert(idiomSetting.Value, typeof(T), null, null);
 			}
+
+			//has any legacy value been set?
+			if (onIdiom._legacyValues.Count == 0)
+				return onIdiom._hasDefault ? onIdiom._default : default(T);
+
+			//legacy fallback
+#pragma warning disable 0618, 0612
+			if (!onIdiom._legacyValues.TryGetValue(Device.Idiom, out var legacyValue))
+			{
+				legacyValue = onIdiom._hasDefault ? onIdiom._default : default(T);
+			}
+			return legacyValue;
+#pragma warning restore 0618, 0612
 		}
+
+
+		T GetLegacyValue( TargetIdiom idiom )
+		{
+			return _legacyValues.TryGetValue(idiom, out var value) 
+				? value : default(T);
+		}
+
+		void SetLegacyValue(TargetIdiom idiom, T value)
+		{
+			_legacyValues[idiom] = value;
+		}
+	}
+
+	[ContentProperty("Value")]
+	public class OnIdiomSetting
+	{
+		[TypeConverter(typeof(ListStringTypeConverter))]
+		public IList<string> Idiom { get; set; }
+		public object Value { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/OnIdiom.cs
+++ b/Xamarin.Forms.Core/OnIdiom.cs
@@ -70,9 +70,8 @@ namespace Xamarin.Forms
 		{
 			var currentIdiom = Device.Idiom.ToString("G");
 			foreach (var idiomSetting in onIdiom.Idioms)
-			{
-				if (idiomSetting.Idiom?.FirstOrDefault(idiom =>
-					    idiom.Equals(currentIdiom, StringComparison.OrdinalIgnoreCase)) == null)
+			{				
+				if (!ContainsIdiomMatch(idiomSetting.Idiom, currentIdiom))
 					continue;
 				if (s_valueConverter == null)
 					continue;
@@ -93,6 +92,19 @@ namespace Xamarin.Forms
 #pragma warning restore 0618, 0612
 		}
 
+		static bool ContainsIdiomMatch(IList<string> idiomList, string currentIdiom)
+		{
+			if (idiomList == null) return false;
+			for (int i = 0; i < idiomList.Count; i++)
+			{
+				var current = idiomList[i];
+				if (current.Equals(currentIdiom, StringComparison.OrdinalIgnoreCase))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
 
 		T GetLegacyValue( TargetIdiom idiom )
 		{


### PR DESCRIPTION
### Description of Change ###

The `OnIdiom<T>` was not matching the format of `OnPlatform<T>`. This PR attempts to upgrade `OnIdiom` to include matching functionality and more friendly XAML interface.

### Issues Resolved ### 

- fixes #4006 

### API Changes ###

Added:
- `T OnIdiom<T>.Default { get; set; }`
- `IList<OnIdiomSetting> OnIdiom.Idioms { get; private set; }`

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

The legacy syntax for `OnIdiom` is still supported and there should be no change required for existing apps.

PR adds support for `Default` value, which is on par with `{OnIdiom}` markup extension and supports even the legacy syntax.

The new syntax is very similar to the one provided by `OnPlatform<T>`:

```
<BoxView WidthRequest="100" HeightRequest="100">
	<BoxView.BackgroundColor>
		<OnIdiom x:TypeArguments="Color" Default="Red">
			<OnIdiomSetting Idiom="Phone" Value="Blue" />
			<OnIdiomSetting Idiom="TV, Tablet" Value="Green" />
		</OnIdiom>
	</BoxView.BackgroundColor>
</BoxView>
```

The only disadvantage is that it is not possible to reuse `<On>` as in `OnPlatform<T>`, because both reside in the same namespace. It would be possible to add `Idiom` property to `On` but that could be confusing to users.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I have created demonstration of the `Default` value on `Issue4006` page in controls gallery.

Functionality of `OnIdiom<T>` has been covered by tests in `Xamarin.Forms.Core.UnitTests.OnIdiomTests`.


### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
