### PR TITLE
[C] Allow recursive parts of binding path

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2243,5 +2243,21 @@ namespace Xamarin.Forms.Core.UnitTests
 			bindable.BindingContext = new MockViewModel();
 			Assert.That(bindable.GetValue(property), Is.EqualTo("fallback"));
 		}
+
+		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/3994
+		public void INPCOnBindingWithSource()
+		{
+			var page = new ContentPage {Title = "Foo"};
+			page.BindingContext = page;
+			var label = new Label();
+			page.Content = label;
+
+			label.SetBinding(Label.TextProperty, new Binding("BindingContext.Title", source:page));
+			Assert.That(label.Text, Is.EqualTo("Foo"));
+
+			page.Title = "Bar";
+			Assert.That(label.Text, Is.EqualTo("Bar"));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -124,8 +124,7 @@ namespace Xamarin.Forms
 				if (!part.IsSelf && current != null)
 				{
 					// Allow the object instance itself to provide its own TypeInfo 
-					var reflectable = current as IReflectableType;
-					TypeInfo currentType = reflectable != null ? reflectable.GetTypeInfo() : current.GetType().GetTypeInfo();
+					TypeInfo currentType = current is IReflectableType reflectable ? reflectable.GetTypeInfo() : current.GetType().GetTypeInfo();
 					if (part.LastGetter == null || !part.LastGetter.DeclaringType.GetTypeInfo().IsAssignableFrom(currentType))
 						SetupPart(currentType, part);
 
@@ -133,21 +132,17 @@ namespace Xamarin.Forms
 						part.TryGetValue(current, out current);
 				}
 
-				if (!part.IsSelf && current != null)
-				{
-					if ((needsGetter && part.LastGetter == null) || (needsSetter && part.NextPart == null && part.LastSetter == null))
-					{
-						Log.Warning("Binding", PropertyNotFoundErrorMessage, part.Content, current, target.GetType(), property.PropertyName);
-						break;
-					}
+				if (   !part.IsSelf
+				    && current != null
+				    && (   (needsGetter && part.LastGetter == null)
+				        || (needsSetter && part.NextPart == null && part.LastSetter == null))) {
+					Log.Warning("Binding", PropertyNotFoundErrorMessage, part.Content, current, target.GetType(), property.PropertyName);
+					break;
 				}
 
-				if (mode == BindingMode.OneWay || mode == BindingMode.TwoWay)
-				{
-					var inpc = current as INotifyPropertyChanged;
-					if (inpc != null && !ReferenceEquals(current, previous))
+				if (part.NextPart != null &&   (mode == BindingMode.OneWay || mode == BindingMode.TwoWay)
+				    && current is INotifyPropertyChanged inpc)
 						part.Subscribe(inpc);
-				}
 
 				previous = current;
 			}


### PR DESCRIPTION
### Description of Change ###

[C] Allow recursive parts of binding path
<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3994

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
