### PR TITLE
Remove redundant comments in the XamlLoader

### DIFF
--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -1,30 +1,3 @@
-//
-// XamlLoader.cs
-//
-// Author:
-//       Stephane Delcroix <stephane@mi8.be>
-//
-// Copyright (c) 2013 Mobile Inception
-// Copyright (c) 2013-2014 Xamarin, Inc
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -46,7 +19,6 @@ namespace Xamarin.Forms.Xaml.Internals
 			internal set {
 				xamlFileProvider = value;
 				Xamarin.Forms.DesignMode.IsDesignModeEnabled = true;
-				//¯\_(ツ)_/¯ the previewer forgot to set that bool
 				DoNotThrowOnExceptions = value != null;
 			}
 		}
@@ -225,7 +197,6 @@ namespace Xamarin.Forms.Xaml
 			return null;
 		}
 
-		//legacy...
 		static bool ResourceMatchesFilename(Assembly assembly, string resource, string filename)
 		{
 			try {
@@ -246,7 +217,6 @@ namespace Xamarin.Forms.Xaml
 			return false;
 		}
 
-		//part of the legacy as well...
 		static string ReadResourceAsXaml(Type type, Assembly assembly, string likelyTargetName, bool validate = false)
 		{
 			using (var stream = assembly.GetManifestResourceStream(likelyTargetName))


### PR DESCRIPTION
### Description of Change ###
delete redundant comments in the XamlLoader Class

### API Changes ###
Added:
 - none

Changed:
 - none
 
 Removed:
 - comments
 
### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable