### PR TITLE
Switchcell oncolor

### DIFF
--- a/Xamarin.Forms.Core/Cells/SwitchCell.cs
+++ b/Xamarin.Forms.Core/Cells/SwitchCell.cs
@@ -12,6 +12,14 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(SwitchCell), default(string));
 
+		public static readonly BindableProperty OnColorProperty = BindableProperty.Create("OnColor", typeof(Color), typeof(SwitchCell), Color.Default);
+
+		public Color OnColor
+		{
+			get { return (Color)GetValue(OnColorProperty); }
+			set { SetValue(OnColorProperty, value); }
+		}
+
 		public bool On
 		{
 			get { return (bool)GetValue(OnProperty); }

--- a/Xamarin.Forms.Core/Cells/SwitchCell.cs
+++ b/Xamarin.Forms.Core/Cells/SwitchCell.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(SwitchCell), default(string));
 
-		public static readonly BindableProperty OnColorProperty = BindableProperty.Create("OnColor", typeof(Color), typeof(SwitchCell), Color.Default);
+		public static readonly BindableProperty OnColorProperty = BindableProperty.Create(nameof(OnColor), typeof(Color), typeof(SwitchCell), Color.Default);
 
 		public Color OnColor
 		{

--- a/Xamarin.Forms.Platform.Android/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/SwitchCellRenderer.cs
@@ -3,12 +3,16 @@ using Android.Content;
 using Android.Views;
 using AView = Android.Views.View;
 using ASwitch = Android.Widget.Switch;
+using Android.OS;
+using Android.Graphics;
+using Android.Graphics.Drawables;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	public class SwitchCellRenderer : CellRenderer
 	{
 		SwitchCellView _view;
+		Drawable _defaultTrackDrawable;
 
 		protected override AView GetCellCore(Cell item, AView convertView, ViewGroup parent, Context context)
 		{
@@ -19,11 +23,16 @@ namespace Xamarin.Forms.Platform.Android
 
 			_view.Cell = cell;
 
+			var aSwitch = _view.AccessoryView as ASwitch;
+			if (aSwitch != null)
+				_defaultTrackDrawable = aSwitch.TrackDrawable;
+
 			UpdateText();
 			UpdateChecked();
 			UpdateHeight();
 			UpdateIsEnabled(_view, cell);
 			UpdateFlowDirection();
+			UpdateOnColor(_view, cell);
 
 			return _view;
 		}
@@ -33,13 +42,18 @@ namespace Xamarin.Forms.Platform.Android
 			if (args.PropertyName == SwitchCell.TextProperty.PropertyName)
 				UpdateText();
 			else if (args.PropertyName == SwitchCell.OnProperty.PropertyName)
+			{
 				UpdateChecked();
+				UpdateOnColor(_view, (SwitchCell)sender);
+			}
 			else if (args.PropertyName == "RenderHeight")
 				UpdateHeight();
 			else if (args.PropertyName == Cell.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled(_view, (SwitchCell)sender);
 			else if (args.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
+			else if (args.PropertyName == SwitchCell.OnColorProperty.PropertyName)
+				UpdateOnColor(_view, (SwitchCell)sender);
 		}
 
 		void UpdateChecked()
@@ -68,6 +82,32 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateText()
 		{
 			_view.MainText = ((SwitchCell)Cell).Text;
+		}
+
+		void UpdateOnColor(SwitchCellView cell, SwitchCell switchCell)
+		{
+			var aSwitch = cell.AccessoryView as ASwitch;
+			if (aSwitch != null)
+			{
+				if (switchCell.On)
+				{
+					if (switchCell.OnColor == Color.Default)
+					{
+						aSwitch.TrackDrawable = _defaultTrackDrawable;
+					}
+					else
+					{
+						if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBean)
+						{
+							aSwitch.TrackDrawable.SetColorFilter(switchCell.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
+						}
+					}
+				}
+				else
+				{
+					aSwitch.TrackDrawable.ClearColorFilter();
+				}
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ActivityIndicatorRenderer.cs
@@ -46,5 +46,11 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 		}
 
+		protected override void UpdateIsEnabled(bool initialize)
+		{
+			base.UpdateIsEnabled(initialize);
+			UpdateIsRunning();
+		}
+
 	};
 }

--- a/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
@@ -9,6 +9,8 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		const string CellName = "Xamarin.SwitchCell";
 
+		UIColor _defaultOnColor;
+
 		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
 		{
 			var tvc = reusableCell as CellTableViewCell;
@@ -32,6 +34,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var boolCell = (SwitchCell)item;
 
+			_defaultOnColor = UISwitch.Appearance.OnTintColor;
+
 			tvc.Cell = item;
 			tvc.PropertyChanged += HandlePropertyChanged;
 			tvc.AccessoryView = uiSwitch;
@@ -44,6 +48,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateBackground(tvc, item);
 			UpdateIsEnabled(tvc, boolCell);
 			UpdateFlowDirection(tvc, boolCell);
+			UpdateOnColor(tvc, boolCell);
 
 			return tvc;
 		}
@@ -54,13 +59,18 @@ namespace Xamarin.Forms.Platform.iOS
 			var realCell = (CellTableViewCell)GetRealCell(boolCell);
 
 			if (e.PropertyName == SwitchCell.OnProperty.PropertyName)
+			{
 				((UISwitch)realCell.AccessoryView).SetState(boolCell.On, true);
+				UpdateOnColor(realCell, boolCell);
+			}
 			else if (e.PropertyName == SwitchCell.TextProperty.PropertyName)
 				realCell.TextLabel.Text = boolCell.Text;
 			else if (e.PropertyName == Cell.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled(realCell, boolCell);
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection(realCell, boolCell);
+			else if (e.PropertyName == SwitchCell.OnColorProperty.PropertyName)
+				UpdateOnColor(realCell, boolCell);
 		}
 
 		void OnSwitchValueChanged(object sender, EventArgs eventArgs)
@@ -96,6 +106,18 @@ namespace Xamarin.Forms.Platform.iOS
 			var uiSwitch = cell.AccessoryView as UISwitch;
 			if (uiSwitch != null)
 				uiSwitch.Enabled = switchCell.IsEnabled;
+		}
+
+		void UpdateOnColor(CellTableViewCell cell, SwitchCell switchCell)
+		{
+			var uiSwitch = cell.AccessoryView as UISwitch;
+			if (uiSwitch != null)
+			{
+				if (switchCell.OnColor == Color.Default)
+					uiSwitch.OnTintColor = _defaultOnColor;
+				else
+					uiSwitch.OnTintColor = switchCell.OnColor.ToUIColor();
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Added OnColor property for changing color of SwitchCell on Android & iOS

### Issues Resolved ### 

- fixes #4027

### API Changes ###

Added:
 - Color OnColor { get; set; } //Bindable Property
 - UpdateOnColor() //Method to set/update the SwitchCell color

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
