### PR TITLE
Add LineBreakMode to Button

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github3106.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github3106.cs
@@ -1,0 +1,92 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3106, "LineBreakMode for Button", PlatformAffected.Default)]
+	public class Github3106 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var stackLayout = new StackLayout()
+			{
+				Spacing = 10
+			};
+
+			var buttonNoWrap = new Button()
+			{
+				LineBreakMode = LineBreakMode.NoWrap,
+				Text = "Button Button Button Button Button Button Button Button Button Button Button Button Button Button Button ",
+				BackgroundColor = Color.SteelBlue,
+				TextColor = Color.White,
+				Padding = new Thickness(15)
+			};
+
+			stackLayout.Children.Add(buttonNoWrap);
+
+			var buttonWordWrap = new Button()
+			{
+				LineBreakMode = LineBreakMode.WordWrap,
+				Text = "Button Button Button Button Button Button Button Button Button Button Button Button Button Button Button ",
+				BackgroundColor = Color.SteelBlue,
+				TextColor = Color.White,
+				Padding = new Thickness(50)
+			};
+
+			stackLayout.Children.Add(buttonWordWrap);
+
+			var buttonCharacterWrap = new Button()
+			{
+				LineBreakMode = LineBreakMode.CharacterWrap,
+				Text = "Button Button Button Button Button Button Button Button Button Button Button Button Button Button Button ",
+				BackgroundColor = Color.SteelBlue,
+				TextColor = Color.White,
+				Padding = new Thickness(15)
+			};
+
+			stackLayout.Children.Add(buttonCharacterWrap);
+
+			var buttonHeadTruncation = new Button()
+			{
+				LineBreakMode = LineBreakMode.HeadTruncation,
+				Text = "Button Button Button Button Button Button Button Button Button Button Button Button Button Button Button ",
+				BackgroundColor = Color.SteelBlue,
+				TextColor = Color.White,
+				Padding = new Thickness(15)
+			};
+
+			stackLayout.Children.Add(buttonHeadTruncation);
+
+			var buttonTailTruncation = new Button()
+			{
+				LineBreakMode = LineBreakMode.TailTruncation,
+				Text = "Button Button Button Button Button Button Button Button Button Button Button Button Button Button Button ",
+				BackgroundColor = Color.SteelBlue,
+				TextColor = Color.White,
+				Padding = new Thickness(15)
+			};
+
+			stackLayout.Children.Add(buttonTailTruncation);
+
+			var buttonMiddleTruncation = new Button()
+			{
+				LineBreakMode = LineBreakMode.MiddleTruncation,
+				Text = "Button Button Button Button Button Button Button Button Button Button Button Button Button Button Button ",
+				BackgroundColor = Color.SteelBlue,
+				TextColor = Color.White,
+				Padding = new Thickness(15)
+			};
+
+			stackLayout.Children.Add(buttonMiddleTruncation);
+
+			Content = stackLayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
       <DependentUpon>Bugzilla60787.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Github3106.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1588.xaml.cs">
       <DependentUpon>Issue1588.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -52,6 +52,16 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
+		public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(
+			nameof(LineBreakMode),
+			typeof(LineBreakMode),
+			typeof(Button),
+			LineBreakMode.NoWrap,
+			propertyChanged: (bindable, oldvalue, newvalue) =>
+			{
+				((Button)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			});
+
 		public Thickness Padding
 		{
 			get { return (Thickness)GetValue (PaddingElement.PaddingProperty); }
@@ -187,6 +197,12 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(FontSizeProperty); }
 			set { SetValue(FontSizeProperty, value); }
+		}
+
+		public LineBreakMode LineBreakMode
+		{
+			get { return (LineBreakMode)GetValue(LineBreakModeProperty); }
+			set { SetValue(LineBreakModeProperty, value); }
 		}
 
 		public event EventHandler Clicked;

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -12,6 +12,7 @@ using AView = Android.Views.View;
 using AMotionEvent = Android.Views.MotionEvent;
 using AMotionEventActions = Android.Views.MotionEventActions;
 using static System.String;
+using Android.Text;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -154,6 +155,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateText();
 			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
 				UpdatePadding();
+			else if (e.PropertyName == Button.LineBreakModeProperty.PropertyName)
+				UpdateLineBreakMode();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -175,6 +178,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			UpdateEnabled();
 			UpdateBackgroundColor();
 			UpdatePadding();
+			UpdateLineBreakMode();
 		}
 
 		void UpdateBitmap()
@@ -313,6 +317,38 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			_paddingDeltaPix = delta ?? new Thickness();
 			UpdatePadding();
+		}
+
+		void UpdateLineBreakMode()
+		{
+			switch (Element.LineBreakMode)
+			{
+				case LineBreakMode.HeadTruncation:
+					Control.Ellipsize = TextUtils.TruncateAt.Start;
+					Control.SetSingleLine(true);
+					break;
+				case LineBreakMode.MiddleTruncation:
+					Control.Ellipsize = TextUtils.TruncateAt.Middle;
+					Control.SetSingleLine(true);
+					break;
+				case LineBreakMode.TailTruncation:
+					Control.Ellipsize = TextUtils.TruncateAt.End;
+					Control.SetSingleLine(true);
+					break;
+				case LineBreakMode.NoWrap:
+					Control.Ellipsize = null;
+					Control.SetSingleLine(true);
+					break;
+				case LineBreakMode.CharacterWrap:
+					((Xamarin.Forms.Button)Element).Text = ((Xamarin.Forms.Button)Element).Text.Replace(' ', '\u00A0');
+					Control.Ellipsize = null;
+					Control.SetSingleLine(false);
+					break;
+				case LineBreakMode.WordWrap:
+					Control.Ellipsize = null;
+					Control.SetSingleLine(false);
+					break;
+			}
 		}
 
 		class ButtonClickListener : Object, AView.IOnClickListener

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -10,6 +10,7 @@ using AView = Android.Views.View;
 using AMotionEvent = Android.Views.MotionEvent;
 using AMotionEventActions = Android.Views.MotionEventActions;
 using Object = Java.Lang.Object;
+using Android.Text;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -139,6 +140,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateText();
 			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
 				UpdatePadding();
+			else if (e.PropertyName == Button.LineBreakModeProperty.PropertyName)
+				UpdateLineBreakMode();
 
 			base.OnElementPropertyChanged(sender, e);
 		}
@@ -160,6 +163,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateEnabled();
 			UpdateBackgroundColor();
 			UpdatePadding();
+			UpdateLineBreakMode();
 		}
 
 		void UpdateBitmap()
@@ -278,6 +282,38 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			_paddingDeltaPix = delta ?? new Thickness();
 			UpdatePadding();
+		}
+
+		void UpdateLineBreakMode()
+		{
+			switch (Element.LineBreakMode)
+			{
+				case LineBreakMode.HeadTruncation:
+					Control.Ellipsize = TextUtils.TruncateAt.Start;
+					Control.SetSingleLine(true);
+					break;
+				case LineBreakMode.MiddleTruncation:
+					Control.Ellipsize = TextUtils.TruncateAt.Middle;
+					Control.SetSingleLine(true);
+					break;
+				case LineBreakMode.TailTruncation:
+					Control.Ellipsize = TextUtils.TruncateAt.End;
+					Control.SetSingleLine(true);
+					break;
+				case LineBreakMode.NoWrap:
+					Control.Ellipsize = null;
+					Control.SetSingleLine(true);
+					break;
+				case LineBreakMode.CharacterWrap:
+					Element.Text = ((Button)Element).Text.Replace(' ', '\u00A0');
+					Control.Ellipsize = null;
+					Control.SetSingleLine(false);
+					break;
+				case LineBreakMode.WordWrap:
+					Control.Ellipsize = null;
+					Control.SetSingleLine(false);
+					break;
+			}
 		}
 
 		class ButtonClickListener : Object, IOnClickListener

--- a/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
@@ -58,6 +58,9 @@ namespace Xamarin.Forms.Platform.UWP
 				if (Element.IsSet(Button.PaddingProperty) && Element.Padding != (Thickness)Button.PaddingProperty.DefaultValue)
 					UpdatePadding();
 
+				if (Element.IsSet(Button.LineBreakModeProperty) && Element.LineBreakMode != (LineBreakMode)Button.LineBreakModeProperty.DefaultValue)
+					UpdateLineBreakMode();
+
 				UpdateFont();
 			}
 		}
@@ -110,6 +113,10 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
 			{
 				UpdatePadding();
+			}
+			else if (e.PropertyName ==Button.LineBreakModeProperty.PropertyName)
+			{
+				UpdateLineBreakMode();
 			}
 		}
 
@@ -266,6 +273,30 @@ namespace Xamarin.Forms.Platform.UWP
 				Element.Padding.Right,
 				Element.Padding.Bottom
 			);
+		}
+
+		void UpdateLineBreakMode()
+		{
+			switch (Element.LineBreakMode)
+			{
+				case LineBreakMode.WordWrap:
+					Control.TextWrapping = Windows.UI.Xaml.TextWrapping.WrapWholeWords;
+					//Control.TextTrimming = TextTrimming.None;
+					break;
+				case LineBreakMode.NoWrap:
+					Control.TextWrapping = Windows.UI.Xaml.TextWrapping.NoWrap;
+					//Control.TextTrimming = TextTrimming.CharacterEllipsis;
+					break;
+				case LineBreakMode.CharacterWrap:
+					Control.TextWrapping = Windows.UI.Xaml.TextWrapping.Wrap;
+					//Control.TextTrimming = TextTrimming.None;
+					break;
+				case LineBreakMode.TailTruncation:
+					Control.TextWrapping = TextWrapping.NoWrap;
+					//Control.TextTrimming = Windows.UI.Xaml.TextTrimming.Clip;
+					break;
+
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/FormsButton.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsButton.cs
@@ -20,12 +20,6 @@ namespace Xamarin.Forms.Platform.UWP
 			typeof(FormsButton),
 			new PropertyMetadata(TextWrapping.NoWrap, OnTextWrappingChanged));
 
-		//public static readonly DependencyProperty TextTrimmingProperty = DependencyProperty.Register(
-		//	nameof(TextTrimming),
-		//	typeof(TextTrimming),
-		//	typeof(FormsButton),
-		//	new PropertyMetadata(TextTrimming.None, OnTextTrimmingChanged));
-
 		WContentPresenter _contentPresenter;
 
 		public Brush BackgroundColor
@@ -64,8 +58,6 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_contentPresenter = GetTemplateChild("ContentPresenter") as WContentPresenter;
 
-			var a = _contentPresenter.GetChildren<Windows.UI.Xaml.Controls.TextBlock>();
-
 			UpdateBackgroundColor();
 			UpdateBorderRadius();
 			UpdateTextWrapping();
@@ -85,10 +77,6 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			((FormsButton)d).UpdateTextWrapping();
 		}
-
-		//static void OnTextTrimmingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-		//{
-		//}
 
 		void UpdateBackgroundColor()
 		{

--- a/Xamarin.Forms.Platform.UAP/FormsButton.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsButton.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml;
+﻿using System;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 
 using WContentPresenter = Windows.UI.Xaml.Controls.ContentPresenter;
@@ -12,6 +13,18 @@ namespace Xamarin.Forms.Platform.UWP
 
 		public static readonly DependencyProperty BackgroundColorProperty = DependencyProperty.Register(nameof(BackgroundColor), typeof(Brush), typeof(FormsButton),
 			new PropertyMetadata(default(Brush), OnBackgroundColorChanged));
+
+		public static readonly DependencyProperty TextWrappingProperty = DependencyProperty.Register(
+			nameof(TextWrapping),
+			typeof(TextWrapping),
+			typeof(FormsButton),
+			new PropertyMetadata(TextWrapping.NoWrap, OnTextWrappingChanged));
+
+		//public static readonly DependencyProperty TextTrimmingProperty = DependencyProperty.Register(
+		//	nameof(TextTrimming),
+		//	typeof(TextTrimming),
+		//	typeof(FormsButton),
+		//	new PropertyMetadata(TextTrimming.None, OnTextTrimmingChanged));
 
 		WContentPresenter _contentPresenter;
 
@@ -39,14 +52,23 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
+		public TextWrapping TextWrapping
+		{
+			get { return (TextWrapping)GetValue(TextWrappingProperty); }
+			set { SetValue(TextWrappingProperty, value); }
+		}
+
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
 
 			_contentPresenter = GetTemplateChild("ContentPresenter") as WContentPresenter;
 
+			var a = _contentPresenter.GetChildren<Windows.UI.Xaml.Controls.TextBlock>();
+
 			UpdateBackgroundColor();
 			UpdateBorderRadius();
+			UpdateTextWrapping();
 		}
 
 		static void OnBackgroundColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -58,6 +80,15 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			((FormsButton)d).UpdateBorderRadius();
 		}
+
+		static void OnTextWrappingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			((FormsButton)d).UpdateTextWrapping();
+		}
+
+		//static void OnTextTrimmingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		//{
+		//}
 
 		void UpdateBackgroundColor()
 		{
@@ -74,6 +105,14 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (_contentPresenter != null)
 				_contentPresenter.CornerRadius = new Windows.UI.Xaml.CornerRadius(BorderRadius);
+		}
+
+		void UpdateTextWrapping()
+		{
+			if (_contentPresenter != null)
+			{
+				_contentPresenter.TextWrapping = TextWrapping;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateImage();
 				UpdateTextColor();
 				UpdatePadding();
+				UpdateLineBreakMode();
 			}
 		}
 
@@ -106,6 +107,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateImage();
 			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
 				UpdatePadding();
+			else if (e.PropertyName == Button.LineBreakModeProperty.PropertyName)
+				UpdateLineBreakMode();
 		}
     
 		protected override void SetAccessibilityLabel()
@@ -313,6 +316,31 @@ namespace Xamarin.Forms.Platform.iOS
 
 			button.ImageEdgeInsets = new UIEdgeInsets(-imageVertOffset, horizontalImageOffset, imageVertOffset, -horizontalImageOffset);
 			button.TitleEdgeInsets = new UIEdgeInsets(titleVertOffset, -horizontalTitleOffset, -titleVertOffset, horizontalTitleOffset);
+		}
+
+		void UpdateLineBreakMode()
+		{
+			switch (Element.LineBreakMode)
+			{
+				case LineBreakMode.HeadTruncation:
+					Control.LineBreakMode = UILineBreakMode.HeadTruncation;
+					break;
+				case LineBreakMode.MiddleTruncation:
+					Control.LineBreakMode = UILineBreakMode.MiddleTruncation;
+					break;
+				case LineBreakMode.TailTruncation:
+					Control.LineBreakMode = UILineBreakMode.TailTruncation;
+					break;
+				case LineBreakMode.NoWrap:
+					Control.LineBreakMode = UILineBreakMode.Clip;
+					break;
+				case LineBreakMode.CharacterWrap:
+					Control.LineBreakMode = UILineBreakMode.CharacterWrap;
+					break;
+				case LineBreakMode.WordWrap:
+					Control.LineBreakMode = UILineBreakMode.WordWrap;
+					break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Added LineBreakMode for Button to control text wrapping behavior

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3106

### API Changes ###
Added:
 - LineBreakMode LineBreakMode { get; set; } //Bindable Property

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP (no TextTrimming though)

### Behavioral/Visual Changes ###
None

## PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
