### PR TITLE
[iOS] Label TextColor has no effect with FormattedString

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4040.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4040.xaml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Xamarin.Forms.Controls.Issues.Issue4040">
+    <StackLayout Padding="50, 100">
+
+        <Switch x:Name="swtch"/>
+
+        <Label>
+          <Label.FormattedText>
+            <FormattedString>
+              <Span Text="Using 'FormattedText' Property"/>
+            </FormattedString>
+          </Label.FormattedText>
+          <Label.Triggers>
+            <DataTrigger TargetType="Label"
+                         Binding="{Binding IsToggled, Source={x:Reference swtch}}"
+                         Value="True">
+              <Setter Property="TextColor" Value="Red" />
+              <Setter Property="BackgroundColor" Value="Pink" />
+            </DataTrigger>
+          </Label.Triggers>
+        </Label>
+
+        <Label Text="Using 'Text' Property">
+          <Label.Triggers>
+            <DataTrigger TargetType="Label"
+                         Binding="{Binding IsToggled, Source={x:Reference swtch}}"
+                         Value="True">
+              <Setter Property="TextColor" Value="Red" />
+              <Setter Property="BackgroundColor" Value="Pink" />
+            </DataTrigger>
+          </Label.Triggers>
+        </Label>
+
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4040.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4040.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue (IssueTracker.Github, 4040, "[iOS] Label TextColor has no effect with FormattedString", PlatformAffected.iOS)]
+	public partial class Issue4040 : ContentPage
+	{
+		public Issue4040()
+		{
+			#if APP
+			InitializeComponent ();
+			#endif
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -816,6 +816,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3525.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3275.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3884.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4040.xaml.cs">
+      <DependentUpon>Issue4040.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -926,6 +929,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla54977.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4040.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -24,6 +24,10 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		bool _perfectSizeValid;
 
+		FormattedString _formatted;
+
+		bool IsTextFormatted => _formatted != null;
+
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			if (!_perfectSizeValid)
@@ -293,9 +297,6 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 #endif
 		}
-
-		FormattedString _formatted;
-		bool IsTextFormatted => _formatted != null;
 
 		void UpdateText()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -294,17 +294,17 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 		}
 
-		FormattedString formatted;
-		bool IsTextFormatted => formatted != null;
+		FormattedString _formatted;
+		bool IsTextFormatted => _formatted != null;
 
 		void UpdateText()
 		{
 			_perfectSizeValid = false;
 			var values = Element.GetValues(Label.FormattedTextProperty, Label.TextProperty);
 
-			formatted = values[0] as FormattedString;
-			if (formatted == null && Element.LineHeight >= 0)
-				formatted = (string)values[1];
+			_formatted = values[0] as FormattedString;
+			if (_formatted == null && Element.LineHeight >= 0)
+				_formatted = (string)values[1];
 
 			if (IsTextFormatted)
 			{
@@ -324,9 +324,9 @@ namespace Xamarin.Forms.Platform.MacOS
 		void UpdateFormattedText()
 		{
 #if __MOBILE__
-			Control.AttributedText = formatted.ToAttributed(Element, Element.TextColor, Element.LineHeight);
+			Control.AttributedText = _formatted.ToAttributed(Element, Element.TextColor, Element.LineHeight);
 #else
-			Control.AttributedStringValue = formatted.ToAttributed(Element, Element.TextColor, Element.LineHeight);
+			Control.AttributedStringValue = _formatted.ToAttributed(Element, Element.TextColor, Element.LineHeight);
 #endif
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -294,24 +294,21 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 		}
 
-		bool isTextFormatted;
+		FormattedString formatted;
+		bool IsTextFormatted => formatted != null;
+
 		void UpdateText()
 		{
 			_perfectSizeValid = false;
-			var values = Element.GetValues(Label.FormattedTextProperty, Label.TextProperty, Label.TextColorProperty);
+			var values = Element.GetValues(Label.FormattedTextProperty, Label.TextProperty);
 
-			var formatted = values[0] as FormattedString;
+			formatted = values[0] as FormattedString;
 			if (formatted == null && Element.LineHeight >= 0)
 				formatted = (string)values[1];
 
-			if (formatted != null)
+			if (IsTextFormatted)
 			{
-#if __MOBILE__
-				Control.AttributedText = formatted.ToAttributed(Element, (Color)values[2], Element.LineHeight);
-#else
-				Control.AttributedStringValue = formatted.ToAttributed(Element, (Color)values[2], Element.LineHeight);
-#endif
-				isTextFormatted = true;
+				UpdateFormattedText();
 			}
 			else
 			{
@@ -320,15 +317,26 @@ namespace Xamarin.Forms.Platform.MacOS
 #else
 				Control.StringValue = (string)values[1] ?? "";
 #endif
-				isTextFormatted = false;
 			}
 			UpdateLayout();
 		}
 
+		void UpdateFormattedText()
+		{
+#if __MOBILE__
+			Control.AttributedText = formatted.ToAttributed(Element, Element.TextColor, Element.LineHeight);
+#else
+			Control.AttributedStringValue = formatted.ToAttributed(Element, Element.TextColor, Element.LineHeight);
+#endif
+		}
+
 		void UpdateFont()
 		{
-			if (isTextFormatted)
+			if (IsTextFormatted)
+			{
+				UpdateFormattedText();
 				return;
+			}
 			_perfectSizeValid = false;
 
 #if __MOBILE__
@@ -341,8 +349,11 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateTextColor()
 		{
-			if (isTextFormatted)
+			if (IsTextFormatted)
+			{
+				UpdateFormattedText();
 				return;
+			}
 
 			_perfectSizeValid = false;
 


### PR DESCRIPTION
### Description of Change ###
Allow to skip setting Font and/or TextColor for each Span (You may set Label.TextColor and/or FontSize, FontFamily, FontAttributes

### Issues Resolved ### 
- fixes #4040

### API Changes ###
 None (Only internal LabelRenderer logic)

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Described in issue ticket

### Testing Procedure ###
Described in issue ticket
