### PR TITLE
[XamlC] [Bug] Instantiate generic parameters in base type generic arguments

### DIFF
--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -154,13 +154,13 @@ namespace Xamarin.Forms.Build.Tasks
 							tr.InterfaceType.FullName.StartsWith(@interface, StringComparison.Ordinal) &&
 							tr.InterfaceType.IsGenericInstance && (tr.InterfaceType as GenericInstanceType).HasGenericArguments)) != null)
 			{
-				interfaceReference = iface.InterfaceType as GenericInstanceType;
-				genericArguments = (iface.InterfaceType as GenericInstanceType).GenericArguments;
+				interfaceReference = (iface.InterfaceType as GenericInstanceType).ResolveGenericParameters(typeRef);
+				genericArguments = interfaceReference.GenericArguments;
 				return true;
 			}
 			var baseTypeRef = typeDef.BaseType;
 			if (baseTypeRef != null && baseTypeRef.FullName != "System.Object")
-				return baseTypeRef.ImplementsGenericInterface(@interface, out interfaceReference, out genericArguments);
+				return baseTypeRef.ResolveGenericParameters(typeRef).ImplementsGenericInterface(@interface, out interfaceReference, out genericArguments);
 			return false;
 		}
 
@@ -336,21 +336,23 @@ namespace Xamarin.Forms.Build.Tasks
 		public static TypeReference ResolveGenericParameters(this TypeReference self, TypeReference declaringTypeReference)
 		{
 			var genericself = self as GenericInstanceType;
-			if (genericself == null)
-				return self;
+			return genericself == null ? self : ResolveGenericParameters(genericself, declaringTypeReference);
+		}
 
+		static GenericInstanceType ResolveGenericParameters(this GenericInstanceType self, TypeReference declaringTypeReference)
+		{
 			var genericdeclType = declaringTypeReference as GenericInstanceType;
 			if (genericdeclType == null)
 				return self;
 
 			List<TypeReference> args = new List<TypeReference>();
-			for (var i = 0; i < genericself.GenericArguments.Count; i++) {
-				if (!genericself.GenericArguments[i].IsGenericParameter)
-					args.Add(genericself.GenericArguments[i].ResolveGenericParameters(declaringTypeReference));
+			for (var i = 0; i < self.GenericArguments.Count; i++) {
+				if (!self.GenericArguments[i].IsGenericParameter)
+					args.Add(self.GenericArguments[i].ResolveGenericParameters(declaringTypeReference));
 				else
-					args.Add(genericdeclType.GenericArguments[(genericself.GenericArguments[i] as GenericParameter).Position]);
+					args.Add(genericdeclType.GenericArguments[(self.GenericArguments[i] as GenericParameter).Position]);
 			}
-			return self.GetElementType().MakeGenericInstanceType(args.ToArray());
+			return self.ElementType.MakeGenericInstanceType(args.ToArray());
 		}
 
 		static Dictionary<TypeReference, TypeDefinition> resolves = new Dictionary<TypeReference, TypeDefinition>();

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
@@ -43,6 +43,18 @@ namespace Xamarin.Forms.XamlcUnitTests
 		{
 		}
 
+		interface IGrault<T>
+		{
+		}
+
+		class Grault<T> : IGrault<T>
+		{
+		}
+
+		class Garply<T> : Grault<T>
+		{
+		}
+
 		ModuleDefinition module;
 
 		[SetUp]
@@ -142,6 +154,21 @@ namespace Xamarin.Forms.XamlcUnitTests
 
 			Assert.AreEqual("System", resolvedType.Namespace);
 			Assert.AreEqual("Byte", resolvedType.Name);
+		}
+
+		[Test]
+		public void TestImplementsGenericInterface()
+		{
+			GenericInstanceType igrault;
+			IList<TypeReference> arguments;
+			var garply = module.ImportReference(typeof(Garply<System.Byte>));
+
+			Assert.That(garply.ImplementsGenericInterface("Xamarin.Forms.XamlcUnitTests.TypeReferenceExtensionsTests/IGrault`1<T>", out igrault, out arguments));
+
+			Assert.AreEqual("System", igrault.GenericArguments[0].Namespace);
+			Assert.AreEqual("Byte", igrault.GenericArguments[0].Name);
+			Assert.AreEqual("System", arguments[0].Namespace);
+			Assert.AreEqual("Byte", arguments[0].Name);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

XamlC traverses a type chain to find the generic argument of  `Xamarin.Forms.Xaml.IMarkupExtension`. A generic instance type may be present in such a chain, and the generic argument of `Xamarin.Forms.Xaml.IMarkupExtension` can be a generic parameter of the type. This change allows to resolve such a generic parameter. Consider the following type and XAML for example:

````C#
class C<T> : IMarkupExtension<T>
````

```XAML
<C x:TypeArguments="int" />
```

The XAML instantiates `C<int>` in XAML. XamlC traverses the type chain and finds `IMarkupExtension` has `T` as its generic argument. However, `T` is not a real type but is a generic parameter. The code added in this change replaces `T` with `int`, the generic argument for `C`.

This is a change similar to #1533.

### Issues Resolved ### 

I was too lazy to open an issue.

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Run the added test.

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
