### PR TITLE
Bindable layouts

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -377,6 +377,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new UnevenListGallery(), "UnevenList Gallery - Legacy"),
 				new GalleryPageFactory(() => new ViewCellGallery(), "ViewCell Gallery - Legacy"),
 				new GalleryPageFactory(() => new WebViewGallery(), "WebView Gallery - Legacy"),
+				new GalleryPageFactory(() => new BindableLayoutGalleryPage(), "BindableLayout Gallery - Legacy"),
 			};
 
 		public CorePageView(Page rootPage, NavigationBehavior navigationBehavior = NavigationBehavior.PushAsync)

--- a/Xamarin.Forms.Controls/GalleryPages/BindableLayoutGalleryPage.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/BindableLayoutGalleryPage.xaml
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="clr-namespace:Xamarin.Forms.Controls.GalleryPages"
+			 x:Class="Xamarin.Forms.Controls.GalleryPages.BindableLayoutGalleryPage">
+	<ContentPage.Resources>
+		<!-- Template for integer items -->
+		<DataTemplate x:Key="MyIntTemplate">
+			<Frame Padding="10"
+				   BackgroundColor="Yellow">
+				<Label Text="{Binding }" />
+			</Frame>
+		</DataTemplate>
+		<!-- Template for character items -->
+		<DataTemplate x:Key="MyCharTemplate">
+			<Frame Padding="10"
+				   BackgroundColor="Azure">
+				<Label Text="{Binding }" />
+			</Frame>
+		</DataTemplate>
+		<local:BindableLayoutItemTemplateSelector x:Key="ItemTemplateSelector"
+												  IntTemplate="{StaticResource MyIntTemplate}"
+												  CharTemplate="{StaticResource MyCharTemplate}" />
+	</ContentPage.Resources>
+	<Grid RowSpacing="0">
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<ScrollView VerticalScrollBarVisibility="Never"
+					HorizontalScrollBarVisibility="Always">
+			<StackLayout BindableLayout.ItemsSource="{Binding ItemsSource}"
+						 BindableLayout.ItemTemplateSelector="{StaticResource ItemTemplateSelector}"
+						 Spacing="7"
+						 Padding="10, 5" />
+		</ScrollView>
+		<StackLayout BackgroundColor="Green"
+					 Orientation="Horizontal"
+					 Spacing="0"
+					 Grid.Row="1">
+			<Button Command="{Binding AddItemCommand}"
+					Text="Add" />
+			<Button Command="{Binding RemoveItemCommand}"
+					Text="Remove" />
+			<Button Command="{Binding ReplaceItemCommand}"
+					Text="Replace" />
+			<Button Command="{Binding MoveItemCommand}"
+					Text="Move" />
+			<Button Command="{Binding ClearCommand}"
+					Text="Clear" />
+		</StackLayout>
+	</Grid>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/BindableLayoutGalleryPage.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/BindableLayoutGalleryPage.xaml.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class BindableLayoutGalleryPage : ContentPage
+	{
+		public BindableLayoutGalleryPage()
+		{
+			InitializeComponent();
+			BindingContext = new PageViewModel();
+		}
+
+		[Preserve(AllMembers = true)]
+		class PageViewModel
+		{
+			public ObservableCollection<object> ItemsSource { get; set; }
+			public ICommand AddItemCommand { get; }
+			public ICommand RemoveItemCommand { get; }
+			public ICommand ReplaceItemCommand { get; }
+			public ICommand MoveItemCommand { get; }
+			public ICommand ClearCommand { get; }
+
+			public PageViewModel()
+			{
+				ItemsSource = new ObservableCollection<object>(Enumerable.Range(0, 10).Cast<object>().ToList());
+
+				int i = ItemsSource.Count;
+				AddItemCommand = new Command(() => ItemsSource.Add(i++));
+				RemoveItemCommand = new Command(() =>
+				{
+					if (ItemsSource.Count > 0) ItemsSource.RemoveAt(0);
+				});
+				ReplaceItemCommand = new Command(() =>
+				{
+					// Switch between integers and character representation
+					for (int i1 = 0; i1 < ItemsSource.Count; ++i1)
+					{
+						if (ItemsSource[i1] is int a)
+						{
+							ItemsSource[i1] = (char)('A' + a);
+						}
+						else
+						{
+							ItemsSource[i1] = (int)((char)ItemsSource[i1] - 'A');
+						}
+					}
+				});
+				MoveItemCommand = new Command(() =>
+				{
+					// Move first item to the last position
+					if (ItemsSource.Count > 0)
+					{
+						ItemsSource.Move(0, ItemsSource.Count - 1);
+					}
+				});
+				ClearCommand = new Command(() =>
+				{
+					ItemsSource.Clear();
+				});
+			}
+		}
+	}
+
+	class BindableLayoutItemTemplateSelector : DataTemplateSelector
+	{
+		public DataTemplate IntTemplate { get; set; }
+		public DataTemplate CharTemplate { get; set; }
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			return item is int ? IntTemplate : CharTemplate;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -40,9 +40,15 @@
     <EmbeddedResource Include="GalleryPages\crimson.jpg" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
+    <Compile Update="GalleryPages\BindableLayoutGalleryPage.xaml.cs">
+      <DependentUpon>BindableLayoutGalleryPage.xaml</DependentUpon>
+    </Compile>
     <Compile Update="GalleryPages\VisualStateManagerGalleries\OnPlatformExample.xaml.cs">
       <DependentUpon>OnPlatformExample.xaml</DependentUpon>
     </Compile>
+    <EmbeddedResource Update="GalleryPages\BindableLayoutGalleryPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\TitleView.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
@@ -1,0 +1,375 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class BindableLayoutTests : BaseTestFixture
+	{
+		[Test]
+		public void TracksEmpty()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>();
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void TracksAdd()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>();
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			itemsSource.Add(1);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void TracksInsert()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>();
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			itemsSource.Insert(0, 1);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void TracksRemove()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>() { 0, 1 };
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			itemsSource.RemoveAt(0);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+
+			itemsSource.Remove(1);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void TracksReplace()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>() { 0, 1, 2 };
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			itemsSource[0] = 3;
+			itemsSource[1] = 4;
+			itemsSource[2] = 5;
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void TracksMove()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>() { 0, 1 };
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			itemsSource.Move(0, 1);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+
+			itemsSource.Move(1, 0);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void TracksClear()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>() { 0, 1 };
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			itemsSource.Clear();
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void TracksNull()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+
+			itemsSource = null;
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void ItemTemplateIsSet()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			BindableLayout.SetItemTemplate(layout, new DataTemplateBoxView());
+
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+			Assert.AreEqual(itemsSource.Count, layout.Children.Cast<BoxView>().Count());
+		}
+
+		[Test]
+		public void ItemTemplateSelectorIsSet()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			BindableLayout.SetItemTemplateSelector(layout, new DataTemplateSelectorFrame());
+
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+			Assert.AreEqual(itemsSource.Count, layout.Children.Cast<Frame>().Count());
+		}
+
+		[Test]
+		public void ItemTemplateTakesPrecendenceOverItemTemplateSelector()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			BindableLayout.SetItemTemplate(layout, new DataTemplateBoxView());
+			BindableLayout.SetItemTemplateSelector(layout, new DataTemplateSelectorFrame());
+
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+			Assert.AreEqual(itemsSource.Count, layout.Children.Cast<BoxView>().Count());
+		}
+
+		[Test]
+		public void ItemsSourceTakePrecendenceOverLayoutChildren()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			layout.Children.Add(new Label());
+			layout.Children.Add(new Label());
+			layout.Children.Add(new Label());
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void LayoutIsGarbageCollectedAfterItsRemoved()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			var pageRoot = new Grid();
+			pageRoot.Children.Add(layout);
+			var page = new ContentPage() { Content = pageRoot };
+
+			var weakReference = new WeakReference(layout);
+			pageRoot.Children.Remove(layout);
+			layout = null;
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			Assert.IsFalse(weakReference.IsAlive);
+		}
+
+		[Test]
+		public void ThrowsExceptionOnUsingDataTemplateSelectorForItemTemplate()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			Assert.Throws(typeof(NotSupportedException), () => BindableLayout.SetItemTemplate(layout, new DataTemplateSelectorFrame()));
+		}
+
+		[Test]
+		public void DontTrackAfterItemsSourceChanged()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			BindableLayout.SetItemsSource(layout, new ObservableCollection<int>(Enumerable.Range(0, 10)));
+
+			bool wasCalled = false;
+			layout.ChildAdded += (_, __) => wasCalled = true;
+			itemsSource.Add(11);
+			Assert.IsFalse(wasCalled);
+		}
+
+		[Test]
+		public void WorksWithNullItems()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int?>(Enumerable.Range(0, 10).Cast<int?>());
+			itemsSource.Add(null);
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public void WorksWithDuplicateItems()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform()
+			};
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			foreach (int item in itemsSource.ToList())
+			{
+				itemsSource.Add(item);
+			}
+
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+
+			itemsSource.Remove(0);
+			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		// Checks if for every item in the items source there's a corresponding view
+		static bool IsLayoutWithItemsSource(IEnumerable itemsSource, Layout layout)
+		{
+			if (itemsSource == null)
+			{
+				return layout.Children.Count() == 0;
+			}
+
+			int i = 0;
+			foreach (object item in itemsSource)
+			{
+				if (BindableLayout.GetItemTemplate(layout) is DataTemplate dataTemplate ||
+					BindableLayout.GetItemTemplateSelector(layout) is DataTemplateSelector dataTemplateSelector)
+				{
+					if (!Equals(item, layout.Children[i].BindingContext))
+					{
+						return false;
+					}
+				}
+				else
+				{
+					if (!Equals(item?.ToString(), ((Label)layout.Children[i]).Text))
+					{
+						return false;
+					}
+				}
+
+				++i;
+			}
+
+			return layout.Children.Count == i;
+		}
+
+		class DataTemplateBoxView : DataTemplate
+		{
+			public DataTemplateBoxView() : base(() => new BoxView())
+			{
+			}
+		}
+
+		class DataTemplateFrame : DataTemplate
+		{
+			public DataTemplateFrame() : base(() => new Frame())
+			{
+			}
+		}
+
+		class DataTemplateSelectorFrame : DataTemplateSelector
+		{
+			DataTemplateFrame dt = new DataTemplateFrame();
+
+			protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+			{
+				return dt;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="AnimatableKeyTests.cs" />
     <Compile Include="BaseTestFixture.cs" />
     <Compile Include="AbsoluteLayoutTests.cs" />
+    <Compile Include="BindableLayoutTests.cs" />
     <Compile Include="BindableObjectExtensionTests.cs" />
     <Compile Include="BindableObjectUnitTests.cs" />
     <Compile Include="BindablePropertyUnitTests.cs" />

--- a/Xamarin.Forms.Core/BindableLayout.cs
+++ b/Xamarin.Forms.Core/BindableLayout.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Specialized;
+
+namespace Xamarin.Forms
+{
+	public static class BindableLayout
+	{
+		public static readonly BindableProperty ItemsSourceProperty =
+			BindableProperty.CreateAttached("ItemsSource", typeof(IEnumerable), typeof(Layout<View>), default(IEnumerable),
+				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemsSource = (IEnumerable)n; });
+
+		public static readonly BindableProperty ItemTemplateProperty =
+			BindableProperty.CreateAttached("ItemTemplate", typeof(DataTemplate), typeof(Layout<View>), default(DataTemplate),
+				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemTemplate = (DataTemplate)n; });
+
+		public static readonly BindableProperty ItemTemplateSelectorProperty =
+			BindableProperty.CreateAttached("ItemTemplateSelector", typeof(DataTemplateSelector), typeof(Layout<View>), default(DataTemplateSelector),
+				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemTemplateSelector = (DataTemplateSelector)n; });
+
+		static readonly BindableProperty BindableLayoutControllerProperty =
+			 BindableProperty.CreateAttached("BindableLayoutController", typeof(BindableLayoutController), typeof(Layout<View>), default(BindableLayoutController),
+				 defaultValueCreator: (b) => new BindableLayoutController((Layout<View>)b),
+				 propertyChanged: (b, o, n) => OnControllerChanged(b, (BindableLayoutController)o, (BindableLayoutController)n));
+
+		public static void SetItemsSource(BindableObject b, IEnumerable value)
+		{
+			b.SetValue(ItemsSourceProperty, value);
+		}
+
+		public static IEnumerable GetItemsSource(BindableObject b)
+		{
+			return (IEnumerable)b.GetValue(ItemsSourceProperty);
+		}
+
+		public static void SetItemTemplate(BindableObject b, DataTemplate value)
+		{
+			b.SetValue(ItemTemplateProperty, value);
+		}
+
+		public static DataTemplate GetItemTemplate(BindableObject b)
+		{
+			return (DataTemplate)b.GetValue(ItemTemplateProperty);
+		}
+
+		public static void SetItemTemplateSelector(BindableObject b, DataTemplateSelector value)
+		{
+			b.SetValue(ItemTemplateSelectorProperty, value);
+		}
+
+		public static DataTemplateSelector GetItemTemplateSelector(BindableObject b)
+		{
+			return (DataTemplateSelector)b.GetValue(ItemTemplateSelectorProperty);
+		}
+
+		static BindableLayoutController GetBindableLayoutController(BindableObject b)
+		{
+			return (BindableLayoutController)b.GetValue(BindableLayoutControllerProperty);
+		}
+
+		static void SetBindableLayoutController(BindableObject b, BindableLayoutController value)
+		{
+			b.SetValue(BindableLayoutControllerProperty, value);
+		}
+
+		static void OnControllerChanged(BindableObject b, BindableLayoutController oldC, BindableLayoutController newC)
+		{
+			if (oldC != null)
+			{
+				oldC.ItemsSource = null;
+			}
+
+			if (newC == null)
+			{
+				return;
+			}
+
+			newC.StartBatchUpdate();
+			newC.ItemsSource = GetItemsSource(b);
+			newC.ItemTemplate = GetItemTemplate(b);
+			newC.ItemTemplateSelector = GetItemTemplateSelector(b);
+			newC.EndBatchUpdate();
+		}
+	}
+
+	class BindableLayoutController
+	{
+		readonly WeakReference<Layout<View>> _layoutWeakReference;
+		IEnumerable _itemsSource;
+		DataTemplate _itemTemplate;
+		DataTemplateSelector _itemTemplateSelector;
+		bool _isBatchUpdate;
+
+		public IEnumerable ItemsSource { get => _itemsSource; set => SetItemsSource(value); }
+		public DataTemplate ItemTemplate { get => _itemTemplate; set => SetItemTemplate(value); }
+		public DataTemplateSelector ItemTemplateSelector { get => _itemTemplateSelector; set => SetItemTemplateSelector(value); }
+
+
+		public BindableLayoutController(Layout<View> layout)
+		{
+			_layoutWeakReference = new WeakReference<Layout<View>>(layout);
+		}
+
+		internal void StartBatchUpdate()
+		{
+			_isBatchUpdate = true;
+		}
+
+		internal void EndBatchUpdate()
+		{
+			_isBatchUpdate = false;
+			CreateChildren();
+		}
+
+		void SetItemsSource(IEnumerable itemsSource)
+		{
+			if (_itemsSource is INotifyCollectionChanged c)
+			{
+				c.CollectionChanged -= ItemsSourceCollectionChanged;
+			}
+
+			_itemsSource = itemsSource;
+
+			if (_itemsSource is INotifyCollectionChanged c1)
+			{
+				c1.CollectionChanged += ItemsSourceCollectionChanged;
+			}
+
+			if (!_isBatchUpdate)
+			{
+				CreateChildren();
+			}
+		}
+
+		void SetItemTemplate(DataTemplate itemTemplate)
+		{
+			if (itemTemplate is DataTemplateSelector)
+			{
+				throw new NotSupportedException($"You are using an instance of {nameof(DataTemplateSelector)} to set the {nameof(BindableLayout)}.{BindableLayout.ItemTemplateProperty.PropertyName} property. Use {nameof(BindableLayout)}.{BindableLayout.ItemTemplateSelectorProperty.PropertyName} property instead to set an item template selector");
+			}
+
+			_itemTemplate = itemTemplate;
+
+			if (!_isBatchUpdate)
+			{
+				CreateChildren();
+			}
+		}
+
+		void SetItemTemplateSelector(DataTemplateSelector itemTemplateSelector)
+		{
+			_itemTemplateSelector = itemTemplateSelector;
+
+			if (!_isBatchUpdate)
+			{
+				CreateChildren();
+			}
+		}
+
+		void CreateChildren()
+		{
+			Layout<View> layout;
+			if (!_layoutWeakReference.TryGetTarget(out layout))
+			{
+				return;
+			}
+
+			layout.Children.Clear();
+
+			if (_itemsSource == null)
+			{
+				return;
+			}
+
+			int i = 0;
+			foreach (object item in _itemsSource)
+			{
+				layout.Children.Add(CreateItemView(item, i++));
+			}
+		}
+
+		View CreateItemView(object item, int index)
+		{
+			return CreateItemView(item, index, _itemTemplate ?? _itemTemplateSelector?.SelectTemplate(item, null));
+		}
+
+		View CreateItemView(object item, int index, DataTemplate dataTemplate)
+		{
+			if (dataTemplate != null)
+			{
+				var view = (View)dataTemplate.CreateContent();
+				view.BindingContext = item;
+				return view;
+			}
+			else
+			{
+				return new Label() { Text = item?.ToString() };
+			}
+		}
+
+		void ItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			Layout<View> layout;
+			if (!_layoutWeakReference.TryGetTarget(out layout))
+			{
+				return;
+			}
+
+			switch (e.Action)
+			{
+				case NotifyCollectionChangedAction.Add:
+					{
+						if (e.NewStartingIndex == -1)
+							goto case NotifyCollectionChangedAction.Reset;
+						int i = e.NewStartingIndex;
+						foreach (object item in e.NewItems)
+						{
+							layout.Children.Add(CreateItemView(item, i++));
+						}
+					}
+					break;
+				case NotifyCollectionChangedAction.Remove:
+					{
+						if (e.OldStartingIndex == -1)
+							goto case NotifyCollectionChangedAction.Reset;
+						for (int i = 0; i < e.OldItems.Count; ++i)
+						{
+							layout.Children.RemoveAt(i + e.OldStartingIndex);
+						}
+					}
+					break;
+				case NotifyCollectionChangedAction.Replace:
+					{
+						if (e.OldStartingIndex == -1)
+							goto case NotifyCollectionChangedAction.Reset;
+						int i = e.NewStartingIndex;
+						foreach (object item in e.NewItems)
+						{
+							layout.Children[i] = CreateItemView(item, i);
+							++i;
+						}
+					}
+					break;
+				case NotifyCollectionChangedAction.Move:
+					{
+						if (e.OldStartingIndex == -1 || e.NewStartingIndex == -1)
+							goto case NotifyCollectionChangedAction.Reset;
+						for (int i = 0; i < e.NewItems.Count; ++i)
+						{
+							int iFrom = e.OldStartingIndex + i;
+							int iTo = e.NewStartingIndex + i;
+							View fromView = layout.Children[iFrom];
+							View toView = layout.Children[iTo];
+							layout.Children.Remove(fromView);
+							layout.Children.Remove(toView);
+							layout.Children.Insert(iFrom, toView);
+							layout.Children.Insert(iTo, fromView);
+						}
+					}
+					break;
+
+				case NotifyCollectionChangedAction.Reset:
+					layout.Children.Clear();
+					break;
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

It allows any `Layout<View>` to generate its content (child views) by binding to an items source, with option to set item template or item template selector:

```
<StackLayout BindableLayout.ItemsSource="{Binding Items}" />

<StackLayout BindableLayout.ItemsSource="{Binding Items}"
             BindableLayout.ItemTemplate="{Binding MyItemTemplate}" />

<StackLayout BindableLayout.ItemsSource="{Binding Items}"
             BindableLayout.ItemTemplateSelector="{Binding MyItemTemplateSelector}" />
```

In the first example, where neither item template nor item template selector are set, every item is a `Label`. If both item template and selector are set, the item template is used. If `Items` property is set, it is ignored.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #1718

### API Changes ###

Added static class BindableLayout with following attached properties to `Layout<View>`:

 - public IEnumerable ItemsSource{ get; set; }
 - public DataTemplate ItemTemplate { get; set; }
 - public DataTemplateSelector ItemTemplateSelector { get; set; }
 - private BindableLayoutController BindableLayoutController { get; set; }

Added private class BindableLayoutController which encapsulates updating layout children based on changes on the collection, item template or item template selector.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Testing Procedure ###

I added a gallery page (see screenshot below) which helps with testing all operations on a collection.

###  Before/After Screenshots ###

This change doesn't affect layout appearance, no matter the layout.  
However I attached a screenshot which shows the gallery page:
![image](https://user-images.githubusercontent.com/743918/46918637-e1a14f00-cfdc-11e8-9fa1-bc69a05df172.png)

The buttons should be self explanatory. "Replace" turns integers into chars to demonstrate replacing items in the observable collection. "Move" moves first item to last.

### PR Checklist ###

- [x] Has automated tests (See `BindableLayoutTests` unit tests) <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
