### PR TITLE
[XamlC] Resolve parameters in nested generics

### DIFF
--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -334,13 +334,10 @@ namespace Xamarin.Forms.Build.Tasks
 			if (genericdeclType == null)
 				return self;
 
-			if (!genericself.GenericArguments.Any(arg => arg.IsGenericParameter))
-				return self;
-
 			List<TypeReference> args = new List<TypeReference>();
 			for (var i = 0; i < genericself.GenericArguments.Count; i++) {
 				if (!genericself.GenericArguments[i].IsGenericParameter)
-					args.Add(genericself.GenericArguments[i]);
+					args.Add(genericself.GenericArguments[i].ResolveGenericParameters(declaringTypeReference));
 				else
 					args.Add(genericdeclType.GenericArguments[(genericself.GenericArguments[i] as GenericParameter).Position]);
 			}

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
@@ -35,6 +35,14 @@ namespace Xamarin.Forms.Xaml.XamlcUnitTests
 		{
 		}
 
+		class Quux<T> : Foo<Foo<T>>
+		{
+		}
+
+		class Corge<T> : Foo<Foo<Foo<T>>>
+		{
+		}
+
 		ModuleDefinition module;
 
 		[SetUp]
@@ -117,6 +125,23 @@ namespace Xamarin.Forms.Xaml.XamlcUnitTests
 			var test = typeof(TypeReferenceExtensionsTests).Assembly;
 
 			Assert.False(TestInheritsFromOrImplements(test.GetType("Xamarin.Forms.Effect"), core.GetType("Xamarin.Forms.Effect")));
+		}
+
+		[TestCase(typeof(Bar<byte>), 1)]
+		[TestCase(typeof(Quux<byte>), 2)]
+		[TestCase(typeof(Corge<byte>), 3)]
+		public void TestResolveGenericParameters(Type typeRef, int depth)
+		{
+			var imported = module.ImportReference(typeRef);
+			var resolvedType = imported.Resolve().BaseType.ResolveGenericParameters(imported);
+
+			for (var count = 0; count < depth; count++)
+			{
+				resolvedType = ((GenericInstanceType)resolvedType).GenericArguments[0];
+			}
+
+			Assert.AreEqual("System", resolvedType.Namespace);
+			Assert.AreEqual("Byte", resolvedType.Name);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Generics can be nested; an argument for a parameter of a generic instance type can be another generic
 instance type, which has its own parameters. The parameters in a nested argument must be resolved to specialize such a generic instance type, which `ResolveGenericParameters` basically does.

Consider the following types for example:

```C#
class Foo<T>
{
}

class Bar<T>
{
}

class Quux<T> : Foo<Bar<T>>
{
}
```

Now resolve the base type of `Quux<int>`. The old rash implementation of `ResolveGenericParameters` reads arguments of `Foo`, finds `Bar` is a concrete type, and considers there is nothing to do and returns `Foo<Bar<T>>` as a resolved one. But that is not true. The new implementation checks the argument of `Bar`, finds it is a generic parameter, replaces with a concrete type, `int`, and returns `Foo<Bar<int>>`.

### Issues Resolved ### 
I was too lazy to open an issue.

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
