### PR TITLE
Correct minor typo

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Extensions/NSViewControllerExtensions.cs
+++ b/Xamarin.Forms.Platform.MacOS/Extensions/NSViewControllerExtensions.cs
@@ -7,12 +7,12 @@ namespace Xamarin.Forms.Platform.MacOS
 	internal static class NSViewControllerExtensions
 	{
 		public static Task<T> HandleAsyncAnimation<T>(this NSViewController container, NSViewController fromViewController,
-			NSViewController toViewController, NSViewControllerTransitionOptions transitonOption,
+			NSViewController toViewController, NSViewControllerTransitionOptions transitionOption,
 			Action animationFinishedCallback, T result)
 		{
 			var tcs = new TaskCompletionSource<T>();
 
-			container.TransitionFromViewController(fromViewController, toViewController, transitonOption, () =>
+			container.TransitionFromViewController(fromViewController, toViewController, transitionOption, () =>
 			{
 				tcs.SetResult(result);
 				animationFinishedCallback?.Invoke();


### PR DESCRIPTION
Correcting a very small typo.

Given this is an internal class and never invoked including parameter name explicitly (using named parameters), it should be a safe change.