### PR TITLE
Added UI test to B45027

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
@@ -82,5 +82,22 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.DoubleTap(q => q.Marked(TOOLBAR_DELETE_TEXT));
 		}
 #endif
+
+#if UITEST && __IOS__
+		[Test]
+		public void Bugzilla45027Test()
+		{
+			var firstItemList = "0";
+			RunningApp.WaitForElement(q => q.Marked(firstItemList));
+
+			RunningApp.SwipeRightToLeft(q => q.Marked(firstItemList));
+			RunningApp.WaitForElement(q => q.Marked(TOOLBAR_ACTION_TEXT));
+			RunningApp.DoubleTap(q => q.Marked(TOOLBAR_ACTION_TEXT));
+
+			RunningApp.SwipeRightToLeft(q => q.Marked(firstItemList));
+			RunningApp.WaitForElement(q => q.Marked(TOOLBAR_DELETE_TEXT));
+			RunningApp.DoubleTap(q => q.Marked(TOOLBAR_DELETE_TEXT));
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = stackLayout;
 		}
 
-#if UITEST
+#if UITEST && __ANDROID__
 		[Test]
 		public void Bugzilla45027Test()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
@@ -13,6 +13,9 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Bugzilla, 45027, "App crashes when double tapping on ToolbarItem or MenuItem very quickly", PlatformAffected.Android)]
 	public class Bugzilla45027 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
+		const string TOOLBAR_ACTION_TEXT = "Action";
+		const string TOOLBAR_DELETE_TEXT = "Delete";
+
 		protected override void Init()
 		{
 			var list = new List<int>();
@@ -48,11 +51,11 @@ namespace Xamarin.Forms.Controls.Issues
 						},
 						ContextActions = { new MenuItem
 						{
-							Text = "Action"
+							Text = TOOLBAR_ACTION_TEXT
 						},
 						new MenuItem
 						{
-							Text = "Delete",
+							Text = TOOLBAR_DELETE_TEXT,
 							IsDestructive = true
 						} }
 					};
@@ -62,5 +65,22 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Content = stackLayout;
 		}
+
+#if UITEST
+		[Test]
+		public void Bugzilla45027Test()
+		{
+			var firstItemList = "0";
+			RunningApp.WaitForElement(q => q.Marked(firstItemList));
+
+			RunningApp.TouchAndHold(q => q.Marked(firstItemList));
+			RunningApp.WaitForElement(q => q.Marked(TOOLBAR_ACTION_TEXT));
+			RunningApp.DoubleTap(q => q.Marked(TOOLBAR_ACTION_TEXT));
+
+			RunningApp.TouchAndHold(q => q.Marked(firstItemList));
+			RunningApp.WaitForElement(q => q.Marked(TOOLBAR_DELETE_TEXT));
+			RunningApp.DoubleTap(q => q.Marked(TOOLBAR_DELETE_TEXT));
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45027.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
+using System.Collections.Generic;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
@@ -13,15 +14,27 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Bugzilla, 45027, "App crashes when double tapping on ToolbarItem or MenuItem very quickly", PlatformAffected.Android)]
 	public class Bugzilla45027 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
-		const string TOOLBAR_ACTION_TEXT = "Action";
-		const string TOOLBAR_DELETE_TEXT = "Delete";
+		const string BUTTON_ACTION_TEXT = "Action";
+		const string BUTTON_DELETE_TEXT = "Delete";
+
+		List<int> _list;
+		public List<int> List
+		{
+			get 
+			{
+				if (_list == null)
+				{
+					_list = new List<int>();
+					for (var i = 0; i < 10; i++)
+						_list.Add(i);
+				}
+
+				return _list;
+			}
+		}
 
 		protected override void Init()
 		{
-			var list = new List<int>();
-			for (var i = 0; i < 10; i++)
-				list.Add(i);
-
 			var stackLayout = new StackLayout
 			{
 				Orientation = StackOrientation.Vertical,
@@ -37,7 +50,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var listView = new ListView
 			{
-				ItemsSource = list,
+				ItemsSource = List,
 				ItemTemplate = new DataTemplate(() =>
 				{
 					var label = new Label();
@@ -51,11 +64,11 @@ namespace Xamarin.Forms.Controls.Issues
 						},
 						ContextActions = { new MenuItem
 						{
-							Text = TOOLBAR_ACTION_TEXT
+							Text = BUTTON_ACTION_TEXT
 						},
 						new MenuItem
 						{
-							Text = TOOLBAR_DELETE_TEXT,
+							Text = BUTTON_DELETE_TEXT,
 							IsDestructive = true
 						} }
 					};
@@ -70,16 +83,16 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla45027Test()
 		{
-			var firstItemList = "0";
+			var firstItemList = List.First().ToString();
 			RunningApp.WaitForElement(q => q.Marked(firstItemList));
 
 			RunningApp.TouchAndHold(q => q.Marked(firstItemList));
-			RunningApp.WaitForElement(q => q.Marked(TOOLBAR_ACTION_TEXT));
-			RunningApp.DoubleTap(q => q.Marked(TOOLBAR_ACTION_TEXT));
+			RunningApp.WaitForElement(q => q.Marked(BUTTON_ACTION_TEXT));
+			RunningApp.DoubleTap(q => q.Marked(BUTTON_ACTION_TEXT));
 
 			RunningApp.TouchAndHold(q => q.Marked(firstItemList));
-			RunningApp.WaitForElement(q => q.Marked(TOOLBAR_DELETE_TEXT));
-			RunningApp.DoubleTap(q => q.Marked(TOOLBAR_DELETE_TEXT));
+			RunningApp.WaitForElement(q => q.Marked(BUTTON_DELETE_TEXT));
+			RunningApp.DoubleTap(q => q.Marked(BUTTON_DELETE_TEXT));
 		}
 #endif
 
@@ -87,16 +100,16 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla45027Test()
 		{
-			var firstItemList = "0";
+			var firstItemList = List.First().ToString();
 			RunningApp.WaitForElement(q => q.Marked(firstItemList));
 
 			RunningApp.SwipeRightToLeft(q => q.Marked(firstItemList));
-			RunningApp.WaitForElement(q => q.Marked(TOOLBAR_ACTION_TEXT));
-			RunningApp.DoubleTap(q => q.Marked(TOOLBAR_ACTION_TEXT));
+			RunningApp.WaitForElement(q => q.Marked(BUTTON_ACTION_TEXT));
+			RunningApp.DoubleTap(q => q.Marked(BUTTON_ACTION_TEXT));
 
 			RunningApp.SwipeRightToLeft(q => q.Marked(firstItemList));
-			RunningApp.WaitForElement(q => q.Marked(TOOLBAR_DELETE_TEXT));
-			RunningApp.DoubleTap(q => q.Marked(TOOLBAR_DELETE_TEXT));
+			RunningApp.WaitForElement(q => q.Marked(BUTTON_DELETE_TEXT));
+			RunningApp.DoubleTap(q => q.Marked(BUTTON_DELETE_TEXT));
 		}
 #endif
 	}


### PR DESCRIPTION
### Description of Change ###

Added UI test to issue #2385 (Bugzilla 45027), but don't was tested using Xamarin.Forms 2.3.2 (where the problem occurs).

A question: How I run this UI test using specific version of Xamarin.Forms in this project? Go back to the release-2.3.2 tag and create this test to certified that this UI test will fail?

### Issues Resolved ### 

- fixes #2385 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard