### PR TITLE
[macOS] Fix NRE on Mojave when aligning the title

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
@@ -302,8 +302,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			_titleGroup.Group.View = view;
 			//save a reference so we can paint this for the background
 			_nsToolbarItemViewer = _titleGroup.Group.View.Superview;
+			if (_nsToolbarItemViewer == null)
+				return;
 			//position is hard .. we manually set the title to be centered 
-			var totalWidth = _titleGroup.Group.View.Superview.Superview.Frame.Width;
+			var totalWidth = _nsToolbarItemViewer.Superview.Frame.Width;
 			var fieldWidth = titleField.Frame.Width;
 			var x = ((totalWidth - fieldWidth) / 2) - _nsToolbarItemViewer.Frame.X;
 			titleField.Frame = new CGRect(x, 0, fieldWidth, ToolbarHeight);


### PR DESCRIPTION
### Description of Change ###

On Mojave we will need a different way to check the title frame. 

### Issues Resolved ### 
- fixes #3031

### API Changes ###
 
 None

### Platforms Affected ### 
- macOs

### Behavioral/Visual Changes ###

Text might be not entered on the Titlebar on Mojave

### Testing Procedure ###

just use the gallery on Mojave it would break without this fix.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard