### PR TITLE
[Android] Fixes AutomationProperties.Name on Button

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4053.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4053.cs
@@ -1,0 +1,24 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4053, "AutomationProperties.Name on Button is visible on Android", PlatformAffected.Android)]
+	public class Issue4053 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Button button = new Button ();
+			AutomationProperties.SetName(button, "invisible text");
+
+			Content = new StackLayout
+			{
+				Children = {
+					new Label { Text = "The text on the button below should be empty. But TalkBack should read 'invisible text'" },
+					button
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -19,6 +19,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Github3856.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1937.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4053.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3809.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3306.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -12,6 +12,7 @@ using AView = Android.Views.View;
 using AMotionEvent = Android.Views.MotionEvent;
 using AMotionEventActions = Android.Views.MotionEventActions;
 using static System.String;
+using Xamarin.Forms.Platform.Android.FastRenderers;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -25,6 +26,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		bool _isDisposed;
 		int _imageHeight = -1;
 		Thickness _paddingDeltaPix = new Thickness();
+		string _defaultContentDescription;
 
 		public ButtonRenderer(Context context) : base(context)
 		{
@@ -136,6 +138,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				UpdateAll();
 			}
+		}
+
+		protected override void SetContentDescription()
+		{
+			if (_defaultContentDescription == null)
+				_defaultContentDescription = Control.ContentDescription;
+			var value = AutomationPropertiesProvider.ConcatenateNameAndHelpText(Element);
+			Control.ContentDescription = !IsNullOrWhiteSpace(value) ? value : _defaultContentDescription;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Hint property on Button is displayed when the text is empty. So it disabled.

### Issues Resolved ### 

- fixes #4053 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Set `AutomationProperties.Name` no more replacing text on the button

### Before/After Screenshots ### 

**Before**
![screenshot_3](https://user-images.githubusercontent.com/27482193/47013786-07e7fb80-d151-11e8-9a9e-c9caf559ef9c.png)

**After**
![screenshot_2](https://user-images.githubusercontent.com/27482193/47013708-ceaf8b80-d150-11e8-8111-77fc7ec9dfdb.png)

### Testing Procedure ###

- run UITest 4053 in Control Gallery

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
