### PR TITLE
Resilient xaml

### DIFF
--- a/Xamarin.Forms.Core/Element_StyleSheets.cs
+++ b/Xamarin.Forms.Core/Element_StyleSheets.cs
@@ -15,11 +15,15 @@ namespace Xamarin.Forms
 
 		string IStyleSelectable.Id => StyleId;
 
+		internal string _cssFallbackTypeName;
+
 		string[] _styleSelectableNameAndBaseNames;
 		string[] IStyleSelectable.NameAndBases {
 			get {
 				if (_styleSelectableNameAndBaseNames == null) {
 					var list = new List<string>();
+					if (_cssFallbackTypeName != null)
+						list.Add(_cssFallbackTypeName);
 					var t = GetType();
 					while (t != typeof(BindableObject)) {
 						list.Add(t.Name);

--- a/Xamarin.Forms.Core/MergedStyle.cs
+++ b/Xamarin.Forms.Core/MergedStyle.cs
@@ -105,6 +105,7 @@ namespace Xamarin.Forms
 		void OnImplicitStyleChanged()
 		{
 			var first = true;
+			ImplicitStyle = null;
 			foreach (BindableProperty implicitStyleProperty in _implicitStyles)
 			{
 				var implicitStyle = (Style)Target.GetValue(implicitStyleProperty);
@@ -132,6 +133,24 @@ namespace Xamarin.Forms
 				if (s_stopAtTypes.Contains(type))
 					return;
 			}
+		}
+
+		internal void ReRegisterImplicitStyles(string fallbackTypeName)
+		{
+			//Clear old implicit Styles
+			for (var i = 0; i < _implicitStyles.Count; i++)
+				Target.RemoveDynamicResource(_implicitStyles[i]);
+			_implicitStyles.Clear();
+
+			//Register the fallback
+			BindableProperty implicitStyleProperty = BindableProperty.Create("ImplicitStyle", typeof(Style), typeof(VisualElement), default(Style),
+						propertyChanged: (bindable, oldvalue, newvalue) => OnImplicitStyleChanged());
+			_implicitStyles.Add(implicitStyleProperty);
+			Target.SetDynamicResource(implicitStyleProperty, fallbackTypeName);
+
+			//and proceed as usual
+			RegisterImplicitStyles();
+			Apply(Target);
 		}
 
 		void SetStyle(IStyle implicitStyle, IList<Style> classStyles, IStyle style)

--- a/Xamarin.Forms.Core/Style.cs
+++ b/Xamarin.Forms.Core/Style.cs
@@ -25,10 +25,7 @@ namespace Xamarin.Forms
 
 		public Style([TypeConverter(typeof(TypeTypeConverter))] [Parameter("TargetType")] Type targetType)
 		{
-			if (targetType == null)
-				throw new ArgumentNullException("targetType");
-
-			TargetType = targetType;
+			TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
 			Setters = new List<Setter>();
 		}
 

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -1,26 +1,67 @@
-﻿//
-// DesignTimeLoaderTests.cs
-//
-// Author:
-//       Stephane Delcroix <stdelc@microsoft.com>
-//
-// Copyright (c) 2018 
-using System;
+﻿using System;
 
+using NUnit.Framework;
 using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
-	public class DesignTimeLoaderTests : ContentPage
+	[TestFixture]
+	public class DesignTimeLoaderTests
 	{
-		public DesignTimeLoaderTests()
+		[SetUp]
+		public void Setup()
 		{
-			Content = new StackLayout {
-				Children = {
-					new Label { Text = "Hello ContentPage" }
-				}
-			};
+			Device.PlatformServices = new MockPlatformServices();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			XamlLoader.FallbackTypeResolver = null;
+			Device.PlatformServices = null;
+		}
+
+		[Test]
+		public void ContenPageWithMissingClass()
+		{
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+					x:Class=""Xamarin.Forms.Xaml.UnitTests.CustomView""
+				/>";
+
+			Assert.That(XamlLoader.Create(xaml, true), Is.TypeOf<ContentPage>());
+		}
+
+		[Test]
+		public void ViewWithMissingClass()
+		{
+			var xaml = @"
+				<ContentView xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+					x:Class=""Xamarin.Forms.Xaml.UnitTests.CustomView""
+				/>";
+
+			Assert.That(XamlLoader.Create(xaml, true), Is.TypeOf<ContentView>());
+		}
+
+		[Test]
+		public void ContenPageWithMissingType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(MockView);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+					<ContentPage.Content>
+						<local:MyCustomButton />
+					</ContentPage.Content>
+				</ContentPage>";
+
+			var page = (ContentPage) XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<MockView>());
 		}
 	}
 }
-

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -165,5 +165,50 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(new Color(1, 0, 0)));
 		}
 
+		[Test]
+		public void UnknownGenericType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(MockView);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
+					<local:MyCustomButton x:TypeArguments=""local:MyCustomType"" />
+				 </ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<MockView>());
+		}
+
+		[Test]
+		public void UnknownMarkupExtensionOnUnknownType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(MockView);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
+					<local:MyCustomButton Bar=""{local:Foo}"" />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<MockView>());
+		}
+
+		[Test]
+		public void UnknownMarkupExtensionKnownType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(MockView);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
+					<Button Style=""{local:Foo}"" />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<Button>());
+		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-
-using NUnit.Framework;
-using Xamarin.Forms;
+﻿using NUnit.Framework;
 using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
@@ -145,7 +142,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void ImplicitStyleNotAppliedToFallbackType()
+		public void StyleTargetingRealTypeNotAppliedToUnknownType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
 
@@ -162,6 +159,26 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 			Assert.That(page.Content, Is.TypeOf<Button>());
+			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(new Color(1, 0, 0)));
+		}
+
+		[Test]
+		public void StyleTargetingUnknownTypeNotAppliedToFallbackType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
+					<ContentPage.Resources>
+						<Style TargetType=""local:MyCustomButton"">
+							<Setter Property=""BackgroundColor"" Value=""Red"" />
+						</Style>
+					</ContentPage.Resources>
+					<Button />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
 			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(new Color(1, 0, 0)));
 		}
 
@@ -205,6 +222,18 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
 					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
 					<Button Style=""{local:Foo}"" />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<Button>());
+		}
+
+		[Test]
+		public void StaticResourceKeyNotFound()
+		{
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms"">
+					<Button Style=""{StaticResource TestStyle}"" />
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -159,7 +159,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 			Assert.That(page.Content, Is.TypeOf<Button>());
-			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(new Color(1, 0, 0)));
+			//Button Style shouldn't apply to MyButton
+			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(Color.Red));
 		}
 
 		[Test]
@@ -179,7 +180,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
-			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(new Color(1, 0, 0)));
+			//MyButton Style should be applied
+			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(Color.Red));
 		}
 
 		[Test]
@@ -220,8 +222,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
-					<Button Style=""{local:Foo}"" />
+					<Button Text=""{local:Foo}"" />
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
@@ -231,6 +234,20 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[Test]
 		public void StaticResourceKeyNotFound()
 		{
+			var app = @"
+				<Application xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
+					<Application.Resources>
+						<ResourceDictionary>
+							<Style TargetType=""Button"" x:Key=""TestStyle"">
+								<Setter Property=""BackgroundColor"" Value=""HotPink"" />
+							</Style>
+						</ResourceDictionary>
+					</Application.Resources>
+				</Application>
+			";
+			Application.Current = (Application)XamlLoader.Create(app, true);
+
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms"">
 					<Button Style=""{StaticResource TestStyle}"" />

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 			Assert.That(page.Content, Is.TypeOf<Button>());
-			Assert.That(page.Content.BackgroundColor, Is.EqualTo(new Color(1, 0, 0)));
+			Assert.That(page.Content.BackgroundColor, Is.EqualTo(Color.Red));
 		}
 
 		[Test]
@@ -142,11 +142,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var myButton = (Button)page.Content;
 			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
-			Assert.That(myButton.BackgroundColor, Is.EqualTo(new Color(1, 0, 0)));
+			Assert.That(myButton.BackgroundColor, Is.EqualTo(Color.Red));
 		}
 
 		[Test]
-		public void StyleTargetingRealTypeNotAppliedToUnknownType()
+		public void StyleTargetingRealTypeNotAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
 
@@ -171,7 +171,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void StyleTargetingUnknownTypeNotAppliedToFallbackType()
+		public void StyleTargetingMissingTypeNotAppliedToFallbackType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
 
@@ -196,7 +196,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void StyleAppliedToDerivedTypesAppliesToDerivedUnknownType()
+		public void StyleAppliedToDerivedTypesAppliesToDerivedMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
 
@@ -237,7 +237,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void UnknownMarkupExtensionOnUnknownType()
+		public void UnknownMarkupExtensionOnMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(MockView);
 
@@ -304,6 +304,89 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 			Assert.That(page.Content, Is.TypeOf<Button>());
+		}
+
+		[Test]
+		public void CssStyleAppliedToMissingType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
+					<ContentPage.Resources>
+						<StyleSheet>
+							<![CDATA[
+							MyCustomButton {
+								background-color: blue;
+							}
+							]]>
+						</StyleSheet>
+					</ContentPage.Resources>
+					<local:MyCustomButton />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+
+			var myButton = (Button)page.Content;
+			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+
+			Assert.That(myButton.BackgroundColor, Is.EqualTo(Color.Blue));
+		}
+
+		[Test]
+		public void CssStyleTargetingRealTypeNotAppliedToMissingType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
+					<ContentPage.Resources>
+						<StyleSheet>
+							<![CDATA[
+							Button {
+								background-color: red;
+							}
+							]]>
+						</StyleSheet>
+					</ContentPage.Resources>
+					<local:MyCustomButton />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+
+			var myButton = (Button)page.Content;
+			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+
+			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Red));
+		}
+
+		[Test]
+		public void CssStyleTargetingMissingTypeNotAppliedToFallbackType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms"">
+					<ContentPage.Resources>
+						<StyleSheet>
+							<![CDATA[
+							MyCustomButton {
+								background-color: blue;
+							}
+							]]>
+						</StyleSheet>
+					</ContentPage.Resources>
+					<Button />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+
+			var myButton = (Button)page.Content;
+			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+
+			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Blue));
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -109,11 +109,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly""
 					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
 					<ContentPage.Resources>
-						<Style x:Key=""Test"" TargetType=""local:MyCustomButton"">
+						<Style x:Key=""LocalStyle"" TargetType=""local:MyCustomButton"">
 							<Setter Property=""BackgroundColor"" Value=""Red"" />
 						</Style>
 					</ContentPage.Resources>
-					<local:MyCustomButton Style=""{StaticResource Test}"" />
+					<local:MyCustomButton Style=""{StaticResource LocalStyle}"" />
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
@@ -138,8 +138,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
-			Assert.That(page.Content, Is.TypeOf<Button>());
-			Assert.That(page.Content.BackgroundColor, Is.EqualTo(new Color(1, 0, 0)));
+
+			var myButton = (Button)page.Content;
+			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+
+			Assert.That(myButton.BackgroundColor, Is.EqualTo(new Color(1, 0, 0)));
 		}
 
 		[Test]
@@ -159,9 +162,12 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
-			Assert.That(page.Content, Is.TypeOf<Button>());
-			//Button Style shouldn't apply to MyButton
-			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(Color.Red));
+
+			var myButton = (Button)page.Content;
+			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+
+			//Button Style shouldn't apply to MyCustomButton
+			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Red));
 		}
 
 		[Test]
@@ -182,11 +188,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 
-			var myButton = (VisualElement)page.Content;
-			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyButton");
+			var myButton = (Button)page.Content;
+			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
-			//MyButton Style should be applied
-			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(Color.Red));
+			//MyCustomButton Style should not be applied
+			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Red));
 		}
 
 		[Test]
@@ -237,14 +243,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void StaticResourceKeyNotFound()
+		public void StaticResourceKeyInApp()
 		{
 			var app = @"
 				<Application xmlns=""http://xamarin.com/schemas/2014/forms""
 					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
 					<Application.Resources>
 						<ResourceDictionary>
-							<Style TargetType=""Button"" x:Key=""TestStyle"">
+							<Style TargetType=""Button"" x:Key=""StyleInApp"">
 								<Setter Property=""BackgroundColor"" Value=""HotPink"" />
 							</Style>
 						</ResourceDictionary>
@@ -255,7 +261,20 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms"">
-					<Button Style=""{StaticResource TestStyle}"" />
+					<Button Style=""{StaticResource StyleInApp}"" />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<Button>());
+			Assert.That(page.Content.BackgroundColor, Is.EqualTo(Color.HotPink));
+		}
+
+		[Test]
+		public void StaticResourceKeyNotFound()
+		{
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms"">
+					<Button Style=""{StaticResource MissingStyle}"" />
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void ContenPageWithMissingClass()
+		public void ContentPageWithMissingClass()
 		{
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void ContenPageWithMissingType()
+		public void ContentPageWithMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(MockView);
 
@@ -63,5 +63,107 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var page = (ContentPage) XamlLoader.Create(xaml, true);
 			Assert.That(page.Content, Is.TypeOf<MockView>());
 		}
+
+		[Test]
+		public void MissingTypeWithKnownProperty()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+					<ContentPage.Content>
+						<local:MyCustomButton BackgroundColor=""Red"" />
+					</ContentPage.Content>
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<Button>());
+			Assert.That(page.Content.BackgroundColor, Is.EqualTo(new Color(1,0,0)));
+		}
+
+		[Test]
+		public void MissingTypeWithUnknownProperty()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+					<ContentPage.Content>
+						<local:MyCustomButton MyColor=""Red"" />
+					</ContentPage.Content>
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<Button>());
+		}
+
+		[Test]
+		public void ExplicitStyleAppliedToMissingType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
+					<ContentPage.Resources>
+						<Style x:Key=""Test"" TargetType=""local:MyCustomButton"">
+							<Setter Property=""BackgroundColor"" Value=""Red"" />
+						</Style>
+					</ContentPage.Resources>
+					<local:MyCustomButton Style=""{StaticResource Test}"" />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<Button>());
+			Assert.That(page.Content.BackgroundColor, Is.EqualTo(new Color(1, 0, 0)));
+		}
+
+		[Test]
+		public void ImplicitStyleAppliedToMissingType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
+					<ContentPage.Resources>
+						<Style TargetType=""local:MyCustomButton"">
+							<Setter Property=""BackgroundColor"" Value=""Red"" />
+						</Style>
+					</ContentPage.Resources>
+					<local:MyCustomButton />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<Button>());
+			Assert.That(page.Content.BackgroundColor, Is.EqualTo(new Color(1, 0, 0)));
+		}
+
+		[Test]
+		public void ImplicitStyleNotAppliedToFallbackType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
+					<ContentPage.Resources>
+						<Style TargetType=""Button"">
+							<Setter Property=""BackgroundColor"" Value=""Red"" />
+						</Style>
+					</ContentPage.Resources>
+					<local:MyCustomButton />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.TypeOf<Button>());
+			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(new Color(1, 0, 0)));
+		}
+
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -196,6 +196,31 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
+		public void StyleAppliedToDerivedTypesAppliesToDerivedUnknownType()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
+					<ContentPage.Resources>
+						<Style TargetType=""Button"" ApplyToDerivedTypes=""True"">
+							<Setter Property=""BackgroundColor"" Value=""Red"" />
+						</Style>
+					</ContentPage.Resources>
+					<local:MyCustomButton />
+				</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+
+			var myButton = (Button)page.Content;
+			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+
+			//Button Style should apply to MyCustomButton
+			Assert.That(myButton.BackgroundColor, Is.EqualTo(Color.Red));
+		}
+
+		[Test]
 		public void UnknownGenericType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(MockView);

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -1,0 +1,26 @@
+﻿//
+// DesignTimeLoaderTests.cs
+//
+// Author:
+//       Stephane Delcroix <stdelc@microsoft.com>
+//
+// Copyright (c) 2018 
+using System;
+
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class DesignTimeLoaderTests : ContentPage
+	{
+		public DesignTimeLoaderTests()
+		{
+			Content = new StackLayout {
+				Children = {
+					new Label { Text = "Hello ContentPage" }
+				}
+			};
+		}
+	}
+}
+

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Linq;
+using NUnit.Framework;
 using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
@@ -180,6 +181,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
+
+			var myButton = (VisualElement)page.Content;
+			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyButton");
+
 			//MyButton Style should be applied
 			Assert.That(page.Content.BackgroundColor, Is.Not.EqualTo(Color.Red));
 		}

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using Xamarin.Forms.Core.UnitTests;
 
@@ -121,7 +123,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(page.Content.BackgroundColor, Is.EqualTo(Color.Red));
 		}
 
-		//[Test]
+		[Test][Ignore]
 		public void ImplicitStyleAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
@@ -294,7 +296,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(page.Content.BackgroundColor, Is.EqualTo(Color.HotPink));
 		}
 
-		//[Test]
+		[Test]
 		public void StaticResourceKeyNotFound()
 		{
 			var xaml = @"
@@ -302,11 +304,15 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					<Button Style=""{StaticResource MissingStyle}"" />
 				</ContentPage>";
 
+			var exceptions = new List<Exception>();
+			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
+
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 			Assert.That(page.Content, Is.TypeOf<Button>());
+			Assert.That(exceptions.Count, Is.EqualTo(2));
 		}
 
-		//[Test]
+		[Test][Ignore]
 		public void CssStyleAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void Setup()
 		{
 			Device.PlatformServices = new MockPlatformServices();
+			Xamarin.Forms.Internals.Registrar.RegisterAll(new Type[0]);
 		}
 
 		[TearDown]
@@ -351,20 +352,25 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					<ContentPage.Resources>
 						<StyleSheet>
 							<![CDATA[
-							Button {
+							button {
 								background-color: red;
 							}
 							]]>
 						</StyleSheet>
 					</ContentPage.Resources>
-					<local:MyCustomButton />
+					<StackLayout>
+						<Button />
+						<MyCustomButton />
+					</StackLayout>
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 
-			var myButton = (Button)page.Content;
+			var button = ((StackLayout)page.Content).Children[0];
+			var myButton = ((StackLayout)page.Content).Children[1];
 			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
+			Assert.That(button.BackgroundColor, Is.EqualTo(Color.Red));
 			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Red));
 		}
 

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(page.Content.BackgroundColor, Is.EqualTo(Color.Red));
 		}
 
-		[Test]
+		//[Test]
 		public void ImplicitStyleAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
@@ -294,7 +294,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(page.Content.BackgroundColor, Is.EqualTo(Color.HotPink));
 		}
 
-		[Test]
+		//[Test]
 		public void StaticResourceKeyNotFound()
 		{
 			var xaml = @"
@@ -306,7 +306,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(page.Content, Is.TypeOf<Button>());
 		}
 
-		[Test]
+		//[Test]
 		public void CssStyleAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -19,8 +19,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TearDown]
 		public void TearDown()
 		{
-			XamlLoader.FallbackTypeResolver = null;
 			Device.PlatformServices = null;
+			XamlLoader.FallbackTypeResolver = null;
+			XamlLoader.ValueCreatedCallback = null;
+			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = null;
 		}
 
 		[Test]
@@ -69,6 +71,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void MissingTypeWithKnownProperty()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -88,6 +95,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void MissingTypeWithUnknownProperty()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -106,6 +118,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void ExplicitStyleAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -128,6 +145,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void ImplicitStyleAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -143,7 +165,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 
 			var myButton = (Button)page.Content;
-			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
 			Assert.That(myButton.BackgroundColor, Is.EqualTo(Color.Red));
 		}
@@ -152,6 +173,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void StyleTargetingRealTypeNotAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -167,16 +193,20 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 
 			var myButton = (Button)page.Content;
-			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
 			//Button Style shouldn't apply to MyCustomButton
 			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Red));
 		}
 
-		[Test]
+		[Test][Ignore]
 		public void StyleTargetingMissingTypeNotAppliedToFallbackType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -192,7 +222,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 
 			var myButton = (Button)page.Content;
-			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
 			//MyCustomButton Style should not be applied
 			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Red));
@@ -202,6 +231,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void StyleAppliedToDerivedTypesAppliesToDerivedMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -217,7 +251,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 
 			var myButton = (Button)page.Content;
-			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
 			//Button Style should apply to MyCustomButton
 			Assert.That(myButton.BackgroundColor, Is.EqualTo(Color.Red));
@@ -313,10 +346,18 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(exceptions.Count, Is.EqualTo(2));
 		}
 
-		[Test][Ignore]
+		[Test]
 		public void CssStyleAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is Element e) {
+					e._cssFallbackTypeName = "MyCustomButton";
+				}
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -336,7 +377,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 
 			var myButton = (Button)page.Content;
-			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
 			Assert.That(myButton.BackgroundColor, Is.EqualTo(Color.Blue));
 		}
@@ -345,6 +385,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void CssStyleTargetingRealTypeNotAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is Element e) {
+					e._cssFallbackTypeName = "MyCustomButton";
+				}
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -368,7 +416,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var button = ((StackLayout)page.Content).Children[0];
 			var myButton = ((StackLayout)page.Content).Children[1];
-			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
 			Assert.That(button.BackgroundColor, Is.EqualTo(Color.Red));
 			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Red));
@@ -378,7 +425,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void CssStyleTargetingMissingTypeNotAppliedToFallbackType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
-
+			XamlLoader.ValueCreatedCallback = (x, v) => {
+				if (x.XmlTypeName == "MyCustomButton" && v is VisualElement ve) {
+					ve._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
+				}
+			};
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms"">
 					<ContentPage.Resources>
@@ -396,7 +447,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 
 			var myButton = (Button)page.Content;
-			myButton._mergedStyle.ReRegisterImplicitStyles("MissingNamespace.MyCustomButton");
 
 			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Blue));
 		}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -667,6 +667,7 @@
     <Compile Include="Issues\Gh4348.xaml.cs">
       <DependentUpon>Gh4348.xaml</DependentUpon>
     </Compile>
+    <Compile Include="DesignTimeLoaderTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -231,10 +231,17 @@ namespace Xamarin.Forms.Xaml
 			if (serviceProvider != null && propertyName != XmlName.Empty)
 				((XamlValueTargetProvider)serviceProvider.IProvideValueTarget).TargetProperty = GetTargetProperty(source, propertyName, Context, node);
 
-			if (markupExtension != null)
-				value = markupExtension.ProvideValue(serviceProvider);
-			else if (valueProvider != null)
-				value = valueProvider.ProvideValue(serviceProvider);
+			try {
+				if (markupExtension != null)
+					value = markupExtension.ProvideValue(serviceProvider);
+				else if (valueProvider != null)
+					value = valueProvider.ProvideValue(serviceProvider);
+			} catch (Exception e) {
+				if (Context.ExceptionHandler != null)
+					Context.ExceptionHandler(e);
+				else
+					throw e;
+			}
 		}
 
 		static string GetContentPropertyName(IEnumerable<CustomAttributeData> attributes)

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -50,7 +50,6 @@ namespace Xamarin.Forms.Xaml
 				throw xpe;
 
 			Context.Types[node] = type;
-			string ctorargname;
 			if (IsXaml2009LanguagePrimitive(node))
 				value = CreateLanguagePrimitive(type, node);
 			else if (node.Properties.ContainsKey(XmlName.xArguments) || node.Properties.ContainsKey(XmlName.xFactoryMethod))
@@ -60,25 +59,21 @@ namespace Xamarin.Forms.Xaml
 					.DeclaredConstructors.Any(
 						ci =>
 							ci.IsPublic && ci.GetParameters().Length != 0 &&
-							ci.GetParameters().All(pi => pi.CustomAttributes.Any(attr => attr.AttributeType == typeof (ParameterAttribute)))) &&
-				ValidateCtorArguments(type, node, out ctorargname))
+							ci.GetParameters().All(pi => pi.CustomAttributes.Any(attr => attr.AttributeType == typeof(ParameterAttribute)))) &&
+				ValidateCtorArguments(type, node, out string ctorargname))
 				value = CreateFromParameterizedConstructor(type, node);
 			else if (!type.GetTypeInfo().DeclaredConstructors.Any(ci => ci.IsPublic && ci.GetParameters().Length == 0) &&
-			         !ValidateCtorArguments(type, node, out ctorargname))
-			{
+					 !ValidateCtorArguments(type, node, out ctorargname)) {
 				throw new XamlParseException($"The Property {ctorargname} is required to create a {type.FullName} object.", node);
 			}
-			else
-			{
+			else {
 				//this is a trick as the DataTemplate parameterless ctor is internal, and we can't CreateInstance(..., false) on WP7
-				try
-				{
-					if (type == typeof (DataTemplate))
+				try {
+					if (type == typeof(DataTemplate))
 						value = new DataTemplate();
-					if (type == typeof (ControlTemplate))
+					if (type == typeof(ControlTemplate))
 						value = new ControlTemplate();
-					if (value == null && node.CollectionItems.Any() && node.CollectionItems.First() is ValueNode)
-					{
+					if (value == null && node.CollectionItems.Any() && node.CollectionItems.First() is ValueNode) {
 						var serviceProvider = new XamlServiceProvider(node, Context);
 						var converted = ((ValueNode)node.CollectionItems.First()).Value.ConvertTo(type, () => type.GetTypeInfo(),
 							serviceProvider);
@@ -88,8 +83,7 @@ namespace Xamarin.Forms.Xaml
 					if (value == null)
 						value = Activator.CreateInstance(type);
 				}
-				catch (TargetInvocationException e)
-				{
+				catch (TargetInvocationException e) {
 					if (e.InnerException is XamlParseException || e.InnerException is XmlException)
 						throw e.InnerException;
 					throw;
@@ -98,9 +92,7 @@ namespace Xamarin.Forms.Xaml
 
 			Values[node] = value;
 
-			var markup = value as IMarkupExtension;
-			if (markup != null && (value is TypeExtension || value is StaticExtension || value is ArrayExtension))
-			{
+			if (value is IMarkupExtension markup && (value is TypeExtension || value is StaticExtension || value is ArrayExtension)) {
 				var serviceProvider = new XamlServiceProvider(node, Context);
 
 				var visitor = new ApplyPropertiesVisitor(Context);
@@ -111,8 +103,7 @@ namespace Xamarin.Forms.Xaml
 
 				value = markup.ProvideValue(serviceProvider);
 
-				INode xKey;
-				if (!node.Properties.TryGetValue(XmlName.xKey, out xKey))
+				if (!node.Properties.TryGetValue(XmlName.xKey, out INode xKey))
 					xKey = null;
 
 				node.Properties.Clear();
@@ -124,8 +115,7 @@ namespace Xamarin.Forms.Xaml
 				Values[node] = value;
 			}
 
-			var bindableValue = value as BindableObject;
-			if (bindableValue != null && node.Namescope != (parentNode as IElementNode)?.Namescope)
+			if (value is BindableObject bindableValue && node.Namescope != (parentNode as IElementNode)?.Namescope)
 				NameScope.SetNameScope(bindableValue, node.Namescope);
 		}
 

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -117,6 +117,13 @@ namespace Xamarin.Forms.Xaml
 
 			if (value is BindableObject bindableValue && node.Namescope != (parentNode as IElementNode)?.Namescope)
 				NameScope.SetNameScope(bindableValue, node.Namescope);
+
+			if (XamlLoader.ValueCreatedCallback != null) {
+				var name = node.XmlType.Name;
+				if (name.Contains(":"))
+					name = name.Substring(name.LastIndexOf(':') + 1);
+				XamlLoader.ValueCreatedCallback(new XamlLoader.CallbackTypeInfo { XmlNamespace = node.XmlType.NamespaceUri, XmlTypeName = name }, value);
+			}
 		}
 
 		public void Visit(RootNode node, INode parentNode)

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -97,7 +97,6 @@ namespace Xamarin.Forms.Xaml
 			}
 		}
 
-		[Obsolete ("Use the XamlFileProvider to provide xaml files. We will remove this when Cycle 8 hits Stable.")]
 		public static object Create (string xaml, bool doNotThrow = false)
 		{
 			object inflatedView = null;

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -70,10 +70,8 @@ namespace Xamarin.Forms.Xaml
 		public static void Load(object view, string xaml)
 		{
 			using (var textReader = new StringReader(xaml))
-			using (var reader = XmlReader.Create(textReader))
-			{
-				while (reader.Read())
-				{
+			using (var reader = XmlReader.Create(textReader)) {
+				while (reader.Read()) {
 					//Skip until element
 					if (reader.NodeType == XmlNodeType.Whitespace)
 						continue;
@@ -84,12 +82,12 @@ namespace Xamarin.Forms.Xaml
 						continue;
 					}
 
-					var rootnode = new RuntimeRootNode (new XmlType (reader.NamespaceURI, reader.Name, null), view, (IXmlNamespaceResolver)reader);
-					XamlParser.ParseXaml (rootnode, reader);
-					Visit (rootnode, new HydrationContext {
+					var rootnode = new RuntimeRootNode(new XmlType(reader.NamespaceURI, reader.Name, null), view, (IXmlNamespaceResolver)reader);
+					XamlParser.ParseXaml(rootnode, reader);
+					Visit(rootnode, new HydrationContext {
 						RootElement = view,
 #pragma warning disable 0618
-						ExceptionHandler = ResourceLoader.ExceptionHandler ?? (Internals.XamlLoader.DoNotThrowOnExceptions ? e => { }: (Action<Exception>)null)
+						ExceptionHandler = ResourceLoader.ExceptionHandler ?? (Internals.XamlLoader.DoNotThrowOnExceptions ? e => { } : (Action<Exception>)null)
 #pragma warning restore 0618
 					});
 					break;
@@ -97,12 +95,12 @@ namespace Xamarin.Forms.Xaml
 			}
 		}
 
-		public static object Create (string xaml, bool doNotThrow = false)
+		public static object Create(string xaml, bool doNotThrow = false)
 		{
 			object inflatedView = null;
 			using (var textreader = new StringReader(xaml))
-			using (var reader = XmlReader.Create (textreader)) {
-				while (reader.Read ()) {
+			using (var reader = XmlReader.Create(textreader)) {
+				while (reader.Read()) {
 					//Skip until element
 					if (reader.NodeType == XmlNodeType.Whitespace)
 						continue;
@@ -113,33 +111,33 @@ namespace Xamarin.Forms.Xaml
 						continue;
 					}
 
-					var rootnode = new RuntimeRootNode (new XmlType (reader.NamespaceURI, reader.Name, null), null, (IXmlNamespaceResolver)reader);
-					XamlParser.ParseXaml (rootnode, reader);
+					var rootnode = new RuntimeRootNode(new XmlType(reader.NamespaceURI, reader.Name, null), null, (IXmlNamespaceResolver)reader);
+					XamlParser.ParseXaml(rootnode, reader);
 					var visitorContext = new HydrationContext {
 						ExceptionHandler = doNotThrow ? e => { } : (Action<Exception>)null,
 					};
-					var cvv = new CreateValuesVisitor (visitorContext);
-					cvv.Visit ((ElementNode)rootnode, null);
-					inflatedView = rootnode.Root = visitorContext.Values [rootnode];
+					var cvv = new CreateValuesVisitor(visitorContext);
+					cvv.Visit((ElementNode)rootnode, null);
+					inflatedView = rootnode.Root = visitorContext.Values[rootnode];
 					visitorContext.RootElement = inflatedView as BindableObject;
 
-					Visit (rootnode, visitorContext);
+					Visit(rootnode, visitorContext);
 					break;
 				}
 			}
 			return inflatedView;
 		}
 
-		static void Visit (RootNode rootnode, HydrationContext visitorContext)
+		static void Visit(RootNode rootnode, HydrationContext visitorContext)
 		{
-			rootnode.Accept (new XamlNodeVisitor ((node, parent) => node.Parent = parent), null); //set parents for {StaticResource}
-			rootnode.Accept (new ExpandMarkupsVisitor (visitorContext), null);
-			rootnode.Accept (new PruneIgnoredNodesVisitor(), null);
-			rootnode.Accept (new NamescopingVisitor (visitorContext), null); //set namescopes for {x:Reference}
-			rootnode.Accept (new CreateValuesVisitor (visitorContext), null);
-			rootnode.Accept (new RegisterXNamesVisitor (visitorContext), null);
-			rootnode.Accept (new FillResourceDictionariesVisitor (visitorContext), null);
-			rootnode.Accept (new ApplyPropertiesVisitor (visitorContext, true), null);
+			rootnode.Accept(new XamlNodeVisitor((node, parent) => node.Parent = parent), null); //set parents for {StaticResource}
+			rootnode.Accept(new ExpandMarkupsVisitor(visitorContext), null);
+			rootnode.Accept(new PruneIgnoredNodesVisitor(), null);
+			rootnode.Accept(new NamescopingVisitor(visitorContext), null); //set namescopes for {x:Reference}
+			rootnode.Accept(new CreateValuesVisitor(visitorContext), null);
+			rootnode.Accept(new RegisterXNamesVisitor(visitorContext), null);
+			rootnode.Accept(new FillResourceDictionariesVisitor(visitorContext), null);
+			rootnode.Accept(new ApplyPropertiesVisitor(visitorContext, true), null);
 		}
 
 		static string GetXamlForType(Type type)
@@ -172,7 +170,7 @@ namespace Xamarin.Forms.Xaml
 		}
 
 		//if the assembly was generated using a version of XamlG that doesn't outputs XamlResourceIdAttributes, we still need to find the resource, and load it
-		static readonly Dictionary<Type, string> XamlResources = new Dictionary<Type, string>();		
+		static readonly Dictionary<Type, string> XamlResources = new Dictionary<Type, string>();
 		static string LegacyGetXamlForType(Type type)
 		{
 			var assembly = type.GetTypeInfo().Assembly;
@@ -276,12 +274,14 @@ namespace Xamarin.Forms.Xaml
 
 		public class RuntimeRootNode : RootNode
 		{
-			public RuntimeRootNode(XmlType xmlType, object root, IXmlNamespaceResolver resolver) : base (xmlType, resolver)
+			public RuntimeRootNode(XmlType xmlType, object root, IXmlNamespaceResolver resolver) : base(xmlType, resolver)
 			{
 				Root = root;
 			}
 
 			public object Root { get; internal set; }
 		}
+
+		internal static Func<IList<(string clrNamespace, string typeName, string assemblyName, string xmlNamespace)>, Type, Type> FallbackTypeResolver { get; set; }
 	}
 }

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -292,6 +292,14 @@ namespace Xamarin.Forms.Xaml
 			public string XmlNamespace { get; internal set; }
 		}
 
+		public struct CallbackTypeInfo
+		{
+			public string XmlNamespace { get; internal set; }
+			public string XmlTypeName { get; internal set; }
+
+		}
+
 		internal static Func<IList<FallbackTypeInfo>, Type, Type> FallbackTypeResolver { get; set; }
+		internal static Action<CallbackTypeInfo, object> ValueCreatedCallback  { get; set; }
 	}
 }

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -97,6 +97,8 @@ namespace Xamarin.Forms.Xaml
 
 		public static object Create(string xaml, bool doNotThrow = false)
 		{
+			doNotThrow = doNotThrow || ResourceLoader.ExceptionHandler != null;
+			var exceptionHandler = doNotThrow ? (ResourceLoader.ExceptionHandler ?? (e => { })) : null;
 			object inflatedView = null;
 			using (var textreader = new StringReader(xaml))
 			using (var reader = XmlReader.Create(textreader)) {
@@ -114,7 +116,7 @@ namespace Xamarin.Forms.Xaml
 					var rootnode = new RuntimeRootNode(new XmlType(reader.NamespaceURI, reader.Name, null), null, (IXmlNamespaceResolver)reader);
 					XamlParser.ParseXaml(rootnode, reader);
 					var visitorContext = new HydrationContext {
-						ExceptionHandler = doNotThrow ? e => { } : (Action<Exception>)null,
+						ExceptionHandler = exceptionHandler,
 					};
 					var cvv = new CreateValuesVisitor(visitorContext);
 					cvv.Visit((ElementNode)rootnode, null);

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -282,6 +282,14 @@ namespace Xamarin.Forms.Xaml
 			public object Root { get; internal set; }
 		}
 
-		internal static Func<IList<(string clrNamespace, string typeName, string assemblyName, string xmlNamespace)>, Type, Type> FallbackTypeResolver { get; set; }
+		public struct FallbackTypeInfo
+		{
+			public string ClrNamespace { get; internal set; }
+			public string TypeName { get; internal set; }
+			public string AssemblyName { get; internal set; }
+			public string XmlNamespace { get; internal set; }
+		}
+
+		internal static Func<IList<FallbackTypeInfo>, Type, Type> FallbackTypeResolver { get; set; }
 	}
 }

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -368,13 +368,19 @@ namespace Xamarin.Forms.Xaml
 
 			Type type = null;
 
-			IList<(string clrNamespace, string typeName, string assemblyName, string xmlNamespace)> potentialTypes = new List<(string, string, string, string)>();
-			for (var i = 0; i < lookupAssemblies.Count; i++)
-				for (var j = 0; j < lookupNames.Count; j++)
-					potentialTypes.Add((lookupAssemblies[i].ClrNamespace, lookupNames[j], lookupAssemblies[i].AssemblyName, lookupAssemblies[i].XmlNamespace));
+			IList<XamlLoader.FallbackTypeInfo> potentialTypes = new List<XamlLoader.FallbackTypeInfo>();
+			foreach (XmlnsDefinitionAttribute xmlnsDefinitionAttribute in lookupAssemblies)
+			foreach (string typeName in lookupNames)
+				potentialTypes.Add(new XamlLoader.FallbackTypeInfo
+				{
+					ClrNamespace = xmlnsDefinitionAttribute.ClrNamespace,
+					TypeName = typeName,
+					AssemblyName = xmlnsDefinitionAttribute.AssemblyName,
+					XmlNamespace = xmlnsDefinitionAttribute.XmlNamespace
+				});
 
-			for (var i = 0; i < potentialTypes.Count; i++)
-				if ((type = Type.GetType($"{potentialTypes[i].clrNamespace}.{potentialTypes[i].typeName}, {potentialTypes[i].assemblyName}")) != null)
+			foreach (XamlLoader.FallbackTypeInfo typeInfo in potentialTypes)
+				if ((type = Type.GetType($"{typeInfo.ClrNamespace}.{typeInfo.TypeName}, {typeInfo.AssemblyName}")) != null)
 					break;
 
 			if (type != null && typeArguments != null)

--- a/Xamarin.Forms.Xaml/XamlServiceProvider.cs
+++ b/Xamarin.Forms.Xaml/XamlServiceProvider.cs
@@ -261,8 +261,7 @@ namespace Xamarin.Forms.Xaml.Internals
 			return getTypeFromXmlName(new XmlType(namespaceuri, name, null), xmlLineInfo, currentAssembly, out exception);
 		}
 
-		internal delegate Type GetTypeFromXmlName(
-			XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly, out XamlParseException exception);
+		internal delegate Type GetTypeFromXmlName(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly, out XamlParseException exception);
 	}
 
 	class XamlRootObjectProvider : IRootObjectProvider


### PR DESCRIPTION
### Description of Change ###

Make the Xaml Loader more resilient, and allow loading xaml without compiling the project.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard

> VS bug [#706955](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/706955)