### PR TITLE
[GTK] Do not show a label in gtk slider renderer

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/SliderRenderer.cs
@@ -35,7 +35,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 					double stepping = Math.Min((e.NewElement.Maximum - e.NewElement.Minimum) / 10, 1);
 
 					// Use gtk.HScale, a horizontal slider widget for selecting a value from a range.
-					SetNativeControl(new Gtk.HScale(_minimum, _maximum, stepping));
+					SetNativeControl(new Gtk.HScale(_minimum, _maximum, stepping)
+					{
+						// Do not show a label in order to mimic the rest of the Xamarin.Forms backends
+						DrawValue = false
+					});
 					Control.ValueChanged += OnControlValueChanged;
 				}
 


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->
Modified GTK slider renderer so it does not show a label with the slider value, thus behaving like the other Xamarin.Forms slider backends.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- GTK+

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

The slider will no longer show a label with the slider value on Xamarin.Forms.GTK

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before
![imagen](https://user-images.githubusercontent.com/11756311/47021354-8ba6e580-d15b-11e8-9996-88ab90f40f7f.png)

After
![imagen](https://user-images.githubusercontent.com/11756311/47021358-906b9980-d15b-11e8-8907-eeeee1cdb1a7.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
