### PR TITLE
Remove unnecessary ToArray to reduce number of BindableObject[] allocations

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -434,9 +434,8 @@ namespace Xamarin.Forms
 
 		internal void ApplyBindings(bool skipBindingContext, bool fromBindingContextChanged)
 		{
-			var prop = _properties.ToArray();
-			for (int i = 0, propLength = prop.Length; i < propLength; i++) {
-				BindablePropertyContext context = prop [i];
+			for (int i = 0, propLength = _properties.Count; i < propLength; i++) {
+				BindablePropertyContext context = _properties [i];
 				BindingBase binding = context.Binding;
 				if (binding == null)
 					continue;


### PR DESCRIPTION
### Description of Change ###

Every call to ApplyBindings is copying the properties `List` to an array before iterating over it, which can result in many thousands of extra `BindableObject[]` allocations. This change iterates over the `List` directly to avoid the extra allocations.

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
