### PR TITLE
Implementation of method ForceUpdateSize for Cell on macOS

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AppKit;
 using CoreGraphics;
+using Foundation;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
@@ -45,7 +46,15 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			_onForceUpdateSizeRequested = (sender, e) =>
 			{
-				//TODO: Implement ForceUpdateSize
+                var index = tableView?.RowForView(nativeCell);
+                if (index != null)
+                {
+                    NSAnimationContext.BeginGrouping();
+                    NSAnimationContext.CurrentContext.Duration = 0;
+                    var indexSetRow = NSIndexSet.FromIndex(index.Value);
+                    tableView.NoteHeightOfRowsWithIndexesChanged(indexSetRow);
+                    NSAnimationContext.EndGrouping();
+                }
 			};
 
 			cell.ForceUpdateSizeRequested += _onForceUpdateSizeRequested;

--- a/Xamarin.Forms.Platform.MacOS/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellRenderer.cs
@@ -46,15 +46,15 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			_onForceUpdateSizeRequested = (sender, e) =>
 			{
-                var index = tableView?.RowForView(nativeCell);
-                if (index != null)
-                {
-                    NSAnimationContext.BeginGrouping();
-                    NSAnimationContext.CurrentContext.Duration = 0;
-                    var indexSetRow = NSIndexSet.FromIndex(index.Value);
-                    tableView.NoteHeightOfRowsWithIndexesChanged(indexSetRow);
-                    NSAnimationContext.EndGrouping();
-                }
+				var index = tableView?.RowForView(nativeCell);
+				if (index != null)
+				{
+					NSAnimationContext.BeginGrouping();
+					NSAnimationContext.CurrentContext.Duration = 0;
+					var indexSetRow = NSIndexSet.FromIndex(index.Value);
+					tableView.NoteHeightOfRowsWithIndexesChanged(indexSetRow);
+					NSAnimationContext.EndGrouping();
+				}
 			};
 
 			cell.ForceUpdateSizeRequested += _onForceUpdateSizeRequested;


### PR DESCRIPTION
### Description of Change ###

Updated the CellRenderer code with the implementation of ForceUpdateSize for Cell on macOS

### Issues Resolved ### 
None

### API Changes ###
None

Changed:
 - protected void WireUpForceUpdateSizeRequested(ICellController cell, NSView nativeCell, NSTableView tableView)

### Platforms Affected ### 
- macOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
