### PR TITLE
Bump minimum Microsoft.NETCore.UniversalWindowsPlatform version to 6.0.12

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -22,7 +22,7 @@
       </group>
       <group targetFramework="uap10.0">
         <dependency id="NETStandard.Library" version="2.0.1"/>
-        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.0.1" />
+        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.0.12" />
       </group>
       <group targetFramework="tizen40">
         <dependency id="Tizen.NET" version="4.0.0"/>


### PR DESCRIPTION
### Description of Change ###

Increases the minimum required version of [UniversalWindowsPlatform](https://www.nuget.org/packages/Microsoft.NETCore.UniversalWindowsPlatform) to [6.0.12]
(https://github.com/Microsoft/dotnet/blob/master/releases/UWP/net-native2.0/README.md#uwp-6012-net-native-tools-203-october-9th-2018). 

### Issues Resolved ### 

- Bumps users up to a minimum version with several security fixes. 

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable
