### PR TITLE
[iOS] Rapidly clicking span (6 times at least) on UITest 3525 throws a null exception

### DIFF
--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -181,6 +181,11 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				var recognizers = childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfTapsRequired);
 
+				if(recognizers == null)
+				{
+					return;
+				}
+
 				var tapGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as TapGestureRecognizer;
 				foreach (var item in recognizers)
 					if (item == tapGestureRecognizer && view != null)

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -182,9 +182,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				var recognizers = childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfTapsRequired);
 
 				if(recognizers == null)
-				{
 					return;
-				}
 
 				var tapGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as TapGestureRecognizer;
 				foreach (var item in recognizers)


### PR DESCRIPTION
### Description of Change ###
Prevent enumeration through null collection

Fairy case for real app, but possibly somebody doesn't use NavigationPage and manages screens by setting MainPage... in theory, if user click on span and separate task starting to change MainPage it can cause the same issue like we have in UITest 3525 :) 

### Issues Resolved ### 
- fixes #3930

### API Changes ###
Added extra null check in ios EventTracker/CreateRecognizerHandler
 
### Platforms Affected ### 
iOS

### Behavioral/Visual Changes ###
UITest 3525 doesn't crash

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Open UITest 3525 and click 6 times rapidly

