### PR TITLE
[IOS] label not rendering in BOLD when using a STYLE

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2831.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2831.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using Xamarin.Forms.Controls.Effects;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2831, "[IOS] label not rendering in BOLD when using a STYLE",
+		PlatformAffected.iOS)]
+	public class Issue2831 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children = {
+					new Label
+					{
+						VerticalOptions = LayoutOptions.CenterAndExpand,
+						HorizontalOptions = LayoutOptions.CenterAndExpand,
+						HorizontalTextAlignment = TextAlignment.Center,
+						Text = "MUST BE BOLD",
+						TextColor = Color.Black,
+						FontSize = 50,
+						FontAttributes = FontAttributes.Bold,
+						Style = Device.Styles.ListItemDetailTextStyle,
+					}
+				}
+			};
+		}
+	}
+
+#if UITEST
+
+#endif
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -820,6 +820,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3525.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3275.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3884.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2831.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FontExtensions.cs
@@ -15,6 +15,13 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	public static class FontExtensions
 	{
+
+#if __MOBILE__
+		static readonly string DefaultFontName = UIFont.SystemFontOfSize(12).Name;
+#else
+		static readonly string DefaultFontName = UIFont.SystemFontOfSize(12).FontName;
+#endif
+
 		static readonly Dictionary<ToUIFontKey, UIFont> ToUiFont = new Dictionary<ToUIFontKey, UIFont>();
 #if __MOBILE__
 		public static UIFont ToUIFont(this Font self)
@@ -49,7 +56,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			var bold = self.FontAttributes.HasFlag(FontAttributes.Bold);
 			var italic = self.FontAttributes.HasFlag(FontAttributes.Italic);
 
-			if (self.FontFamily != null)
+			if (self.FontFamily != null && self.FontFamily != DefaultFontName)
 			{
 				try
 				{
@@ -157,7 +164,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			var bold = (attributes & FontAttributes.Bold) != 0;
 			var italic = (attributes & FontAttributes.Italic) != 0;
 
-			if (family != null)
+			if (family != null && family != DefaultFontName)
 			{
 				try
 				{


### PR DESCRIPTION
### Description of Change ###

UIFont.FamilyNames method doesn't return default font name

### Issues Resolved ### 

- fixes #2831

### API Changes ###

Changed: _ToUIFont fontFamily check

### Platforms Affected ### 
- iOS


### Behavioral/Visual Changes ###

Now we can use Bold fontAttribute with style

### Before/After Screenshots ### 
<img width="310" alt="2" src="https://user-images.githubusercontent.com/10124814/47057143-1d4c3c80-d1c8-11e8-84fe-79a520c25395.png">

<img width="294" alt="1" src="https://user-images.githubusercontent.com/10124814/47057147-20472d00-d1c8-11e8-935a-793678a1d088.png">

### Testing Procedure ###
Check Issue2831 test case
