### PR TITLE
[GTK] Fix several memory leaks in the GTK backend

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Cells/ViewCell.cs
+++ b/Xamarin.Forms.Platform.GTK/Cells/ViewCell.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
 			return request.Request.Height;
 		}
 
-		public override void Dispose()
+		public override void Destroy()
 		{
 			IVisualElementRenderer renderer;
 			if (_rendererRef != null && _rendererRef.TryGetTarget(out renderer) && renderer.Element != null)
@@ -59,7 +59,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
 				_rendererRef = null;
 			}
 
-			base.Dispose();
+			base.Destroy();
 		}
 
 		protected override void UpdateCell()

--- a/Xamarin.Forms.Platform.GTK/Controls/DatePicker.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/DatePicker.cs
@@ -153,8 +153,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 		private void Close()
 		{
 			Helpers.GrabHelper.RemoveGrab(this);
-			this.Dispose();
-			this.Destroy();
+			Destroy();
 		}
 
 		private void NotifyDateChanged()

--- a/Xamarin.Forms.Platform.GTK/Controls/ImageButton.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/ImageButton.cs
@@ -117,10 +117,9 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			}
 		}
 
-		public override void Dispose()
+		public override void Destroy()
 		{
-			base.Dispose();
-
+			base.Destroy();
 			_label = null;
 			_image = null;
 			_imageAndLabelContainer = null;

--- a/Xamarin.Forms.Platform.GTK/Controls/ListView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/ListView.cs
@@ -115,6 +115,23 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			_selectionColor = DefaultSelectionColor;
 		}
 
+		public override void Destroy()
+		{
+			_store?.Dispose();
+			_store = null;
+			_root = null;
+			_refreshButton = null;
+			_refreshLabel = null;
+			_headerContainer = null;
+			_header = null;
+			_list = null;
+			_footerContainer = null;
+			_footer = null;
+			_viewPort = null;
+			_refreshHeader = null;
+			base.Destroy();
+		}
+
 		public static Gdk.Color DefaultSelectionColor = Color.FromHex("#3498DB").ToGtkColor();
 
 		public Widget Header

--- a/Xamarin.Forms.Platform.GTK/Controls/NavigationChildPage.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/NavigationChildPage.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms.Platform.GTK.Controls
 {
-	public class NavigationChildPage : Gtk.Object
+	public class NavigationChildPage : IDisposable
 	{
 		bool _disposed;
 
@@ -12,15 +12,13 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			Identifier = Guid.NewGuid().ToString();
 		}
 
-		public override void Dispose()
+		public void Dispose()
 		{
 			if (!_disposed)
 			{
 				_disposed = true;
 				Page = null;
 			}
-
-			base.Dispose();
 		}
 
 		public string Identifier { get; set; }

--- a/Xamarin.Forms.Platform.GTK/Controls/OpenGLView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/OpenGLView.cs
@@ -72,13 +72,13 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			GLib.Source.Remove(_timerId);
 		}
 
-		public override void Dispose()
+		public override void Destroy()
 		{
-			base.Dispose();
+			base.Destroy();
 
 			if (_glWidget != null)
 			{
-				_glWidget.Dispose();
+				_glWidget.Destroy();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.GTK/Controls/Page.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Page.cs
@@ -95,14 +95,19 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			Children.Last().Show();
 		}
 
-		public override void Dispose()
+		public override void Destroy()
 		{
-			base.Dispose();
-
+			base.Destroy();
 			if (_contentContainerWrapper != null)
 			{
 				_contentContainerWrapper.SizeAllocated -= OnContentContainerWrapperSizeAllocated;
+				_contentContainerWrapper = null;
 			}
+			_contentContainer = null;
+			_image = null;
+			_toolbar = null;
+			_content = null;
+			_headerContainer = null;
 		}
 
 		private void BuildPage()
@@ -135,7 +140,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
 		private void RefreshToolbar(HBox newToolbar)
 		{
-			_headerContainer.RemoveFromContainer(_toolbar);
+			_toolbar.Destroy();
 			_toolbar = newToolbar;
 			_headerContainer.Add(_toolbar);
 			_toolbar.ShowAll();
@@ -143,7 +148,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
 		private void RefreshContent(GtkFormsContainer newContent)
 		{
-			_contentContainer.RemoveFromContainer(_content);
+			_content.Destroy();
 			_content = newContent;
 			_contentContainer.Add(_content);
 			_content.ShowAll();

--- a/Xamarin.Forms.Platform.GTK/Controls/SearchEntry.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/SearchEntry.cs
@@ -109,9 +109,9 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			}
 		}
 
-		public override void Dispose()
+		public override void Destroy()
 		{
-			base.Dispose();
+			base.Destroy();
 
 			if (_entryWrapper?.Entry != null)
 			{

--- a/Xamarin.Forms.Platform.GTK/Extensions/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.GTK/Extensions/VisualElementExtensions.cs
@@ -48,14 +48,14 @@ namespace Xamarin.Forms.Platform.GTK.Extensions
 				IVisualElementRenderer childRenderer = Platform.GetRenderer(visual);
 				if (childRenderer != null)
 				{
-					childRenderer.Dispose();
+					((Gtk.Widget)childRenderer).Destroy();
 					Platform.SetRenderer(visual, null);
 				}
 			}
 
 			if (renderer != null)
 			{
-				renderer.Dispose();
+				((Gtk.Widget)renderer).Destroy();
 				Platform.SetRenderer(self, null);
 			}
 		}

--- a/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
@@ -370,17 +370,20 @@ namespace Xamarin.Forms.Platform.GTK
 
 			if (NavigationPage.GetHasNavigationBar(currentPage))
 			{
-				_toolbar = ConfigureToolbar();
-
-				_toolbarIcon = new ImageControl
+				if (_toolbar == null)
 				{
-					WidthRequest = 1,
-					Aspect = ImageAspect.AspectFit
-				};
-				_toolbarTitleSection.PackStart(_toolbarIcon, false, false, 8);
+					_toolbar = ConfigureToolbar();
 
-				_toolbarTitle = new Gtk.Label();
-				_toolbarTitleSection.PackEnd(_toolbarTitle, true, true, 0);
+					_toolbarIcon = new ImageControl
+					{
+						WidthRequest = 1,
+						Aspect = ImageAspect.AspectFit
+					};
+					_toolbarTitleSection.PackStart(_toolbarIcon, false, false, 8);
+
+					_toolbarTitle = new Gtk.Label();
+					_toolbarTitleSection.PackEnd(_toolbarTitle, true, true, 0);
+				}
 
 				FindParentMasterDetail();
 

--- a/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
@@ -209,6 +209,7 @@ namespace Xamarin.Forms.Platform.GTK
 		{
 			foreach (var child in _toolbarSection.Children)
 			{
+				child.Destroy();
 				_toolbarSection.Remove(child);
 			}
 

--- a/Xamarin.Forms.Platform.GTK/Platform.cs
+++ b/Xamarin.Forms.Platform.GTK/Platform.cs
@@ -58,8 +58,7 @@ namespace Xamarin.Forms.Platform.GTK
 
 			renderer = GetRenderer((VisualElement)view);
 
-			renderer?.Dispose();
-
+			(renderer as Widget)?.Destroy();
 			view.ClearValue(RendererProperty);
 		}
 
@@ -110,7 +109,7 @@ namespace Xamarin.Forms.Platform.GTK
 				DisposeModelAndChildrenRenderers(modal);
 			DisposeModelAndChildrenRenderers(Page);
 
-			PlatformRenderer.Dispose();
+			PlatformRenderer.Destroy();
 		}
 
 		internal void SetPage(Page newRoot)

--- a/Xamarin.Forms.Platform.GTK/Platform.cs
+++ b/Xamarin.Forms.Platform.GTK/Platform.cs
@@ -106,9 +106,9 @@ namespace Xamarin.Forms.Platform.GTK
 			MessagingCenter.Unsubscribe<Page, AlertArguments>(this, Page.AlertSignalName);
 			MessagingCenter.Unsubscribe<Page, bool>(this, Page.BusySetSignalName);
 
-			DisposeModelAndChildrenRenderers(Page);
 			foreach (var modal in _modals)
 				DisposeModelAndChildrenRenderers(modal);
+			DisposeModelAndChildrenRenderers(Page);
 
 			PlatformRenderer.Dispose();
 		}

--- a/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
@@ -54,11 +54,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			VisualElement oldElement = Element;
 			Element = element;
 
-			if (element != null)
-			{
-				element.PropertyChanged += _propertyChangedHandler;
-			}
-
 			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
 			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);

--- a/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
@@ -79,9 +79,9 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			return Container.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 
-		public override void Dispose()
+		public override void Destroy()
 		{
-			base.Dispose();
+			base.Destroy();
 
 			if (!_disposed)
 			{
@@ -118,18 +118,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			_appeared = true;
 
 			PageController.SendAppearing();
-		}
-
-		protected override void OnDestroyed()
-		{
-			base.OnDestroyed();
-
-			if (!_appeared || _disposed)
-				return;
-
-			_appeared = false;
-
-			PageController.SendDisappearing();
 		}
 
 		protected override void OnSizeAllocated(Gdk.Rectangle allocation)

--- a/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
@@ -128,6 +128,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				{
 					_listView.OnItemTapped -= OnItemTapped;
 					_listView.OnRefresh -= OnRefresh;
+					_listView.Destroy();
+					_listView = null;
 				}
 
 				if (_footerRenderer != null)

--- a/Xamarin.Forms.Platform.GTK/Renderers/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/MasterDetailPageRenderer.cs
@@ -10,6 +10,9 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 {
 	public class MasterDetailPageRenderer : AbstractPageRenderer<Controls.MasterDetailPage, MasterDetailPage>
 	{
+		Page _currentMaster;
+		Page _currentDetail;
+
 		public MasterDetailPageRenderer()
 		{
 			MessagingCenter.Subscribe(this, Forms.BarTextColor, (NavigationPage sender, Color color) =>
@@ -122,22 +125,29 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 		{
 			Gtk.Application.Invoke(async delegate
 			{
-				Page.Master.PropertyChanged -= HandleMasterPropertyChanged;
 				await UpdateHamburguerIconAsync();
-
-				if (Platform.GetRenderer(Page.Master) == null)
-					Platform.SetRenderer(Page.Master, Platform.CreateRenderer(Page.Master));
-				if (Platform.GetRenderer(Page.Detail) == null)
-					Platform.SetRenderer(Page.Detail, Platform.CreateRenderer(Page.Detail));
-
-				Widget.Master = Platform.GetRenderer(Page.Master).Container;
-				Widget.Detail = Platform.GetRenderer(Page.Detail).Container;
-				Widget.MasterTitle = Page.Master?.Title ?? string.Empty;
-
+				if (Page.Master != _currentMaster)
+				{
+					if (_currentMaster != null)
+					{
+						_currentMaster.PropertyChanged -= HandleMasterPropertyChanged;
+					}
+					if (Platform.GetRenderer(Page.Master) == null)
+						Platform.SetRenderer(Page.Master, Platform.CreateRenderer(Page.Master));
+					Widget.Master = Platform.GetRenderer(Page.Master).Container;
+					Widget.MasterTitle = Page.Master?.Title ?? string.Empty;
+					Page.Master.PropertyChanged += HandleMasterPropertyChanged;
+					_currentMaster = Page.Master;
+				}
+				if (Page.Detail != _currentDetail)
+				{
+					if (Platform.GetRenderer(Page.Detail) == null)
+						Platform.SetRenderer(Page.Detail, Platform.CreateRenderer(Page.Detail));
+					Widget.Detail = Platform.GetRenderer(Page.Detail).Container;
+					_currentDetail = Page.Detail;
+				}
 				UpdateBarTextColor();
 				UpdateBarBackgroundColor();
-
-				Page.Master.PropertyChanged += HandleMasterPropertyChanged;
 			});
 		}
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -67,6 +67,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				if (_currentPage != null)
 				{
 					_currentPage.PropertyChanged -= OnCurrentPagePropertyChanged;
+					_currentPage = null;
+				}
+				if (_currentStack != null)
+				{
+					_currentStack.ForEach(s => s.Dispose());
+					_currentStack = null;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
@@ -87,6 +87,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				if (Control.Vadjustment != null)
 					Control.Vadjustment.ValueChanged -= OnScrollEvent;
 			}
+			if (_viewPort != null)
+			{
+				_viewPort.Destroy();
+				_viewPort = null;
+			}
 
 			base.Dispose(disposing);
 		}

--- a/Xamarin.Forms.Platform.GTK/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/ViewRenderer.cs
@@ -15,13 +15,12 @@ namespace Xamarin.Forms.Platform.GTK
 
 		protected override void Dispose(bool disposing)
 		{
-			base.Dispose(disposing);
-
 			if (Control != null)
 			{
-				Control.Dispose();
+				Control.Destroy();
 				Control = null;
 			}
+			base.Dispose(disposing);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<TView> e)

--- a/Xamarin.Forms.Platform.GTK/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/VisualElementRenderer.cs
@@ -137,10 +137,9 @@ namespace Xamarin.Forms.Platform.GTK
 			UpdateIsVisible();
 		}
 
-		public override void Dispose()
+		public override void Destroy()
 		{
-			base.Dispose();
-
+			base.Destroy();
 			Dispose(true);
 		}
 

--- a/Xamarin.Forms.Platform.GTK/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/VisualElementTracker.cs
@@ -170,7 +170,7 @@ namespace Xamarin.Forms.Platform.GTK
 				_control.ButtonPressEvent -= OnControlButtonPressEvent;
 			}
 
-			Container.Dispose();
+			Container.Destroy();
 			Container = null;
 		}
 


### PR DESCRIPTION
### Description of Change ###

This serie of patches fixes several memory leaks in the GTK backend.
~~The first one is the MasterDetailPage that is not cleaning up old pages when the Detail or Menu page is changed.~~

Another issue is how disposal of Gtk objects is handled, wich is now incorrectly done using the Dispose function. Gtk objects should be disposed using the Destroy function that will automatically iterate over the children and destroy them too (https://developer.gnome.org/gtk2/stable/GtkWidget.html#gtk-widget-destroy).

The gtk-sharp bindings discourage the use of Dispose and don't even call the base class, leaving it without effect (https://github.com/mono/gtk-sharp/blob/gtk-sharp-2-12-branch/gtk/Object.custom#L98), so that's why Gtk objects should override the Destroy function. Problably the gtk-sharp bindings should be changed at some point to have a more idiomatic pattern for disposal, but that would break backwards compatibility, so right now the only possible solution is to use Destroy. 

I created a demo application with a MaterDetail that calls the GC on each Detail change. As you can see the number of live objects in master keeps growing while in this branch it's mostly steady going up and down.

Before
<img width="874" alt="screen shot 2018-10-17 at 11 26 54" src="https://user-images.githubusercontent.com/111134/47077296-ed6d5b00-d200-11e8-8c07-1bcece2e2d92.png">

After
<img width="874" alt="screen shot 2018-10-17 at 11 25 13" src="https://user-images.githubusercontent.com/111134/47077898-51445380-d202-11e8-9e3e-d13e56a9163b.png">


### Issues Resolved ### 


### API Changes ###
 None

### Platforms Affected ### 
- Gtk

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Create a sample MasterDetail application with 2 pages and some content inside the pages.
Call a full garbage collection after switching pages that also waits for pending finalizers.
Launch the application in the profiler with automatic snapshots on garbage collection.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
