### PR TITLE
[XamlC] fix the argument match check for events

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -879,8 +879,9 @@ namespace Xamarin.Forms.Build.Tasks
 				throw new XamlParseException($"Signature (number of arguments) of EventHandler \"{context.Body.Method.DeclaringType.FullName}.{value}\" doesn't match the event type", iXmlLineInfo);
 			if (!invoke.ContainsGenericParameter)
 				for (var i = 0; i < invoke.Parameters.Count;i++)
-					if (!handler.Parameters[i].ParameterType.InheritsFromOrImplements(invoke.Parameters[i].ParameterType))
+					if (!invoke.Parameters[i].ParameterType.InheritsFromOrImplements(handler.Parameters[i].ParameterType))
 						throw new XamlParseException($"Signature (parameter {i}) of EventHandler \"{context.Body.Method.DeclaringType.FullName}.{value}\" doesn't match the event type", iXmlLineInfo);
+			//TODO check generic parameters if any
 
 			if (handler.IsVirtual) {
 				yield return Create(Ldarg_0);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4130.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4130.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+			 x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4130">
+	<ContentPage.Content>
+		<local:Gh4130Control TextChanged="OnTextChanged" />
+	</ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4130.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4130.xaml.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh4130Control:ContentView
+	{
+		public delegate void TextChangedEventHandler(object sender, TextChangedEventArgs args);
+#pragma warning disable 067
+		public event TextChangedEventHandler TextChanged;
+#pragma warning restore 067
+		public void FireEvent()
+		{
+			TextChanged?.Invoke(this, new TextChangedEventArgs(null, null));
+		}
+	}
+
+	public partial class Gh4130 : ContentPage
+	{
+		public Gh4130()
+		{
+			InitializeComponent();
+			var c = new Gh4130Control();
+		}
+
+		public Gh4130(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		void OnTextChanged(object sender, EventArgs e)
+		{
+			Assert.Pass();
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(false),TestCase(true)]
+			public void NonGenericEventHanlders(bool useCompiledXaml)
+			{
+				var layout = new Gh4130(useCompiledXaml);
+				var control = layout.Content as Gh4130Control;
+				control.FireEvent();
+				Assert.Fail();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -655,6 +655,9 @@
     <Compile Include="Issues\Gh4099.xaml.cs">
       <DependentUpon>Gh4099.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh4130.xaml.cs">
+      <DependentUpon>Gh4130.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
@@ -1206,6 +1209,10 @@
     <EmbeddedResource Include="Issues\Gh4099.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh4130.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Well, it looks like the order of arguments of InheritOrImplements was
reversed... a totally fine and normal Friday so far

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4130

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
