### PR TITLE
[MacOS] EntryRenderer crash when MainWindow get focus

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			void HandleWindowDidBecomeKey(object sender, EventArgs args)
 			{
-				if (CurrentEditor == Window.FirstResponder)
+				if (Window != null && CurrentEditor == Window.FirstResponder)
 					FocusChanged?.Invoke(this, new BoolEventArgs(true));
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Added null check, prevent crash

### Issues Resolved ### 

- fixes #4076 

### API Changes ###

Added nullCheck to HandleWindowDidBecomeKey in EntryRenderer

### Platforms Affected ### 
- MacOS

### Behavioral/Visual Changes ###

App doesn't crashes

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Described in original issue ticket (but I'm able to create test-case for this issue if it's needed)

