### PR TITLE
Fix https://github.com/xamarin/Xamarin.Forms/issues/3301

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ActivityIndicatorRenderer.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using AppKit;
 using CoreImage;
+using System.Linq;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
@@ -45,7 +46,13 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			var newColor = Element.Color.ToNSColor();
 			if (Equals(s_currentColor, newColor))
+			{
+				if(Control.ContentFilters?.FirstOrDefault() != s_currentColorFilter)
+				{
+					Control.ContentFilters = new CIFilter[] { s_currentColorFilter };
+				}
 				return;
+			}
 
 			s_currentColor = newColor;
 

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ProgressBarRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Linq;
 using AppKit;
 using CoreImage;
 
@@ -58,7 +59,13 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			var newColor = color.ToNSColor();
 			if (Equals(s_currentColor, newColor))
+			{
+				if (Control.ContentFilters?.FirstOrDefault() != s_currentColorFilter)
+				{
+					Control.ContentFilters = new CIFilter[] { s_currentColorFilter };
+				}
 				return;
+			}
 
 			s_currentColor = newColor;
 


### PR DESCRIPTION
### Description of Change ###

Fixed color reset issue after removing indicator/progressBar and adding again

### Issues Resolved ### 

- fixes #3301 

### API Changes ###

Changed SetBackgroundColor in ProgressBarRenderer (added color filter check)
Changed UpdateColor in ActivityIndicatorRenderer (added color filter check)

### Platforms Affected ### 

- MacOS

### Behavioral/Visual Changes ###
Indicator/Progress don't reset color after adding/removing

### Testing Procedure ###

```csharp
		public App()
		{
			var indicator = new ActivityIndicator
			{
				Color = Color.LightGreen,
				IsVisible = true,
				IsRunning = true,
				VerticalOptions = LayoutOptions.CenterAndExpand,
			};
			MainPage = new ContentPage
			{
				Padding = new Thickness(50),
				Content = indicator
			};

			Task.Run(async () =>
			{
				while(true)
				{
					await Task.Delay(2000);
					Device.BeginInvokeOnMainThread(() => {
						(MainPage as ContentPage).Content = (MainPage as ContentPage).Content == null ? indicator : null;
					});
				}
			});
		}
```

## Comment
Is there any reason to hold these fields? https://github.com/xamarin/Xamarin.Forms/blob/bd31e1e9fc8b2f9ad94cc99e0c7ab058174821f3/Xamarin.Forms.Platform.MacOS/Renderers/ActivityIndicatorRenderer.cs#L10-L11

They seems to be redundant and i suggest to remove them