### PR TITLE
[Core] Fix layout padding update issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2763.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2763.cs
@@ -13,9 +13,11 @@ namespace Xamarin.Forms.Controls
 	{
 		protected override void Init()
 		{
+			Title = "Padding update issue";
 			StackLayout parentLayout1 = null;
 			StackLayout parentLayout2 = null;
 			StackLayout parentLayout3 = null;
+			StackLayout parentLayout4 = null;
 
 			StackLayout stackLayout = new StackLayout
 			{
@@ -26,6 +28,22 @@ namespace Xamarin.Forms.Controls
 				{
 					new BoxView
 					{
+						Color = Color.Red,
+						HeightRequest = 100,
+						WidthRequest = 100,
+					}
+				}
+			};
+			StackLayout stackLayout2 = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				BackgroundColor = Color.Blue,
+				Children =
+				{
+					new BoxView
+					{
+						HorizontalOptions = LayoutOptions.Start,
 						Color = Color.Red,
 						HeightRequest = 100,
 						WidthRequest = 100,
@@ -73,6 +91,7 @@ namespace Xamarin.Forms.Controls
 			stackLayout.SetBinding(Forms.Layout.PaddingProperty, new Binding() { Path = "Value", Source = paddingSlider });
 			contentView.SetBinding(Forms.Layout.PaddingProperty, new Binding() { Path = "Value", Source = paddingSlider });
 			flex.SetBinding(Forms.Layout.PaddingProperty, new Binding() { Path = "Value", Source = paddingSlider });
+			stackLayout2.SetBinding(Forms.Layout.PaddingProperty, new Binding() { Path = "Value", Source = paddingSlider });
 
 			// Build the page.
 			this.Padding = new Thickness(20);
@@ -105,6 +124,8 @@ namespace Xamarin.Forms.Controls
 							parentLayout2.Children.Remove(boxview);
 							parentLayout3.Children.Add(boxview);
 							parentLayout3.Children.Remove(boxview);
+							parentLayout4.Children.Add(boxview);
+							parentLayout4.Children.Remove(boxview);
 						})
 					},
 					new ScrollView
@@ -116,6 +137,11 @@ namespace Xamarin.Forms.Controls
 							Spacing = 20,
 							Children =
 							{
+								(parentLayout4 = new StackLayout
+								{
+									HeightRequest = 200,
+									Children = { new Label { Text = "StackLayout2" }, stackLayout2 },
+								}),
 								(parentLayout1 = new StackLayout
 								{
 									Children = { new Label { Text = "StackLayout" }, stackLayout },

--- a/Xamarin.Forms.Core.UnitTests/StackLayoutUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/StackLayoutUnitTests.cs
@@ -615,5 +615,73 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			stack.Layout (new Rectangle (0, 0, 100, 100));
 		}
+
+		[Test]
+		public void PaddingResizeTest()
+		{
+			var child = new BoxView
+			{
+				IsPlatformEnabled = true,
+				WidthRequest = 20,
+				HeightRequest = 20,
+			};
+
+			var innerStack = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				IsPlatformEnabled = true,
+				Children = { child }
+			};
+
+			var outterLayout = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform(),
+				Children = { innerStack }
+			};
+
+			outterLayout.Layout(new Rectangle(0, 0, 100, 100));
+			var beforeSize = innerStack.Bounds.Size;
+			innerStack.Padding = new Thickness(30);
+			var afterSize = innerStack.Bounds.Size;
+			Assert.AreNotEqual(beforeSize, afterSize, "Padding was grow, so Size should be bigger");
+		}
+
+		[Test]
+		public void PaddingChildRelayoutTest()
+		{
+			var child = new BoxView
+			{
+				IsPlatformEnabled = true,
+				WidthRequest = 20,
+				HeightRequest = 20,
+			};
+
+			var innerStack = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				IsPlatformEnabled = true,
+				Children = { child }
+			};
+
+			var outterLayout = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				IsPlatformEnabled = true,
+				Platform = new UnitPlatform(),
+				Children = { innerStack }
+			};
+
+			outterLayout.Layout(new Rectangle(0, 0, 100, 100));
+			var before = child.Bounds;
+			innerStack.Padding = new Thickness(30);
+			var after = child.Bounds;
+			Assert.AreNotEqual(before, after, "child should be moved within padding size");
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -102,7 +102,7 @@ namespace Xamarin.Forms
 
 		void IPaddingElement.OnPaddingPropertyChanged(Thickness oldValue, Thickness newValue)
 		{
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			InvalidateLayout();
 		}
 
 		internal ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
 This PR update code of `IPaddingElement.OnPaddingPropertyChanged` on Layout
from `InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged)` to `InvalidateLayout()`

Because, When size of layout was not changed by Padding, children element does not re-layouting with `InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged)`

### Issues Resolved ### 
- fixes #4165

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->
* Before
![before](https://user-images.githubusercontent.com/1029155/47273617-7b1ac300-d5d2-11e8-9c75-8573d1146f7a.gif)

* After
![after](https://user-images.githubusercontent.com/1029155/47273619-82da6780-d5d2-11e8-92b5-1d84d2336909.gif)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
