### PR TITLE
[UWP] fixes entering text into SearchBar with UI Tests

### DIFF
--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -112,14 +112,33 @@ namespace Xamarin.Forms.Core.UITests
 			_session.Keyboard.SendKeys(text);
 		}
 
+		void SendKeysToControl(WindowsElement element, string text)
+		{
+			if (element.TagName == "ControlType.Group")
+			{
+				try
+				{
+					element.FindElementByTagName("Edit").SendKeys(text);
+				}
+				catch (InvalidOperationException)
+				{
+					element.SendKeys(text);
+				}
+			}
+			else
+			{
+				element.SendKeys(text);
+			}
+		}
+
 		public void EnterText(Func<AppQuery, AppQuery> query, string text)
 		{
-			QueryWindows(query).First().SendKeys(text);
+			SendKeysToControl(QueryWindows(query).First(), text);
 		}
 
 		public void EnterText(string marked, string text)
 		{
-			QueryWindows(marked).First().SendKeys(text);
+			SendKeysToControl(QueryWindows(marked).First(), text);
 		}
 
 		public void EnterText(Func<AppQuery, AppWebQuery> query, string text)

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -112,33 +112,14 @@ namespace Xamarin.Forms.Core.UITests
 			_session.Keyboard.SendKeys(text);
 		}
 
-		void SendKeysToControl(WindowsElement element, string text)
-		{
-			if (element.TagName == "ControlType.Group")
-			{
-				try
-				{
-					element.FindElementByTagName("Edit").SendKeys(text);
-				}
-				catch (InvalidOperationException)
-				{
-					element.SendKeys(text);
-				}
-			}
-			else
-			{
-				element.SendKeys(text);
-			}
-		}
-
 		public void EnterText(Func<AppQuery, AppQuery> query, string text)
 		{
-			SendKeysToControl(QueryWindows(query).First(), text);
+			QueryWindows(query).First().SendKeys(text);
 		}
 
 		public void EnterText(string marked, string text)
 		{
-			SendKeysToControl(QueryWindows(marked).First(), text);
+			QueryWindows(marked).First().SendKeys(text);
 		}
 
 		public void EnterText(Func<AppQuery, AppWebQuery> query, string text)

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -174,7 +174,7 @@ namespace Xamarin.Forms.Platform.UWP
 		void OnGotFocus(object sender, RoutedEventArgs e)
 		{
 			if (e.OriginalSource == Control)
-				FocusManager.TryMoveFocus(focusDirection);
+				FocusManager.TryMoveFocus(focusDirection != FocusNavigationDirection.None ? focusDirection : FocusNavigationDirection.Next);
 		}
 
 		public event EventHandler<ElementChangedEventArgs<TElement>> ElementChanged;


### PR DESCRIPTION
### Description of Change ###

Fixes the selection of controls with `ITabStopOnDescendants` interface from Selenium

### Issues Resolved ### 

- fixes #4159

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- Set yourself up to be able to run UWP UI tests https://github.com/xamarin/Xamarin.Forms#ui-tests
- Try to run a UI Tests

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
