### PR TITLE
[Enhancement] Possibility to change IsPassword for MacOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2223.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2223.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers = true)]
+	[Issue (IssueTracker.Github, 2223, "Possibility to change IsPassword", PlatformAffected.macOS)]
+	public class Issue2223 : TestContentPage
+	{
+		protected override void Init ()
+		{
+			var checkEntry = new Entry
+			{
+				HeightRequest = 100,
+				FontSize = 50,
+				Placeholder = "I can be both secure and non-secure"
+			};
+			Content = new StackLayout
+			{
+				Padding = new Thickness(100),
+				Children = {
+					checkEntry,
+					new Button
+					{
+						HeightRequest = 80,
+						FontSize = 40,
+						BackgroundColor = Color.LightBlue,
+						TextColor = Color.Black,
+						Text = "Click me to change IsPassword of the entry",
+						Command = new Command(() => checkEntry.IsPassword = !checkEntry.IsPassword)
+					}
+				}
+			};
+		}
+
+#if UITEST
+#endif
+
+	}
+}
+
+

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -827,6 +827,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue4040.xaml.cs">
       <DependentUpon>Issue4040.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2223.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -95,33 +95,12 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (Control == null)
 			{
-				NSTextField textField;
-				if (e.NewElement.IsPassword)
-					textField = new NSSecureTextField();
-				else
-				{
-					textField = new FormsNSTextField();
-					(textField as FormsNSTextField).FocusChanged += TextFieldFocusChanged;
-					(textField as FormsNSTextField).Completed += OnCompleted;
-				}
-
-				SetNativeControl(textField);
-
-				_defaultTextColor = textField.TextColor;
-
-				textField.Changed += OnChanged;
-				textField.EditingBegan += OnEditingBegan;
-				textField.EditingEnded += OnEditingEnded;
+				CreateControl();
 			}
 
 			if (e.NewElement != null)
 			{
-				UpdatePlaceholder();
-				UpdateText();
-				UpdateColor();
-				UpdateFont();
-				UpdateAlignment();
-				UpdateMaxLength();
+				UpdateControl();
 			}
 		}
 
@@ -171,22 +150,59 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (disposing && !_disposed)
 			{
 				_disposed = true;
-				if (Control != null)
-				{
-					Control.EditingBegan -= OnEditingBegan;
-					Control.Changed -= OnChanged;
-					Control.EditingEnded -= OnEditingEnded;
-					var formsNSTextField = (Control as FormsNSTextField);
-					if (formsNSTextField != null)
-					{
-						formsNSTextField.FocusChanged -= TextFieldFocusChanged;
-						formsNSTextField.Completed -= OnCompleted;
-					}
-				}
+				ClearControl();
 			}
 
 			base.Dispose(disposing);
 		}
+
+		void CreateControl()
+		{
+			NSTextField textField;
+			if (Element.IsPassword)
+				textField = new NSSecureTextField();
+			else
+			{
+				textField = new FormsNSTextField();
+				(textField as FormsNSTextField).FocusChanged += TextFieldFocusChanged;
+				(textField as FormsNSTextField).Completed += OnCompleted;
+			}
+
+			SetNativeControl(textField);
+
+			_defaultTextColor = textField.TextColor;
+
+			textField.Changed += OnChanged;
+			textField.EditingBegan += OnEditingBegan;
+			textField.EditingEnded += OnEditingEnded;
+		}
+
+		void ClearControl()
+		{
+			if (Control != null)
+			{
+				Control.EditingBegan -= OnEditingBegan;
+				Control.Changed -= OnChanged;
+				Control.EditingEnded -= OnEditingEnded;
+				var formsNSTextField = (Control as FormsNSTextField);
+				if (formsNSTextField != null)
+				{
+					formsNSTextField.FocusChanged -= TextFieldFocusChanged;
+					formsNSTextField.Completed -= OnCompleted;
+				}
+			}
+		}
+
+		void UpdateControl()
+		{
+			UpdatePlaceholder();
+			UpdateText();
+			UpdateColor();
+			UpdateFont();
+			UpdateAlignment();
+			UpdateMaxLength();
+		}
+
 		void TextFieldFocusChanged(object sender, BoolEventArgs e)
 		{
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, e.Value);
@@ -231,10 +247,10 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdatePassword()
 		{
-			if (Element.IsPassword && (Control is NSSecureTextField))
-				return;
-			if (!Element.IsPassword && !(Control is NSSecureTextField))
-				return;
+			ClearControl();
+			CreateControl();
+			UpdateControl();
+			Layout();
 		}
 
 		void UpdateFont()


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 

- fixes #2223

### API Changes ###

Changed: EntryRenderer (Update control on IsPassword change)

### Platforms Affected ### 
- MacOS

### Behavioral/Visual Changes ###

You can change IsPassword for entry


### Testing Procedure ###
Create entry and button. Change IsPassword of entry on button click. It should work

