### PR TITLE
[Android] Java.Lang.RuntimeException: Animators may only be run on Lo…

### DIFF
--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -58,14 +58,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void DisableTimer()
 		{
-			var handler = new Handler(Looper.MainLooper);
-			handler.Post(() =>
+			Device.BeginInvokeOnMainThread(new Action(() =>
 			{
 				_val?.Cancel();
-
-				handler.Dispose();
-				handler = null;
-			});
+			}));
 		}
 
 		protected override void EnableTimer()

--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -58,7 +58,14 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void DisableTimer()
 		{
-			_val?.Cancel();
+			var handler = new Handler(Looper.MainLooper);
+			handler.Post(() =>
+			{
+				_val?.Cancel();
+
+				handler.Dispose();
+				handler = null;
+			});
 		}
 
 		protected override void EnableTimer()


### PR DESCRIPTION
[Android] Java.Lang.RuntimeException: Animators may only be run on Looper threads on Battery Saver Mode

### Description of Change ###
Animators may only be run on Looper threads

### Issues Resolved ### 
- fixes #4176 

### Platforms Affected ### 
- Android


### Behavioral/Visual Changes ###
None
