### PR TITLE
[iOS] Prevent crash during setting NULL-Element via interface method

### DIFF
--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -156,9 +156,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected bool TabStop { get; set; } = true;
 
-		protected void UpdateTabStop () => TabStop = Element.IsTabStop;
+		protected void UpdateTabStop () => TabStop = Element?.IsTabStop ?? true;
 
-		protected void UpdateTabIndex () => TabIndex = Element.TabIndex;
+		protected void UpdateTabIndex() => TabIndex = Element?.TabIndex ?? 0;
 
 		public NativeView FocusSearch(bool forwardDirection)
 		{


### PR DESCRIPTION
### Description of Change ###

Set default values to TabStop and TabIndex in NULL-case instead of crashing

### Issues Resolved ### 

- fixes #4178 

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###

No crash

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
It can be adopted as is because there is nothing bad in additional null-check, i hope =)

