### PR TITLE
[Android] Changing from Portrait to Landspace while the calendar is open causes MinimumDate and MaximumDate to be visually ignored

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -162,8 +162,10 @@ namespace Xamarin.Forms.Platform.Android
 				if (currentDialog != null && currentDialog.IsShowing)
 				{
 					currentDialog.Dismiss();
-					_dialog = CreateDatePickerDialog(currentDialog.DatePicker.Year, currentDialog.DatePicker.Month, currentDialog.DatePicker.DayOfMonth);
-					_dialog.Show();
+					if (Forms.IsLollipopOrNewer)
+						currentDialog.CancelEvent -= OnCancelButtonClicked;
+
+					ShowPickerDialog(currentDialog.DatePicker.Year, currentDialog.DatePicker.Month, currentDialog.DatePicker.DayOfMonth);
 				}
 			}
 		}
@@ -178,7 +180,12 @@ namespace Xamarin.Forms.Platform.Android
 			DatePicker view = Element;
 			((IElementController)view).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 
-			_dialog = CreateDatePickerDialog(view.Date.Year, view.Date.Month - 1, view.Date.Day);
+			ShowPickerDialog(view.Date.Year, view.Date.Month - 1, view.Date.Day);
+		}
+
+		void ShowPickerDialog(int year, int month, int day)
+		{
+			_dialog = CreateDatePickerDialog(year, month, day);
 
 			UpdateMinimumDate();
 			UpdateMaximumDate();


### PR DESCRIPTION
### Description of Change ###
Created **ShowPickerDialog** method, which shows picker dialog with proper boundaries

### Issues Resolved ### 

- fixes #2315 

### API Changes ###
None (private methods only)

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
Min and Max date are the same as well as they were before rotating

### Testing Procedure ###

- Run Issue2987 in the Android Control Gallery
- click the box to open the calendar
- Rotate the phone

