### PR TITLE
[Android] Fix effects not attached on Frame

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -5,6 +5,7 @@ using Android.Graphics.Drawables;
 using Android.Support.V4.View;
 using Android.Support.V7.Widget;
 using Android.Views;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.Android.FastRenderers;
 using AColor = Android.Graphics.Color;
 using AView = Android.Views.View;
@@ -80,8 +81,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			var frame = element as Frame;
 			if (frame == null)
 				throw new ArgumentException("Element must be of type Frame");
+			VisualElement oldElement = Element;
 			Element = frame;
 			_motionEventHelper.UpdateElement(frame);
+
+			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);
 
 			if (!string.IsNullOrEmpty(Element.AutomationId))
 				ContentDescription = Element.AutomationId;


### PR DESCRIPTION
### Description of Change ###

Since the use of FastRenderers, the effects are not correctly attached anymore on the Frame element. Explicitly use old renderer makes it works. In fact, unlike others fast renderers, the Frame FastRenderer doesn't register the EffectControlProvider when element is set.

### Issues Resolved ### 

- fixes #3548

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- Create a PlatformEffect
- Attach effect to a Frame element
- Add a log message to the OnAttached method of the PlatformEffect
- Ensure this message is displayed

### PR Checklist ###

- [x] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
