### PR TITLE
[msbuild] use portable pdb files on Android

### DIFF
--- a/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
+++ b/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
-    <DebugType>Full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -34,7 +34,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>PdbOnly</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <Optimize>True</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -39,7 +39,7 @@
     <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG;__ANDROID__</DefineConstants>
@@ -32,7 +32,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
@@ -57,7 +57,7 @@
     </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -34,7 +34,7 @@
     </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/Xamarin.Forms.Platform.Android.FormsViewGroup/Xamarin.Forms.Platform.Android.FormsViewGroup.csproj
+++ b/Xamarin.Forms.Platform.Android.FormsViewGroup/Xamarin.Forms.Platform.Android.FormsViewGroup.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -29,7 +29,7 @@
     <NoWarn>CS0109</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
@@ -34,7 +34,7 @@
     <NoWarn>CS0109</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>


### PR DESCRIPTION
### Description of Change ###

Currently, on the first build of a "Hello World" Xamarin.Forms app,
you will see this in the build log:

    ConvertDebuggingFiles
        Parameters
            Files
                C:\Users\myuser\.nuget\packages\xamarin.forms\3.1.0.697729\lib\MonoAndroid10\FormsViewGroup.pdb
                C:\Users\myuser\.nuget\packages\xamarin.forms\3.1.0.697729\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.pdb
        OutputItems
            _ConvertedDebuggingFiles
                C:\Users\myuser\.nuget\packages\xamarin.forms\3.1.0.697729\lib\MonoAndroid10\FormsViewGroup.dll
                C:\Users\myuser\.nuget\packages\xamarin.forms\3.1.0.697729\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll

The logging is a little weird here, but this `ConvertDebuggingFiles`
MSBuild task takes about 100ms on my machine.

#### What is it doing?

The Mono debugger can support two types of debugging files:
- `mdb` files
- "portable" `pdb` files

If Xamarin.Android's build finds a "non-portable" `pdb` file, we have
to run it through this task to convert to an `mdb` file... This gives
us proper stacktraces for `FormsViewGroup.dll` and
`Xamarin.Forms.Platform.Android.dll`.

You can change the type of debugging symbols in your project with the
`DebugType` setting, which has these options:
- Blank or `None`: don't generate symbols. (Although Xamarin.Android
  has funny behavior here, see:
  https://github.com/xamarin/xamarin-android/issues/2282)
- `Full` generates an `mdb` file, this is a Windows-proprietary format
  for debug builds
- `PdbOnly` generates a "non-portable" `pdb` file, a
  Windows-proprietary format for release builds
- `Portable` generates a "portable" pdb file, which is the new
  standard that works for debug and release builds. New SDK-style
  MSBuild projects use this option by default.

These values are not case sensitive, I have mostly seen them lower
case in newer projects.

#### So what does Xamarin.Forms need to do?

Use `<DebugType>portable</DebugType>` in any Android class library or
app project. Other platforms, this is optional, not as much benefit. I
have heard that `DebugType=portable` might cause a problem on UWP.

* Xamarin.Forms will ship "portable" `pdbs` in its NuGet package for
  `FormsViewGroup.dll` and `Xamarin.Forms.*.Android.dll`. Developers
  won't pay the 100ms on initial build.
* Initial build times for `Xamarin.Forms.sln` will be slightly better
  for development, although I didn't measure the difference here.

### Issues Resolved ### 

None filed, but `ConvertDebuggingFiles` is taking 100ms of build time on initial builds for a Xamarin.Forms Android head. We can avoid this by using "portable" `pdb` files.

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

It would be worth checking `ConvertDebuggingFiles` is skipped, and that you still get stacktraces for a crash in `Xamarin.Forms.*.Android.dll` assemblies.

### PR Checklist ###

- [ ] Has automated tests (not sure if a test applies)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard