### PR TITLE
[C] avoid AmbiguousMatchexception in Bindings

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4215.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4215.xaml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4215">
+	<Label x:Name="l0" Text="{Binding .}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4215.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4215.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh4215 : ContentPage
+	{
+		public class Gh4215VM
+		{
+			public static implicit operator DateTime(Gh4215VM value) => DateTime.UtcNow;
+			public static implicit operator string(Gh4215VM value) => "foo";
+			public static implicit operator long(Gh4215VM value) => long.MaxValue;
+			public static implicit operator Rectangle(Gh4215VM value) => new Rectangle();
+		}
+
+		public Gh4215()
+		{
+			InitializeComponent();
+		}
+
+		public Gh4215(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void AvoidAmbiguousMatch(bool useCompiledXaml)
+			{
+				var layout = new Gh4215();
+				Assert.DoesNotThrow(() => layout.BindingContext = new Gh4215VM());
+				Assert.That(layout.l0.Text, Is.EqualTo("foo"));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -655,6 +655,9 @@
     <Compile Include="Issues\Gh4099.xaml.cs">
       <DependentUpon>Gh4099.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh4215.xaml.cs">
+      <DependentUpon>Gh4215.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
@@ -1206,6 +1209,10 @@
     <EmbeddedResource Include="Issues\Gh4099.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh4215.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

if a type defines multiple op_implicit from the same type to different
ones, trying to retrieve it with GetMethod() throws an
AmbiguousMatchException. If this happens, we have to do the resolution
ourself.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4215

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
