### PR TITLE
[Android] Enforce clipping on fast renderer ImageRenderer when using AspectFill

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Android.Content;
+using Android.Graphics;
 using AImageView = Android.Widget.ImageView;
 using AView = Android.Views.View;
 using Android.Views;
@@ -213,6 +214,12 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 
 			await Control.UpdateBitmap(_element, previous);
+		}
+
+		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+		{
+			base.OnLayout(changed, left, top, right, bottom);
+			ClipBounds = GetScaleType() == ScaleType.CenterCrop ? new Rect(0, 0, right - left, bottom - top) : null;
 		}
 
 		void UpdateAspect()


### PR DESCRIPTION
### Description of Change ###

The fix for Android's clipping issues (https://github.com/xamarin/Xamarin.Forms/pull/3559) broke the fast ImageRenderer when using AspectFill, because the cropping caused by `setClipChildren` was no longer in play.

This change adds clipping to the boundaries of the `ImageView` when the `ScaleType` is set to `CENTER_CROP`. 

### Issues Resolved ### 

- fixes #4133

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None


### Before/After Screenshots ### 

See #4133 for 'before' screenshots.

After:
![screenshot_1540501345](https://user-images.githubusercontent.com/538025/47530149-057b5500-d867-11e8-9a2e-afb1811c64e1.png)

### Testing Procedure ###

Open the Image Gallery in Control Gallery, select the AspectFill test. The image should look like it does in the "after" screenshot above.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
