### PR TITLE
[C] Add Default value to OnIdiom

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ViewUnitTests.cs
@@ -407,6 +407,15 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void TestOnIdiomDefault()
+		{
+			Device.Idiom = TargetIdiom.Tablet;
+			Assert.That((int)(new OnIdiom<int> { Tablet = 12, Default = 42 }), Is.EqualTo(12));
+			Device.Idiom = TargetIdiom.Watch;
+			Assert.That((int)(new OnIdiom<int> { Tablet = 12, Default = 42 }), Is.EqualTo(42));
+		}
+
+		[Test]
 		public void TestBatching ()
 		{
 			var view = new View ();

--- a/Xamarin.Forms.Core/OnIdiom.cs
+++ b/Xamarin.Forms.Core/OnIdiom.cs
@@ -2,31 +2,76 @@ namespace Xamarin.Forms
 {
 	public class OnIdiom<T>
 	{
-		public T Phone { get; set; }
+		T _phone;
+		T _tablet;
+		T _desktop;
+		T _tV;
+		T _watch;
+		T _default;
+		bool _isPhoneSet;
+		bool _isTabletSet;
+		bool _isDesktopSet;
+		bool _isTVSet;
+		bool _isWatchSet;
+		bool _isDefaultSet;
 
-		public T Tablet { get; set; }
-		
-		public T Desktop { get; set; }
-
-		public T TV { get; set; }
-
-		public T Watch { get; set; }
+		public T Phone {
+			get => _phone;
+			set {
+				_phone = value;
+				_isPhoneSet = true;
+			}
+		}
+		public T Tablet {
+			get => _tablet;
+			set {
+				_tablet = value;
+				_isTabletSet = true;
+			}
+		}
+		public T Desktop {
+			get => _desktop;
+			set {
+				_desktop = value;
+				_isDesktopSet = true;
+			}
+		}
+		public T TV {
+			get => _tV;
+			set {
+				_tV = value;
+				_isTVSet = true;
+			}
+		}
+		public T Watch {
+			get => _watch;
+			set {
+				_watch = value;
+				_isWatchSet = true;
+			}
+		}
+		public T Default {
+			get => _default;
+			set {
+				_default = value;
+				_isDefaultSet = true;
+			}
+		}
 
 		public static implicit operator T(OnIdiom<T> onIdiom)
 		{
-			switch (Device.Idiom)
-			{
-				default:
-				case TargetIdiom.Phone:
-					return onIdiom.Phone;
-				case TargetIdiom.Tablet:
-					return onIdiom.Tablet;
-				case TargetIdiom.Desktop:
-					return onIdiom.Desktop;
-				case TargetIdiom.TV:
-					return onIdiom.TV;
-				case TargetIdiom.Watch:
-					return onIdiom.Watch;
+			switch (Device.Idiom) {
+			default:
+			case TargetIdiom.Phone:
+				return onIdiom._isPhoneSet ? onIdiom.Phone : (onIdiom._isDefaultSet ? onIdiom.Default : default(T));
+			case TargetIdiom.Tablet:
+				return onIdiom._isTabletSet ? onIdiom.Tablet : (onIdiom._isDefaultSet ? onIdiom.Default : default(T));
+			case TargetIdiom.Desktop:
+				return onIdiom._isDesktopSet ? onIdiom.Desktop : (onIdiom._isDefaultSet ? onIdiom.Default : default(T));
+			case TargetIdiom.TV:
+				return onIdiom._isTVSet ? onIdiom.TV : (onIdiom._isDefaultSet ? onIdiom.Default : default(T));
+			case TargetIdiom.Watch:
+				return onIdiom._isWatchSet ? onIdiom.Watch : (onIdiom._isDefaultSet ? onIdiom.Default : default(T));
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

[C] Add Default value to OnIdiom

### Issues Resolved ### 

- fixes #4006
- closes #4025

### API Changes ###

Added:
 - `public T OnIdiom<T>.Default {get; set;}`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
