### PR TITLE
Added instructions and UI test for test Bugzilla44096

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44096.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44096.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Controls.Issues
 	public class Bugzilla44096 : TestContentPage
 	{
 		bool _flag;
-		const string Child = "Child";
 		const string Original = "Original";
 		const string ToggleColor = "color";
 		const string ToggleIsEnabled = "disabled";
@@ -79,8 +78,6 @@ namespace Xamarin.Forms.Controls.Issues
 					})
 				}
 			};
-			 
-
 			AddTapGesture(result, contentView);
 
 			var stackLayout = new StackLayout
@@ -110,7 +107,6 @@ namespace Xamarin.Forms.Controls.Issues
 				AutomationId = RelativeLayout,
 				Padding = new Thickness(10)
 			};
-
 			relativeLayout.Children.Add(new Button
 			{
 				WidthRequest = 150,
@@ -121,7 +117,6 @@ namespace Xamarin.Forms.Controls.Issues
 					result.Text = RelativeLayoutButton;
 				})
 			},()=>0, ()=>0,()=>200,()=>50 );
-
 			AddTapGesture(result, relativeLayout);
 
 			var color = new Button
@@ -260,7 +255,6 @@ namespace Xamarin.Forms.Controls.Issues
 			var label = RunningApp.WaitForElement(q => q.Marked(ResultLabel))[0];
 			Assert.AreEqual(expectedResult, label.Description);
 		}
-
 #endif
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Added instructions and UI test for test Bugzilla44096
I updated the test, including a nested button inside the views. From the bug description, it seemed to me that the problem was that nested controls were still clickable after disabling the parent view.
In order to test click on both nested and parent view, i had to be a bit creative with layouts and click.
Also one thing: is it correct that transparent views will not trigger clicks on UWP? This behavior is different on Android.

### Issues Resolved ### 

- fixes #2378

### API Changes ###

 None

### Platforms Affected ### 
- Core/XAML (all platforms)
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [X] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard

