### PR TITLE
[Mac] Fixes crash after changing main page

### DIFF
--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -186,19 +186,19 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 #if __MACOS__
-		public override NativeView NextKeyView { 
+		public override NativeView NextKeyView {
 			get {
-				return FocusSearch (forwardDirection: true) ?? base.NextKeyView;
+				return Element == null ? null : (FocusSearch(forwardDirection: true) ?? base.NextKeyView);
 			}
 			set {
-				if (value != null) // setting the value to null throws an exception
+				if (Element != null && value != null) // setting the value to null throws an exception
 					base.NextKeyView = value;
 			}
 		}
 
 		public override NativeView PreviousKeyView {
 			get {
-				return FocusSearch (forwardDirection: false) ?? base.PreviousKeyView;
+				return Element == null ? null : (FocusSearch(forwardDirection: false) ?? base.PreviousKeyView);
 			}
 		}
 #else


### PR DESCRIPTION
### Description of Change ###

When view is disposed, don't try to get the next or previous native view.

### Issues Resolved ### 

- fixes #4156 

### API Changes ###
 
 None

### Platforms Affected ### 

- MacOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- run ControlGallery on Mac
- click on `SwapRoot - MasterDetailPage`
- the application shouldn't crash

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
