### PR TITLE
[Xaml] Support correctly custom resource providers

### DIFF
--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -157,6 +157,11 @@ namespace Xamarin.Forms.Xaml
 			var assembly = type.GetTypeInfo().Assembly;
 			var resourceId = XamlResourceIdAttribute.GetResourceIdForType(type);
 
+			var alternateXaml = ResourceLoader.ResourceProvider?.Invoke(assembly.GetName(), XamlResourceIdAttribute.GetPathForType(type));
+			if (alternateXaml != null) {
+				return alternateXaml;
+			}
+
 			if (resourceId == null)
 				return LegacyGetXamlForType(type);
 
@@ -168,8 +173,7 @@ namespace Xamarin.Forms.Xaml
 					xaml = null;
 			}
 
-			var alternateXaml = ResourceLoader.ResourceProvider?.Invoke(assembly.GetName(), XamlResourceIdAttribute.GetPathForType(type));
-			return alternateXaml ?? xaml;
+			return xaml;
 		}
 
 		//if the assembly was generated using a version of XamlG that doesn't outputs XamlResourceIdAttributes, we still need to find the resource, and load it


### PR DESCRIPTION
### Description of Change ###

When having a resources provider set, we should return the resource as soon as possible without having to read the original one from assembly.
This fixes live-reload scenarios in which reloading of code is done creating new types in dynamic assemblies, where GetManifestResourceStream is not available.

### Issues Resolved ### 


### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
