### PR TITLE
[GTK] Fix synchronization context fairness

### DIFF
--- a/Xamarin.Forms.Platform.GTK/GtkSynchronizationContext.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkSynchronizationContext.cs
@@ -8,10 +8,9 @@ namespace Xamarin.Forms.Platform.GTK
 	{
 		public override void Post(SendOrPostCallback d, object state)
 		{
-			Idle.Add(() =>
+			Gtk.Application.Invoke((s, e) =>
 			{
 				d(state);
-				return false;
 			});
 		}
 
@@ -26,7 +25,7 @@ namespace Xamarin.Forms.Platform.GTK
 				var evt = new ManualResetEvent(false);
 				Exception exception = null;
 
-				Idle.Add(() =>
+				Gtk.Application.Invoke((s, e) =>
 				{
 					try
 					{
@@ -40,7 +39,6 @@ namespace Xamarin.Forms.Platform.GTK
 					{
 						evt.Set();
 					}
-					return false;
 				});
 
 				evt.WaitOne();


### PR DESCRIPTION

### Description of Change ###

GLib.Idle.Add enqueues functions in the main loop with the lowest priority, so while the UI is updating tasks will be queued in the main loop. Using Gtk.Application.Invoke they are interleaved with UI
updates and handled with more fairness.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Gtk
### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
