### PR TITLE
[XamlC] Always enable implicit casting and boxing and unboxing

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
@@ -35,10 +35,12 @@ namespace Xamarin.Forms.Core.XamlC
 			if (resourceId == null)
 				throw new XamlParseException($"Resource '{value}' not found.", node);
 
+			var resourceDictionaryType = ("Xamarin.Forms.Core", "Xamarin.Forms", "ResourceDictionary");
 
 			//abuse the converter, produce some side effect, but leave the stack untouched
 			//public void SetAndLoadSource(Uri value, string resourceID, Assembly assembly, System.Xml.IXmlLineInfo lineInfo)
-			yield return Create(Ldloc, context.Variables[rdNode]); //the resourcedictionary
+			foreach (var instruction in context.Variables[rdNode].LoadAs(module.GetTypeDefinition(resourceDictionaryType), module))
+				yield return instruction;
 			foreach (var instruction in (new UriTypeConverter()).ConvertFromString(value, context, node))
 				yield return instruction; //the Uri
 
@@ -55,7 +57,7 @@ namespace Xamarin.Forms.Core.XamlC
 
 			foreach (var instruction in node.PushXmlLineInfo(context))
 				yield return instruction; //lineinfo
-			yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "ResourceDictionary"),
+			yield return Create(Callvirt, module.ImportMethodReference(resourceDictionaryType,
 			                                                           methodName: "SetAndLoadSource",
 			                                                           parameterTypes: new[] { ("System", "System", "Uri"), ("mscorlib", "System", "String"), ("mscorlib", "System.Reflection", "Assembly"), ("System.Xml.ReaderWriter", "System.Xml", "IXmlLineInfo") }));
 			//ldloc the stored uri as return value

--- a/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
@@ -33,16 +33,18 @@ namespace Xamarin.Forms.Core.XamlC
 				yield break;
 
 			var value = ((string)((ValueNode)valueNode).Value);
+			var setterType = ("Xamarin.Forms.Core", "Xamarin.Forms", "Setter");
 
 			//push the setter
-			yield return Instruction.Create(OpCodes.Ldloc, vardefref.VariableDefinition);
+			foreach (var instruction in vardefref.VariableDefinition.LoadAs(module.GetTypeDefinition(setterType), module))
+				yield return instruction;
 
 			//push the value
 			foreach (var instruction in ((ValueNode)valueNode).PushConvertedValue(context, bpRef, valueNode.PushServiceProvider(context, bpRef: bpRef), boxValueTypes: true, unboxValueTypes: false))
 				yield return instruction;
 
 			//set the value
-			yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Core", "Xamarin.Forms", "Setter"), propertyName: "Value"));
+			yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference(setterType, propertyName: "Value"));
 		}
 
 		static bool SetterValueIsCollection(FieldReference bindablePropertyReference, ModuleDefinition module, BaseNode node, ILContext context)

--- a/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 				ctorInfo = factoryCtorInfo;
 				if (!typedef.IsValueType) //for ctor'ing typedefs, we first have to ldloca before the params
-					Context.IL.Append(PushCtorXArguments(factoryCtorInfo, node));
+					Context.IL.Append(PushCtorXArguments(factoryCtorInfo.ResolveGenericParameters(typeref, Module), node));
 			} else if (node.Properties.ContainsKey(XmlName.xFactoryMethod)) {
 				var factoryMethod = (string)(node.Properties [XmlName.xFactoryMethod] as ValueNode).Value;
 				factoryMethodInfo = typedef.AllMethods().FirstOrDefault(md => !md.IsConstructor &&
@@ -117,7 +117,7 @@ namespace Xamarin.Forms.Build.Tasks
 					throw new XamlParseException(
 						String.Format("No static method found for {0}::{1} ({2})", typedef.FullName, factoryMethod, null), node);
 				}
-				Context.IL.Append(PushCtorXArguments(factoryMethodInfo, node));
+				Context.IL.Append(PushCtorXArguments(factoryMethodInfo.ResolveGenericParameters(typeref, Module), node));
 			}
 			if (ctorInfo == null && factoryMethodInfo == null) {
 				parameterizedCtorInfo = typedef.Methods.FirstOrDefault(md => md.IsConstructor &&
@@ -134,7 +134,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (parameterizedCtorInfo != null && ValidateCtorArguments(parameterizedCtorInfo, node, out missingCtorParameter)) {
 				ctorInfo = parameterizedCtorInfo;
 //				IL_0000:  ldstr "foo"
-				Context.IL.Append(PushCtorArguments(parameterizedCtorInfo, node));
+				Context.IL.Append(PushCtorArguments(parameterizedCtorInfo.ResolveGenericParameters(typeref, Module), node));
 			}
 			ctorInfo = ctorInfo ?? typedef.Methods.FirstOrDefault(md => md.IsConstructor && !md.HasParameters && !md.IsStatic);
 			if (parameterizedCtorInfo != null && ctorInfo == null)
@@ -184,7 +184,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 					var ctor = Module.ImportReference(ctorinforef);
 					Context.IL.Emit(OpCodes.Ldloca, vardef);
-					Context.IL.Append(PushCtorXArguments(factoryCtorInfo, node));
+					Context.IL.Append(PushCtorXArguments(ctor, node));
 					Context.IL.Emit(OpCodes.Call, ctor);
 				} else {
 //					IL_0000:  ldloca.s 0
@@ -261,7 +261,7 @@ namespace Xamarin.Forms.Build.Tasks
 			return true;
 		}
 
-		IEnumerable<Instruction> PushCtorArguments(MethodDefinition ctorinfo, ElementNode enode)
+		IEnumerable<Instruction> PushCtorArguments(MethodReference ctorinfo, ElementNode enode)
 		{
 			foreach (var parameter in ctorinfo.Parameters)
 			{
@@ -276,7 +276,8 @@ namespace Xamarin.Forms.Build.Tasks
 				ValueNode vnode = null;
 
 				if (node is IElementNode && (vardef = Context.Variables[node as IElementNode]) != null)
-					yield return Instruction.Create(OpCodes.Ldloc, vardef);
+					foreach (var instruction in vardef.LoadAs(parameter.ParameterType.ResolveGenericParameters(ctorinfo), Module))
+						yield return instruction;
 				else if ((vnode = node as ValueNode) != null)
 				{
 					foreach (var instruction in vnode.PushConvertedValue(Context,
@@ -288,7 +289,7 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 		}
 
-		IEnumerable<Instruction> PushCtorXArguments(MethodDefinition factoryCtorInfo, ElementNode enode)
+		IEnumerable<Instruction> PushCtorXArguments(MethodReference factoryCtorInfo, ElementNode enode)
 		{
 			if (!enode.Properties.ContainsKey(XmlName.xArguments))
 				yield break;
@@ -312,7 +313,8 @@ namespace Xamarin.Forms.Build.Tasks
 				ValueNode vnode = null;
 
 				if (arg is IElementNode && (vardef = Context.Variables[arg as IElementNode]) != null)
-					yield return Instruction.Create(OpCodes.Ldloc, vardef);
+					foreach (var instruction in vardef.LoadAs(parameter.ParameterType.ResolveGenericParameters(factoryCtorInfo), Module))
+						yield return instruction;
 				else if ((vnode = arg as ValueNode) != null)
 				{
 					foreach (var instruction in vnode.PushConvertedValue(Context,

--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -438,9 +438,8 @@ namespace Xamarin.Forms.Build.Tasks
 					var en = nodes[i];
 					yield return Instruction.Create(OpCodes.Dup);
 					yield return Instruction.Create(OpCodes.Ldc_I4, i);
-					yield return Instruction.Create(OpCodes.Ldloc, context.Variables[en]);
-					if (context.Variables[en].VariableType.IsValueType)
-						yield return Instruction.Create(OpCodes.Box, module.ImportReference(context.Variables[en].VariableType));
+					foreach (var instruction in context.Variables[en].LoadAs(module.TypeSystem.Object, module))
+						yield return instruction;
 					yield return Instruction.Create(OpCodes.Stelem_Ref);
 				}
 			}

--- a/Xamarin.Forms.Build.Tasks/SetFieldVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetFieldVisitor.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (field == null)
 				return;
 			Context.IL.Emit(OpCodes.Ldarg_0);
-			Context.IL.Emit(OpCodes.Ldloc, Context.Variables[(IElementNode)parentNode]);
+			Context.IL.Append(Context.Variables[(IElementNode)parentNode].LoadAs(field.FieldType, Context.Module));
 			Context.IL.Emit(OpCodes.Stfld, field);
 		}
 

--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Forms.Build.Tasks
 				string contentProperty;
 
 				if (CanAddToResourceDictionary(parentVar, parentVar.VariableType, node, node, Context)) {
-					Context.IL.Emit(Ldloc, parentVar);
+					Context.IL.Append(parentVar.LoadAs(Module.GetTypeDefinition(("Xamarin.Forms.Core", "Xamarin.Forms", "ResourceDictionary")), Module));
 					Context.IL.Append(AddToResourceDictionary(node, node, Context));
 				}
 				// Collection element, implicit content, or implicit collection element.
@@ -150,7 +150,7 @@ namespace Xamarin.Forms.Build.Tasks
 					adderRef = Module.ImportReference(adderRef.ResolveGenericParameters(adderTuple.Item2, Module));
 
 					Context.IL.Emit(Ldloc, parentVar);
-					Context.IL.Emit(Ldloc, vardef);
+					Context.IL.Append(vardef.LoadAs(adderRef.Parameters[0].ParameterType.ResolveGenericParameters(adderRef), Module));
 					Context.IL.Emit(Callvirt, adderRef);
 					if (adderRef.ReturnType.FullName != "System.Void")
 						Context.IL.Emit(Pop);
@@ -196,7 +196,7 @@ namespace Xamarin.Forms.Build.Tasks
 				var adderRef = Module.ImportReference(adderTuple.Item1);
 				adderRef = Module.ImportReference(adderRef.ResolveGenericParameters(adderTuple.Item2, Module));
 
-				Context.IL.Emit(OpCodes.Ldloc, vardef);
+				Context.IL.Append(vardef.LoadAs(adderRef.Parameters[0].ParameterType.ResolveGenericParameters(adderRef), Module));
 				Context.IL.Emit(OpCodes.Callvirt, adderRef);
 				if (adderRef.ReturnType.FullName != "System.Void")
 						Context.IL.Emit(OpCodes.Pop);
@@ -268,7 +268,8 @@ namespace Xamarin.Forms.Build.Tasks
 					vardefref.VariableDefinition = new VariableDefinition(module.ImportReference(arrayTypeRef.MakeArrayType()));
 				else
 					vardefref.VariableDefinition = new VariableDefinition(module.ImportReference(genericArguments.First()));
-				yield return Instruction.Create(OpCodes.Ldloc, context.Variables[node]);
+				foreach (var instruction in context.Variables[node].LoadAs(markupExtension, module))
+					yield return instruction;
 				foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
 					yield return instruction;
 				yield return Instruction.Create(OpCodes.Callvirt, provideValue);
@@ -294,7 +295,8 @@ namespace Xamarin.Forms.Build.Tasks
 					module.ImportReference(provideValue.ResolveGenericParameters(markupExtension, module));
 
 				vardefref.VariableDefinition = new VariableDefinition(module.ImportReference(genericArguments.First()));
-				yield return Instruction.Create(OpCodes.Ldloc, context.Variables[node]);
+				foreach (var instruction in context.Variables[node].LoadAs(markupExtension, module))
+					yield return instruction;
 				if (acceptEmptyServiceProvider)
 					yield return Instruction.Create(OpCodes.Ldnull);
 				else
@@ -306,14 +308,16 @@ namespace Xamarin.Forms.Build.Tasks
 			else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IMarkupExtension"))))
 			{
 				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module, ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "AcceptEmptyServiceProviderAttribute")) != null;
+				var markupExtensionType = ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IMarkupExtension");
 				vardefref.VariableDefinition = new VariableDefinition(module.TypeSystem.Object);
-				yield return Create(Ldloc, context.Variables[node]);
+				foreach (var instruction in context.Variables[node].LoadAs(module.GetTypeDefinition(markupExtensionType), module))
+					yield return instruction;
 				if (acceptEmptyServiceProvider)
 					yield return Create(Ldnull);
 				else
 					foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
 						yield return instruction;
-				yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IMarkupExtension"),
+				yield return Create(Callvirt, module.ImportMethodReference(markupExtensionType,
 																		   methodName: "ProvideValue",
 																		   parameterTypes: new[] { ("System.ComponentModel", "System", "IServiceProvider") }));
 				yield return Create(Stloc, vardefref.VariableDefinition);
@@ -338,14 +342,16 @@ namespace Xamarin.Forms.Build.Tasks
 					yield break;
 				}
 
+				var valueProviderInterface = ("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IValueProvider");
 				vardefref.VariableDefinition = new VariableDefinition(module.TypeSystem.Object);
-				yield return Create(Ldloc, context.Variables[node]);
+				foreach (var instruction in context.Variables[node].LoadAs(module.GetTypeDefinition(valueProviderInterface), module))
+					yield return instruction;
 				if (acceptEmptyServiceProvider)
 					yield return Create(Ldnull);
 				else
 					foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
 						yield return instruction;
-				yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml", "IValueProvider"),
+				yield return Create(Callvirt, module.ImportMethodReference(valueProviderInterface,
 																		   methodName: "ProvideValue",
 																		   parameterTypes: new[] { ("System.ComponentModel", "System", "IServiceProvider") }));
 				yield return Create(Stloc, vardefref.VariableDefinition);
@@ -408,7 +414,10 @@ namespace Xamarin.Forms.Build.Tasks
 					&& !md.HasCustomAttributes (module.ImportReference(("mscorlib", "System", "ObsoleteAttribute")))));
 			var ctorinforef = ctorInfo.MakeGeneric(typedBindingRef, funcRef, actionRef, tupleRef);
 
-			yield return Create(Ldloc, bindingExt);
+			var bindingExtensionType = ("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml", "BindingExtension");
+
+			foreach (var instruction in bindingExt.LoadAs(module.GetTypeDefinition(bindingExtensionType), module))
+				yield return instruction;
 			foreach (var instruction in CompiledBindingGetGetter(tSourceRef, tPropertyRef, properties, node, context))
 				yield return instruction;
 			if (declaredmode != BindingMode.OneTime && declaredmode != BindingMode.OneWay) { //if the mode is explicitly 1w, or 1t, no need for setters
@@ -422,7 +431,7 @@ namespace Xamarin.Forms.Build.Tasks
 			} else
 				yield return Create(Ldnull);
 			yield return Create(Newobj, module.ImportReference(ctorinforef));
-			yield return Create(Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml", "BindingExtension"), propertyName: "TypedBinding"));
+			yield return Create(Callvirt, module.ImportPropertySetterReference(bindingExtensionType, propertyName: "TypedBinding"));
 		}
 
 		static IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> ParsePath(string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module)
@@ -893,6 +902,8 @@ namespace Xamarin.Forms.Build.Tasks
 			var module = context.Body.Method.Module;
 			TypeReference eventDeclaringTypeRef;
 			var eventinfo = elementType.GetEvent(ed => ed.Name == localName, out eventDeclaringTypeRef);
+			var adder = module.ImportReference(eventinfo.AddMethod);
+			adder = adder.ResolveGenericParameters(eventDeclaringTypeRef, module);
 
 //			IL_0007:  ldloc.0 
 //			IL_0008:  ldarg.0 
@@ -909,7 +920,8 @@ namespace Xamarin.Forms.Build.Tasks
 
 			yield return Create(Ldloc, parent);
 			if (context.Root is VariableDefinition)
-				yield return Create(Ldloc, context.Root as VariableDefinition);
+				foreach (var instruction in (context.Root as VariableDefinition).LoadAs(adder.Parameters[0].ParameterType.ResolveGenericParameters(adder), module))
+					yield return instruction;
 			else if (context.Root is FieldDefinition) {
 				yield return Create(Ldarg_0);
 				yield return Create(Ldfld, context.Root as FieldDefinition);
@@ -946,8 +958,6 @@ namespace Xamarin.Forms.Build.Tasks
 			ctor = ctor.ResolveGenericParameters(eventinfo.EventType, module);
 			yield return Create(Newobj, module.ImportReference(ctor));
 			//Check if the handler has the same signature as the ctor (it should)
-			var adder = module.ImportReference(eventinfo.AddMethod);
-			adder = adder.ResolveGenericParameters(eventDeclaringTypeRef, module);
 			yield return Create(Callvirt, module.ImportReference(adder));
 		}
 
@@ -968,12 +978,16 @@ namespace Xamarin.Forms.Build.Tasks
 		static IEnumerable<Instruction> SetDynamicResource(VariableDefinition parent, FieldReference bpRef, IElementNode elementNode, IXmlLineInfo iXmlLineInfo, ILContext context)
 		{
 			var module = context.Body.Method.Module;
+			var dynamicResourceType = ("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "DynamicResource");
+			var dynamicResourceHandlerType = ("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "IDynamicResourceHandler");
 
-			yield return Create(Ldloc, parent);
+			foreach (var instruction in parent.LoadAs(module.GetTypeDefinition(dynamicResourceHandlerType), module))
+				yield return instruction;
 			yield return Create(Ldsfld, bpRef);
-			yield return Create(Ldloc, context.Variables[elementNode]);
-			yield return Create(Callvirt, module.ImportPropertyGetterReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "DynamicResource"), propertyName: "Key"));
-			yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "IDynamicResourceHandler"),
+			foreach (var instruction in context.Variables[elementNode].LoadAs(module.GetTypeDefinition(dynamicResourceType), module))
+				yield return instruction;
+			yield return Create(Callvirt, module.ImportPropertyGetterReference(dynamicResourceType, propertyName: "Key"));
+			yield return Create(Callvirt, module.ImportMethodReference(dynamicResourceHandlerType,
 																	   methodName: "SetDynamicResource",
 																	   parameterTypes: new[] {
 																		   ("Xamarin.Forms.Core", "Xamarin.Forms", "BindableProperty"),
@@ -1004,22 +1018,21 @@ namespace Xamarin.Forms.Build.Tasks
 		static IEnumerable<Instruction> SetBinding(VariableDefinition parent, FieldReference bpRef, IElementNode elementNode, IXmlLineInfo iXmlLineInfo, ILContext context)
 		{
 			var module = context.Body.Method.Module;
-			var varValue = context.Variables [elementNode];
-			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindingBase")), module);
+			var bindableObjectType = ("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject");
+			var parameterTypes = new[] {
+				("Xamarin.Forms.Core", "Xamarin.Forms", "BindableProperty"),
+				("Xamarin.Forms.Core", "Xamarin.Forms", "BindingBase"),
+			};
 
 			//TODO: check if parent is a BP
-			yield return Create(Ldloc, parent);
+			foreach (var instruction in parent.LoadAs(module.GetTypeDefinition(bindableObjectType), module))
+				yield return instruction;
 			yield return Create(Ldsfld, bpRef);
-			yield return Create(Ldloc, varValue);
-			if (implicitOperator != null) 
-//				IL_000f:  call !0 class [Xamarin.Forms.Core]Xamarin.Forms.OnPlatform`1<BindingBase>::op_Implicit(class [Xamarin.Forms.Core]Xamarin.Forms.OnPlatform`1<!0>)
-				yield return Create(Call, module.ImportReference(implicitOperator));
+			foreach (var instruction in context.Variables [elementNode].LoadAs(module.GetTypeDefinition(parameterTypes[1]), module))
+				yield return instruction;
 			yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"),
 																	   methodName: "SetBinding",
-																	   parameterTypes: new[] {
-																		   ("Xamarin.Forms.Core", "Xamarin.Forms", "BindableProperty"),
-																		   ("Xamarin.Forms.Core", "Xamarin.Forms", "BindingBase"),
-																	   }));
+																	   parameterTypes: parameterTypes));
 		}
 
 		static bool CanSetValue(FieldReference bpRef, bool attached, INode node, IXmlLineInfo iXmlLineInfo, ILContext context)
@@ -1077,13 +1090,16 @@ namespace Xamarin.Forms.Build.Tasks
 			var valueNode = node as ValueNode;
 			var elementNode = node as IElementNode;
 			var module = context.Body.Method.Module;
+			var bindableObjectType = ("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject");
 
 //			IL_0007:  ldloc.0 
 //			IL_0008:  ldsfld class [Xamarin.Forms.Core]Xamarin.Forms.BindableProperty [Xamarin.Forms.Core]Xamarin.Forms.Label::TextProperty
 //			IL_000d:  ldstr "foo"
 //			IL_0012:  callvirt instance void class [Xamarin.Forms.Core]Xamarin.Forms.BindableObject::SetValue(class [Xamarin.Forms.Core]Xamarin.Forms.BindableProperty, object)
 
-			yield return Create(Ldloc, parent);
+			foreach (var instruction in parent.LoadAs(module.GetTypeDefinition(bindableObjectType), module))
+				yield return instruction;
+
 			yield return Create(Ldsfld, bpRef);
 
 			if (valueNode != null) {
@@ -1091,18 +1107,12 @@ namespace Xamarin.Forms.Build.Tasks
 					yield return instruction;
 			} else if (elementNode != null) {
 				var bpTypeRef = bpRef.GetBindablePropertyType(iXmlLineInfo, module);
-				var varDef = context.Variables[elementNode];
-				var varType = varDef.VariableType;
-				var implicitOperator = varDef.VariableType.GetImplicitOperatorTo(bpTypeRef, module);
-				yield return Create(Ldloc, varDef);
-				if (implicitOperator != null) {
-					yield return Create(Call, module.ImportReference(implicitOperator));
-					varType = module.ImportReference(bpTypeRef);
-				}
-				if (varType.IsValueType)
-					yield return Create(Box, varType);
+				foreach (var instruction in context.Variables[elementNode].LoadAs(bpTypeRef, module))
+					yield return instruction;
+				if (bpTypeRef.IsValueType)
+					yield return Create(Box, module.ImportReference(bpTypeRef));
 			}
-			yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"),
+			yield return Create(Callvirt, module.ImportMethodReference(bindableObjectType,
 																	   methodName: "SetValue",
 																	   parameterTypes: new[] {
 																		   ("Xamarin.Forms.Core", "Xamarin.Forms", "BindableProperty"),
@@ -1112,16 +1122,22 @@ namespace Xamarin.Forms.Build.Tasks
 
 		static IEnumerable<Instruction> GetValue(VariableDefinition parent, FieldReference bpRef, IXmlLineInfo iXmlLineInfo, ILContext context, out TypeReference propertyType)
 		{
-			var module = context.Body.Method.Module;
-			propertyType = bpRef.GetBindablePropertyType(iXmlLineInfo, module);
+			propertyType = bpRef.GetBindablePropertyType(iXmlLineInfo, context.Body.Method.Module);
+			return GetValue(parent, bpRef, iXmlLineInfo, context);
+		}
 
-			return new[] {
-				Create(Ldloc, parent),
-				Create(Ldsfld, bpRef),
-				Create(Callvirt,  module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject"),
-															   methodName: "GetValue",
-															   parameterTypes: new[] { ("Xamarin.Forms.Core", "Xamarin.Forms", "BindableProperty")})),
-			};
+		static IEnumerable<Instruction> GetValue(VariableDefinition parent, FieldReference bpRef, IXmlLineInfo iXmlLineInfo, ILContext context)
+		{
+			var module = context.Body.Method.Module;
+			var bindableObjectType = ("Xamarin.Forms.Core", "Xamarin.Forms", "BindableObject");
+
+			foreach (var instruction in parent.LoadAs(module.GetTypeDefinition(bindableObjectType), module))
+				yield return instruction;
+
+			yield return Create(Ldsfld, bpRef);
+			yield return Create(Callvirt,  module.ImportMethodReference(bindableObjectType,
+																		methodName: "GetValue",
+																		parameterTypes: new[] { ("Xamarin.Forms.Core", "Xamarin.Forms", "BindableProperty")}));
 		}
 
 		static bool CanSet(VariableDefinition parent, string localName, INode node, ILContext context)
@@ -1213,16 +1229,8 @@ namespace Xamarin.Forms.Build.Tasks
 				else
 					yield return Instruction.Create(OpCodes.Callvirt, propertySetterRef);
 			} else if (elementNode != null) {
-				var vardef = context.Variables [elementNode];
-				var implicitOperator = vardef.VariableType.GetImplicitOperatorTo(propertyType, module);
-				yield return Instruction.Create(OpCodes.Ldloc, vardef);
-				if (!vardef.VariableType.InheritsFromOrImplements(propertyType) && implicitOperator != null) {
-//					IL_000f:  call !0 class [Xamarin.Forms.Core]Xamarin.Forms.OnPlatform`1<bool>::op_Implicit(class [Xamarin.Forms.Core]Xamarin.Forms.OnPlatform`1<!0>)
-					yield return Instruction.Create(OpCodes.Call, module.ImportReference(implicitOperator));
-				} else if (!vardef.VariableType.IsValueType && propertyType.IsValueType)
-					yield return Instruction.Create(OpCodes.Unbox_Any, module.ImportReference(propertyType));
-				else if (vardef.VariableType.IsValueType && propertyType.FullName == "System.Object")
-					yield return Instruction.Create(OpCodes.Box, vardef.VariableType);
+				foreach (var instruction in context.Variables [elementNode].LoadAs(propertyType, module))
+					yield return instruction;
 				if (parent.VariableType.IsValueType)
 					yield return Instruction.Create(OpCodes.Call, propertySetterRef);
 				else
@@ -1321,14 +1329,9 @@ namespace Xamarin.Forms.Build.Tasks
 			var adderTuple = propertyType.GetMethods(md => md.Name == "Add" && md.Parameters.Count == 1, module).FirstOrDefault();
 			var adderRef = module.ImportReference(adderTuple.Item1);
 			adderRef = module.ImportReference(adderRef.ResolveGenericParameters(adderTuple.Item2, module));
-			var childType = GetParameterType(adderRef.Parameters[0]);
-			var implicitOperator = vardef.VariableType.GetImplicitOperatorTo(childType, module);
 
-			yield return Instruction.Create(OpCodes.Ldloc, vardef);
-			if (implicitOperator != null)
-				yield return Instruction.Create(OpCodes.Call, module.ImportReference(implicitOperator));
-			if (implicitOperator == null && vardef.VariableType.IsValueType && !childType.IsValueType)
-				yield return Instruction.Create(OpCodes.Box, vardef.VariableType);
+			foreach (var instruction in vardef.LoadAs(adderRef.Parameters[0].ParameterType.ResolveGenericParameters(adderRef), module))
+				yield return instruction;
 			yield return Instruction.Create(OpCodes.Callvirt, adderRef);
 			if (adderRef.ReturnType.FullName != "System.Void")
 				yield return Instruction.Create(OpCodes.Pop);
@@ -1343,10 +1346,8 @@ namespace Xamarin.Forms.Build.Tasks
 //				IL_0019:  ldstr "foo"
 //				IL_001e:  callvirt instance void class [Xamarin.Forms.Core]Xamarin.Forms.ResourceDictionary::Add(string, object)
 				yield return Create(Ldstr, (node.Properties[XmlName.xKey] as ValueNode).Value as string);
-				var varDef = context.Variables[node];
-				yield return Create(Ldloc, varDef);
-				if (varDef.VariableType.IsValueType)
-					yield return Create(Box, module.ImportReference(varDef.VariableType));
+				foreach (var instruction in context.Variables[node].LoadAs(module.TypeSystem.Object, module))
+					yield return instruction;
 				yield return Create(Callvirt, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "ResourceDictionary"),
 																		   methodName: "Add",
 																		   parameterTypes: new[] {
@@ -1362,14 +1363,6 @@ namespace Xamarin.Forms.Build.Tasks
 																	   methodName: "Add",
 																	   parameterTypes: new[] { (nodeTypeRef.Scope.Name, nodeTypeRef.Namespace, nodeTypeRef.Name) }));
 			yield break;
-		}
-
-		public static TypeReference GetParameterType(ParameterDefinition param)
-		{
-			if (!param.ParameterType.IsGenericParameter)
-				return param.ParameterType;
-			var type = (param.Method as MethodReference).DeclaringType as GenericInstanceType;
-			return type.GenericArguments [0];
 		}
 
 		static bool GetNameAndTypeRef(ref TypeReference elementType, string namespaceURI, ref string localname,
@@ -1389,16 +1382,17 @@ namespace Xamarin.Forms.Build.Tasks
 		static void SetDataTemplate(IElementNode parentNode, ElementNode node, ILContext parentContext,
 			IXmlLineInfo xmlLineInfo)
 		{
+			var module = parentContext.Module;
+			var dataTemplateType = ("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "IDataTemplate");
 			var parentVar = parentContext.Variables[parentNode];
 			//Push the DataTemplate to the stack, for setting the template
-			parentContext.IL.Emit(OpCodes.Ldloc, parentVar);
+			parentContext.IL.Append(parentVar.LoadAs(module.GetTypeDefinition(dataTemplateType), module));
 
 			//Create nested class
 			//			.class nested private auto ansi sealed beforefieldinit '<Main>c__AnonStorey0'
 			//			extends [mscorlib]System.Object
 
 
-			var module = parentContext.Module;
 			var anonType = new TypeDefinition(
 				null,
 				"<" + parentContext.Body.Method.Name + ">_anonXamlCDataTemplate_" + dtcount++,
@@ -1447,7 +1441,7 @@ namespace Xamarin.Forms.Build.Tasks
 			node.Accept(new SetResourcesVisitor(templateContext), null);
 			node.Accept(new SetPropertiesVisitor(templateContext, stopOnResourceDictionary: true), null);
 
-			templateIl.Emit(OpCodes.Ldloc, templateContext.Variables[node]);
+			templateIl.Append(templateContext.Variables[node].LoadAs(module.TypeSystem.Object, module));
 			templateIl.Emit(OpCodes.Ret);
 
 			//Instanciate nested class
@@ -1460,7 +1454,7 @@ namespace Xamarin.Forms.Build.Tasks
 			parentIl.Emit(OpCodes.Stfld, parentValues);
 			parentIl.Emit(OpCodes.Dup); //Duplicate the nestedclass instance
 			if (parentContext.Root is VariableDefinition)
-				parentIl.Emit(OpCodes.Ldloc, parentContext.Root as VariableDefinition);
+				parentIl.Append((parentContext.Root as VariableDefinition).LoadAs(module.TypeSystem.Object, module));
 			else if (parentContext.Root is FieldDefinition)
 			{
 				parentIl.Emit(OpCodes.Ldarg_0);
@@ -1476,7 +1470,7 @@ namespace Xamarin.Forms.Build.Tasks
 															 classArguments: new[] { ("mscorlib", "System", "Object") },
 															 paramCount: 2));
 
-			parentContext.IL.Emit(OpCodes.Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "IDataTemplate"), propertyName: "LoadTemplate"));
+			parentContext.IL.Emit(OpCodes.Callvirt, module.ImportPropertySetterReference(dataTemplateType, propertyName: "LoadTemplate"));
 
 			loadTemplate.Body.Optimize();
 		}

--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -333,6 +333,38 @@ namespace Xamarin.Forms.Build.Tasks
 			return null;
 		}
 
+		public static TypeReference ResolveGenericParameters(this TypeReference self, MethodReference declaringMethodReference)
+		{
+			var genericself = self as GenericParameter;
+			if (genericself != null) {
+				IGenericInstance instance;
+
+				switch (genericself.Type) {
+				case GenericParameterType.Method:
+					instance = (IGenericInstance)declaringMethodReference;
+					break;
+
+				case GenericParameterType.Type:
+					instance = (IGenericInstance)declaringMethodReference.DeclaringType;
+					break;
+
+				default:
+					throw new Exception("unknown generic parameter type");
+				}
+
+				return instance.GenericArguments[genericself.Position];
+			}
+
+			var genericInstanceSelf = self as GenericInstanceType;
+			if (genericInstanceSelf != null) {
+				var genericArguments = genericInstanceSelf.GenericArguments;
+				var arguments = genericArguments.Select(argument => argument.ResolveGenericParameters(declaringMethodReference));
+				return genericInstanceSelf.ElementType.MakeGenericInstanceType(arguments.ToArray());
+			}
+
+			return self;
+		}
+
 		public static TypeReference ResolveGenericParameters(this TypeReference self, TypeReference declaringTypeReference)
 		{
 			var genericself = self as GenericInstanceType;

--- a/Xamarin.Forms.Build.Tasks/VariableDefinitionExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/VariableDefinitionExtensions.cs
@@ -1,0 +1,23 @@
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using System.Collections.Generic;
+
+namespace Xamarin.Forms.Build.Tasks
+{
+	static class VariableDefinitionExtensions
+	{
+		public static IEnumerable<Instruction> LoadAs(this VariableDefinition self, TypeReference type, ModuleDefinition module)
+		{
+			var implicitOperator = self.VariableType.GetImplicitOperatorTo(type, module);
+
+			yield return Instruction.Create(OpCodes.Ldloc, self);
+
+			if (!self.VariableType.InheritsFromOrImplements(type) && implicitOperator != null)
+				yield return Instruction.Create(OpCodes.Call, module.ImportReference(implicitOperator));
+			else if (self.VariableType.IsValueType && !type.IsValueType)
+				yield return Instruction.Create(OpCodes.Box, module.ImportReference(self.VariableType));
+			else if (!self.VariableType.IsValueType && type.IsValueType)
+				yield return Instruction.Create(OpCodes.Unbox_Any, module.ImportReference(type));
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4238.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4238.xaml
@@ -1,0 +1,10 @@
+﻿<x:Object
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:collections="clr-namespace:System.Collections;assembly=mscorlib"
+    x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4238">
+    <x:Object.Property>
+        <collections:ArrayList>
+            <x:Single>0</x:Single>
+        </collections:ArrayList>
+    </x:Object.Property>
+</x:Object>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4238.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4238.xaml.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+    [TestFixture]
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class Gh4238
+    {
+        public System.Collections.ArrayList Property { get; set; }
+
+        [Test]
+        public void Test()
+        {
+            InitializeComponent();
+            Assert.AreEqual(0f, Property[0]);
+        }
+    }
+}

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/MethodReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/MethodReferenceExtensionsTests.cs
@@ -18,6 +18,8 @@ namespace Xamarin.Forms.XamlcUnitTests
 		abstract class TestClass<T>
 		{
 			public abstract T UnresolvedGenericReturnType ();
+			public abstract void CustmAttributeParameterMethod ([Parameter("Parameter")] int parameter);
+			public abstract void UnresolvedGenericInstanceTypeMethod (TestClass<T> unresolved);
 		}
 
 		[SetUp]
@@ -102,6 +104,26 @@ namespace Xamarin.Forms.XamlcUnitTests
 			var resolved = method.ResolveGenericParameters (type, module);
 
 			Assert.AreEqual ("T", resolved.ReturnType.Name);
+		}
+
+		[Test]
+		public void CustomAttributes ()
+		{
+			var type = module.ImportReference (typeof (TestClass<int>));
+			var method = type.Resolve ().Methods.Where (md => md.Name == "CustmAttributeParameterMethod").Single ();
+			var resolved = method.ResolveGenericParameters (type, module);
+
+			Assert.AreEqual ("Xamarin.Forms.ParameterAttribute", resolved.Parameters[0].CustomAttributes[0].AttributeType.FullName);
+		}
+
+		[Test]
+		public void ImportUnresolvedGenericInstanceType ()
+		{
+			var type = module.ImportReference (typeof (TestClass<int>));
+			var method = type.Resolve ().Methods.Where (md => md.Name == "UnresolvedGenericInstanceTypeMethod").Single ();
+			var resolved = method.ResolveGenericParameters (type, module);
+
+			Assert.AreEqual ("foo", resolved.Parameters[0].ParameterType.Module.Name);
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
@@ -43,6 +43,21 @@ namespace Xamarin.Forms.XamlcUnitTests
 		{
 		}
 
+		abstract class Grault
+		{
+			public abstract void Method<T>(T t);
+		}
+
+		abstract class Garply<T>
+		{
+			public abstract void Method(T t);
+		}
+
+		abstract class Waldo<T>
+		{
+			public abstract void Method(Foo<T> t);
+		}
+
 		ModuleDefinition module;
 
 		[SetUp]
@@ -142,6 +157,26 @@ namespace Xamarin.Forms.XamlcUnitTests
 
 			Assert.AreEqual("System", resolvedType.Namespace);
 			Assert.AreEqual("Byte", resolvedType.Name);
+		}
+
+		public void TestResolveGenericParametersOfGenericMethod()
+		{
+			var method = new GenericInstanceMethod(module.ImportReference(typeof(Grault)).Resolve().Methods[0]);
+			method.GenericArguments.Add(module.TypeSystem.Byte);
+			var resolved = method.ReturnType.ResolveGenericParameters(method);
+
+			Assert.That(TypeRefComparer.Default.Equals(module.TypeSystem.Byte, resolved));
+		}
+
+		[TestCase(typeof(Garply<byte>), typeof(byte))]
+		[TestCase(typeof(Waldo<byte>), typeof(Foo<byte>))]
+		public void TestResolveGenericParametersOfMethodOfGeneric(Type typeRef, Type returnType)
+		{
+			var type = module.ImportReference(typeRef);
+			var method = type.Resolve().Methods[0].ResolveGenericParameters(type, module);
+			var resolved = method.Parameters[0].ParameterType.ResolveGenericParameters(method);
+
+			Assert.That(TypeRefComparer.Default.Equals(module.ImportReference(returnType), resolved));
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

XamlC often uses single instruction `ldloc` to load a local variable to stack to use as an argument for a method, but the instruction does not do necessary type conversion. For example, the following XAML code does not work because it does not box value type where `collections` is `clr-namespace:System.Collections;assembly=mscorlib`:

```XAML
<collections:List>
  <x:Single>0</x:Single>
</collections:List>
```

Some code emitting `ldloc` emits implicit casting code and boxing/unboxing instructions as well, but such code are duplicated over the codebase and the behavior is inconsistent.

This change introduces an internal method `Xamarin.Forms.Build.Tasks.VariableDefinitionExtensions.LoadAs` rather than duplicating such type conversion code even more after all `ldloc` emission and checking they are all consistent.

It has grown big because of the comprehensive change, so I decided to limit the scope it deals with. Specifically, it does __not__:

* add type conversion after `ldfld`, `call`, `callvirt`,
* validate the type conversion, or
* add code to load pointer of value type for `this` parameter (`ldloca` should be used instead of `ldloc` for such case.)

In future, you may add such features to `Xamarin.Forms.Build.Tasks.VariableDefinitionExtensions.LoadAs` or add a similar method.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

I didn't find any issues involved, but maybe there are.

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
