### PR TITLE
[Android] AppCompat version of EntryRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/EntryRenderer.cs
@@ -1,0 +1,417 @@
+﻿using Android.Content;
+using Android.Text;
+using Android.Text.Method;
+using Android.Util;
+using Android.Views;
+using Android.Views.InputMethods;
+using Android.Widget;
+using Java.Lang;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+
+namespace Xamarin.Forms.Platform.Android.AppCompat
+{
+	public class EntryRenderer : ViewRenderer<Entry, FormsAppCompatEditText>, ITextWatcher, TextView.IOnEditorActionListener
+	{
+		TextColorSwitcher _hintColorSwitcher;
+		TextColorSwitcher _textColorSwitcher;
+		bool _disposed;
+		ImeAction _currentInputImeFlag;
+		IElementController ElementController => Element as IElementController;
+
+		bool _cursorPositionChangePending;
+		bool _selectionLengthChangePending;
+		bool _nativeSelectionIsUpdating;
+
+		public EntryRenderer(Context context) : base(context)
+		{
+			AutoPackage = false;
+		}
+
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use EntryRenderer(Context) instead.")]
+		public EntryRenderer()
+		{
+			AutoPackage = false;
+		}
+
+		bool TextView.IOnEditorActionListener.OnEditorAction(TextView v, ImeAction actionId, KeyEvent e)
+		{
+			// Fire Completed and dismiss keyboard for hardware / physical keyboards
+			if (actionId == ImeAction.Done || actionId == _currentInputImeFlag || (actionId == ImeAction.ImeNull && e.KeyCode == Keycode.Enter && e.Action == KeyEventActions.Up))
+			{
+				Control.ClearFocus();
+				v.HideKeyboard();
+				((IEntryController)Element).SendCompleted();
+			}
+
+			return true;
+		}
+
+		void ITextWatcher.AfterTextChanged(IEditable s)
+		{
+		}
+
+		void ITextWatcher.BeforeTextChanged(ICharSequence s, int start, int count, int after)
+		{
+		}
+
+		void ITextWatcher.OnTextChanged(ICharSequence s, int start, int before, int count)
+		{
+			if (string.IsNullOrEmpty(Element.Text) && s.Length() == 0)
+				return;
+
+			((IElementController)Element).SetValueFromRenderer(Entry.TextProperty, s.ToString());
+		}
+
+		protected override FormsAppCompatEditText CreateNativeControl()
+		{
+			return new FormsAppCompatEditText(Context);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
+		{
+			base.OnElementChanged(e);
+
+			HandleKeyboardOnFocus = true;
+
+			if (e.OldElement == null)
+			{
+				var textView = CreateNativeControl();
+
+				textView.AddTextChangedListener(this);
+				textView.SetOnEditorActionListener(this);
+				textView.OnKeyboardBackPressed += OnKeyboardBackPressed;
+				textView.SelectionChanged += SelectionChanged;
+
+				var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
+
+				_textColorSwitcher = new TextColorSwitcher(textView.TextColors, useLegacyColorManagement);
+				_hintColorSwitcher = new TextColorSwitcher(textView.HintTextColors, useLegacyColorManagement);
+				SetNativeControl(textView);
+			}
+
+			// When we set the control text, it triggers the SelectionChanged event, which updates CursorPosition and SelectionLength;
+			// These one-time-use variables will let us initialize a CursorPosition and SelectionLength via ctor/xaml/etc.
+			_cursorPositionChangePending = Element.IsSet(Entry.CursorPositionProperty);
+			_selectionLengthChangePending = Element.IsSet(Entry.SelectionLengthProperty);
+
+			Control.Hint = Element.Placeholder;
+			Control.Text = Element.Text;
+			UpdateInputType();
+
+			UpdateColor();
+			UpdateAlignment();
+			UpdateFont();
+			UpdatePlaceholderColor();
+			UpdateMaxLength();
+			UpdateImeOptions();
+			UpdateReturnType();
+
+			if (_cursorPositionChangePending || _selectionLengthChangePending)
+				UpdateCursorSelection();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				if (Control != null)
+				{
+					Control.OnKeyboardBackPressed -= OnKeyboardBackPressed;
+					Control.SelectionChanged -= SelectionChanged;
+				}
+			}
+
+			base.Dispose(disposing);
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == Entry.PlaceholderProperty.PropertyName)
+				Control.Hint = Element.Placeholder;
+			else if (e.PropertyName == Entry.IsPasswordProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == Entry.TextProperty.PropertyName)
+			{
+				if (Control.Text != Element.Text)
+				{
+					Control.Text = Element.Text;
+					if (Control.IsFocused)
+					{
+						Control.SetSelection(Control.Text.Length);
+						Control.ShowKeyboard();
+					}
+				}
+			}
+			else if (e.PropertyName == Entry.TextColorProperty.PropertyName)
+				UpdateColor();
+			else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == Entry.IsTextPredictionEnabledProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
+				UpdateAlignment();
+			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.FontFamilyProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.FontSizeProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
+				UpdatePlaceholderColor();
+			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
+				UpdateAlignment();
+			else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+				UpdateMaxLength();
+			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.Entry.ImeOptionsProperty.PropertyName)
+				UpdateImeOptions();
+			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
+				UpdateReturnType();
+			else if (e.PropertyName == Entry.SelectionLengthProperty.PropertyName)
+				UpdateCursorSelection();
+			else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName)
+				UpdateCursorSelection();
+
+			base.OnElementPropertyChanged(sender, e);
+		}
+
+		protected virtual NumberKeyListener GetDigitsKeyListener(InputTypes inputTypes)
+		{
+			// Override this in a custom renderer to use a different NumberKeyListener
+			// or to filter out input types you don't want to allow
+			// (e.g., inputTypes &= ~InputTypes.NumberFlagSigned to disallow the sign)
+			return LocalizedDigitsKeyListener.Create(inputTypes);
+		}
+
+		protected virtual void UpdateImeOptions()
+		{
+			if (Element == null || Control == null)
+				return;
+			var imeOptions = Element.OnThisPlatform().ImeOptions();
+			_currentInputImeFlag = imeOptions.ToAndroidImeOptions();
+			Control.ImeOptions = _currentInputImeFlag;
+		}
+
+		void UpdateAlignment()
+		{
+			Control.UpdateHorizontalAlignment(Element.HorizontalTextAlignment, Context.HasRtlSupport());
+		}
+
+		void UpdateColor()
+		{
+			_textColorSwitcher.UpdateTextColor(Control, Element.TextColor);
+		}
+
+		void UpdateFont()
+		{
+			Control.Typeface = Element.ToTypeface();
+			Control.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
+		}
+
+		void UpdateInputType()
+		{
+			Entry model = Element;
+			var keyboard = model.Keyboard;
+
+			Control.InputType = keyboard.ToInputType();
+			if (!(keyboard is Internals.CustomKeyboard))
+			{
+				if (model.IsSet(InputView.IsSpellCheckEnabledProperty))
+				{
+					if ((Control.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsSpellCheckEnabled)
+							Control.InputType = Control.InputType | InputTypes.TextFlagNoSuggestions;
+					}
+				}
+				if (model.IsSet(Entry.IsTextPredictionEnabledProperty))
+				{
+					if ((Control.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsTextPredictionEnabled)
+							Control.InputType = Control.InputType | InputTypes.TextFlagNoSuggestions;
+					}
+				}
+			}
+
+			if (keyboard == Keyboard.Numeric)
+			{
+				Control.KeyListener = GetDigitsKeyListener(Control.InputType);
+			}
+
+			if (model.IsPassword && ((Control.InputType & InputTypes.ClassText) == InputTypes.ClassText))
+				Control.InputType = Control.InputType | InputTypes.TextVariationPassword;
+			if (model.IsPassword && ((Control.InputType & InputTypes.ClassNumber) == InputTypes.ClassNumber))
+				Control.InputType = Control.InputType | InputTypes.NumberVariationPassword;
+
+			UpdateFont();
+		}
+
+		void UpdatePlaceholderColor()
+		{
+			_hintColorSwitcher.UpdateTextColor(Control, Element.PlaceholderColor, Control.SetHintTextColor);
+		}
+
+		void OnKeyboardBackPressed(object sender, EventArgs eventArgs)
+		{
+			Control?.ClearFocus();
+		}
+
+		void UpdateMaxLength()
+		{
+			var currentFilters = new List<IInputFilter>(Control?.GetFilters() ?? new IInputFilter[0]);
+
+			for (var i = 0; i < currentFilters.Count; i++)
+			{
+				if (currentFilters[i] is InputFilterLengthFilter)
+				{
+					currentFilters.RemoveAt(i);
+					break;
+				}
+			}
+
+			currentFilters.Add(new InputFilterLengthFilter(Element.MaxLength));
+
+			Control?.SetFilters(currentFilters.ToArray());
+
+			var currentControlText = Control?.Text;
+
+			if (currentControlText.Length > Element.MaxLength)
+				Control.Text = currentControlText.Substring(0, Element.MaxLength);
+		}
+
+		void UpdateReturnType()
+		{
+			if (Control == null || Element == null)
+				return;
+
+			Control.ImeOptions = Element.ReturnType.ToAndroidImeAction();
+			_currentInputImeFlag = Control.ImeOptions;
+		}
+
+		void SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (_nativeSelectionIsUpdating || Control == null || Element == null)
+				return;
+
+			int cursorPosition = Element.CursorPosition;
+			int selectionStart = Control.SelectionStart;
+
+			if (!_cursorPositionChangePending)
+			{
+				var start = cursorPosition;
+
+				if (selectionStart != start)
+					SetCursorPositionFromRenderer(selectionStart);
+			}
+
+			if (!_selectionLengthChangePending)
+			{
+				int elementSelectionLength = System.Math.Min(Control.Text.Length - cursorPosition, Element.SelectionLength);
+
+				var controlSelectionLength = Control.SelectionEnd - selectionStart;
+				if (controlSelectionLength != elementSelectionLength)
+					SetSelectionLengthFromRenderer(controlSelectionLength);
+			}
+		}
+
+		void UpdateCursorSelection()
+		{
+			if (_nativeSelectionIsUpdating || Control == null || Element == null)
+				return;
+
+			if (Control.RequestFocus())
+			{
+				try
+				{
+					int start = GetSelectionStart();
+					int end = GetSelectionEnd(start);
+
+					Control.SetSelection(start, end);
+				}
+				catch (System.Exception ex)
+				{
+					Internals.Log.Warning("Entry", $"Failed to set Control.Selection from CursorPosition/SelectionLength: {ex}");
+				}
+				finally
+				{
+					_cursorPositionChangePending = _selectionLengthChangePending = false;
+				}
+			}
+		}
+
+		int GetSelectionEnd(int start)
+		{
+			int end = start;
+			int selectionLength = Element.SelectionLength;
+
+			if (Element.IsSet(Entry.SelectionLengthProperty))
+				end = System.Math.Max(start, System.Math.Min(Control.Length(), start + selectionLength));
+
+			int newSelectionLength = System.Math.Max(0, end - start);
+			if (newSelectionLength != selectionLength)
+				SetSelectionLengthFromRenderer(newSelectionLength);
+
+			return end;
+		}
+
+		int GetSelectionStart()
+		{
+			int start = Control.Length();
+			int cursorPosition = Element.CursorPosition;
+
+			if (Element.IsSet(Entry.CursorPositionProperty))
+				start = System.Math.Min(Control.Text.Length, cursorPosition);
+
+			if (start != cursorPosition)
+				SetCursorPositionFromRenderer(start);
+
+			return start;
+		}
+
+		void SetCursorPositionFromRenderer(int start)
+		{
+			try
+			{
+				_nativeSelectionIsUpdating = true;
+				ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, start);
+			}
+			catch (System.Exception ex)
+			{
+				Internals.Log.Warning("Entry", $"Failed to set CursorPosition from renderer: {ex}");
+			}
+			finally
+			{
+				_nativeSelectionIsUpdating = false;
+			}
+		}
+
+		void SetSelectionLengthFromRenderer(int selectionLength)
+		{
+			try
+			{
+				_nativeSelectionIsUpdating = true;
+				ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+			}
+			catch (System.Exception ex)
+			{
+				Internals.Log.Warning("Entry", $"Failed to set SelectionLength from renderer: {ex}");
+			}
+			finally
+			{
+				_nativeSelectionIsUpdating = false;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -86,11 +86,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected void LoadApplication(Application application)
 		{
-			if(!_activityCreated)
+			if (!_activityCreated)
 			{
-			    throw new InvalidOperationException("Activity OnCreate was not called prior to loading the application. Did you forget a base.OnCreate call?");
+				throw new InvalidOperationException("Activity OnCreate was not called prior to loading the application. Did you forget a base.OnCreate call?");
 			}
-			
+
 			if (!_renderersAdded)
 			{
 				RegisterHandlerForDefaultRenderer(typeof(NavigationPage), typeof(NavigationPageRenderer), typeof(NavigationRenderer));
@@ -99,6 +99,7 @@ namespace Xamarin.Forms.Platform.Android
 				RegisterHandlerForDefaultRenderer(typeof(Switch), typeof(AppCompat.SwitchRenderer), typeof(SwitchRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(Picker), typeof(AppCompat.PickerRenderer), typeof(PickerRenderer));
 				RegisterHandlerForDefaultRenderer(typeof(CarouselPage), typeof(AppCompat.CarouselPageRenderer), typeof(CarouselPageRenderer));
+				RegisterHandlerForDefaultRenderer(typeof(Entry), typeof(AppCompat.EntryRenderer), typeof(EntryRenderer));
 
 				if (Forms.Flags.Contains(Flags.FastRenderersExperimental))
 				{

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatEditText.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatEditText.cs
@@ -1,0 +1,81 @@
+﻿using Android.Content;
+using Android.Graphics;
+using Android.Support.V4.Graphics.Drawable;
+using Android.Support.V7.Widget;
+using Android.Views;
+using System;
+
+namespace Xamarin.Forms.Platform.Android.AppCompat
+{
+	public class FormsAppCompatEditText : AppCompatEditText, IDescendantFocusToggler
+	{
+		DescendantFocusToggler _descendantFocusToggler;
+
+		public FormsAppCompatEditText(Context context) : base(context)
+		{
+			DrawableCompat.Wrap(Background);
+		}
+
+		bool IDescendantFocusToggler.RequestFocus(global::Android.Views.View control, Func<bool> baseRequestFocus)
+		{
+			_descendantFocusToggler = _descendantFocusToggler ?? new DescendantFocusToggler();
+
+			return _descendantFocusToggler.RequestFocus(control, baseRequestFocus);
+		}
+
+		public override bool OnKeyPreIme(Keycode keyCode, KeyEvent e)
+		{
+			if (keyCode != Keycode.Back || e.Action != KeyEventActions.Down)
+			{
+				return base.OnKeyPreIme(keyCode, e);
+			}
+
+			this.HideKeyboard();
+
+			OnKeyboardBackPressed?.Invoke(this, EventArgs.Empty);
+			return true;
+		}
+
+		public override bool RequestFocus(FocusSearchDirection direction, Rect previouslyFocusedRect)
+		{
+			return (this as IDescendantFocusToggler).RequestFocus(this, () => base.RequestFocus(direction, previouslyFocusedRect));
+		}
+
+		protected override void OnSelectionChanged(int selStart, int selEnd)
+		{
+			base.OnSelectionChanged(selStart, selEnd);
+			SelectionChanged?.Invoke(this, new SelectionChangedEventArgs(selStart, selEnd));
+		}
+
+		internal event EventHandler OnKeyboardBackPressed;
+		internal event EventHandler<SelectionChangedEventArgs> SelectionChanged;
+	}
+
+	public class SelectionChangedEventArgs : EventArgs
+	{
+		public int Start { get; private set; }
+		public int End { get; private set; }
+
+		public SelectionChangedEventArgs(int start, int end)
+		{
+			Start = start;
+			End = end;
+		}
+	}
+
+	[Obsolete("EntryEditText is obsolete as of version 2.4.0. Please use Xamarin.Forms.Platform.Android.AppCompat.FormsAppCompatEditText instead.")]
+	public class EntryEditText : FormsAppCompatEditText
+	{
+		public EntryEditText(Context context) : base(context)
+		{
+		}
+	}
+
+	[Obsolete("EditorEditText is obsolete as of version 2.4.0. Please use Xamarin.Forms.Platform.Android.AppCompat.FormsAppCompatEditText instead.")]
+	public class EditorEditText : FormsAppCompatEditText
+	{
+		public EditorEditText(Context context) : base(context)
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -111,6 +111,8 @@
     <Compile Include="ActivityResultCallbackRegistry.cs" />
     <Compile Include="AndroidApplicationLifecycleState.cs" />
     <Compile Include="AndroidTitleBarVisibility.cs" />
+    <Compile Include="AppCompat\EntryRenderer.cs" />
+    <Compile Include="AppCompat\FormsAppCompatEditText.cs" />
     <Compile Include="AppCompat\FrameRenderer.cs" />
     <Compile Include="AppCompat\ILifeCycleState.cs" />
     <Compile Include="ButtonBackgroundTracker.cs" />


### PR DESCRIPTION
Since there hasn't been any traction with #2151 since March, I wanted to redo this. The code added here is an exact copy of the previous renderer with the inclusion of `FormsAppCompatEditText` in addition. I ran the Entry Gallery and did not see any visible change compared to the previous renderer. Please run UI tests and let me know if this breaks anything.