### PR TITLE
[macOS] ContextActions on ListView not working (TextCell for example)

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
@@ -182,6 +182,11 @@ namespace Xamarin.Forms.Platform.MacOS
 
 	class TrackingClickNSView : NSView
 	{
+		public TrackingClickNSView()
+		{
+			AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
+		}
+
 		public override void RightMouseDown(NSEvent theEvent)
 		{
 			HandleContextActions(theEvent);

--- a/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
@@ -182,7 +182,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 	class TrackingClickNSView : NSView
 	{
-		public TrackingClickNSView()
+		internal TrackingClickNSView()
 		{
 			AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
 		}


### PR DESCRIPTION
### Description of Change ###

Force expand touch-catcher to cover full size of the cell

### Issues Resolved ### 

- fixes #2881 

### API Changes ###
 None

### Platforms Affected ### 
- MacOs

### Behavioral/Visual Changes ###
Now it's possible to call context actions on TextCell


### Testing Procedure ###
Open test case 31330 and try to right click over any cell 