### PR TITLE
[XamlC] Resolve generic parameters of a method with generic return type

### DIFF
--- a/Xamarin.Forms.Build.Tasks/MethodReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/MethodReferenceExtensions.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Build.Tasks
 			if (declaringTypeRef == null)
 				throw new ArgumentNullException(nameof(declaringTypeRef));
 
-			var reference = new MethodReference(self.Name, module.ImportReference(self.ReturnType))
+			var reference = new MethodReference(self.Name, ImportUnresolvedType(self.ReturnType, module))
 			{
 				DeclaringType = module.ImportReference(declaringTypeRef),
 				HasThis = self.HasThis,
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Build.Tasks
 			};
 
 			foreach (var parameter in self.Parameters) {
-				var p = parameter.ParameterType.IsGenericParameter ? parameter.ParameterType : module.ImportReference(parameter.ParameterType);
+				var p = ImportUnresolvedType(parameter.ParameterType, module);
 				reference.Parameters.Add(new ParameterDefinition(p));
 			}
 
@@ -30,6 +30,11 @@ namespace Xamarin.Forms.Build.Tasks
 				reference.GenericParameters.Add(new GenericParameter(generic_parameter.Name, reference));
 
 			return reference;
+		}
+
+		static TypeReference ImportUnresolvedType(TypeReference type, ModuleDefinition module)
+		{
+			return type.IsGenericParameter ? type : module.ImportReference(type);
 		}
 
 		public static void ImportTypes(this MethodReference self, ModuleDefinition module)

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/MethodReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/MethodReferenceExtensionsTests.cs
@@ -15,6 +15,11 @@ namespace Xamarin.Forms.Xaml.XamlcUnitTests
 	{
 		ModuleDefinition module;
 
+		abstract class TestClass<T>
+		{
+			public abstract T UnresolvedGenericReturnType ();
+		}
+
 		[SetUp]
 		public void SetUp ()
 		{
@@ -87,6 +92,16 @@ namespace Xamarin.Forms.Xaml.XamlcUnitTests
 			Assert.AreEqual ("System.Void System.Collections.Generic.ICollection`1::Add(T)", adderRef.FullName);
 			adderRef = adderRef.ResolveGenericParameters (ptype, module);
 			Assert.AreEqual ("System.Void System.Collections.Generic.ICollection`1<Xamarin.Forms.View>::Add(T)", adderRef.FullName);
+		}
+
+		[Test]
+		public void GenericParameterReturnType ()
+		{
+			var type = module.ImportReference (typeof (TestClass<int>));
+			var method = type.Resolve ().Methods.Where (md => md.Name == "UnresolvedGenericReturnType").Single ();
+			var resolved = method.ResolveGenericParameters (type, module);
+
+			Assert.AreEqual ("T", resolved.ReturnType.Name);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

`Xamarin.Forms.Build.Tasks.ResolveGenericParameters` treats generic parameters as special, but return type can also be generic. Handle it in a similar way.

I recommend to merge this before #4238 because it increases probability to encounter a method with such return type.

### Issues Resolved ### 

I have not opened an issue for the problem this issue addresses.

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->
An automated test is available.

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
