### PR TITLE
[MacOs] Image from file not getting searched in the bundle

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/ImageSourceHandlers.cs
+++ b/Xamarin.Forms.Platform.MacOS/ImageSourceHandlers.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using AppKit;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
@@ -20,7 +21,13 @@ namespace Xamarin.Forms.Platform.MacOS
 			var filesource = imagesource as FileImageSource;
 			var file = filesource?.File;
 			if (!string.IsNullOrEmpty(file))
-				image = File.Exists(file) ? new NSImage(file) : null;
+				image = File.Exists(file) ? new NSImage(file) : NSImage.ImageNamed(file);
+
+			if (image == null)
+			{
+				Log.Warning(nameof(FileImageSourceHandler), "Could not find image: {0}", imagesource);
+			}
+
 			return Task.FromResult(image);
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Implement possibility to set FileImageSource without setting extension (you can set "image" instead of "image.png") 
Added Log warning, if images wasn't found

### Issues Resolved ### 
- fixes #2322 

### API Changes ###
None

### Platforms Affected ### 
- MacOs

### Behavioral/Visual Changes ###
Images is shown

### Before/After Screenshots ### 
Not applicable
(Without fix you don't see the image, but if you apply it you will see the image)

### Testing Procedure ###
```csharp
new ContentPage { Content = new Image { Source = "image" } } ;
```
