### PR TITLE
[UITests] fix dismiss page crash

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/CoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/CoreGalleryPage.cs
@@ -48,7 +48,13 @@ namespace Xamarin.Forms.Controls
 
 			var modalDismissButton = new Button () {
 				Text = "Dismiss Page",
-				Command = new Command (async () => await Navigation.PopModalAsync ())
+				Command = new Command (async () =>
+				{
+					if (_picker.SelectedIndex == 0)
+						await Navigation.PopAsync();
+					else
+						_picker.SelectedIndex--;
+				})
 			};
 			Layout.Children.Add (modalDismissButton);
 


### PR DESCRIPTION
### Description of Change ###
The dismiss page button looks to be based on an older version of the control gallery where it was pushing modal pages and not just a single page swapping out layouts. 

This fix makes that button functional again instead of causing crashing

### Testing Procedure ###
- Go to any of the control gallery pages that use the Dismiss Button (ImageGallery, Button Gallery, etc..)
- Click move next
- click Dismiss Page
- make sure no crashing happens

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
