### PR TITLE
[iOS] Add JavaScript dialog delegate to WkWebView

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/Properties/AssemblyInfo.cs
@@ -42,3 +42,4 @@ using Xamarin.Forms.Controls;
 // Deliberately broken image source and handler so we can test handling of image loading errors
 [assembly: ExportImageSourceHandler(typeof(FailImageSource), typeof(BrokenImageSourceHandler))]
 [assembly: ExportRenderer(typeof(WkWebView), typeof(Xamarin.Forms.Platform.iOS.WkWebViewRenderer))]
+

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -26,7 +26,8 @@
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>True</MtouchDebug>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignEntitlements>
+    </CodesignEntitlements>
     <MtouchProfiling>False</MtouchProfiling>
     <MtouchFastDev>False</MtouchFastDev>
     <MtouchEnableGenericValueTypeSharing>True</MtouchEnableGenericValueTypeSharing>

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -26,8 +26,7 @@
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>True</MtouchDebug>
-    <CodesignEntitlements>
-    </CodesignEntitlements>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchProfiling>False</MtouchProfiling>
     <MtouchFastDev>False</MtouchFastDev>
     <MtouchEnableGenericValueTypeSharing>True</MtouchEnableGenericValueTypeSharing>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1666.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1666.cs
@@ -29,6 +29,10 @@ namespace Xamarin.Forms.Controls.Issues
 			var buttonState = new Button() { Text = "?", BackgroundColor = Color.LightBlue, AutomationId = "buttonState" };
 			var buttonStop = new Button() { Text = "X", BackgroundColor = Color.LightBlue, AutomationId = "buttonStop" };
 
+			var buttonJsAlert = new Button() { Text = "ALERT", BackgroundColor = Color.LightBlue, AutomationId = "buttonJsAlert" };
+			var buttonJsPrompt = new Button() { Text = "PROMPT", BackgroundColor = Color.LightBlue, AutomationId = "buttonJsPrompt" };
+			var buttonJsConfirm = new Button() { Text = "CONFIRM", BackgroundColor = Color.LightBlue, AutomationId = "buttonJsConfirm" };
+
 			var buttonA = new Button() { Text = "GO", BackgroundColor = Color.LightBlue, AutomationId = "buttonA" };
 			var buttonB = new Button() { Text = "HTML", BackgroundColor = Color.LightBlue, AutomationId = "buttonB" };
 			var buttonC = new Button() { Text = "EVAL", BackgroundColor = Color.LightBlue, AutomationId = "buttonC" };
@@ -52,9 +56,13 @@ namespace Xamarin.Forms.Controls.Issues
 			var entry = new Entry() { AutomationId = "entry" };
 			entry.BackgroundColor = Color.Wheat;
 
+			var jsAlerts = new Grid();
+			jsAlerts.Children.AddHorizontal(new[] { buttonJsAlert, buttonJsPrompt, buttonJsConfirm });
+
 			var buttons = new Grid();
 			buttons.Children.AddVertical(vcr);
 			buttons.Children.AddVertical(evals);
+			buttons.Children.AddVertical(jsAlerts);
 			buttons.Children.AddVertical(entry);
 
 			var console = new Label()
@@ -107,6 +115,10 @@ namespace Xamarin.Forms.Controls.Issues
 				log($"F/B: {webView.CanGoBack}/{webView.CanGoForward}");
 				log($"Source: {webView.Source.ToString()}");
 			};
+
+			buttonJsAlert.Clicked += async (s, e) => { await webView.EvaluateJavaScriptAsync("alert('foo')"); };
+			buttonJsPrompt.Clicked += async (s, e) => { log($"{await webView.EvaluateJavaScriptAsync("prompt('enter something:')")} was enterred"); };
+			buttonJsConfirm.Clicked += async (s, e) => { log($"{await webView.EvaluateJavaScriptAsync("confirm('choose')")} was chosen"); };
 
 			bool navigating = false;
 			webView.Navigating += (s, e) =>

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -320,6 +320,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new TableViewCoreGalleryPage(), "TableView Gallery"),
 				new GalleryPageFactory(() => new TimePickerCoreGalleryPage(), "TimePicker Gallery"),
 				new GalleryPageFactory(() => new WebViewCoreGalleryPage(), "WebView Gallery"),
+				new GalleryPageFactory(() => new WebViewCoreGalleryPage(), "WkWebView Gallery"),
 				//pages
  				new GalleryPageFactory(() => new RootContentPage ("Content"), "RootPages Gallery"),
 				new GalleryPageFactory(() => new MasterDetailPageTabletPage(), "MasterDetailPage Tablet Page"),

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -320,7 +320,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new TableViewCoreGalleryPage(), "TableView Gallery"),
 				new GalleryPageFactory(() => new TimePickerCoreGalleryPage(), "TimePicker Gallery"),
 				new GalleryPageFactory(() => new WebViewCoreGalleryPage(), "WebView Gallery"),
-				new GalleryPageFactory(() => new WebViewCoreGalleryPage(), "WkWebView Gallery"),
+				new GalleryPageFactory(() => new WkWebViewCoreGalleryPage(), "WkWebView Gallery"),
 				//pages
  				new GalleryPageFactory(() => new RootContentPage ("Content"), "RootPages Gallery"),
 				new GalleryPageFactory(() => new MasterDetailPageTabletPage(), "MasterDetailPage Tablet Page"),

--- a/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
@@ -30,7 +30,10 @@ namespace Xamarin.Forms.Controls
 				}
 			);
 
-			const string html = "<html><div class=\"test\"><h2>I am raw html</h2></div></html>";
+			const string html = "<!DOCTYPE html><html>" +
+				"<head><meta name='viewport' content='width=device-width,initial-scale=1.0'></head>" +
+				"<body><div class=\"test\"><h2>I am raw html</h2></div></body></html>";
+
 			var htmlWebViewSourceContainer = new ViewContainer<WebView> (Test.WebView.HtmlWebViewSource, 
 				new WebView {
 					Source = new HtmlWebViewSource { Html = html },
@@ -40,9 +43,11 @@ namespace Xamarin.Forms.Controls
 
 			var htmlFileWebSourceContainer = new ViewContainer<WebView> (Test.WebView.LoadHtml,
 				new WebView {
-					Source = new HtmlWebViewSource { 
-						Html = @"<html>
+					Source = new HtmlWebViewSource
+					{
+						Html = @"<!DOCTYPE html><html>
 <head>
+<meta name='viewport' content='width=device-width,initial-scale=1.0'>
 <link rel=""stylesheet"" href=""default.css"">
 </head>
 <body>
@@ -90,8 +95,9 @@ namespace Xamarin.Forms.Controls
 			{
 				Source = new HtmlWebViewSource
 				{
-					Html = @"<html>
+					Html = @"<!DOCTYPE html><html>
 <head>
+<meta name='viewport' content='width=device-width,initial-scale=1.0'>
 <link rel=""stylesheet"" href=""default.css"">
 </head>
 <body>

--- a/Xamarin.Forms.Controls/CoreGalleryPages/WkWebViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/WkWebViewCoreGalleryPage.cs
@@ -1,0 +1,137 @@
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
+
+namespace Xamarin.Forms.Controls
+{
+	internal class WkWebViewCoreGalleryPage : CoreGalleryPage<WkWebView>
+	{
+		protected override bool SupportsFocus
+		{
+			get { return false; }
+		}
+
+		protected override void InitializeElement (WkWebView element)
+		{
+			element.HeightRequest = 200;
+
+			element.Source = new UrlWebViewSource { Url = "http://xamarin.com/" };
+		}
+
+		protected override void Build (StackLayout stackLayout)
+		{
+			base.Build (stackLayout);
+
+			var urlWebViewSourceContainer = new ViewContainer<WkWebView> (Test.WebView.UrlWebViewSource, 
+				new WkWebView {
+					Source = new UrlWebViewSource { Url = "https://www.google.com/" },
+					HeightRequest = 200
+				}
+			);
+
+			const string html = "<html><div class=\"test\"><h2>I am raw html</h2></div></html>";
+			var htmlWebViewSourceContainer = new ViewContainer<WkWebView> (Test.WebView.HtmlWebViewSource, 
+				new WkWebView {
+					Source = new HtmlWebViewSource { Html = html },
+					HeightRequest = 200
+				}
+			);
+
+			var htmlFileWebSourceContainer = new ViewContainer<WkWebView> (Test.WebView.LoadHtml,
+				new WkWebView {
+					Source = new HtmlWebViewSource { 
+						Html = @"<html>
+<head>
+<link rel=""stylesheet"" href=""default.css"">
+</head>
+<body>
+<h1>Xamarin.Forms</h1>
+<p>The CSS and image are loaded from local files!</p>
+<img src='WebImages/XamarinLogo.png'/>
+<p><a href=""local.html"">next page</a></p>
+</body>
+</html>"
+					},
+					HeightRequest = 200
+				}
+			);
+
+			// NOTE: Currently the ability to programmatically enable/disable mixed content only exists on Android
+			if (Device.RuntimePlatform == Device.Android)
+			{
+				var mixedContentTestPage = "https://mixed-content-test.appspot.com/";
+
+				var mixedContentDisallowedWebView = new WkWebView() { HeightRequest = 1000 };
+				mixedContentDisallowedWebView.On<Android>().SetMixedContentMode(MixedContentHandling.NeverAllow);
+				mixedContentDisallowedWebView.Source = new UrlWebViewSource
+				{
+					Url = mixedContentTestPage
+				};
+
+				var mixedContentAllowedWebView = new WkWebView() { HeightRequest = 1000 };
+				mixedContentAllowedWebView.On<Android>().SetMixedContentMode(MixedContentHandling.AlwaysAllow);
+				mixedContentAllowedWebView.Source = new UrlWebViewSource
+				{
+					Url = mixedContentTestPage
+				};
+
+				var mixedContentDisallowedContainer = new ViewContainer<WkWebView>(Test.WebView.MixedContentDisallowed,
+					mixedContentDisallowedWebView);
+				var mixedContentAllowedContainer = new ViewContainer<WkWebView>(Test.WebView.MixedContentAllowed,
+					mixedContentAllowedWebView);
+
+				Add(mixedContentDisallowedContainer);
+				Add(mixedContentAllowedContainer);
+			}
+
+
+			var jsAlertWebView = new WkWebView
+			{
+				Source = new HtmlWebViewSource
+				{
+					Html = @"<html>
+<head>
+<link rel=""stylesheet"" href=""default.css"">
+</head>
+<body>
+<button onclick=""window.alert('foo');"">Click</button>
+</body>
+</html>"
+				},
+				HeightRequest = 200
+			};
+
+			jsAlertWebView.On<Windows>().SetIsJavaScriptAlertEnabled(true);
+			
+			var javascriptAlertWebSourceContainer = new ViewContainer<WkWebView>(Test.WebView.JavaScriptAlert,
+				jsAlertWebView
+			);
+
+			var evaluateJsWebView = new WkWebView
+			{
+				Source = new UrlWebViewSource { Url = "https://www.google.com/" },
+				HeightRequest = 50
+			};
+			var evaluateJsWebViewSourceContainer = new ViewContainer<WkWebView>(Test.WebView.EvaluateJavaScript,
+				evaluateJsWebView
+			);
+
+			var resultsLabel = new Label();
+			var execButton = new Button();
+			execButton.Text = "Evaluate Javascript";
+			execButton.Command = new Command(async() => resultsLabel.Text = await evaluateJsWebView.EvaluateJavaScriptAsync(
+												"var test = function(){ return 'This string came from Javascript!'; }; test();"));
+
+			evaluateJsWebViewSourceContainer.ContainerLayout.Children.Add(resultsLabel);
+			evaluateJsWebViewSourceContainer.ContainerLayout.Children.Add(execButton);
+
+
+			Add (urlWebViewSourceContainer);
+			Add (htmlWebViewSourceContainer);
+			Add (htmlFileWebSourceContainer);
+			Add (javascriptAlertWebSourceContainer);
+			Add (evaluateJsWebViewSourceContainer);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/CoreGalleryPages/WkWebViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/WkWebViewCoreGalleryPage.cs
@@ -30,7 +30,10 @@ namespace Xamarin.Forms.Controls
 				}
 			);
 
-			const string html = "<html><div class=\"test\"><h2>I am raw html</h2></div></html>";
+			const string html = "<!DOCTYPE html><html>" +
+				"<head><meta name='viewport' content='width=device-width,initial-scale=1.0'></head>" +
+				"<body><div class=\"test\"><h2>I am raw html</h2></div></body></html>";
+
 			var htmlWebViewSourceContainer = new ViewContainer<WkWebView> (Test.WebView.HtmlWebViewSource, 
 				new WkWebView {
 					Source = new HtmlWebViewSource { Html = html },
@@ -41,8 +44,9 @@ namespace Xamarin.Forms.Controls
 			var htmlFileWebSourceContainer = new ViewContainer<WkWebView> (Test.WebView.LoadHtml,
 				new WkWebView {
 					Source = new HtmlWebViewSource { 
-						Html = @"<html>
+						Html = @"<!DOCTYPE html><html>
 <head>
+<meta name='viewport' content='width=device-width,initial-scale=1.0'>
 <link rel=""stylesheet"" href=""default.css"">
 </head>
 <body>
@@ -90,8 +94,9 @@ namespace Xamarin.Forms.Controls
 			{
 				Source = new HtmlWebViewSource
 				{
-					Html = @"<html>
+					Html = @"<!DOCTYPE html><html>
 <head>
+<meta name='viewport' content='width=device-width,initial-scale=1.0'>
 <link rel=""stylesheet"" href=""default.css"">
 </head>
 <body>

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.iOS
 			WebView.GoBackRequested += OnGoBackRequested;
 			WebView.GoForwardRequested += OnGoForwardRequested;
 			WebView.ReloadRequested += OnReloadRequested;
-			NavigationDelegate = new CustomWebViewDelegate(this);
+			NavigationDelegate = new CustomWebViewNavigationDelegate(this);
 			UIDelegate = new CustomWebViewUIDelegate();
 
 			BackgroundColor = UIColor.Clear;
@@ -189,12 +189,12 @@ namespace Xamarin.Forms.Platform.iOS
 			((IWebViewController)WebView).CanGoForward = CanGoForward;
 		}
 
-		class CustomWebViewDelegate : WKNavigationDelegate
+		class CustomWebViewNavigationDelegate : WKNavigationDelegate
 		{
 			readonly WkWebViewRenderer _renderer;
 			WebNavigationEvent _lastEvent;
 
-			public CustomWebViewDelegate(WkWebViewRenderer renderer)
+			public CustomWebViewNavigationDelegate(WkWebViewRenderer renderer)
 			{
 				if (renderer == null)
 					throw new ArgumentNullException("renderer");

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -318,7 +318,7 @@ namespace Xamarin.Forms.Platform.iOS
 				// The scheme and host are used unless local html content is what the webview is displaying,
 				// in which case the bundle file name is used.
 
-				if (webView.Url == null)
+				if (webView.Url != null && webView.Url.AbsoluteString != $"file://{NSBundle.MainBundle.BundlePath}/")
 					return $"{webView.Url.Scheme}://{webView.Url.Host}";
 				
 				return new NSString(NSBundle.MainBundle.BundlePath).LastPathComponent;
@@ -328,6 +328,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var action = UIAlertAction.Create(LocalOK, UIAlertActionStyle.Default, (_) => handler());
 				controller.AddAction(action);
+				controller.PreferredAction = action;
 				return action;
 			}
 
@@ -335,7 +336,6 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var action = UIAlertAction.Create(LocalCancel, UIAlertActionStyle.Cancel, (_) => handler());
 				controller.AddAction(action);
-				controller.PreferredAction = action;
 				return action;
 			}
 


### PR DESCRIPTION
### Description of Change ###
The default renderer for `WebView` on iOS uses `UIWebView`, which handles Javascript-based user dialogs automatically. With `WKWebView`, these dialogs need to be set up manually with a delate.

This will allow users choosing to "upgrade" to `WkWebView` to retain the functionality of any javascript dialogs their web source may be using.

### Issues Resolved ### 
- Fixes #4253

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
Without this change, dialogs created via Javascript in the `WKWebView` would never appear, now they will appear at the same times as they do when using `UIWebView`.

### Testing Procedure ###
Use the repro steps mentioned in #4253 and the updated UI test to ensure the dialogs appear and behave correctly (confirm logs a bool, prompt logs an input string, etc).

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
