### PR TITLE
[iOS] Removed custom entitlements entry for test simulator builds

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -26,7 +26,6 @@
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>True</MtouchDebug>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchProfiling>False</MtouchProfiling>
     <MtouchFastDev>False</MtouchFastDev>
     <MtouchEnableGenericValueTypeSharing>True</MtouchEnableGenericValueTypeSharing>
@@ -51,7 +50,6 @@
     <MtouchLink>None</MtouchLink>
     <MtouchArch>i386, x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">


### PR DESCRIPTION
### Description of Change ###

Removed custom entitlements entry for test simulator builds.
Everybody will be able debug test project easily without necessity to disable it in test project.

### Issues Resolved ### 

Now i can't build project as is.

### API Changes ###
None

### Platforms Affected ### 
- iOS test project

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Remove your iOS provision profile and try to start debugging of Xamarin.Forms.ControlGallery.iOS
