### PR TITLE
[XamlC] Explicitly cast values for ldc.i4

### DIFF
--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -161,17 +161,17 @@ namespace Xamarin.Forms.Build.Tasks
 			if (targetTypeRef.ResolveCached().BaseType != null && targetTypeRef.ResolveCached().BaseType.FullName == "System.Enum")
 				yield return PushParsedEnum(targetTypeRef, str, node);
 			else if (targetTypeRef.FullName == "System.Char")
-				yield return Instruction.Create(OpCodes.Ldc_I4, Char.Parse(str));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)Char.Parse(str)));
 			else if (targetTypeRef.FullName == "System.SByte")
-				yield return Instruction.Create(OpCodes.Ldc_I4, SByte.Parse(str, CultureInfo.InvariantCulture));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)SByte.Parse(str, CultureInfo.InvariantCulture)));
 			else if (targetTypeRef.FullName == "System.Int16")
-				yield return Instruction.Create(OpCodes.Ldc_I4, Int16.Parse(str, CultureInfo.InvariantCulture));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)Int16.Parse(str, CultureInfo.InvariantCulture)));
 			else if (targetTypeRef.FullName == "System.Int32")
 				yield return Instruction.Create(OpCodes.Ldc_I4, Int32.Parse(str, CultureInfo.InvariantCulture));
 			else if (targetTypeRef.FullName == "System.Int64")
 				yield return Instruction.Create(OpCodes.Ldc_I8, Int64.Parse(str, CultureInfo.InvariantCulture));
 			else if (targetTypeRef.FullName == "System.Byte")
-				yield return Instruction.Create(OpCodes.Ldc_I4, Byte.Parse(str, CultureInfo.InvariantCulture));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)Byte.Parse(str, CultureInfo.InvariantCulture)));
 			else if (targetTypeRef.FullName == "System.UInt16")
 				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)UInt16.Parse(str, CultureInfo.InvariantCulture)));
 			else if (targetTypeRef.FullName == "System.UInt32")

--- a/Xamarin.Forms.Xaml.UnitTests/SetValue.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/SetValue.xaml
@@ -83,7 +83,7 @@
 				<d:IgnorableElement />
 			</ContentView.Content>
 		</ContentView>
-		<local:MockViewWithValues x:Name="mockView0" UShort="32" ADecimal="42" />
+		<local:MockViewWithValues x:Name="mockView0" AChar="!" AByte="2" ASByte="-12" AShort="-22" UShort="32" ADecimal="42" />
 		<local:ViewWithEnums x:Name="enums" IntEnum="Foo" ByteEnum="Bar" />
 		<local:MockViewWithValues x:Name="implicit0">
 			<local:MockViewWithValues.BPBar>

--- a/Xamarin.Forms.Xaml.UnitTests/SetValue.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/SetValue.xaml.cs
@@ -16,6 +16,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 	public class MockViewWithValues : View
 	{ 
+		public char AChar { get; set; }
+		public byte AByte { get; set; }
+		public sbyte ASByte { get; set; }
+		public Int16 AShort { get; set; }
 		public UInt16 UShort { get; set; }
 		public decimal ADecimal { get; set; }
 		public SV_Foo Foo { get; set; }
@@ -292,6 +296,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			public void MorePrimitiveTypes(bool useCompiledXaml)
 			{ 
 				var page = new SetValue(useCompiledXaml);
+				Assert.AreEqual('!', page.mockView0.AChar);
+				Assert.AreEqual((byte)2, page.mockView0.AByte);
+				Assert.AreEqual((sbyte)-12, page.mockView0.ASByte);
+				Assert.AreEqual((short)-22, page.mockView0.AShort);
 				Assert.AreEqual((ushort)32, page.mockView0.UShort);
 				Assert.AreEqual((decimal)42, page.mockView0.ADecimal);
 			}


### PR DESCRIPTION
### Description of Change ###

This is a bug fix. Mono.Cecil accepts only `System.Int32` as an operand for `OpCodes.Ldc_I4` and casting is required for this case.

### Issues Resolved ### 

I didn't find any relevant issue.

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Just try to set a `System.Byte` property with XamlC. For example, the following XAML will cause an exception where `Foo.Bar` is a property whose type is `System.Byte`.

```XAML
<Foo Bar="42" />
```

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
