### PR TITLE
WPF - Map - Fix initial load of pins

### DIFF
--- a/Xamarin.Forms.Maps.WPF/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.WPF/MapRenderer.cs
@@ -45,6 +45,8 @@ namespace Xamarin.Forms.Maps.WPF
 				// Suscribe element event
 				MessagingCenter.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", (s, a) => MoveToRegion(a), Element);
 				((ObservableCollection<Pin>)Element.Pins).CollectionChanged += OnCollectionChanged;
+
+				LoadPins();
 			}
 
 			base.OnElementChanged(e);


### PR DESCRIPTION
### Description of Change ###

On WPF, if there are any pins set on the Map, they are not being loaded.

### Platforms Affected ### 
- WPF

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
