### PR TITLE
 [iOS] Clear the delegate from ContextActionCell 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4314.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4314.cs
@@ -13,8 +13,8 @@ namespace Xamarin.Forms.Controls.Issues
 	[Category(UITestCategories.ContextActions)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 4341, "When ListView items is removed and it is empty, Xamarin Forms crash", PlatformAffected.iOS)]
-	public class Issue4341 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	[Issue(IssueTracker.Github, 4314, "When ListView items is removed and it is empty, Xamarin Forms crash", PlatformAffected.iOS)]
+	public class Issue4314 : TestNavigationPage // or TestMasterDetailPage, etc ...
 	{
 		const string Success = "Success";
 #if !UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4314.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4314.cs
@@ -42,10 +42,10 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Issue4341Test() 
 		{
 			RunningApp.WaitForElement(c=> c.Marked("Email"));
-			RunningApp.SwipeRightToLeft("Subject Line 0");
+			RunningApp.ActivateContextMenu("Subject Line 0");
 			RunningApp.WaitForElement("Delete");
 			RunningApp.Tap("Delete");
-			RunningApp.SwipeRightToLeft("Subject Line 1");
+			RunningApp.ActivateContextMenu("Subject Line 1");
 			RunningApp.Tap("Delete");
 			RunningApp.WaitForElement(c=> c.Marked(Success));
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4314.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4314.cs
@@ -48,6 +48,9 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.ActivateContextMenu("Subject Line 1");
 			RunningApp.Tap("Delete");
 			RunningApp.WaitForElement(c=> c.Marked(Success));
+			RunningApp.Back();
+			RunningApp.WaitForElement(c => c.Marked("Email"));
+			RunningApp.SwipeRightToLeft();
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4341.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4341.cs
@@ -1,0 +1,54 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ContextActions)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4341, "When ListView items is removed and it is empty, Xamarin Forms crash", PlatformAffected.iOS)]
+	public class Issue4341 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		const string Success = "Success";
+#if !UITEST
+		MessagesViewModel viewModel;
+		protected override void Init()
+		{
+			var page = new ContextActionsGallery(false, true, 2) { Title = "Swipe and delete both" };
+			viewModel = page.BindingContext as MessagesViewModel;
+			viewModel.Messages.CollectionChanged += (s, e) =>
+			{
+				if (viewModel.Messages.Count == 0)
+				{
+					Navigation.PushAsync(new ContentPage { Title = "Success", Content = new Label { Text = Success } });
+				}
+			};
+			Navigation.PushAsync(page);
+		}
+#else
+		protected override void Init()
+		{
+		}
+#endif
+#if UITEST && __IOS__
+		[Test]
+		public void Issue4341Test() 
+		{
+			RunningApp.WaitForElement(c=> c.Marked("Email"));
+			RunningApp.SwipeRightToLeft("Subject Line 0");
+			RunningApp.WaitForElement("Delete");
+			RunningApp.Tap("Delete");
+			RunningApp.SwipeRightToLeft("Subject Line 1");
+			RunningApp.Tap("Delete");
+			RunningApp.WaitForElement(c=> c.Marked(Success));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -820,6 +820,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3884.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4001.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4138.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4341.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -820,7 +820,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3884.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4001.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4138.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue4341.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4314.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls/GalleryPages/EditableList.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/EditableList.cs
@@ -7,9 +7,9 @@ namespace Xamarin.Forms.Controls
 {
 	internal class MessagesViewModel : ViewModelBase
 	{
-		public MessagesViewModel()
+		public MessagesViewModel(int messagesCount)
 		{
-			Messages = new ObservableCollection<MessageViewModel> (Enumerable.Range (0, 100).Select (i => {
+			Messages = new ObservableCollection<MessageViewModel> (Enumerable.Range (0, messagesCount).Select (i => {
 				return new MessageViewModel { Subject = "Subject Line " + i, MessagePreview = "Lorem ipsum dolorem monkeys bonkers " + i };
 			}));
 
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Controls
 	}
 
 	[Preserve (AllMembers = true)]
-	internal class MessageViewModel : ViewModelBase
+	public class MessageViewModel : ViewModelBase
 	{
 		public MessageViewModel()
 		{
@@ -86,13 +86,16 @@ namespace Xamarin.Forms.Controls
 			}
 		}
 
-		public ContextActionsGallery (bool tableView = false)
+		public ContextActionsGallery (bool tableView = false, bool hasUnevenRows = false, int messagesCount = 100)
 		{
-			BindingContext = new MessagesViewModel();
+			BindingContext = new MessagesViewModel(messagesCount);
 
 			View list;
 			if (!tableView) {
-				list = new ListView();
+				list = new ListView
+				{
+					HasUnevenRows = hasUnevenRows
+				};
 				list.SetBinding (ListView.ItemsSourceProperty, "Messages");
 				((ListView)list).ItemTemplate = new DataTemplate (typeof (MessageCell));
 			} else {

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -276,6 +276,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_scroller != null)
 				{
+					_scroller.Delegate = null;
 					_scroller.Dispose();
 					_scroller = null;
 				}


### PR DESCRIPTION
### Description of Change ###

Clear the global closer delegate from ContextActionCell when disposing. 

### Issues Resolved ### 

- fixes #4314 

### API Changes ###

 None

### Platforms Affected ### 

- iOS
### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Use issue 4314 gallery page.
Swipe the 2 cell to reveal content actions and delete both items. 
Should go the other page without crash

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard