### PR TITLE
[XamlC] resolve properties in base interfaces

### DIFF
--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -68,6 +68,15 @@ namespace Xamarin.Forms.Build.Tasks
 			var properties = typeDef.Properties.Where(predicate);
 			if (properties.Any())
 				return properties.Single();
+			if (typeDef.IsInterface) {
+				foreach (var face in typeDef.Interfaces) {
+					var p = face.InterfaceType.GetProperty(predicate, out var interfaceDeclaringTypeRef);
+					if (p != null) {
+						declaringTypeRef = interfaceDeclaringTypeRef;
+						return p;
+					}
+				}
+			}
 			if (typeDef.BaseType == null || typeDef.BaseType.FullName == "System.Object")
 				return null;
 			return typeDef.BaseType.ResolveGenericParameters(typeRef).GetProperty(predicate, out declaringTypeRef);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4227.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4227.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+			 x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4227"
+			 x:DataType="local:IGh4227Level1">
+	<StackLayout>
+		<Label x:Name="label0" Text="{Binding Level0}"/>
+		<Label x:Name="label1" Text="{Binding Level1}"/>
+	</StackLayout>
+</ContentPage>
+

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4227.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4227.xaml.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public interface IGh4227Level0
+	{
+		string Level0 { get; }
+	}
+
+	public interface IGh4227Level1 : IGh4227Level0
+	{
+		string Level1 { get; }
+	}
+
+	public class Gh4227VM : IGh4227Level1
+	{
+		public string Level0 => "level0";
+		public string Level1 => "level1";
+	}
+
+	public partial class Gh4227 : ContentPage
+	{
+		public Gh4227()
+		{
+			InitializeComponent();
+		}
+
+		public Gh4227(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void FindMemberOnInterfaces(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh4227)));
+				var layout = new Gh4227(useCompiledXaml) { BindingContext = new Gh4227VM()};
+				Assert.That(layout.label0.Text, Is.EqualTo("level0"));
+				Assert.That(layout.label1.Text, Is.EqualTo("level1"));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -658,6 +658,9 @@
     <Compile Include="Issues\Gh4215.xaml.cs">
       <DependentUpon>Gh4215.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh4227.xaml.cs">
+      <DependentUpon>Gh4227.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
@@ -1211,6 +1214,10 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh4215.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh4227.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>


### PR DESCRIPTION
### Description of Change ###

[XamlC] resolve properties in base interfaces

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4227

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
