### PR TITLE
[XamlC] allow internal for x:Static

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4326.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4326.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+			 x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4326">
+    <StackLayout>
+        <Label x:Name="labelfoo" Text="{x:Static local:Gh4326.Foo}" />
+        <Label x:Name="labelbar" Text="{x:Static local:Gh4326.Bar}" />
+		<Label x:Name="labelinternalvisibleto" Text="{x:Static Style.StyleClassPrefix}" />
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4326.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4326.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh4326 : ContentPage
+	{
+		public static string Foo = "Foo";
+		internal static string Bar = "Bar";
+
+		public Gh4326()
+		{
+			InitializeComponent();
+		}
+
+		public Gh4326(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void FindStaticInternal(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh4326)));
+				var layout = new Gh4326(useCompiledXaml);
+
+				Assert.That(layout.labelfoo.Text, Is.EqualTo("Foo"));
+				Assert.That(layout.labelbar.Text, Is.EqualTo("Bar"));
+				Assert.That(layout.labelinternalvisibleto.Text, Is.EqualTo(Style.StyleClassPrefix));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -661,6 +661,9 @@
     <Compile Include="Issues\Gh4227.xaml.cs">
       <DependentUpon>Gh4227.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh4326.xaml.cs">
+      <DependentUpon>Gh4326.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
@@ -1218,6 +1221,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh4227.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh4326.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>


### PR DESCRIPTION
### Description of Change ###

[XamlC] accept internal for x:Static

### Issues Resolved ### 

- fixes #4326

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
