### PR TITLE
[Android] fixes Picker list showing up incorrectly when focus is set on other controls

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 4187, "Picker list shows up, when focus is set on other controls", PlatformAffected.Android)]
+	public class Issue4187 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var items = new List<Issue4187Model>
+			{
+				new Issue4187Model
+				{
+					Label = "Label 1",
+					PickerSource = new List<string> {"Flower", "Harvest", "Propagation", "Vegetation"},
+					Text = "Text 1"
+				},
+				new Issue4187Model
+				{
+					Label = "Label 2",
+					PickerSource = new List<string> {"1", "2", "3", "4"},
+					Text = "Text 2"
+				}
+			};
+			var listView = new ListView
+			{
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				HasUnevenRows = true,
+				ItemsSource = items,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label() { Text = "Status" };
+					label.SetBinding(Label.TextProperty, new Binding(nameof(Issue4187Model.Label)));
+					var picker = new Picker();
+					picker.SetBinding(Picker.ItemsSourceProperty, new Binding(nameof(Issue4187Model.PickerSource)));
+					var entry = new Entry()
+					{
+						BackgroundColor = Color.Aqua
+					};
+					entry.SetBinding(Entry.TextProperty, new Binding(nameof(Issue4187Model.Text)));
+					return new ViewCell
+					{
+						View = new StackLayout
+						{
+							Children = {
+								label,
+								picker,
+								new DatePicker(),
+								new TimePicker(),
+								entry
+							}
+						}
+					};
+				})
+			};
+
+			Content = new StackLayout()
+			{
+				Children = {
+					listView
+				}
+			};
+		}
+
+		[Preserve(AllMembers = true)]
+		class Issue4187Model
+		{
+			public string Label { get; set; }
+			public List<string> PickerSource { get; set; }
+			public string Text { get; set; }
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
@@ -21,13 +22,15 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					Label = "Label 1",
 					PickerSource = new List<string> {"Flower", "Harvest", "Propagation", "Vegetation"},
-					Text = "Text 1"
+					Text = "Text 1",
+					Date = DateTime.Now
 				},
 				new Issue4187Model
 				{
 					Label = "Label 2",
 					PickerSource = new List<string> {"1", "2", "3", "4"},
-					Text = "Text 2"
+					Text = "Text 2",
+					Date = DateTime.Now.AddDays(1)
 				}
 			};
 			var listView = new ListView
@@ -37,27 +40,30 @@ namespace Xamarin.Forms.Controls.Issues
 				ItemsSource = items,
 				ItemTemplate = new DataTemplate(() =>
 				{
-					var label = new Label { Text = "Status" };
-					label.SetBinding(Label.TextProperty, new Binding(nameof(Issue4187Model.Label)));
-					var picker = new Picker();
-					picker.SetBinding(Picker.ItemsSourceProperty, new Binding(nameof(Issue4187Model.PickerSource)));
-					var entry = new Entry();
-					entry.SetBinding(Entry.TextProperty, new Binding(nameof(Issue4187Model.Text)));
-
-					return new ViewCell
-					{
-						View = new StackLayout
-						{
-							Children = {
-								label,
-								picker,
-								new DatePicker(),
-								new TimePicker(),
-								entry
-							}
-						}
-					};
+					return GetViewCell();
 				})
+			};
+
+			var tableView = new TableView
+			{
+				BackgroundColor = Color.Wheat,
+				HasUnevenRows = true,
+				RowHeight = 100
+			};
+			tableView.Root = new TableRoot
+			{
+				new TableSection
+				{
+					GetViewCell(),
+					GetViewCell(),
+				}
+			};
+			tableView.BindingContext = new Issue4187Model
+			{
+				Label = "Label 1",
+				PickerSource = new List<string> { "Flower", "Harvest", "Propagation", "Vegetation" },
+				Text = "Text 1",
+				Date = DateTime.Now
 			};
 
 			Children.Add(new ContentPage
@@ -76,7 +82,7 @@ namespace Xamarin.Forms.Controls.Issues
 				BackgroundColor = Color.Red,
 				Content = new StackLayout
 				{
-					Children = { GenerateNewPicker() }
+					Children = { GenerateNewPicker(), tableView }
 				}
 			});
 
@@ -88,6 +94,35 @@ namespace Xamarin.Forms.Controls.Issues
 					Children = { GenerateNewPicker() }
 				}
 			});
+		}
+
+		static ViewCell GetViewCell()
+		{
+			var label = new Label { Text = "Status" };
+			label.SetBinding(Label.TextProperty, new Binding(nameof(Issue4187Model.Label)));
+			var picker = new Picker();
+			picker.SetBinding(Picker.ItemsSourceProperty, new Binding(nameof(Issue4187Model.PickerSource)));
+
+			var datePicker = new DatePicker();
+			datePicker.SetBinding(DatePicker.DateProperty, new Binding(nameof(Issue4187Model.Date)));
+
+			var entry = new Entry();
+			entry.SetBinding(Entry.TextProperty, new Binding(nameof(Issue4187Model.Text)));
+
+			return new ViewCell
+			{
+				View = new StackLayout
+				{
+					BackgroundColor = Color.Pink,
+					Children = {
+								label,
+								picker,
+								datePicker,
+								new TimePicker(),
+								entry
+							}
+				}
+			};
 		}
 
 		Picker GenerateNewPicker()
@@ -104,6 +139,7 @@ namespace Xamarin.Forms.Controls.Issues
 			public string Label { get; set; }
 			public List<string> PickerSource { get; set; }
 			public string Text { get; set; }
+			public DateTime Date { get; set; }
 		}
 
 #if UITEST && __ANDROID__

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
@@ -38,10 +38,7 @@ namespace Xamarin.Forms.Controls.Issues
 				VerticalOptions = LayoutOptions.FillAndExpand,
 				HasUnevenRows = true,
 				ItemsSource = items,
-				ItemTemplate = new DataTemplate(() =>
-				{
-					return GetViewCell();
-				})
+				ItemTemplate = new DataTemplate(() => GetViewCell())
 			};
 
 			var tableView = new TableView
@@ -115,12 +112,12 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					BackgroundColor = Color.Pink,
 					Children = {
-								label,
-								picker,
-								datePicker,
-								new TimePicker(),
-								entry
-							}
+						label,
+						picker,
+						datePicker,
+						new TimePicker(),
+						entry
+					}
 				}
 			};
 		}
@@ -191,7 +188,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				if (layout.Rect.X > 0 && layout.Rect.Y > 0 && layout.Description.Contains(@"id/content"))
 				{
-					// tap on close button
+					// close dialog
 					RunningApp.Back();
 					Thread.Sleep(1500);
 					return true;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
@@ -1,12 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+#if UITEST
+using NUnit.Framework;
+#endif
+
 namespace Xamarin.Forms.Controls
 {
-	[Preserve (AllMembers=true)]
-	[Issue (IssueTracker.Github, 4187, "Picker list shows up, when focus is set on other controls", PlatformAffected.Android)]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4187, "Picker list shows up, when focus is set on other controls", PlatformAffected.Android)]
 	public class Issue4187 : TestContentPage
 	{
 		protected override void Init()
@@ -33,15 +36,13 @@ namespace Xamarin.Forms.Controls
 				ItemsSource = items,
 				ItemTemplate = new DataTemplate(() =>
 				{
-					var label = new Label() { Text = "Status" };
+					var label = new Label { Text = "Status" };
 					label.SetBinding(Label.TextProperty, new Binding(nameof(Issue4187Model.Label)));
 					var picker = new Picker();
 					picker.SetBinding(Picker.ItemsSourceProperty, new Binding(nameof(Issue4187Model.PickerSource)));
-					var entry = new Entry()
-					{
-						BackgroundColor = Color.Aqua
-					};
+					var entry = new Entry();
 					entry.SetBinding(Entry.TextProperty, new Binding(nameof(Issue4187Model.Text)));
+
 					return new ViewCell
 					{
 						View = new StackLayout
@@ -73,5 +74,44 @@ namespace Xamarin.Forms.Controls
 			public List<string> PickerSource { get; set; }
 			public string Text { get; set; }
 		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void Issue4187Test()
+		{
+			void TapOnPicker(int index)
+			{
+				var picker = RunningApp.Query(q => q.TextField().Class("PickerEditText"))[index];
+				var location = picker.Rect;
+				RunningApp.TapCoordinates(location.X + 10, location.Y + location.Height / 2);
+			}
+
+			bool DialogIsOpened()
+			{
+				var frameLayouts = RunningApp.Query(q => q.Class("FrameLayout"));
+				foreach (var layout in frameLayouts)
+				{
+					if (layout.Rect.X > 0 && layout.Rect.Y > 0 && layout.Description.Contains(@"id/content"))
+					{
+						// tap on close button
+						RunningApp.Tap(q => q.Button().Id("button2"));
+						return true;
+					}
+				}
+				return false;
+			}
+
+			RunningApp.WaitForElement("Text 1");
+			Assert.AreEqual(6, RunningApp.Query(q => q.TextField().Class("PickerEditText")).Length);
+			TapOnPicker(0);
+			Assert.IsTrue(DialogIsOpened());
+			RunningApp.Tap("Text 2");
+			Assert.IsFalse(DialogIsOpened());
+			TapOnPicker(3);
+			Assert.IsTrue(DialogIsOpened());
+			RunningApp.Tap("Text 1");
+			Assert.IsFalse(DialogIsOpened());
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
@@ -93,7 +93,7 @@ namespace Xamarin.Forms.Controls.Issues
 		Picker GenerateNewPicker()
 		{
 			var picker = new Picker();
-			for (int i = 1; i < 10; i++)
+			for (int i = 1; i < 100; i++)
 				picker.Items.Add($"item {i}");
 			return picker;
 		}
@@ -111,31 +111,31 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Issue4187Test()
 		{
 			RunningApp.WaitForElement("Text 1");
-			Assert.AreEqual(7, RunningApp.Query(q => q.TextField().Class("PickerEditText")).Length);
+			Assert.AreEqual(7, RunningApp.Query(q => q.TextField().Class("PickerEditText")).Length, "picker count");
 			TapOnPicker(1);
-			Assert.IsTrue(DialogIsOpened());
+			Assert.IsTrue(DialogIsOpened(), "#1");
 			RunningApp.Tap("Text 2");
-			Assert.IsFalse(DialogIsOpened());
+			Assert.IsFalse(DialogIsOpened(), "#2");
 			TapOnPicker(3);
-			Assert.IsTrue(DialogIsOpened());
+			Assert.IsTrue(DialogIsOpened(), "#3");
 			RunningApp.Tap("Text 1");
-			Assert.IsFalse(DialogIsOpened());
+			Assert.IsFalse(DialogIsOpened(), "#5");
 
 			// Carousel - first page
 			TapOnPicker(0);
-			Assert.IsTrue(DialogIsOpened());
+			Assert.IsTrue(DialogIsOpened(), "Carousel - #1");
 
 			// Red page
 			RunningApp.SwipeRightToLeft();
-			Assert.IsFalse(DialogIsOpened());
+			Assert.IsFalse(DialogIsOpened(), "Carousel - #2");
 			TapOnPicker(0);
-			Assert.IsTrue(DialogIsOpened());
+			Assert.IsTrue(DialogIsOpened(), "Carousel - #3");
 
 			// Blue page
 			RunningApp.SwipeRightToLeft();
-			Assert.IsFalse(DialogIsOpened());
+			Assert.IsFalse(DialogIsOpened(), "Carousel - #4");
 			TapOnPicker(0);
-			Assert.IsTrue(DialogIsOpened());
+			Assert.IsTrue(DialogIsOpened(), "Carousel - #5");
 		}
 
 		void TapOnPicker(int index)
@@ -154,7 +154,7 @@ namespace Xamarin.Forms.Controls.Issues
 				if (layout.Rect.X > 0 && layout.Rect.Y > 0 && layout.Description.Contains(@"id/content"))
 				{
 					// tap on close button
-					RunningApp.Tap(q => q.Button().Id("button2"));
+					RunningApp.Tap(q => q.Button());
 					Thread.Sleep(1500);
 					return true;
 				}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using System.Threading;
 #endif
 
-namespace Xamarin.Forms.Controls
+namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 4187, "Picker list shows up, when focus is set on other controls", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
@@ -122,6 +122,8 @@ namespace Xamarin.Forms.Controls.Issues
 			Assert.IsFalse(DialogIsOpened(), "#5");
 
 			// Carousel - first page
+			RunningApp.Back();
+			RunningApp.ScrollUp();
 			TapOnPicker(0);
 			Assert.IsTrue(DialogIsOpened(), "Carousel - #1");
 
@@ -154,7 +156,7 @@ namespace Xamarin.Forms.Controls.Issues
 				if (layout.Rect.X > 0 && layout.Rect.Y > 0 && layout.Description.Contains(@"id/content"))
 				{
 					// tap on close button
-					RunningApp.Tap(q => q.Button());
+					RunningApp.Back();
 					Thread.Sleep(1500);
 					return true;
 				}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -516,6 +516,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1236.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1259.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1267.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4187.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1305.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1329.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1384.cs" />

--- a/Xamarin.Forms.Controls/GalleryPages/CarouselPageGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CarouselPageGallery.cs
@@ -44,7 +44,8 @@ namespace Xamarin.Forms.Controls
 				Content = new StackLayout {
 					Children = {
 						pageOneLabel,
-						pageOneButton
+						pageOneButton,
+						CreatePicker()
 					}
 				}
 			});
@@ -55,7 +56,8 @@ namespace Xamarin.Forms.Controls
 				Content = new StackLayout {
 					Children = {
 						pageTwoLabel,
-						pageTwoButton
+						pageTwoButton,
+						CreatePicker()
 					}
 				}
 			});
@@ -66,10 +68,19 @@ namespace Xamarin.Forms.Controls
 				Content = new StackLayout {
 					Children = {
 						pageThreeLabel,
-						pageThreeButton
+						pageThreeButton,
+						CreatePicker()
 					}
 				}
 			});
+		}
+
+		Picker CreatePicker()
+		{
+			var picker = new Picker();
+			for (int i = 1; i < 10; i++)
+				picker.Items.Add($"item {i}");
+			return picker;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CarouselPageGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CarouselPageGallery.cs
@@ -44,8 +44,7 @@ namespace Xamarin.Forms.Controls
 				Content = new StackLayout {
 					Children = {
 						pageOneLabel,
-						pageOneButton,
-						CreatePicker()
+						pageOneButton
 					}
 				}
 			});
@@ -56,8 +55,7 @@ namespace Xamarin.Forms.Controls
 				Content = new StackLayout {
 					Children = {
 						pageTwoLabel,
-						pageTwoButton,
-						CreatePicker()
+						pageTwoButton
 					}
 				}
 			});
@@ -68,19 +66,10 @@ namespace Xamarin.Forms.Controls
 				Content = new StackLayout {
 					Children = {
 						pageThreeLabel,
-						pageThreeButton,
-						CreatePicker()
+						pageThreeButton
 					}
 				}
 			});
-		}
-
-		Picker CreatePicker()
-		{
-			var picker = new Picker();
-			for (int i = 1; i < 10; i++)
-				picker.Items.Add($"item {i}");
-			return picker;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -1,29 +1,18 @@
 using Android.App;
-using Android.Content.Res;
-using Android.Text;
 using Android.Util;
-using Android.Widget;
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using Android.Content;
-using Object = Java.Lang.Object;
-using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
-using System.Collections.Generic;
-using Android.Views;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
-	public class PickerRenderer : ViewRenderer<Picker, EditText>
+	public class PickerRenderer : ViewRenderer<Picker, PickerEditText>, IPickerRenderer
 	{
 		AlertDialog _dialog;
 		bool _disposed;
 		TextColorSwitcher _textColorSwitcher;
-
-		HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
-			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
-		});
 
 		public PickerRenderer(Context context) : base(context)
 		{
@@ -36,9 +25,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AutoPackage = false;
 		}
 
-		protected override EditText CreateNativeControl()
+		protected override PickerEditText CreateNativeControl()
 		{
-			return new EditText(Context);
+			return new PickerEditText(Context, this);
 		}
 
 		protected override void Dispose(bool disposing)
@@ -63,17 +52,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				((INotifyCollectionChanged)e.NewElement.Items).CollectionChanged += RowsCollectionChanged;
 				if (Control == null)
 				{
-					EditText textField = CreateNativeControl();
-					textField.Focusable = true;
-					textField.Clickable = true;
-					textField.Tag = this;
-					textField.InputType = InputTypes.Null;
-					textField.KeyPress += TextFieldKeyPress;
-					textField.SetOnClickListener(PickerListener.Instance);
+					var textField = CreateNativeControl();
 
 					var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors, useLegacyColorManagement);
-					
+
 					SetNativeControl(textField);
 				}
 				UpdateFont();
@@ -82,24 +65,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 
 			base.OnElementChanged(e);
-		}
-
-		void TextFieldKeyPress(object sender, KeyEventArgs e)
-		{
-			if (availableKeys.Contains(e.KeyCode))
-			{
-				e.Handled = false;
-				return;
-			}
-			e.Handled = true;
-			OnClick();
-		}
-
-		internal override void OnNativeFocusChanged(bool hasFocus)
-		{
-			base.OnNativeFocusChanged(hasFocus);
-			if (hasFocus)
-				OnClick();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -121,7 +86,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			base.OnFocusChangeRequested(sender, e);
 
 			if (e.Focus)
-				OnClick();
+				CallOnClick();
 			else if (_dialog != null)
 			{
 				_dialog.Hide();
@@ -131,7 +96,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 
-		void OnClick()
+		void IPickerRenderer.OnClick()
 		{
 			Picker model = Element;
 			if (_dialog == null)
@@ -143,7 +108,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					builder.SetItems(items, (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
 
 					builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) => { });
-					
+
 					((IElementController)Element).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 
 					_dialog = builder.Create();
@@ -184,21 +149,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdateTextColor()
 		{
 			_textColorSwitcher?.UpdateTextColor(Control, Element.TextColor);
-		}
-
-		class PickerListener : Object, IOnClickListener
-		{
-			#region Statics
-
-			public static readonly PickerListener Instance = new PickerListener();
-
-			#endregion
-
-			public void OnClick(global::Android.Views.View v)
-			{
-				var renderer = v.Tag as PickerRenderer;
-				renderer?.OnClick();
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -5,10 +5,11 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using Android.Content;
+using Android.Widget;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
-	public class PickerRenderer : ViewRenderer<Picker, PickerEditText>, IPickerRenderer
+	public class PickerRenderer : ViewRenderer<Picker, EditText>, IPickerRenderer
 	{
 		AlertDialog _dialog;
 		bool _disposed;
@@ -25,7 +26,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AutoPackage = false;
 		}
 
-		protected override PickerEditText CreateNativeControl()
+		protected override EditText CreateNativeControl()
 		{
 			return new PickerEditText(Context, this);
 		}

--- a/Xamarin.Forms.Platform.Android/IPickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/IPickerRenderer.cs
@@ -1,0 +1,7 @@
+namespace Xamarin.Forms.Platform.Android
+{
+	public interface IPickerRenderer
+	{
+		void OnClick();
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -1,28 +1,16 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using Android.App;
 using Android.Content;
-using Android.Content.Res;
-using Android.Text;
 using Android.Util;
-using Android.Views;
-using Android.Widget;
-using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
-using AView = Android.Views.View;
-using Object = Java.Lang.Object;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class DatePickerRenderer : ViewRenderer<DatePicker, EditText>
+	public class DatePickerRenderer : ViewRenderer<DatePicker, PickerEditText>, IPickerRenderer
 	{
 		DatePickerDialog _dialog;
 		bool _disposed;
 		TextColorSwitcher _textColorSwitcher;
-
-		HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
-			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
-		});
 
 		public DatePickerRenderer(Context context) : base(context)
 		{
@@ -60,9 +48,9 @@ namespace Xamarin.Forms.Platform.Android
 			base.Dispose(disposing);
 		}
 
-		protected override EditText CreateNativeControl()
+		protected override PickerEditText CreateNativeControl()
 		{
-			return new EditText(Context) { Focusable = true, Clickable = true, Tag = this };
+			return new PickerEditText(Context, this);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<DatePicker> e)
@@ -73,9 +61,6 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				var textField = CreateNativeControl();
 
-				textField.SetOnClickListener(TextFieldClickHandler.Instance);
-				textField.InputType = InputTypes.Null;
-				textField.KeyPress += TextFieldKeyPress;
 				SetNativeControl(textField);
 
 				var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
@@ -88,24 +73,6 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateMinimumDate();
 			UpdateMaximumDate();
 			UpdateTextColor();
-		}
-
-		void TextFieldKeyPress(object sender, KeyEventArgs e)
-		{
-			if (availableKeys.Contains(e.KeyCode))
-			{
-				e.Handled = false;
-				return;
-			}
-			e.Handled = true;
-			OnTextFieldClicked();
-		}
-
-		internal override void OnNativeFocusChanged(bool hasFocus)
-		{
-			base.OnNativeFocusChanged(hasFocus);
-			if (hasFocus)
-				OnTextFieldClicked();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -129,7 +96,7 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnFocusChangeRequested(sender, e);
 
 			if (e.Focus)
-				OnTextFieldClicked();
+				CallOnClick();
 			else if (_dialog != null)
 			{
 				_dialog.Hide();
@@ -168,7 +135,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		void OnTextFieldClicked()
+		void IPickerRenderer.OnClick()
 		{
 			if (_dialog != null && _dialog.IsShowing)
 			{
@@ -224,16 +191,6 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateTextColor()
 		{
 			_textColorSwitcher?.UpdateTextColor(Control, Element.TextColor);
-		}
-
-		class TextFieldClickHandler : Object, IOnClickListener
-		{
-			public static readonly TextFieldClickHandler Instance = new TextFieldClickHandler();
-
-			public void OnClick(AView v)
-			{
-				((DatePickerRenderer)v.Tag).OnTextFieldClicked();
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -3,10 +3,11 @@ using System.ComponentModel;
 using Android.App;
 using Android.Content;
 using Android.Util;
+using Android.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class DatePickerRenderer : ViewRenderer<DatePicker, PickerEditText>, IPickerRenderer
+	public class DatePickerRenderer : ViewRenderer<DatePicker, EditText>, IPickerRenderer
 	{
 		DatePickerDialog _dialog;
 		bool _disposed;
@@ -48,7 +49,7 @@ namespace Xamarin.Forms.Platform.Android
 			base.Dispose(disposing);
 		}
 
-		protected override PickerEditText CreateNativeControl()
+		protected override EditText CreateNativeControl()
 		{
 			return new PickerEditText(Context, this);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
@@ -1,0 +1,58 @@
+using Android.Content;
+using Android.Views;
+using Android.Widget;
+using Android.Text;
+using Java.Lang;
+using System.Collections.Generic;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	public class PickerEditText : EditText
+	{
+		HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
+			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
+		});
+
+		readonly IPickerRenderer owner;
+
+		public PickerEditText(Context context, IPickerRenderer pickerRenderer) : base(context)
+		{
+			Focusable = true;
+			Clickable = true;
+			InputType = InputTypes.Null;
+			KeyPress += OnKeyPress;
+			owner = pickerRenderer;
+			SetOnClickListener(PickerListener.Instance);
+		}
+
+		private void OnKeyPress(object sender, KeyEventArgs e)
+		{
+			if (availableKeys.Contains(e.KeyCode))
+			{
+				e.Handled = false;
+				return;
+			}
+			e.Handled = true;
+			CallOnClick();
+		}
+
+		public override bool OnTouchEvent(MotionEvent e)
+		{
+			if (e.Action == MotionEventActions.Up && !IsFocused)
+				RequestFocus();
+			return base.OnTouchEvent(e); // raises the OnClick event if focus is already received
+		}
+
+		class PickerListener : Object, IOnClickListener
+		{
+			#region Statics
+			public static readonly PickerListener Instance = new PickerListener();
+			#endregion
+
+			public void OnClick(global::Android.Views.View v)
+			{
+				(v as PickerEditText)?.owner.OnClick();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
@@ -4,16 +4,20 @@ using Android.Widget;
 using Android.Text;
 using Java.Lang;
 using System.Collections.Generic;
+using Android.Graphics;
+using Android.Runtime;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	public class PickerEditText : EditText
 	{
-		HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
+		readonly static HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
 			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
 		});
 
-		readonly IPickerRenderer owner;
+		System.WeakReference<IPickerRenderer> rendererRef;
+
+		internal bool FromFocusSearch;
 
 		public PickerEditText(Context context, IPickerRenderer pickerRenderer) : base(context)
 		{
@@ -21,11 +25,19 @@ namespace Xamarin.Forms.Platform.Android
 			Clickable = true;
 			InputType = InputTypes.Null;
 			KeyPress += OnKeyPress;
-			owner = pickerRenderer;
+			rendererRef = new System.WeakReference<IPickerRenderer>(pickerRenderer);
 			SetOnClickListener(PickerListener.Instance);
 		}
 
-		private void OnKeyPress(object sender, KeyEventArgs e)
+		protected override void OnFocusChanged(bool gainFocus, [GeneratedEnum] FocusSearchDirection direction, Rect previouslyFocusedRect)
+		{
+			base.OnFocusChanged(gainFocus, direction, previouslyFocusedRect);
+			if (gainFocus && FromFocusSearch)
+				CallOnClick();
+			FromFocusSearch = false;
+		}
+
+		void OnKeyPress(object sender, KeyEventArgs e)
 		{
 			if (availableKeys.Contains(e.KeyCode))
 			{
@@ -43,15 +55,27 @@ namespace Xamarin.Forms.Platform.Android
 			return base.OnTouchEvent(e); // raises the OnClick event if focus is already received
 		}
 
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				KeyPress -= OnKeyPress;
+				rendererRef = null;
+			}
+			base.Dispose(disposing);
+		}
+
 		class PickerListener : Object, IOnClickListener
 		{
-			#region Statics
 			public static readonly PickerListener Instance = new PickerListener();
-			#endregion
 
 			public void OnClick(global::Android.Views.View v)
 			{
-				(v as PickerEditText)?.owner.OnClick();
+				if (v is PickerEditText picker)
+				{
+					picker.rendererRef.TryGetTarget(out IPickerRenderer renderer);
+					renderer?.OnClick();
+				}
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -1,5 +1,4 @@
 using Android.App;
-using Android.Content.Res;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
@@ -7,26 +6,16 @@ using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
-using ADatePicker = Android.Widget.DatePicker;
-using ATimePicker = Android.Widget.TimePicker;
-using Object = Java.Lang.Object;
 using Orientation = Android.Widget.Orientation;
 using Android.Content;
-using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
-using System.Collections.Generic;
-using Android.Text;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class PickerRenderer : ViewRenderer<Picker, EditText>
+	public class PickerRenderer : ViewRenderer<Picker, PickerEditText>, IPickerRenderer
 	{
 		AlertDialog _dialog;
 		bool _isDisposed;
 		TextColorSwitcher _textColorSwitcher;
-
-		HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
-			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
-		});
 
 		public PickerRenderer(Context context) : base(context)
 		{
@@ -52,9 +41,9 @@ namespace Xamarin.Forms.Platform.Android
 			base.Dispose(disposing);
 		}
 
-		protected override EditText CreateNativeControl()
+		protected override PickerEditText CreateNativeControl()
 		{
-			return new EditText(Context) { Focusable = true, Clickable = true, Tag = this };
+			return new PickerEditText(Context, this);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
@@ -68,40 +57,19 @@ namespace Xamarin.Forms.Platform.Android
 				if (Control == null)
 				{
 					var textField = CreateNativeControl();
-					textField.SetOnClickListener(PickerListener.Instance);
-					textField.InputType = InputTypes.Null;
-					textField.KeyPress += TextFieldKeyPress;
 
 					var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors, useLegacyColorManagement);
 
 					SetNativeControl(textField);
 				}
-				
+
 				UpdateFont();
 				UpdatePicker();
 				UpdateTextColor();
 			}
 
 			base.OnElementChanged(e);
-		}
-
-		void TextFieldKeyPress(object sender, KeyEventArgs e)
-		{
-			if (availableKeys.Contains(e.KeyCode))
-			{
-				e.Handled = false;
-				return;
-			}
-			e.Handled = true;
-			OnClick();
-		}
-
-		internal override void OnNativeFocusChanged(bool hasFocus)
-		{
-			base.OnNativeFocusChanged(hasFocus);
-			if (hasFocus)
-				OnClick();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -123,7 +91,7 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnFocusChangeRequested(sender, e);
 
 			if (e.Focus)
-				OnClick();
+				CallOnClick();
 			else if (_dialog != null)
 			{
 				_dialog.Hide();
@@ -132,7 +100,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		void OnClick()
+		void IPickerRenderer.OnClick()
 		{
 			Picker model = Element;
 
@@ -211,20 +179,6 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateTextColor()
 		{
 			_textColorSwitcher?.UpdateTextColor(Control, Element.TextColor);
-		}
-
-		class PickerListener : Object, IOnClickListener
-		{
-			public static readonly PickerListener Instance = new PickerListener();
-
-			public void OnClick(global::Android.Views.View v)
-			{
-				var renderer = v.Tag as PickerRenderer;
-				if (renderer == null)
-					return;
-
-				renderer.OnClick();
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -11,7 +11,7 @@ using Android.Content;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class PickerRenderer : ViewRenderer<Picker, PickerEditText>, IPickerRenderer
+	public class PickerRenderer : ViewRenderer<Picker, EditText>, IPickerRenderer
 	{
 		AlertDialog _dialog;
 		bool _isDisposed;
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Platform.Android
 			base.Dispose(disposing);
 		}
 
-		protected override PickerEditText CreateNativeControl()
+		protected override EditText CreateNativeControl()
 		{
 			return new PickerEditText(Context, this);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -3,27 +3,16 @@ using System.ComponentModel;
 using Android.App;
 using Android.Content;
 using Android.Util;
-using Android.Widget;
 using Android.Text.Format;
 using ATimePicker = Android.Widget.TimePicker;
-using Object = Java.Lang.Object;
-using AView = Android.Views.View;
 using Android.OS;
-using Android.Views;
-using System.Collections.Generic;
-using Android.Text;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class TimePickerRenderer : ViewRenderer<TimePicker, EditText>, TimePickerDialog.IOnTimeSetListener
+	public class TimePickerRenderer : ViewRenderer<TimePicker, PickerEditText>, TimePickerDialog.IOnTimeSetListener, IPickerRenderer
 	{
 		AlertDialog _dialog;
 		TextColorSwitcher _textColorSwitcher;
-		 
-
-		HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
-			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
-		});
 
 		bool Is24HourView
 		{
@@ -55,9 +44,9 @@ namespace Xamarin.Forms.Platform.Android
 			_dialog = null;
 		}
 
-		protected override EditText CreateNativeControl()
+		protected override PickerEditText CreateNativeControl()
 		{
-			return new EditText(Context) { Focusable = true, Clickable = true, Tag = this };
+			return new PickerEditText(Context, this);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<TimePicker> e)
@@ -68,9 +57,6 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				var textField = CreateNativeControl();
 
-				textField.SetOnClickListener(TimePickerListener.Instance);
-				textField.InputType = InputTypes.Null;
-				textField.KeyPress += TextFieldKeyPress;
 				SetNativeControl(textField);
 
 				var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
@@ -83,24 +69,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			if ((int)Build.VERSION.SdkInt > 16)
 				Control.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
-		}
-
-		void TextFieldKeyPress(object sender, KeyEventArgs e)
-		{
-			if (availableKeys.Contains(e.KeyCode))
-			{
-				e.Handled = false;
-				return;
-			}
-			e.Handled = true;
-			OnClick();
-		}
-
-		internal override void OnNativeFocusChanged(bool hasFocus)
-		{
-			base.OnNativeFocusChanged(hasFocus);
-			if (hasFocus)
-				OnClick();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -120,7 +88,7 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnFocusChangeRequested(sender, e);
 
 			if (e.Focus)
-				OnClick();
+				CallOnClick();
 			else if (_dialog != null)
 			{
 				_dialog.Hide();
@@ -143,7 +111,7 @@ namespace Xamarin.Forms.Platform.Android
 			return dialog;
 		}
 
-		void OnClick()
+		void IPickerRenderer.OnClick()
 		{
 			if (_dialog != null && _dialog.IsShowing)
 			{
@@ -177,20 +145,6 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateTextColor()
 		{
 			_textColorSwitcher?.UpdateTextColor(Control, Element.TextColor);
-		}
-
-		class TimePickerListener : Object, IOnClickListener
-		{
-			public static readonly TimePickerListener Instance = new TimePickerListener();
-
-			public void OnClick(AView v)
-			{
-				var renderer = v.Tag as TimePickerRenderer;
-				if (renderer == null)
-					return;
-
-				renderer.OnClick();
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -6,10 +6,11 @@ using Android.Util;
 using Android.Text.Format;
 using ATimePicker = Android.Widget.TimePicker;
 using Android.OS;
+using Android.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class TimePickerRenderer : ViewRenderer<TimePicker, PickerEditText>, TimePickerDialog.IOnTimeSetListener, IPickerRenderer
+	public class TimePickerRenderer : ViewRenderer<TimePicker, EditText>, TimePickerDialog.IOnTimeSetListener, IPickerRenderer
 	{
 		AlertDialog _dialog;
 		TextColorSwitcher _textColorSwitcher;
@@ -44,7 +45,7 @@ namespace Xamarin.Forms.Platform.Android
 			_dialog = null;
 		}
 
-		protected override PickerEditText CreateNativeControl()
+		protected override EditText CreateNativeControl()
 		{
 			return new PickerEditText(Context, this);
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -166,7 +166,8 @@ namespace Xamarin.Forms.Platform.Android
 			} while (!(control?.Focusable == true || ++attempt >= maxAttempts));
 
 			// when the user focuses on picker show a popup dialog
-			(control as PickerEditText)?.CallOnClick();
+			if (control is PickerEditText picker)
+				picker.FromFocusSearch = true;
 
 			return control;
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -165,6 +165,9 @@ namespace Xamarin.Forms.Platform.Android
 				control = (renderer as ITabStop)?.TabStop;
 			} while (!(control?.Focusable == true || ++attempt >= maxAttempts));
 
+			// when the user focuses on picker show a popup dialog
+			(control as PickerEditText)?.CallOnClick();
+
 			return control;
 		}
 

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -160,6 +160,8 @@
     <Compile Include="GetDesiredSizeDelegate.cs" />
     <Compile Include="IDeviceInfoProvider.cs" />
     <Compile Include="ITabStop.cs" />
+    <Compile Include="IPickerRenderer.cs" />
+    <Compile Include="Renderers\PickerEditText.cs" />
     <Compile Include="Renderers\FormsWebViewClient.cs" />
     <Compile Include="Renderers\IImageViewHandler.cs" />
     <Compile Include="InnerGestureListener.cs" />


### PR DESCRIPTION
### Description of Change ###

The picker dialog is shown only if the focus was obtained by tabulation or touch event.

### Issues Resolved ### 

- fixes #4318
- fixes #4187
- fixes #4494

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Before/After Screenshots ### 

Before
http://recordit.co/IULOwzWY2k
After
http://recordit.co/GjiYmiSFQv

### Testing Procedure ###
**In cell**
- run UItest 4187
- single click on the Picker and select any option
- click on any TextBox (the dialogue with the options of the picker should't open)

**Carousel page**
- run UItest 4187
- single click on the upper Picker and select any option
- swipe to next page (the dialogue with the options of the picker should't open)

**Tab stops**
- run UItest 1700
- single click on the Picker and select any option
- check that the Picker's dialogue opens if he gets the focus at the tabulation

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
