### PR TITLE
[XamlC] resolve props on generics for bindings

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -421,16 +421,15 @@ namespace Xamarin.Forms.Build.Tasks
 			yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Xaml", "Xamarin.Forms.Xaml", "BindingExtension"), propertyName: "TypedBinding"));
 		}
 
-		static IList<Tuple<PropertyDefinition, string>> ParsePath(string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module)
+		static IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> ParsePath(string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module)
 		{
 			if (string.IsNullOrWhiteSpace(path))
 				return null;
 			path = path.Trim(' ', '.'); //trim leading or trailing dots
 			var parts = path.Split(new [] { '.' }, StringSplitOptions.RemoveEmptyEntries);
-			var properties = new List<Tuple<PropertyDefinition, string>>();
+			var properties = new List<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)>();
 
 			var previousPartTypeRef = tSourceRef;
-			TypeReference _;
 			foreach (var part in parts) {
 				var p = part;
 				string indexArg = null;
@@ -453,16 +452,16 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 
 				if (p.Length > 0) {
-					var property = previousPartTypeRef.GetProperty(pd => pd.Name == p && pd.GetMethod != null && pd.GetMethod.IsPublic, out _)
+					var property = previousPartTypeRef.GetProperty(pd => pd.Name == p && pd.GetMethod != null && pd.GetMethod.IsPublic, out var propDeclTypeRef)
 					                                  ?? throw new XamlParseException($"Binding: Property '{p}' not found on '{previousPartTypeRef}'", lineInfo);
-					properties.Add(new Tuple<PropertyDefinition, string>(property,null));
+					properties.Add((property, propDeclTypeRef, null));
 					previousPartTypeRef = property.PropertyType;
 				}
 				if (indexArg != null) {
 					var defaultMemberAttribute = previousPartTypeRef.GetCustomAttribute(module, ("mscorlib", "System.Reflection", "DefaultMemberAttribute"));
 					var indexerName = defaultMemberAttribute?.ConstructorArguments?.FirstOrDefault().Value as string ?? "Item";
-					var indexer = previousPartTypeRef.GetProperty(pd => pd.Name == indexerName && pd.GetMethod != null && pd.GetMethod.IsPublic, out _);
-					properties.Add(new Tuple<PropertyDefinition, string>(indexer, indexArg));
+					var indexer = previousPartTypeRef.GetProperty(pd => pd.Name == indexerName && pd.GetMethod != null && pd.GetMethod.IsPublic, out var indexerDeclTypeRef);
+					properties.Add((indexer, indexerDeclTypeRef, indexArg));
 					if (indexer.PropertyType != module.TypeSystem.String && indexer.PropertyType != module.TypeSystem.Int32)
 						throw new XamlParseException($"Binding: Unsupported indexer index type: {indexer.PropertyType.FullName}", lineInfo);
 					previousPartTypeRef = indexer.PropertyType;
@@ -471,7 +470,7 @@ namespace Xamarin.Forms.Build.Tasks
 			return properties;
 		}
 
-		static IEnumerable<Instruction> CompiledBindingGetGetter(TypeReference tSourceRef, TypeReference tPropertyRef, IList<Tuple<PropertyDefinition, string>> properties, ElementNode node, ILContext context)
+		static IEnumerable<Instruction> CompiledBindingGetGetter(TypeReference tSourceRef, TypeReference tPropertyRef, IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> properties, ElementNode node, ILContext context)
 		{
 //			.method private static hidebysig default string '<Main>m__0' (class ViewModel vm)  cil managed
 //			{
@@ -508,22 +507,25 @@ namespace Xamarin.Forms.Build.Tasks
 					il.Emit(Ldarg_0);
 
 				foreach (var propTuple in properties) {
-					var property = propTuple.Item1;
-					var indexerArg = propTuple.Item2;
+					var property = propTuple.property;
+					var propDeclType = propTuple.propDeclTypeRef;
+					var indexerArg = propTuple.indexArg;
 					if (indexerArg != null) {
 						if (property.GetMethod.Parameters[0].ParameterType == module.TypeSystem.String)
 							il.Emit(Ldstr, indexerArg);
 						else if (property.GetMethod.Parameters[0].ParameterType == module.TypeSystem.Int32) {
-							int index;
-							if (!int.TryParse(indexerArg, out index))
+							if (!int.TryParse(indexerArg, out int index))
 								throw new XamlParseException($"Binding: {indexerArg} could not be parsed as an index for a {property.Name}", node as IXmlLineInfo);
 							il.Emit(Ldc_I4, index);
 						}
 					}
+					var getMethod = module.ImportReference(property.GetMethod);
+					getMethod = module.ImportReference(getMethod.ResolveGenericParameters(propDeclType, module));
+
 					if (property.GetMethod.IsVirtual)
-						il.Emit(Callvirt, module.ImportReference(property.GetMethod));
+						il.Emit(Callvirt, getMethod);
 					else
-						il.Emit(Call, module.ImportReference(property.GetMethod));
+						il.Emit(Call, getMethod);
 					}
 
 				il.Emit(Ret);
@@ -539,7 +541,7 @@ namespace Xamarin.Forms.Build.Tasks
 			yield return Create(Newobj, module.ImportCtorReference(("mscorlib", "System", "Func`2"), paramCount: 2, classArguments: new[] { tSourceRef, tPropertyRef }));
 		}
 
-		static IEnumerable<Instruction> CompiledBindingGetSetter(TypeReference tSourceRef, TypeReference tPropertyRef, IList<Tuple<PropertyDefinition, string>> properties, ElementNode node, ILContext context)
+		static IEnumerable<Instruction> CompiledBindingGetSetter(TypeReference tSourceRef, TypeReference tPropertyRef, IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> properties, ElementNode node, ILContext context)
 		{
 			if (properties == null || properties.Count == 0) {
 				yield return Create(Ldnull);
@@ -572,20 +574,23 @@ namespace Xamarin.Forms.Build.Tasks
 			setter.Body.InitLocals = true;
 
 			var il = setter.Body.GetILProcessor();
-			var lastProperty = properties.LastOrDefault();
-			var setterRef = lastProperty?.Item1.SetMethod;
-			if (setterRef == null) {
+			if (!properties.Any() || properties.Last().property.SetMethod == null) {
 				yield return Create(Ldnull); //throw or not ?
 				yield break;
 			}
+
+			var setterRef = module.ImportReference(properties.Last().property.SetMethod);
+			setterRef = module.ImportReference(setterRef.ResolveGenericParameters(properties.Last().propDeclTypeRef, module));
 
 			if (tSourceRef.IsValueType)
 				il.Emit(Ldarga_S, (byte)0);
 			else
 				il.Emit(Ldarg_0);
 			for (int i = 0; i < properties.Count - 1; i++) {
-				var property = properties[i].Item1;
-				var indexerArg = properties[i].Item2;
+				var property = properties[i].property;
+				var propDeclType = properties[i].propDeclTypeRef;
+				var indexerArg = properties[i].indexArg;
+
 				if (indexerArg != null) {
 					if (property.GetMethod.Parameters [0].ParameterType == module.TypeSystem.String)
 						il.Emit(Ldstr, indexerArg);
@@ -596,30 +601,33 @@ namespace Xamarin.Forms.Build.Tasks
 						il.Emit(Ldc_I4, index);
 					}
 				}
+
+				var getMethod = module.ImportReference(property.GetMethod);
+				getMethod = module.ImportReference(getMethod.ResolveGenericParameters(propDeclType, module));
+
 				if (property.GetMethod.IsVirtual)
-					il.Emit(Callvirt, module.ImportReference(property.GetMethod));
+					il.Emit(Callvirt, getMethod);
 				else
-					il.Emit(Call, module.ImportReference(property.GetMethod));
+					il.Emit(Call, getMethod);
 			}
 
-			var indexer = properties.Last().Item2;
+			var indexer = properties.Last().indexArg;
 			if (indexer != null) {
-				if (lastProperty.Item1.GetMethod.Parameters [0].ParameterType == module.TypeSystem.String)
+				if (properties.Last().property.GetMethod.Parameters [0].ParameterType == module.TypeSystem.String)
 					il.Emit(Ldstr, indexer);
-				else if (lastProperty.Item1.GetMethod.Parameters [0].ParameterType == module.TypeSystem.Int32) {
-					int index;
-					if (!int.TryParse(indexer, out index))
-						throw new XamlParseException($"Binding: {indexer} could not be parsed as an index for a {lastProperty.Item1.Name}", node as IXmlLineInfo);
+				else if (properties.Last().property.GetMethod.Parameters [0].ParameterType == module.TypeSystem.Int32) {
+					if (!int.TryParse(indexer, out int index))
+						throw new XamlParseException($"Binding: {indexer} could not be parsed as an index for a {properties.Last().property.Name}", node as IXmlLineInfo);
 					il.Emit(Ldc_I4, index);
 				}
 			}
 
 			il.Emit(Ldarg_1);
 
-			if (setterRef.IsVirtual)
-				il.Emit(Callvirt, module.ImportReference(setterRef));
+			if (properties.Last().property.SetMethod.IsVirtual)
+				il.Emit(Callvirt, setterRef);
 			else
-				il.Emit(Call, module.ImportReference(setterRef));
+				il.Emit(Call, setterRef);
 
 			il.Emit(Ret);
 
@@ -636,7 +644,7 @@ namespace Xamarin.Forms.Build.Tasks
 																   new[] { tSourceRef, tPropertyRef }));
 		}
 
-		static IEnumerable<Instruction> CompiledBindingGetHandlers(TypeReference tSourceRef, TypeReference tPropertyRef, IList<Tuple<PropertyDefinition, string>> properties, ElementNode node, ILContext context)
+		static IEnumerable<Instruction> CompiledBindingGetHandlers(TypeReference tSourceRef, TypeReference tPropertyRef, IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> properties, ElementNode node, ILContext context)
 		{
 //			.method private static hidebysig default object '<Main>m__2'(class ViewModel vm)  cil managed {
 //				.custom instance void class [mscorlib] System.Runtime.CompilerServices.CompilerGeneratedAttribute::'.ctor'() =  (01 00 00 00 ) // ....
@@ -655,7 +663,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 			var partGetters = new List<MethodDefinition>();
 			if (properties == null || properties.Count == 0) {
-				yield return Instruction.Create(OpCodes.Ldnull);
+				yield return Create(Ldnull);
 				yield break;
 			}
 				
@@ -690,28 +698,35 @@ namespace Xamarin.Forms.Build.Tasks
 				var lastGetterTypeRef = tSourceRef;
 				for (int j = 0; j < i; j++) {
 					var propTuple = properties [j];
-					var property = propTuple.Item1;
-					var indexerArg = propTuple.Item2;
+					var property = propTuple.property;
+					var indexerArg = propTuple.indexArg;
+					var propDeclType = propTuple.propDeclTypeRef;
+
 					if (indexerArg != null) {
 						if (property.GetMethod.Parameters [0].ParameterType == module.TypeSystem.String)
-							il.Emit(OpCodes.Ldstr, indexerArg);
+							il.Emit(Ldstr, indexerArg);
 						else if (property.GetMethod.Parameters [0].ParameterType == module.TypeSystem.Int32) {
 							int index;
 							if (!int.TryParse(indexerArg, out index))
 								throw new XamlParseException($"Binding: {indexerArg} could not be parsed as an index for a {property.Name}", node as IXmlLineInfo);
-							il.Emit(OpCodes.Ldc_I4, index);
+							il.Emit(Ldc_I4, index);
 						}
 					}
+
+					var getMethod = module.ImportReference(property.GetMethod);
+					getMethod = module.ImportReference(getMethod.ResolveGenericParameters(propDeclType, module));
+
 					if (property.GetMethod.IsVirtual)
-						il.Emit(Callvirt, module.ImportReference(property.GetMethod));
+						il.Emit(Callvirt, getMethod);
 					else
-						il.Emit(Call, module.ImportReference(property.GetMethod));
+						il.Emit(Call, getMethod);
+
 					lastGetterTypeRef = property.PropertyType;
 				}
 				if (lastGetterTypeRef.IsValueType)
 					il.Emit(Box, module.ImportReference(lastGetterTypeRef));
 
-				il.Emit(OpCodes.Ret);
+				il.Emit(Ret);
 				context.Body.Method.DeclaringType.Methods.Add(partGetter);
 				partGetters.Add(partGetter);
 			}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4348.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4348.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+			 x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4348"
+			 x:DataType="local:Gh4348VM">	
+	<Label x:Name="labelCount" Text="{Binding Count, Mode=OneTime}" /> 
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4348.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4348.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh4348VM : ObservableCollection<string>
+	{
+		public Gh4348VM()
+		{
+			Add("foo");
+			Add("bar");
+		}
+	}
+
+	public partial class Gh4348 : ContentPage
+	{
+		public Gh4348()
+		{
+			InitializeComponent();
+		}
+
+		public Gh4348(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void GenericBaseClassResolution(bool useCompiledXaml)
+			{
+				var layout = new Gh4348(useCompiledXaml) { BindingContext = new Gh4348VM() };
+				Assert.That(layout.labelCount.Text, Is.EqualTo("2"));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -664,6 +664,9 @@
     <Compile Include="Issues\Gh4326.xaml.cs">
       <DependentUpon>Gh4326.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Issues\Gh4348.xaml.cs">
+      <DependentUpon>Gh4348.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
@@ -1225,6 +1228,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="Issues\Gh4326.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Issues\Gh4348.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>


### PR DESCRIPTION
### Description of Change ###

[XamlC] resolve props on generics for bindings

Somehow, we weren't doing that up to now...

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4348

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
