### PR TITLE
Add fake Platform property to Page to keep Previewer happy

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/PreviewerReflectionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PreviewerReflectionTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class PreviewerReflectionTests
+	{
+		[Test]
+		public void PageHasPlatformProperty()
+		{
+			var page = new Page();
+
+			var setPlatform = page.GetType ().GetProperty ("Platform", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+			Assert.That(setPlatform, Is.Not.Null, "Previewer requires that Page have a property called 'Platform'");
+
+			TestDelegate setValue = () => setPlatform.SetValue(page, new object(), null);
+			Assert.That(setValue, Throws.Nothing, "'Page.Platform' must have a setter");
+		}
+
+		[Test]
+		public void RegisterAllExists()
+		{
+			var type = typeof(Registrar);
+
+			var methods = type.GetMethods(BindingFlags.Static | BindingFlags.NonPublic);
+			var method = methods.Single(t =>
+			{
+				var parameters = t.GetParameters();
+
+				return t.Name == "RegisterAll"
+						&& parameters.Length == 1
+						&& parameters[0].ParameterType == typeof(Type[]);
+			});
+
+			Assert.That(method, Is.Not.Null, "Previewer requires that Registrar have a static non-public method "
+											+ "'RegisterAll' which takes a single parameter of Type[]");
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ImageButtonUnitTest.cs" />
     <Compile Include="LayoutChildIntoBoundingRegionTests.cs" />
     <Compile Include="MenuUnitTests.cs" />
+    <Compile Include="PreviewerReflectionTests.cs" />
     <Compile Include="RegionTests.cs" />
     <Compile Include="SpanTests.cs" />
     <Compile Include="TitleViewUnitTests.cs" />

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -442,6 +442,6 @@ namespace Xamarin.Forms
 		// Platform isn't needed anymore, but the Previewer will still try to set it via reflection
 		// and throw an NRE if it's not available; this fake property keeps it happy.
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public object Platform { get; set; }
+		internal object Platform { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -437,5 +437,11 @@ namespace Xamarin.Forms
 
 			_titleView = newTitleView;
 		}
+
+		// This is a dummy property for the Previewer
+		// Platform isn't needed anymore, but the Previewer will still try to set it via reflection
+		// and throw an NRE if it's not available; this fake property keeps it happy.
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public object Platform { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -442,6 +442,7 @@ namespace Xamarin.Forms
 		// Platform isn't needed anymore, but the Previewer will still try to set it via reflection
 		// and throw an NRE if it's not available; this fake property keeps it happy.
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("This property is no longer used as of version 3.4.")]
 		internal object Platform { get; set; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Forms Elements used to have an internal API property `Platform` which needed to be set on each Element. That property is no longer needed and has been removed. But the Previewer still sets that property via reflection, which now causes a NullReferenceException.

This change creates a dummy property for the Previewer to set, avoiding the NRE. 

### Issues Resolved ### 

- fixes #4351

### API Changes ###
 
 None

### Platforms Affected ### 

None

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Open the previewer.

