### PR TITLE
[iOS] Better fix for EstimatedRowHeight 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4356.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4356.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+using System.Threading.Tasks;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4356, "[iOS] NSInternalInconsistencyException thrown when adding item to ListView after clearing bound ObservableCollection")]
+	public partial class Issue4356 : TestContentPage
+	{
+#if UITEST
+		[Test]
+		public void Issue4356Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Will this repo work?"));
+			RunningApp.WaitForElement(q => q.Marked("Remove item"));
+			RunningApp.Tap(q => q.Marked("Remove item"));
+			RunningApp.Tap(q => q.Marked("Remove item"));
+			RunningApp.Tap(q => q.Marked("Add item"));
+			RunningApp.WaitForElement(q => q.Marked("Added from Button Command"));
+		}
+#endif
+
+		FavoritesViewModel ViewModel
+		{
+			get { return BindingContext as FavoritesViewModel; }
+		}
+
+		public Issue4356()
+		{
+#if APP
+			InitializeComponent();
+			BindingContext = new FavoritesViewModel();
+
+			listView.SeparatorVisibility = SeparatorVisibility.Default;
+			listView.SeparatorColor = Color.FromHex("#ababab");
+
+			listView.ItemTapped += (sender, args) =>
+			{
+				if (listView.SelectedItem == null)
+					return;
+
+				//do nothing anyway
+				return;
+			};
+#endif
+
+		}
+
+		protected override void Init()
+		{
+
+		}
+
+#pragma warning disable 1998 // considered for removal
+		public async void OnDelete(object sender, EventArgs e)
+#pragma warning restore 1998
+		{
+			var mi = ((MenuItem)sender);
+			if (mi.CommandParameter == null)
+				return;
+
+			var articlelistingitem = mi.CommandParameter;
+
+			if (articlelistingitem != null)
+				DisplayAlert("Alert", "I'm not deleting just refreshing...", "Ok");
+			ViewModel.LoadFavoritesCommand.Execute(null);
+		}
+
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			if (ViewModel == null || !ViewModel.CanLoadMore || ViewModel.IsBusy)
+				return;
+
+			Device.BeginInvokeOnMainThread(() =>
+			{
+				ViewModel.LoadFavoritesCommand.Execute(null);
+			});
+		}
+
+		[Preserve(AllMembers = true)]
+		public class FavoritesViewModel : BaseViewModelF
+		{
+			public ObservableCollection<ArticleListing> FavoriteArticles { get; set; }
+			public int Count { get; private set; } = 0;
+			readonly object _listLock = new object();
+
+			public FavoritesViewModel()
+			{
+				Title = "Favorites";
+				FavoriteArticles = new ObservableCollection<ArticleListing>();
+				AddCommand = new Command(() =>
+				{
+					lock (_listLock)
+					{
+						FavoriteArticles.Add(new ArticleListing
+						{
+							ArticleTitle = "Added from Button Command",
+							AuthorString = "Rui Marinho",
+							FormattedPostedDate = "08-11-2018"
+						});
+					}
+				});
+
+				RemoveCommand = new Command(() =>
+				{
+					lock (_listLock)
+					{
+						if (FavoriteArticles.Count > 0)
+						{
+							FavoriteArticles.RemoveAt(FavoriteArticles.Count - 1);
+							--Count;
+						}
+					}
+				});
+
+			}
+
+			public Command AddCommand { get; }
+			public Command RemoveCommand { get; }
+
+
+			Command _loadFavoritesCommand;
+
+			public Command LoadFavoritesCommand
+			{
+				get
+				{
+					return _loadFavoritesCommand ??
+					(_loadFavoritesCommand = new Command(async () =>
+					{
+						await ExecuteFavoritesCommand();
+					}, () =>
+					{
+						return !IsBusy;
+					}));
+				}
+			}
+
+#pragma warning disable 1998 // considered for removal
+			public async Task ExecuteFavoritesCommand()
+#pragma warning restore 1998
+			{
+				if (IsBusy)
+					return;
+
+				IsBusy = true;
+				LoadFavoritesCommand.ChangeCanExecute();
+				FavoriteArticles.Clear();
+				var articles = new ObservableCollection<ArticleListing> {
+					new ArticleListing {
+						ArticleTitle = "Will this repo work?",
+						AuthorString = "Ben Crispin",
+						FormattedPostedDate = "7-28-2015"
+					},
+					new ArticleListing {
+						ArticleTitle = "Xamarin Forms BugZilla",
+						AuthorString = "Some Guy",
+						FormattedPostedDate = "7-28-2015"
+					}
+				};
+				var templist = new ObservableCollection<ArticleListing>();
+				foreach (var article in articles)
+				{
+					//templist.Add(article);
+					FavoriteArticles.Add(article);
+				}
+				//FavoriteArticles = templist;
+				OnPropertyChanged("FavoriteArticles");
+				IsBusy = false;
+				LoadFavoritesCommand.ChangeCanExecute();
+			}
+
+		}
+	}
+}
+

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4356.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4356.xaml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:local="clr-namespace:Xamarin.Forms.Controls" x:Class="Xamarin.Forms.Controls.Issues.Issue4356">
+    <StackLayout Orientation="Vertical">
+        <StackLayout Orientation="Horizontal">
+            <Button Text="Add item" HorizontalOptions="CenterAndExpand" Command="{Binding AddCommand}" />
+            <Button Text="Remove item" HorizontalOptions="CenterAndExpand" Command="{Binding RemoveCommand}" />
+        </StackLayout>
+        <ListView x:Name="listView" 
+                  ItemsSource="{Binding FavoriteArticles}" 
+                  HasUnevenRows="True" 
+                  IsPullToRefreshEnabled="True" 
+                  HorizontalOptions="FillAndExpand"
+                  VerticalOptions="FillAndExpand"
+                  SeparatorVisibility="None"
+                  SeparatorColor="Transparent"
+                  BackgroundColor="#F0F0F0"
+                  RefreshCommand="{Binding LoadFavoritesCommand}" 
+                  IsRefreshing="{Binding IsBusy, Mode=OneWay}">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <ViewCell Height="85">
+                      <!--  <ViewCell.ContextActions>
+                            <MenuItem Clicked="OnDelete" CommandParameter="{Binding .}" Text="Delete" IsDestructive="True" />
+                        </ViewCell.ContextActions>-->
+                        <Grid Padding="10,5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <StackLayout Grid.Column="1" Padding="5" Spacing="1" VerticalOptions="Center">
+                                <Label Text="{Binding ArticleTitle}" FontSize="Medium" FontAttributes="Bold" TextColor="#333333" LineBreakMode="WordWrap" />
+                                <Label Text="{Binding AuthorString}" FontSize="Small" TextColor="#919191" LineBreakMode="TailTruncation" />
+                                <Label Text="{Binding FormattedPostedDate}" FontSize="Small" TextColor="#919191" LineBreakMode="NoWrap" />
+                                <Label Text="{Binding ItemId}" FontSize="Small" TextColor="#919191" LineBreakMode="NoWrap" IsVisible="false" />
+                            </StackLayout>
+                        </Grid>
+                    </ViewCell>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -887,6 +887,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue4314.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5172.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2204.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4356.cs">
+      <DependentUpon>Issue4356.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1004,6 +1007,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)VisualControlsPage.xaml">
       <SubType>Designer</SubType>
+       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4356.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1554,6 +1554,11 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateIsRefreshing(true);
 		}
 
+		public override void ViewWillLayoutSubviews()
+		{
+			(TableView?.Source as ListViewRenderer.ListViewDataSource)?.DetermineEstimatedRowHeight();
+		}
+
 		public void UpdateRefreshControlColor(UIColor color)
 		{
 			if (RefreshControl != null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -555,7 +555,6 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				case NotifyCollectionChangedAction.Add:
 
-					Device.BeginInvokeOnMainThread(UpdateEstimatedRowHeight);
 					if (e.NewStartingIndex == -1 || groupReset)
 						goto case NotifyCollectionChangedAction.Reset;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1565,11 +1565,6 @@ namespace Xamarin.Forms.Platform.iOS
 				RefreshControl.TintColor = color;
 		}
 
-		public override void ViewWillLayoutSubviews()
-		{
-			(TableView?.Source as ListViewRenderer.ListViewDataSource)?.DetermineEstimatedRowHeight();
-		}
-
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1190,7 +1190,7 @@ namespace Xamarin.Forms.Platform.iOS
 						// its cell size/estimate
 						_estimatedRowHeight = false;
 					}
-					_previousCount = countOverride;
+					_wasEmpty = countOverride == 0;
 					return countOverride;
 				}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1184,7 +1184,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (Counts.TryGetValue((int)section, out countOverride))
 				{
 					Counts.Remove((int)section);
-					if (_previousCount == 0 && countOverride > 0)
+					if (_wasEmpty && countOverride > 0)
 					{
 						// We've moved from no items to having at least one item; it's likely that the layout needs to update
 						// its cell size/estimate

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -555,7 +555,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				case NotifyCollectionChangedAction.Add:
 
-					UpdateEstimatedRowHeight();
+					Device.BeginInvokeOnMainThread(UpdateEstimatedRowHeight);
 					if (e.NewStartingIndex == -1 || groupReset)
 						goto case NotifyCollectionChangedAction.Reset;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -817,7 +817,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			protected override void UpdateEstimatedRowHeight(UITableView tableView)
 			{
-				tableView.EstimatedRowHeight = GetEstimatedRowHeight(tableView);
+				var estimatedRowheight  = GetEstimatedRowHeight(tableView);
+				//if we are providing 0 we are disabling EstimatedRowHeight,
+				//this works fine on newer versions, but iOS10 it will cause a crash so we leave the default value
+				if (estimatedRowheight == 0 && Forms.IsiOS11OrNewer)
+					tableView.EstimatedRowHeight = estimatedRowheight;
 			}
 
 			internal Cell GetPrototypicalCell(NSIndexPath indexPath)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -809,7 +809,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return CalculateHeightForCell(table, firstCell);
 			}
 
-			internal override void InvalidatePrototypicalCellCache()
+			internal override void InvalidatingPrototypicalCellCache()
 			{
 				ClearPrototype();
 				_prototypicalCellByTypeOrDataTemplate.Clear();
@@ -974,9 +974,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UIColor DefaultBackgroundColor => UIColor.Clear;
 
-			internal virtual void InvalidatePrototypicalCellCache()
+			internal void InvalidatePrototypicalCellCache()
 			{
 				_estimatedRowHeight = false;
+				InvalidatingPrototypicalCellCache();
+			}
+
+			internal virtual void InvalidatingPrototypicalCellCache()
+			{
 			}
 
 			public override void DraggingEnded(UIScrollView scrollView, bool willDecelerate)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -942,7 +942,7 @@ namespace Xamarin.Forms.Platform.iOS
 			bool _isDragging;
 			bool _selectionFromNative;
 			bool _disposed;
-			int _previousCount = -1;
+			bool _wasEmpty;
 			bool _estimatedRowHeight;
 
 			public UITableViewRowAnimation ReloadSectionsAnimation { get; set; } = UITableViewRowAnimation.Automatic;


### PR DESCRIPTION
### Description of Change ###

When setting the EstimatedRowHeight it caused to UITableView to try to reload itself. This is an issue if we are trying to insert rows at the same time. If the row height didn't changed it wasn't a issue as the EstimatedRowHeight didn't change, but if we change that value it will queue a reload of the UITableView. 

We know moved to a better way to set EstimatedRowHeight based on the same fix we did for CollectionVIiew on #4688, this logic is now mostly handle in the DataSource.

Row will try to be estimated when the initial TableVIew is shown,  also before we show a cell we make sure we estimated, because the collection could be empty and this is our first item.


### Issues Resolved ### 

- fixes #4356

### API Changes ###
 
On internal `ListViewDataSource`
- `protected virtual void UpdateEstimatedRowHeight(UITableView tableView)`
- `public void DetermineEstimatedRowHeight()`

-changed 
- `internal void InvalidatePrototypicalCellCache()` (remove virtual)
- `internal virtual void InvalidatingPrototypicalCellCache()` (replace InvalidatePrototypicalCellCache)
-  `nfloat GetEstimatedRowHeight(UITableView table)` (remove internal)

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Visit 4356 on the gallery, remove the 2 items and add 2 items, the app shouldn't crash when adding items.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard