### PR TITLE
[iOS] Fixed keyboard type for cells in TableView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1386.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1386.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Children = {
 					new Label
 					{
-						Margin (15, 0),
+						Margin = new Thickness (15, 0),
 						Text = "1) Tap 'CHANGE THE SECOND CELL' and make sure, that the second cell has numeric keyboard" +
 							"\n2) Tap 'CHANGE THE SECOND CELL' again and make sure, that the second cel has plain keyboard"
 					},

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1386.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1386.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				new TextCell
 				{
-					Text = "MAIN BUTTON",
+					Text = "CHANGE THE SECOND CELL",
 					Command = new Command(() =>
 					{
 						root.Remove(_selectionOne);
@@ -70,16 +70,16 @@ namespace Xamarin.Forms.Controls.Issues
 				Children = {
 					new Label
 					{
-						Text = "1) Tap MAIN BUTTON and make sure, that the second cell has numeric keyboard" +
-							"\n2) Tap MAIN BUTTON again and make sure, that the second cel has plain keyboard"          
+						Margin (15, 0),
+						Text = "1) Tap 'CHANGE THE SECOND CELL' and make sure, that the second cell has numeric keyboard" +
+							"\n2) Tap 'CHANGE THE SECOND CELL' again and make sure, that the second cel has plain keyboard"
+					},
+					new TableView
+					{
+						Intent = TableIntent.Form,
+						Root = root
 					}
 				}
-			};
-
-			Content = new TableView
-			{
-				Intent = TableIntent.Form,
-				Root = root
 			};
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1386.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1386.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1386,
+		"[iOS] EntryCell within TableView using wrong keyboard",
+		PlatformAffected.iOS)]
+	public class Issue1386 : TestContentPage
+	{
+		bool _state;
+		TableSection _selectionOne;
+		TableSection _selectionTwo;
+
+		protected override void Init()
+		{
+			var root = new TableRoot();
+
+			var section1 = new TableSection("1")
+			{
+				new TextCell
+				{
+					Text = "MAIN BUTTON",
+					Command = new Command(() =>
+					{
+						root.Remove(_selectionOne);
+						root.Remove(_selectionTwo);
+
+						if (!_state)
+						{
+							root.Insert(1, _selectionOne);
+						}
+						else
+						{
+							root.Insert(1, _selectionTwo);
+						}
+
+						_state = !_state;
+					})
+				}
+			};
+
+			root.Add(section1);
+
+			_selectionOne = new TableSection("2")
+			{
+				new EntryCell
+				{
+					Label = "Numeric Keyboard",
+					Placeholder = "Tap here",
+					Keyboard = Keyboard.Numeric
+				}
+			};
+
+			_selectionTwo = new TableSection("2")
+			{
+				new EntryCell
+				{
+					Label = "Plain Keyboard",
+					Placeholder = "Tap here",
+					Keyboard = Keyboard.Plain,
+				}
+			};
+
+			Content = new StackLayout
+			{
+				Padding = new Thickness(0, 50),
+				Children = {
+					new Label
+					{
+						Text = "1) Tap MAIN BUTTON and make sure, that the second cell has numeric keyboard" +
+							"\n2) Tap MAIN BUTTON again and make sure, that the second cel has plain keyboard"          
+					}
+				}
+			};
+
+			Content = new TableView
+			{
+				Intent = TableIntent.Form,
+				Root = root
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -844,6 +844,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ContactsPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\FailImageSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ICacheService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1386.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -10,13 +10,13 @@ namespace Xamarin.Forms.Platform.iOS
 			textInput.AutocapitalizationType = UITextAutocapitalizationType.None;
 			textInput.AutocorrectionType = UITextAutocorrectionType.No;
 			textInput.SpellCheckingType = UITextSpellCheckingType.No;
+			textInput.KeyboardType = UIKeyboardType.Default;
 
 			if (keyboard == Keyboard.Default)
 			{
 				textInput.AutocapitalizationType = UITextAutocapitalizationType.Sentences;
 				textInput.AutocorrectionType = UITextAutocorrectionType.Default;
 				textInput.SpellCheckingType = UITextSpellCheckingType.Default;
-				textInput.KeyboardType = UIKeyboardType.Default;
 			}
 			else if (keyboard == Keyboard.Chat)
 			{


### PR DESCRIPTION
### Description of Change ###

Reset KeyboardType for table view cell each time it is updated.

### Issues Resolved ### 

- fixes #1386

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
Entry cell has correct keyboard type

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Follow steps described in test case 1386
