### PR TITLE
[Android] Handle accessibility importance when using modal pages

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3622.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3622.cs
@@ -42,22 +42,20 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				var nameLabel = new Label
 				{
-					FontSize = Device.GetNamedSize(NamedSize.Medium, typeof(Label)),
-					FontAttributes = FontAttributes.Bold
-				};
+					Style = Device.Styles.TitleStyle
+				};	
 				nameLabel.SetBinding(Label.TextProperty, "Name");
 
 				var ageLabel = new Label
 				{
-					FontSize = Device.GetNamedSize(NamedSize.Medium, typeof(Label)),
-					FontAttributes = FontAttributes.Bold
+					Style = Device.Styles.CaptionStyle
+
 				};
 				ageLabel.SetBinding(Label.TextProperty, "Age");
 
 				var occupationLabel = new Label
 				{
-					FontSize = Device.GetNamedSize(NamedSize.Medium, typeof(Label)),
-					FontAttributes = FontAttributes.Bold
+					Style = Device.Styles.BodyStyle
 				};
 				occupationLabel.SetBinding(Label.TextProperty, "Occupation");
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3622.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3622.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3622, "Android TalkBack reads elements behind modal pages", PlatformAffected.Android, NavigationBehavior.PushModalAsync)]
+	public class Issue3622 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		[Preserve(AllMembers = true)]
+		public class Contact
+		{
+			public string Name { get; set; }
+
+			public int Age { get; set; }
+
+			public string Occupation { get; set; }
+
+			public string Country { get; set; }
+
+			public override string ToString()
+			{
+				return Name;
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class DetailPageCS : ContentPage
+		{
+			public DetailPageCS()
+			{
+				var nameLabel = new Label
+				{
+					FontSize = Device.GetNamedSize(NamedSize.Medium, typeof(Label)),
+					FontAttributes = FontAttributes.Bold
+				};
+				nameLabel.SetBinding(Label.TextProperty, "Name");
+
+				var ageLabel = new Label
+				{
+					FontSize = Device.GetNamedSize(NamedSize.Medium, typeof(Label)),
+					FontAttributes = FontAttributes.Bold
+				};
+				ageLabel.SetBinding(Label.TextProperty, "Age");
+
+				var occupationLabel = new Label
+				{
+					FontSize = Device.GetNamedSize(NamedSize.Medium, typeof(Label)),
+					FontAttributes = FontAttributes.Bold
+				};
+				occupationLabel.SetBinding(Label.TextProperty, "Occupation");
+
+				var countryLabel = new Label
+				{
+					FontSize = Device.GetNamedSize(NamedSize.Medium, typeof(Label)),
+					FontAttributes = FontAttributes.Bold
+				};
+				countryLabel.SetBinding(Label.TextProperty, "Country");
+
+				var dismissButton = new Button { Text = "Dismiss" };
+				dismissButton.Clicked += OnDismissButtonClicked;
+
+				Content = new StackLayout
+				{
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center,
+					Children = {
+					new StackLayout {
+						Orientation = StackOrientation.Horizontal,
+						Children = {
+							new Label {
+								Text = "Name:",
+								FontSize = Device.GetNamedSize (NamedSize.Medium, typeof(Label)),
+								HorizontalOptions = LayoutOptions.FillAndExpand
+							},
+							nameLabel
+						}
+					},
+					new StackLayout {
+						Orientation = StackOrientation.Horizontal,
+						Children = {
+							new Label {
+								Text = "Age:",
+								FontSize = Device.GetNamedSize (NamedSize.Medium, typeof(Label)),
+								HorizontalOptions = LayoutOptions.FillAndExpand
+							},
+							ageLabel
+						}
+					},
+					new StackLayout {
+						Orientation = StackOrientation.Horizontal,
+						Children = {
+							new Label {
+								Text = "Occupation:",
+								FontSize = Device.GetNamedSize (NamedSize.Medium, typeof(Label)),
+								HorizontalOptions = LayoutOptions.FillAndExpand
+							},
+							occupationLabel
+						}
+					},
+					new StackLayout {
+						Orientation = StackOrientation.Horizontal,
+						Children = {
+							new Label {
+								Text = "Country:",
+								FontSize = Device.GetNamedSize (NamedSize.Medium, typeof(Label)),
+								HorizontalOptions = LayoutOptions.FillAndExpand
+							},
+							countryLabel
+						}
+					},
+					dismissButton
+				}
+				};
+			}
+
+			async void OnDismissButtonClicked(object sender, EventArgs args)
+			{
+				await Navigation.PopModalAsync();
+			}
+		}
+
+		ListView listView;
+		List<Contact> contacts;
+
+		protected override void Init()
+		{
+			SetupData();
+
+			listView = new ListView
+			{
+				Header = new Label { Text = "Enable TalkBack. Make sure Android reads this list, when you tap an item make sure it reads the details page and not this list" },
+				ItemsSource = contacts
+			};
+			listView.ItemSelected += OnItemSelected;
+
+			Thickness padding;
+			switch (Device.RuntimePlatform)
+			{
+				case Device.iOS:
+					padding = new Thickness(0, 40, 0, 0);
+					break;
+				default:
+					padding = new Thickness();
+					break;
+			}
+
+			Padding = padding;
+			Content = new StackLayout
+			{
+				Children = {
+					listView
+				}
+			};
+		}
+
+		async void OnItemSelected(object sender, SelectedItemChangedEventArgs e)
+		{
+			if (listView.SelectedItem != null)
+			{
+				var detailPage = new DetailPageCS();
+				detailPage.BindingContext = e.SelectedItem as Contact;
+				listView.SelectedItem = null;
+				await Navigation.PushModalAsync(detailPage);
+			}
+		}
+
+		void SetupData()
+		{
+			contacts = new List<Contact>();
+			contacts.Add(new Contact
+			{
+				Name = "Jane Doe",
+				Age = 30,
+				Occupation = "Developer",
+				Country = "USA"
+			});
+			contacts.Add(new Contact
+			{
+				Name = "John Doe",
+				Age = 34,
+				Occupation = "Tester",
+				Country = "USA"
+			});
+			contacts.Add(new Contact
+			{
+				Name = "John Smith",
+				Age = 52,
+				Occupation = "PM",
+				Country = "UK"
+			});
+			contacts.Add(new Contact
+			{
+				Name = "Kath Smith",
+				Age = 55,
+				Occupation = "Business Analyst",
+				Country = "UK"
+			});
+			contacts.Add(new Contact
+			{
+				Name = "Steve Smith",
+				Age = 19,
+				Occupation = "Junior Developer",
+				Country = "UK"
+			});
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -848,6 +848,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ContactsPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\FailImageSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ICacheService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3622.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1052,7 +1053,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4194.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -115,6 +115,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 			}
 
+			UpdateAccessibilityImportance(CurrentPageController as Page, ImportantForAccessibility.Auto, true);
+
 			return source.Task;
 		}
 
@@ -146,12 +148,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		async Task INavigation.PushModalAsync(Page modal, bool animated)
 		{
 			CurrentPageController?.SendDisappearing();
+			UpdateAccessibilityImportance(CurrentPageController as Page, ImportantForAccessibility.NoHideDescendants, false);
 
 			_navModel.PushModal(modal);
 
 			Task presentModal = PresentModal(modal, animated);
 
 			await presentModal;
+
+			UpdateAccessibilityImportance(modal, ImportantForAccessibility.Auto, true);
 
 			// Verify that the modal is still on the stack
 			if (_navModel.CurrentPage == modal)
@@ -260,6 +265,18 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				SetPageInternal(newRoot);
 			}
+		}
+
+		void UpdateAccessibilityImportance(Page page, ImportantForAccessibility importantForAccessibility, bool forceFocus)
+		{
+
+			var pageRenderer = Android.Platform.GetRenderer(page);
+			if (pageRenderer?.View == null)
+				return;
+			pageRenderer.View.ImportantForAccessibility = importantForAccessibility;
+			if(forceFocus)
+				pageRenderer.View.SendAccessibilityEvent(global::Android.Views.Accessibility.EventTypes.ViewFocused);
+			
 		}
 
 		void SetPageInternal(Page newRoot)


### PR DESCRIPTION
### Description of Change ###

The Android TalkBack has no sense of our navigation. So showing a Modal on top of other page that is still in the hierarchy will make accessibility read the page below de modal.

We handle this by setting the accessibility importance of those views when pushing and popping modal pages.

### Issues Resolved ### 

- fixes #3622 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
By enabling TalkBack the top modal page should be read by the system.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
This will need to be tested on a device. Enable TalkBack on accessibility settings. 
Navigate to issue 3622 on the gallery.
Tap an item of the list.
Make sure it doesn't read list, but it reads the details of the pushed page.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard