### PR TITLE
Ignore null context change on UAP

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ImageGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ImageGallery.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -8,16 +9,16 @@ namespace Xamarin.Forms.Controls
 {
 	public class ImageGallery : ContentPage
 	{
-		public ImageGallery ()
+		public ImageGallery()
 		{
 
-			Padding = new Thickness (20);
+			Padding = new Thickness(20);
 
-			var normal = new Image { Source = ImageSource.FromFile ("cover1.jpg") };
-			var disabled = new Image { Source = ImageSource.FromFile ("cover1.jpg") };
-			var rotate = new Image { Source = ImageSource.FromFile ("cover1.jpg") };
-			var transparent = new Image { Source = ImageSource.FromFile ("cover1.jpg") };
-			var embedded = new Image { Source = ImageSource.FromResource ("Xamarin.Forms.Controls.ControlGalleryPages.crimson.jpg", typeof (ImageGallery)) };
+			var normal = new Image { Source = ImageSource.FromFile("cover1.jpg") };
+			var disabled = new Image { Source = ImageSource.FromFile("cover1.jpg") };
+			var rotate = new Image { Source = ImageSource.FromFile("cover1.jpg") };
+			var transparent = new Image { Source = ImageSource.FromFile("cover1.jpg") };
+			var embedded = new Image { Source = ImageSource.FromResource("Xamarin.Forms.Controls.GalleryPages.crimson.jpg", typeof(ImageGallery).GetTypeInfo().Assembly) };
 
 			// let the stack shrink the images
 			normal.MinimumHeightRequest = normal.MinimumHeightRequest = 10;
@@ -27,45 +28,63 @@ namespace Xamarin.Forms.Controls
 			embedded.MinimumHeightRequest = 10;
 
 			disabled.IsEnabled = false;
-			rotate.GestureRecognizers.Add (new TapGestureRecognizer { Command = new Command (o => rotate.RelRotateTo (180))});
+			rotate.GestureRecognizers.Add(new TapGestureRecognizer { Command = new Command(o => rotate.RelRotateTo(180)) });
 			transparent.Opacity = .5;
 
-			Content = new StackLayout {
-				Orientation = StackOrientation.Horizontal,
-				Children = {
-					new StackLayout {
-						//MinimumWidthRequest = 20,
-						HorizontalOptions = LayoutOptions.FillAndExpand,
-						Children = {
-							normal,
-							disabled,
-							transparent,
-							rotate,
-							embedded,
-							new StackLayout {
-								HeightRequest = 30,
-								Orientation = StackOrientation.Horizontal,
-								Children = {
+			Content =
+				new ScrollView()
+				{
+					Content = new StackLayout
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							new StackLayout
+							{
+								//MinimumWidthRequest = 20,
+								HorizontalOptions = LayoutOptions.FillAndExpand,
+								Children =
+								{
+									new Label(){ Text = "Normal"},
+									normal,
+									new Label(){ Text = "Disabled"},
+									disabled,
+									new Label(){ Text = "Transparent"},
+									transparent,
+									new Label(){ Text = "Rotate"},
+									rotate,
+									new Label(){ Text = "Embedded"},
+									embedded,
+									new Label(){ Text = "Horizontal"},
+									new StackLayout
+									{
+										HeightRequest = 30,
+										Orientation = StackOrientation.Horizontal,
+										Children =
+										{
+											new Image {Source = "cover1.jpg"},
+											new Image {Source = "cover1.jpg"},
+											new Image {Source = "cover1.jpg"},
+											new Image {Source = "cover1.jpg"}
+										}
+									}
+								}
+							},
+							new StackLayout
+							{
+								WidthRequest = 30,
+								Children =
+								{
 									new Image {Source = "cover1.jpg"},
 									new Image {Source = "cover1.jpg"},
 									new Image {Source = "cover1.jpg"},
 									new Image {Source = "cover1.jpg"}
 								}
 							}
-						}
-					},
-					new StackLayout {
-						WidthRequest = 30,
-						Children = {
-							new Image {Source = "cover1.jpg"},
-							new Image {Source = "cover1.jpg"},
-							new Image {Source = "cover1.jpg"},
-							new Image {Source = "cover1.jpg"}
+
 						}
 					}
-
-				}
-			};
+				};
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
@@ -80,6 +80,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			bitmap?.Dispose();
 			imageController?.SetIsLoading(false);
+			imageController?.NativeSizeChanged();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/CellControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CellControl.cs
@@ -161,6 +161,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
 		{
+			if (args.NewValue == null)
+				return;
+
 			// We don't want to set the Cell until the ListView is realized, just in case the 
 			// Cell has an ItemTemplate. Instead, we'll store the new data item, and it will be
 			// set on MeasureOverrideDelegate. However, if the parent is a TableView, we'll already 


### PR DESCRIPTION
### Description of Change ###

If you set ListView ItemTemplate property to custom DataTemplateSelector, then while scrolling overridden OnSelectTemplate method will be called with item argument equal to null.
Unable to reproduce issue on Android. It seems that returning null when item == null does not affect ListView elements and everything works as expected.

### Issues Resolved ### 
- fixes #4373 

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Testing Procedure ###
See bug

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
