### PR TITLE
[Tizen] Fix ToolbarItem

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/ToolbarItemButton.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/ToolbarItemButton.cs
@@ -1,0 +1,110 @@
+using System;
+using System.ComponentModel;
+using EColor = ElmSharp.Color;
+
+namespace Xamarin.Forms.Platform.Tizen.Native
+{
+	public class ToolbarItemButton : Button
+	{
+		const string StyleDefault = "default";
+		const string StyleDefaultToolbarIcon = "naviframe/drawers";
+		const string StyleLeftToolBarButton = "naviframe/title_left";
+		const string StyleRightToolbarButton = "naviframe/title_right";
+
+		ToolbarItem _item;
+
+		public ToolbarItemButton(ToolbarItem item) : base(Forms.NativeParent)
+		{
+			_item = item;
+			BackgroundColor = EColor.Transparent;
+
+			Clicked += OnClicked;
+			Deleted += OnDeleted;
+			_item.PropertyChanged += OnToolbarItemPropertyChanged;
+
+			UpdateText();
+			UpdateIsEnabled();
+			UpdateIcon();
+		}
+
+		void OnDeleted(object sender, EventArgs e)
+		{
+			Clicked -= OnClicked;
+			Deleted -= OnDeleted;
+			_item.PropertyChanged -= OnToolbarItemPropertyChanged;
+		}
+
+		void OnClicked(object sender, EventArgs e)
+		{
+			_item.Activate();
+		}
+
+		void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == ToolbarItem.TextProperty.PropertyName)
+			{
+				UpdateText();
+			}
+			else if (e.PropertyName == ToolbarItem.IsEnabledProperty.PropertyName)
+			{
+				UpdateIsEnabled();
+			}
+			else if (e.PropertyName == ToolbarItem.IconProperty.PropertyName)
+			{
+				UpdateIcon();
+			}
+		}
+
+		void UpdateText()
+		{
+			UpdateStyle();
+			Text = _item.Text;
+		}
+
+		void UpdateIsEnabled()
+		{
+			IsEnabled = _item.IsEnabled;
+		}
+
+		void UpdateIcon()
+		{
+			if (string.IsNullOrEmpty(_item.Icon))
+			{
+				//On 5.0, the part content should be removed before the style is changed, otherwise, EFL does not remove the part content.
+				Image = null;
+				UpdateStyle();
+			}
+			else
+			{
+				// In reverse, the style should be set before setting the part content.
+				UpdateStyle();
+				Native.Image iconImage = new Native.Image(Forms.NativeParent);
+				var task = iconImage.LoadFromImageSourceAsync(_item.Icon);
+				Image = iconImage;
+			}
+		}
+
+		void UpdateStyle()
+		{
+			if (string.IsNullOrEmpty(_item.Icon))
+			{
+				if (string.IsNullOrEmpty(_item.Text))
+				{
+					// We assumed the default toolbar icon is "naviframe/drawer" if there are no icon and text.
+					Style = StyleDefaultToolbarIcon;
+				}
+				else
+				{
+					if (_item.Order == ToolbarItemOrder.Primary)
+						Style = StyleRightToolbarButton;
+					else
+						Style = StyleLeftToolBarButton;
+				}
+			}
+			else
+			{
+				Style = StyleDefault;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/NavigationPageRenderer.cs
@@ -26,10 +26,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		const string PartLeftToolbar = "title_left_btn";
 		const string PartRightToolbar = "title_right_btn";
 		const string PartNavigationBar = "navigationbar";
-		const string StyleLeftToolBarButton = "naviframe/title_left";
-		const string StyleRightToolbarButton = "naviframe/title_right";
 		const string StyleBackButton = "naviframe/back_btn/default";
-		const string StyleDefaultToolbarIcon = "naviframe/drawers";
 		const string StyleNavigationBar = "navigationbar";
 
 		readonly List<Widget> _naviItemContentPartList = new List<Widget>();
@@ -317,37 +314,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (item == default(ToolbarItem))
 				return null;
 
-			Native.Button button = new Native.Button(Forms.NativeParent);
-			button.Clicked += (s, e) =>
-			{
-				IMenuItemController control = item;
-				control.Activate();
-			};
-			button.Text = item.Text;
-			button.BackgroundColor = Color.Transparent.ToNative();
-
-			if (string.IsNullOrEmpty(item.Icon))
-			{
-				if (string.IsNullOrEmpty(item.Text))
-				{
-					// We assumed the default toolbar icon is "naviframe/drawer" if there are no icon and text.
-					button.Style = StyleDefaultToolbarIcon;
-				}
-				else
-				{
-					if (position == ToolbarButtonPosition.Right)
-						button.Style = StyleRightToolbarButton;
-					else
-						button.Style = StyleLeftToolBarButton;
-				}
-			}
-			else
-			{
-				Native.Image iconImage = new Native.Image(Forms.NativeParent);
-				var task = iconImage.LoadFromImageSourceAsync(item.Icon);
-				button.Image = iconImage;
-			}
-
+			Native.ToolbarItemButton button = new Native.ToolbarItemButton(item);
 			return button;
 		}
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This PR is to fix a ToolbarItem issue

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Tizen

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

The changes of some properties(Text, IsEnabled, Icon) are applied after page loading. But the changes that affect the order of toolbaritems such as Order and Priority are ignored.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

- Before
tb1.IsEnabled is false. But It is not applied when the page is loaded.
![1](https://user-images.githubusercontent.com/20968023/48531470-aea1f200-e8df-11e8-9332-48f43db6521d.png)

- After
tb1.IsEnabled is false. tb1 is disabled.
![2](https://user-images.githubusercontent.com/20968023/48531475-b2357900-e8df-11e8-916f-24296f0143bb.png)
After then, If a user changes tb1.IsEnabeld to true, it will be changed as follow.
![3](https://user-images.githubusercontent.com/20968023/48531478-b3ff3c80-e8df-11e8-973d-3c2ea95176a5.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
