### PR TITLE
[Enhancement] Add drag started and completed events/commands to Slider

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/SliderCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/SliderCoreGalleryPage.cs
@@ -26,6 +26,11 @@ namespace Xamarin.Forms.Controls
 			var thumbColorContainer = new ValueViewContainer<Slider> (Test.Slider.ThumbColor, new Slider { ThumbColor = Color.Red, Value = 0.5 }, "Value", value => value.ToString ());
 			var thumbImageContainer = new ValueViewContainer<Slider> (Test.Slider.ThumbImage, new Slider { ThumbImage = "coffee.png", Value = 0.5 }, "Value", value => value.ToString ());
 
+			var dragStartedContainer = new EventViewContainer<Slider>(Test.Slider.DragStarted, new Slider { Value = 0.5 });
+			dragStartedContainer.View.DragStarted += (sender, args) => dragStartedContainer.EventFired();
+			var dragCompletedContainer = new EventViewContainer<Slider>(Test.Slider.DragCompleted, new Slider { Value = 0.5 });
+			dragCompletedContainer.View.DragCompleted += (sender, args) => dragCompletedContainer.EventFired();
+
 			Add (maximumContainer);
 			Add (minimumContainer);
 			Add (valueContainer);
@@ -33,6 +38,8 @@ namespace Xamarin.Forms.Controls
 			Add (maxTrackColorContainer);
 			Add (thumbColorContainer);
 			Add (thumbImageContainer);
+			Add (dragStartedContainer);
+			Add (dragCompletedContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/SliderUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/SliderUnitTests.cs
@@ -108,5 +108,29 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (initialValue, oldValue);
 			Assert.AreEqual (finalValue, newValue);
 		}
+
+		[Test]
+		public void TestDragStarted()
+		{
+			var slider = new Slider();
+			var started = false;
+
+			slider.DragStarted += (sender, arg) => started = true;
+			slider.SendDragStarted();
+
+			Assert.True(started);			
+		}
+
+		[Test]
+		public void TestDragCompleted()
+		{
+			var slider = new Slider();
+			var completed = false;
+
+			slider.DragCompleted += (sender, arg) => completed = true;
+			slider.SendDragCompleted();
+
+			Assert.True(completed);
+		}
 	}	
 }

--- a/Xamarin.Forms.Core/ISliderController.cs
+++ b/Xamarin.Forms.Core/ISliderController.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.Forms
+{
+	public interface ISliderController
+	{
+		void SendDragStarted();
+		void SendDragCompleted();
+	}
+}

--- a/Xamarin.Forms.Core/Slider.cs
+++ b/Xamarin.Forms.Core/Slider.cs
@@ -1,11 +1,13 @@
 using System;
+using System.ComponentModel;
+using System.Windows.Input;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_SliderRenderer))]
-	public class Slider : View, IElementConfiguration<Slider>
+	public class Slider : View, ISliderController, IElementConfiguration<Slider>
 	{
 		public static readonly BindableProperty MinimumProperty = BindableProperty.Create("Minimum", typeof(double), typeof(Slider), 0d, validateValue: (bindable, value) =>
 		{
@@ -48,6 +50,10 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty ThumbColorProperty = BindableProperty.Create(nameof(ThumbColor), typeof(Color), typeof(Slider), Color.Default);
 
 		public static readonly BindableProperty ThumbImageProperty = BindableProperty.Create(nameof(ThumbImage), typeof(FileImageSource), typeof(Slider), default(FileImageSource));
+
+		public static readonly BindableProperty DragStartedCommandProperty = BindableProperty.Create(nameof(DragStartedCommand), typeof(ICommand), typeof(Slider), default(ICommand));
+
+		public static readonly BindableProperty DragCompletedCommandProperty = BindableProperty.Create(nameof(DragCompletedCommand), typeof(ICommand), typeof(Slider), default(ICommand));
 
 		readonly Lazy<PlatformConfigurationRegistry<Slider>> _platformConfigurationRegistry;
 
@@ -98,6 +104,18 @@ namespace Xamarin.Forms
 			set { SetValue(ThumbImageProperty, value); }
 		}
 
+		public ICommand DragStartedCommand
+		{
+			get { return (ICommand)GetValue(DragStartedCommandProperty); }
+			set { SetValue(DragStartedCommandProperty, value); }
+		}
+
+		public ICommand DragCompletedCommand
+		{
+			get { return (ICommand)GetValue(DragCompletedCommandProperty); }
+			set { SetValue(DragCompletedCommandProperty, value); }
+		}
+
 		public double Maximum
 		{
 			get { return (double)GetValue(MaximumProperty); }
@@ -117,6 +135,28 @@ namespace Xamarin.Forms
 		}
 
 		public event EventHandler<ValueChangedEventArgs> ValueChanged;
+		public event EventHandler DragStarted;
+		public event EventHandler DragCompleted;
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendDragStarted()
+		{
+			if (IsEnabled)
+			{
+				DragStartedCommand?.Execute(null);
+				DragStarted?.Invoke(this, null);
+			}
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendDragCompleted()
+		{
+			if (IsEnabled)
+			{
+				DragCompletedCommand?.Execute(null);
+				DragCompleted?.Invoke(this, null);
+			}
+		}
 
 		public IPlatformElementConfiguration<T, Slider> On<T>() where T : IConfigPlatform
 		{

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -687,7 +687,9 @@ namespace Xamarin.Forms.CustomAttributes
 			MinimumTrackColor,
 			MaximumTrackColor,
 			ThumbColor,
-			ThumbImage
+			ThumbImage,
+			DragStarted,
+			DragCompleted
 		}
 
 		public enum StackLayout

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -44,11 +44,13 @@ namespace Xamarin.Forms.Platform.Android
 		void SeekBar.IOnSeekBarChangeListener.OnStartTrackingTouch(SeekBar seekBar)
 		{
 			_isTrackingChange = true;
+			((ISliderController)Element)?.SendDragStarted();
 		}
 
 		void SeekBar.IOnSeekBarChangeListener.OnStopTrackingTouch(SeekBar seekBar)
 		{
 			_isTrackingChange = false;
+			((ISliderController)Element)?.SendDragCompleted();
 		}
 
 		protected override SeekBar CreateNativeControl()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
@@ -56,6 +56,16 @@ namespace Xamarin.Forms.Platform.MacOS
 		void OnControlActivated(object sender, EventArgs eventArgs)
 		{
 			ElementController?.SetValueFromRenderer(Slider.ValueProperty, Control.DoubleValue);
+
+			var controlEvent = NSApplication.SharedApplication.CurrentEvent;
+			if (controlEvent.Type == NSEventType.LeftMouseDown)
+			{
+				((ISliderController)Element)?.SendDragStarted();
+			}
+			else if (controlEvent.Type == NSEventType.LeftMouseUp)
+			{
+				((ISliderController)Element)?.SendDragCompleted();
+			}
 		}
 
 		void UpdateMaximum()

--- a/Xamarin.Forms.Platform.UAP/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SliderRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 
@@ -12,6 +13,27 @@ namespace Xamarin.Forms.Platform.UWP
 		Brush defaultforegroundcolor;
 		Brush defaultbackgroundcolor;
 		Brush _defaultThumbColor;
+
+		PointerEventHandler _pointerPressedHandler;
+		PointerEventHandler _pointerReleasedHandler;
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				if (Control != null)
+				{
+					Control.RemoveHandler(PointerPressedEvent, _pointerPressedHandler);
+					Control.RemoveHandler(PointerReleasedEvent, _pointerReleasedHandler);
+					Control.RemoveHandler(PointerCanceledEvent, _pointerReleasedHandler);
+
+					_pointerPressedHandler = null;
+					_pointerReleasedHandler = null;
+				}
+			}
+
+			base.Dispose(disposing);
+		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Slider> e)
 		{
@@ -55,6 +77,13 @@ namespace Xamarin.Forms.Platform.UWP
 
 						slider.Margin = new Windows.UI.Xaml.Thickness(0, 7, 0, 0);
 					}
+
+					_pointerPressedHandler = new PointerEventHandler(OnPointerPressed);
+					_pointerReleasedHandler = new PointerEventHandler(OnPointerReleased);
+
+					Control.AddHandler(PointerPressedEvent, _pointerPressedHandler, true);
+					Control.AddHandler(PointerReleasedEvent, _pointerReleasedHandler, true);
+					Control.AddHandler(PointerCanceledEvent, _pointerReleasedHandler, true);
 				}
 
 				double stepping = Math.Min((e.NewElement.Maximum - e.NewElement.Minimum) / 1000, 1);
@@ -180,6 +209,16 @@ namespace Xamarin.Forms.Platform.UWP
 		void OnNativeValueChanged(object sender, RangeBaseValueChangedEventArgs e)
 		{
 			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, e.NewValue);
+		}
+
+		void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+		{
+			((ISliderController)Element)?.SendDragStarted();
+		}
+
+		void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+		{
+			((ISliderController)Element)?.SendDragCompleted();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
@@ -28,6 +28,9 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.RemoveGestureRecognizer(_sliderTapRecognizer);
 					_sliderTapRecognizer = null;
 				}
+
+				Control.RemoveTarget(OnTouchDownControlEvent, UIControlEvent.TouchDown);
+				Control.RemoveTarget(OnTouchUpControlEvent, UIControlEvent.TouchUpInside | UIControlEvent.TouchUpOutside);
 			}
 
 			base.Dispose(disposing);
@@ -54,6 +57,9 @@ namespace Xamarin.Forms.Platform.iOS
 					// except if your not running iOS 7... then it fails...
 					if (_fitSize.Width <= 0 || _fitSize.Height <= 0)
 						_fitSize = new SizeF(22, 22); // Per the glorious documentation known as the SDK docs
+
+					Control.AddTarget(OnTouchDownControlEvent, UIControlEvent.TouchDown);
+					Control.AddTarget(OnTouchUpControlEvent, UIControlEvent.TouchUpInside | UIControlEvent.TouchUpOutside);
 				}
 
 				UpdateMaximum();
@@ -170,6 +176,16 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnControlValueChanged(object sender, EventArgs eventArgs)
 		{
 			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, Control.Value);
+		}
+
+		void OnTouchDownControlEvent(object sender, EventArgs e)
+		{
+			((ISliderController)Element)?.SendDragStarted();
+		}
+
+		void OnTouchUpControlEvent(object sender, EventArgs e)
+		{
+			((ISliderController)Element)?.SendDragCompleted();
 		}
 
 		void UpdateTapRecognizer()


### PR DESCRIPTION
### Description of Change ###

PR implementation for #1450.
Add DragStarted and DragCompleted events/commands to the Slider control.
These fire at the beginning and end of the slider drag action.

### Issues Resolved  ###
fixes #1450

### API Changes ###

Added to `Slider`:
- EventHandler DragStarted
- EventHandler DragCompleted
 - ICommand DragStartedCommand { get; set; } // Bindable Property
 - ICommand DragCompletedCommand { get; set; } // Bindable Property
 - public void SendDragStarted()
 - public void SendDragCompleted()

### Platforms Affected ###

- Core/XAML (all platforms)
- iOS
- Android
- UWP
- MacOS

**Contributions welcome for Tizen, GTK and WPF!**

### Behavioral/Visual Changes ###

Extends behavior of `Slider` to add events/commands for drag started and completed.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard