### PR TITLE
[Android] Remove WebViewRenderer dependency on Activity

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebChromeClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebChromeClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Android.App;
 using Android.Content;
 using Android.Webkit;
+using Xamarin.Forms.Internals;
 using Object = Java.Lang.Object;
 
 namespace Xamarin.Forms.Platform.Android
@@ -33,6 +34,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected bool ChooseFile(IValueCallback filePathCallback, Intent intent, string title)
 		{
+			if (_activity == null)
+				return false;
+
 			Action<Result, Intent> callback = (resultCode, intentData) =>
 			{
 				if (filePathCallback == null)
@@ -65,12 +69,11 @@ namespace Xamarin.Forms.Platform.Android
 			return FileChooserParams.ParseResult((int)resultCode, data);
 		}
 
-		internal void SetContext(Activity thisActivity)
+		internal void SetContext(Context thisActivity)
 		{
-			if (thisActivity == null)
-				throw new ArgumentNullException(nameof(thisActivity));
-
-			_activity = thisActivity;
+			_activity = thisActivity as Activity;
+			if (_activity == null)
+				Log.Warning(nameof(WebViewRenderer), $"Failed to set the activity of the WebChromeClient, can't show pickers on the Webview");
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Forms.Platform.Android
 				webView.SetWebViewClient(_webViewClient);
 
 				_webChromeClient = GetFormsWebChromeClient();
-				_webChromeClient.SetContext(Context as Activity);
+				_webChromeClient.SetContext(Context);
 				webView.SetWebChromeClient(_webChromeClient);
 
 				webView.Settings.JavaScriptEnabled = true;


### PR DESCRIPTION
### Description of Change ###

The context is not always an Activity, for example running on the Previewer. Remove the Exception , handle fail gracefully with a Log warning 
### Issues Resolved ### 

- fixes #4107

### API Changes ###
none
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
IF running in the previewer you won't be able to open alerts or the file picker for a WebView.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Check if the previewer doesn't crash in a Xaml page with a <WebView>

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard

> VS bug [#730672](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/730672)