### PR TITLE
[Android] Fix Label size when using Hint text

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2580.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2580.cs
@@ -20,23 +20,24 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var instructions = new Label { Text = "Manual check that both Label 1 have the same size, if the 1st is bigger than this test failed." };
 			var label = new Label { Text = "Label 1", BackgroundColor = Color.Red };
-			AutomationProperties.SetHelpText(label, "This is a The longer this is, the worse the problem");
+			AutomationProperties.SetHelpText(label, "The longer this label hit is, the worse the problem");
+			var image = new Image { Source = "bank.png", BackgroundColor = Color.Red };
+			AutomationProperties.SetHelpText(image, "The longer this image hint is, the worse the problem");
+			var image2 = new Image { Source = "bank.png", BackgroundColor = Color.Red };
 			var label2 = new Label { Text = "Label 1", BackgroundColor = Color.Red };
 			var horizontalLayout = new StackLayout
 			{
 				Orientation = StackOrientation.Horizontal,
-				Children = { label
-					//,new Label { Text = "label 2" }, new Label { Text = "label 3" }, new Label { Text = "label 4" } }
-				}
+				Children = { label, image, new Label { Text = "label 2" }, new Label { Text = "label 3" }, new Label { Text = "label 4" } }
 			};
 			Content = new StackLayout
 			{
 				Children = {
-					//instructions,
-					horizontalLayout
-					//, new StackLayout { Orientation = StackOrientation.Horizontal, Children = { label2, new Label { Text = "label 2" }, new Label { Text = "label 3" }, new Label { Text = "label 4" } } } } };
-			}
+					instructions,
+					horizontalLayout,
+					new StackLayout { Orientation = StackOrientation.Horizontal, Children = { label2, image2, new Label { Text = "label 2" }, new Label { Text = "label 3" }, new Label { Text = "label 4" } } } }
 			};
+
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2580.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2580.cs
@@ -1,0 +1,42 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2580, "Adding accessibility tags to a label seems to cause the renderer to need more space", PlatformAffected.Android)]
+	public class Issue2580 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var instructions = new Label { Text = "Manual check that both Label 1 have the same size, if the 1st is bigger than this test failed." };
+			var label = new Label { Text = "Label 1", BackgroundColor = Color.Red };
+			AutomationProperties.SetHelpText(label, "This is a The longer this is, the worse the problem");
+			var label2 = new Label { Text = "Label 1", BackgroundColor = Color.Red };
+			var horizontalLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal,
+				Children = { label
+					//,new Label { Text = "label 2" }, new Label { Text = "label 3" }, new Label { Text = "label 4" } }
+				}
+			};
+			Content = new StackLayout
+			{
+				Children = {
+					//instructions,
+					horizontalLayout
+					//, new StackLayout { Orientation = StackOrientation.Horizontal, Children = { label2, new Label { Text = "label 2" }, new Label { Text = "label 3" }, new Label { Text = "label 4" } } } } };
+			}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -536,6 +536,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3049.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewClipBoundsShouldUpdate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3988.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -71,7 +71,16 @@ namespace Xamarin.Forms.Platform.Android
 					return _lastSizeRequest.Value;
 			}
 
+			//We need to clear the Hint or else it will interfere with the sizing of the Label
+			var hint = Control.Hint;
+			if(!string.IsNullOrEmpty(hint))
+				Control.Hint = string.Empty;
+		
 			SizeRequest result = base.GetDesiredSize(widthConstraint, heightConstraint);
+
+			//Set Hint back after sizing
+			Control.Hint = hint;
+
 			result.Minimum = new Size(Math.Min(Context.ToPixels(10), result.Request.Width), result.Request.Height);
 
 			_lastConstraintWidth = widthConstraint;


### PR DESCRIPTION
### Description of Change ###

When setting the `HelpText` for accessibility on a `Label` it causes to set the `Hint` text on a `TextView` . 
Later when we are Measuring it  Android will take the Hint text size in account and return wrong sizes that won't fit just the text but hint also. 
We need to clear the Hint before measure.

Trying to move the calls to set hint to other places is no good because sizing is called sometimes multiple times when text is changing. 

### Issues Resolved ### 

- fixes #2580

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Labels with HelpText with size correctly 


### Before/After Screenshots ### 

BEFORE:
![screenshot-1542302349417](https://user-images.githubusercontent.com/1235097/48569814-a4412180-e8fa-11e8-8290-5434b51ae0ad.jpg)

AFTER:
![screenshot-1542302279780](https://user-images.githubusercontent.com/1235097/48569813-a4412180-e8fa-11e8-8237-e60b97d9e967.jpg)


### Testing Procedure ###
Go to issue 2580 make sure the 2 rows look the same. 

### PR Checklist ###

- [ ] Has automated tests 
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
