### PR TITLE
[C] ToStringValueConverter shouldn't be public

### DIFF
--- a/Xamarin.Forms.Core/ToStringValueConverter.cs
+++ b/Xamarin.Forms.Core/ToStringValueConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace Xamarin.Forms
 {
-	public class ToStringValueConverter : IValueConverter
+	class ToStringValueConverter : IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{


### PR DESCRIPTION
#4016 introduce this new public API that I think we shouldn't expose. we could, in the future,  expose a set of commonly used converters, but a single one doesn't make sense.