### PR TITLE
Cherry-Pick #4016 and #4442 to 3.4.0

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ToStringValueConverterTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ToStringValueConverterTests.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using System.Globalization;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class ToStringValueConverterTests : BaseTestFixture
+	{
+		static readonly CultureInfo _enUsCulture = CultureInfo.GetCultureInfo("en-US");
+		static readonly CultureInfo _skSkCulture = CultureInfo.GetCultureInfo("sk-SK");
+
+		[SetUp]
+		public override void Setup()
+		{
+			base.Setup();
+			System.Threading.Thread.CurrentThread.CurrentCulture = _enUsCulture;
+		}
+
+		[Test]
+		public void NullObjectConvertsToNull()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(null, null, null, null);
+
+			Assert.That(result, Is.Null);
+		}
+
+		[Test]
+		public void NullObjectWithTargetTypeConvertsToNull()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(null, typeof(string), null, null);
+
+			Assert.That(result, Is.Null);
+		}
+
+		[Test]
+		public void ObjectConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(new object(), typeof(string), null, null);
+
+			Assert.That(result, Is.EqualTo("System.Object"));
+		}
+
+		[Test]
+		public void EmptyStringConvertsToEmptyString()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(string.Empty, typeof(string), null, null);
+
+			Assert.That(result, Is.EqualTo(string.Empty));
+		}
+
+		[Test]
+		public void StringConvertsToString()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert("Hello, World!", typeof(string), null, null);
+
+			Assert.That(result, Is.EqualTo("Hello, World!"));
+		}
+
+		private class ToStringObject
+		{
+			public ToStringObject(string value)
+			{
+				Value = value;
+			}
+
+			public string Value { get; set; }
+
+			public int ToStringCounter { get; private set; }
+
+			public override string ToString()
+			{
+				ToStringCounter++;
+				return Value;
+			}
+		}
+
+		[Test]
+		public void CustomObjectWithNullValueConvertsToNull()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			var value = new ToStringObject(null);
+			object result = toStringValueConverter.Convert(value, typeof(string), null, null);
+
+			Assert.That(result, Is.Null);
+			Assert.That(value.ToStringCounter, Is.EqualTo(1));
+		}
+
+		[Test]
+		public void CustomObjectWithEmptyStringConvertsToEmptyString()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			var value = new ToStringObject(string.Empty);
+			object result = toStringValueConverter.Convert(value, typeof(string), null, null);
+
+			Assert.That(result, Is.EqualTo(string.Empty));
+			Assert.That(value.ToStringCounter, Is.EqualTo(1));
+		}
+
+		[Test]
+		public void CustomObjectWithStringConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			var value = new ToStringObject("Test string");
+			object result = toStringValueConverter.Convert(value, typeof(string), null, null);
+
+			Assert.That(result, Is.EqualTo("Test string"));
+			Assert.That(value.ToStringCounter, Is.EqualTo(1));
+		}
+
+		[Test]
+		public void ExecutesToStringTwice()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			var value = new ToStringObject("Test string");
+			object result = toStringValueConverter.Convert(value, typeof(string), null, _skSkCulture);
+
+			Assert.That(result, Is.EqualTo("Test string"));
+
+			value.Value = "Hello, World!";
+			result = toStringValueConverter.Convert(value, typeof(string), null, _skSkCulture);
+
+			Assert.That(result, Is.EqualTo("Hello, World!"));
+			Assert.That(value.ToStringCounter, Is.EqualTo(2));
+		}
+
+		[Test]
+		public void DoubleValueConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(99123.567, typeof(string), null, null);
+
+			Assert.That(result, Is.EqualTo("99123.567"));
+		}
+
+		[Test]
+		public void DoubleValueWithSkCultureConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(99123.567, typeof(string), null, _skSkCulture);
+
+			Assert.That(result, Is.EqualTo("99123,567"));
+		}
+
+		[Test]
+		public void DoubleValueWithEmptyParameterConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(99123.567, typeof(string), string.Empty, null);
+
+			Assert.That(result, Is.EqualTo("99123.567"));
+		}
+
+		[Test]
+		public void DoubleValueWithEmptyParameterAndSkCultureConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(99123.567, typeof(string), string.Empty, _skSkCulture);
+
+			Assert.That(result, Is.EqualTo("99123,567"));
+		}
+
+		[Test]
+		public void DoubleValueWithNumberFormatConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(99123.567, typeof(string), "N2", null);
+
+			Assert.That(result, Is.EqualTo("99,123.57"));
+		}
+
+		[Test]
+		public void DoubleValueWithNumberFormatAndSkCultureConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			object result = toStringValueConverter.Convert(99123.567, typeof(string), "N2", _skSkCulture);
+
+			Assert.That(result, Is.EqualTo("99 123,57"));
+		}
+
+		[Test]
+		public void DoubleValueWithSpecificFormatConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			var format = new ToStringObject("#,##0.000");
+			object result = toStringValueConverter.Convert(99123.56, typeof(string), format, null);
+
+			Assert.That(result, Is.EqualTo("99,123.560"));
+		}
+
+		[Test]
+		public void DoubleValueWithSpecificFormatAndSkCultureConvertsToStringValue()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			var format = new ToStringObject("#,##0.000");
+			object result = toStringValueConverter.Convert(99123.56, typeof(string), format, _skSkCulture);
+
+			Assert.That(result, Is.EqualTo("99 123,560"));
+		}
+
+		[Test]
+		public void NullObjectConvertsBackThrowsException()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			TestDelegate action = () => toStringValueConverter.ConvertBack(null, null, null, null);
+
+			Assert.That(action, Throws.InstanceOf<NotSupportedException>());
+		}
+
+		[Test]
+		public void ObjectConvertsBackThrowsException()
+		{
+			var toStringValueConverter = new ToStringValueConverter();
+
+			TestDelegate action = () => toStringValueConverter.ConvertBack(new object(), typeof(string), null, null);
+
+			Assert.That(action, Throws.InstanceOf<NotSupportedException>());
+		}
+	}
+}

--- a/Xamarin.Forms.Core/ToStringValueConverter.cs
+++ b/Xamarin.Forms.Core/ToStringValueConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Globalization;
+
+namespace Xamarin.Forms
+{
+	public class ToStringValueConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value == null)
+			{
+				return null;
+			}
+
+			if (value is IFormattable formattable)
+			{
+				return formattable.ToString(parameter?.ToString(), culture);
+			}
+
+			return value.ToString();
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/Xamarin.Forms.Core/ToStringValueConverter.cs
+++ b/Xamarin.Forms.Core/ToStringValueConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace Xamarin.Forms
 {
-	public class ToStringValueConverter : IValueConverter
+	class ToStringValueConverter : IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{


### PR DESCRIPTION
### Description of Change ###

Fix ListView not calling ToString() when no template is set.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4426
- fixes #3715 on 3.4.0

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
