### PR TITLE
[Core]Call invalidate measure after the FormattedText is set

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4026.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4026.cs
@@ -16,21 +16,16 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 4026, "Bindable Span height Issue", PlatformAffected.All)]
 	public class Issue4026 : TestContentPage
 	{
-		public Issue4026()
-		{
-			BindingContext = this;
-		}
 		protected override void Init()
 		{
+			Padding = new Thickness(0, 40, 0, 0);
 			BackgroundColor = Color.Aquamarine;
-			var layout = new StackLayout { VerticalOptions = LayoutOptions.Start, BackgroundColor = Color.CadetBlue, Padding = new Thickness(10) };
-			var btn = new Button { Text = "Add More Text to Span", Command = new Command(() => Title += " More Text") };
-			var spanBindable = new Span { TextColor = Color.Blue };
+			var btn = new Button { Text = "Add More Text to Span", Command = new Command(() => Title += " More Text is here") };
+			var spanBindable = new Span { TextColor = Color.Blue, };
 			spanBindable.SetBinding(Span.TextProperty, new Binding(nameof(Title), BindingMode.OneWay));
-			var label = new Label { BackgroundColor = Color.Red, FormattedText = new FormattedString { Spans = { new Span { Text = "Span Test Span Test Span Test Span Test" }, spanBindable } } };
-			layout.Children.Add(btn);
-			layout.Children.Add(label);
-			Content = layout;
+			var label = new Label { LineBreakMode = LineBreakMode.WordWrap, VerticalTextAlignment = TextAlignment.Center, BackgroundColor = Color.Red, FormattedText = new FormattedString { Spans = { new Span { Text = "Span Test Span Test Span Test Span Test" }, spanBindable } } };
+			BindingContext = this;
+			Content = new StackLayout { VerticalOptions = LayoutOptions.Start, BackgroundColor = Color.CadetBlue, Padding = new Thickness(10), Children = { new Label { Text = "When you add new spans, all of them should appear, they should not be cut." }, btn, label } };
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4026.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4026.cs
@@ -1,0 +1,36 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4026, "Bindable Span height Issue", PlatformAffected.All)]
+	public class Issue4026 : TestContentPage
+	{
+		public Issue4026()
+		{
+			BindingContext = this;
+		}
+		protected override void Init()
+		{
+			BackgroundColor = Color.Aquamarine;
+			var layout = new StackLayout { VerticalOptions = LayoutOptions.Start, BackgroundColor = Color.CadetBlue, Padding = new Thickness(10) };
+			var btn = new Button { Text = "Add More Text to Span", Command = new Command(() => Title += " More Text") };
+			var spanBindable = new Span { TextColor = Color.Blue };
+			spanBindable.SetBinding(Span.TextProperty, new Binding(nameof(Title), BindingMode.OneWay));
+			var label = new Label { BackgroundColor = Color.Red, FormattedText = new FormattedString { Spans = { new Span { Text = "Span Test Span Test Span Test Span Test" }, spanBindable } } };
+			layout.Children.Add(btn);
+			layout.Children.Add(label);
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -537,6 +537,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ViewClipBoundsShouldUpdate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3988.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2580.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4026.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Core/FormattedString.cs
+++ b/Xamarin.Forms.Core/FormattedString.cs
@@ -54,7 +54,11 @@ namespace Xamarin.Forms
 					var bo = item as Span;
 					bo.Parent = null;
 					if (bo != null)
+					{
+						bo.PropertyChanging -= OnItemPropertyChanging;
 						bo.PropertyChanged -= OnItemPropertyChanged;
+					}
+						
 				}
 			}
 
@@ -65,7 +69,11 @@ namespace Xamarin.Forms
 					var bo = item as Span;
 					bo.Parent = this;
 					if (bo != null)
+					{
+						bo.PropertyChanging += OnItemPropertyChanging;
 						bo.PropertyChanged += OnItemPropertyChanged;
+					}
+						
 				}
 			}
 
@@ -76,6 +84,11 @@ namespace Xamarin.Forms
 		void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			OnPropertyChanged(nameof(Spans));
+		}
+
+		void OnItemPropertyChanging(object sender, PropertyChangingEventArgs e)
+		{
+			OnPropertyChanging(nameof(Spans));
 		}
 
 		class SpanCollection : ObservableCollection<Span>

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms
 
 					formattedString.SpansCollectionChanged -= label.Span_CollectionChanged;
 					formattedString.PropertyChanged -= label.OnFormattedTextChanged;
+					formattedString.PropertyChanging -= label.OnFormattedTextChanging;
 					formattedString.Parent = null;
 					label.RemoveSpans(formattedString.Spans);
 				}
@@ -59,6 +60,7 @@ namespace Xamarin.Forms
 				{
 					var formattedString = (FormattedString)newvalue;
 					formattedString.Parent = label;
+					formattedString.PropertyChanging += label.OnFormattedTextChanging;
 					formattedString.PropertyChanged += label.OnFormattedTextChanged;
 					formattedString.SpansCollectionChanged += label.Span_CollectionChanged;
 					label.SetupSpans(formattedString.Spans);
@@ -208,6 +210,10 @@ namespace Xamarin.Forms
 		void ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue) =>
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
+		void OnFormattedTextChanging(object sender, PropertyChangingEventArgs e)
+		{
+			OnPropertyChanging("FormattedText");
+		}
 		void OnFormattedTextChanged(object sender, PropertyChangedEventArgs e)
 		{
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);

--- a/Xamarin.Forms.Core/Label.cs
+++ b/Xamarin.Forms.Core/Label.cs
@@ -216,8 +216,8 @@ namespace Xamarin.Forms
 		}
 		void OnFormattedTextChanged(object sender, PropertyChangedEventArgs e)
 		{
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 			OnPropertyChanged("FormattedText");
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
 		void SetupSpans(System.Collections.IEnumerable spans)

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -164,7 +164,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				|| e.PropertyName == Label.FormattedTextProperty.PropertyName
 				|| e.PropertyName == Label.LineBreakModeProperty.PropertyName
 				|| e.PropertyName == Label.LineHeightProperty.PropertyName
-				|| e.PropertyName == Label.TextColorProperty.PropertyName)
+				|| e.PropertyName == Label.TextColorProperty.PropertyName
+				|| e.PropertyName == Label.FontProperty.PropertyName)
 			{
 				_perfectSizeValid = false;
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -117,12 +117,27 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		}
 
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+			if (disposing)
+			{
+				Element.PropertyChanging -= ElementPropertyChanging;
+			}
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
 		{
+			if (e.OldElement != null)
+			{
+				Element.PropertyChanging -= ElementPropertyChanging;
+			}
+
 			if (e.NewElement != null)
 			{
 				if (Control == null)
 				{
+					Element.PropertyChanging += ElementPropertyChanging;
 					SetNativeControl(new NativeLabel(RectangleF.Empty));
 #if !__MOBILE__
 					Control.Editable = false;
@@ -141,6 +156,18 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 
 			base.OnElementChanged(e);
+		}
+
+		void ElementPropertyChanging(object sender, PropertyChangingEventArgs e)
+		{
+			if (e.PropertyName == Label.TextProperty.PropertyName
+				|| e.PropertyName == Label.FormattedTextProperty.PropertyName
+				|| e.PropertyName == Label.LineBreakModeProperty.PropertyName
+				|| e.PropertyName == Label.LineHeightProperty.PropertyName
+				|| e.PropertyName == Label.TextColorProperty.PropertyName)
+			{
+				_perfectSizeValid = false;
+			}
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -253,7 +280,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateLineBreakMode()
 		{
-			_perfectSizeValid = false;
 #if __MOBILE__
 			switch (Element.LineBreakMode)
 			{
@@ -303,7 +329,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateText()
 		{
-			_perfectSizeValid = false;
 			var values = Element.GetValues(Label.FormattedTextProperty, Label.TextProperty);
 
 			_formatted = values[0] as FormattedString;
@@ -341,7 +366,6 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateFormattedText();
 				return;
 			}
-			_perfectSizeValid = false;
 
 #if __MOBILE__
 			Control.Font = Element.ToUIFont();
@@ -358,8 +382,6 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateFormattedText();
 				return;
 			}
-
-			_perfectSizeValid = false;
 
 			var textColor = (Color)Element.GetValue(Label.TextColorProperty);
 


### PR DESCRIPTION
### Description of Change ###

When the FormattedText was changed we invalidate measure before the Text was update on the control. 

[iOS]
Hook the PropertyChanging event to clear the perfectSize cache

### Issues Resolved ### 

- fixes #4026 

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

The invalidate measure is called after PropertyChanged.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Go to issue 4026 on the gallery, add tab "Add More Text to Span", make sure all text is shown. Click it more times to see new lines are added and it always shows all new texto added.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
