### PR TITLE
[Enhancement] Add Visual progress behind feature flag 

### DIFF
--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -22,6 +22,12 @@
         <dependency id="Xamarin.Android.Support.v7.AppCompat" version="27.0.2"/>
         <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
+      <group targetFramework="MonoAndroid90">
+        <dependency id="Xamarin.GooglePlayServices.Maps" version="60.1142.1"/>
+        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0-preview7"/>
+        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0-preview7"/>
+        <dependency id="Xamarin.Forms" version="$version$"/>
+      </group>
       <group targetFramework="tizen40">
         <dependency id="Tizen.NET" version="4.0.0"/>
       </group>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -20,6 +20,13 @@
         <dependency id="Xamarin.Android.Support.v7.CardView" version="27.0.2"/>
         <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="27.0.2"/>
       </group>
+      <group targetFramework="MonoAndroid90">
+        <dependency id="Xamarin.Android.Support.v4" version="28.0.0-preview7"/>
+        <dependency id="Xamarin.Android.Support.Design" version="28.0.0-preview7"/>
+        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0-preview7"/>
+        <dependency id="Xamarin.Android.Support.v7.CardView" version="28.0.0-preview7"/>
+        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0-preview7"/>
+      </group>
       <group targetFramework="uap10.0">
         <dependency id="NETStandard.Library" version="2.0.1"/>
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.0.12" />
@@ -41,13 +48,20 @@
             <reference file="Xamarin.Forms.Xaml.dll" /> 
             <reference file="Xamarin.Forms.Platform.iOS.dll" /> 
         </group>    
-        <group targetFramework="MonoAndroid10"> 
+        <group targetFramework="MonoAndroid90"> 
             <reference file="Xamarin.Forms.Core.dll" /> 
             <reference file="Xamarin.Forms.Platform.dll" /> 
             <reference file="Xamarin.Forms.Xaml.dll" /> 
             <reference file="FormsViewGroup.dll" /> 
             <reference file="Xamarin.Forms.Platform.Android.dll" /> 
-        </group>    
+        </group>
+        <group targetFramework="MonoAndroid81">
+          <reference file="Xamarin.Forms.Core.dll" />
+          <reference file="Xamarin.Forms.Platform.dll" />
+          <reference file="Xamarin.Forms.Xaml.dll" />
+          <reference file="FormsViewGroup.dll" />
+          <reference file="Xamarin.Forms.Platform.Android.dll" />
+        </group>   
         <group targetFramework="uap10.0">   
             <reference file="Xamarin.Forms.Core.dll" /> 
             <reference file="Xamarin.Forms.Platform.dll" /> 
@@ -126,8 +140,10 @@
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\netstandard1.0\Design" />
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\netstandard1.0\Design" />
 
-    <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\MonoAndroid10\Design" /> 
-    <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\MonoAndroid10\Design" /> 
+    <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\MonoAndroid90\Design" /> 
+    <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\MonoAndroid90\Design" />
+    <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\MonoAndroid81\Design" />
+    <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\MonoAndroid81\Design" />
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\Xamarin.iOS10\Design" /> 
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\Xamarin.iOS10\Design" /> 
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\uap10.0\Design" />   
@@ -137,18 +153,31 @@
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\tizen40\Design" />   
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\tizen40\Design" />
     
-    <!--Android-->
-    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\Xamarin.Forms.Platform.Android.dll" target="lib\MonoAndroid10" />
-    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\Xamarin.Forms.Platform.Android.*pdb" target="lib\MonoAndroid10" />
-    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.dll" target="lib\MonoAndroid10" />
-    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.*pdb" target="lib\MonoAndroid10" />
-    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\MonoAndroid10" />
-    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\MonoAndroid10" />
-    <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\MonoAndroid10" />
-    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\MonoAndroid10" />
-    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\MonoAndroid10" />
-    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid10" />
-    <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid10" />
+    <!--Android 81-->
+    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid81\Xamarin.Forms.Platform.Android.dll" target="lib\MonoAndroid81" />
+    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid81\Xamarin.Forms.Platform.Android.*pdb" target="lib\MonoAndroid81" />
+    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.dll" target="lib\MonoAndroid81" />
+    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.*pdb" target="lib\MonoAndroid81" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\MonoAndroid81" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\MonoAndroid81" />
+    <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\MonoAndroid81" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\MonoAndroid81" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\MonoAndroid81" />
+    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid81" />
+    <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid81\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid81" />
+    
+    <!--Android 90-->
+    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Platform.Android.dll" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Platform.Android.*pdb" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.dll" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.*pdb" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\MonoAndroid90" />
+    <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\MonoAndroid90" />
+    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid90" />
+    <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid90" />
 
     <!--iPhone Unified-->
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.dll" target="lib\Xamarin.iOS10" />

--- a/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
+++ b/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
@@ -15,7 +15,8 @@
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v9.0</AndroidTargetFrameworkVersion>
+    <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -109,9 +110,20 @@
   <ItemGroup>
     <AndroidEnvironment Include="environment.txt" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
+      <Version>27.0.2.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/EmbeddingTestBeds/Embedding.Droid/Properties/AndroidManifest.xml
+++ b/EmbeddingTestBeds/Embedding.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Embedding.Droid.Embedding.Droid" android:versionCode="1" android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="16" />
-  <application android:label="Embedding.Droid"></application>
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28"  />
+	<application android:label="Embedding.Droid"></application>
 </manifest>

--- a/EmbeddingTestBeds/Embedding.iOS/Embedding.iOS.csproj
+++ b/EmbeddingTestBeds/Embedding.iOS/Embedding.iOS.csproj
@@ -107,5 +107,10 @@
       <Name>Xamarin.Forms.Platform.iOS (Forwarders)</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.iOS.MaterialComponents">
+      <Version>60.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -16,7 +16,8 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v9.0</AndroidTargetFrameworkVersion>
+    <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />
@@ -265,65 +266,112 @@
     <PackageReference Include="System.Xml.XDocument">
       <Version>4.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Arch.Core.Common">
-      <Version>1.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common">
-      <Version>1.0.3</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Runtime">
-      <Version>1.0.3</Version>
-    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Annotations">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Compat">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Core.UI">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Core.Utils">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.CustomTabs">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Design">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Fragment">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Media.Compat">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Transition">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.CardView">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.Palette">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">
+    <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Annotations">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Compat">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Core.UI">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Core.Utils">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.CustomTabs">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Design">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Fragment">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Media.Compat">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Transition">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.CardView">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.Palette">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Vector.Drawable">
+      <Version>27.0.2.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/PagesGallery/PagesGallery.Droid/Properties/AndroidManifest.xml
+++ b/PagesGallery/PagesGallery.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="15" />
+	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="28"  />
 	<application></application>
 </manifest>

--- a/PagesGallery/PagesGallery.iOS/Info.plist
+++ b/PagesGallery/PagesGallery.iOS/Info.plist
@@ -21,7 +21,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>6.0</string>
+	<string>8.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>PagesGallery</string>
 	<key>CFBundleIdentifier</key>

--- a/PagesGallery/PagesGallery.iOS/PagesGallery.iOS.csproj
+++ b/PagesGallery/PagesGallery.iOS/PagesGallery.iOS.csproj
@@ -134,6 +134,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Xamarin.iOS.MaterialComponents" Version="60.1.0" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -17,7 +17,8 @@
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v9.0</AndroidTargetFrameworkVersion>
+    <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <PackageId>Xamarin.Forms.Platform.AndroidForwarders</PackageId>
@@ -26,7 +27,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">bin\Debug\monoandroid81\</OutputPath>
+    <OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">bin\Debug\monoandroid90\</OutputPath>
     <DefineConstants>TRACE;DEBUG;__ANDROID__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -35,7 +37,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">bin\Release\monoandroid81\</OutputPath>
+    <OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">bin\Release\monoandroid90\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -69,12 +72,20 @@
       <Name>Xamarin.Forms.Platform.Android</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
+      <Version>27.0.2.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -42,13 +42,12 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 #if TEST_EXPERIMENTAL_RENDERERS
 			// CollectionView lets us test CollectionView stuff until it's officially released
-			Forms.SetFlags("FastRenderers_Experimental");
+			Forms.SetFlags("FastRenderers_Experimental"/*, "CollectionView_Experimental", "Visual_Experimental"*/); 
 #else
 			// Fake_Flag is here so we can test for flag initialization issues
 			// CollectionView lets us test CollectionView stuff until it's officially released
-			Forms.SetFlags("Fake_Flag"); 
+			Forms.SetFlags("Fake_Flag"/*, "CollectionView_Experimental", "Visual_Experimental"*/); 
 #endif
-
 			Forms.Init(this, bundle);
 
 			FormsMaps.Init(this, bundle);

--- a/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="AndroidControlGallery.AndroidControlGallery" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="26" />
+	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="28" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -15,7 +15,8 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v9.0</AndroidTargetFrameworkVersion>
+    <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
@@ -28,6 +29,7 @@
     <AndroidTlsProvider>
     </AndroidTlsProvider>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <AndroidKeyStore>True</AndroidKeyStore>
@@ -44,16 +46,16 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <AndroidLinkMode>Full</AndroidLinkMode>
+    <AndroidLinkMode>None</AndroidLinkMode>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi;armeabi-v7a;x86</AndroidSupportedAbis>
-    <Debugger>.Net (Xamarin)</Debugger>
+    <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
+    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -62,19 +64,16 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
-    <AndroidLinkSkip />
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
-    <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />
-    <JavaOptions />
     <MonoDroidExtraArgs />
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
+    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
@@ -155,10 +154,6 @@
     <AndroidResource Include="Resources\drawable\cover1.jpg" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\PagesGallery\PagesGallery.Droid\PagesGallery.Droid.csproj">
-      <Project>{5EB6EB6B-A412-4F41-A89B-D7C9AAD237F2}</Project>
-      <Name>PagesGallery.Droid</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Stubs\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android (Forwarders).csproj">
       <Project>{6e53feb1-1100-46ae-8013-17bba35cc197}</Project>
       <Name>Xamarin.Forms.Platform.Android (Forwarders)</Name>
@@ -208,7 +203,9 @@
     </AndroidResource>
   </ItemGroup>
   <ItemGroup>
-    <TransformFile Include="Properties\AndroidManifest.xml" />
+    <TransformFile Include="Properties\AndroidManifest.xml">
+      <SubType>Designer</SubType>
+    </TransformFile>
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\error.xml" />
@@ -264,60 +261,6 @@
     <PackageReference Include="Xam.Plugin.DeviceInfo">
       <Version>3.0.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Arch.Core.Common">
-      <Version>1.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common">
-      <Version>1.0.3</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Runtime">
-      <Version>1.0.3</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Annotations">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Compat">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Core.UI">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Design">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Fragment">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Media.Compat">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Transition">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v7.CardView">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v7.Palette">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Vector.Drawable">
-      <Version>27.0.2</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.Build.Download">
       <Version>0.4.9</Version>
     </PackageReference>
@@ -338,6 +281,112 @@
     </PackageReference>
     <PackageReference Include="Xamarin.GooglePlayServices.Tasks">
       <Version>60.1142.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
+    <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Annotations">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Compat">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Core.UI">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Core.Utils">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.CustomTabs">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Design">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Fragment">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Media.Compat">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Transition">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.CardView">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.Palette">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Vector.Drawable">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">
+    <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Annotations">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Compat">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Core.UI">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Core.Utils">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.CustomTabs">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Design">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Fragment">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Media.Compat">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Transition">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.CardView">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.Palette">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Vector.Drawable">
+      <Version>27.0.2.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -46,7 +46,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidLinkMode>Full</AndroidLinkMode>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi;armeabi-v7a;x86</AndroidSupportedAbis>

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -159,7 +159,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			App.IOSVersion = int.Parse(versionPart[0]);
 
 			Xamarin.Calabash.Start();
-			
+			// Forms.SetFlags("CollectionView_Experimental", "Visual_Experimental");
 			Forms.Init();
 			FormsMaps.Init();
 			Forms.ViewInitialized += (object sender, ViewInitializedEventArgs e) =>

--- a/Xamarin.Forms.ControlGallery.iOS/Info.plist
+++ b/Xamarin.Forms.ControlGallery.iOS/Info.plist
@@ -22,7 +22,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>6.1</string>
+	<string>8.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>XamControl</string>
 	<key>CFBundleIdentifier</key>

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -263,6 +263,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.Insights" Version="1.12.3" />
+    <PackageReference Include="Xamarin.iOS.MaterialComponents" Version="60.1.0" />
     <PackageReference Include="Xamarin.TestCloud.Agent" Version="0.21.7" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
@@ -23,7 +23,7 @@
 						<Label Text="Discover modern interpretations of traditional architectural styles."
 									 TextColor="#666"
 									 FontSize="18"/>
-						<Button Image="coffee" Text="learn more">
+						<Button Image="bank" Text="learn more">
 
 						</Button>
 					</StackLayout>

--- a/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
@@ -1,70 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ContentPage 
-	xmlns="http://xamarin.com/schemas/2014/forms" 
-	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+<ContentPage
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	x:Class="Xamarin.Forms.Controls.VisualGallery"
 	Visual="Material"
 	>
-       <ContentPage.Content>
-        <ScrollView>
-            <StackLayout Spacing="20">
-                <ProgressBar
-                    x:Name="progressBar"
-                    ProgressColor="#52d"
-                    HeightRequest="5"/>
-                
-                <Frame 
-                       HasShadow="true"
-                       CornerRadius="0"
-                       Margin="10"
-                       Padding="0"
-                       >
-                    <StackLayout BackgroundColor="White" Padding="20,10" Spacing="20">
-                        <Image Source="photo.jpg" Margin="-20,-10" Aspect="AspectFit"/>
-                        <Label Text="Walk below the arches"
-                               Margin="0,10,0,0"
-                           FontSize="28"
-                           TextColor="Black"
-                         />
-                        <Label Text="Discover modern interpretations of traditional architectural styles."
-                               TextColor="#666"
-                               FontSize="18"/>
-                        <Button Text="learn more" />
-                    </StackLayout>
-                </Frame>
-                
-                <FlexLayout Direction="Row" Margin="10" Wrap="Wrap" JustifyContent="SpaceBetween">
-                    <Entry
-						Placeholder="Title"
-						PlaceholderColor="Green"
-						Text="Vintage Dress"
-						BackgroundColor="#ddd"
-						FlexLayout.Grow="1"
-						TextColor="Green"
-                       />
-                    
-                    <Entry 
-						Placeholder="Price"
-						PlaceholderColor="Purple"
-						Text="$10" FlexLayout.Basis="30%"
-						BackgroundColor="#ddd"
-						TextColor="Purple"
-                       />
-                    
-                    <Entry 
-						Placeholder="Location"
-						PlaceholderColor="Black"
-						BackgroundColor="#ddd"
-						FlexLayout.Basis="60%"
-						TextColor="Black"
-                       />
-                </FlexLayout>
-                
-                <!--
+	<ContentPage.Content>
+		<ScrollView>
+			<StackLayout Spacing="20">
+				<ProgressBar x:Name="progressBar" />
+				<Frame
+							 HasShadow="true"
+							 CornerRadius="0"
+							 Margin="10"
+							 Padding="0">
+					<StackLayout BackgroundColor="White" Padding="20,10" Spacing="20">
+						<Image Source="photo.jpg" Margin="-20,-10" Aspect="AspectFit"/>
+						<Label Text="Walk below the arches"
+									 Margin="0,10,0,0"
+									 FontSize="28"
+									 TextColor="Black" />
+						<Label Text="Discover modern interpretations of traditional architectural styles."
+									 TextColor="#666"
+									 FontSize="18"/>
+						<Button Image="coffee" Text="learn more">
+
+						</Button>
+					</StackLayout>
+				</Frame>
+
+				<FlexLayout Direction="Row" Margin="10" Wrap="Wrap" JustifyContent="SpaceBetween">
+					<Entry
+							Placeholder="Title"
+							PlaceholderColor="Green"
+							Text="Vintage Dress"
+							BackgroundColor="#ddd"
+							FlexLayout.Grow="1"
+							TextColor="Green" />
+
+					<Entry
+							Placeholder="Price"
+							PlaceholderColor="Purple"
+							Text="$10" FlexLayout.Basis="30%"
+							BackgroundColor="#ddd"
+							TextColor="Purple"/>
+
+					<Entry
+							Placeholder="Location"
+							PlaceholderColor="Black"
+							BackgroundColor="#ddd"
+							FlexLayout.Basis="60%"
+							TextColor="Black"  />
+				</FlexLayout>
+
+				<!--
                 <Button Text="Material Button" Visual="Material"/>
                 <Button Text="Any Button" />
                 -->
-            </StackLayout>
-        </ScrollView>
-    </ContentPage.Content>
+			</StackLayout>
+		</ScrollView>
+	</ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+	xmlns="http://xamarin.com/schemas/2014/forms" 
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+	x:Class="Xamarin.Forms.Controls.VisualGallery"
+	Visual="Material"
+	>
+       <ContentPage.Content>
+        <ScrollView>
+            <StackLayout Spacing="20">
+                <ProgressBar
+                    x:Name="progressBar"
+                    ProgressColor="#52d"
+                    HeightRequest="5"/>
+                
+                <Frame 
+                       HasShadow="true"
+                       CornerRadius="0"
+                       Margin="10"
+                       Padding="0"
+                       >
+                    <StackLayout BackgroundColor="White" Padding="20,10" Spacing="20">
+                        <Image Source="photo.jpg" Margin="-20,-10" Aspect="AspectFit"/>
+                        <Label Text="Walk below the arches"
+                               Margin="0,10,0,0"
+                           FontSize="28"
+                           TextColor="Black"
+                         />
+                        <Label Text="Discover modern interpretations of traditional architectural styles."
+                               TextColor="#666"
+                               FontSize="18"/>
+                        <Button Text="learn more" />
+                    </StackLayout>
+                </Frame>
+                
+                <FlexLayout Direction="Row" Margin="10" Wrap="Wrap" JustifyContent="SpaceBetween">
+                    <Entry
+						Placeholder="Title"
+						PlaceholderColor="Green"
+						Text="Vintage Dress"
+						BackgroundColor="#ddd"
+						FlexLayout.Grow="1"
+						TextColor="Green"
+                       />
+                    
+                    <Entry 
+						Placeholder="Price"
+						PlaceholderColor="Purple"
+						Text="$10" FlexLayout.Basis="30%"
+						BackgroundColor="#ddd"
+						TextColor="Purple"
+                       />
+                    
+                    <Entry 
+						Placeholder="Location"
+						PlaceholderColor="Black"
+						BackgroundColor="#ddd"
+						FlexLayout.Basis="60%"
+						TextColor="Black"
+                       />
+                </FlexLayout>
+                
+                <!--
+                <Button Text="Material Button" Visual="Material"/>
+                <Button Text="Any Button" />
+                -->
+            </StackLayout>
+        </ScrollView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Controls
+{
+	public partial class VisualGallery : ContentPage
+	{
+		public VisualGallery()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml.cs
@@ -7,9 +7,31 @@ namespace Xamarin.Forms.Controls
 {
 	public partial class VisualGallery : ContentPage
 	{
+		bool isVisible = false;
 		public VisualGallery()
 		{
 			InitializeComponent();
+		}
+
+		protected override void OnAppearing()
+		{
+			isVisible = true;
+			base.OnAppearing();
+			Device.StartTimer(TimeSpan.FromSeconds(1), () =>
+			{
+				var progress = progressBar.Progress + 0.1;
+				if (progress > 1)
+					progress = 0;
+
+				progressBar.Progress = progress;
+				return isVisible;
+			});
+		}
+
+		protected override void OnDisappearing()
+		{
+			isVisible = false;
+			base.OnDisappearing();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -323,6 +323,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new SwitchCoreGalleryPage(), "Switch Gallery"),
 				new GalleryPageFactory(() => new TableViewCoreGalleryPage(), "TableView Gallery"),
 				new GalleryPageFactory(() => new TimePickerCoreGalleryPage(), "TimePicker Gallery"),
+				new GalleryPageFactory(() => new VisualGallery(), "Visual Gallery"),
 				new GalleryPageFactory(() => new WebViewCoreGalleryPage(), "WebView Gallery"),
 				new GalleryPageFactory(() => new WkWebViewCoreGalleryPage(), "WkWebView Gallery"),
 				//pages

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>

--- a/Xamarin.Forms.Core.UnitTests/DependencyResolutionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DependencyResolutionTests.cs
@@ -173,7 +173,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var context = "Pretend this is an Android context";
 
-			var result = Internals.Registrar.Registered.GetHandler(typeof(MockElement), context);
+			var result = Internals.Registrar.Registered.GetHandler(typeof(MockElement), null, context);
 			var typedRenderer = (MockRendererWithParam)result;
 
 			Assert.That(typedRenderer, Is.InstanceOf(typeof(MockRendererWithParam)));

--- a/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
 using Xamarin.Forms;
@@ -6,20 +7,116 @@ using Xamarin.Forms.Core.UnitTests;
 
 [assembly: TestHandler (typeof (Button), typeof (ButtonTarget))]
 [assembly: TestHandler (typeof (Slider), typeof (SliderTarget))]
+[assembly: TestHandler(typeof(ButtonChild), typeof(ButtonChildTarget))]
+[assembly: TestHandler(typeof(Button), typeof(VisualButtonTarget), new[] { typeof(VisualMarkerUnitTests) })]
+[assembly: TestHandler(typeof(Slider), typeof(VisualSliderTarget), new[] { typeof(VisualMarkerUnitTests) })]
 
 namespace Xamarin.Forms.Core.UnitTests
 {
 	internal class TestHandlerAttribute : HandlerAttribute
 	{
-		public TestHandlerAttribute (Type handler, Type target) : base (handler, target)
+		public TestHandlerAttribute (Type handler, Type target, Type[] supportedVisuals = null) : base(handler, target, supportedVisuals)
 		{
 			
 		}
 	}
+	public class VisualMarkerUnitTests : IVisual { }
+	public class RegisteredWithNobodyMarker : IVisual { }
+
+	internal class RenderWithTarget : IRegisterable { }
+	[RenderWith(typeof(RenderWithTarget))]
+	internal class RenderWith { }
+	internal class RenderWithChild : RenderWith { }
+	internal class RenderWithChildTarget : IRegisterable { }
+
+	internal class VisualButtonTarget : IRegisterable { }
+	internal class VisualSliderTarget : IRegisterable { }
+	internal class ButtonChildTarget : IRegisterable { }
+	internal class ButtonChild : Button, IRegisterable { }
 
 	internal class ButtonTarget : IRegisterable {}
 
 	internal class SliderTarget : IRegisterable {}
+
+	[TestFixture]
+	public class VisualRegistrarTests : BaseTestFixture
+	{
+		[SetUp]
+		public override void Setup()
+		{
+			base.Setup();
+			Device.SetFlags(new List<string> { ExperimentalFlags.VisualExperimental });
+			Device.PlatformServices = new MockPlatformServices();
+			Internals.Registrar.RegisterAll(new[] {
+				typeof (TestHandlerAttribute)
+			});
+
+		}
+
+		[TearDown]
+		public override void TearDown()
+		{
+			base.TearDown();
+			Device.PlatformServices = null;
+		}
+
+
+		[Test]
+		public void EnsureDefaultChildRendererTrumpsParentRenderWith()
+		{
+			Xamarin.Forms.Internals.Registrar.Registered.Register(typeof(RenderWithChild), typeof(RenderWithChildTarget));
+
+			IRegisterable renderWithTarget;
+
+			renderWithTarget = Internals.Registrar.Registered.GetHandler(typeof(RenderWithChild));
+			Assert.IsNotNull(renderWithTarget);
+			Assert.That(renderWithTarget, Is.InstanceOf<RenderWithChildTarget>());
+
+			renderWithTarget = Internals.Registrar.Registered.GetHandler(typeof(RenderWithChild), typeof(RegisteredWithNobodyMarker));
+			Assert.IsNotNull(renderWithTarget);
+			Assert.That(renderWithTarget, Is.InstanceOf<RenderWithChildTarget>());
+
+			renderWithTarget = Internals.Registrar.Registered.GetHandler(typeof(RenderWithChild), typeof(VisualMarkerUnitTests));
+			Assert.IsNotNull(renderWithTarget);
+			Assert.That(renderWithTarget, Is.InstanceOf<RenderWithChildTarget>());
+		}
+
+		[Test]
+		public void GetButtonChildHandler()
+		{
+			var buttonTarget = Internals.Registrar.Registered.GetHandler(typeof(ButtonChild), typeof(RegisteredWithNobodyMarker));
+			Assert.IsNotNull(buttonTarget);
+			Assert.That(buttonTarget, Is.InstanceOf<ButtonChildTarget>());
+
+			buttonTarget = Internals.Registrar.Registered.GetHandler(typeof(ButtonChild), typeof(VisualMarkerUnitTests));
+			Assert.IsNotNull(buttonTarget);
+			Assert.That(buttonTarget, Is.InstanceOf<ButtonChildTarget>());
+		}
+
+		[Test]
+		public void GetButtonHandler()
+		{
+			var buttonTarget = Internals.Registrar.Registered.GetHandler(typeof(Button), typeof(VisualMarkerUnitTests));
+			Assert.IsNotNull(buttonTarget);
+			Assert.That(buttonTarget, Is.InstanceOf<VisualButtonTarget>());
+
+			buttonTarget = Internals.Registrar.Registered.GetHandler(typeof(Button));
+			Assert.IsNotNull(buttonTarget);
+			Assert.That(buttonTarget, Is.InstanceOf<ButtonTarget>());
+		}
+
+		[Test]
+		public void GetSliderHandler()
+		{
+			var sliderTarget = Internals.Registrar.Registered.GetHandler(typeof(Slider), typeof(VisualMarkerUnitTests));
+			Assert.IsNotNull(sliderTarget);
+			Assert.That(sliderTarget, Is.InstanceOf<VisualSliderTarget>());
+
+			sliderTarget = Internals.Registrar.Registered.GetHandler<SliderTarget>(typeof(Slider));
+			Assert.IsNotNull(sliderTarget);
+			Assert.That(sliderTarget, Is.InstanceOf<SliderTarget>());
+		}
+	}
 
 	[TestFixture]
 	public class RegistrarTests : BaseTestFixture

--- a/Xamarin.Forms.Core.UnitTests/VisualTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualTests.cs
@@ -417,17 +417,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assume.That(child.Visual == Forms.VisualMarker.MatchParent, "child view Visual should be MatchParent");
 		}
 
-		//static void AddImplicitToDefaultScrollView(ScrollView parent, View child)
-		//{
-		//	parent.Content = child;
-
-		//	IVisualController controller = child;
-
-		//	Assume.That(controller.EffectiveVisual.IsImplicit(), "child view EffectiveVisual should be Implicit");
-		//	Assume.That(controller.EffectiveVisual.IsDefault(), "child view EffectiveVisual should be Default");
-		//	Assume.That(child.Visual == Visual.MatchParent, "child view Visual should be MatchParent");
-		//}
-
 		static void AddImplicitToMaterial(StackLayout parent, View child)
 		{
 			parent.Children.Add(child);
@@ -448,18 +437,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assume.That(controller.EffectiveVisual == Forms.VisualMarker.Material, "child view EffectiveVisual should be Material");
 			Assume.That(child.Visual == Forms.VisualMarker.MatchParent, "child view Visual should be MatchParent");
 		}
-
-		//static ScrollView ExplicitDefaultScrollView()
-		//{
-		//	var layout = new ScrollView { Visual = Visual.Default };
-
-		//	IVisualController controller = layout;
-
-		//	Assume.That(controller.EffectiveVisual.IsExplicit(), "Explicit Default view EffectiveVisual should be Explicit");
-		//	Assume.That(controller.EffectiveVisual.IsDefault(), "Explicit Default view EffectiveVisual should be Default");
-		//	Assume.That(layout.Visual == Visual.Default, "Explicit Default view Visual should be Default");
-		//	return layout;
-		//}
 
 		static StackLayout ExplicitDefaultLayout()
 		{
@@ -507,19 +484,6 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			return layout;
 		}
-
-		//static View ExplicitMaterialView()
-		//{
-		//	var view = new View { Visual = Visual.Material };
-
-		//	IVisualController controller = view;
-
-		//	Assume.That(controller.EffectiveVisual.IsExplicit(), "Explicit RTL view EffectiveVisual should be Explicit");
-		//	Assume.That(controller.EffectiveVisual.IsMaterial(), "Explicit RTL view EffectiveVisual should be Material");
-		//	Assume.That(((View)view).Visual == Visual.Material, "Explicit RTL view Visual should be Material");
-
-		//	return view;
-		//}
 
 		static ScrollView ImplicitDefaultScrollView()
 		{

--- a/Xamarin.Forms.Core.UnitTests/VisualTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualTests.cs
@@ -1,0 +1,573 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class VisualTests : BaseTestFixture
+	{
+		[SetUp]
+		public override void Setup()
+		{
+			Device.SetFlags(new List<string> { ExperimentalFlags.VisualExperimental });
+			base.Setup();
+			var mockDeviceInfo = new TestDeviceInfo();
+			Device.Info = mockDeviceInfo;
+		}
+
+		[Test]
+		public void ListViewVisualIsInheritedByViewCells()
+		{
+			var lv = new ListView { Visual = Forms.VisualMarker.Material, ItemTemplate = new DataTemplate(() => new ViewCell { View = new View() }) };
+
+			lv.ItemsSource = Enumerable.Range(0, 10);
+
+			ViewCell cell = lv.TemplatedItems[0] as ViewCell;
+			IVisualController target = cell.View;
+			Assert.AreEqual(Forms.VisualMarker.Material, target.EffectiveVisual, "ViewCell View is not Material");
+		}
+
+		[Test]
+		public void ListViewVisualIsInheritedByImageInViewCells()
+		{
+			var lv = new ListView { Visual = Forms.VisualMarker.Material, ItemTemplate = new DataTemplate(() => new ViewCell { View = new Label() }) };
+
+			lv.ItemsSource = Enumerable.Range(0, 10);
+
+			ViewCell cell = lv.TemplatedItems[0] as ViewCell;
+			IVisualController target = cell.View;
+			Assert.AreEqual(Forms.VisualMarker.Material, target.EffectiveVisual, "ViewCell View is not Material");
+		}
+
+		[Test]
+		public void ScrollViewSetsVisualAndGrandchildMaintainsParentExplicitValue()
+		{
+			var layout = ImplicitDefaultScrollView();
+			var layout2 = ExplicitMaterialScrollView();
+			IVisualController view = ImplicitDefaultView();
+
+			AddExplicitMaterialToScrollView(layout, layout2);
+			AddImplicitToMaterialScrollView(layout2, (View)view);
+
+			layout.Visual = Forms.VisualMarker.Default;
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(target == Forms.VisualMarker.Material, "EffectiveVisual should be Material");
+
+			Assert.AreEqual(Forms.VisualMarker.MatchParent, ((View)view).Visual);
+			Assert.AreEqual(Forms.VisualMarker.Material, layout2.Visual);
+		}
+
+		[Test]
+		public void GrandparentSetsVisualAndGrandchildMaintainsParentExplicitValue()
+		{
+			var layout = ImplicitDefaultLayout();
+			var layout2 = ExplicitDefaultLayout();
+			IVisualController view = ImplicitDefaultView();
+
+			AddExplicitDefaultToLayout(layout, layout2);
+			AddImplicitToDefault(layout2, (View)view);
+
+			layout.Visual = Forms.VisualMarker.Material;
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(!target.IsMaterial(), "EffectiveVisual should be Default");
+			Assert.IsTrue(target.IsDefault(), "EffectiveVisual should be Default");
+
+			Assert.AreEqual(Forms.VisualMarker.MatchParent, ((View)view).Visual);
+			Assert.AreEqual(Forms.VisualMarker.Default, layout2.Visual);
+		}
+
+		[Test]
+		public void GrandparentSetsVisualAndImplicitDescendentsInheritValue()
+		{
+			var layout = ImplicitDefaultLayout();
+			var layout2 = ImplicitDefaultLayout();
+			IVisualController view = ImplicitDefaultView();
+
+			AddImplicitToDefault(layout, layout2);
+
+			AddImplicitToDefault(layout2, (View)view);
+
+			layout.Visual = Forms.VisualMarker.Material;
+
+			Assume.That(((IVisualController)layout).EffectiveVisual.IsMaterial());
+			Assume.That(((IVisualController)layout2).EffectiveVisual.IsMaterial());
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(target.IsMaterial(), "EffectiveVisual should be Material");
+			Assert.IsTrue(!target.IsDefault(), "EffectiveVisual should be Material");
+
+			Assert.AreEqual(Forms.VisualMarker.MatchParent, ((View)view).Visual);
+			Assert.AreEqual(Forms.VisualMarker.MatchParent, layout2.Visual);
+		}
+
+		[Test]
+		public void GrandparentSetsOppositeVisualAndGrandchildInheritsParentExplicitValue()
+		{
+			var layout = ExplicitMaterialLayout();
+			var layout2 = ExplicitMaterialLayout();
+			IVisualController view = ImplicitDefaultView();
+
+			AddExplicitMaterialToLayout(layout, layout2);
+
+			AddImplicitToMaterial(layout2, (View)view);
+
+			layout.Visual = Forms.VisualMarker.Default;
+
+			Assume.That(((IVisualController)layout).EffectiveVisual.IsDefault());
+
+			Assume.That(((IVisualController)layout2).EffectiveVisual.IsMaterial());
+
+			Assume.That(view.EffectiveVisual.IsMaterial());
+
+			var target = ((View)view).Visual;
+
+			Assert.AreEqual(Forms.VisualMarker.MatchParent, target);
+		}
+
+		[Test]
+		public void NotifyVisualChangedDoesNotTriggerVisualPropertyChangedUnnecessarily()
+		{
+			var layout = ExplicitMaterialLayout();
+			var layout2 = ImplicitDefaultLayout();
+			IVisualController view = new PropertyWatchingView();
+
+			AddImplicitToMaterial(layout, layout2);
+
+			AddImplicitToMaterial(layout2, (View)view);
+
+			layout2.Visual = Forms.VisualMarker.Material;
+			Assume.That(view.EffectiveVisual.IsMaterial(), "Implicit Visual not set on view");
+
+			layout.Visual = Forms.VisualMarker.Default;
+			Assume.That(layout2.Visual == Forms.VisualMarker.Material, "Explicit Visual not respected on inner layout");
+			Assume.That(view.EffectiveVisual.IsMaterial(), "Implicit Visual not set on view");
+
+			var target = ((PropertyWatchingView)view).VisualPropertyChangedCount;
+
+			Assert.AreEqual(1, target);
+		}
+
+		[Test]
+		public void ReParentAndInheritNewParentValue()
+		{
+			var layout = ExplicitMaterialLayout();
+			IVisualController view = ImplicitDefaultView();
+			var layout2 = ExplicitDefaultLayout();
+
+			AddImplicitToMaterial(layout, (View)view);
+
+			((View)view).Parent = layout2;
+
+			Assume.That(((IVisualController)layout2).EffectiveVisual.IsDefault());
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(!target.IsMaterial(), "EffectiveVisual should be Default");
+			Assert.IsTrue(target.IsDefault(), "EffectiveVisual should be Default");
+
+			Assert.AreEqual(Forms.VisualMarker.MatchParent, ((View)view).Visual);
+		}
+
+		[Test]
+		public void ReParentParentAndInheritNewGrandParentValue()
+		{
+			var layout = ExplicitMaterialLayout();
+			var layout2 = ImplicitDefaultLayout();
+			IVisualController view = ImplicitDefaultView();
+			var layout3 = ExplicitDefaultLayout();
+
+			AddImplicitToMaterial(layout, layout2);
+			AddImplicitToMaterial(layout2, (View)view);
+
+			layout2.Parent = layout3;
+
+			Assume.That(((IVisualController)layout2).EffectiveVisual.IsDefault());
+
+			Assume.That(view.EffectiveVisual.IsDefault());
+
+			var target = ((View)view).Visual;
+
+			Assert.AreEqual(Forms.VisualMarker.MatchParent, target);
+		}
+
+		[Test]
+		public void SetVisualToMatchParentAndInheritParentValue()
+		{
+			var layout = ImplicitDefaultLayout();
+			var layout2 = ExplicitMaterialLayout();
+			IVisualController view = ExplicitDefaultView();
+
+			AddExplicitMaterialToLayout(layout, layout2);
+
+			AddExplicitDefaultToLayout(layout2, (View)view);
+
+			((View)view).Visual = Forms.VisualMarker.MatchParent;
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(target.IsMaterial(), "EffectiveVisual should be Material");
+			Assert.IsTrue(!target.IsDefault(), "EffectiveVisual should be Material");
+		}
+
+		[Test]
+		public void SetGrandparentAndInheritExplicitParentValue()
+		{
+			var layout = ExplicitMaterialLayout();
+			var layout2 = ExplicitDefaultLayout();
+			IVisualController view = ImplicitDefaultView();
+
+			AddExplicitDefaultToLayout(layout, layout2);
+			AddImplicitToDefault(layout2, (View)view);
+
+			var target = view.EffectiveVisual;
+
+			Assume.That(((IVisualController)layout).EffectiveVisual.IsMaterial());
+
+			Assume.That(((IVisualController)layout2).EffectiveVisual.IsDefault());
+
+			Assert.IsTrue(!target.IsMaterial(), "EffectiveVisual should be Default");
+			Assert.IsTrue(target.IsDefault(), "EffectiveVisual should be Default");
+		}
+
+		[Test]
+		public void SetGrandparentUsingAnonCtorAndMaintainExplicitParentValue()
+		{
+			var layout = new StackLayout
+			{
+				Visual = Forms.VisualMarker.Material,
+				Children = {
+					new StackLayout {
+						Visual = Forms.VisualMarker.Default,
+						Children = { ImplicitDefaultView() }
+					}
+				}
+			};
+
+			var layout2 = layout.Children[0] as StackLayout;
+			IVisualController view = layout2.Children[0] as View;
+
+			var target = view.EffectiveVisual;
+
+			Assume.That(((IVisualController)layout).EffectiveVisual.IsMaterial());
+
+			Assume.That(((IVisualController)layout2).EffectiveVisual.IsDefault());
+
+			Assert.IsTrue(!target.IsMaterial(), "EffectiveVisual should be Default");
+			Assert.IsTrue(target.IsDefault(), "EffectiveVisual should be Default");
+		}
+
+		[Test]
+		public void SetGrandparentUsingCtorAndMaintainExplicitParentValue()
+		{
+			IVisualController view = ImplicitDefaultView();
+			var layout2 = new StackLayout { Visual = Forms.VisualMarker.Default, Children = { (View)view } };
+			var layout = new StackLayout { Visual = Forms.VisualMarker.Material, Children = { layout2 } };
+
+			var target = view.EffectiveVisual;
+
+			Assume.That(((IVisualController)layout).EffectiveVisual.IsMaterial());
+
+			Assume.That(((IVisualController)layout2).EffectiveVisual.IsDefault());
+
+			Assert.IsTrue(!target.IsMaterial(), "EffectiveVisual should be Default");
+			Assert.IsTrue(target.IsDefault(), "EffectiveVisual should be Default");
+		}
+
+		[Test]
+		public void SetParentAndGrandchildrenInheritValue()
+		{
+			var layout = ExplicitMaterialLayout();
+			var layout2 = ImplicitDefaultLayout();
+			IVisualController view = ImplicitDefaultView();
+
+			AddImplicitToMaterial(layout, layout2);
+
+			AddImplicitToMaterial(layout2, (View)view);
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(target.IsMaterial(), "EffectiveVisual should be Material");
+			Assert.IsTrue(!target.IsDefault(), "EffectiveVisual should be Material");
+		}
+
+		[Test]
+		public void SetParentAndContentAndGrandchildrenInheritValue()
+		{
+			var layout = ExplicitMaterialLayout();
+			var layout2 = ImplicitDefaultScrollView();
+			IVisualController view = ImplicitDefaultView();
+
+			AddImplicitToMaterial(layout, layout2);
+
+			AddImplicitToMaterialScrollView(layout2, (View)view);
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(target.IsMaterial(), "EffectiveVisual should be Material");
+			Assert.IsTrue(!target.IsDefault(), "EffectiveVisual should be Material");
+		}
+
+
+		[Test]
+		public void SetParentAndInheritExplicitParentValue()
+		{
+			var layout = ExplicitMaterialLayout();
+			IVisualController view = ImplicitDefaultView();
+
+			AddImplicitToMaterial(layout, (View)view);
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(target.IsMaterial(), "EffectiveVisual should be Material");
+			Assert.IsTrue(!target.IsDefault(), "EffectiveVisual should be Material");
+		}
+
+		[Test]
+		public void SetParentAndMaintainExplicitValue()
+		{
+			var layout = ExplicitMaterialLayout();
+			IVisualController view = ExplicitDefaultView();
+
+			AddExplicitDefaultToLayout(layout, (View)view);
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(!target.IsMaterial(), "EffectiveVisual should be Default");
+			Assert.IsTrue(target.IsDefault(), "EffectiveVisual should be Default");
+			Assert.AreEqual(Forms.VisualMarker.Default, ((View)view).Visual);
+		}
+
+		[Test]
+		public void SetParentUsingCtorAndInheritParentValue()
+		{
+			IVisualController view = ImplicitDefaultView();
+			var layout = new StackLayout { Visual = Forms.VisualMarker.Material, Children = { (View)view } };
+
+			Assume.That(((IVisualController)layout).EffectiveVisual.IsMaterial());
+
+			Assume.That(((View)view).Visual == Forms.VisualMarker.MatchParent);
+
+			var target = view.EffectiveVisual;
+
+			Assert.IsTrue(target.IsMaterial(), "EffectiveVisual should be Material");
+			Assert.IsTrue(!target.IsDefault(), "EffectiveVisual should be Material");
+			Assert.AreEqual(Forms.VisualMarker.MatchParent, ((View)view).Visual);
+		}
+
+		[TearDown]
+		public override void TearDown()
+		{
+			base.TearDown();
+			Device.PlatformServices = null;
+		}
+
+		static void AddExplicitLTRToScrollView(ScrollView parent, View child)
+		{
+			parent.Content = child;
+
+			IVisualController controller = child;
+
+			Assume.That(controller.EffectiveVisual.IsDefault(), "child view Visual should be Default");
+			Assume.That(child.Visual == Forms.VisualMarker.Default, "child view Visual should be Default");
+		}
+
+		static void AddExplicitDefaultToLayout(StackLayout parent, View child)
+		{
+			parent.Children.Add(child);
+
+			IVisualController controller = child;
+
+			Assume.That(controller.EffectiveVisual.IsDefault(), "child view Visual should be Default");
+			Assume.That(child.Visual == Forms.VisualMarker.Default, "child view Visual should be Default");
+		}
+
+		static void AddExplicitMaterialToScrollView(ScrollView parent, View child)
+		{
+			parent.Content = child;
+
+			IVisualController controller = child;
+
+			Assume.That(child.Visual == Forms.VisualMarker.Material, "child view Visual should be Material");
+		}
+
+		static void AddExplicitMaterialToLayout(StackLayout parent, View child)
+		{
+			parent.Children.Add(child);
+
+			IVisualController controller = child;
+
+			Assume.That(controller.EffectiveVisual.IsMaterial(), "child view EffectiveVisual should be Material");
+			Assume.That(child.Visual == Forms.VisualMarker.Material, "child view Visual should be Material");
+		}
+
+		static void AddImplicitToDefault(StackLayout parent, View child)
+		{
+			parent.Children.Add(child);
+
+			IVisualController controller = child;
+
+			Assume.That(child.Visual == Forms.VisualMarker.MatchParent, "child view Visual should be MatchParent");
+		}
+
+		//static void AddImplicitToDefaultScrollView(ScrollView parent, View child)
+		//{
+		//	parent.Content = child;
+
+		//	IVisualController controller = child;
+
+		//	Assume.That(controller.EffectiveVisual.IsImplicit(), "child view EffectiveVisual should be Implicit");
+		//	Assume.That(controller.EffectiveVisual.IsDefault(), "child view EffectiveVisual should be Default");
+		//	Assume.That(child.Visual == Visual.MatchParent, "child view Visual should be MatchParent");
+		//}
+
+		static void AddImplicitToMaterial(StackLayout parent, View child)
+		{
+			parent.Children.Add(child);
+
+			IVisualController controller = child;
+
+
+			Assume.That(controller.EffectiveVisual.IsMaterial(), "child view EffectiveVisual should be Material");
+			Assume.That(child.Visual == Forms.VisualMarker.MatchParent, "child view Visual should be MatchParent");
+		}
+
+		static void AddImplicitToMaterialScrollView(ScrollView parent, View child)
+		{
+			parent.Content = child;
+
+			IVisualController controller = child;
+
+			Assume.That(controller.EffectiveVisual == Forms.VisualMarker.Material, "child view EffectiveVisual should be Material");
+			Assume.That(child.Visual == Forms.VisualMarker.MatchParent, "child view Visual should be MatchParent");
+		}
+
+		//static ScrollView ExplicitDefaultScrollView()
+		//{
+		//	var layout = new ScrollView { Visual = Visual.Default };
+
+		//	IVisualController controller = layout;
+
+		//	Assume.That(controller.EffectiveVisual.IsExplicit(), "Explicit Default view EffectiveVisual should be Explicit");
+		//	Assume.That(controller.EffectiveVisual.IsDefault(), "Explicit Default view EffectiveVisual should be Default");
+		//	Assume.That(layout.Visual == Visual.Default, "Explicit Default view Visual should be Default");
+		//	return layout;
+		//}
+
+		static StackLayout ExplicitDefaultLayout()
+		{
+			var layout = new StackLayout { Visual = Forms.VisualMarker.Default };
+
+			IVisualController controller = layout;
+
+			Assume.That(controller.EffectiveVisual == Forms.VisualMarker.Default, "Explicit Default view EffectiveVisual should be Default");
+			Assume.That(layout.Visual == Forms.VisualMarker.Default, "Explicit Default view Visual should be Default");
+			return layout;
+		}
+
+		static View ExplicitDefaultView()
+		{
+			var view = new View { Visual = Forms.VisualMarker.Default };
+
+			IVisualController controller = view;
+
+			Assume.That(controller.EffectiveVisual.IsDefault(), "Explicit Default view EffectiveVisual should be Default");
+			Assume.That(((View)view).Visual == Forms.VisualMarker.Default, "Explicit Default view Visual should be Default");
+
+			return view;
+		}
+
+		static ScrollView ExplicitMaterialScrollView()
+		{
+			var layout = new ScrollView { Visual = Forms.VisualMarker.Material };
+
+			IVisualController controller = layout;
+
+			Assume.That(controller.EffectiveVisual == Forms.VisualMarker.Material, "Explicit RTL view EffectiveVisual should be Material");
+			Assume.That(layout.Visual == Forms.VisualMarker.Material, "Explicit RTL view Visual should be Material");
+
+			return layout;
+		}
+
+		static StackLayout ExplicitMaterialLayout()
+		{
+			var layout = new StackLayout { Visual = Forms.VisualMarker.Material };
+
+			IVisualController controller = layout;
+
+			Assume.That(controller.EffectiveVisual.IsMaterial(), "Explicit RTL view EffectiveVisual should be Material");
+			Assume.That(layout.Visual == Forms.VisualMarker.Material, "Explicit RTL view Visual should be Material");
+
+			return layout;
+		}
+
+		//static View ExplicitMaterialView()
+		//{
+		//	var view = new View { Visual = Visual.Material };
+
+		//	IVisualController controller = view;
+
+		//	Assume.That(controller.EffectiveVisual.IsExplicit(), "Explicit RTL view EffectiveVisual should be Explicit");
+		//	Assume.That(controller.EffectiveVisual.IsMaterial(), "Explicit RTL view EffectiveVisual should be Material");
+		//	Assume.That(((View)view).Visual == Visual.Material, "Explicit RTL view Visual should be Material");
+
+		//	return view;
+		//}
+
+		static ScrollView ImplicitDefaultScrollView()
+		{
+			var layout = new ScrollView();
+
+			IVisualController controller = layout;
+
+			Assume.That(controller.EffectiveVisual == Forms.VisualMarker.Default, "New view EffectiveVisual should be Default");
+			Assume.That(layout.Visual == Forms.VisualMarker.MatchParent, "New view Visual should be MatchParent");
+
+			return layout;
+		}
+
+		static StackLayout ImplicitDefaultLayout()
+		{
+			var layout = new StackLayout();
+
+			IVisualController controller = layout;
+
+
+			Assume.That(controller.EffectiveVisual == Forms.VisualMarker.Default, "New view EffectiveVisual should be Default");
+			Assume.That(layout.Visual == Forms.VisualMarker.MatchParent, "New view Visual should be MatchParent");
+
+			return layout;
+		}
+
+		static View ImplicitDefaultView()
+		{
+			var view = new View();
+
+			IVisualController controller = view;
+
+			Assume.That(((View)view).Visual == Forms.VisualMarker.MatchParent, "New view Visual should be MatchParent");
+
+			return view;
+		}
+
+		class PropertyWatchingView : View
+		{
+			public int VisualPropertyChangedCount { get; private set; }
+
+			protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+			{
+				base.OnPropertyChanged(propertyName);
+
+				if (propertyName == View.VisualProperty.PropertyName)
+					VisualPropertyChangedCount++;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="CommandTests.cs" />
     <Compile Include="DependencyResolutionTests.cs" />
     <Compile Include="EffectiveFlowDirectionExtensions.cs" />
+    <Compile Include="VisualTests.cs" />
     <Compile Include="FlowDirectionTests.cs" />
     <Compile Include="ImageButtonUnitTest.cs" />
     <Compile Include="ItemsViewTests.cs" />

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
@@ -387,6 +388,27 @@ namespace Xamarin.Forms
 				}
 
 				return new ButtonContentLayout(position, spacing);
+			}
+		}
+
+
+		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			base.OnPropertyChanged(propertyName);
+
+			if (propertyName == VisualProperty.PropertyName ||
+				propertyName == BackgroundColorProperty.PropertyName ||
+				propertyName == TextColorProperty.PropertyName)
+			{
+				// Todo fix reset behavior if user sets back 
+				if ((this as IVisualController).EffectiveVisual == VisualMarker.Material)
+				{
+					if (BackgroundColor == Color.Default)
+						BackgroundColor = Color.Black;
+
+					if (TextColor == Color.Default)
+						TextColor = Color.White;
+				}
 			}
 		}
 	}

--- a/Xamarin.Forms.Core/Cells/Cell.cs
+++ b/Xamarin.Forms.Core/Cells/Cell.cs
@@ -8,7 +8,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	public abstract class Cell : Element, ICellController, IFlowDirectionController
+	public abstract class Cell : Element, ICellController, IFlowDirectionController, IPropertyPropagationController, IVisualController
 	{
 		public const int DefaultCellHeight = 40;
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool), typeof(Cell), true, propertyChanged: OnIsEnabledPropertyChanged);
@@ -36,9 +36,22 @@ namespace Xamarin.Forms
 			}
 		}
 
+		IVisual _effectiveVisual = Xamarin.Forms.VisualMarker.Default;
+		IVisual IVisualController.EffectiveVisual
+		{
+			get { return _effectiveVisual; }
+			set
+			{
+				_effectiveVisual = value;
+				OnPropertyChanged(VisualElement.VisualProperty.PropertyName);
+			}
+		}
+		IVisual IVisualController.Visual => Xamarin.Forms.VisualMarker.MatchParent;
+
 		bool IFlowDirectionController.ApplyEffectiveFlowDirectionToChildContainer => true;
 
 		IFlowDirectionController FlowController => this;
+		IPropertyPropagationController PropertyPropagationController => this;
 
 		public IList<MenuItem> ContextActions
 		{
@@ -150,7 +163,7 @@ namespace Xamarin.Forms
 
 			base.OnParentSet();
 
-			FlowController.NotifyFlowDirectionChanged();
+			PropertyPropagationController.PropagatePropertyChanged(null);
 		}
 
 		protected override void OnPropertyChanging(string propertyName = null)
@@ -163,7 +176,7 @@ namespace Xamarin.Forms
 					RealParent.PropertyChanging -= OnParentPropertyChanging;
 				}
 
-				FlowController.NotifyFlowDirectionChanged();
+				PropertyPropagationController.PropagatePropertyChanged(null);
 			}
 
 			base.OnPropertyChanging(propertyName);
@@ -189,16 +202,19 @@ namespace Xamarin.Forms
 				container.SendCellDisappearing(this);
 		}
 
-		void IFlowDirectionController.NotifyFlowDirectionChanged()
+		void IPropertyPropagationController.PropagatePropertyChanged(string propertyName)
 		{
-			SetFlowDirectionFromParent(this);
+			// TODO further generalize this
+			if (propertyName == null || propertyName == VisualElement.FlowDirectionProperty.PropertyName)
+				SetFlowDirectionFromParent(this);
+
+			if (propertyName == null || propertyName == VisualElement.VisualProperty.PropertyName)
+				SetVisualfromParent(this);
 
 			foreach (var element in LogicalChildren)
 			{
-				var view = element as IFlowDirectionController;
-				if (view == null)
-					continue;
-				view.NotifyFlowDirectionChanged();
+				if (element is IPropertyPropagationController view)
+					view.PropagatePropertyChanged(propertyName);
 			}
 		}
 
@@ -230,8 +246,9 @@ namespace Xamarin.Forms
 			// its uncommon enough that we don't want to take the penalty of N GetValue calls to verify.
 			if (e.PropertyName == "RowHeight")
 				OnPropertyChanged("RenderHeight");
-			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
-				FlowController.NotifyFlowDirectionChanged();
+			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName ||
+					 e.PropertyName == VisualElement.VisualProperty.PropertyName)
+				PropertyPropagationController.PropagatePropertyChanged(e.PropertyName);
 		}
 
 		void OnParentPropertyChanging(object sender, PropertyChangingEventArgs e)

--- a/Xamarin.Forms.Core/EffectiveVisualExtensions.cs
+++ b/Xamarin.Forms.Core/EffectiveVisualExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.ComponentModel;
+
+namespace Xamarin.Forms
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static class EffectiveVisualExtensions
+	{
+		public static bool IsDefault(this IVisual visual) => visual == VisualMarker.Default;
+		public static bool IsMatchParent(this IVisual visual) => visual == VisualMarker.MatchParent;
+		public static bool IsMaterial(this IVisual visual) => visual == VisualMarker.Material;
+	}
+}

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -478,9 +478,6 @@ namespace Xamarin.Forms
 				controller.EffectiveVisual = parentView.EffectiveVisual;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public event EventHandler PlatformSet;
-
 		internal virtual void SetChildInheritedBindingContext(Element child, object context)
 		{
 			SetInheritedBindingContext(child, context);

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -462,6 +462,25 @@ namespace Xamarin.Forms
 			}
 		}
 
+		internal static void SetVisualfromParent(Element child)
+		{
+			IVisualController controller = child as IVisualController;
+			if (controller == null)
+				return;
+
+			if (controller.Visual != VisualMarker.MatchParent)
+			{
+				controller.EffectiveVisual = controller.Visual;
+				return;
+			}
+
+			if (child.Parent is IVisualController parentView)
+				controller.EffectiveVisual = parentView.EffectiveVisual;
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler PlatformSet;
+
 		internal virtual void SetChildInheritedBindingContext(Element child, object context)
 		{
 			SetInheritedBindingContext(child, context);

--- a/Xamarin.Forms.Core/ExperimentalFlags.cs
+++ b/Xamarin.Forms.Core/ExperimentalFlags.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Xamarin.Forms
+{
+	internal static class ExperimentalFlags
+	{
+		internal const string CollectionViewExperimental = "CollectionView_Experimental";
+		internal const string VisualExperimental = "Visual_Experimental";
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void VerifyFlagEnabled(
+			string coreComponentName,
+			string flagName,
+			string constructorHint = null,
+			[CallerMemberName] string memberName = "")
+		{
+			if (Device.Flags == null || !Device.Flags.Contains(flagName))
+			{
+				if (!String.IsNullOrEmpty(memberName))
+				{
+					if (!String.IsNullOrEmpty(constructorHint))
+					{
+						constructorHint = constructorHint + " ";
+					}
+
+					var call = $"('{constructorHint}{memberName}')";
+
+					var errorMessage = $"The class, property, or method you are attempting to use {call} is part of "
+										+ $"{coreComponentName}; to use it, you must opt-in by calling "
+										+ $"Forms.SetFlags(\"{flagName}\") before calling Forms.Init().";
+					throw new InvalidOperationException(errorMessage);
+				}
+
+				var genericErrorMessage =
+					$"To use {coreComponentName} or associated classes, you must opt-in by calling "
+					+ $"Forms.SetFlags(\"{flagName}\") before calling Forms.Init().";
+				throw new InvalidOperationException(genericErrorMessage);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Core/HandlerAttribute.cs
+++ b/Xamarin.Forms.Core/HandlerAttribute.cs
@@ -5,12 +5,14 @@ namespace Xamarin.Forms
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
 	public abstract class HandlerAttribute : Attribute
 	{
-		protected HandlerAttribute(Type handler, Type target)
+		protected HandlerAttribute(Type handler, Type target, Type[] supportedVisuals = null)
 		{
+			SupportedVisuals = supportedVisuals ?? new[] { typeof(VisualRendererMarker.Default) };
 			TargetType = target;
 			HandlerType = handler;
 		}
 
+		internal Type[] SupportedVisuals { get; private set; }
 		internal Type HandlerType { get; private set; }
 
 		internal Type TargetType { get; private set; }

--- a/Xamarin.Forms.Core/IFlowDirectionController.cs
+++ b/Xamarin.Forms.Core/IFlowDirectionController.cs
@@ -6,8 +6,6 @@ namespace Xamarin.Forms
 
 		double Width { get; }
 
-		void NotifyFlowDirectionChanged();
-
 		bool ApplyEffectiveFlowDirectionToChildContainer { get; }
 	}
 }

--- a/Xamarin.Forms.Core/IPropertyPropagationController.cs
+++ b/Xamarin.Forms.Core/IPropertyPropagationController.cs
@@ -1,0 +1,7 @@
+namespace Xamarin.Forms
+{
+	interface IPropertyPropagationController
+	{
+		void PropagatePropertyChanged(string propertyName);
+	}
+}

--- a/Xamarin.Forms.Core/IVisualController.cs
+++ b/Xamarin.Forms.Core/IVisualController.cs
@@ -1,0 +1,8 @@
+namespace Xamarin.Forms
+{
+	internal interface IVisualController
+	{
+		IVisual EffectiveVisual { get; set; }
+		IVisual Visual { get; }
+	}
+}

--- a/Xamarin.Forms.Core/Items/CollectionView.cs
+++ b/Xamarin.Forms.Core/Items/CollectionView.cs
@@ -24,28 +24,7 @@ namespace Xamarin.Forms
 			string constructorHint = null,
 			[CallerMemberName] string memberName = "")
 		{
-			if (Device.Flags == null || !Device.Flags.Contains(CollectionViewExperimental))
-			{
-				if (!String.IsNullOrEmpty(memberName))
-				{
-					if (!String.IsNullOrEmpty(constructorHint))
-					{
-						constructorHint = constructorHint + " ";
-					}
-
-					var call = $"('{constructorHint}{memberName}')";
-
-					var errorMessage = $"The class, property, or method you are attempting to use {call} is part of "
-										+ "CollectionView; to use it, you must opt-in by calling "
-										+  $"Forms.SetFlags(\"{CollectionViewExperimental}\") before calling Forms.Init().";
-					throw new InvalidOperationException(errorMessage);
-				}
-
-				var genericErrorMessage = 
-					$"To use CollectionView or associated classes, you must opt-in by calling " 
-					+ $"Forms.SetFlags(\"{CollectionViewExperimental}\") before calling Forms.Init().";
-				throw new InvalidOperationException(genericErrorMessage);
-			}
+			ExperimentalFlags.VerifyFlagEnabled(nameof(CollectionView), ExperimentalFlags.CollectionViewExperimental);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/ProgressBar.cs
+++ b/Xamarin.Forms.Core/ProgressBar.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
@@ -45,6 +46,31 @@ namespace Xamarin.Forms
 		public IPlatformElementConfiguration<T, ProgressBar> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
+		}
+
+
+		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			base.OnPropertyChanged(propertyName);
+
+			if (propertyName == VisualProperty.PropertyName ||
+				propertyName == BackgroundColorProperty.PropertyName ||
+				propertyName == ProgressColorProperty.PropertyName ||
+				propertyName == HeightRequestProperty.PropertyName)
+			{
+				// Todo fix reset behavior if user sets back 
+				if ((this as IVisualController).EffectiveVisual == VisualMarker.Material)
+				{
+					if (BackgroundColor == Color.Default)
+						BackgroundColor = Color.FromRgb(179, 215, 243);
+
+					if (ProgressColor == Color.Default)
+						ProgressColor = Color.FromRgb(33, 150, 243);
+
+					if (!IsSet(HeightRequestProperty))
+						HeightRequest = 5;
+				}
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -106,3 +106,4 @@ using Xamarin.Forms.StyleSheets;
 [assembly: StyleProperty("-xf-thumb-color", typeof(Slider), nameof(Slider.ThumbColorProperty))]
 [assembly: StyleProperty("-xf-spacing", typeof(StackLayout), nameof(StackLayout.SpacingProperty))]
 [assembly: StyleProperty("-xf-orientation", typeof(StackLayout), nameof(StackLayout.OrientationProperty))]
+[assembly: StyleProperty("-xf-visual", typeof(VisualElement), nameof(VisualElement.VisualProperty))]

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -18,19 +18,34 @@ namespace Xamarin.Forms.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class Registrar<TRegistrable> where TRegistrable : class
 	{
-		readonly Dictionary<Type, Type> _handlers = new Dictionary<Type, Type>();
+		readonly Dictionary<Type, Dictionary<Type, Type>> _handlers = new Dictionary<Type, Dictionary<Type, Type>>();
+		static Type _defaultVisualType = typeof(VisualRendererMarker.Default);
+		static Type[] _defaultVisualRenderers = new[] { _defaultVisualType };
 
-		public void Register(Type tview, Type trender)
+		public void Register(Type tview, Type trender, Type[] supportedVisuals)
 		{
+			supportedVisuals = supportedVisuals ?? _defaultVisualRenderers;
 			//avoid caching null renderers
 			if (trender == null)
 				return;
-			_handlers[tview] = trender;
-		}
 
-		internal TRegistrable GetHandler(Type type)
+			if (!_handlers.TryGetValue(tview, out Dictionary<Type, Type> visualRenderers))
+			{
+				visualRenderers = new Dictionary<Type, Type>();
+				_handlers[tview] = visualRenderers;
+			}
+
+			for (int i = 0; i < supportedVisuals.Length; i++)
+				visualRenderers[supportedVisuals[i]] = trender;
+		}
+		
+		public void Register(Type tview, Type trender) => Register(tview, trender, _defaultVisualRenderers);
+
+		internal TRegistrable GetHandler(Type type) => GetHandler(type, _defaultVisualType);
+
+		internal TRegistrable GetHandler(Type type, Type visualType)
 		{
-			Type handlerType = GetHandlerType(type);
+			Type handlerType = GetHandlerType(type, visualType ?? _defaultVisualType);
 			if (handlerType == null)
 				return null;
 
@@ -39,14 +54,14 @@ namespace Xamarin.Forms.Internals
 			return (TRegistrable)handler;
 		}
 
-		internal TRegistrable GetHandler(Type type, params object[] args)
+		internal TRegistrable GetHandler(Type type, IVisual visual, params object[] args)
 		{
 			if (args.Length == 0)
 			{
-				return GetHandler(type);
+				return GetHandler(type, visual?.GetType() ?? _defaultVisualType);
 			}
 
-			Type handlerType = GetHandlerType(type);
+			Type handlerType = GetHandlerType(type, visual?.GetType() ?? _defaultVisualType);
 			if (handlerType == null)
 				return null;
 
@@ -60,7 +75,7 @@ namespace Xamarin.Forms.Internals
 
 		public TOut GetHandler<TOut>(Type type, params object[] args) where TOut : class, TRegistrable
 		{
-			return GetHandler(type, args) as TOut;
+			return GetHandler(type, null, args) as TOut;
 		}
 
 		public TOut GetHandlerForObject<TOut>(object obj) where TOut : class, TRegistrable
@@ -71,7 +86,7 @@ namespace Xamarin.Forms.Internals
 			var reflectableType = obj as IReflectableType;
 			var type = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : obj.GetType();
 
-			return GetHandler(type) as TOut;
+			return GetHandler(type, (obj as IVisualController)?.EffectiveVisual?.GetType()) as TOut;
 		}
 
 		public TOut GetHandlerForObject<TOut>(object obj, params object[] args) where TOut : class, TRegistrable
@@ -82,20 +97,40 @@ namespace Xamarin.Forms.Internals
 			var reflectableType = obj as IReflectableType;
 			var type = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : obj.GetType();
 
-			return GetHandler(type, args) as TOut;
+			return GetHandler(type, (obj as IVisualController)?.EffectiveVisual, args) as TOut;
 		}
 
-		public Type GetHandlerType(Type viewType)
+		TOut GetHandlerForObject<TOut>(object obj, IVisual visual, params object[] args) where TOut : class, TRegistrable
 		{
+			if (obj == null)
+				throw new ArgumentNullException(nameof(obj));
+
+			var reflectableType = obj as IReflectableType;
+			var type = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : obj.GetType();
+
+			return GetHandler(type, visual, args) as TOut;
+		}
+
+		public Type GetHandlerType(Type viewType) => GetHandlerType(viewType, _defaultVisualType);
+
+		public Type GetHandlerType(Type viewType, Type visualType)
+		{
+			visualType = visualType ?? _defaultVisualType;
+
 			// 1. Do we have this specific type registered already?
-			if (_handlers.TryGetValue(viewType, out Type specificTypeRenderer))
-				return specificTypeRenderer;
+			if (_handlers.TryGetValue(viewType, out Dictionary<Type, Type> visualRenderers))
+				if (visualRenderers.TryGetValue(visualType, out Type specificTypeRenderer))
+					return specificTypeRenderer;
+
+			if (visualType != _defaultVisualType && _handlers.TryGetValue(_defaultVisualType, out visualRenderers))
+				if (visualRenderers.TryGetValue(_defaultVisualType, out Type specificTypeRenderer))
+					return specificTypeRenderer;
 
 			// 2. Do we have a RenderWith for this type or its base types? Register them now.
-			RegisterRenderWithTypes(viewType);
+			RegisterRenderWithTypes(viewType, visualType);
 
 			// 3. Do we have a custom renderer for a base type or did we just register an appropriate renderer from RenderWith?
-			if (LookupHandlerType(viewType, out Type baseTypeRenderer))
+			if (LookupHandlerType(viewType, visualType, out Type baseTypeRenderer))
 				return baseTypeRenderer;
 			else
 				return null;
@@ -112,12 +147,21 @@ namespace Xamarin.Forms.Internals
 			return GetHandlerType(type);
 		}
 
-		bool LookupHandlerType(Type viewType, out Type handlerType)
+		bool LookupHandlerType(Type viewType, Type visualType, out Type handlerType)
 		{
+			if (_defaultVisualType != visualType)
+				VisualElement.VerifyVisualFlagEnabled();
+
+			visualType = visualType ?? _defaultVisualType;
 			while (viewType != null && viewType != typeof(Element))
 			{
-				if (_handlers.TryGetValue(viewType, out handlerType))
-					return true;
+				if (_handlers.TryGetValue(viewType, out Dictionary<Type, Type> visualRenderers))
+					if (visualRenderers.TryGetValue(visualType, out handlerType))
+						return true;
+
+				if (visualType != _defaultVisualType && _handlers.TryGetValue(viewType, out visualRenderers))
+					if (visualRenderers.TryGetValue(_defaultVisualType, out handlerType))
+						return true;
 
 				viewType = viewType.GetTypeInfo().BaseType;
 			}
@@ -126,24 +170,26 @@ namespace Xamarin.Forms.Internals
 			return false;
 		}
 
-		void RegisterRenderWithTypes(Type viewType)
+		void RegisterRenderWithTypes(Type viewType, Type visualType)
 		{
+			visualType = visualType ?? _defaultVisualType;
+
 			// We're going to go through each type in this viewType's inheritance chain to look for classes
 			// decorated with a RenderWithAttribute. We're going to register each specific type with its
-			// renderer. 
-
+			// renderer.
 			while (viewType != null && viewType != typeof(Element))
 			{
 				// Only go through this process if we have not registered something for this type;
 				// we don't want RenderWith renderers to override ExportRenderers that are already registered.
 				// Plus, there's no need to do this again if we already have a renderer registered.
-				if (!_handlers.ContainsKey(viewType))
+				if (!_handlers.TryGetValue(viewType, out Dictionary<Type, Type> visualRenderers) || !visualRenderers.ContainsKey(visualType))
 				{
 					// get RenderWith attribute for just this type, do not inherit attributes from base types
 					var attribute = viewType.GetTypeInfo().GetCustomAttributes<RenderWithAttribute>(false).FirstOrDefault();
 					if (attribute == null)
 					{
-						Register(viewType, null); // Cache this result so we don't have to do GetCustomAttributes again
+						// TODO this doesn't appear to do anything. Register just returns as a NOOP if the renderer is null
+						Register(viewType, null, new[] { visualType }); // Cache this result so we don't have to do GetCustomAttributes again
 					}
 					else
 					{
@@ -154,18 +200,30 @@ namespace Xamarin.Forms.Internals
 							// TODO: Remove attribute2 once renderer names have been unified across all platforms
 							var attribute2 = specificTypeRenderer.GetTypeInfo().GetCustomAttribute<RenderWithAttribute>();
 							if (attribute2 != null)
-								specificTypeRenderer = attribute2.Type;
+							{
+								for (int i = 0; i < attribute2.SupportedVisuals.Length; i++)
+								{
+									if (attribute2.SupportedVisuals[i] == _defaultVisualType)
+										specificTypeRenderer = attribute2.Type;
+
+									if (attribute2.SupportedVisuals[i] == visualType)
+									{
+										specificTypeRenderer = attribute2.Type;
+										break;
+									}
+								}
+							}
 
 							if (specificTypeRenderer.Name.StartsWith("_", StringComparison.Ordinal))
 							{
-								Register(viewType, null); // Cache this result so we don't work through this chain again
+								Register(viewType, null, new[] { visualType }); // Cache this result so we don't work through this chain again
 
 								viewType = viewType.GetTypeInfo().BaseType;
 								continue;
 							}
 						}
 
-						Register(viewType, specificTypeRenderer); // Register this so we don't have to look for the RenderWithAttibute again in the future
+						Register(viewType, specificTypeRenderer, new[] { visualType }); // Register this so we don't have to look for the RenderWithAttibute again in the future
 					}
 				}
 
@@ -222,11 +280,11 @@ namespace Xamarin.Forms.Internals
 						continue;
 					}
 					var length = attributes.Length;
-					for (var i = 0; i < length;i++)
+					for (var i = 0; i < length; i++)
 					{
 						var attribute = (HandlerAttribute)attributes[i];
 						if (attribute.ShouldRegister())
-							Registered.Register(attribute.HandlerType, attribute.TargetType);
+							Registered.Register(attribute.HandlerType, attribute.TargetType, attribute.SupportedVisuals);
 					}
 				}
 
@@ -237,10 +295,10 @@ namespace Xamarin.Forms.Internals
 
 				Attribute[] effectAttributes = assembly.GetCustomAttributes(typeof(ExportEffectAttribute)).ToArray();
 				var exportEffectsLength = effectAttributes.Length;
-				for (var i = 0; i < exportEffectsLength;i++)
+				for (var i = 0; i < exportEffectsLength; i++)
 				{
 					var effect = (ExportEffectAttribute)effectAttributes[i];
-					Effects [resolutionName + "." + effect.Id] = effect.Type;
+					Effects[resolutionName + "." + effect.Id] = effect.Type;
 				}
 
 				Attribute[] styleAttributes = assembly.GetCustomAttributes(typeof(StyleSheets.StylePropertyAttribute)).ToArray();

--- a/Xamarin.Forms.Core/RenderWithAttribute.cs
+++ b/Xamarin.Forms.Core/RenderWithAttribute.cs
@@ -5,11 +5,13 @@ namespace Xamarin.Forms
 	[AttributeUsage(AttributeTargets.Class)]
 	public sealed class RenderWithAttribute : Attribute
 	{
-		public RenderWithAttribute(Type type)
+		public RenderWithAttribute(Type type, Type[] supportedVisuals = null)
 		{
 			Type = type;
+			SupportedVisuals = supportedVisuals ?? new[] { typeof(VisualRendererMarker.Default) };
 		}
 
+		public Type[] SupportedVisuals { get; }
 		public Type Type { get; }
 	}
 }

--- a/Xamarin.Forms.Core/Visual.cs
+++ b/Xamarin.Forms.Core/Visual.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	public static class VisualMarker
+	{
+		public static IVisual MatchParent { get; } = new VisualRendererMarker.MatchParent();
+		public static IVisual Default { get; } = new VisualRendererMarker.Default();
+		public static IVisual Material { get; } = new VisualRendererMarker.Material();
+	}
+
+	public static class VisualRendererMarker
+	{
+		public sealed class Material : IVisual { }
+		public sealed class Default : IVisual { }
+		internal sealed class MatchParent : IVisual { }
+	}
+
+	[TypeConverter(typeof(VisualTypeConverter))]
+	public interface IVisual
+	{
+
+	}
+
+	[Xaml.TypeConversion(typeof(IVisual))]
+	public class VisualTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null)
+			{
+				switch (value.Trim().ToLowerInvariant())
+				{
+					case "matchparent": return VisualMarker.MatchParent;
+					case "material": return VisualMarker.Material;
+					case "default":
+					default: return VisualMarker.Default;
+				}
+			}
+			throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(IVisual)}");
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Visual.cs
+++ b/Xamarin.Forms.Core/Visual.cs
@@ -11,9 +11,9 @@ namespace Xamarin.Forms
 
 	public static class VisualRendererMarker
 	{
-		public sealed class Material : IVisual { }
-		public sealed class Default : IVisual { }
-		internal sealed class MatchParent : IVisual { }
+		public sealed class Material : IVisual { internal Material() { } }
+		public sealed class Default : IVisual { internal Default() { } }
+		internal sealed class MatchParent : IVisual { internal MatchParent() { } }
 	}
 
 	[TypeConverter(typeof(VisualTypeConverter))]

--- a/Xamarin.Forms.Core/Visual.cs
+++ b/Xamarin.Forms.Core/Visual.cs
@@ -29,13 +29,13 @@ namespace Xamarin.Forms
 		{
 			if (value != null)
 			{
-				switch (value.Trim().ToLowerInvariant())
-				{
-					case "matchparent": return VisualMarker.MatchParent;
-					case "material": return VisualMarker.Material;
-					case "default":
-					default: return VisualMarker.Default;
-				}
+				var sc = StringComparison.OrdinalIgnoreCase;
+				if (value.Equals(nameof(VisualMarker.MatchParent), sc))
+					return VisualMarker.MatchParent;
+				else if (value.Equals(nameof(VisualMarker.Material), sc))
+					return VisualMarker.Material;
+				else
+					return VisualMarker.Default;
 			}
 			throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(IVisual)}");
 		}

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -14,7 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v9.0</AndroidTargetFrameworkVersion>
+    <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>
@@ -79,14 +80,24 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>27.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <Version>27.0.2</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.GooglePlayServices.Maps">
       <Version>60.1142.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
+      <Version>27.0.2.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -12,7 +12,8 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AssemblyName>Xamarin.Forms.Platform.Android.AppLinks</AssemblyName>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v9.0</AndroidTargetFrameworkVersion>
+    <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -61,11 +62,18 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>27.0.2</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.GooglePlayServices.AppIndexing">
       <Version>60.1142.1</Version>
+    </PackageReference>
+  </ItemGroup>  
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+  </ItemGroup>  
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>27.0.2.1</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android/ExportRendererAttribute.cs
+++ b/Xamarin.Forms.Platform.Android/ExportRendererAttribute.cs
@@ -5,7 +5,11 @@ namespace Xamarin.Forms
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
 	public sealed class ExportRendererAttribute : HandlerAttribute
 	{
-		public ExportRendererAttribute(Type handler, Type target) : base(handler, target)
+		public ExportRendererAttribute(Type handler, Type target) : this(handler, target, null)
+		{
+		}
+
+		public ExportRendererAttribute(Type handler, Type target, Type[] supportedVisuals) : base(handler, target, supportedVisuals)
 		{
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Material/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialButtonRenderer.cs
@@ -27,7 +27,7 @@ using ADrawableCompat = Android.Support.V4.Graphics.Drawable.DrawableCompat;
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Button), typeof(MaterialButtonRenderer), new[] { typeof(VisualRendererMarker.Material) })]
 namespace Xamarin.Forms.Platform.Android.Material
 {
-	internal sealed class MaterialButtonRenderer : MButton, IVisualElementRenderer, AView.IOnAttachStateChangeListener,
+	public class MaterialButtonRenderer : MButton, IVisualElementRenderer, AView.IOnAttachStateChangeListener,
 		AView.IOnFocusChangeListener, AView.IOnClickListener, AView.IOnTouchListener, IViewRenderer, ITabStop, IBorderVisualElementRenderer
 	{
 		float _defaultFontSize;
@@ -51,9 +51,16 @@ namespace Xamarin.Forms.Platform.Android.Material
 
 		public MaterialButtonRenderer(Context context) : base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialTheme))
 		{
+			VisualElement.VerifyVisualFlagEnabled();
 			_automationPropertiesProvider = new AutomationPropertiesProvider(this);
 
-			Initialize();
+			SoundEffectsEnabled = false;
+			SetOnClickListener(this);
+			SetOnTouchListener(this);
+			AddOnAttachStateChangeListener(this);
+			OnFocusChangeListener = this;
+
+			Tag = this;
 		}
 
 		public Color BackgroundColor => Element?.BackgroundColor != Color.Default ? Element.BackgroundColor : Color.Black;
@@ -209,7 +216,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 			return new Size();
 		}
 
-		void OnElementChanged(ElementChangedEventArgs<Button> e)
+		protected virtual void OnElementChanged(ElementChangedEventArgs<Button> e)
 		{
 			if (e.NewElement != null && !_isDisposed)
 			{
@@ -232,7 +239,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
 		}
 
-		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Button.TextProperty.PropertyName)
 			{
@@ -327,7 +334,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 
 
 
-			
+
 			base.OnLayout(changed, l, t, r, b);
 		}
 
@@ -375,17 +382,6 @@ namespace Xamarin.Forms.Platform.Android.Material
 			element.SendViewInitialized(nativeView);
 		}
 
-		void Initialize()
-		{
-			SoundEffectsEnabled = false;
-			SetOnClickListener(this);
-			SetOnTouchListener(this);
-			AddOnAttachStateChangeListener(this);
-			OnFocusChangeListener = this;
-
-			Tag = this;
-		}
-
 		void UpdateBitmap()
 		{
 			if (Element == null || _isDisposed)
@@ -412,10 +408,12 @@ namespace Xamarin.Forms.Platform.Android.Material
 			if (_defaultIconPadding == -1)
 				_defaultIconPadding = 0;
 
+			// disable tint for now
+			IconTint = null;
 			Icon = image;
 
 			if (layout.Position == Button.ButtonContentLayout.ImagePosition.Right || layout.Position == Button.ButtonContentLayout.ImagePosition.Left)
-			{ 
+			{
 				IconGravity = IconGravityTextStart;
 				// setting the icon property causes the base class to calculate things like padding
 				// required to set the image to the start of the text
@@ -446,7 +444,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 			}
 		}
 
-	
+
 
 		void UpdateFont()
 		{
@@ -520,7 +518,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 
 		void UpdatePadding()
 		{
-			if(Element.IsSet(Button.PaddingProperty))
+			if (Element.IsSet(Button.PaddingProperty))
 				SetPadding(
 					(int)(Context.ToPixels(Button.Padding.Left) + _paddingDeltaPix.Left),
 					(int)(Context.ToPixels(Button.Padding.Top) + _paddingDeltaPix.Top),

--- a/Xamarin.Forms.Platform.Android/Material/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialButtonRenderer.cs
@@ -1,0 +1,538 @@
+#if __ANDROID81__
+#else
+using System;
+using System.ComponentModel;
+using Android.Content;
+using Android.Graphics;
+using Android.Graphics.Drawables;
+using Android.Support.V7.Widget;
+using Android.Util;
+using Android.Views;
+using Xamarin.Forms.Internals;
+using AView = Android.Views.View;
+using static System.String;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android.FastRenderers;
+using MButton = Android.Support.Design.Button.MaterialButton;
+using Xamarin.Forms.Platform.Android.Material;
+using Android.Content.Res;
+using Android.Support.V4.Widget;
+using AMotionEventActions = Android.Views.MotionEventActions;
+using Android.Support.V4.View;
+using AColor = Android.Graphics.Color;
+using AViewCompat = Android.Support.V4.View.ViewCompat;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+using ADrawableCompat = Android.Support.V4.Graphics.Drawable.DrawableCompat;
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Button), typeof(MaterialButtonRenderer), new[] { typeof(VisualRendererMarker.Material) })]
+namespace Xamarin.Forms.Platform.Android.Material
+{
+	internal sealed class MaterialButtonRenderer : MButton, IVisualElementRenderer, AView.IOnAttachStateChangeListener,
+		AView.IOnFocusChangeListener, AView.IOnClickListener, AView.IOnTouchListener, IViewRenderer, ITabStop, IBorderVisualElementRenderer
+	{
+		float _defaultFontSize;
+		int? _defaultLabelFor;
+		readonly int _defaultCornerRadius = 5;
+		Typeface _defaultTypeface;
+		int _imageHeight = -1;
+		bool _isDisposed;
+		bool _inputTransparent;
+		Lazy<TextColorSwitcher> _textColorSwitcher;
+		readonly AutomationPropertiesProvider _automationPropertiesProvider;
+		VisualElementTracker _tracker;
+		VisualElementRenderer _visualElementRenderer;
+		Thickness _paddingDeltaPix = new Thickness();
+		IPlatformElementConfiguration<PlatformConfiguration.Android, Button> _platformElementConfiguration;
+		private Button _button;
+
+		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;
+
+		public MaterialButtonRenderer(Context context) : base(context)
+		{
+			_automationPropertiesProvider = new AutomationPropertiesProvider(this);
+
+			Initialize();
+		}
+
+		public Color BackgroundColor => Element?.BackgroundColor != Color.Default ? Element.BackgroundColor : Color.Black;
+		public VisualElement Element => Button;
+		AView IVisualElementRenderer.View => this;
+		ViewGroup IVisualElementRenderer.ViewGroup => null;
+		VisualElementTracker IVisualElementRenderer.Tracker => _tracker;
+
+		Button Button
+		{
+			get => _button;
+			set
+			{
+				_button = value;
+				_platformElementConfiguration = null;
+			}
+		}
+
+		AView ITabStop.TabStop => this;
+
+		void IOnClickListener.OnClick(AView v) => ButtonElementManager.OnClick(Button, Button, v);
+
+		bool IOnTouchListener.OnTouch(AView v, MotionEvent e) => ButtonElementManager.OnTouch(Button, Button, v, e);
+
+		void IOnAttachStateChangeListener.OnViewAttachedToWindow(AView attachedView)
+		{
+			UpdateText();
+		}
+
+		void IOnAttachStateChangeListener.OnViewDetachedFromWindow(AView detachedView)
+		{
+		}
+
+		void IOnFocusChangeListener.OnFocusChange(AView v, bool hasFocus)
+		{
+			((IElementController)Button).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, hasFocus);
+		}
+
+		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
+		{
+			UpdateText();
+
+			AView view = this;
+
+			// with material something is removing the padding between it being set and 
+			// the measure call that's requested here
+			UpdatePadding();
+			view.Measure(widthConstraint, heightConstraint);
+
+			return new SizeRequest(new Size(MeasuredWidth, MeasuredHeight), MinimumSize());
+		}
+
+		void IVisualElementRenderer.SetElement(VisualElement element)
+		{
+			if (element == null)
+			{
+				throw new ArgumentNullException(nameof(element));
+			}
+
+			if (!(element is Button))
+			{
+				throw new ArgumentException($"{nameof(element)} must be of type {nameof(Button)}");
+			}
+
+			VisualElement oldElement = Button;
+			Button = (Button)element;
+
+			Performance.Start(out string reference);
+
+			if (oldElement != null)
+			{
+				oldElement.PropertyChanged -= OnElementPropertyChanged;
+			}
+
+
+			element.PropertyChanged += OnElementPropertyChanged;
+
+			if (_tracker == null)
+			{
+				// Can't set up the tracker in the constructor because it access the Element (for now)
+				SetTracker(new VisualElementTracker(this));
+			}
+			if (_visualElementRenderer == null)
+			{
+				_visualElementRenderer = new VisualElementRenderer(this);
+			}
+
+			OnElementChanged(new ElementChangedEventArgs<Button>(oldElement as Button, Button));
+
+			SendVisualElementInitialized(element, this);
+
+			Performance.Stop(reference);
+		}
+
+		void IVisualElementRenderer.SetLabelFor(int? id)
+		{
+			if (_defaultLabelFor == null)
+			{
+				_defaultLabelFor = ViewCompat.GetLabelFor(this);
+			}
+
+			ViewCompat.SetLabelFor(this, (int)(id ?? _defaultLabelFor));
+		}
+
+		void IVisualElementRenderer.UpdateLayout() => _tracker?.UpdateLayout();
+
+		void IViewRenderer.MeasureExactly()
+		{
+			ViewRenderer.MeasureExactly(this, Element, Context);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+
+			_isDisposed = true;
+
+			if (disposing)
+			{
+				SetOnClickListener(null);
+				SetOnTouchListener(null);
+				RemoveOnAttachStateChangeListener(this);
+
+				_automationPropertiesProvider?.Dispose();
+				_tracker?.Dispose();
+				_visualElementRenderer?.Dispose();
+
+				if (Element != null)
+				{
+					Element.PropertyChanged -= OnElementPropertyChanged;
+
+					if (Platform.GetRenderer(Element) == this)
+						Element.ClearValue(Platform.RendererProperty);
+				}
+			}
+
+			base.Dispose(disposing);
+		}
+
+		public override bool OnTouchEvent(MotionEvent e)
+		{
+			if (!Enabled || (_inputTransparent && Enabled))
+				return false;
+
+			return base.OnTouchEvent(e);
+		}
+
+		Size MinimumSize()
+		{
+			return new Size();
+		}
+
+		void OnElementChanged(ElementChangedEventArgs<Button> e)
+		{
+			if (e.NewElement != null && !_isDisposed)
+			{
+				this.EnsureId();
+
+				_textColorSwitcher = new Lazy<TextColorSwitcher>(
+					() => new TextColorSwitcher(TextColors, e.NewElement.UseLegacyColorManagement()));
+
+				UpdateFont();
+				UpdateText();
+				UpdateBitmap();
+				UpdateTextColor();
+				UpdateInputTransparent();
+				UpdateBackgroundColor();
+				UpdatePadding();
+
+				ElevationHelper.SetElevation(this, e.NewElement);
+			}
+
+			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
+		}
+
+		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == Button.TextProperty.PropertyName)
+			{
+				UpdateText();
+			}
+			else if (e.PropertyName == Button.TextColorProperty.PropertyName)
+			{
+				UpdateTextColor();
+			}
+			else if (e.PropertyName == Button.FontProperty.PropertyName)
+			{
+				UpdateFont();
+			}
+			else if (e.PropertyName == Button.ImageProperty.PropertyName)
+			{
+				UpdateBitmap();
+			}
+			else if (e.PropertyName == VisualElement.IsVisibleProperty.PropertyName)
+			{
+				UpdateText();
+			}
+			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
+			{
+				UpdateInputTransparent();
+			}
+			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
+			{
+				UpdatePadding();
+			}
+			else if (e.PropertyName == Button.BorderWidthProperty.PropertyName || e.PropertyName == Button.CornerRadiusProperty.PropertyName || e.PropertyName == Button.BorderColorProperty.PropertyName)
+				UpdateBorder();
+
+			ElementPropertyChanged?.Invoke(this, e);
+		}
+
+		private void UpdateBorder()
+		{
+			int cornerRadius = _defaultCornerRadius;
+
+			if (Element.IsSet(Button.CornerRadiusProperty) && Button.CornerRadius != (int)Button.CornerRadiusProperty.DefaultValue)
+				cornerRadius = Button.CornerRadius;
+
+			this.CornerRadius = (int)Context.ToPixels(cornerRadius);
+
+			int[][] States =
+			{
+				new int[0]
+			};
+
+			Color borderColor = Button.BorderColor;
+			if (borderColor.IsDefault)
+			{
+				StrokeColor = new global::Android.Content.Res.ColorStateList
+				(
+					States,
+					new int[] { AColor.Transparent }
+				);
+
+				StrokeWidth = 0;
+			}
+			else
+			{
+				StrokeColor = new global::Android.Content.Res.ColorStateList
+				(
+					States,
+					new int[] { borderColor.ToAndroid() }
+				);
+
+				StrokeWidth = (int)Button.BorderWidth;
+			}
+		}
+
+		protected override void OnLayout(bool changed, int l, int t, int r, int b)
+		{
+			if (Element == null || _isDisposed)
+			{
+				return;
+			}
+
+			if (_imageHeight > -1)
+			{
+				// We've got an image (and no text); it's already centered horizontally,
+				// we just need to adjust the padding so it centers vertically
+				var diff = ((b - Context.ToPixels(Button.Padding.Bottom + Button.Padding.Top)) - t - _imageHeight) / 2;
+				diff = Math.Max(diff, 0);
+				UpdateContentEdge(new Thickness(0, diff, 0, -diff));
+			}
+			else
+			{
+				UpdateContentEdge();
+			}
+
+			base.OnLayout(changed, l, t, r, b);
+		}
+
+		void SetTracker(VisualElementTracker tracker)
+		{
+			_tracker = tracker;
+		}
+
+		void UpdateBackgroundColor()
+		{
+			int[][] States =
+			{
+				new int[0] {  }
+			};
+
+			ColorStateList colorStateList = new ColorStateList(
+						States,
+						new int[] { BackgroundColor.ToAndroid() }
+				);
+
+			AViewCompat.SetBackgroundTintList(this, colorStateList);
+		}
+
+		internal void OnNativeFocusChanged(bool hasFocus)
+		{
+		}
+
+		internal void SendVisualElementInitialized(VisualElement element, AView nativeView)
+		{
+			element.SendViewInitialized(nativeView);
+		}
+
+		void Initialize()
+		{
+			SoundEffectsEnabled = false;
+			SetOnClickListener(this);
+			SetOnTouchListener(this);
+			AddOnAttachStateChangeListener(this);
+			OnFocusChangeListener = this;
+
+			Tag = this;
+		}
+
+		void UpdateBitmap()
+		{
+			if (Element == null || _isDisposed)
+			{
+				return;
+			}
+
+			FileImageSource elementImage = Button.Image;
+			string imageFile = elementImage?.File;
+			_imageHeight = -1;
+
+			if (elementImage == null || IsNullOrEmpty(imageFile))
+			{
+				SetCompoundDrawablesWithIntrinsicBounds(null, null, null, null);
+				return;
+			}
+
+			Drawable image = Context.GetDrawable(imageFile);
+			Button.ButtonContentLayout layout = Button.ContentLayout;
+			CompoundDrawablePadding = (int)layout.Spacing;
+			image = ADrawableCompat.Wrap(image).Mutate();
+			ADrawableCompat.SetTintList(image, IconTint);
+			IconGravity = IconGravityTextStart;
+
+			if (IsNullOrEmpty(Button.Text))
+			{
+				// No text, so no need for relative position; just center the image
+				// There's no option for just plain-old centering, so we'll use Top 
+				// (which handles the horizontal centering) and some tricksy padding (in OnLayout)
+				// to handle the vertical centering 
+
+				// Clear any previous padding and set the image as top/center
+				UpdateContentEdge();
+				SetCompoundDrawablesWithIntrinsicBounds(null, image, null, null);
+
+				// Keep track of the image height so we can use it in OnLayout
+				_imageHeight = image.IntrinsicHeight;
+
+				image.Dispose();
+				return;
+			}
+
+			
+
+			switch (layout.Position)
+			{
+				case Button.ButtonContentLayout.ImagePosition.Top:
+					SetCompoundDrawablesWithIntrinsicBounds(null, image, null, null);
+					break;
+				case Button.ButtonContentLayout.ImagePosition.Bottom:
+					SetCompoundDrawablesWithIntrinsicBounds(null, null, null, image);
+					break;
+				case Button.ButtonContentLayout.ImagePosition.Right:
+					SetCompoundDrawablesWithIntrinsicBounds(null, null, image, null);
+					break;
+				default:
+					// Defaults to image on the left
+					SetCompoundDrawablesWithIntrinsicBounds(image, null, null, null);
+					break;
+			}			
+
+			image?.Dispose();
+		}
+
+		void UpdateFont()
+		{
+			if (Element == null || _isDisposed)
+			{
+				return;
+			}
+
+			Font font = Button.Font;
+
+			if (font == Font.Default && _defaultFontSize == 0f)
+			{
+				return;
+			}
+
+			if (_defaultFontSize == 0f)
+			{
+				_defaultTypeface = Typeface;
+				_defaultFontSize = TextSize;
+			}
+
+			if (font == Font.Default)
+			{
+				Typeface = _defaultTypeface;
+				SetTextSize(ComplexUnitType.Px, _defaultFontSize);
+			}
+			else
+			{
+				Typeface = font.ToTypeface();
+				SetTextSize(ComplexUnitType.Sp, font.ToScaledPixel());
+			}
+		}
+
+		void UpdateInputTransparent()
+		{
+			if (Element == null || _isDisposed)
+			{
+				return;
+			}
+
+			_inputTransparent = Element.InputTransparent;
+		}
+
+		void UpdateText()
+		{
+			if (Element == null || _isDisposed)
+			{
+				return;
+			}
+
+			string oldText = Text;
+			Text = Button.Text;
+
+			// If we went from or to having no text, we need to update the image position
+			if (IsNullOrEmpty(oldText) != IsNullOrEmpty(Text))
+			{
+				UpdateBitmap();
+			}
+		}
+
+		void UpdateTextColor()
+		{
+			if (Element == null || _isDisposed || _textColorSwitcher == null)
+				return;
+
+			if (Button.TextColor == Color.Default)
+				_textColorSwitcher.Value.UpdateTextColor(this, Button.TextColor);
+			else
+				_textColorSwitcher.Value.UpdateTextColor(this, Color.White);
+		}
+
+		void UpdatePadding()
+		{
+			SetPadding(
+				(int)(Context.ToPixels(Button.Padding.Left) + _paddingDeltaPix.Left),
+				(int)(Context.ToPixels(Button.Padding.Top) + _paddingDeltaPix.Top),
+				(int)(Context.ToPixels(Button.Padding.Right) + _paddingDeltaPix.Right),
+				(int)(Context.ToPixels(Button.Padding.Bottom) + _paddingDeltaPix.Bottom)
+			);
+		}
+
+		void UpdateContentEdge(Thickness? delta = null)
+		{
+			_paddingDeltaPix = delta ?? new Thickness();
+			UpdatePadding();
+		}
+
+		float IBorderVisualElementRenderer.ShadowRadius => ShadowRadius;
+		float IBorderVisualElementRenderer.ShadowDx => ShadowDx;
+		float IBorderVisualElementRenderer.ShadowDy => ShadowDy;
+		AColor IBorderVisualElementRenderer.ShadowColor => ShadowColor;
+		bool IBorderVisualElementRenderer.UseDefaultPadding() => OnThisPlatform().UseDefaultPadding();
+		bool IBorderVisualElementRenderer.UseDefaultShadow() => OnThisPlatform().UseDefaultShadow();
+		bool IBorderVisualElementRenderer.IsShadowEnabled() => true;
+		AView IBorderVisualElementRenderer.View => this;
+
+		IPlatformElementConfiguration<PlatformConfiguration.Android, Button> OnThisPlatform()
+		{
+			if (_platformElementConfiguration == null)
+				_platformElementConfiguration = Button.OnThisPlatform();
+
+			return _platformElementConfiguration;
+		}
+	}
+}
+#endif

--- a/Xamarin.Forms.Platform.Android/Material/MaterialEntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialEntryRenderer.cs
@@ -1,0 +1,587 @@
+﻿#if __ANDROID81__
+#else
+using System;
+using System.ComponentModel;
+using Android.Content;
+using Android.Graphics;
+using Android.Util;
+using Android.Views;
+using Xamarin.Forms.Internals;
+using AView = Android.Views.View;
+using Android.Support.V4.View;
+using Xamarin.Forms.Platform.Android.Material;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android.FastRenderers;
+using System.Collections.Generic;
+using Android.Content.Res;
+using Android.Text;
+using Android.Text.Method;
+using Android.Views.InputMethods;
+using Android.Widget;
+using Java.Lang;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+using MTextInputLayout = Android.Support.Design.Widget.TextInputLayout;
+using Android.OS;
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Entry), typeof(MaterialEntryRenderer), new[] { typeof(VisualRendererMarker.Material) })]
+namespace Xamarin.Forms.Platform.Android.Material
+{
+	public class MaterialEntryRenderer :
+		MTextInputLayout,
+		ITextWatcher, TextView.IOnEditorActionListener,
+		IVisualElementRenderer, IViewRenderer, IEffectControlProvider
+
+	{
+		int? _defaultLabelFor;
+		TextColorSwitcher _hintColorSwitcher;
+		TextColorSwitcher _textColorSwitcher;
+		readonly AutomationPropertiesProvider _automationPropertiesProvider;
+		readonly EffectControlProvider _effectControlProvider;
+		bool _disposed;
+		ImeAction _currentInputImeFlag;
+
+		bool _cursorPositionChangePending;
+		bool _selectionLengthChangePending;
+		bool _nativeSelectionIsUpdating;
+		private MaterialFormsEditText _textInputEditText;
+		VisualElementTracker _tracker;
+		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;
+
+		public MaterialEntryRenderer(Context context) : base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialTheme))
+		{
+			VisualElement.VerifyVisualFlagEnabled();
+			_automationPropertiesProvider = new AutomationPropertiesProvider(this);
+			_effectControlProvider = new EffectControlProvider(this);
+		}
+
+		IElementController ElementController => Element as IElementController;
+		public VisualElement Element => Entry;
+		AView IVisualElementRenderer.View => this;
+		ViewGroup IVisualElementRenderer.ViewGroup => null;
+		VisualElementTracker IVisualElementRenderer.Tracker => _tracker;
+
+		Entry Entry { get; set; }
+
+		bool TextView.IOnEditorActionListener.OnEditorAction(TextView v, ImeAction actionId, KeyEvent e)
+		{
+			// Fire Completed and dismiss keyboard for hardware / physical keyboards
+			if (actionId == ImeAction.Done || actionId == _currentInputImeFlag || (actionId == ImeAction.ImeNull && e.KeyCode == Keycode.Enter && e.Action == KeyEventActions.Up))
+			{
+				ClearFocus();
+				v.HideKeyboard();
+				((IEntryController)Element).SendCompleted();
+			}
+
+			return true;
+		}
+
+		void IViewRenderer.MeasureExactly()
+		{
+			ViewRenderer.MeasureExactly(this, Element, Context);
+		}
+
+		void IEffectControlProvider.RegisterEffect(Effect effect)
+		{
+			_effectControlProvider.RegisterEffect(effect);
+		}
+
+		void IVisualElementRenderer.UpdateLayout()
+		{
+			_tracker?.UpdateLayout();
+		}
+
+
+		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
+		{
+			AView view = this;
+			view.Measure(widthConstraint, heightConstraint);
+			return new SizeRequest(new Size(MeasuredWidth, MeasuredHeight), MinimumSize());
+		}
+
+		void IVisualElementRenderer.SetLabelFor(int? id)
+		{
+			if (_defaultLabelFor == null)
+			{
+				_defaultLabelFor = ViewCompat.GetLabelFor(this);
+			}
+
+			ViewCompat.SetLabelFor(this, (int)(id ?? _defaultLabelFor));
+		}
+
+		Size MinimumSize()
+		{
+			return new Size();
+		}
+
+		void ITextWatcher.AfterTextChanged(IEditable s)
+		{
+		}
+
+		void ITextWatcher.BeforeTextChanged(ICharSequence s, int start, int count, int after)
+		{
+		}
+
+		void ITextWatcher.OnTextChanged(ICharSequence s, int start, int before, int count)
+		{
+			if (string.IsNullOrEmpty(Entry.Text) && s.Length() == 0)
+				return;
+
+			((IElementController)Element).SetValueFromRenderer(Entry.TextProperty, s.ToString());
+		}
+
+
+		public override void OnViewAdded(AView child)
+		{
+			base.OnViewAdded(child);
+
+			/*AView someView = FindViewById(Resource.Id.materialtextinputlayoutfilledBox_edittext);
+			var otherView = GetChildAt(0);
+			_textInputEditText = FindViewById<MaterialFormsEditText>(Resource.Id.materialtextinputlayoutfilledBox_edittext);*/
+		}
+
+		void IVisualElementRenderer.SetElement(VisualElement element)
+		{
+
+			if (element == null)
+				throw new ArgumentNullException(nameof(element));
+
+			if (!(element is Entry))
+				throw new ArgumentException($"{nameof(element)} must be of type {nameof(Entry)}");
+
+			VisualElement oldElement = Entry;
+			Entry = (Entry)element;
+
+			Performance.Start(out string reference);
+
+			if (oldElement != null)
+			{
+				oldElement.PropertyChanged -= OnElementPropertyChanged;
+				oldElement.FocusChangeRequested -= OnFocusChangeRequested;
+			}
+
+			if (oldElement == null)
+			{
+				_textInputEditText = new MaterialFormsEditText(Context);
+				AddView(_textInputEditText);
+
+				_textInputEditText.FocusChange += _textInputEditText_FocusChange;
+				Hint = Entry.Placeholder;
+
+				_textInputEditText.AddTextChangedListener(this);
+				_textInputEditText.SetOnEditorActionListener(this);
+				_textInputEditText.OnKeyboardBackPressed += OnKeyboardBackPressed;
+				_textInputEditText.SelectionChanged += SelectionChanged;
+
+				var useLegacyColorManagement = Entry.UseLegacyColorManagement();
+
+				_textColorSwitcher = new TextColorSwitcher(_textInputEditText.TextColors, useLegacyColorManagement);
+				_hintColorSwitcher = new TextColorSwitcher(_textInputEditText.HintTextColors, useLegacyColorManagement);
+			}
+
+			// When we set the control text, it triggers the SelectionChanged event, which updates CursorPosition and SelectionLength;
+			// These one-time-use variables will let us initialize a CursorPosition and SelectionLength via ctor/xaml/etc.
+			_cursorPositionChangePending = Element.IsSet(Entry.CursorPositionProperty);
+			_selectionLengthChangePending = Element.IsSet(Entry.SelectionLengthProperty);
+
+
+			Hint = Entry.Placeholder;
+			_textInputEditText.Text = Entry.Text;
+			UpdateInputType();
+			UpdateColor();
+			UpdateAlignment();
+			UpdateFont();
+			UpdatePlaceholderColor(true);
+			UpdateMaxLength();
+			UpdateImeOptions();
+			UpdateReturnType();
+			UpdateBackgroundColor();
+
+			if (_cursorPositionChangePending || _selectionLengthChangePending)
+				UpdateCursorSelection();
+
+			element.PropertyChanged += OnElementPropertyChanged;
+			if (_tracker == null)
+			{
+				_tracker = new VisualElementTracker(this);
+			}
+			element.SendViewInitialized(this);
+			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);
+			Performance.Stop(reference);
+			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(oldElement, element));
+
+			element.FocusChangeRequested += OnFocusChangeRequested;
+		}
+
+		// Todo Generalize this from View Renderer
+		internal virtual void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
+		{
+			e.Result = true;
+
+			if (e.Focus)
+			{
+				// use post being BeginInvokeOnMainThread will not delay on android
+				Looper looper = Context.MainLooper;
+				var handler = new Handler(looper);
+				handler.Post(() =>
+				{
+					_textInputEditText.RequestFocus();
+				});
+			}
+			else
+			{
+				_textInputEditText.ClearFocus();
+			}
+
+			if (e.Focus)
+				this.ShowKeyboard();
+			else
+				this.HideKeyboard();
+		}
+
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				_textInputEditText.OnKeyboardBackPressed -= OnKeyboardBackPressed;
+				_textInputEditText.SelectionChanged -= SelectionChanged;
+			}
+
+			base.Dispose(disposing);
+		}
+
+
+		void _textInputEditText_FocusChange(object sender, FocusChangeEventArgs e)
+		{
+			// TODO figure out better way to do this
+			// this is a hack that changes the active underline color from the accent color to whatever the user 
+			// specified
+			Device.BeginInvokeOnMainThread(() => UpdatePlaceholderColor(false));
+		}
+
+		void UpdatePlaceholderColor(bool reset)
+		{
+			int[][] States =
+			{
+				new []{ global::Android.Resource.Attribute.StateFocused  },
+				new []{ -global::Android.Resource.Attribute.StateFocused  },
+			};
+
+			var placeHolderColor = new ColorStateList(
+						States,
+						new int[]{
+							Entry.PlaceholderColor.ToAndroid(),
+							Entry.PlaceholderColor.ToAndroid()
+						}
+				);
+
+			if (reset)
+				DefaultHintTextColor = placeHolderColor;
+
+			ViewCompat.SetBackgroundTintList(_textInputEditText, placeHolderColor);
+		}
+
+		void UpdateBackgroundColor()
+		{
+			SetBoxBackgroundMode(MTextInputLayout.BoxBackgroundFilled);
+			BoxBackgroundColor = Element.BackgroundColor.ToAndroid();
+
+			// need to make corner radius settable
+			SetBoxCornerRadii(10, 10, 10, 10);
+		}
+
+
+		protected void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == Entry.PlaceholderProperty.PropertyName)
+				Hint = Entry.Placeholder;
+			else if (e.PropertyName == Entry.IsPasswordProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == Entry.TextProperty.PropertyName)
+			{
+				if (_textInputEditText.Text != Entry.Text)
+				{
+					_textInputEditText.Text = Entry.Text;
+					if (IsFocused)
+					{
+						_textInputEditText.SetSelection(_textInputEditText.Text.Length);
+						this.ShowKeyboard();
+					}
+				}
+			}
+			else if (e.PropertyName == Entry.TextColorProperty.PropertyName)
+				UpdateColor();
+			else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == InputView.IsSpellCheckEnabledProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == Entry.IsTextPredictionEnabledProperty.PropertyName)
+				UpdateInputType();
+			else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
+				UpdateAlignment();
+			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.FontFamilyProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.FontSizeProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
+			{
+				UpdatePlaceholderColor(true);
+			}
+			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
+				UpdateAlignment();
+			else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
+				UpdateMaxLength();
+			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.Entry.ImeOptionsProperty.PropertyName)
+				UpdateImeOptions();
+			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
+				UpdateReturnType();
+			else if (e.PropertyName == Entry.SelectionLengthProperty.PropertyName)
+				UpdateCursorSelection();
+			else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName)
+				UpdateCursorSelection();
+			else if (e.PropertyName == Entry.BackgroundColorProperty.PropertyName)
+				UpdateBackgroundColor();
+
+			ElementPropertyChanged?.Invoke(this, e);
+		}
+
+		protected virtual NumberKeyListener GetDigitsKeyListener(InputTypes inputTypes)
+		{
+			// Override this in a custom renderer to use a different NumberKeyListener
+			// or to filter out input types you don't want to allow
+			// (e.g., inputTypes &= ~InputTypes.NumberFlagSigned to disallow the sign)
+			return LocalizedDigitsKeyListener.Create(inputTypes);
+		}
+
+		protected virtual void UpdateImeOptions()
+		{
+			if (Element == null)
+				return;
+			var imeOptions = Entry.OnThisPlatform().ImeOptions();
+			_currentInputImeFlag = imeOptions.ToAndroidImeOptions();
+			_textInputEditText.ImeOptions = _currentInputImeFlag;
+		}
+
+		void UpdateAlignment()
+		{
+			_textInputEditText.UpdateHorizontalAlignment(Entry.HorizontalTextAlignment, Context.HasRtlSupport());
+		}
+
+		void UpdateColor()
+		{
+			_textColorSwitcher.UpdateTextColor(_textInputEditText, Entry.TextColor);
+		}
+
+		void UpdateFont()
+		{
+			Typeface = Entry.ToTypeface();
+			_textInputEditText.SetTextSize(ComplexUnitType.Sp, (float)Entry.FontSize);
+		}
+
+		void UpdateInputType()
+		{
+			Entry model = Entry;
+			var keyboard = model.Keyboard;
+
+			_textInputEditText.InputType = keyboard.ToInputType();
+			if (!(keyboard is Internals.CustomKeyboard))
+			{
+				if (model.IsSet(InputView.IsSpellCheckEnabledProperty))
+				{
+					if ((_textInputEditText.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsSpellCheckEnabled)
+							_textInputEditText.InputType = _textInputEditText.InputType | InputTypes.TextFlagNoSuggestions;
+					}
+				}
+				if (model.IsSet(Entry.IsTextPredictionEnabledProperty))
+				{
+					if ((_textInputEditText.InputType & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
+					{
+						if (!model.IsTextPredictionEnabled)
+							_textInputEditText.InputType = _textInputEditText.InputType | InputTypes.TextFlagNoSuggestions;
+					}
+				}
+			}
+
+			if (keyboard == Keyboard.Numeric)
+			{
+				_textInputEditText.KeyListener = GetDigitsKeyListener(_textInputEditText.InputType);
+			}
+
+			if (model.IsPassword && ((_textInputEditText.InputType & InputTypes.ClassText) == InputTypes.ClassText))
+				_textInputEditText.InputType = _textInputEditText.InputType | InputTypes.TextVariationPassword;
+			if (model.IsPassword && ((_textInputEditText.InputType & InputTypes.ClassNumber) == InputTypes.ClassNumber))
+				_textInputEditText.InputType = _textInputEditText.InputType | InputTypes.NumberVariationPassword;
+
+			UpdateFont();
+		}
+
+		void OnKeyboardBackPressed(object sender, EventArgs eventArgs)
+		{
+			_textInputEditText.ClearFocus();
+		}
+
+		void UpdateMaxLength()
+		{
+			var currentFilters = new List<IInputFilter>(_textInputEditText?.GetFilters() ?? new IInputFilter[0]);
+
+			for (var i = 0; i < currentFilters.Count; i++)
+			{
+				if (currentFilters[i] is InputFilterLengthFilter)
+				{
+					currentFilters.RemoveAt(i);
+					break;
+				}
+			}
+
+			currentFilters.Add(new InputFilterLengthFilter(Entry.MaxLength));
+
+			_textInputEditText?.SetFilters(currentFilters.ToArray());
+
+			var currentControlText = _textInputEditText?.Text;
+
+			if (currentControlText.Length > Entry.MaxLength)
+				_textInputEditText.Text = currentControlText.Substring(0, Entry.MaxLength);
+		}
+
+		void UpdateReturnType()
+		{
+			if (Element == null)
+				return;
+
+			_textInputEditText.ImeOptions = Entry.ReturnType.ToAndroidImeAction();
+			_currentInputImeFlag = _textInputEditText.ImeOptions;
+		}
+
+		void SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (_nativeSelectionIsUpdating || Element == null)
+				return;
+
+			int cursorPosition = Entry.CursorPosition;
+			int selectionStart = _textInputEditText.SelectionStart;
+
+			if (!_cursorPositionChangePending)
+			{
+				var start = cursorPosition;
+
+				if (selectionStart != start)
+					SetCursorPositionFromRenderer(selectionStart);
+			}
+
+			if (!_selectionLengthChangePending)
+			{
+				int elementSelectionLength = System.Math.Min(_textInputEditText.Text.Length - cursorPosition, Entry.SelectionLength);
+
+				var controlSelectionLength = _textInputEditText.SelectionEnd - selectionStart;
+				if (controlSelectionLength != elementSelectionLength)
+					SetSelectionLengthFromRenderer(controlSelectionLength);
+			}
+		}
+
+		void UpdateCursorSelection()
+		{
+			if (_nativeSelectionIsUpdating || Element == null)
+				return;
+
+			if (_textInputEditText.RequestFocus())
+			{
+				try
+				{
+					int start = GetSelectionStart();
+					int end = GetSelectionEnd(start);
+
+					_textInputEditText.SetSelection(start, end);
+				}
+				catch (System.Exception ex)
+				{
+					Internals.Log.Warning("Entry", $"Failed to set Control.Selection from CursorPosition/SelectionLength: {ex}");
+				}
+				finally
+				{
+					_cursorPositionChangePending = _selectionLengthChangePending = false;
+				}
+			}
+		}
+
+		int GetSelectionEnd(int start)
+		{
+			int end = start;
+			int selectionLength = Entry.SelectionLength;
+
+			if (Element.IsSet(Entry.SelectionLengthProperty))
+				end = System.Math.Max(start, System.Math.Min(_textInputEditText.Length(), start + selectionLength));
+
+			int newSelectionLength = System.Math.Max(0, end - start);
+			if (newSelectionLength != selectionLength)
+				SetSelectionLengthFromRenderer(newSelectionLength);
+
+			return end;
+		}
+
+		int GetSelectionStart()
+		{
+			int start = _textInputEditText.Length();
+			int cursorPosition = Entry.CursorPosition;
+
+			if (Element.IsSet(Entry.CursorPositionProperty))
+				start = System.Math.Min(_textInputEditText.Text.Length, cursorPosition);
+
+			if (start != cursorPosition)
+				SetCursorPositionFromRenderer(start);
+
+			return start;
+		}
+
+		void SetCursorPositionFromRenderer(int start)
+		{
+			try
+			{
+				_nativeSelectionIsUpdating = true;
+				ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, start);
+			}
+			catch (System.Exception ex)
+			{
+				Internals.Log.Warning("Entry", $"Failed to set CursorPosition from renderer: {ex}");
+			}
+			finally
+			{
+				_nativeSelectionIsUpdating = false;
+			}
+		}
+
+		void SetSelectionLengthFromRenderer(int selectionLength)
+		{
+			try
+			{
+				_nativeSelectionIsUpdating = true;
+				ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+			}
+			catch (System.Exception ex)
+			{
+				Internals.Log.Warning("Entry", $"Failed to set SelectionLength from renderer: {ex}");
+			}
+			finally
+			{
+				_nativeSelectionIsUpdating = false;
+			}
+		}
+
+		//void UpdatePlaceholderColor()
+		//{
+		//	_hintColorSwitcher.UpdateTextColor(_textInputEditText, Element.PlaceholderColor, _textInputEditText.SetHintTextColor);
+		//}
+	}
+}
+#endif

--- a/Xamarin.Forms.Platform.Android/Material/MaterialFormsEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialFormsEditText.cs
@@ -1,0 +1,59 @@
+#if __ANDROID81__
+#else
+using System;
+using Android.Content;
+using Android.Graphics;
+using Android.Views;
+using Android.Widget;
+using Android.Support.V4.Graphics.Drawable;
+using Android.Support.Design.Widget;
+
+namespace Xamarin.Forms.Platform.Android.Material
+{
+	public class MaterialFormsEditText : TextInputEditText, IDescendantFocusToggler
+	{
+		DescendantFocusToggler _descendantFocusToggler;
+
+		public MaterialFormsEditText(Context context) : base(context)
+		{
+			VisualElement.VerifyVisualFlagEnabled();
+			DrawableCompat.Wrap(Background);
+		}
+
+
+		bool IDescendantFocusToggler.RequestFocus(global::Android.Views.View control, Func<bool> baseRequestFocus)
+		{
+			_descendantFocusToggler = _descendantFocusToggler ?? new DescendantFocusToggler();
+
+			return _descendantFocusToggler.RequestFocus(control, baseRequestFocus);
+		}
+
+		public override bool OnKeyPreIme(Keycode keyCode, KeyEvent e)
+		{
+			if (keyCode != Keycode.Back || e.Action != KeyEventActions.Down)
+			{
+				return base.OnKeyPreIme(keyCode, e);
+			}
+
+			this.HideKeyboard();
+
+			OnKeyboardBackPressed?.Invoke(this, EventArgs.Empty);
+			return true;
+		}
+
+		public override bool RequestFocus(FocusSearchDirection direction, Rect previouslyFocusedRect)
+		{
+			return (this as IDescendantFocusToggler).RequestFocus(this, () => base.RequestFocus(direction, previouslyFocusedRect));
+		}
+
+		protected override void OnSelectionChanged(int selStart, int selEnd)
+		{
+			base.OnSelectionChanged(selStart, selEnd);
+			SelectionChanged?.Invoke(this, new SelectionChangedEventArgs(selStart, selEnd));
+		}
+
+		internal event EventHandler OnKeyboardBackPressed;
+		internal event EventHandler<SelectionChangedEventArgs> SelectionChanged;
+	}
+}
+#endif

--- a/Xamarin.Forms.Platform.Android/Material/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialFrameRenderer.cs
@@ -1,0 +1,308 @@
+#if __ANDROID81__
+#else
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Android.Content;
+using Android.Graphics.Drawables;
+using Android.Support.V4.View;
+using Android.Support.V7.Widget;
+using Android.Views;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android.FastRenderers;
+using Xamarin.Forms.Platform.Android.Material;
+using MaterialCardView = Android.Support.Design.Card.MaterialCardView;
+using AColor = Android.Graphics.Color;
+using AView = Android.Views.View;
+
+// this won't go here permanently it's just for testing at this point
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Frame), typeof(MaterialFrameRenderer), new[] { typeof(VisualRendererMarker.Material) })]
+namespace Xamarin.Forms.Platform.Android.Material
+{
+	public class MaterialFrameRenderer : MaterialCardView, IVisualElementRenderer, IEffectControlProvider, IViewRenderer, ITabStop
+	{
+		float _defaultElevation = -1f;
+		float _defaultCornerRadius = -1f;
+		int? _defaultLabelFor;
+
+		bool _disposed;
+		Frame _element;
+
+		VisualElementPackager _visualElementPackager;
+		VisualElementTracker _visualElementTracker;
+
+		readonly GestureManager _gestureManager;
+		readonly EffectControlProvider _effectControlProvider;
+		readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
+
+		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;
+
+		public MaterialFrameRenderer(Context context) : base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialTheme))
+		{
+			VisualElement.VerifyVisualFlagEnabled();
+			_gestureManager = new GestureManager(this);
+			_effectControlProvider = new EffectControlProvider(this);
+			UseCompatPadding = true;
+		}
+
+		protected CardView Control => this;
+
+		AView ITabStop.TabStop => this;
+
+		protected Frame Element
+		{
+			get { return _element; }
+			set
+			{
+				if (_element == value)
+					return;
+
+				Frame oldElement = _element;
+				_element = value;
+
+				OnElementChanged(new ElementChangedEventArgs<Frame>(oldElement, _element));
+
+				_element?.SendViewInitialized(Control);
+			}
+		}
+
+		VisualElement IVisualElementRenderer.Element => Element;
+		ViewGroup IVisualElementRenderer.ViewGroup => this;
+		AView IVisualElementRenderer.View => this;
+
+		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
+		{
+			Context context = Context;
+			return new SizeRequest(new Size(context.ToPixels(20), context.ToPixels(20)));
+		}
+
+		void IVisualElementRenderer.SetElement(VisualElement element)
+		{
+			var frame = element as Frame;
+			if (frame == null)
+				throw new ArgumentException("Element must be of type Frame");
+			Element = frame;
+			_motionEventHelper.UpdateElement(frame);
+
+			if (!string.IsNullOrEmpty(Element.AutomationId))
+				ContentDescription = Element.AutomationId;
+		}
+
+		void IVisualElementRenderer.SetLabelFor(int? id)
+		{
+			if (_defaultLabelFor == null)
+				_defaultLabelFor = ViewCompat.GetLabelFor(this);
+
+			ViewCompat.SetLabelFor(this, (int)(id ?? _defaultLabelFor));
+		}
+
+		VisualElementTracker IVisualElementRenderer.Tracker => _visualElementTracker;
+
+		void IVisualElementRenderer.UpdateLayout()
+		{
+			VisualElementTracker tracker = _visualElementTracker;
+			tracker?.UpdateLayout();
+		}
+
+		void IEffectControlProvider.RegisterEffect(Effect effect)
+		{
+			_effectControlProvider.RegisterEffect(effect);
+		}
+
+		void IViewRenderer.MeasureExactly()
+		{
+			ViewRenderer.MeasureExactly(this, Element, Context);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				_gestureManager?.Dispose();
+
+				if (_visualElementTracker != null)
+				{
+					_visualElementTracker.Dispose();
+					_visualElementTracker = null;
+				}
+
+				if (_visualElementPackager != null)
+				{
+					_visualElementPackager.Dispose();
+					_visualElementPackager = null;
+				}
+
+				int count = ChildCount;
+				for (var i = 0; i < count; i++)
+				{
+					AView child = GetChildAt(i);
+					child.Dispose();
+				}
+
+				if (Element != null)
+				{
+					Element.PropertyChanged -= OnElementPropertyChanged;
+
+					if (Platform.GetRenderer(Element) == this)
+						Element.ClearValue(Platform.RendererProperty);
+				}
+
+			}
+
+			base.Dispose(disposing);
+		}
+
+		protected virtual void OnElementChanged(ElementChangedEventArgs<Frame> e)
+		{
+			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
+
+			if (e.OldElement != null)
+			{
+				e.OldElement.PropertyChanged -= OnElementPropertyChanged;
+			}
+
+			if (e.NewElement != null)
+			{
+				this.EnsureId();
+				//this.SetBackground(_backgroundDrawable);
+
+				if (_visualElementTracker == null)
+				{
+					_visualElementTracker = new VisualElementTracker(this);
+					_visualElementPackager = new VisualElementPackager(this);
+					_visualElementPackager.Load();
+				}
+
+				e.NewElement.PropertyChanged += OnElementPropertyChanged;
+				UpdateShadow();
+				UpdateBackgroundColor();
+				UpdateCornerRadius();
+				UpdateBorderColor();
+
+				ElevationHelper.SetElevation(this, e.NewElement);
+			}
+		}
+
+		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+		{
+			if (Element == null)
+				return;
+
+			var children = ((IElementController)Element).LogicalChildren;
+			for (var i = 0; i < children.Count; i++)
+			{
+				var visualElement = children[i] as VisualElement;
+				if (visualElement == null)
+					continue;
+				IVisualElementRenderer renderer = Android.Platform.GetRenderer(visualElement);
+				renderer?.UpdateLayout();
+			}
+		}
+
+		public override bool OnTouchEvent(MotionEvent e)
+		{
+			if (_gestureManager.OnTouchEvent(e) || base.OnTouchEvent(e))
+			{
+				return true;
+			}
+
+			return _motionEventHelper.HandleMotionEvent(Parent, e);
+		}
+
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			ElementPropertyChanged?.Invoke(this, e);
+
+			if (e.PropertyName == Frame.HasShadowProperty.PropertyName)
+				UpdateShadow();
+			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
+				UpdateBackgroundColor();
+			else if (e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
+				UpdateCornerRadius();
+			else if (e.PropertyName == Frame.BorderColorProperty.PropertyName)
+				UpdateBorderColor();
+		}
+
+		void UpdateBackgroundColor()
+		{
+			if (_disposed)
+				return;
+
+			Color bgColor = Element.BackgroundColor;
+
+			int[][] States =
+			{
+				new int[0]
+			};
+
+			CardBackgroundColor = new global::Android.Content.Res.ColorStateList
+				(
+					States,
+					new int[] { bgColor.IsDefault ? AColor.White : bgColor.ToAndroid() }
+				);
+			
+		}
+
+		void UpdateBorderColor()
+		{
+			if (_disposed)
+				return;
+
+			Color borderColor = Element.BorderColor;
+			if (borderColor.IsDefault)
+			{
+				StrokeColor = AColor.Transparent;
+				StrokeWidth = 0;
+			}
+			else
+			{
+				StrokeColor = borderColor.ToAndroid();
+				StrokeWidth = 25;
+			}
+
+		}
+
+		void UpdateShadow()
+		{
+			if (_disposed)
+				return;
+
+			float elevation = _defaultElevation;
+
+			if (elevation == -1f)
+				_defaultElevation = elevation = CardElevation;
+			 
+			if (Element.HasShadow)
+				CardElevation = _defaultElevation;
+			else
+				CardElevation = 0f;
+		}
+
+		void UpdateCornerRadius()
+		{
+			if (_disposed)
+				return;
+
+			if (_defaultCornerRadius == -1f)
+			{
+				_defaultCornerRadius = Radius;
+			}
+
+			float cornerRadius = Element.CornerRadius;
+
+			if (cornerRadius == -1f)
+				cornerRadius = _defaultCornerRadius;
+			else
+				cornerRadius = Context.ToPixels(cornerRadius);
+
+			this.Radius = cornerRadius;
+		}
+	}
+}
+#endif

--- a/Xamarin.Forms.Platform.Android/Material/MaterialProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialProgressBarRenderer.cs
@@ -1,0 +1,80 @@
+using System;
+using System.ComponentModel;
+using Android.Content;
+using Android.Content.Res;
+using Android.Graphics;
+using Android.OS;
+using Android.Support.V7.View;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android.Material;
+using AProgressBar = Android.Widget.ProgressBar;
+using AViewCompat = Android.Support.V4.View.ViewCompat;
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.ProgressBar), typeof(MaterialProgressBarRenderer), new[] { typeof(VisualRendererMarker.Material) })]
+namespace Xamarin.Forms.Platform.Android.Material
+{
+	public class MaterialProgressBarRenderer : ProgressBarRenderer
+	{
+		public MaterialProgressBarRenderer(Context context) : base(context)
+		{
+			AutoPackage = false;
+		}
+
+		protected override AProgressBar CreateNativeControl()
+		{
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
+			{
+				return new AProgressBar(new ContextThemeWrapper(Context, Resource.Style.XamarinFormsMaterialProgressBarHorizontal), null, Resource.Style.XamarinFormsMaterialProgressBarHorizontal)
+				{
+					Indeterminate = false,
+					Max = 10000,
+
+				};
+			}
+
+			return base.CreateNativeControl();
+
+		}
+
+		protected override void UpdateBackgroundColor()
+		{
+			if (Control == null)
+				return;
+
+			var color = Element.BackgroundColor;
+			if (color != Color.Default)
+				Control.ProgressBackgroundTintList = ColorStateList.ValueOf(color.ToAndroid());
+		}
+
+		internal protected override void UpdateProgressColor()
+		{
+			if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
+			{
+				base.UpdateProgressColor();
+				return;
+			}
+
+			if (Element == null || Control == null)
+				return;
+
+			Color color = Element.ProgressColor;
+			if (color == Color.Default)
+				return;
+
+			var tintList = ColorStateList.ValueOf(color.ToAndroid());
+			if (Control.Indeterminate)
+				Control.IndeterminateTintList = tintList;
+			else
+				Control.ProgressTintList = tintList;
+
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<ProgressBar> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+				UpdateBackgroundColor();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Material/MaterialProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialProgressBarRenderer.cs
@@ -1,3 +1,5 @@
+#if __ANDROID81__
+#else
 using System;
 using System.ComponentModel;
 using Android.Content;
@@ -78,3 +80,4 @@ namespace Xamarin.Forms.Platform.Android.Material
 		}
 	}
 }
+#endif

--- a/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateProgressColor();
 		}
 
-		void UpdateProgressColor()
+		internal virtual protected void UpdateProgressColor()
 		{
 			if (Element == null || Control == null)
 				return;

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -19,6 +19,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static Type ResourceClass { get; set; }
 
+		public static Type StyleClass { get; set; }
+
 		internal static Drawable GetFormsDrawable(this Context context, FileImageSource fileImageSource)
 		{
 			var file = fileImageSource.File;
@@ -94,10 +96,17 @@ namespace Xamarin.Forms.Platform.Android
 			return IdFromTitle(name, ResourceClass);
 		}
 
+		public static int GetStyleByName(string name)
+		{
+			return IdFromTitle(name, StyleClass);
+		}
+
 		public static void Init(Assembly masterAssembly)
 		{
 			DrawableClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == "Drawable" || x.Name == "Resource_Drawable");
 			ResourceClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == "Id" || x.Name == "Resource_Id");
+			StyleClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == "Style" || x.Name == "Resource_Style");
+			
 		}
 
 		internal static int IdFromTitle(string title, Type type)

--- a/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <style name="XamarinFormsMaterialTheme" parent="Theme.MaterialComponents">
+  </style>
+</resources>

--- a/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
@@ -2,4 +2,6 @@
 <resources>
   <style name="XamarinFormsMaterialTheme" parent="Theme.MaterialComponents">
   </style>
+  <style name="XamarinFormsMaterialProgressBarHorizontal" parent="android:Widget.ProgressBar.Horizontal">
+  </style>
 </resources>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -14,7 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v9.0</AndroidTargetFrameworkVersion>
+    <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>
@@ -26,7 +27,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">bin\Debug\monoandroid81\</OutputPath>
+    <OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">bin\Debug\monoandroid90\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -36,12 +38,19 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">bin\Release\monoandroid81\</OutputPath>
+    <OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">bin\Release\monoandroid90\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS0109</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">
+    <DefineConstants>$(DefineConstants);__ANDROID81__</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
+    <DefineConstants>$(DefineConstants);__ANDROID90__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />
@@ -98,7 +107,6 @@
     <Compile Include="AppCompat\IManageFragments.cs" />
     <Compile Include="AppCompat\MasterDetailContainer.cs" />
     <Compile Include="AppCompat\Platform.cs" />
-    <Compile Include="AppCompat\Resource.cs" />
     <Compile Include="CellAdapter.cs" />
     <Compile Include="Cells\EntryCellEditText.cs" />
     <Compile Include="Cells\EntryCellView.cs" />
@@ -133,6 +141,10 @@
     <Compile Include="IBorderVisualElementRenderer.cs" />
     <Compile Include="IDeviceInfoProvider.cs" />
     <Compile Include="ITabStop.cs" />
+    <Compile Include="Material\MaterialFrameRenderer.cs" />
+    <Compile Include="Material\MaterialFormsEditText.cs" />
+    <Compile Include="Material\MaterialButtonRenderer.cs" />
+    <Compile Include="Material\MaterialEntryRenderer.cs" />
     <Compile Include="Renderers\FormsWebViewClient.cs" />
     <Compile Include="Renderers\IImageViewHandler.cs" />
     <Compile Include="InnerGestureListener.cs" />
@@ -257,6 +269,12 @@
     <Compile Include="SwipeGestureHandler.cs" />
     <Compile Include="Extensions\AccessibilityExtensions.cs" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
+    <Compile Include="Resources\Resource.Designer.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">
+    <Compile Include="AppCompat\Resource.cs" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -275,16 +293,55 @@
       <Name>Xamarin.Forms.Platform.Android.FormsViewGroup</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.Design">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.CardView">
-      <Version>27.0.2</Version>
+      <Version>28.0.0-preview7</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">
+    <PackageReference Include="Xamarin.Android.Support.Design">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.CardView">
+      <Version>27.0.2.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <ItemGroup>
+    <ProjectToBuild Include="../Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj">
+      <Properties>CreateAllAndroidTargets=false;Configuration=$(Configuration);Platform=$(Platform);AndroidTargetFrameworkVersion=v8.1</Properties>
+    </ProjectToBuild>
+    <ProjectToBuild Include="Xamarin.Forms.Platform.Android.csproj">
+      <Properties>CreateAllAndroidTargets=false;Configuration=$(Configuration);Platform=$(Platform);AndroidTargetFrameworkVersion=v8.1</Properties>
+    </ProjectToBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\Layout\" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
+    <AndroidResource Include="Resources\values\styles.xml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
+  <Target Name="BeforeBuild" Condition=" '$(CreateAllAndroidTargets)' == 'true' ">
+    <!--  create 8.1 binaries-->
+    <MSBuild Targets="Restore" Projects="@(ProjectToBuild)">
+    </MSBuild>
+    <MSBuild Projects="@(ProjectToBuild)">
+    </MSBuild>
+    <!-- restore 9.0 binaries-->
+    <MSBuild Targets="Restore" Projects="../Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj" Properties="CreateAllAndroidTargets=false;Configuration=$(Configuration);Platform=$(Platform);">
+    </MSBuild>
+    <MSBuild Targets="Restore" Projects="Xamarin.Forms.Platform.Android.csproj" Properties="CreateAllAndroidTargets=false;Configuration=$(Configuration);Platform=$(Platform);">
+    </MSBuild>
+  </Target>
 </Project>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Material\MaterialFormsEditText.cs" />
     <Compile Include="Material\MaterialButtonRenderer.cs" />
     <Compile Include="Material\MaterialEntryRenderer.cs" />
+    <Compile Include="Material\MaterialProgressBarRenderer.cs" />
     <Compile Include="Renderers\FormsWebViewClient.cs" />
     <Compile Include="Renderers\IImageViewHandler.cs" />
     <Compile Include="InnerGestureListener.cs" />

--- a/Xamarin.Forms.Platform.iOS/ExportRendererAttribute.cs
+++ b/Xamarin.Forms.Platform.iOS/ExportRendererAttribute.cs
@@ -10,17 +10,27 @@ namespace Xamarin.Forms
 	public sealed class ExportRendererAttribute : HandlerAttribute
 	{
 #if __MOBILE__
-		public ExportRendererAttribute(Type handler, Type target, UIUserInterfaceIdiom idiom) : base(handler, target)
+		public ExportRendererAttribute(Type handler, Type target, UIUserInterfaceIdiom idiom, Type[] supportedVisuals) : base(handler, target, supportedVisuals)
 		{
 			Idiomatic = true;
 			Idiom = idiom;
 		}
+
+
+		public ExportRendererAttribute(Type handler, Type target, UIUserInterfaceIdiom idiom) : this(handler, target, idiom, null)
+		{
+		}
+
 		internal UIUserInterfaceIdiom Idiom { get; }
 #endif
 
-		public ExportRendererAttribute(Type handler, Type target) : base(handler, target)
+		public ExportRendererAttribute(Type handler, Type target, Type[] supportedVisuals) : base(handler, target, supportedVisuals)
 		{
 			Idiomatic = false;
+		}
+
+		public ExportRendererAttribute(Type handler, Type target) : this(handler, target, null)
+		{
 		}
 
 		internal bool Idiomatic { get; }

--- a/Xamarin.Forms.Platform.iOS/Material/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Material/MaterialButtonRenderer.cs
@@ -194,13 +194,14 @@ namespace Xamarin.Forms.Platform.iOS.Material
 				UIButton button = Control;
 				if (button != null && uiimage != null)
 				{
-					button.SetImage(uiimage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate), UIControlState.Normal);
+					button.SetImage(uiimage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal), UIControlState.Normal);
 
 					button.ImageView.ContentMode = UIViewContentMode.ScaleAspectFit;
 
 					ComputeEdgeInsets(Control, Element.ContentLayout);
 
-					Control.SetImageTintColor(UIColor.White, UIControlState.Normal);
+					// disable tint for now
+					// Control.SetImageTintColor(UIColor.White, UIControlState.Normal);
 				}
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/Material/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Material/MaterialButtonRenderer.cs
@@ -200,7 +200,7 @@ namespace Xamarin.Forms.Platform.iOS.Material
 
 					ComputeEdgeInsets(Control, Element.ContentLayout);
 
-					Control.SetImageTintColor(UIColor.Black, UIControlState.Normal);
+					Control.SetImageTintColor(UIColor.White, UIControlState.Normal);
 				}
 			}
 			else
@@ -247,12 +247,16 @@ namespace Xamarin.Forms.Platform.iOS.Material
 			var uiElement = button ?? Control;
 			if (uiElement == null)
 				return;
-			uiElement.ContentEdgeInsets = new UIEdgeInsets(
-				(float)(Element.Padding.Top + _paddingDelta.Top),
-				(float)(Element.Padding.Left + _paddingDelta.Left),
-				(float)(Element.Padding.Bottom + _paddingDelta.Bottom),
-				(float)(Element.Padding.Right + _paddingDelta.Right)
-			);
+
+			if (Element.IsSet(Button.PaddingProperty))
+			{
+				uiElement.ContentEdgeInsets = new UIEdgeInsets(
+					(float)(Element.Padding.Top + _paddingDelta.Top),
+					(float)(Element.Padding.Left + _paddingDelta.Left),
+					(float)(Element.Padding.Bottom + _paddingDelta.Bottom),
+					(float)(Element.Padding.Right + _paddingDelta.Right)
+				);
+			}
 		}
 
 		void UpdateContentEdge(UIButton button, UIEdgeInsets? delta = null)

--- a/Xamarin.Forms.Platform.iOS/Material/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Material/MaterialButtonRenderer.cs
@@ -1,0 +1,336 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using Foundation;
+using UIKit;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using SizeF = CoreGraphics.CGSize;
+using MButton = MaterialComponents.Button;
+using Xamarin.Forms;
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Button), typeof(Xamarin.Forms.Platform.iOS.Material.MaterialButtonRenderer), new[] { typeof(VisualRendererMarker.Material) })]
+namespace Xamarin.Forms.Platform.iOS.Material
+{
+	public class MaterialButtonRenderer : ViewRenderer<Button, MButton>
+	{
+
+		UIColor _buttonTextColorDefaultDisabled;
+		UIColor _buttonTextColorDefaultHighlighted;
+		UIColor _buttonTextColorDefaultNormal;
+		bool _useLegacyColorManagement;
+		bool _titleChanged;
+		SizeF _titleSize;
+		UIEdgeInsets _paddingDelta = new UIEdgeInsets();
+
+		// This looks like it should be a const under iOS Classic,
+		// but that doesn't work under iOS 
+		// ReSharper disable once BuiltInTypeReferenceStyle
+		// Under iOS Classic Resharper wants to suggest this use the built-in type ref
+		// but under iOS that suggestion won't work
+		readonly nfloat _minimumButtonHeight = 44; // Apple docs
+		readonly nfloat _defaultCornerRadius = 5;
+
+		static readonly UIControlState[] s_controlStates = { UIControlState.Normal, UIControlState.Highlighted, UIControlState.Disabled };
+
+		public MaterialButtonRenderer()
+		{
+			VisualElement.VerifyVisualFlagEnabled();
+		}
+
+		public override SizeF SizeThatFits(SizeF size)
+		{
+			var result = base.SizeThatFits(size);
+
+			if (result.Height < _minimumButtonHeight)
+			{
+				result.Height = _minimumButtonHeight;
+			}
+
+			return result;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (Control != null)
+			{
+				Control.TouchUpInside -= OnButtonTouchUpInside;
+				Control.TouchDown -= OnButtonTouchDown;
+			}
+
+			base.Dispose(disposing);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+			{
+				if (Control == null)
+				{
+					SetNativeControl(CreateNativeControl());
+
+					Debug.Assert(Control != null, "Control != null");
+
+					SetControlPropertiesFromProxy();
+
+					_useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
+
+					_buttonTextColorDefaultNormal = Control.TitleColor(UIControlState.Normal);
+					_buttonTextColorDefaultHighlighted = Control.TitleColor(UIControlState.Highlighted);
+					_buttonTextColorDefaultDisabled = Control.TitleColor(UIControlState.Disabled);
+
+					Control.TouchUpInside += OnButtonTouchUpInside;
+					Control.TouchDown += OnButtonTouchDown;
+				}
+
+				UpdateText();
+				UpdateFont();
+				UpdateBorder();
+				UpdateImage();
+				UpdateTextColor();
+				UpdatePadding();
+			}
+		}
+
+		protected override MButton CreateNativeControl()
+		{
+			return new MButton();
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == Button.TextProperty.PropertyName)
+				UpdateText();
+			else if (e.PropertyName == Button.TextColorProperty.PropertyName)
+				UpdateTextColor();
+			else if (e.PropertyName == Button.FontProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Button.BorderWidthProperty.PropertyName || e.PropertyName == Button.CornerRadiusProperty.PropertyName || e.PropertyName == Button.BorderColorProperty.PropertyName)
+				UpdateBorder();
+			else if (e.PropertyName == Button.ImageProperty.PropertyName)
+				UpdateImage();
+			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
+				UpdatePadding();
+		}
+
+		protected override void SetAccessibilityLabel()
+		{
+			// If we have not specified an AccessibilityLabel and the AccessibilityLabel is currently bound to the Title,
+			// exit this method so we don't set the AccessibilityLabel value and break the binding.
+			// This may pose a problem for users who want to explicitly set the AccessibilityLabel to null, but this
+			// will prevent us from inadvertently breaking UI Tests that are using Query.Marked to get the dynamic Title 
+			// of the Button.
+
+			var elemValue = (string)Element?.GetValue(AutomationProperties.NameProperty);
+			if (string.IsNullOrWhiteSpace(elemValue) && Control?.AccessibilityLabel == Control?.Title(UIControlState.Normal))
+				return;
+
+			base.SetAccessibilityLabel();
+		}
+
+		void SetControlPropertiesFromProxy()
+		{
+			foreach (UIControlState uiControlState in s_controlStates)
+			{
+				Control.SetTitleColor(UIButton.Appearance.TitleColor(uiControlState), uiControlState); // if new values are null, old values are preserved.
+				Control.SetTitleShadowColor(UIButton.Appearance.TitleShadowColor(uiControlState), uiControlState);
+				Control.SetBackgroundImage(UIButton.Appearance.BackgroundImageForState(uiControlState), uiControlState);
+			}
+		}
+
+		void OnButtonTouchUpInside(object sender, EventArgs eventArgs)
+		{
+			((IButtonController)Element)?.SendReleased();
+			((IButtonController)Element)?.SendClicked();
+		}
+
+		void OnButtonTouchDown(object sender, EventArgs eventArgs)
+		{
+			((IButtonController)Element)?.SendPressed();
+		}
+
+		void UpdateBorder()
+		{
+			var uiButton = Control;
+			var button = Element;
+
+			if (button.BorderColor != Color.Default)
+				uiButton.SetBorderColor(button.BorderColor.ToUIColor(), UIControlState.Normal);
+
+			uiButton.SetBorderWidth(Math.Max(0f, (float)button.BorderWidth), UIControlState.Normal);
+
+			nfloat cornerRadius = _defaultCornerRadius;
+
+			if (button.IsSet(Button.CornerRadiusProperty) && button.CornerRadius != (int)Button.CornerRadiusProperty.DefaultValue)
+				cornerRadius = button.CornerRadius;
+
+			uiButton.Layer.CornerRadius = cornerRadius; 
+		}
+
+		void UpdateFont()
+		{
+			Control.SetTitleFont(Element.ToUIFont(), UIControlState.Normal);
+		}
+
+		async void UpdateImage()
+		{
+			IImageSourceHandler handler;
+			FileImageSource source = Element.Image;
+			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
+			{
+				UIImage uiimage;
+				try
+				{
+					uiimage = await handler.LoadImageAsync(source, scale: (float)UIScreen.MainScreen.Scale);
+				}
+				catch (OperationCanceledException)
+				{
+					uiimage = null;
+				}
+				UIButton button = Control;
+				if (button != null && uiimage != null)
+				{
+					button.SetImage(uiimage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal), UIControlState.Normal);
+
+					button.ImageView.ContentMode = UIViewContentMode.ScaleAspectFit;
+
+					ComputeEdgeInsets(Control, Element.ContentLayout);
+				}
+			}
+			else
+			{
+				Control.SetImage(null, UIControlState.Normal);
+				ClearEdgeInsets(Control);
+			}
+			((IVisualElementController)Element).NativeSizeChanged();
+		}
+
+		void UpdateText()
+		{
+			var newText = Element.Text;
+
+			if (Control.Title(UIControlState.Normal) != newText)
+			{
+				Control.SetTitle(Element.Text, UIControlState.Normal);
+				_titleChanged = true;
+			}
+		}
+
+		void UpdateTextColor()
+		{
+			if (Element.TextColor == Color.Default)
+			{
+				Control.SetTitleColor(_buttonTextColorDefaultNormal, UIControlState.Normal);
+				Control.SetTitleColor(_buttonTextColorDefaultHighlighted, UIControlState.Highlighted);
+				Control.SetTitleColor(_buttonTextColorDefaultDisabled, UIControlState.Disabled);
+			}
+			else
+			{
+				var color = Element.TextColor.ToUIColor();
+
+				Control.SetTitleColor(color, UIControlState.Normal);
+				Control.SetTitleColor(color, UIControlState.Highlighted);
+				Control.SetTitleColor(_useLegacyColorManagement ? _buttonTextColorDefaultDisabled : color, UIControlState.Disabled);
+
+				Control.TintColor = color;
+			}
+		}
+
+		void UpdatePadding(UIButton button = null)
+		{
+			var uiElement = button ?? Control;
+			if (uiElement == null)
+				return;
+			uiElement.ContentEdgeInsets = new UIEdgeInsets(
+				(float)(Element.Padding.Top + _paddingDelta.Top),
+				(float)(Element.Padding.Left + _paddingDelta.Left),
+				(float)(Element.Padding.Bottom + _paddingDelta.Bottom),
+				(float)(Element.Padding.Right + _paddingDelta.Right)
+			);
+		}
+
+		void UpdateContentEdge(UIButton button, UIEdgeInsets? delta = null)
+		{
+			_paddingDelta = delta ?? new UIEdgeInsets();
+			UpdatePadding(button);
+		}
+
+		void ClearEdgeInsets(UIButton button)
+		{
+			if (button == null)
+				return;
+
+			Control.ImageEdgeInsets = new UIEdgeInsets(0, 0, 0, 0);
+			Control.TitleEdgeInsets = new UIEdgeInsets(0, 0, 0, 0);
+			UpdateContentEdge(Control);
+		}
+
+		void ComputeEdgeInsets(UIButton button, Button.ButtonContentLayout layout)
+		{
+			if (button?.ImageView?.Image == null || string.IsNullOrEmpty(button.TitleLabel?.Text))
+				return;
+
+			var position = layout.Position;
+			var spacing = (nfloat)(layout.Spacing / 2);
+
+			if (position == Button.ButtonContentLayout.ImagePosition.Left)
+			{
+				button.ImageEdgeInsets = new UIEdgeInsets(0, -spacing, 0, spacing);
+				button.TitleEdgeInsets = new UIEdgeInsets(0, spacing, 0, -spacing);
+				UpdateContentEdge(button, new UIEdgeInsets(0, 2 * spacing, 0, 2 * spacing));
+				return;
+			}
+
+			if (_titleChanged)
+			{
+				var stringToMeasure = new NSString(button.TitleLabel.Text);
+				UIStringAttributes attribs = new UIStringAttributes { Font = button.TitleLabel.Font };
+				_titleSize = stringToMeasure.GetSizeUsingAttributes(attribs);
+				_titleChanged = false;
+			}
+
+			var labelWidth = _titleSize.Width;
+			var imageWidth = button.ImageView.Image.Size.Width;
+
+			if (position == Button.ButtonContentLayout.ImagePosition.Right)
+			{
+				button.ImageEdgeInsets = new UIEdgeInsets(0, labelWidth + spacing, 0, -labelWidth - spacing);
+				button.TitleEdgeInsets = new UIEdgeInsets(0, -imageWidth - spacing, 0, imageWidth + spacing);
+				UpdateContentEdge(button, new UIEdgeInsets(0, 2 * spacing, 0, 2 * spacing));
+				return;
+			}
+
+			var imageVertOffset = (_titleSize.Height / 2);
+			var titleVertOffset = (button.ImageView.Image.Size.Height / 2);
+
+			var edgeOffset = (float)Math.Min(imageVertOffset, titleVertOffset);
+
+			UpdateContentEdge(button, new UIEdgeInsets(edgeOffset, 0, edgeOffset, 0));
+
+			var horizontalImageOffset = labelWidth / 2;
+			var horizontalTitleOffset = imageWidth / 2;
+
+			if (position == Button.ButtonContentLayout.ImagePosition.Bottom)
+			{
+				imageVertOffset = -imageVertOffset;
+				titleVertOffset = -titleVertOffset;
+			}
+
+			button.ImageEdgeInsets = new UIEdgeInsets(-imageVertOffset, horizontalImageOffset, imageVertOffset, -horizontalImageOffset);
+			button.TitleEdgeInsets = new UIEdgeInsets(titleVertOffset, -horizontalTitleOffset, -titleVertOffset, horizontalTitleOffset);
+		}
+
+
+		//protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
+		//{
+		//	base.OnElementChanged(e);
+		//	SetNativeControl(new MButton());
+		//	Control.BackgroundColor = Element.BackgroundColor.ToUIColor();
+		//	Control.SetTitle(Element.Text, UIControlState.Normal);
+		//}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Material/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Material/MaterialButtonRenderer.cs
@@ -194,11 +194,13 @@ namespace Xamarin.Forms.Platform.iOS.Material
 				UIButton button = Control;
 				if (button != null && uiimage != null)
 				{
-					button.SetImage(uiimage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal), UIControlState.Normal);
+					button.SetImage(uiimage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate), UIControlState.Normal);
 
 					button.ImageView.ContentMode = UIViewContentMode.ScaleAspectFit;
 
 					ComputeEdgeInsets(Control, Element.ContentLayout);
+
+					Control.SetImageTintColor(UIColor.Black, UIControlState.Normal);
 				}
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/Material/MaterialEntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Material/MaterialEntryRenderer.cs
@@ -1,0 +1,521 @@
+﻿using System;
+using System.ComponentModel;
+
+using System.Drawing;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using Specifics = Xamarin.Forms.PlatformConfiguration.iOSSpecific.Entry;
+using MTextField = MaterialComponents.TextField;
+using MTextInputControllerOutlined = MaterialComponents.TextInputControllerOutlined;
+using MTextInputControllerFilled = MaterialComponents.TextInputControllerFilled;
+using MTextInputControllerBase = MaterialComponents.TextInputControllerBase;
+using MTextInputControllerUnderline = MaterialComponents.TextInputControllerUnderline;
+
+using Xamarin.Forms;
+
+// for now using separate renderer as there's some areas of conflict (like place holder)
+// plus we want the linker to be able to link this out if not used
+// possibly use base class for common behavior
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Entry), typeof(Xamarin.Forms.Platform.iOS.Material.MaterialEntryRenderer), new[] { typeof(VisualRendererMarker.Material) })]
+namespace Xamarin.Forms.Platform.iOS.Material
+{
+	public class MaterialEntryRenderer : ViewRenderer<Entry, MTextField>
+	{
+		UIColor _defaultTextColor;
+
+		// Placeholder default color is 70% gray
+		// https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UITextField_Class/index.html#//apple_ref/occ/instp/UITextField/placeholder
+		readonly Color _defaultPlaceholderColor = ColorExtensions.SeventyPercentGrey.ToColor();
+		UIColor _defaultCursorColor;
+		bool _useLegacyColorManagement;
+
+		bool _disposed;
+		IDisposable _selectedTextRangeObserver;
+		bool _nativeSelectionIsUpdating;
+
+		bool _cursorPositionChangePending;
+		bool _selectionLengthChangePending;
+
+		//static readonly int baseHeight = 30;
+		static CGSize initialSize = CGSize.Empty;
+
+		public MaterialEntryRenderer()
+		{
+			VisualElement.VerifyVisualFlagEnabled();
+		}
+
+		//public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		//{
+		//	var baseResult = base.GetDesiredSize(widthConstraint, heightConstraint);
+
+		//	if (Forms.IsiOS11OrNewer)
+		//		return baseResult;
+
+		//	NSString testString = new NSString("Tj");
+		//	var testSize = testString.GetSizeUsingAttributes(new UIStringAttributes { Font = Control.Font });
+		//	double height = baseHeight + testSize.Height - initialSize.Height;
+		//	height = Math.Round(height);
+
+		//	return new SizeRequest(new Size(baseResult.Request.Width, height));
+		//}
+
+		IElementController ElementController => Element as IElementController;
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				//_defaultTextColor = null;
+
+				if (Control != null)
+				{
+					_defaultCursorColor = Control.TintColor;
+					Control.EditingDidBegin -= OnEditingBegan;
+					Control.EditingChanged -= OnEditingChanged;
+					Control.EditingDidEnd -= OnEditingEnded;
+					Control.ShouldChangeCharacters -= ShouldChangeCharacters;
+					_selectedTextRangeObserver?.Dispose();
+				}
+			}
+
+			base.Dispose(disposing);
+		}
+
+		MTextInputControllerBase _activeTextinputController;
+
+		protected override MTextField CreateNativeControl()
+		{
+			var field = new MTextField();
+			field.BorderStyle = UITextBorderStyle.None;
+			field.ClearButtonMode = UITextFieldViewMode.UnlessEditing;
+			_activeTextinputController = new MTextInputControllerFilled(field);
+			return field;
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement == null)
+				return;
+
+			if (Control == null)
+			{
+				var textField = CreateNativeControl();
+				SetNativeControl(textField);
+
+				// Cache the default text color
+				_defaultTextColor = textField.TextColor;
+
+				_useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
+
+			//textField.BorderStyle = UITextBorderStyle.RoundedRect;
+				//textField.ClipsToBounds = true;
+
+				textField.EditingChanged += OnEditingChanged;
+				textField.ShouldReturn = OnShouldReturn;
+
+				textField.EditingDidBegin += OnEditingBegan;
+				textField.EditingDidEnd += OnEditingEnded;
+				textField.ShouldChangeCharacters += ShouldChangeCharacters;
+				_selectedTextRangeObserver = textField.AddObserver("selectedTextRange", NSKeyValueObservingOptions.New, UpdateCursorFromControl);
+			}
+
+			// When we set the control text, it triggers the UpdateCursorFromControl event, which updates CursorPosition and SelectionLength;
+			// These one-time-use variables will let us initialize a CursorPosition and SelectionLength via ctor/xaml/etc.
+			_cursorPositionChangePending = Element.IsSet(Entry.CursorPositionProperty);
+			_selectionLengthChangePending = Element.IsSet(Entry.SelectionLengthProperty);
+
+			UpdatePlaceholder();
+			UpdatePassword();
+			UpdateText();
+			UpdateColor();
+			UpdateFont();
+			UpdateKeyboard();
+			UpdateAlignment();
+			UpdateAdjustsFontSizeToFitWidth();
+			UpdateMaxLength();
+			UpdateReturnType();
+
+			if (_cursorPositionChangePending || _selectionLengthChangePending)
+				UpdateCursorSelection();
+
+			UpdateCursorColor();
+		}
+
+
+		protected override void SetBackgroundColor(Color color)
+		{
+			if (_activeTextinputController != null)
+			{
+				_activeTextinputController.BorderFillColor = color.ToUIColor();
+			}
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == Entry.PlaceholderProperty.PropertyName || e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
+				UpdatePlaceholder();
+			else if (e.PropertyName == Entry.IsPasswordProperty.PropertyName)
+				UpdatePassword();
+			else if (e.PropertyName == Entry.TextProperty.PropertyName)
+				UpdateText();
+			else if (e.PropertyName == Entry.TextColorProperty.PropertyName)
+				UpdateColor();
+			else if (e.PropertyName == Xamarin.Forms.InputView.KeyboardProperty.PropertyName)
+				UpdateKeyboard();
+			else if (e.PropertyName == Xamarin.Forms.InputView.IsSpellCheckEnabledProperty.PropertyName)
+				UpdateKeyboard();
+			else if (e.PropertyName == Entry.IsTextPredictionEnabledProperty.PropertyName)
+				UpdateKeyboard();
+			else if (e.PropertyName == Entry.HorizontalTextAlignmentProperty.PropertyName)
+				UpdateAlignment();
+			else if (e.PropertyName == Entry.FontAttributesProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.FontFamilyProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == Entry.FontSizeProperty.PropertyName)
+				UpdateFont();
+			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+			{
+				UpdateColor();
+				UpdatePlaceholder();
+			}
+			else if (e.PropertyName == Specifics.AdjustsFontSizeToFitWidthProperty.PropertyName)
+				UpdateAdjustsFontSizeToFitWidth();
+			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
+				UpdateAlignment();
+			else if (e.PropertyName == Xamarin.Forms.InputView.MaxLengthProperty.PropertyName)
+				UpdateMaxLength();
+			else if (e.PropertyName == Entry.ReturnTypeProperty.PropertyName)
+				UpdateReturnType();
+			else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName)
+				UpdateCursorSelection();
+			else if (e.PropertyName == Entry.SelectionLengthProperty.PropertyName)
+				UpdateCursorSelection();
+			else if (e.PropertyName == Specifics.CursorColorProperty.PropertyName)
+				UpdateCursorColor();
+
+			base.OnElementPropertyChanged(sender, e);
+		}
+
+		void OnEditingBegan(object sender, EventArgs e)
+		{
+			if (!_cursorPositionChangePending && !_selectionLengthChangePending)
+				UpdateCursorFromControl(null);
+			else
+				UpdateCursorSelection();
+
+			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
+		}
+
+		void OnEditingChanged(object sender, EventArgs eventArgs)
+		{
+			ElementController.SetValueFromRenderer(Entry.TextProperty, Control.Text);
+			UpdateCursorFromControl(null);
+		}
+
+		void OnEditingEnded(object sender, EventArgs e)
+		{
+			// Typing aid changes don't always raise EditingChanged event
+			if (Control.Text != Element.Text)
+			{
+				ElementController.SetValueFromRenderer(Entry.TextProperty, Control.Text);
+			}
+
+			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
+		}
+
+		protected virtual bool OnShouldReturn(UITextField view)
+		{
+			Control.ResignFirstResponder();
+			((IEntryController)Element).SendCompleted();
+			return false;
+		}
+
+		void UpdateAlignment()
+		{
+			Control.TextAlignment = Element.HorizontalTextAlignment.ToNativeTextAlignment(((IVisualElementController)Element).EffectiveFlowDirection);
+		}
+
+		void UpdateColor()
+		{
+			var textColor = Element.TextColor;
+
+			if (_useLegacyColorManagement)
+			{
+				Control.TextColor = textColor.IsDefault || !Element.IsEnabled ? _defaultTextColor : textColor.ToUIColor();
+			}
+			else
+			{
+				Control.TextColor = textColor.IsDefault ? _defaultTextColor : textColor.ToUIColor();
+			}
+		}
+
+		void UpdateAdjustsFontSizeToFitWidth()
+		{
+			Control.AdjustsFontSizeToFitWidth = Element.OnThisPlatform().AdjustsFontSizeToFitWidth();
+		}
+
+		void UpdateFont()
+		{
+			if (initialSize == CGSize.Empty)
+			{
+				NSString testString = new NSString("Tj");
+				initialSize = testString.StringSize(Control.Font);
+			}
+
+			Control.Font = Element.ToUIFont();
+		}
+
+		void UpdateKeyboard()
+		{
+			var keyboard = Element.Keyboard;
+			Control.ApplyKeyboard(keyboard);
+			if (!(keyboard is Internals.CustomKeyboard))
+			{
+				if (Element.IsSet(Xamarin.Forms.InputView.IsSpellCheckEnabledProperty))
+				{
+					if (!Element.IsSpellCheckEnabled)
+					{
+						Control.SpellCheckingType = UITextSpellCheckingType.No;
+					}
+				}
+				if (Element.IsSet(Xamarin.Forms.Entry.IsTextPredictionEnabledProperty))
+				{
+					if (!Element.IsTextPredictionEnabled)
+					{
+						Control.AutocorrectionType = UITextAutocorrectionType.No;
+					}
+				}
+			}
+			Control.ReloadInputViews();
+		}
+
+		void UpdatePassword()
+		{
+			if (Element.IsPassword && Control.IsFirstResponder)
+			{
+				Control.Enabled = false;
+				Control.SecureTextEntry = true;
+				Control.Enabled = Element.IsEnabled;
+				Control.BecomeFirstResponder();
+			}
+			else
+				Control.SecureTextEntry = Element.IsPassword;
+		}
+
+		void UpdatePlaceholder()
+		{
+			var placeholderText = Element.Placeholder;
+
+			if (placeholderText == null)
+				return;
+
+			var targetColor = Element.PlaceholderColor;
+
+			UIColor iosColor;
+			if (_useLegacyColorManagement)
+			{
+				var color = targetColor.IsDefault || !Element.IsEnabled ? _defaultPlaceholderColor : targetColor;
+				iosColor = color.ToUIColor();
+			}
+			else
+			{
+				// Using VSM color management; take whatever is in Element.PlaceholderColor
+				var color = targetColor.IsDefault ? _defaultPlaceholderColor : targetColor;
+				iosColor = color.ToUIColor();
+			}
+
+			_activeTextinputController.NormalColor = iosColor;
+			_activeTextinputController.ActiveColor = iosColor;
+
+			//Control.Underline.Color = iosColor;
+			_activeTextinputController.InlinePlaceholderColor = iosColor;
+			_activeTextinputController.FloatingPlaceholderActiveColor = iosColor;
+			_activeTextinputController.FloatingPlaceholderNormalColor = iosColor;
+			_activeTextinputController.PlaceholderText = placeholderText;
+			_activeTextinputController.UnderlineViewMode = UITextFieldViewMode.Always;
+
+		}
+
+		void UpdateText()
+		{
+			// ReSharper disable once RedundantCheckBeforeAssignment
+			if (Control.Text != Element.Text)
+				Control.Text = Element.Text;
+		}
+
+		void UpdateMaxLength()
+		{
+			var currentControlText = Control.Text;
+
+			if (currentControlText.Length > Element.MaxLength)
+				Control.Text = currentControlText.Substring(0, Element.MaxLength);
+		}
+
+		bool ShouldChangeCharacters(UITextField textField, NSRange range, string replacementString)
+		{
+			var newLength = textField?.Text?.Length + replacementString.Length - range.Length;
+			return newLength <= Element?.MaxLength;
+		}
+
+		void UpdateReturnType()
+		{
+			if (Control == null || Element == null)
+				return;
+			Control.ReturnKeyType = Element.ReturnType.ToUIReturnKeyType();
+		}
+
+		void UpdateCursorFromControl(NSObservedChange obj)
+		{
+			if (_nativeSelectionIsUpdating || Control == null || Element == null)
+				return;
+
+			var currentSelection = Control.SelectedTextRange;
+			if (currentSelection != null)
+			{
+				if (!_cursorPositionChangePending)
+				{
+					int newCursorPosition = (int)Control.GetOffsetFromPosition(Control.BeginningOfDocument, currentSelection.Start);
+					if (newCursorPosition != Element.CursorPosition)
+						SetCursorPositionFromRenderer(newCursorPosition);
+				}
+
+				if (!_selectionLengthChangePending)
+				{
+					int selectionLength = (int)Control.GetOffsetFromPosition(currentSelection.Start, currentSelection.End);
+
+					if (selectionLength != Element.SelectionLength)
+						SetSelectionLengthFromRenderer(selectionLength);
+				}
+			}
+		}
+
+		void UpdateCursorSelection()
+		{
+			if (_nativeSelectionIsUpdating || Control == null || Element == null)
+				return;
+
+			_cursorPositionChangePending = _selectionLengthChangePending = true;
+
+			// If this is run from the ctor, the control is likely too early in its lifecycle to be first responder yet. 
+			// Anything done here will have no effect, so we'll skip this work until later.
+			// We'll try again when the control does become first responder later OnEditingBegan
+			if (Control.BecomeFirstResponder())
+			{
+				try
+				{
+					int cursorPosition = Element.CursorPosition;
+
+					UITextPosition start = GetSelectionStart(cursorPosition, out int startOffset);
+					UITextPosition end = GetSelectionEnd(cursorPosition, start, startOffset);
+
+					Control.SelectedTextRange = Control.GetTextRange(start, end);
+				}
+				catch (Exception ex)
+				{
+					Internals.Log.Warning("Entry", $"Failed to set Control.SelectedTextRange from CursorPosition/SelectionLength: {ex}");
+				}
+				finally
+				{
+					_cursorPositionChangePending = _selectionLengthChangePending = false;
+				}
+			}
+		}
+
+		UITextPosition GetSelectionEnd(int cursorPosition, UITextPosition start, int startOffset)
+		{
+			UITextPosition end = start;
+			int endOffset = startOffset;
+			int selectionLength = Element.SelectionLength;
+
+			if (Element.IsSet(Entry.SelectionLengthProperty))
+			{
+				end = Control.GetPosition(start, Math.Max(startOffset, Math.Min(Control.Text.Length - cursorPosition, selectionLength))) ?? start;
+				endOffset = Math.Max(startOffset, (int)Control.GetOffsetFromPosition(Control.BeginningOfDocument, end));
+			}
+
+			int newSelectionLength = Math.Max(0, endOffset - startOffset);
+			if (newSelectionLength != selectionLength)
+				SetSelectionLengthFromRenderer(newSelectionLength);
+
+			return end;
+		}
+
+		UITextPosition GetSelectionStart(int cursorPosition, out int startOffset)
+		{
+			UITextPosition start = Control.EndOfDocument;
+			startOffset = Control.Text.Length;
+
+			if (Element.IsSet(Entry.CursorPositionProperty))
+			{
+				start = Control.GetPosition(Control.BeginningOfDocument, cursorPosition) ?? Control.EndOfDocument;
+				startOffset = Math.Max(0, (int)Control.GetOffsetFromPosition(Control.BeginningOfDocument, start));
+			}
+
+			if (startOffset != cursorPosition)
+				SetCursorPositionFromRenderer(startOffset);
+
+			return start;
+		}
+
+		void UpdateCursorColor()
+		{
+			var control = Control;
+			if (control == null || Element == null)
+				return;
+
+			if (Element.IsSet(Specifics.CursorColorProperty))
+			{
+				var color = Element.OnThisPlatform().GetCursorColor();
+				if (color == Color.Default)
+					control.TintColor = _defaultCursorColor;
+				else
+					control.TintColor = color.ToUIColor();
+			}
+		}
+
+		void SetCursorPositionFromRenderer(int start)
+		{
+			try
+			{
+				_nativeSelectionIsUpdating = true;
+				ElementController?.SetValueFromRenderer(Entry.CursorPositionProperty, start);
+			}
+			catch (Exception ex)
+			{
+				Internals.Log.Warning("Entry", $"Failed to set CursorPosition from renderer: {ex}");
+			}
+			finally
+			{
+				_nativeSelectionIsUpdating = false;
+			}
+		}
+
+		void SetSelectionLengthFromRenderer(int selectionLength)
+		{
+			try
+			{
+				_nativeSelectionIsUpdating = true;
+				ElementController?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+			}
+			catch (Exception ex)
+			{
+				Internals.Log.Warning("Entry", $"Failed to set SelectionLength from renderer: {ex}");
+			}
+			finally
+			{
+				_nativeSelectionIsUpdating = false;
+			}
+		}
+	}
+
+}

--- a/Xamarin.Forms.Platform.iOS/Material/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Material/MaterialFrameRenderer.cs
@@ -1,0 +1,165 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using CoreAnimation;
+using MaterialComponents;
+using UIKit;
+using Xamarin.Forms;
+using MCard = MaterialComponents.Card;
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Frame), typeof(Xamarin.Forms.Platform.iOS.Material.MaterialFrameRenderer), new[] { typeof(VisualRendererMarker.Material) })]
+namespace Xamarin.Forms.Platform.iOS.Material
+{
+	public class MaterialFrameRenderer : MCard, IVisualElementRenderer
+	{
+		private VisualElementPackager _packager;
+		private VisualElementTracker _tracker;
+
+		public MaterialFrameRenderer()
+		{
+			VisualElement.VerifyVisualFlagEnabled();
+		}
+
+		Xamarin.Forms.Frame FrameElement
+		{
+			get { return Element as Xamarin.Forms.Frame; }
+		}
+
+		public VisualElement Element { get; private set; }
+
+		public UIView NativeView
+		{
+			get { return this; }
+		}
+
+		public UIViewController ViewController
+		{
+			get { return null; }
+		}
+
+		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+
+
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e) => ElementChanged?.Invoke(this, e);
+
+		public void SetElement(VisualElement element)
+		{
+			var oldElement = Element;
+			Element = element;
+
+			if (oldElement != null)
+			{
+				oldElement.PropertyChanged -= HandlePropertyChanged;
+			}
+
+			if (element != null)
+			{
+				element.PropertyChanged += HandlePropertyChanged;
+				if (_packager == null)
+				{
+					_packager = new VisualElementPackager(this);
+					_packager.Load();
+
+					_tracker = new VisualElementTracker(this);
+					_tracker.NativeControlUpdated += OnNativeControlUpdated;
+					//_events = new EventTracker(this);
+					//	_events.LoadEvents(this);
+
+					//_insetTracker = new KeyboardInsetTracker(this, () => Window, insets => ContentInset = ScrollIndicatorInsets = insets, point =>
+					//{
+					//	var offset = ContentOffset;
+					//	offset.Y += point.Y;
+					//	SetContentOffset(offset, true);
+					//});
+				}
+
+				SetupLayer();
+			}
+
+			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
+		}
+
+		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName ||
+				e.PropertyName == Xamarin.Forms.Frame.BorderColorProperty.PropertyName ||
+				e.PropertyName == Xamarin.Forms.Frame.HasShadowProperty.PropertyName ||
+				e.PropertyName == Xamarin.Forms.Frame.CornerRadiusProperty.PropertyName)
+				SetupLayer();
+		}
+
+
+		protected override void Dispose(bool disposing)
+		{
+
+			if (disposing)
+			{
+				if (_packager == null)
+					return;
+
+				SetElement(null);
+
+				_packager.Dispose();
+				_packager = null;
+
+				_tracker.NativeControlUpdated -= OnNativeControlUpdated;
+				_tracker.Dispose();
+				_tracker = null;
+			}
+
+			base.Dispose(disposing);
+		}
+		void OnNativeControlUpdated(object sender, EventArgs eventArgs)
+		{
+
+		}
+
+		void SetupLayer()
+		{
+			float cornerRadius = FrameElement.CornerRadius;
+
+			if (cornerRadius == -1f)
+				cornerRadius = 5f; // default corner radius
+
+			CornerRadius = cornerRadius;
+
+			if (Element.BackgroundColor == Color.Default)
+				BackgroundColor = UIColor.White;
+			else
+				BackgroundColor = Element.BackgroundColor.ToUIColor();
+
+			if (FrameElement.HasShadow)
+			{
+				Layer.ShadowRadius = 5;
+				SetShadowColor(UIColor.Black, UIControlState.Normal);
+				
+				SetShadowElevation(3, UIControlState.Normal);				
+				//Layer.ShadowColor = UIColor.Black.CGColor;
+			}
+			else
+			{
+				//SetShadowColor(UIColor.Black, UIControlState.Normal);
+				SetShadowColor(UIColor.Clear, UIControlState.Normal);
+			}
+			
+
+			if (FrameElement.BorderColor == Color.Default)
+				SetBorderColor(UIColor.Clear, UIControlState.Normal);
+			else
+			{
+				SetBorderColor(FrameElement.BorderColor.ToUIColor(), UIControlState.Normal);
+				SetBorderWidth(3, UIControlState.Normal);
+			}
+		}
+
+		public SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			return NativeView.GetSizeRequest(widthConstraint, heightConstraint, 44, 44);
+		}
+
+		public void SetElementSize(Size size)
+		{
+			Layout.LayoutChildIntoBoundingRegion(Element, new Rectangle(Element.X, Element.Y, size.Width, size.Height));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Material/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Material/MaterialFrameRenderer.cs
@@ -49,12 +49,12 @@ namespace Xamarin.Forms.Platform.iOS.Material
 
 			if (oldElement != null)
 			{
-				oldElement.PropertyChanged -= HandlePropertyChanged;
+				oldElement.PropertyChanged -= OnElementPropertyChanged;
 			}
 
 			if (element != null)
 			{
-				element.PropertyChanged += HandlePropertyChanged;
+				element.PropertyChanged += OnElementPropertyChanged;
 				if (_packager == null)
 				{
 					_packager = new VisualElementPackager(this);
@@ -79,7 +79,7 @@ namespace Xamarin.Forms.Platform.iOS.Material
 			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 		}
 
-		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName ||
 				e.PropertyName == Xamarin.Forms.Frame.BorderColorProperty.PropertyName ||

--- a/Xamarin.Forms.Platform.iOS/Material/MaterialProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Material/MaterialProgressBarRenderer.cs
@@ -29,7 +29,6 @@ namespace Xamarin.Forms.Platform.iOS.Material
 			base.OnElementChanged(e);
 			Control.SetHidden(false, true, (completion) => { });
 			Element.WidthRequest = 10;
-
 		}
 
 
@@ -67,16 +66,18 @@ namespace Xamarin.Forms.Platform.iOS.Material
 		{
 			base.SetBackgroundColor(color);
 
-			if (Control == null)
+			if (Control == null || color == Color.Default)
 				return;
 
-			Control.TrackTintColor = color != Color.Default ? color.ToUIColor() : null;
+			Control.TrackTintColor = color.ToUIColor();
 		}
 
 		void UpdateProgressColor()
 		{
-			//Doesn't work on material
-			//Control.ProgressTintColor = Element.ProgressColor == Color.Default ? null : Element.ProgressColor.ToUIColor();
+			if (Element.ProgressColor == Color.Default)
+				return;
+
+			Control.ProgressTintColor = Element.ProgressColor.ToUIColor();
 		}
 
 		void UpdateProgress()

--- a/Xamarin.Forms.Platform.iOS/Material/MaterialProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Material/MaterialProgressBarRenderer.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel;
+using UIKit;
+using SizeF = CoreGraphics.CGSize;
+using MProgressView = MaterialComponents.ProgressView;
+using Xamarin.Forms;
+using CoreGraphics;
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.ProgressBar), typeof(Xamarin.Forms.Platform.iOS.Material.MaterialProgressBarRenderer), new[] { typeof(VisualRendererMarker.Material) })]
+namespace Xamarin.Forms.Platform.iOS.Material
+{
+	public class MaterialProgressBarRenderer : ViewRenderer<ProgressBar, MProgressView>
+	{
+		public MaterialProgressBarRenderer()
+		{
+			VisualElement.VerifyVisualFlagEnabled();
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<ProgressBar> e)
+		{
+			if (e.NewElement != null)
+			{
+				if (Control == null)
+					SetNativeControl(new MProgressView());
+
+				UpdateProgressColor();
+				UpdateProgress();
+			}
+
+			base.OnElementChanged(e);
+			Control.SetHidden(false, true, (completion) => { });
+			Element.WidthRequest = 10;
+
+		}
+
+
+		public override SizeF SizeThatFits(SizeF size)
+		{
+			var result = base.SizeThatFits(size);
+			var height = result.Height;
+
+			if(height == 0)
+			{
+				if(System.nfloat.IsInfinity(size.Height))
+				{
+					height = 5;
+				}
+				else
+				{
+					height = size.Height;
+				}
+
+			}
+			return new SizeF(10, height);
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == ProgressBar.ProgressColorProperty.PropertyName)
+				UpdateProgressColor();
+			else if (e.PropertyName == ProgressBar.ProgressProperty.PropertyName)
+				UpdateProgress();
+		}
+
+		protected override void SetBackgroundColor(Color color)
+		{
+			base.SetBackgroundColor(color);
+
+			if (Control == null)
+				return;
+
+			Control.TrackTintColor = color != Color.Default ? color.ToUIColor() : null;
+		}
+
+		void UpdateProgressColor()
+		{
+			//Doesn't work on material
+			//Control.ProgressTintColor = Element.ProgressColor == Color.Default ? null : Element.ProgressColor.ToUIColor();
+		}
+
+		void UpdateProgress()
+		{
+			Control.Progress = (float)Element.Progress;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -42,7 +42,11 @@
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="Xamarin.iOS.MaterialComponents">
+      <Version>60.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ContextActionCell.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContextScrollViewDelegate.cs" />
@@ -139,6 +143,9 @@
     <Compile Include="Flags.cs" />
     <Compile Include="Renderers\ImageElementManager.cs" />
     <Compile Include="IVisualNativeElementRenderer.cs" />
+    <Compile Include="Material\MaterialButtonRenderer.cs" />
+    <Compile Include="Material\MaterialEntryRenderer.cs" />
+    <Compile Include="Material\MaterialProgressBarRenderer.cs" />
     <Compile Include="NativeViewWrapper.cs" />
     <Compile Include="NativeViewWrapperRenderer.cs" />
     <Compile Include="PlatformEffect.cs" />
@@ -165,6 +172,7 @@
     <Compile Include="NativeValueConverterService.cs" />
     <Compile Include="NativeBindingService.cs" />
     <Compile Include="Extensions\AccessibilityExtensions.cs" />
+    <Compile Include="Material\MaterialFrameRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\StringResources.ar.resx" />

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -21,7 +21,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Core.UnitTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.ControlGallery.Android", "Xamarin.Forms.ControlGallery.Android\Xamarin.Forms.ControlGallery.Android.csproj", "{1346A7F1-4457-4BB4-A371-2C8E28BBD53E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Xaml.UnitTests", "Xamarin.Forms.Xaml.UnitTests\Xamarin.Forms.Xaml.UnitTests.csproj", "{4B14D295-C09B-4C38-B880-7CC768E50585}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.Xaml.UnitTests", "Xamarin.Forms.Xaml.UnitTests\Xamarin.Forms.Xaml.UnitTests.csproj", "{4B14D295-C09B-4C38-B880-7CC768E50585}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuspec", ".nuspec", "{7E12C50D-A570-4DF1-94E1-8599843FA87C}"
 	ProjectSection(SolutionItems) = preProject
@@ -172,7 +172,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Xaml.Design",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XFCorePostProcessor.Tasks", "XFCorePostProcessor.Tasks\XFCorePostProcessor.Tasks.csproj", "{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Platform.Tizen (Forwarders)", "Stubs\Xamarin.Forms.Platform.Tizen\Xamarin.Forms.Platform.Tizen (Forwarders).csproj", "{39B3457F-01D8-43D0-8E84-D8C4F73CF48E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.Platform.Tizen (Forwarders)", "Stubs\Xamarin.Forms.Platform.Tizen\Xamarin.Forms.Platform.Tizen (Forwarders).csproj", "{39B3457F-01D8-43D0-8E84-D8C4F73CF48E}"
 	ProjectSection(ProjectDependencies) = postProject
 		{83790029-272E-45AF-A41D-E7716684E5B8} = {83790029-272E-45AF-A41D-E7716684E5B8}
 	EndProjectSection
@@ -316,6 +316,7 @@ Global
 		{1346A7F1-4457-4BB4-A371-2C8E28BBD53E}.Release|x86.Build.0 = Release|Any CPU
 		{1346A7F1-4457-4BB4-A371-2C8E28BBD53E}.Release|x86.Deploy.0 = Release|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B14D295-C09B-4C38-B880-7CC768E50585}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Debug|ARM.Build.0 = Debug|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -337,7 +338,6 @@ Global
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Release|x64.Build.0 = Release|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Release|x86.ActiveCfg = Release|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Release|x86.Build.0 = Release|Any CPU
-		{4B14D295-C09B-4C38-B880-7CC768E50585}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57B8B73D-C3B5-4C42-869E-7B2F17D354AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{57B8B73D-C3B5-4C42-869E-7B2F17D354AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57B8B73D-C3B5-4C42-869E-7B2F17D354AC}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -1520,6 +1520,18 @@ Global
 		{65BC4888-CC59-428A-9B75-540CF1C09480}.Release|x64.Build.0 = Release|Any CPU
 		{65BC4888-CC59-428A-9B75-540CF1C09480}.Release|x86.ActiveCfg = Release|Any CPU
 		{65BC4888-CC59-428A-9B75-540CF1C09480}.Release|x86.Build.0 = Release|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|x64.ActiveCfg = Release|Any CPU
+		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|x86.ActiveCfg = Release|Any CPU
 		{39B3457F-01D8-43D0-8E84-D8C4F73CF48E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{39B3457F-01D8-43D0-8E84-D8C4F73CF48E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{39B3457F-01D8-43D0-8E84-D8C4F73CF48E}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -1544,18 +1556,6 @@ Global
 		{39B3457F-01D8-43D0-8E84-D8C4F73CF48E}.Release|x64.Build.0 = Release|Any CPU
 		{39B3457F-01D8-43D0-8E84-D8C4F73CF48E}.Release|x86.ActiveCfg = Release|Any CPU
 		{39B3457F-01D8-43D0-8E84-D8C4F73CF48E}.Release|x86.Build.0 = Release|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|ARM.ActiveCfg = Release|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|x64.ActiveCfg = Release|Any CPU
-		{5BBF4A3F-4AD1-47FD-B250-05EA793F939D}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -21,7 +21,7 @@ steps:
 
         configuration: '$(BuildConfiguration)'
 
-        msbuildArguments: '/nowarn:VSX1000'
+        msbuildArguments: '/nowarn:VSX1000 /p:CreateAllAndroidTargets=true'
 
         clean: true
 


### PR DESCRIPTION
### Description of Change ###
Add a Visual property to VisualElement that allows us to swap out different renderers based on a Visual Type property

https://github.com/xamarin/Xamarin.Forms/issues/4435

This PR also adds a starting set of Material Renderers as the first use case for this behavior
- Button
- Entry
- Frame (CardView)
- ProgressBar (iOS)

### API Changes ###

Added:

```C#
public class VisualElement
{
		public IVisual Visual
		{
			get { return (IVisual)GetValue(VisualProperty); }
			set { SetValue(VisualProperty, value); }
		}
}

```
```C#
public sealed class ExportRendererAttribute : HandlerAttribute
{
		public ExportRendererAttribute(Type handler, Type target) : this(handler, target, null)
		{
		}
}
// Example Usage
[assembly: ExportRenderer(typeof(Xamarin.Forms.Button), typeof(Xamarin.Forms.Platform.iOS.Material.MaterialButtonRenderer), new[] { typeof(VisualRendererMarker.Material) })]
namespace Xamarin.Forms.Platform.iOS.Material
{
	public class MaterialButtonRenderer : ViewRenderer<Button, MButton>

```




### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Before/After Screenshots ### 
There should be no visual changes to standard Default Renderers 
Here is the view when using Material Visuals

![image](https://user-images.githubusercontent.com/5375137/48643300-9b089100-e99c-11e8-8742-5de12dbed301.png)

![image](https://user-images.githubusercontent.com/5375137/48644475-e96b5f00-e99f-11e8-802a-387f5228cc45.png)


### Testing Procedure ###
- Make sure Visuals are hidden behind the experimental flag correctly
- Make sure all current renderer behavior has been maintained (lots of changes to registrar) so that this change isn't breaking

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
