### PR TITLE
[XamlC] Port #1035 to compiled bindings

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -164,7 +164,7 @@ namespace Xamarin.Forms
 				else
 					value = Binding.FallbackValue ?? property.DefaultValue;
 
-				if (!TryConvert(part, ref value, property.ReturnType, true))
+				if (!TryConvert(ref value, property, property.ReturnType, true))
 				{
 					Log.Warning("Binding", "{0} can not be converted to type '{1}'", value, property.ReturnType);
 					return;
@@ -176,7 +176,7 @@ namespace Xamarin.Forms
 			{
 				object value = Binding.GetTargetValue(target.GetValue(property), part.SetterType);
 
-				if (!TryConvert(part, ref value, part.SetterType, false))
+				if (!TryConvert(ref value, property, part.SetterType, false))
 				{
 					Log.Warning("Binding", "{0} can not be converted to type '{1}'", value, part.SetterType);
 					return;
@@ -415,16 +415,15 @@ namespace Xamarin.Forms
 		}
 		static Type[] DecimalTypes = new[] { typeof(float), typeof(decimal), typeof(double) };
 
-		bool TryConvert(BindingExpressionPart part, ref object value, Type convertTo, bool toTarget)
+		internal static bool TryConvert(ref object value, BindableProperty targetProperty, Type convertTo, bool toTarget)
 		{
 			if (value == null)
 				return true;
-			if ((toTarget && _targetProperty.TryConvert(ref value)) || (!toTarget && convertTo.IsInstanceOfType(value)))
+			if ((toTarget && targetProperty.TryConvert(ref value)) || (!toTarget && convertTo.IsInstanceOfType(value)))
 				return true;
 
 			object original = value;
-			try
-			{
+			try {
 				var stringValue = value as string ?? string.Empty;
 				// see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
 				// do not canonicalize "*.[.]"; "1." should not update bound BindableProperty
@@ -442,18 +441,7 @@ namespace Xamarin.Forms
 				value = Convert.ChangeType(value, convertTo, CultureInfo.InvariantCulture);
 				return true;
 			}
-			catch (InvalidCastException)
-			{
-				value = original;
-				return false;
-			}
-			catch (FormatException)
-			{
-				value = original;
-				return false;
-			}
-			catch (OverflowException)
-			{
+			catch (Exception ex) when (ex is InvalidCastException || ex is FormatException || ex is OverflowException) {
 				value = original;
 				return false;
 			}

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -203,7 +203,7 @@ namespace Xamarin.Forms.Internals
 					} catch (Exception ex) when (ex is NullReferenceException || ex is KeyNotFoundException) {
 					}
 				}
-				if (!TryConvert(ref value, property, property.ReturnType, true)) {
+				if (!BindingExpression.TryConvert(ref value, property, property.ReturnType, true)) {
 					Log.Warning("Binding", "{0} can not be converted to type '{1}'", value, property.ReturnType);
 					return;
 				}
@@ -214,28 +214,11 @@ namespace Xamarin.Forms.Internals
 			var needsSetter = (mode == BindingMode.TwoWay && fromTarget) || mode == BindingMode.OneWayToSource;
 			if (needsSetter && _setter != null && isTSource) {
 				var value = GetTargetValue(target.GetValue(property), typeof(TProperty));
-				if (!TryConvert(ref value, property, typeof(TProperty), false)) {
+				if (!BindingExpression.TryConvert(ref value, property, typeof(TProperty), false)) {
 					Log.Warning("Binding", "{0} can not be converted to type '{1}'", value, typeof(TProperty));
 					return;
 				}
 				_setter((TSource)sourceObject, (TProperty)value);
-			}
-		}
-
-		static bool TryConvert(ref object value, BindableProperty targetProperty, Type convertTo, bool toTarget)
-		{
-			if (value == null)
-				return true;
-			if ((toTarget && targetProperty.TryConvert(ref value)) || (!toTarget && convertTo.IsInstanceOfType(value)))
-				return true;
-
-			object original = value;
-			try {
-				value = Convert.ChangeType(value, convertTo, CultureInfo.InvariantCulture);
-				return true;
-			} catch (Exception ex ) when (ex is InvalidCastException || ex is FormatException||ex is OverflowException) {
-				value = original;
-				return false;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

[XamlC] Port #1035 to comiled bindings
And share the TryConvert implementation to avoid future diverges

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

/

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard