### PR TITLE
[Xaml] Add provided value to collection

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/ApplyPropertiesVisitorTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/ApplyPropertiesVisitorTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using System.Collections;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[TestFixture]
+	public static class ApplyPropertiesVisitorTests
+	{
+		public class MarkupExtension : IMarkupExtension
+		{
+			public object ProvideValue(System.IServiceProvider serviceProvider)
+			{
+				return "provided value";
+			}
+		}
+
+		public class ArrayListOwner
+		{
+			public ArrayList ArrayList { get; } = new ArrayList();
+		}
+
+		[Test]
+		public static void ProvideValueForCollectionItem()
+		{
+			const string NAMESPACE = "clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests";
+			var resolver = new MockNameSpaceResolver();
+			var type = new XmlType(NAMESPACE, "ApplyPropertiesVisitorTests+MarkupExtension", null);
+			var listNode = new ListNode(new[]
+			{
+				new ElementNode(type, NAMESPACE, resolver),
+				new ElementNode(type, NAMESPACE, resolver)
+			}, resolver);
+			var rootElement = new ArrayListOwner();
+			var rootType = new XmlType(NAMESPACE, "ApplyPropertiesVisitorTests+ArrayListOwner", null);
+			var rootNode = new XamlLoader.RuntimeRootNode(rootType, rootElement, null);
+			var context = new HydrationContext { RootElement = rootElement };
+
+			rootNode.Properties.Add(new XmlName(null, "ArrayList"), listNode);
+			rootNode.Accept(new XamlNodeVisitor((node, parent) => node.Parent = parent), null);
+			rootNode.Accept(new CreateValuesVisitor(context), null);
+			rootNode.Accept(new ApplyPropertiesVisitor(context), null);
+
+			CollectionAssert.AreEqual(new[] { "provided value", "provided value" }, rootElement.ArrayList);
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -161,7 +161,7 @@ namespace Xamarin.Forms.Xaml
 
 				MethodInfo addMethod;
 				if (xpe == null && (addMethod = collection.GetType().GetRuntimeMethods().First(mi => mi.Name == "Add" && mi.GetParameters().Length == 1)) != null) {
-					addMethod.Invoke(collection, new[] { Values[node] });
+					addMethod.Invoke(collection, new[] { value });
 					return;
 				}
 				xpe = xpe ?? new XamlParseException($"Value of {parentList.XmlName.LocalName} does not have a Add() method", node);


### PR DESCRIPTION
### Description of Change ###

There is a line with the following content prior to the changed one:
```C#
ProvideValue(ref value, node, source, XmlName.Empty);
```

`ProvideValue` executes `IMarkupExtension` and `IValueProvider`. However, the modified `value` was ignored and `Values[node]` was used instead. This change fixes the problem.
<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
