### PR TITLE
[iOS] center title icon on ios if there is no titleview

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4138.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4138.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Github, 4138, "[iOS] NavigationPage.TitleIcon no longer centered",
+        PlatformAffected.iOS)]
+#if UITEST
+    [NUnit.Framework.Category(UITestCategories.Navigation)]
+#endif
+    public class Issue4138 : TestNavigationPage
+    {
+        protected override void Init()
+        {
+            ContentPage contentPage = new ContentPage();
+
+            NavigationPage.SetTitleIcon(contentPage, "coffee.png");
+
+            PushAsync(contentPage);
+        }
+
+
+#if UITEST && __IOS__
+		[Test]
+        public void TitleIconIsCentered()
+        {
+            var element = RunningApp.WaitForElement("coffee.png")[0];
+			var rect = RunningApp.RootViewRect();
+			Assert.AreEqual(element.Rect.CenterX, rect.CenterX);
+        }
+#endif
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -819,6 +819,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3275.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3884.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4001.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4138.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1007,7 +1008,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -58,8 +58,8 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.UITest, Version=2.2.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.UITest.2.2.6\lib\net45\Xamarin.UITest.dll</HintPath>
+    <Reference Include="Xamarin.UITest">
+      <HintPath>..\packages\Xamarin.UITest.2.2.7\lib\net45\Xamarin.UITest.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.iOS.UITests/packages.config
+++ b/Xamarin.Forms.Core.iOS.UITests/packages.config
@@ -3,5 +3,5 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="Xam.Plugin.DeviceInfo" version="3.0.2" targetFramework="net47" />
-  <package id="Xamarin.UITest" version="2.2.6" targetFramework="net47" />
+  <package id="Xamarin.UITest" version="2.2.7" targetFramework="net47" />
 </packages>

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1414,9 +1414,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_child?.Element != null)
 				{
-					var layoutBounds = new Rectangle(IconWidth, 0, Bounds.Width - IconWidth, height);
+					Rectangle layoutBounds = new Rectangle(IconWidth, 0, Bounds.Width - IconWidth, height);
 					if (_child.Element.Bounds != layoutBounds)
 						Layout.LayoutChildIntoBoundingRegion(_child.Element, layoutBounds);
+				}
+				else if(_icon != null && Superview != null)
+				{
+					_icon.Center = new PointF(Superview.Frame.Width / 2 - Frame.X, Superview.Frame.Height / 2);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

If there is no title view present then center the title icon. This is how it used to work before the titleview changes were made for creating a full width titleview

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4138 

### Platforms Affected ### 
- iOS

### Before/After Screenshots ### 
refer to #4138 to see how it should look.

### Testing Procedure ###
- Go to the titleview gallery
- toggle the titleview until there isn't one
- toggle the title icon
- ensure that it is centered

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard