### PR TITLE
[iOS, macOS] Fix WebViews using HtmlWebViewSource switching to UrlWebViewSource

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
@@ -203,6 +203,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (Renderer.Control.IsLoading)
 					return;
 
+				if (Renderer.Control.MainFrameUrl == $"file://{NSBundle.MainBundle.BundlePath}/")
+					return;
+
 				Renderer._ignoreSourceChanges = true;
 				Renderer.Element?.SetValueFromRenderer(WebView.SourceProperty, new UrlWebViewSource { Url = Renderer.Control.MainFrameUrl });
 				Renderer._ignoreSourceChanges = false;

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -220,8 +220,12 @@ namespace Xamarin.Forms.Platform.iOS
 				if (webView.IsLoading)
 					return;
 
-				_renderer._ignoreSourceChanges = true;
 				var url = GetCurrentUrl();
+
+				if (url == $"file://{NSBundle.MainBundle.BundlePath}/")
+					return;
+
+				_renderer._ignoreSourceChanges = true;
 				WebView.SetValueFromRenderer(WebView.SourceProperty, new UrlWebViewSource { Url = url });
 				_renderer._ignoreSourceChanges = false;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -216,8 +216,11 @@ namespace Xamarin.Forms.Platform.iOS
 				if (webView.IsLoading)
 					return;
 
-				_renderer._ignoreSourceChanges = true;
 				var url = GetCurrentUrl();
+				if (url == $"file://{NSBundle.MainBundle.BundlePath}/")
+					return;
+
+				_renderer._ignoreSourceChanges = true;
 				WebView.SetValueFromRenderer(WebView.SourceProperty, new UrlWebViewSource { Url = url });
 				_renderer._ignoreSourceChanges = false;
 


### PR DESCRIPTION
### Description of Change ###
Accidentally discovered #2952 on my own while fixing #4254.

On a succesful load, all `WebView`s set the Source property to a new `UrlWebViewSource` with the current url, presumably to keep the Url property of the `UrlWebViewSource` in sync in the case that the provided url resulted in a redirect. On all platform besides iOS/macOS, this behavior is skipped if the value of the current url indicates that the WebView has loaded local html instead of content from a remote server. On iOS/macOS, the source will be converted to a `UrlWebViewSource` even if a `HtmlWebViewSource` is what was used to the load the content.

This fix aligns macOS and iOS with the behavior of the other platforms.

### Issues Resolved ### 
- fixes #2952

### API Changes ###
None

### Platforms Affected ### 
- macOS
- iOS

### Behavioral/Visual Changes ###
A webview that is using `HtmlWebViewSource` that is bound to an element and then removed and re-added to that element will now correctly have its content load and display *both* times. Previously the content would load correctly only the first time before switching to use `UrlWebViewSource`.
Additionally, the `Navigated` event will no longer fire when `HtmlWebViewSource` is used on iOS or macOS as a result of this change, as is the case on the other platforms.

### Testing Procedure ###
Run the repro project in #2952, or perhaps even more simply:
1. Run the Gallery Project.
2. Select the WebView Gallery.
3. Choose the HtmlWebViewSourceView, LoadHtmlView, or JavaScriptAlertView. It should load correctly.
4. Choose any other view in the list (doesn't matter if its one of the ones mentioned above or not).
5. Return to the view you originally chose in step 3. It should load correctly again (previously was blank).

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
