### PR TITLE
[C] Fix check for CollectionView flag

### DIFF
--- a/Xamarin.Forms.Core/Items/CollectionView.cs
+++ b/Xamarin.Forms.Core/Items/CollectionView.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms
 			string constructorHint = null,
 			[CallerMemberName] string memberName = "")
 		{
-			if (!Device.Flags.Contains(CollectionViewExperimental))
+			if (Device.Flags == null || !Device.Flags.Contains(CollectionViewExperimental))
 			{
 				if (!String.IsNullOrEmpty(memberName))
 				{


### PR DESCRIPTION
### Description of Change ###

If `Device.Flags` is `null`, the code supposed to check for the presence of
the flags throws a `NullReferenceException`. Most users will get that
instead of the helpful version of it. Which is not very inclusive of the
people too lazy to read the docs.


<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
