### PR TITLE
[Core] Move TextProperty, ITextElement, and IPlaceholderElement to InputView

### DIFF
--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -6,7 +6,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_EditorRenderer))]
-	public class Editor : InputView, IEditorController, IFontElement, IPlaceholderElement, ITextElement, IElementConfiguration<Editor>
+	public class Editor : InputView, IEditorController, IFontElement, IElementConfiguration<Editor>
 	{
 		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(Editor), null, BindingMode.TwoWay, propertyChanged: (bindable, oldValue, newValue)
 			=> OnTextChanged((Editor)bindable, (string)oldValue, (string)newValue));
@@ -17,13 +17,13 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
+		public new static readonly BindableProperty TextColorProperty = InputView.TextColorProperty;
 
-		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
+		public new static readonly BindableProperty CharacterSpacingProperty = InputView.CharacterSpacingProperty;
 
-		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
+		public new static readonly BindableProperty PlaceholderProperty = InputView.PlaceholderProperty;
 
-		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
+		public new static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
 
 		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Editor), true, BindingMode.Default);
 
@@ -42,28 +42,6 @@ namespace Xamarin.Forms
 		{
 			get { return (string)GetValue(TextProperty); }
 			set { SetValue(TextProperty, value); }
-		}
-
-		public Color TextColor
-		{
-			get { return (Color)GetValue(TextElement.TextColorProperty); }
-			set { SetValue(TextElement.TextColorProperty, value); }
-		}
-
-		public double CharacterSpacing
-		{
-			get { return (double)GetValue(TextElement.CharacterSpacingProperty); }
-			set { SetValue(TextElement.CharacterSpacingProperty, value); }
-		}
-
-		public string Placeholder {
-			get => (string)GetValue(PlaceholderElement.PlaceholderProperty);
-			set => SetValue(PlaceholderElement.PlaceholderProperty, value);
-		}
-
-		public Color PlaceholderColor {
-			get => (Color)GetValue(PlaceholderElement.PlaceholderColorProperty);
-			set => SetValue(PlaceholderElement.PlaceholderColorProperty, value);
 		}
 
 		public FontAttributes FontAttributes
@@ -139,17 +117,7 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendCompleted()
 			=> Completed?.Invoke(this, EventArgs.Empty);
-
-		void ITextElement.OnTextColorPropertyChanged(Color oldValue, Color newValue)
-		{
-		}
-
-		void ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue)
-		{
-			InvalidateMeasure();
-		}
-
-
+		
 		private static void OnTextChanged(Editor bindable, string oldValue, string newValue)
 		{
 			bindable.TextChanged?.Invoke(bindable, new TextChangedEventArgs(oldValue, newValue));

--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -8,8 +8,7 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_EditorRenderer))]
 	public class Editor : InputView, IEditorController, IFontElement, IElementConfiguration<Editor>
 	{
-		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(Editor), null, BindingMode.TwoWay, propertyChanged: (bindable, oldValue, newValue)
-			=> OnTextChanged((Editor)bindable, (string)oldValue, (string)newValue));
+		public new static readonly BindableProperty TextProperty = InputView.TextProperty;
 
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
@@ -36,12 +35,6 @@ namespace Xamarin.Forms
 		{
 			get { return (EditorAutoSizeOption)GetValue(AutoSizeProperty); }
 			set { SetValue(AutoSizeProperty, value); }
-		}
-
-		public string Text
-		{
-			get { return (string)GetValue(TextProperty); }
-			set { SetValue(TextProperty, value); }
 		}
 
 		public FontAttributes FontAttributes
@@ -102,8 +95,6 @@ namespace Xamarin.Forms
 
 		public event EventHandler Completed;
 
-		public event EventHandler<TextChangedEventArgs> TextChanged;
-
 		public Editor()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Editor>>(() => new PlatformConfigurationRegistry<Editor>(this));
@@ -117,13 +108,14 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendCompleted()
 			=> Completed?.Invoke(this, EventArgs.Empty);
-		
-		private static void OnTextChanged(Editor bindable, string oldValue, string newValue)
+
+		protected override void OnTextChanged(string oldValue, string newValue)
 		{
-			bindable.TextChanged?.Invoke(bindable, new TextChangedEventArgs(oldValue, newValue));
-			if (bindable.AutoSize == EditorAutoSizeOption.TextChanges)
+			base.OnTextChanged(oldValue, newValue);
+
+			if (AutoSize == EditorAutoSizeOption.TextChanges)
 			{
-				bindable.InvalidateMeasure();
+				InvalidateMeasure();
 			}
 		}
 	}

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty IsPasswordProperty = BindableProperty.Create("IsPassword", typeof(bool), typeof(Entry), default(bool));
 
-		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(Entry), null, BindingMode.TwoWay, propertyChanged: OnTextChanged);
+		public new static readonly BindableProperty TextProperty = InputView.TextProperty;
 
 		public new static readonly BindableProperty TextColorProperty = InputView.TextColorProperty;
 
@@ -68,12 +68,6 @@ namespace Xamarin.Forms
 		{
 			get { return (bool)GetValue(IsPasswordProperty); }
 			set { SetValue(IsPasswordProperty, value); }
-		}
-
-		public string Text
-		{
-			get { return (string)GetValue(TextProperty); }
-			set { SetValue(TextProperty, value); }
 		}
 
 		public FontAttributes FontAttributes
@@ -154,8 +148,6 @@ namespace Xamarin.Forms
 
 		public event EventHandler Completed;
 
-		public event EventHandler<TextChangedEventArgs> TextChanged;
-
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendCompleted()
 		{
@@ -168,13 +160,6 @@ namespace Xamarin.Forms
 					ReturnCommand.Execute(ReturnCommandParameter);
 				}
 			}
-		}
-
-		static void OnTextChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			var entry = (Entry)bindable;
-
-			entry.TextChanged?.Invoke(entry, new TextChangedEventArgs((string)oldValue, (string)newValue));
 		}
 
 		public IPlatformElementConfiguration<T, Entry> On<T>() where T : IConfigPlatform

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_EntryRenderer))]
-	public class Entry : InputView, IFontElement, IPlaceholderElement, ITextElement, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>
+	public class Entry : InputView, IFontElement, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>
 	{
 		public static readonly BindableProperty ReturnTypeProperty = BindableProperty.Create(nameof(ReturnType), typeof(ReturnType), typeof(Entry), ReturnType.Default);
 
@@ -15,17 +15,17 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty ReturnCommandParameterProperty = BindableProperty.Create(nameof(ReturnCommandParameter), typeof(object), typeof(Entry), default(object));
 
-		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
+		public new static readonly BindableProperty PlaceholderProperty = InputView.PlaceholderProperty;
 
-		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
+		public new static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
 
 		public static readonly BindableProperty IsPasswordProperty = BindableProperty.Create("IsPassword", typeof(bool), typeof(Entry), default(bool));
 
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(Entry), null, BindingMode.TwoWay, propertyChanged: OnTextChanged);
 
-		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
+		public new static readonly BindableProperty TextColorProperty = InputView.TextColorProperty;
 
-		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
+		public new static readonly BindableProperty CharacterSpacingProperty = InputView.CharacterSpacingProperty;
 
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
@@ -70,34 +70,10 @@ namespace Xamarin.Forms
 			set { SetValue(IsPasswordProperty, value); }
 		}
 
-		public string Placeholder
-		{
-			get { return (string)GetValue(PlaceholderProperty); }
-			set { SetValue(PlaceholderProperty, value); }
-		}
-
-		public Color PlaceholderColor
-		{
-			get { return (Color)GetValue(PlaceholderColorProperty); }
-			set { SetValue(PlaceholderColorProperty, value); }
-		}
-
 		public string Text
 		{
 			get { return (string)GetValue(TextProperty); }
 			set { SetValue(TextProperty, value); }
-		}
-
-		public Color TextColor
-		{
-			get { return (Color)GetValue(TextElement.TextColorProperty); }
-			set { SetValue(TextElement.TextColorProperty, value); }
-		}
-
-		public double CharacterSpacing
-		{
-			get { return (double)GetValue(TextElement.CharacterSpacingProperty); }
-			set { SetValue(TextElement.CharacterSpacingProperty, value); }
 		}
 
 		public FontAttributes FontAttributes
@@ -204,15 +180,6 @@ namespace Xamarin.Forms
 		public IPlatformElementConfiguration<T, Entry> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
-		}
-
-		void ITextElement.OnTextColorPropertyChanged(Color oldValue, Color newValue)
-		{
-		}
-
-		void ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue)
-		{
-			InvalidateMeasure();
 		}
 
 

--- a/Xamarin.Forms.Core/InputView.cs
+++ b/Xamarin.Forms.Core/InputView.cs
@@ -1,10 +1,16 @@
+using System;
+
 namespace Xamarin.Forms
 {
 	public class InputView : View, IPlaceholderElement, ITextElement
 	{
-		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create("Keyboard", typeof(Keyboard), typeof(InputView), Keyboard.Default,
+		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(InputView),
+			propertyChanged: (bindable, oldValue, newValue) => ((InputView)bindable).OnTextChanged((string)oldValue, (string)newValue));
+
+		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create(nameof(Keyboard), typeof(Keyboard), typeof(InputView), Keyboard.Default,
 			coerceValue: (o, v) => (Keyboard)v ?? Keyboard.Default);
-		public static readonly BindableProperty IsSpellCheckEnabledProperty = BindableProperty.Create("IsSpellCheckEnabled", typeof(bool), typeof(InputView), true);
+
+		public static readonly BindableProperty IsSpellCheckEnabledProperty = BindableProperty.Create(nameof(IsSpellCheckEnabled), typeof(bool), typeof(InputView), true);
 
 		public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(nameof(MaxLength), typeof(int), typeof(int), int.MaxValue);
 
@@ -26,6 +32,12 @@ namespace Xamarin.Forms
 
 		internal InputView()
 		{
+		}
+
+		public string Text
+		{
+			get => (string)GetValue(TextProperty);
+			set => SetValue(TextProperty, value);
 		}
 
 		public Keyboard Keyboard
@@ -68,6 +80,13 @@ namespace Xamarin.Forms
 		{
 			get => (double)GetValue(CharacterSpacingProperty);
 			set => SetValue(CharacterSpacingProperty, value);
+		}
+
+		public event EventHandler<TextChangedEventArgs> TextChanged;
+
+		protected virtual void OnTextChanged(string oldValue, string newValue)
+		{
+			TextChanged?.Invoke(this, new TextChangedEventArgs(oldValue, newValue));
 		}
 
 		void ITextElement.OnTextColorPropertyChanged(Color oldValue, Color newValue)

--- a/Xamarin.Forms.Core/InputView.cs
+++ b/Xamarin.Forms.Core/InputView.cs
@@ -1,6 +1,6 @@
 namespace Xamarin.Forms
 {
-	public class InputView : View
+	public class InputView : View, IPlaceholderElement, ITextElement
 	{
 		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create("Keyboard", typeof(Keyboard), typeof(InputView), Keyboard.Default,
 			coerceValue: (o, v) => (Keyboard)v ?? Keyboard.Default);
@@ -10,10 +10,18 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(nameof(IsReadOnly), typeof(bool), typeof(InputView), false);
 
+		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
+
+		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
+
+		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
+
+		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
+
 		public int MaxLength
 		{
-			get { return (int)GetValue(MaxLengthProperty); }
-			set { SetValue(MaxLengthProperty, value); }
+			get => (int)GetValue(MaxLengthProperty);
+			set => SetValue(MaxLengthProperty, value);
 		}
 
 		internal InputView()
@@ -22,20 +30,53 @@ namespace Xamarin.Forms
 
 		public Keyboard Keyboard
 		{
-			get { return (Keyboard)GetValue(KeyboardProperty); }
-			set { SetValue(KeyboardProperty, value); }
+			get => (Keyboard)GetValue(KeyboardProperty);
+			set => SetValue(KeyboardProperty, value);
 		}
 
 		public bool IsSpellCheckEnabled
 		{
-			get { return (bool)GetValue(IsSpellCheckEnabledProperty); }
-			set { SetValue(IsSpellCheckEnabledProperty, value); }
+			get => (bool)GetValue(IsSpellCheckEnabledProperty);
+			set => SetValue(IsSpellCheckEnabledProperty, value);
 		}
 
 		public bool IsReadOnly
 		{
-			get { return (bool)GetValue(IsReadOnlyProperty); }
-			set { SetValue(IsReadOnlyProperty, value); }
+			get => (bool)GetValue(IsReadOnlyProperty);
+			set => SetValue(IsReadOnlyProperty, value);
+		}
+
+		public string Placeholder
+		{
+			get => (string)GetValue(PlaceholderProperty);
+			set => SetValue(PlaceholderProperty, value);
+		}
+
+		public Color PlaceholderColor
+		{
+			get => (Color)GetValue(PlaceholderColorProperty);
+			set => SetValue(PlaceholderColorProperty, value);
+		}
+
+		public Color TextColor
+		{
+			get => (Color)GetValue(TextColorProperty);
+			set => SetValue(TextColorProperty, value);
+		}
+
+		public double CharacterSpacing
+		{
+			get => (double)GetValue(CharacterSpacingProperty);
+			set => SetValue(CharacterSpacingProperty, value);
+		}
+
+		void ITextElement.OnTextColorPropertyChanged(Color oldValue, Color newValue)
+		{
+		}
+
+		void ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue)
+		{
+			InvalidateMeasure();
 		}
 	}
 

--- a/Xamarin.Forms.Core/InputView.cs
+++ b/Xamarin.Forms.Core/InputView.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Forms
 {
 	public class InputView : View, IPlaceholderElement, ITextElement
 	{
-		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(InputView),
+		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(InputView), defaultBindingMode: BindingMode.TwoWay,
 			propertyChanged: (bindable, oldValue, newValue) => ((InputView)bindable).OnTextChanged((string)oldValue, (string)newValue));
 
 		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create(nameof(Keyboard), typeof(Keyboard), typeof(InputView), Keyboard.Default,

--- a/Xamarin.Forms.Core/SearchBar.cs
+++ b/Xamarin.Forms.Core/SearchBar.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Platform;
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_SearchBarRenderer))]
-	public class SearchBar : InputView, IFontElement, IPlaceholderElement, ITextElement, ITextAlignmentElement, ISearchBarController, IElementConfiguration<SearchBar>
+	public class SearchBar : InputView, IFontElement, ITextAlignmentElement, ISearchBarController, IElementConfiguration<SearchBar>
 	{
 		public static readonly BindableProperty SearchCommandProperty = BindableProperty.Create("SearchCommand", typeof(ICommand), typeof(SearchBar), null, propertyChanged: OnCommandChanged);
 
@@ -24,9 +24,9 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty CancelButtonColorProperty = BindableProperty.Create("CancelButtonColor", typeof(Color), typeof(SearchBar), default(Color));
 
-		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
+		public new static readonly BindableProperty PlaceholderProperty = InputView.PlaceholderProperty;
 
-		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
+		public new static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
 
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
@@ -38,9 +38,9 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty VerticalTextAlignmentProperty = TextAlignmentElement.VerticalTextAlignmentProperty;
 
-		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
+		public new static readonly BindableProperty TextColorProperty = InputView.TextColorProperty;
 
-		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
+		public new static readonly BindableProperty CharacterSpacingProperty = InputView.CharacterSpacingProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<SearchBar>> _platformConfigurationRegistry;
 
@@ -62,16 +62,6 @@ namespace Xamarin.Forms
 			set { SetValue(TextAlignmentElement.VerticalTextAlignmentProperty, value); }
 		}
 
-		public string Placeholder {
-			get => (string)GetValue(PlaceholderElement.PlaceholderProperty);
-			set => SetValue(PlaceholderElement.PlaceholderProperty, value);
-		}
-
-		public Color PlaceholderColor {
-			get => (Color)GetValue(PlaceholderElement.PlaceholderColorProperty);
-			set => SetValue(PlaceholderElement.PlaceholderColorProperty, value);
-		}
-
 		public ICommand SearchCommand
 		{
 			get { return (ICommand)GetValue(SearchCommandProperty); }
@@ -88,18 +78,6 @@ namespace Xamarin.Forms
 		{
 			get { return (string)GetValue(TextProperty); }
 			set { SetValue(TextProperty, value); }
-		}
-
-		public Color TextColor
-		{
-			get { return (Color)GetValue(TextElement.TextColorProperty); }
-			set { SetValue(TextElement.TextColorProperty, value); }
-		}
-
-		public double CharacterSpacing
-		{
-			get { return (double)GetValue(TextElement.CharacterSpacingProperty); }
-			set { SetValue(TextElement.CharacterSpacingProperty, value); }
 		}
 
 		bool IsEnabledCore
@@ -198,15 +176,6 @@ namespace Xamarin.Forms
 		public IPlatformElementConfiguration<T, SearchBar> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
-		}
-
-		void ITextElement.OnTextColorPropertyChanged(Color oldValue, Color newValue)
-		{
-		}
-
-		void ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue)
-		{
-			InvalidateMeasure();
 		}
 
 		void ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(TextAlignment oldValue, TextAlignment newValue)

--- a/Xamarin.Forms.Core/SearchBar.cs
+++ b/Xamarin.Forms.Core/SearchBar.cs
@@ -13,14 +13,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty SearchCommandParameterProperty = BindableProperty.Create("SearchCommandParameter", typeof(object), typeof(SearchBar), null);
 
-		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(SearchBar), default(string), BindingMode.TwoWay,
-			propertyChanged: (bindable, oldValue, newValue) =>
-			{
-				var searchBar = (SearchBar)bindable;
-				EventHandler<TextChangedEventArgs> eh = searchBar.TextChanged;
-				if (eh != null)
-					eh(searchBar, new TextChangedEventArgs((string)oldValue, (string)newValue));
-			});
+		public new static readonly BindableProperty TextProperty = InputView.TextProperty;
 
 		public static readonly BindableProperty CancelButtonColorProperty = BindableProperty.Create("CancelButtonColor", typeof(Color), typeof(SearchBar), default(Color));
 
@@ -74,12 +67,6 @@ namespace Xamarin.Forms
 			set { SetValue(SearchCommandParameterProperty, value); }
 		}
 
-		public string Text
-		{
-			get { return (string)GetValue(TextProperty); }
-			set { SetValue(TextProperty, value); }
-		}
-
 		bool IsEnabledCore
 		{
 			set { SetValueCore(IsEnabledProperty, value); }
@@ -124,8 +111,6 @@ namespace Xamarin.Forms
 		}
 
 		public event EventHandler SearchButtonPressed;
-
-		public event EventHandler<TextChangedEventArgs> TextChanged;
 
 		public SearchBar()
 		{


### PR DESCRIPTION
### Description of Change ###

The Entry, Editor, and SearchBar classes are all subclasses of InputView, but each separately implements the interfaces ITextElement and IPlaceholderElement and a Text property. This PR moves these properties into InputView while maintaining ABI backwards compatibility.

### Issues Resolved ### 

- N/A

### API Changes ###

Changed:
- Moved `Text` property, `TextChanged` event, `OnTextChanged` method, `IPlaceholderElement` implementation, `ITextElement` implementation from `Entry`, `Editor`, and `SearchBar` to `InputView`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

N/A

### Testing Procedure ###

N/A

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
