### PR TITLE
[XamlC] comp binding to generic properties

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -392,7 +392,11 @@ namespace Xamarin.Forms.Build.Tasks
 				yield break; //throw
 
 			var properties = ParsePath(path, tSourceRef, node as IXmlLineInfo, module);
-			var tPropertyRef = properties != null && properties.Any() ? properties.Last().Item1.PropertyType : tSourceRef;
+			TypeReference tPropertyRef = tSourceRef;
+			if (properties != null && properties.Count > 0) {
+				var lastProp = properties[properties.Count - 1];
+				tPropertyRef = lastProp.property.ResolveGenericPropertyType(lastProp.propDeclTypeRef, module);
+			}
 			tPropertyRef = module.ImportReference(tPropertyRef);
 
 			var funcRef = module.ImportReference(module.ImportReference(("mscorlib", "System", "Func`2")).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4438.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4438.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4438"
+		x:DataType="local:Gh4438VM">
+	<Label x:Name="label" Text="{Binding SelectedItem}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4438.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4438.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh4438VM : Gh4438VMBase<string>
+	{
+		public Gh4438VM()
+		{
+			Add("test");
+			SelectedItem = this.First();
+		}
+	}
+
+	public class Gh4438VMBase<T> : Collection<string>
+	{
+		public virtual T SelectedItem { get; set; }
+	}
+
+	public partial class Gh4438 : ContentPage
+	{
+		public Gh4438()
+		{
+			InitializeComponent();
+		}
+
+		public Gh4438(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void GenericBaseClassResolution(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh4438)));
+				var layout = new Gh4438(useCompiledXaml) { BindingContext = new Gh4438VM() };
+				Assert.That(layout.label.Text, Is.EqualTo("test"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

[XamlC] comp binding to generic properties

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4438

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard