### PR TITLE
Added UI test to B44044

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44044.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44044.cs
@@ -19,6 +19,9 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Bugzilla, 44044, "TabbedPage steals swipe gestures", PlatformAffected.Android)]
 	public class Bugzilla44044 : TestTabbedPage
 	{
+		string _btnToggleSwipe = "btnToggleSwipe";
+		string _btnDisplayAlert = "btnDisplayAlert";
+
 		protected override void Init()
 		{
 			Children.Add(new ContentPage()
@@ -31,7 +34,8 @@ namespace Xamarin.Forms.Controls.Issues
 						new Button
 						{
 							Text = "Click to Toggle Swipe Paging",
-							Command = new Command(() => On<Android>().SetIsSwipePagingEnabled(!On<Android>().IsSwipePagingEnabled()))
+							Command = new Command(() => On<Android>().SetIsSwipePagingEnabled(!On<Android>().IsSwipePagingEnabled())), 
+							AutomationId = _btnToggleSwipe
 						}
 					}
 				}
@@ -47,11 +51,33 @@ namespace Xamarin.Forms.Controls.Issues
 						new Button
 						{
 							Text = "Click to DisplayAlert",
-							Command = new Command(() => DisplayAlert("Page 2", "Message", "Cancel"))
+							Command = new Command(() => DisplayAlert("Page 2", "Message", "Cancel")), 
+							AutomationId = _btnDisplayAlert
 						}
 					}
 				}
 			});
 		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void Bugzilla44044Test()
+		{
+			RunningApp.WaitForElement(_btnToggleSwipe);
+			
+			RunningApp.SwipeRightToLeft();
+			RunningApp.WaitForNoElement(_btnToggleSwipe);
+			RunningApp.WaitForElement(_btnDisplayAlert);
+			
+			RunningApp.SwipeLeftToRight();
+			RunningApp.WaitForNoElement(_btnDisplayAlert);
+			RunningApp.WaitForElement(_btnToggleSwipe);
+			
+			RunningApp.Tap(_btnToggleSwipe);
+			RunningApp.SwipeRightToLeft();
+			RunningApp.WaitForNoElement(_btnDisplayAlert);
+			RunningApp.WaitForElement(_btnToggleSwipe);
+		}
+#endif
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Added UI test to B44044. The test is only for Android because iOS don't have gesture in tabbed page to change tab visualization.

### Issues Resolved ### 

- fixes #2377

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run UI test.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard