### PR TITLE
[iOS] ScrollViewRenderer: clear the renderer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -160,6 +160,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_packager == null)
 					return;
 
+				Element?.ClearValue(Platform.RendererProperty);
 				SetElement(null);
 
 				_packager.Dispose();


### PR DESCRIPTION
### Description of Change ###

On Dispose(), the Renderer is supposed to be cleared on the element.
That's taken care of by VisualElementRenderer`1.Dispose().
Unfortunately, ScrollViewRenderer doesn't inherit from it.

I find it strange that this never was triggered before the Shell, but
I'm learning to live surrounded by strange behaviors.

No tests, as it's hard to reproduce in a UITest

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4381

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
