### PR TITLE
[C] support TargetNullValue in TypedBindings

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
@@ -1004,6 +1004,22 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/4103
+		public void TestTargetNullValue()
+		{
+			var property = BindableProperty.Create("Text", typeof(string), typeof(MockBindable), default(string));
+			var binding = new TypedBinding<MockViewModel, string>(vm => vm.Text, null, null) { TargetNullValue = "target null"};
+			var bindable = new MockBindable();
+			bindable.SetBinding(property, binding);
+			bindable.BindingContext = new MockViewModel("initial");
+			Assert.That(bindable.GetValue(property), Is.EqualTo("initial"));
+
+			bindable.BindingContext = new MockViewModel(null);
+			Assert.That(bindable.GetValue(property), Is.EqualTo("target null"));
+
+		}
+
+		[Test]
 		[Description("OneWay bindings should not double apply on source updates.")]
 		public void OneWayBindingsDontDoubleApplyOnSourceUpdates()
 		{

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -148,11 +148,7 @@ namespace Xamarin.Forms.Internals
 			if (Converter != null)
 				value = Converter.Convert(value, targetPropertyType, ConverterParameter, CultureInfo.CurrentUICulture);
 
-			//return base.GetSourceValue(value, targetPropertyType);
-			if (StringFormat != null)
-				return string.Format(StringFormat, value);
-
-			return value;
+			return base.GetSourceValue(value, targetPropertyType);
 		}
 
 		internal override object GetTargetValue(object value, Type sourcePropertyType)

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4103.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4103.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4103"
+		x:DataType="local:Gh4103VM">
+	<Label x:Name="label" Text="{Binding SomeNullableValue, TargetNullValue='target null', FallbackValue='fallback'}"/>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4103.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4103.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh4103VM
+	{
+		public string SomeNullableValue { get; set; } = "initial";
+	}
+	public partial class Gh4103 : ContentPage
+	{
+		private string _someNullableValue = "initial";
+
+		public Gh4103()
+		{
+			InitializeComponent();
+		}
+
+		public Gh4103(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[TestCase(true), TestCase(false)]
+			public void CompiledBindingsTargetNullValue(bool useCompiledXaml)
+			{
+				var layout = new Gh4103(useCompiledXaml) { BindingContext = new Gh4103VM() };
+				Assert.That(layout.label.Text, Is.EqualTo("initial"));
+
+				layout.BindingContext = new Gh4103VM { SomeNullableValue = null };
+				Assert.That(layout.label.Text, Is.EqualTo("target null"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Call base.GetSourceValue so the TargetNullValue is returned in case of a
null value. I have no idea why the code was there, but commented out,
and I don't want any of you to start digging at the why it wasn't
enabled before.

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4103

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
