### PR TITLE
[Android] add Element and Element Property Changed hooks for ImageButton

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -172,8 +172,13 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateInputTransparent();
 			UpdatePadding();
 
-			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(oldElement, ImageButton));
+			OnElementChanged(new ElementChangedEventArgs<ImageButton>(oldElement, ImageButton));
 			ImageButton?.SendViewInitialized(Control);
+		}
+
+		protected virtual void OnElementChanged(ElementChangedEventArgs<ImageButton> e)
+		{
+			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
 		}
 
 		public override void Draw(Canvas canvas)
@@ -258,8 +263,7 @@ namespace Xamarin.Forms.Platform.Android
 			_inputTransparent = ImageButton.InputTransparent;
 		}
 
-		// Image related
-		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
 				UpdateInputTransparent();


### PR DESCRIPTION
### Description of Change ###
ImageButton Renderer for Android didn't provide overrides that are consistent with other renderers for hooking into element and element property change events


### API Changes ###

Added the following methods to the ImageButtonRenderer
```C#
protected virtual void OnElementChanged(ElementChangedEventArgs<ImageButton> e);
protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e);
```

### Platforms Affected ### 
- Android

### Testing Procedure ###
Add a custom ImageButtonRenderer for Android

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
