### PR TITLE
[Xaml] OnIdiomMarkupExt uses converters on BPs

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4319.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4319.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4319">
+	<ContentPage.Resources>	
+		<Style x:Key="style" TargetType="Label">
+			<Setter Property="FontSize" Value="{OnPlatform iOS=Micro, Default=Small}" />	
+		</Style>
+	</ContentPage.Resources>
+	<Label x:Name="label" Style="{StaticResource style}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4319.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4319.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh4319 : ContentPage
+	{
+		public Gh4319() => InitializeComponent();
+		public Gh4319(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[TestCase(true), TestCase(false)]
+			public void OnPlatformMarkupAndNamedSizes(bool useCompiledXaml)
+			{
+				((MockPlatformServices)Device.PlatformServices).RuntimePlatform = Device.iOS;
+				var layout = new Gh4319(useCompiledXaml);
+				Assert.That(layout.label.FontSize, Is.EqualTo(4d));
+
+				((MockPlatformServices)Device.PlatformServices).RuntimePlatform = Device.Android;
+				layout = new Gh4319(useCompiledXaml);
+				Assert.That(layout.label.FontSize, Is.EqualTo(8d));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Reflection;
+using System.Xml;
 
 namespace Xamarin.Forms.Xaml
 {
@@ -58,11 +59,37 @@ namespace Xamarin.Forms.Xaml
 				return Converter.Convert(value, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);
 
 			var converterProvider = serviceProvider?.GetService<IValueConverterProvider>();
+			if (converterProvider != null) {
+				MemberInfo minforetriever()
+				{
+					if (pi != null)
+						return pi;
 
+					MemberInfo minfo = null;
+					try {
+						minfo = bp.DeclaringType.GetRuntimeProperty(bp.PropertyName);
+					}
+					catch (AmbiguousMatchException e) {
+						IXmlLineInfo lineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+						throw new XamlParseException($"Multiple properties with name '{bp.DeclaringType}.{bp.PropertyName}' found.", lineInfo, innerException: e);
+					}
+					if (minfo != null)
+						return minfo;
+					try {
+						return bp.DeclaringType.GetRuntimeMethod("Get" + bp.PropertyName, new[] { typeof(BindableObject) });
+					}
+					catch (AmbiguousMatchException e) {
+						IXmlLineInfo lineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+						throw new XamlParseException($"Multiple methods with name '{bp.DeclaringType}.Get{bp.PropertyName}' found.", lineInfo, innerException: e);
+					}
+				}
+
+				return converterProvider.Convert(value, propertyType, minforetriever, serviceProvider);
+			}
 			if (converterProvider != null)
 				return converterProvider.Convert(value, propertyType, () => pi, serviceProvider);
-			else
-				return value.ConvertTo(propertyType, () => pi, serviceProvider);
+
+			return value.ConvertTo(propertyType, () => pi, serviceProvider);
 		}
 
 		object GetValue()

--- a/Xamarin.Forms.Xaml/MarkupExtensions/OnPlatformExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/OnPlatformExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Reflection;
+using System.Xml;
 
 namespace Xamarin.Forms.Xaml
 {
@@ -22,14 +23,14 @@ namespace Xamarin.Forms.Xaml
 
 		public object ProvideValue(IServiceProvider serviceProvider)
 		{
-			if (   Android == null
-			    && GTK == null
-			    && iOS == null
-			    && macOS == null
-			    && Tizen == null
-			    && UWP == null
-			    && WPF == null
-			    && Default == null) {
+			if (Android == null
+				&& GTK == null
+				&& iOS == null
+				&& macOS == null
+				&& Tizen == null
+				&& UWP == null
+				&& WPF == null
+				&& Default == null) {
 				var lineInfo = serviceProvider?.GetService<IXmlLineInfoProvider>()?.XmlLineInfo ?? new XmlLineInfo();
 				throw new XamlParseException("OnPlatformExtension requires a non-null value to be specified for at least one platform or Default.", lineInfo);
 			}
@@ -60,11 +61,34 @@ namespace Xamarin.Forms.Xaml
 				return Converter.Convert(value, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);
 
 			var converterProvider = serviceProvider?.GetService<IValueConverterProvider>();
+			if (converterProvider != null) {
+				MemberInfo minforetriever()
+				{
+					if (pi != null)
+						return pi;
 
-			if (converterProvider != null)
-				return converterProvider.Convert(value, propertyType, () => pi, serviceProvider);
-			else
-				return value.ConvertTo(propertyType, () => pi, serviceProvider);
+					MemberInfo minfo = null;
+					try {
+						minfo = bp.DeclaringType.GetRuntimeProperty(bp.PropertyName);
+					}
+					catch (AmbiguousMatchException e) {
+						IXmlLineInfo lineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+						throw new XamlParseException($"Multiple properties with name '{bp.DeclaringType}.{bp.PropertyName}' found.", lineInfo, innerException: e);
+					}
+					if (minfo != null)
+						return minfo;
+					try {
+						return bp.DeclaringType.GetRuntimeMethod("Get" + bp.PropertyName, new[] { typeof(BindableObject) });
+					}
+					catch (AmbiguousMatchException e) {
+						IXmlLineInfo lineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+						throw new XamlParseException($"Multiple methods with name '{bp.DeclaringType}.Get{bp.PropertyName}' found.", lineInfo, innerException: e);
+					}
+				}
+
+				return converterProvider.Convert(value, propertyType, minforetriever, serviceProvider);
+			}
+			return value.ConvertTo(propertyType, () => pi, serviceProvider);
 		}
 
 		object GetValue()


### PR DESCRIPTION
### Description of Change ###

Up to now, OnPlatform and OnIdiom markup extensions were checking for
type converters on
- target type
- the property being set

in case of a bindable property, the converter on the BP getter or
GetBP() static method (for attached BPs) wasn't checked.

This PR adds the check for that, plus a unit test.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4319

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
