### PR TITLE
[C] avoid Enum.TryParse for resolving NamedSizes

### DIFF
--- a/Xamarin.Forms.Core/FontSizeConverter.cs
+++ b/Xamarin.Forms.Core/FontSizeConverter.cs
@@ -4,30 +4,40 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms
 {
-	[Xaml.TypeConversion(typeof(double))]
+	[TypeConversion(typeof(double))]
 	public class FontSizeConverter : TypeConverter, IExtendedTypeConverter
 	{
 		[Obsolete("IExtendedTypeConverter.ConvertFrom is obsolete as of version 2.2.0. Please use ConvertFromInvariantString (string, IServiceProvider) instead.")]
 		object IExtendedTypeConverter.ConvertFrom(CultureInfo culture, object value, IServiceProvider serviceProvider)
-		{
-			return ((IExtendedTypeConverter)this).ConvertFromInvariantString(value as string, serviceProvider);
-		}
+			=> ((IExtendedTypeConverter)this).ConvertFromInvariantString(value as string, serviceProvider);
 
 		object IExtendedTypeConverter.ConvertFromInvariantString(string value, IServiceProvider serviceProvider)
 		{
-			if (value != null)
-			{
-				double size;
-				if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out size))
+			if (value != null) {
+				value = value.Trim();
+				if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out double size))
 					return size;
+
 				var ignoreCase = (serviceProvider?.GetService(typeof(IConverterOptions)) as IConverterOptions)?.IgnoreCase ?? false;
-				NamedSize namedSize;
-				if (Enum.TryParse(value, ignoreCase, out namedSize))
-				{
-					Type type;
-					var valueTargetProvider = serviceProvider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
-					type = valueTargetProvider != null ? valueTargetProvider.TargetObject.GetType() : typeof(Label);
-					return Device.GetNamedSize(namedSize, type, false);
+				var sc = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+				NamedSize? namedSize = null;
+
+				if (value.Equals(nameof(NamedSize.Default), sc))
+					namedSize = NamedSize.Default;
+				else if (value.Equals(nameof(NamedSize.Micro), sc))
+					namedSize = NamedSize.Micro;
+				else if (value.Equals(nameof(NamedSize.Small), sc))
+					namedSize = NamedSize.Small;
+				else if (value.Equals(nameof(NamedSize.Medium), sc))
+					namedSize = NamedSize.Medium;
+				else if (value.Equals(nameof(NamedSize.Large), sc))
+					namedSize = NamedSize.Large;
+				else if (Enum.TryParse(value, ignoreCase, out NamedSize ns))
+					namedSize = ns;
+
+				if (namedSize.HasValue) {
+					var type = serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget valueTargetProvider ? valueTargetProvider.TargetObject.GetType() : typeof(Label);
+					return Device.GetNamedSize(namedSize.Value, type, false);
 				}
 			}
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(double)));
@@ -35,13 +45,22 @@ namespace Xamarin.Forms
 
 		public override object ConvertFromInvariantString(string value)
 		{
-			if (value != null)
-			{
-				double size;
-				if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out size))
+			if (value != null) {
+				if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out double size))
 					return size;
-				NamedSize namedSize;
-				if (Enum.TryParse(value, out namedSize))
+				value = value.Trim();
+
+				if (value.Equals(nameof(NamedSize.Default), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Default, typeof(Label), false);
+				if (value.Equals(nameof(NamedSize.Micro), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Micro, typeof(Label), false);
+				if (value.Equals(nameof(NamedSize.Small), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Small, typeof(Label), false);
+				if (value.Equals(nameof(NamedSize.Medium), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Medium, typeof(Label), false);
+				if (value.Equals(nameof(NamedSize.Large), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Large, typeof(Label), false);
+				if (Enum.TryParse(value, out NamedSize namedSize))
 					return Device.GetNamedSize(namedSize, typeof(Label), false);
 			}
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(double)));


### PR DESCRIPTION
### Description of Change ###

Enum.TryParse is quite expensive. replace that by simple value check for
known values. Keep the TryParse as a safeguard in case we ever add new
values to it.


<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

/

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
