### PR TITLE
[Android] set image to null when view is disposed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4484.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4484.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4484, "[Android] ImageButton inside NavigationView.TitleView throw exception during device rotation",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Image)]
+#endif
+	public class Issue4484 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			ContentPage page = new ContentPage();
+
+			NavigationPage.SetTitleView(page,
+				new StackLayout()
+				{
+					Orientation = StackOrientation.Horizontal,
+					Children =
+					{
+						new Button(){ Image = "bank", AutomationId="bank"},
+						new Image(){Source = "bank"},
+						new ImageButton{Source = "bank"}
+					}
+				});
+
+			page.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						Text = "Rotate device. If it doesn't crash then test has passed",
+						AutomationId = "Instructions"
+					}
+				}
+			};
+
+			PushAsync(page);
+		}
+
+#if UITEST
+		[Test]
+		public void RotatingDeviceDoesntCrashTitleView()
+		{
+			RunningApp.WaitForElement("Instructions");
+			RunningApp.SetOrientationLandscape();
+			RunningApp.WaitForElement("Instructions");
+			RunningApp.SetOrientationPortrait();
+			RunningApp.WaitForElement("Instructions");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -17,6 +17,7 @@
       <DependentUpon>Issue1588.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4484.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3509.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Github3856.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1937.cs" />

--- a/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml.cs
@@ -153,7 +153,20 @@ namespace Xamarin.Forms.Controls.GalleryPages
 
 			var label = new Label { Text = "hello", HorizontalOptions = LayoutOptions.Start, BackgroundColor = Color.Yellow };
 			var label2 = new Label { Text = "hello 2", HorizontalOptions = LayoutOptions.Start, BackgroundColor = Color.Yellow };
-			grid.Children.Add(label);
+			grid.Children.Add(
+				new StackLayout()
+				{
+					Orientation = StackOrientation.Horizontal,
+					Children =
+					{
+						label,
+						new ImageButton()
+						{
+							Source = "bank"
+						}
+					}
+				});
+
 			grid.Children.Add(label2);
 			Grid.SetRow(label2, 1);
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
@@ -28,6 +28,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			renderer.ElementPropertyChanged -= OnElementPropertyChanged;
 			renderer.ElementChanged -= OnElementChanged;
 			renderer.LayoutChange -= OnLayoutChange;
+
+			if (renderer.View is ImageView imageView)
+				imageView.SetImageDrawable(null);
 		}
 
 		async static void OnElementChanged(object sender, VisualElementChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###
Set the ImageViews drawable to null otherwise when the view is removed it tries to recreate the imageview because of leaks


### Issues Resolved ### 
- fixes #4484 

### Platforms Affected ### 
- Android


### Testing Procedure ###
Run the added UI Test (4484) and rotate the device a bunch

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
