### PR TITLE
[UWP] Prevent Layouts with no background color from being input transparent

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4360.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4360.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue4360">
+    <ContentPage.Content>
+       <StackLayout HorizontalOptions="FillAndExpand" HeightRequest="50">
+            <StackLayout.GestureRecognizers>
+                <TapGestureRecognizer Tapped="TapGestureRecognizer_OnTapped"/>
+            </StackLayout.GestureRecognizers>
+            
+            <Label x:Name="Label" BackgroundColor="Red" VerticalOptions="FillAndExpand" VerticalTextAlignment="Center" 
+					Text="Tap next to this label (not on it); If the text changes to 'Success', the test has passed." 
+					HorizontalOptions="Center" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4360.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4360.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4360, "UWP: TapGestureRecognizer works on Layout only if BackgroundColor is set", 
+		PlatformAffected.UWP)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Issue4360 : ContentPage
+	{
+		const string Success = "Success";
+
+		public Issue4360()
+		{
+			InitializeComponent();
+		}
+
+		void TapGestureRecognizer_OnTapped(object sender, EventArgs e)
+		{
+			Label.Text = Success;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -411,6 +411,10 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue4136.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4262.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4360.xaml.cs">
+      <DependentUpon>Issue4360.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />
@@ -1051,6 +1055,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4194.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4360.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -617,6 +617,16 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				RemoveBackgroundLayer();
 				IsHitTestVisible = Element.IsEnabled && !Element.InputTransparent;
+
+				if (!IsHitTestVisible)
+				{
+					return;
+				}
+
+				if (Element is Layout && Background == null)
+				{
+					Background = new SolidColorBrush(Windows.UI.Colors.Transparent);
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

On UWP, a Panel with no Background Brush set is automatically invisible to hit testing. Since XF Layouts are rendered with a Panel, this means that a Layout with no BackgroundColor value set will be natively hit test invisible even if the Layout itself is enable and not input transparent. 

This change addresses the problem by setting a Transparent background Brush for the Panel when the Layout has no BackgroundColor but should be hit test visible.

### Issues Resolved ### 

- fixes #4360

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

In Control Gallery, navigate to Issue 4360 and follow the on-screen instructions.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
