### PR TITLE
[C] fallback nicely in case of IndexOutOfRangeEx

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -610,15 +610,16 @@ namespace Xamarin.Forms
 				{
 					if (IsIndexer)
 					{
-						try
-						{
+						try {
 							value = LastGetter.Invoke(value, Arguments);
 						}
-						catch (TargetInvocationException ex)
-						{
-							if (!(ex.InnerException is KeyNotFoundException))
-								throw;
-							value = null;
+						catch (TargetInvocationException ex) {
+							if (ex.InnerException is KeyNotFoundException || ex.InnerException is IndexOutOfRangeException) {
+								value = null;
+								return false;
+							}
+							else
+								throw ex.InnerException;
 						}
 						return true;
 					}

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -197,7 +197,7 @@ namespace Xamarin.Forms.Internals
 				if (isTSource) {
 					try {
 						value = GetSourceValue(_getter((TSource)sourceObject), property.ReturnType);
-					} catch (Exception ex) when (ex is NullReferenceException || ex is KeyNotFoundException) {
+					} catch (Exception ex) when (ex is NullReferenceException || ex is KeyNotFoundException || ex is IndexOutOfRangeException) {
 					}
 				}
 				if (!BindingExpression.TryConvert(ref value, property, property.ReturnType, true)) {

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4516.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4516.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4516">
+	<Image x:Name="image" Source="{Binding Images[0], FallbackValue='foo.jpg'}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4516.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4516.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh4516VM {
+		public Uri[] Images { get; } = { };
+	}
+
+	public partial class Gh4516 : ContentPage
+	{
+		public Gh4516() => InitializeComponent();
+		public Gh4516(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[TestCase(true), TestCase(false)]
+			public void BindingToEmptyCollection(bool useCompiledXaml)
+			{
+				Gh4516 layout = null;
+				Assert.DoesNotThrow(() => layout = new Gh4516(useCompiledXaml) { BindingContext = new Gh4516VM() });
+				Assert.That((layout.image.Source as FileImageSource).File, Is.EqualTo("foo.jpg"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

This PR does 3 things:
- In case of Binding path with indexer, lookout for
  IndexOutOfRangeException in addition to KeyNotFoundException.
- in case of KeyNotFound or IndexOutOfRange, use the FallbackValue if
  any.
- in case of an uncaught exception, throw that exception instead of a
  TargetInvocationException.

### Issues Resolved ### 

- fixes #4516

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
