### PR TITLE
[WIP] support compiled binding to arrays

### DIFF
--- a/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
@@ -193,6 +193,18 @@ namespace Xamarin.Forms.Build.Tasks
 		}
 
 		public static MethodReference ImportMethodReference(this ModuleDefinition module,
+															TypeReference type,
+															string methodName)
+		{
+			var methodKey = $"{type}.{methodName}()";
+			if (MethodRefCache.TryGetValue((module, methodKey), out var methodReference))
+				return methodReference;
+			methodReference = module.ImportMethodReference(type, methodName, null, null);
+			MethodRefCache.Add((module, methodKey), methodReference);
+			return methodReference;
+		}
+
+		public static MethodReference ImportMethodReference(this ModuleDefinition module,
 															(string assemblyName, string clrNamespace, string typeName) type,
 															string methodName,
 															(string assemblyName, string clrNamespace, string typeName)[] parameterTypes,

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4524.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4524.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4524"
+		x:DataType="local:Gh4524VM">
+	<Image x:Name="image" Source="{Binding Images[0], Mode=OneTime}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4524.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4524.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh4524VM {
+		public Uri[] Images { get; } = { new Uri("file://foo.jpg", UriKind.RelativeOrAbsolute)};
+	}
+
+	public partial class Gh4524 : ContentPage
+	{
+		public Gh4524() => InitializeComponent();
+
+		public Gh4524(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[TestCase(true), TestCase(false)]
+			public void BindingCompilerIndexers(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(Gh4524));
+				var layout = new Gh4524(useCompiledXaml) { BindingContext = new Gh4524VM() };
+				Assert.That((layout.image.Source as UriImageSource).Uri.ToString(), Is.EqualTo("file://foo.jpg/"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Allow bindings to arrays to be compiled.
This is still work in progress, I still have to fix
- setters
- handlers
- value types arrays

### Issues Resolved ### 

- fixes #4524

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
