### PR TITLE
[UWP] fixes control render by ViewToRendererConverter in off screen

### DIFF
--- a/Xamarin.Forms.Platform.UAP/TitleViewManager.cs
+++ b/Xamarin.Forms.Platform.UAP/TitleViewManager.cs
@@ -21,9 +21,8 @@ namespace Xamarin.Forms.Platform.UWP
 			_titleViewRendererController = titleViewRendererController;
 			_titleViewRendererController.TitleViewPresenter.Loaded += OnTitleViewPresenterLoaded;
 
-			// Uncomment once https://github.com/xamarin/Xamarin.Forms/issues/4116 is fixed
-			// CommandBar.LayoutUpdated += commandLayoutUpdated;
-			// CommandBar.Unloaded += commandBarUnloaded;
+			CommandBar.LayoutUpdated += commandLayoutUpdated;
+			CommandBar.Unloaded += commandBarUnloaded;
 		}
 
 		internal void OnTitleViewPropertyChanged()

--- a/Xamarin.Forms.Platform.UAP/ViewToRendererConverter.cs
+++ b/Xamarin.Forms.Platform.UAP/ViewToRendererConverter.cs
@@ -68,7 +68,18 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				_view.IsInNativeLayout = true;
 				Layout.LayoutChildIntoBoundingRegion(_view, new Rectangle(0, 0, finalSize.Width, finalSize.Height));
-				FrameworkElement?.Arrange(new Rect(_view.X, _view.Y, _view.Width, _view.Height));
+
+				if (_view.Width <= 0 || _view.Height <= 0)
+				{
+					// Hide Panel when size _view is empty.
+					// It is necessary that this element does not overlap other elements when it should be hidden.
+					Opacity = 0;
+				}
+				else
+				{
+					Opacity = 1;
+					FrameworkElement?.Arrange(new Rect(_view.X, _view.Y, _view.Width, _view.Height));
+				}
 				_view.IsInNativeLayout = false;
 
 				return finalSize;


### PR DESCRIPTION
### Description of Change ###

If a control rendered by `ViewToRendererConverter` is off the screen sizes of the control could be negative, which caused an error. To avoid exception a control don't call Arrage and the panel becomes completely transparent.

### Issues Resolved ### 

- fixes #4463 
- fixes #4116

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

When you change the width of the TitleView, the width of the control automatically changes.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- Go to Navigation Control Gallery (Legacy) which should render a searchbar in the header
- Size the window down horizontally so that the SearchBar is no longer in view
- Сrash should not be

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
