### PR TITLE
Add missing update of items source for iOS CollectionView

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -191,7 +191,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			ElementPropertyChanged?.Invoke(this, changedProperty);
 
-			// TODO hartez 2018/10/24 10:41:55 If the ItemTemplate changes between set and null, we need to make sure to clear the recyclerview pool	
+			// TODO hartez 2018/10/24 10:41:55 If the ItemTemplate changes from set to null, we need to make sure to clear the recyclerview pool	
 
 			if (changedProperty.Is(ItemsView.ItemsSourceProperty))
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewController.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Platform.iOS
 	// TODO hartez 2018/06/01 14:21:24 Add a method for updating the layout	
 	internal class CollectionViewController : UICollectionViewController
 	{
-		readonly IItemsViewSource _itemsSource;
+		IItemsViewSource _itemsSource;
 		readonly ItemsView _itemsView;
 		readonly ItemsViewLayout _layout;
 		bool _initialConstraintsSet;
@@ -66,6 +66,13 @@ namespace Xamarin.Forms.Platform.iOS
 				_layout.ConstrainTo(CollectionView.Bounds.Size);
 				_initialConstraintsSet = true;
 			}
+		}
+
+		public virtual void UpdateItemsSource()
+		{
+			_itemsSource =  ItemsSourceFactory.Create(_itemsView.ItemsSource, CollectionView);
+			CollectionView.ReloadData();
+			CollectionView.CollectionViewLayout.InvalidateLayout();
 		}
 
 		protected virtual void UpdateDefaultCell(DefaultCell cell, NSIndexPath indexPath)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using Foundation;
 using UIKit;
@@ -39,6 +40,16 @@ namespace Xamarin.Forms.Platform.iOS
 			SetUpNewElement(e.NewElement);
 			
 			base.OnElementChanged(e);
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs changedProperty)
+		{
+			base.OnElementPropertyChanged(sender, changedProperty);
+
+			if (changedProperty.Is(ItemsView.ItemsSourceProperty))
+			{
+				_collectionViewController.UpdateItemsSource();
+			}
 		}
 
 		protected virtual ItemsViewLayout SelectLayout(IItemsLayout layoutSpecification)


### PR DESCRIPTION
### Description of Change ###

CollectionView on iOS is not watching for changes to entire items source; this change adds the watch and updates the view accordingly.

### Issues Resolved ### 

- fixes #4474

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

In Control Gallery, navigate to CollectionView Gallery -> Snap Points Gallery and choose any option. In the "Item Count" Entry, change the number and hit the "Update" button. The number of items in the collection should change.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
