### PR TITLE
Modify Android and iOS adapters to handle null items sources

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGallery.cs
@@ -16,6 +16,8 @@
 					Children =
 					{
 						descriptionLabel,
+						GalleryBuilder.NavButton("EmptyView (null ItemsSource)", () =>
+							new EmptyViewNullGallery(), Navigation),
 						GalleryBuilder.NavButton("EmptyView (String)", () =>
 							new EmptyViewStringGallery(), Navigation),
 						GalleryBuilder.NavButton("EmptyView (View)", () =>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewNullGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewNullGallery.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.EmptyViewGalleries.EmptyViewNullGallery">
+    <ContentPage.Content>
+			<CollectionView x:Name="CollectionView">
+				<CollectionView.ItemsLayout>
+					<GridItemsLayout Span="3" Orientation="Vertical"></GridItemsLayout>
+				</CollectionView.ItemsLayout>
+				<CollectionView.EmptyView>
+					Nothing to display.
+				</CollectionView.EmptyView>
+			</CollectionView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewNullGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewNullGallery.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.EmptyViewGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class EmptyViewNullGallery : ContentPage
+	{
+		public EmptyViewNullGallery()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
   </ItemGroup>
-  
+
   <Target Name="CreateControllGalleryConfig" BeforeTargets="Build">
     <CreateItem Include="blank.config">
       <Output TaskParameter="Include" ItemName="ConfigFile" />

--- a/Xamarin.Forms.Platform.Android/CollectionView/EmptySource.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EmptySource.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal class EmptySource : IItemsViewSource
+	{
+		public int Count => 0;
+
+		public object this[int index] => throw new IndexOutOfRangeException("IItemsViewSource is empty");
+	}
+}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
@@ -9,6 +9,11 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		public static IItemsViewSource Create(IEnumerable itemsSource, RecyclerView.Adapter adapter)
 		{
+			if (itemsSource == null)
+			{
+				return new EmptySource();
+			}
+
 			switch (itemsSource)
 			{
 				case IList _ when itemsSource is INotifyCollectionChanged:

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -75,6 +75,7 @@
     <Compile Include="BorderBackgroundManager.cs" />
     <Compile Include="CollectionView\CarouselViewRenderer.cs" />
     <Compile Include="CollectionView\DataChangeObserver.cs" />
+    <Compile Include="CollectionView\EmptySource.cs" />
     <Compile Include="CollectionView\EmptyViewAdapter.cs" />
     <Compile Include="CollectionView\ItemsViewAdapter.cs" />
     <Compile Include="CollectionView\EdgeSnapHelper.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewController.cs
@@ -143,8 +143,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 		UICollectionViewCell GetPrototype()
 		{
+			if (_itemsSource.Count == 0)
+			{
+				return null;
+			}
+
 			// TODO hartez assuming this works, we'll need to evaluate using this nsindexpath (what about groups?)
-			// TODO hartez Also, what about situations where there is no data which matches the path?
 			var indexPath = NSIndexPath.Create(0, 0);
 			return GetCell(CollectionView, indexPath);
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewRenderer.cs
@@ -13,7 +13,6 @@ namespace Xamarin.Forms.Platform.iOS
 		}
 	}
 
-	// TODO hartez 2018/05/30 08:58:42 This follows the same basic scheme as RecyclerView.Adapter; you should be able to reuse the same wrapper class for the IEnumerable	
 	//// TODO hartez 2018/05/30 09:05:38 Think about whether this Controller and/or the new Adapter should be internal or public
 	public class CollectionViewRenderer : ViewRenderer<CollectionView, UIView>
 	{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/EmptySource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/EmptySource.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	internal class EmptySource : IItemsViewSource
+	{
+		public int Count => 0;
+
+		public object this[int index] => null;
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/EmptySource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/EmptySource.cs
@@ -6,6 +6,6 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		public int Count => 0;
 
-		public object this[int index] => null;
+		public object this[int index] => throw new IndexOutOfRangeException("IItemsViewSource is empty");
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsSourceFactory.cs
@@ -9,6 +9,11 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		public static IItemsViewSource Create(IEnumerable itemsSource, UICollectionView collectionView)
 		{
+			if (itemsSource == null)
+			{
+				return new EmptySource();
+			}
+
 			switch (itemsSource)
 			{
 				case IList _ when itemsSource is INotifyCollectionChanged:

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -114,6 +114,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CellExtensions.cs" />
     <Compile Include="CADisplayLinkTicker.cs" />
+    <Compile Include="CollectionView\EmptySource.cs" />
     <Compile Include="CollectionView\IItemsViewSource.cs" />
     <Compile Include="CollectionView\ItemsSourceFactory.cs" />
     <Compile Include="CollectionView\ItemsViewCell.cs" />


### PR DESCRIPTION
### Description of Change ###

The CollectionView on Android and iOS throws an exception if no `ItemsSource` is set before the renderers kick in. This change allows both platforms to handle a `null` `ItemsSource`.

### Issues Resolved ### 

- fixes #4366 

### API Changes ###

 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

In Control Gallery, navigate to CollectionViewGallery -> EmptyView Galleries -> EmptyView (null ItemsSource). Navigation should be successful and the application should not crash.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
