### PR TITLE
Fix edge case in unsubscribing weak events

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/WeakEventManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/WeakEventManagerTests.cs
@@ -190,6 +190,21 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void RemoveHandlerWithMultipleSubscriptionsRemovesOne()
+		{
+			int beforeRun = s_count;
+
+			var source = new TestEventSource();
+			source.TestEvent += Handler;
+			source.TestEvent += Handler;
+			source.TestEvent -= Handler;
+
+			source.FireTestEvent();
+
+			Assert.AreEqual (beforeRun + 1, s_count);
+		}
+
+		[Test]
 		public void StaticHandlerShouldRun()
 		{
 			int beforeRun = s_count;

--- a/Xamarin.Forms.Core/WeakEventManager.cs
+++ b/Xamarin.Forms.Core/WeakEventManager.cs
@@ -153,6 +153,7 @@ namespace Xamarin.Forms
 				}
 
 				subscriptions.Remove(current);
+				break;
 			}
 		}
 


### PR DESCRIPTION
When an event has two subscriptions to the same handler,
unsubscribing cleared all the handlers, not only one.

### Description of Change ###
I added a break to stop unsubscribing after the first successful one.

### Issues Resolved ### 
I think this was not reported before.

### API Changes ###
None

### Platforms Affected ### 
Core

### Behavioral/Visual Changes ###
Subscribing to a weak event twice and unsubscribing once will unsubscribe only once.

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
I found the issue in a unit test, where doing a swap of two elements in a modified ObservableCollection made one of them lose all the PropertyChanged subscriptions.

### PR Checklist ###

- [X] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
