### PR TITLE
[C] Expose Application.LogWarningsListener

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -24,35 +24,10 @@ namespace Xamarin.Forms
 
 		static SemaphoreSlim SaveSemaphore = new SemaphoreSlim(1, 1);
 
-		static Lazy<DelegateLogListener> _applicationOutputListener;
-		static bool _logWarningsToApplicationOutput;
-
-		public static bool LogWarningsToApplicationOutput
-		{
-			get => _logWarningsToApplicationOutput;
-			set
-			{
-				_logWarningsToApplicationOutput = value;
-
-				if (_logWarningsToApplicationOutput)
-				{
-					if (!Log.Listeners.Contains(_applicationOutputListener.Value))
-					{
-						Log.Listeners.Add(_applicationOutputListener.Value);
-					}
-				}
-				else
-				{
-					if (Log.Listeners.Contains(_applicationOutputListener.Value))
-					{
-						Log.Listeners.Remove(_applicationOutputListener.Value);
-					}
-				}
-			}
-		}
+		[Obsolete("Assign the LogWarningsListener")]
+		public static bool LogWarningsToApplicationOutput { get; set; }
 
 		bool MainPageSet { get; set; }
-		
 
 		public Application()
 		{
@@ -65,10 +40,6 @@ namespace Xamarin.Forms
 			SystemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
 			SystemResources.ValuesChanged += OnParentResourcesChanged;
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Application>>(() => new PlatformConfigurationRegistry<Application>(this));
-			_applicationOutputListener = new Lazy<DelegateLogListener>(() => new DelegateLogListener((arg1, arg2) =>
-			{
-				Debug.WriteLine($"{arg1}: {arg2}");
-			}));
 		}
 
 		public void Quit()

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -374,7 +374,7 @@ namespace Xamarin.Forms
 				throw new ArgumentNullException(nameof(property));
 			if (checkAccess && property.IsReadOnly)
 			{
-				Log.Warning("Can not set the BindableProperty \"{0}\" because it is readonly.", property.PropertyName);
+				Log.Warning("BindableObject", "Can not set the BindableProperty \"{0}\" because it is readonly.", property.PropertyName);
 				return;
 			}
 

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -371,10 +371,10 @@ namespace Xamarin.Forms
 			bool converted = (privateAttributes & SetValuePrivateFlags.Converted) != 0;
 
 			if (property == null)
-				throw new ArgumentNullException("property");
+				throw new ArgumentNullException(nameof(property));
 			if (checkAccess && property.IsReadOnly)
 			{
-				Debug.WriteLine("Can not set the BindableProperty \"{0}\" because it is readonly.", property.PropertyName);
+				Log.Warning("Can not set the BindableProperty \"{0}\" because it is readonly.", property.PropertyName);
 				return;
 			}
 

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -498,7 +498,7 @@ namespace Xamarin.Forms
 			if (newValue != null && lv.GroupDisplayBinding != null)
 			{
 				lv.GroupDisplayBinding = null;
-				Debug.WriteLine("GroupHeaderTemplate and GroupDisplayBinding can not be set at the same time, setting GroupDisplayBinding to null");
+				Log.Warning("GroupHeaderTemplate and GroupDisplayBinding can not be set at the same time, setting GroupDisplayBinding to null");
 			}
 		}
 

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -498,7 +498,7 @@ namespace Xamarin.Forms
 			if (newValue != null && lv.GroupDisplayBinding != null)
 			{
 				lv.GroupDisplayBinding = null;
-				Log.Warning("GroupHeaderTemplate and GroupDisplayBinding can not be set at the same time, setting GroupDisplayBinding to null");
+				Log.Warning("ListView", "GroupHeaderTemplate and GroupDisplayBinding can not be set at the same time, setting GroupDisplayBinding to null");
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

The fix proposed in #2911 didn't worked with Release build of XF, aka
the majority of the builds used.
This fix allows the developer to set any logger he might like, but the
plan is to add a default one in the template, that uses Debug.WriteLine,
so it will Log if the user application is build with Debug, and not if
XF binaries are.

This also changes 2 remaining `Debug.WriteLine` into `Log.Warning` in the `Core`

### Issues Resolved ### 

- fixes #1517
- fixes #3873

### API Changes ###

Added:
 - `public static Action<(string Category, string Message)> Application.LogWarningsListerner {get; set;}`
 
### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard