### PR TITLE
[binding] return defaultValueCreator on failure

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -152,12 +152,11 @@ namespace Xamarin.Forms
 			if (needsGetter)
 			{
 				object value = property.DefaultValue;
-				if (part.TryGetValue(current, out value) || part.IsSelf)
-				{
+				if (part.TryGetValue(current, out value) || part.IsSelf) {
 					value = Binding.GetSourceValue(value, property.ReturnType);
 				}
 				else
-					value = Binding.FallbackValue ?? property.DefaultValue;
+					value = Binding.FallbackValue ?? property.GetDefaultValue(target);
 
 				if (!TryConvert(ref value, property, property.ReturnType, true))
 				{

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -193,7 +193,7 @@ namespace Xamarin.Forms.Internals
 				Subscribe((TSource)sourceObject);
 
 			if (needsGetter) {
-				var value = FallbackValue ?? property.DefaultValue;
+				var value = FallbackValue ?? property.GetDefaultValue(target);
 				if (isTSource) {
 					try {
 						value = GetSourceValue(_getter((TSource)sourceObject), property.ReturnType);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2752.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2752.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh2752"
+		x:DataType="local:Gh2752VM"
+		My="{Binding Foo.Bar.Baz}">
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2752.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2752.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh2752VM {
+		public Gh2752VM Foo { get; set; }
+		public Gh2752VM Bar { get; set; }
+		public string Baz { get; set; }
+	}
+	public partial class Gh2752 : ContentPage
+	{
+		public static readonly BindableProperty MyProperty =
+			BindableProperty.Create("My", typeof(string), typeof(Gh2752), default(string), defaultValueCreator: b=> "default created value");
+
+		public string My {
+			get { return (string)GetValue(MyProperty); }
+			set { SetValue(MyProperty, value); }
+		}
+
+		public Gh2752() => InitializeComponent();
+		public Gh2752(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[TestCase(true), TestCase(false)]
+			public void FallbcakToDefaultValueCreator(bool useCompiledXaml)
+			{
+				var layout = new Gh2752(useCompiledXaml) { BindingContext = null };
+				Assert.That(layout.My, Is.EqualTo("default created value"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

if the FallbackValue isn't set, returns the value created by the
defaultValueCreator instead of the DefaultValue when a binding can not
be resolved.

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2752

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
