### PR TITLE
[Android] don't set the tag on ImageButton

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -65,7 +65,9 @@ namespace Xamarin.Forms.Platform.Android
 			SetOnTouchListener(this);
 			OnFocusChangeListener = this;
 
-			Tag = this;
+			// Setting the tag will break Glide
+			// Tag = this;
+
 			_backgroundTracker = new BorderBackgroundManager(this, false);
 		}
 


### PR DESCRIPTION
### Description of Change ###
ImageButton sets it's own tag but it doesn't need to for any reason and this is breaking how it interacts with Glide

### Issues Resolved ### 
https://github.com/jonathanpeppers/glidex/issues/16#issuecomment-441718177

### Platforms Affected ### 
- Android

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
