### PR TITLE
[Xaml] expose XmlnsPrefixAttribute

### DIFF
--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -38,6 +38,7 @@ using Xamarin.Forms.StyleSheets;
 [assembly: Preserve]
 
 [assembly: XmlnsDefinition("http://xamarin.com/schemas/2014/forms", "Xamarin.Forms")]
+[assembly: XmlnsPrefix("http://xamarin.com/schemas/2014/forms", "xf")]
 
 [assembly: StyleProperty("background-color", typeof(VisualElement), nameof(VisualElement.BackgroundColorProperty))]
 [assembly: StyleProperty("background-image", typeof(Page), nameof(Page.BackgroundImageProperty))]

--- a/Xamarin.Forms.Core/XmlnsDefinitionAttribute.cs
+++ b/Xamarin.Forms.Core/XmlnsDefinitionAttribute.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 
-
 namespace Xamarin.Forms
 {
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]

--- a/Xamarin.Forms.Core/XmlnsPrefixAttribute.cs
+++ b/Xamarin.Forms.Core/XmlnsPrefixAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	public sealed class XmlnsPrefixAttribute : Attribute
+	{
+		public XmlnsPrefixAttribute(string xmlNamespace, string prefix)
+		{
+			XmlNamespace = xmlNamespace ?? throw new ArgumentNullException(nameof(xmlNamespace));
+			Prefix = prefix ?? throw new ArgumentNullException(nameof(prefix));
+		}
+
+		public string XmlNamespace { get; }
+		public string Prefix { get; }
+	}
+}


### PR DESCRIPTION
Expose the XmlnsPrefixAttribute, that can be used by external tools to
support object tree serialixation to Xaml.

### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3191

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
