### PR TITLE
Updated MasterDetailPageRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -233,7 +233,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				Device.Info.PropertyChanged -= DeviceInfoPropertyChanged;
 
-				RemoveDrawerListener(this);
+				if (!this.IsDisposed())
+				{
+					RemoveDrawerListener(this);
+				}
 
 				if (Element != null)
 				{


### PR DESCRIPTION
Fix to Objectdisposed crash when closing app

Description of Change
I put the test IsDisposed instead of just call RemoveDrawerListener

Bugs Fixed

fixes #3489

JniPeerMembers.AssertSelf (Java.Interop.IJavaPeerable self)
System.ObjectDisposedException: Cannot access a disposed object. Object name: 'Xamarin.Forms.Platform.Android.AppCompat.MasterDetailPageRenderer'.
