### PR TITLE
Update VisualElement.cs

### DIFF
--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -337,7 +337,7 @@ namespace Xamarin.Forms
 		[TypeConverter(typeof(VisibilityConverter))]
 		public bool IsVisible
 		{
-			get { return (bool)GetValue(IsVisibleProperty); }
+			get { return IsVisibleProperty != null ? (bool)GetValue(IsVisibleProperty) : false; }
 			set { SetValue(IsVisibleProperty, value); }
 		}
 


### PR DESCRIPTION
Fix the error Object reference not set to an instance of an object on IsVisibleProperty

- fixes #4581

<!-- Describe your changes here. -->

### Issues Resolved ### 
System.NullReferenceException: Object reference not set to an instance of an object
  at Xamarin.Forms.BindableObject.GetValue (Xamarin.Forms.BindableProperty property) [0x00016] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.VisualElement.get_IsVisible () [0x00000] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.Layout.OnChildMeasureInvalidated (Xamarin.Forms.VisualElement child, Xamarin.Forms.Internals.InvalidationTrigger trigger) [0x00025] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.Layout.OnChildMeasureInvalidated (System.Object sender, System.EventArgs e) [0x00013] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.VisualElement.InvalidateMeasureInternal (Xamarin.Forms.Internals.InvalidationTrigger trigger) [0x0001d] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.Label.OnTextPropertyChanged (Xamarin.Forms.BindableObject bindable, System.Object oldvalue, System.Object newvalue) [0x0002b] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.BindableObject.SetValueActual (Xamarin.Forms.BindableProperty property, Xamarin.Forms.BindableObject+BindablePropertyContext context, System.Object value, System.Boolean currentlyApplying, Xamarin.Forms.Internals.SetValueFlags attributes, System.Boolean silent) [0x0012a] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.BindableObject.SetValueCore (Xamarin.Forms.BindableProperty property, System.Object value, Xamarin.Forms.Internals.SetValueFlags attributes, Xamarin.Forms.BindableObject+SetValuePrivateFlags privateAttributes) [0x0015b] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.BindableObject.SetValue (Xamarin.Forms.BindableProperty property, System.Object value, System.Boolean fromStyle, System.Boolean checkAccess) [0x0003d] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.BindableObject.SetValue (Xamarin.Forms.BindableProperty property, System.Object value) [0x00000] in <2213e65041254f04b27ae6e57d256a86>:0
  at Xamarin.Forms.Label.set_Text (System.String value) [0x00000] in <2213e65041254f04b27ae6e57d256a86>:0
  at TransisMobileX.View.Conexao.Conexao+<>c__DisplayClass47_0.<AtualizaLabelMensagem>b__0 () [0x00000] in <fcd4fd8ab7b84fe9a0bdaeb3f3221217>:0
  at Java.Lang.Thread+RunnableImplementor.Run () [0x00008] in <616e37f9ed964e569785d5d641b4307c>:0
  at Java.Lang.IRunnableInvoker.n_Run (System.IntPtr jnienv, System.IntPtr native__this) [0x00009] in <616e37f9ed964e569785d5d641b4307c>:0
  at (wrapper dynamic-method) System.Object.24(intptr,intptr)
