### PR TITLE
[build] add a stamp file to shamehat

### DIFF
--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -22,7 +22,17 @@
 	</ItemGroup>
 	<Import Project="..\Xamarin.Flex\Xamarin.Flex.projitems" Label="Shared" Condition="Exists('..\Xamarin.Flex\Xamarin.Flex.projitems')" />
 	<UsingTask TaskName="XFCorePostProcessor.Tasks.FixXFCoreAssembly" AssemblyFile="..\XFCorePostProcessor.Tasks\bin\Debug\net461\XFCorePostProcessor.Tasks.dll" />
-	<Target Condition="$(DesignTimeBuild) != true AND $(BuildingProject) == true" AfterTargets="AfterCompile" Name="ShameHat">
-		<FixXFCoreAssembly Assembly="$(IntermediateOutputPath)$(TargetFileName)" ReferencePath="@(ReferencePath)" />
+	<Target
+		Condition="$(DesignTimeBuild) != true AND $(BuildingProject) == true"
+		AfterTargets="AfterCompile"
+		Name="XFCorePostProcessor"
+		Inputs="$(IntermediateOutputPath)$(TargetFileName)"
+		Outputs="$(IntermediateOutputPath)XFCorePostProcessor.stamp">
+	    <Touch
+		    Files="$(IntermediateOutputPath)XFCorePostProcessor.stamp"
+		    AlwaysCreate="True" />
+	    <FixXFCoreAssembly
+		    Assembly="$(IntermediateOutputPath)$(TargetFileName)"
+		    ReferencePath="@(ReferencePath)" />
 	</Target>
 </Project>


### PR DESCRIPTION
### Description of Change ###

In addition to #4579 that check, in the tool, that the extra
method isn't present, this protects the task itself from being ran
twice.

Both fixes are required for extra performance and safety.

This also removes the last reference to the original name of the tool.
But I'll still remember it fondly, and use it in internal conversations.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4563

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
