### PR TITLE
[Android] Fix ImageSource being set to null and fix ImageCell so it loads images

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4597, "[Android] ImageCell not loading images and setting ImageSource to null has no effect",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Image)]
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue4597 : TestContentPage
+	{
+		ImageButton _imageButton;
+		Button _button;
+		Image _image;
+		ListView _listView;
+
+		string _disappearText = "You should see 4 images. Clicking this should cause the images to all disappear";
+		string _appearText = "Clicking this should cause the images to all appear";
+		string _theListView = "theListViewAutomationId";
+
+		protected override void Init()
+		{
+			string fileName = "coffee";
+			_image = new Image() { Source = fileName, AutomationId = fileName };
+			_button = new Button() { Image = fileName, AutomationId = fileName };
+			_imageButton = new ImageButton() { Source = fileName, AutomationId = fileName };
+			_listView = new ListView()
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var cell = new ImageCell();
+					cell.Disappearing += (_, __) =>
+					{
+						var height = cell.Height;
+						var cellHeight = cell.RenderHeight;
+					};
+					cell.Appearing += (_, __) =>
+					{
+						var height = cell.Height;
+						var cellHeight = cell.RenderHeight;
+
+					};
+					cell.SetBinding(ImageCell.ImageSourceProperty, ".");
+					return cell;
+				}),
+				AutomationId = _theListView,
+				ItemsSource = new[] { fileName },
+				HasUnevenRows = true,
+				BackgroundColor = Color.Purple
+			};
+
+			Button button = null;
+			button =new Button()
+			{
+				AutomationId = "ClickMe",
+				Text = _disappearText,
+				Command = new Command(() =>
+				{
+					if (button.Text == _disappearText)
+					{
+						_image.Source = null;
+						_button.Image = null;
+						_imageButton.Source = null;
+						_listView.ItemsSource = new string[] { null };
+						button.Text = _appearText;
+					}
+					else
+					{
+						_image.Source = fileName;
+						_button.Image = fileName;
+						_imageButton.Source = fileName;
+						_listView.ItemsSource = new string[] { fileName };
+						button.Text = _disappearText;
+					}
+				})
+			};
+
+			var layout = new StackLayout()
+			{
+				Children =
+				{
+					button,
+					_image,
+					_button,
+					_imageButton,
+					_listView,
+				}
+			};
+
+			Content = layout;
+		}
+#if UITEST
+		[Test]
+		public void TestImagesDisappearCorrectly()
+		{
+			RunningApp.WaitForElement("coffee");
+			var elementsBefore = RunningApp.WaitForElement("coffee");
+			var imageCell = RunningApp.Query(app => app.Marked(_theListView).Descendant()).Where(x => x.Class.Contains("Image")).FirstOrDefault();
+
+			Assert.AreEqual(3, elementsBefore.Length);
+			Assert.IsNotNull(imageCell);
+
+			RunningApp.Tap("ClickMe");
+			var elementsAfter = RunningApp.WaitForElement("coffee");
+			var imageCellAfter = RunningApp.Query(app => app.Marked(_theListView).Descendant()).Where(x => x.Class.Contains("Image")).FirstOrDefault();
+			Assert.IsNull(imageCellAfter);
+			Assert.AreEqual(2, elementsAfter.Length);
+
+			foreach(var newElement in elementsAfter)
+			{
+				foreach(var oldElement in elementsBefore)
+				{
+					if(newElement.Class == oldElement.Class)
+					{
+						Assert.IsTrue(newElement.Rect.Height < oldElement.Rect.Height);
+						continue;
+					}
+				}
+			}
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -125,8 +125,6 @@ namespace Xamarin.Forms.Controls.Issues
 			Assert.IsNull(imageCellAfter);
 #if __IOS__
 			Assert.AreEqual(0, elementsAfter.Where(x => x.Class.Contains("Image")).Count());
-#else
-			Assert.AreEqual(2, elementsAfter.Length);
 #endif
 
 #if __ANDROID__

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -111,15 +111,25 @@ namespace Xamarin.Forms.Controls.Issues
 			var elementsBefore = RunningApp.WaitForElement("coffee");
 			var imageCell = RunningApp.Query(app => app.Marked(_theListView).Descendant()).Where(x => x.Class.Contains("Image")).FirstOrDefault();
 
+#if __IOS__
+			Assert.AreEqual(4, elementsBefore.Where(x=> x.Class.Contains("Image")).Count());
+#else
 			Assert.AreEqual(3, elementsBefore.Length);
+#endif
+
 			Assert.IsNotNull(imageCell);
 
 			RunningApp.Tap("ClickMe");
 			var elementsAfter = RunningApp.WaitForElement("coffee");
 			var imageCellAfter = RunningApp.Query(app => app.Marked(_theListView).Descendant()).Where(x => x.Class.Contains("Image")).FirstOrDefault();
 			Assert.IsNull(imageCellAfter);
+#if __IOS__
+			Assert.AreEqual(0, elementsAfter.Where(x => x.Class.Contains("Image")).Count());
+#else
 			Assert.AreEqual(2, elementsAfter.Length);
+#endif
 
+#if __ANDROID__
 			foreach(var newElement in elementsAfter)
 			{
 				foreach(var oldElement in elementsBefore)
@@ -131,7 +141,9 @@ namespace Xamarin.Forms.Controls.Issues
 					}
 				}
 			}
+#endif
+
 		}
 #endif
-	}
+		}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -31,40 +31,29 @@ namespace Xamarin.Forms.Controls.Issues
 		string _disappearText = "You should see 4 images. Clicking this should cause the images to all disappear";
 		string _appearText = "Clicking this should cause the images to all appear";
 		string _theListView = "theListViewAutomationId";
+		string _fileName = "coffee";
 
 		protected override void Init()
 		{
-			string fileName = "coffee";
-			_image = new Image() { Source = fileName, AutomationId = fileName };
-			_button = new Button() { Image = fileName, AutomationId = fileName };
-			_imageButton = new ImageButton() { Source = fileName, AutomationId = fileName };
+			_image = new Image() { Source = _fileName, AutomationId = _fileName };
+			_button = new Button() { Image = _fileName, AutomationId = _fileName };
+			_imageButton = new ImageButton() { Source = _fileName, AutomationId = _fileName };
 			_listView = new ListView()
 			{
 				ItemTemplate = new DataTemplate(() =>
 				{
 					var cell = new ImageCell();
-					cell.Disappearing += (_, __) =>
-					{
-						var height = cell.Height;
-						var cellHeight = cell.RenderHeight;
-					};
-					cell.Appearing += (_, __) =>
-					{
-						var height = cell.Height;
-						var cellHeight = cell.RenderHeight;
-
-					};
 					cell.SetBinding(ImageCell.ImageSourceProperty, ".");
 					return cell;
 				}),
 				AutomationId = _theListView,
-				ItemsSource = new[] { fileName },
+				ItemsSource = new[] { _fileName },
 				HasUnevenRows = true,
 				BackgroundColor = Color.Purple
 			};
 
 			Button button = null;
-			button =new Button()
+			button = new Button()
 			{
 				AutomationId = "ClickMe",
 				Text = _disappearText,
@@ -80,10 +69,10 @@ namespace Xamarin.Forms.Controls.Issues
 					}
 					else
 					{
-						_image.Source = fileName;
-						_button.Image = fileName;
-						_imageButton.Source = fileName;
-						_listView.ItemsSource = new string[] { fileName };
+						_image.Source = _fileName;
+						_button.Image = _fileName;
+						_imageButton.Source = _fileName;
+						_listView.ItemsSource = new string[] { _fileName };
 						button.Text = _disappearText;
 					}
 				})
@@ -107,12 +96,12 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void TestImagesDisappearCorrectly()
 		{
-			RunningApp.WaitForElement("coffee");
-			var elementsBefore = RunningApp.WaitForElement("coffee");
+			RunningApp.WaitForElement(_fileName);
+			var elementsBefore = RunningApp.WaitForElement(_fileName);
 			var imageCell = RunningApp.Query(app => app.Marked(_theListView).Descendant()).Where(x => x.Class.Contains("Image")).FirstOrDefault();
 
 #if __IOS__
-			Assert.AreEqual(4, elementsBefore.Where(x=> x.Class.Contains("Image")).Count());
+			Assert.AreEqual(4, elementsBefore.Where(x => x.Class.Contains("Image")).Count());
 #else
 			Assert.AreEqual(3, elementsBefore.Length);
 #endif
@@ -120,7 +109,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Assert.IsNotNull(imageCell);
 
 			RunningApp.Tap("ClickMe");
-			var elementsAfter = RunningApp.WaitForElement("coffee");
+			var elementsAfter = RunningApp.WaitForElement(_fileName);
 			var imageCellAfter = RunningApp.Query(app => app.Marked(_theListView).Descendant()).Where(x => x.Class.Contains("Image")).FirstOrDefault();
 			Assert.IsNull(imageCellAfter);
 #if __IOS__
@@ -140,8 +129,7 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			}
 #endif
-
 		}
 #endif
-		}
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -18,8 +18,6 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue4597.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue4484.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue3509.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Github3856.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1937.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3809.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -17,6 +17,9 @@
       <DependentUpon>Issue1588.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4597.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4484.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3509.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Github3856.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1937.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3809.cs" />

--- a/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
@@ -24,13 +24,13 @@ namespace Xamarin.Forms.Platform.Android
 		{
 
 			IImageController imageController = newView as IImageController;
-			newImageSource = newView?.Source;
-			previousImageSource = previousView?.Source;
+			newImageSource = newImageSource ?? newView?.Source;
+			previousImageSource = previousImageSource ?? previousView?.Source;
 
-			if (newImageSource == null || imageView.IsDisposed())
+			if (imageView.IsDisposed())
 				return;
 
-			if (Equals(previousImageSource, newImageSource))
+			if (newImageSource != null && Equals(previousImageSource, newImageSource))
 				return;
 
 			imageController?.SetIsLoading(true);


### PR DESCRIPTION
### Description of Change ###
Set the ImageView to null if the ImageSource is set to null. 
Fix ImageCell 

### Issues Resolved ### 
- fixes #4597
- fixes #4584

 None

### Platforms Affected ### 
- Android


### Testing Procedure ###
Go to the included UI test and follow the instructions

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
