### PR TITLE
[Core] remove code setting NavProxy to null

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -36,6 +37,26 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.That(shell.CurrentItem, Is.EqualTo(shellItem));
 		}
+
+		[Test]
+		public void NavigationProxyWireUpTest()
+		{
+			var page = new ContentPage();
+			var shell = new Shell();
+			var shellItem = new ShellItem();
+			var shellSection = new ShellSection();
+			var shellContent = new ShellContent { Content = page };
+			shellSection.Items.Add(shellContent);
+			shellItem.Items.Add(shellSection);
+			shell.Items.Add(shellItem);
+
+			NavigationProxy proxy = page.NavigationProxy.Inner as NavigationProxy;
+			Assert.IsNotNull(proxy);
+
+			NavigationProxy shellProxy = proxy.Inner as ShellSection.NavigationImpl;
+			Assert.IsNotNull(shellProxy);
+		}
+
 
 		[Test]
 		public void CurrentItemDoesNotChangeOnSecondAdd()

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -771,22 +771,6 @@ namespace Xamarin.Forms
 #pragma warning restore 0618
 		}
 
-		protected override void OnParentSet()
-		{
-#pragma warning disable 0618 // retain until ParentView removed
-			base.OnParentSet();
-
-			if (ParentView != null)
-			{
-				NavigationProxy.Inner = ParentView.NavigationProxy;
-			}
-			else
-			{
-				NavigationProxy.Inner = null;
-			}
-#pragma warning restore 0618	    
-		}
-
 		protected virtual void OnSizeAllocated(double width, double height)
 		{
 		}


### PR DESCRIPTION
### Description of Change ###
The code in the original squash removed the code that set the NavProxy to null
https://github.com/xamarin/Xamarin.Forms/blob/shell-squash/Xamarin.Forms.Core/VisualElement.cs#L638

Setting that null in shell is causing the navproxy chain from the page to the shell to break

I'm guessing somewhere along the merge path the code got added back in. 

### Issues Resolved ### 

- fixes #4603 

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
### Testing Procedure ###
Run the shell store in the gallery and test pushing and popping pages

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
