### PR TITLE
[Android] Fixes keyboard navigation in custom view

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -40,7 +40,7 @@ using Xamarin.Forms.Controls.Issues;
 //[assembly: ExportRenderer(typeof(AndroidHelpText.HintLabel), typeof(HintLabel))]
 [assembly: ExportRenderer(typeof(QuickCollectNavigationPage), typeof(QuickCollectNavigationPageRenderer))]
 [assembly: ExportRenderer(typeof(Issue4782.Issue4782ImageButton), typeof(Issue4782ImageButtonImageButtonRenderer))]
-
+[assembly: ExportRenderer(typeof(Issue4561.CustomView), typeof(Issue4561CustomViewRenderer))]
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.NoFlashTestNavigationPage), typeof(Xamarin.Forms.ControlGallery.Android.NoFlashTestNavigationPage))]
 
@@ -683,6 +683,78 @@ namespace Xamarin.Forms.ControlGallery.Android
 		{
 			_gridChild = ViewGroup.GetChildAt(0);
 			_gridChild.SetOnTouchListener(this);
+		}
+	}
+
+	[Preserve]
+	public class Issue4561CustomView : LinearLayout
+	{
+		public Issue4561CustomView(Context context)
+			: base(context)
+		{
+			Initialize();
+		}
+
+		public Issue4561CustomView(Context context, IAttributeSet attrs) :
+			base(context, attrs)
+		{
+			Initialize();
+		}
+
+		public Issue4561CustomView(Context context, IAttributeSet attrs, int defStyle) :
+			base(context, attrs, defStyle)
+		{
+			Initialize();
+		}
+
+		void Initialize()
+		{
+			var editText1 = new EditText(Context)
+			{
+				InputType = InputTypes.NumberFlagDecimal,
+				Id = 12345,
+				Text = "customEdit1"
+			};
+			var editText2 = new EditText(Context)
+			{
+				InputType = InputTypes.NumberFlagDecimal,
+				Id = 123456,
+				Text = "customEdit2"
+			};
+
+			editText1.LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.WrapContent);
+			editText2.LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.WrapContent);
+
+			editText1.NextFocusForwardId = editText2.Id;
+			editText2.NextFocusForwardId = editText1.Id;
+
+			AddView(editText1);
+			AddView(editText2);
+
+			Orientation = Orientation.Vertical;
+		}
+	}
+
+	[Preserve]
+	public class Issue4561CustomViewRenderer : ViewRenderer<Issue4561.CustomView, Issue4561CustomView>
+	{
+		public Issue4561CustomViewRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override Issue4561CustomView CreateNativeControl() => new Issue4561CustomView(Context);
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Issue4561.CustomView> e)
+		{
+			base.OnElementChanged(e);
+			if (Element != null)
+			{
+				if (Control == null)
+				{
+					var view = CreateNativeControl();
+					SetNativeControl(view);
+				}
+			}
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4561.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4561.cs
@@ -1,0 +1,26 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers = true)]
+	[Issue (IssueTracker.Github, 4561, "Keyboard navigation does not work", PlatformAffected.Android)]
+	public class Issue4561 : TestContentPage
+	{
+		[Preserve(AllMembers = true)]
+		public class CustomView : View
+		{
+		}
+
+		protected override void Init ()
+		{
+			Content = new StackLayout
+			{
+				Children = {
+					new Label { Text = "Select any editbox below and try using the TAB key navigation. Focus should change from one editbox to another" },
+					new CustomView()
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -403,6 +403,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3558.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3541.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3840.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4561.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3913.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3979.xaml.cs">
       <DependentUpon>Issue3979.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -144,8 +144,20 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected void UpdateTabIndex() => TabIndex = Element.TabIndex;
 
+		bool CheckCustomNextFocus(AView focused, FocusSearchDirection direction)
+		{
+			return direction == FocusSearchDirection.Forward && focused.NextFocusForwardId != NoId ||
+				direction == FocusSearchDirection.Down && focused.NextFocusDownId != NoId ||
+				direction == FocusSearchDirection.Left && focused.NextFocusLeftId != NoId ||
+				direction == FocusSearchDirection.Right && focused.NextFocusRightId != NoId ||
+				direction == FocusSearchDirection.Up && focused.NextFocusUpId != NoId;
+		}
+
 		public override AView FocusSearch(AView focused, [GeneratedEnum] FocusSearchDirection direction)
 		{
+			if (CheckCustomNextFocus(focused, direction))
+				return base.FocusSearch(focused, direction);
+
 			VisualElement element = Element as VisualElement;
 			int maxAttempts = 0;
 			var tabIndexes = element?.GetTabIndexesOnParentPage(out maxAttempts);


### PR DESCRIPTION
### Description of Change ###

In our implementation of `TabStop` in Android dropped the keyboard navigation via native settings `NextFocus<direction>Id`. For fix it added check if `NextFocus<direction>Id` property is set on focused view then returns the native function result. So, `NextFocus<direction>Id` takes precedence over the implementation of `TabStop`.

### Issues Resolved ### 

- fixes #4561 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Controls with custom renderer can use `NextFocus<direction>Id` to customize keyboard navigation.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- run UItest 4561
- select any textbox and try using the TAB key navigation
- focus should change from one textbox to another

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
