### PR TITLE
[Shell] Allow queryParams navigation

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Xamarin.Forms.Internals;
 
@@ -76,13 +77,24 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(shellItem, shell.CurrentItem);
 		}
 
-		ShellSection MakeSimpleShellSection (string route, string contentRoute)
+		ShellSection MakeSimpleShellSection(string route, string contentRoute)
+		{
+			return MakeSimpleShellSection(route, contentRoute, new ShellTestPage());
+		}
+
+		ShellSection MakeSimpleShellSection (string route, string contentRoute, ContentPage contentPage)
 		{
 			var shellSection = new ShellSection();
 			shellSection.Route = route;
-			var shellContent = new ShellContent { Content = new ContentPage(), Route = contentRoute };
+			var shellContent = new ShellContent { Content = contentPage, Route = contentRoute };
 			shellSection.Items.Add(shellContent);
 			return shellSection;
+		}
+
+		[QueryProperty("SomeQueryParameter", "SomeQueryParameter")]
+		public class ShellTestPage : ContentPage
+		{
+			public string SomeQueryParameter { get; set; }
 		}
 
 		[Test]
@@ -113,6 +125,41 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.GoToAsync(new ShellNavigationState("app:///s/two/tabfour/"));
 
 			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tabfour/content/"));
+		}
+
+
+
+		[Test]
+		public async Task NavigationWithQueryStringWhenPageMatchesBindingContext()
+		{
+			var shell = new Shell();
+			shell.Route = "s";
+
+			var one = new ShellItem { Route = "one" };
+			var two = new ShellItem { Route = "two" };
+
+			var tabone = MakeSimpleShellSection("tabone", "content");
+			var tabfour = MakeSimpleShellSection("tabfour", "content", null);
+
+			one.Items.Add(tabone);
+			two.Items.Add(tabfour);
+
+			shell.Items.Add(one);
+			shell.Items.Add(two);
+
+			ShellTestPage pagetoTest = new ShellTestPage();
+			await shell.GoToAsync(new ShellNavigationState($"app:///s/two/tabfour/content?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+			two.CurrentItem.CurrentItem.ContentTemplate = new DataTemplate(() =>
+			{
+				pagetoTest = new ShellTestPage();
+				pagetoTest.BindingContext = pagetoTest;
+				return pagetoTest;
+			});
+
+			
+			var page = (two.CurrentItem.CurrentItem as IShellContentController).GetOrCreateContent();
+			Assert.AreEqual("1234", (page as ShellTestPage).SomeQueryParameter);
+
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -162,6 +162,30 @@ namespace Xamarin.Forms.Core.UnitTests
 
 		}
 
+
+		[Test]
+		public async Task NavigationWithQueryStringAndNoDataTemplate()
+		{
+			var shell = new Shell();
+			shell.Route = "s";
+
+			var one = new ShellItem { Route = "one" };
+			var two = new ShellItem { Route = "two" };
+
+			var tabone = MakeSimpleShellSection("tabone", "content");
+			var tabfour = MakeSimpleShellSection("tabfour", "content");
+
+			one.Items.Add(tabone);
+			two.Items.Add(tabfour);
+
+			shell.Items.Add(one);
+			shell.Items.Add(two);
+
+			await shell.GoToAsync(new ShellNavigationState($"app:///s/two/tabfour/content?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+			Assert.AreEqual("1234", (two.CurrentItem.CurrentItem.Content as ShellTestPage).SomeQueryParameter);
+
+		}
+
 		[Test]
 		public void CancelNavigation()
 		{

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Reflection;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
@@ -104,5 +105,15 @@ namespace Xamarin.Forms
 		}
 		bool IFlowDirectionController.ApplyEffectiveFlowDirectionToChildContainer => true;
 		double IFlowDirectionController.Width => (Parent as VisualElement)?.Width ?? 0;
+
+
+		internal virtual void ApplyQueryAttributes(IDictionary<string, string> query)
+		{
+		}
+	}
+
+	public interface IQuerryAttributable
+	{
+		void ApplyQueryAttributes(IDictionary<string, string> query);
 	}
 }

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Reflection;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
@@ -112,7 +110,7 @@ namespace Xamarin.Forms
 		}
 	}
 
-	public interface IQuerryAttributable
+	public interface IQueryAttributable
 	{
 		void ApplyQueryAttributes(IDictionary<string, string> query);
 	}

--- a/Xamarin.Forms.Core/Shell/QueryPropertyAttribute.cs
+++ b/Xamarin.Forms.Core/Shell/QueryPropertyAttribute.cs
@@ -5,9 +5,8 @@ namespace Xamarin.Forms
 	[AttributeUsage(AttributeTargets.Class)]
 	public class QueryPropertyAttribute : Attribute
 	{
-		public string Name { get; private set; }
-
-		public string QueryId { get; private set; }
+		public string Name { get;  }
+		public string QueryId { get; }
 
 		public QueryPropertyAttribute(string name, string queryId)
 		{

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -429,71 +429,12 @@ namespace Xamarin.Forms
 			baseShellItem.ApplyQueryAttributes(filteredQuery);
 		}
 
-		static string GenerateQueryString(Dictionary<string, string> queryData)
-		{
-			if (queryData.Count == 0)
-				return string.Empty;
-			string result = "?";
-
-			bool addAnd = false;
-			foreach (var kvp in queryData)
-			{
-				if (addAnd)
-					result += "&";
-				result += kvp.Key + "=" + kvp.Value;
-				addAnd = true;
-			}
-
-			return result;
-		}
-
-		static void GetQueryStringData(Element element, bool isLastItem, Dictionary<string, string> result)
-		{
-//			string prefix = string.Empty;
-//			if (!isLastItem)
-//			{
-//				var route = Routing.GetRoute(element);
-//				if (string.IsNullOrEmpty(route) || route.StartsWith(Routing.ImplicitPrefix, StringComparison.Ordinal))
-//					return;
-//				prefix = route + ".";
-//			}
-
-//			var type = element.GetType();
-//			var typeInfo = type.GetTypeInfo();
-
-//#if NETSTANDARD1_0
-//			var effectAttributes = typeInfo.GetCustomAttributes(typeof(QueryPropertyAttribute), true).ToArray();
-//#else
-//			var effectAttributes = type.GetCustomAttributes(typeof(QueryPropertyAttribute), true);
-//#endif
-
-			//if (effectAttributes.Length == 0)
-			//	return;
-
-			//for (int i = 0; i < effectAttributes.Length; i++)
-			//{
-			//	if (effectAttributes[i] is QueryPropertyAttribute attrib)
-			//	{
-			//		PropertyInfo prop = type.GetRuntimeProperty(attrib.Name);
-
-			//		if (prop != null && prop.CanRead && prop.GetMethod.IsPublic)
-			//		{
-			//			var val = (string)prop.GetValue(element);
-			//			var key = isLastItem ? prefix + attrib.QueryId : attrib.QueryId;
-			//			result[key] = val;
-			//		}
-			//	}
-			//}
-		}
-
 		ShellNavigationState GetNavigationState(ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, IReadOnlyList<Page> sectionStack)
 		{
 			StringBuilder stateBuilder = new StringBuilder($"{RouteScheme}://{RouteHost}/{Route}/");
 			Dictionary<string, string> queryData = new Dictionary<string, string>();
 
 			bool stackAtRoot = sectionStack == null || sectionStack.Count <= 1;
-
-			GetQueryStringData(this, false, queryData);
 
 			if (shellItem != null)
 			{
@@ -504,8 +445,6 @@ namespace Xamarin.Forms
 					stateBuilder.Append("/");
 				}
 
-				GetQueryStringData(shellItem, shellSection == null, queryData);
-
 				if (shellSection != null)
 				{
 					var shellSectionRoute = shellSection.Route;
@@ -515,8 +454,6 @@ namespace Xamarin.Forms
 						stateBuilder.Append("/");
 					}
 
-					GetQueryStringData(shellSection, shellContent == null && stackAtRoot, queryData);
-
 					if (shellContent != null)
 					{
 						var shellContentRoute = shellContent.Route;
@@ -525,8 +462,6 @@ namespace Xamarin.Forms
 							stateBuilder.Append(shellContentRoute);
 							stateBuilder.Append("/");
 						}
-
-						GetQueryStringData(shellContent, stackAtRoot, queryData);
 					}
 
 					if (!stackAtRoot)
@@ -535,7 +470,6 @@ namespace Xamarin.Forms
 						{
 							var page = sectionStack[i];
 							stateBuilder.Append(Routing.GetRoute(page));
-							GetQueryStringData(page, i == sectionStack.Count - 1, queryData);
 							if (i < sectionStack.Count - 1)
 								stateBuilder.Append("/");
 						}
@@ -543,7 +477,6 @@ namespace Xamarin.Forms
 				}
 			}
 
-			stateBuilder.Append(GenerateQueryString(queryData));
 			return stateBuilder.ToString();
 		}
 

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -734,9 +734,10 @@ namespace Xamarin.Forms
 			if (_accumulateNavigatedEvents)
 				_accumulatedEvent = args;
 			else {
-				if (args.Current.Location.AbsolutePath.TrimEnd('/') != _lastNavigating.Location.AbsolutePath.TrimEnd('/'))
+				/* Removing this check for now as it doesn't properly cover all implicit scenarios
+				 * if (args.Current.Location.AbsolutePath.TrimEnd('/') != _lastNavigating.Location.AbsolutePath.TrimEnd('/'))
 					throw new InvalidOperationException($"Navigation: Current location doesn't match navigation uri {args.Current.Location.AbsolutePath} != {_lastNavigating.Location.AbsolutePath}");
-
+					*/
 				Navigated?.Invoke(this, args);
 				//System.Diagnostics.Debug.WriteLine("Navigated: " + args.Current.Location);
 			}

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -421,7 +421,7 @@ namespace Xamarin.Forms
 				if (!q.Key.StartsWith(prefix, StringComparison.Ordinal))
 					continue;
 				var key = q.Key.Substring(prefix.Length);
-				if (key.Contains('.'))
+				if (key.Contains("."))
 					continue;
 				filteredQuery.Add(key, q.Value);
 			}

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -413,7 +413,11 @@ namespace Xamarin.Forms
 			}
 
 			if (!(element is BaseShellItem baseShellItem))
-				return;
+			{
+				baseShellItem = element?.Parent as BaseShellItem;
+				if(baseShellItem == null)
+					return;
+			}
 
 			//filter the query to only apply the keys with matching prefix
 			var filteredQuery = new Dictionary<string, string>(query.Count);

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Reflection;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
@@ -8,15 +10,29 @@ namespace Xamarin.Forms
 	[ContentProperty("Content")]
 	public class ShellContent : BaseShellItem, IShellContentController
 	{
-		#region PropertyKeys
-
 		static readonly BindablePropertyKey MenuItemsPropertyKey =
 			BindableProperty.CreateReadOnly(nameof(MenuItems), typeof(MenuItemCollection), typeof(ShellContent), null,
 				defaultValueCreator: bo => new MenuItemCollection());
 
-		#endregion PropertyKeys
+		public static readonly BindableProperty MenuItemsProperty = MenuItemsPropertyKey.BindableProperty;
 
-		#region IShellContentController
+		public static readonly BindableProperty ContentProperty =
+			BindableProperty.Create(nameof(Content), typeof(object), typeof(ShellContent), null, BindingMode.OneTime, propertyChanged: OnContentChanged);
+
+		public static readonly BindableProperty ContentTemplateProperty =
+			BindableProperty.Create(nameof(ContentTemplate), typeof(DataTemplate), typeof(ShellContent), null, BindingMode.OneTime);
+
+		public MenuItemCollection MenuItems => (MenuItemCollection)GetValue(MenuItemsProperty);
+
+		public object Content {
+			get => GetValue(ContentProperty);
+			set => SetValue(ContentProperty, value);
+		}
+
+		public DataTemplate ContentTemplate {
+			get => (DataTemplate)GetValue(ContentTemplateProperty);
+			set => SetValue(ContentTemplateProperty, value);
+		}
 
 		Page IShellContentController.Page => ContentCache;
 
@@ -40,6 +56,12 @@ namespace Xamarin.Forms
 			if (result != null && result.Parent != this)
 				OnChildAdded(result);
 
+
+			if (_delayedQueryParams != null && result  != null) {
+				ApplyQueryAttributes(result, _delayedQueryParams);
+				_delayedQueryParams = null;
+			}
+
 			return result;
 		}
 
@@ -52,16 +74,6 @@ namespace Xamarin.Forms
 			}
 		}
 
-		#endregion IShellContentController
-
-		public static readonly BindableProperty ContentProperty =
-			BindableProperty.Create(nameof(Content), typeof(object), typeof(ShellContent), null, BindingMode.OneTime, propertyChanged: OnContentChanged);
-
-		public static readonly BindableProperty ContentTemplateProperty =
-			BindableProperty.Create(nameof(ContentTemplate), typeof(DataTemplate), typeof(ShellContent), null, BindingMode.OneTime);
-
-		public static readonly BindableProperty MenuItemsProperty = MenuItemsPropertyKey.BindableProperty;
-
 		Page _contentCache;
 		IList<Element> _logicalChildren = new List<Element>();
 		ReadOnlyCollection<Element> _logicalChildrenReadOnly;
@@ -71,19 +83,7 @@ namespace Xamarin.Forms
 			((INotifyCollectionChanged)MenuItems).CollectionChanged += MenuItemsCollectionChanged;
 		}
 
-		public object Content
-		{
-			get { return GetValue(ContentProperty); }
-			set { SetValue(ContentProperty, value); }
-		}
 
-		public DataTemplate ContentTemplate
-		{
-			get { return (DataTemplate)GetValue(ContentTemplateProperty); }
-			set { SetValue(ContentTemplateProperty, value); }
-		}
-
-		public MenuItemCollection MenuItems => (MenuItemCollection)GetValue(MenuItemsProperty);
 		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
 
 		Page ContentCache {
@@ -142,15 +142,53 @@ namespace Xamarin.Forms
 		void MenuItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (e.NewItems != null)
-			{
 				foreach (Element el in e.NewItems)
 					OnChildAdded(el);
-			}
 
 			if (e.OldItems != null)
-			{
 				foreach (Element el in e.OldItems)
 					OnChildRemoved(el);
+		}
+
+		IDictionary<string, string> _delayedQueryParams;
+		internal override void ApplyQueryAttributes(IDictionary<string, string> query)
+		{
+			base.ApplyQueryAttributes(query);
+			ApplyQueryAttributes(this, query);
+
+			if (Content == null) {
+				_delayedQueryParams = query;
+				return;
+			}
+			ApplyQueryAttributes(Content as Page, query);
+		}
+
+		static void ApplyQueryAttributes(object content, IDictionary<string, string> query)
+		{
+			if (content is IQuerryAttributable attributable)
+				attributable.ApplyQueryAttributes(query);
+
+			if (content is BindableObject bindable && bindable.BindingContext != null)
+				ApplyQueryAttributes(bindable.BindingContext, query);
+
+			var type = content.GetType();
+			var typeInfo = type.GetTypeInfo();
+#if NETSTANDARD1_0
+			var queryPropertyAttributes = typeInfo.GetCustomAttributes(typeof(QueryPropertyAttribute), true).ToArray();
+#else
+			var queryPropertyAttributes = typeInfo.GetCustomAttributes(typeof(QueryPropertyAttribute), true);
+#endif
+
+			if (queryPropertyAttributes.Length == 0)
+				return;
+
+			foreach (QueryPropertyAttribute attrib in queryPropertyAttributes) {
+				if (query.TryGetValue(attrib.QueryId, out var value)) {
+					PropertyInfo prop = type.GetRuntimeProperty(attrib.Name);
+
+					if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
+						prop.SetValue(content, value);
+				}
 			}
 		}
 	}

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -170,7 +170,7 @@ namespace Xamarin.Forms
 
 		static void ApplyQueryAttributes(object content, IDictionary<string, string> query)
 		{
-			if (content is IQuerryAttributable attributable)
+			if (content is IQueryAttributable attributable)
 				attributable.ApplyQueryAttributes(query);
 
 			if (content is BindableObject bindable && bindable.BindingContext != null)

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -2,6 +2,11 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+
+#if NETSTANDARD1_0
+using System.Linq;
+#endif
+
 using System.Reflection;
 using Xamarin.Forms.Internals;
 

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -173,7 +173,7 @@ namespace Xamarin.Forms
 			if (content is IQueryAttributable attributable)
 				attributable.ApplyQueryAttributes(query);
 
-			if (content is BindableObject bindable && bindable.BindingContext != null)
+			if (content is BindableObject bindable && bindable.BindingContext != null && content != bindable.BindingContext)
 				ApplyQueryAttributes(bindable.BindingContext, query);
 
 			var type = content.GetType();

--- a/Xamarin.Forms.Core/Shell/ShellGroupItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellGroupItem.cs
@@ -5,10 +5,9 @@
 		public static readonly BindableProperty FlyoutDisplayOptionsProperty =
 			BindableProperty.Create(nameof(FlyoutDisplayOptions), typeof(FlyoutDisplayOptions), typeof(ShellItem), FlyoutDisplayOptions.AsSingleItem, BindingMode.OneTime);
 
-		public FlyoutDisplayOptions FlyoutDisplayOptions
-		{
-			get { return (FlyoutDisplayOptions)GetValue(FlyoutDisplayOptionsProperty); }
-			set { SetValue(FlyoutDisplayOptionsProperty, value); }
+		public FlyoutDisplayOptions FlyoutDisplayOptions {
+			get => (FlyoutDisplayOptions)GetValue(FlyoutDisplayOptionsProperty);
+			set => SetValue(FlyoutDisplayOptionsProperty, value);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Shell/ShellGroupItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellGroupItem.cs
@@ -5,9 +5,10 @@
 		public static readonly BindableProperty FlyoutDisplayOptionsProperty =
 			BindableProperty.Create(nameof(FlyoutDisplayOptions), typeof(FlyoutDisplayOptions), typeof(ShellItem), FlyoutDisplayOptions.AsSingleItem, BindingMode.OneTime);
 
-		public FlyoutDisplayOptions FlyoutDisplayOptions {
-			get => (FlyoutDisplayOptions)GetValue(FlyoutDisplayOptionsProperty);
-			set => SetValue(FlyoutDisplayOptionsProperty, value);
+		public FlyoutDisplayOptions FlyoutDisplayOptions
+		{
+			get { return (FlyoutDisplayOptions)GetValue(FlyoutDisplayOptionsProperty); }
+			set { SetValue(FlyoutDisplayOptionsProperty, value); }
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

~~NOTE: please merge #4595 first, and rebase this on top~~

Allow uri navigation with queryParams. queryParams can be applied
to:
- the ShellContent (if inherited)
- the Content (or inflated ContentTemplate) of the ShellContent
- the BindingContext of the Content

those 3 can inherit an interface and handle the queryParams, or
the types can be decorated with some [QueryProperty] attributes.
Attributes are handled on the 3 typesL ShellContent, actual content,
or bindingcontext.


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4596

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
