### PR TITLE
[Enhancement] Added GroupHeaderStyle property for iOS specific ListView class

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/GroupHeaderStyle.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/GroupHeaderStyle.cs
@@ -1,0 +1,9 @@
+﻿
+namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	public enum GroupHeaderStyle
+	{
+		Plain,
+		Grouped
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -26,5 +26,29 @@
 			SetSeparatorStyle(config.Element, value);
 			return config;
 		}
+
+		public static readonly BindableProperty GroupHeaderStyleProperty = BindableProperty.Create(nameof(GroupHeaderStyle), typeof(GroupHeaderStyle), typeof(FormsElement), GroupHeaderStyle.Plain);
+
+		public static GroupHeaderStyle GetGroupHeaderStyle(BindableObject element)
+		{
+			return (GroupHeaderStyle)element.GetValue(GroupHeaderStyleProperty);
+		}
+
+		public static void SetGroupHeaderStyle(BindableObject element, GroupHeaderStyle value)
+		{
+			element.SetValue(GroupHeaderStyleProperty, value);
+			var v = (GroupHeaderStyle)element.GetValue(GroupHeaderStyleProperty);
+		}
+
+		public static GroupHeaderStyle GetGroupHeaderStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetGroupHeaderStyle(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetGroupHeaderStyle(this IPlatformElementConfiguration<iOS, FormsElement> config, GroupHeaderStyle value)
+		{
+			SetGroupHeaderStyle(config.Element, value);
+			return config;
+		}
 	}
 }

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -37,7 +37,6 @@
 		public static void SetGroupHeaderStyle(BindableObject element, GroupHeaderStyle value)
 		{
 			element.SetValue(GroupHeaderStyleProperty, value);
-			var v = (GroupHeaderStyle)element.GetValue(GroupHeaderStyleProperty);
 		}
 
 		public static GroupHeaderStyle GetGroupHeaderStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1368,7 +1368,10 @@ namespace Xamarin.Forms.Platform.iOS
 		internal bool _usingLargeTitles;
 		bool _isRefreshing;
 
-		public FormsUITableViewController(ListView element, bool usingLargeTitles)
+		public FormsUITableViewController(ListView element, bool usingLargeTitles) 
+		: base(element.OnThisPlatform().GetGroupHeaderStyle() == GroupHeaderStyle.Plain 
+			? UITableViewStyle.Plain 
+			  : UITableViewStyle.Grouped)
 		{
 			if (Forms.IsiOS9OrNewer)
 				TableView.CellLayoutMarginsFollowReadableWidth = false;


### PR DESCRIPTION
### Description of Change ###
Created possibility to manage group header style from shared code. (Currently it's impossible at all as related class is incapsulated)

### Issues Resolved ### 
fixes https://github.com/xamarin/Xamarin.Forms/pull/4002#issuecomment-431049817
So, it will allow to set Grouped style and avoid such issues

### API Changes ###

Added: ( Xamarin.Forms.PlatformConfiguration.iOSSpecific.ListView)
- GroupHeaderStyleProperty
- SetGroupHeaderStyle (and 1 override)
- GetGroupHeaderStyle

Added: GroupHeaderStyle enum in the same namespace

### Platforms Affected ### 
- Core
- iOS

### Behavioral/Visual Changes ###
![image](https://user-images.githubusercontent.com/10124814/49407289-0d34f000-f769-11e8-8756-13e4bae63f27.png)

### Testing Procedure ###

Add next line of code to Bugzilla34912 after list declaration and see that Grouped style is applied (like on Android)

```csharp
Xamarin.Forms.PlatformConfiguration.iOSSpecific.ListView.SetGroupHeaderStyle(list, PlatformConfiguration.iOSSpecific.GroupHeaderStyle.Grouped);
```
