### PR TITLE
[Shell][Android] fixes crash when switching Bottom Navigation Tabs too fast or click on More menu

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ColorChangeRevealDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ColorChangeRevealDrawable.cs
@@ -60,7 +60,8 @@ namespace Xamarin.Forms.Platform.Android
 		void OnUpdate(object sender, ValueAnimator.AnimatorUpdateEventArgs e)
 		{
 			_progress = (float)e.Animation.AnimatedValue;
-			InvalidateSelf();
+			if (!this.IsDisposed())
+				InvalidateSelf();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -138,7 +138,8 @@ namespace Xamarin.Forms.Platform.Android
 					void clickCallback(object s, EventArgs e)
 					{
 						selectCallback(shellContent, bottomSheetDialog);
-						innerLayout.Click -= clickCallback;
+						if (!innerLayout.IsDisposed())
+							innerLayout.Click -= clickCallback;
 					}
 					innerLayout.Click += clickCallback;
 


### PR DESCRIPTION
### Description of Change ###

Fixes crashes in Bottom Navigation Tabs

### Issues Resolved ### 

- fixes #4382

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- run the Shell Control Gallery project
- click between the bottom tabs quickly
- app shouldn't crash
- click `More` button and select any tabs
- app shouldn't crash

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
