### PR TITLE
[tasks] avoid passing dupe assemblies to Cecil

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 
 				if (!string.IsNullOrEmpty(ReferencePath)) {
-					var paths = ReferencePath.Replace("//", "/").Split(';');
+					var paths = ReferencePath.Replace("//", "/").Split(';').Distinct();
 					foreach (var p in paths) {
 						var searchpath = Path.GetDirectoryName(p);
 						LoggingHelper.LogMessage(Low, $"{new string(' ', 2)}Adding searchpath {searchpath}");

--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var resolver = DefaultAssemblyResolver ?? new XamlCAssemblyResolver();
 			if (resolver is XamlCAssemblyResolver xamlCResolver) {
 				if (!string.IsNullOrEmpty(DependencyPaths)) {
-					foreach (var dep in DependencyPaths.Split(';')) {
+					foreach (var dep in DependencyPaths.Split(';').Distinct()) {
 						LoggingHelper.LogMessage(Low, $"{new string(' ', 2)}Adding searchpath {dep}");
 						xamlCResolver.AddSearchDirectory(dep);
 					}

--- a/Xamarin.Forms.Build.Tasks/XamlGenerator.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGenerator.cs
@@ -385,20 +385,20 @@ namespace Xamarin.Forms.Build.Tasks
 			_xmlnsDefinitions = new List<XmlnsDefinitionAttribute>();
 			_xmlnsModules = new Dictionary<string, ModuleDefinition>();
 
-			if (string.IsNullOrEmpty(this.References))
+			if (string.IsNullOrEmpty(References))
 				return;
 
-			string[] paths = this.References.Split(';');
+			string[] paths = References.Split(';').Distinct().ToArray();
 
-			foreach ( var path in paths ) {
+			foreach (var path in paths) {
 				string asmName = Path.GetFileName(path);
-				if ( AssemblyIsSystem(asmName) )
+				if (AssemblyIsSystem(asmName))
 					// Skip the myriad "System." assemblies and others
 					continue;				
 
 				using (var asmDef = AssemblyDefinition.ReadAssembly(path)) {
-					foreach ( var ca in asmDef.CustomAttributes ) {
-						if ( ca.AttributeType.FullName == typeof(XmlnsDefinitionAttribute).FullName) {
+					foreach (var ca in asmDef.CustomAttributes) {
+						if (ca.AttributeType.FullName == typeof(XmlnsDefinitionAttribute).FullName) {
 							_xmlnsDefinitions.Add(ca.GetXmlnsDefinition(asmDef));
 							_xmlnsModules[asmDef.FullName] = asmDef.MainModule;
 						}


### PR DESCRIPTION
### Description of Change ###

avoid feeding Mono.Cecil with dupes. Removes a negligeable handful
of milliseconds (100ms on average, hard to measure) from XamlC. Even
less from XamlG.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4620

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Build

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
