### PR TITLE
[test] add passing test for #4572

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4572.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4572.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4572">
+	<Label x:Name="label">
+		<Label.Text>
+			<Binding Path="labeltext"/>
+		</Label.Text>
+	</Label>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4572.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4572.xaml.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh4572 : ContentPage
+	{
+		public Gh4572() => InitializeComponent();
+		public Gh4572(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[TestCase(true), TestCase(false)]
+			public void BindingAsElement(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh4572)));
+				var layout = new Gh4572(useCompiledXaml) { BindingContext = new { labeltext = "Foo" } };
+				Assert.That(layout.label.Text, Is.EqualTo("Foo"));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
@@ -178,27 +178,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void TestBindingAsElement ()
-		{
-			var xaml = @"
-			<Label 
-			xmlns=""http://xamarin.com/schemas/2014/forms"">
-				<Label.Text>
-					<Binding Path=""labeltext""/>
-				</Label.Text>
-			</Label>";
-
-			var label = new Label ();
-			label.LoadFromXaml (xaml);
-
-			Assert.AreEqual (Label.TextProperty.DefaultValue, label.Text);
-
-			label.BindingContext = new {labeltext="Foo"};
-			Assert.AreEqual ("Foo", label.Text);
-
-		}
-
-		[Test]
 		public void TestSetBindingToNonBindablePropertyShouldThrow ()
 		{
 			var xaml = @"


### PR DESCRIPTION
### Description of Change ###

This adds a test for #4572, as we were only testing that case with XamlC off in LoaderTests.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- closes #4572

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
