### PR TITLE
[iOS] Update cell size estimates after empty data source

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4600.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4600.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+	[Explicit] // Marked explicit until we have a lane for CollectionView tests
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4600, "[iOS] CollectionView crash with empty ObservableCollection", PlatformAffected.iOS)]
+	public class Issue4600 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			PushAsync(
+				new GalleryPages.CollectionViewGalleries.ObservableCodeCollectionViewGallery(initialItems: 0));
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public void InitiallyEmptySourceDisplaysAddedItem()
+		{
+			RunningApp.WaitForElement("Insert");
+			RunningApp.Tap("Insert");
+			RunningApp.WaitForElement("Inserted");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4600.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4600.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.ManualReview)]
-	[Explicit] // Marked explicit until we have a lane for CollectionView tests
+	[Ignore("Ignoring until we have a lane to run CollectionView test (or CV is not behind a flag")] 
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 4600, "[iOS] CollectionView crash with empty ObservableCollection", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -417,6 +417,7 @@
       <DependentUpon>Issue4360.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4600.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemAdder.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemAdder.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 		{
 			var index = indexes[0];
 
-			if (index > -1 && index < observableCollection.Count)
+			if (index > -1 && (index < observableCollection.Count || index == 0))
 			{
 				var item = new CollectionViewGalleryTestItem(DateTime.Now, "Inserted", "oasis.jpg", index);
 				observableCollection.Insert(index, item);

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCodeCollectionViewGridGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCodeCollectionViewGridGallery.cs
@@ -3,7 +3,7 @@
 	internal class ObservableCodeCollectionViewGallery : ContentPage
 	{
 		public ObservableCodeCollectionViewGallery(ItemsLayoutOrientation orientation = ItemsLayoutOrientation.Vertical, 
-			bool grid = true)
+			bool grid = true, int initialItems = 1000)
 		{
 			var layout = new Grid
 			{ 
@@ -26,7 +26,7 @@
 
 			var collectionView = new CollectionView {ItemsLayout = itemsLayout, ItemTemplate = itemTemplate};
 
-			var generator = new ItemsSourceGenerator(collectionView);
+			var generator = new ItemsSourceGenerator(collectionView, initialItems);
 			
 			var remover = new ItemRemover(collectionView);
 			var adder = new ItemAdder(collectionView);

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCollectionGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCollectionGallery.cs
@@ -24,7 +24,10 @@
 							new ObservableCodeCollectionViewGallery(grid: false), Navigation),
 
 						GalleryBuilder.NavButton("Add/Remove Items (grid)", () =>
-							new ObservableCodeCollectionViewGallery(), Navigation)
+							new ObservableCodeCollectionViewGallery(), Navigation),
+
+						GalleryBuilder.NavButton("Add/Remove Items (grid, initially empty)", () =>
+							new ObservableCodeCollectionViewGallery(initialItems: 0), Navigation)
 					}
 				}
 			};

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -9,6 +9,7 @@
 		public const string BoxView = "BoxView";
 		public const string Button = "Button";
 		public const string Cells = "Cells";
+		public const string CollectionView = "CollectionView";
 		public const string ContextActions = "ContextActions";
 		public const string DatePicker = "DatePicker";
 		public const string DisplayAlert = "DisplayAlert";

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewController.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.iOS
 		readonly ItemsView _itemsView;
 		readonly ItemsViewLayout _layout;
 		bool _initialConstraintsSet;
-		int _previousCount = -1;
+		bool _wasEmpty;
 
 		public CollectionViewController(ItemsView itemsView, ItemsViewLayout layout) : base(layout)
 		{
@@ -45,14 +45,14 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var count = _itemsSource.Count;
 
-			if (_previousCount == 0 && count > 0)
+			if (_wasEmpty && count > 0)
 			{
 				// We've moved from no items to having at least one item; it's likely that the layout needs to update
 				// its cell size/estimate
 				_layout?.SetNeedCellSizeUpdate();
 			}
 
-			_previousCount = count;
+			_wasEmpty = count == 0;
 
 			return count;
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewController.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Platform.iOS
 		readonly ItemsView _itemsView;
 		readonly ItemsViewLayout _layout;
 		bool _initialConstraintsSet;
+		int _previousCount = -1;
 
 		public CollectionViewController(ItemsView itemsView, ItemsViewLayout layout) : base(layout)
 		{
@@ -42,7 +43,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override nint GetItemsCount(UICollectionView collectionView, nint section)
 		{
-			return _itemsSource.Count;
+			var count = _itemsSource.Count;
+
+			if (_previousCount == 0 && count > 0)
+			{
+				// We've moved from no items to having at least one item; it's likely that the layout needs to update
+				// its cell size/estimate
+				_layout?.SetNeedCellSizeUpdate();
+			}
+
+			_previousCount = count;
+
+			return count;
 		}
 
 		public override void ViewDidLoad()
@@ -50,7 +62,6 @@ namespace Xamarin.Forms.Platform.iOS
 			base.ViewDidLoad();
 			AutomaticallyAdjustsScrollViewInsets = false;
 			RegisterCells();
-			CollectionView.WeakDelegate = _layout;
 		}
 
 		public override void ViewWillLayoutSubviews()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CollectionViewRenderer.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_collectionViewController = new CollectionViewController(newElement, _layout);
 			SetNativeControl(_collectionViewController.View);
 			_collectionViewController.CollectionView.BackgroundColor = UIColor.Clear;
-			_collectionViewController.CollectionView.Delegate = _layout;
+			_collectionViewController.CollectionView.WeakDelegate = _layout;
 
 			// Listen for ScrollTo requests
 			newElement.ScrollToRequested += ScrollToRequested;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -138,10 +138,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// We set the EstimatedItemSize here for two reasons:
 			// 1. If we don't set it, iOS versions below 10 will crash
-			// 2. If GetProtoType() cannot return a cell because the items source is empty, we need to have
+			// 2. If GetPrototype() cannot return a cell because the items source is empty, we need to have
 			//		an estimate set so that when a cell _does_ become available (i.e., when the items source
 			//		has at least one item), Autolayout will kick in for the first cell and size it correctly
-			// If GetProtoType() _can_ return a cell, this estimate will be updated once that cell is measured
+			// If GetPrototype() _can_ return a cell, this estimate will be updated once that cell is measured
 			EstimatedItemSize = new CGSize(1, 1);
 			
 			if (!(GetPrototype() is ItemsViewCell prototype))

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using CoreGraphics;
 using Foundation;
 using UIKit;
@@ -13,6 +12,7 @@ namespace Xamarin.Forms.Platform.iOS
 		readonly ItemsLayout _itemsLayout;
 		bool _determiningCellSize;
 		bool _disposed;
+		bool _needCellSizeUpdate;
 
 		protected ItemsViewLayout(ItemsLayout itemsLayout)
 		{
@@ -55,7 +55,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void HandlePropertyChanged(PropertyChangedEventArgs  propertyChanged)
 		{
-			// Nothing to do here for now; may need something here when we implement Snapping
 		}
 
 		public nfloat ConstrainedDimension { get; set; }
@@ -67,8 +66,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public abstract void ConstrainTo(CGSize size);
 
+		[Export("collectionView:willDisplayCell:forItemAtIndexPath:")]
+		public virtual void WillDisplayCell(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath path)
+		{
+			if (_needCellSizeUpdate)
+			{
+				// Our cell size/estimate is out of date, probably because we moved from zero to one item; update it
+				_needCellSizeUpdate = false;
+				DetermineCellSize();
+			}
+		}
+
 		[Export("collectionView:layout:insetForSectionAtIndex:")]
-		[CompilerGenerated]
 		public virtual UIEdgeInsets GetInsetForSection(UICollectionView collectionView, UICollectionViewLayout layout,
 			nint section)
 		{
@@ -76,7 +85,6 @@ namespace Xamarin.Forms.Platform.iOS
 		}
 
 		[Export("collectionView:layout:minimumInteritemSpacingForSectionAtIndex:")]
-		[CompilerGenerated]
 		public virtual nfloat GetMinimumInteritemSpacingForSection(UICollectionView collectionView,
 			UICollectionViewLayout layout, nint section)
 		{
@@ -84,7 +92,6 @@ namespace Xamarin.Forms.Platform.iOS
 		}
 
 		[Export("collectionView:layout:minimumLineSpacingForSectionAtIndex:")]
-		[CompilerGenerated]
 		public virtual nfloat GetMinimumLineSpacingForSection(UICollectionView collectionView,
 			UICollectionViewLayout layout, nint section)
 		{
@@ -129,23 +136,28 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_determiningCellSize = true;
 
-			if (!Forms.IsiOS10OrNewer)
-			{
-				// iOS 9 will throw an exception during auto layout if no EstimatedSize is set
-				EstimatedItemSize = new CGSize(1, 1);
-			}
-
+			// We set the EstimatedItemSize here for two reasons:
+			// 1. If we don't set it, iOS versions below 10 will crash
+			// 2. If GetProtoType() cannot return a cell because the items source is empty, we need to have
+			//		an estimate set so that when a cell _does_ become available (i.e., when the items source
+			//		has at least one item), Autolayout will kick in for the first cell and size it correctly
+			// If GetProtoType() _can_ return a cell, this estimate will be updated once that cell is measured
+			EstimatedItemSize = new CGSize(1, 1);
+			
 			if (!(GetPrototype() is ItemsViewCell prototype))
 			{
+				_determiningCellSize = false;
 				return;
 			}
 
+			// Constrain and measure the prototype cell
 			prototype.ConstrainTo(ConstrainedDimension);
 
 			var measure = prototype.Measure();
 
 			if (UniformSize)
 			{
+				// This is the size we'll give all of our cells from here on out
 				ItemSize = measure;
 
 				// Make sure autolayout is disabled 
@@ -153,6 +165,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
+				// Autolayout is now enabled, and this is the size used to guess scrollbar size and progress
 				EstimatedItemSize = measure;
 			}
 
@@ -174,7 +187,7 @@ namespace Xamarin.Forms.Platform.iOS
 			ScrollDirection = scrollDirection;
 		}
 
-		void UpdateCellConstraints()
+		internal void UpdateCellConstraints()
 		{
 			var cells = CollectionView.VisibleCells;
 
@@ -196,6 +209,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			ConstrainTo(size);
 			UpdateCellConstraints();
+		}
+
+		public void SetNeedCellSizeUpdate()
+		{
+			_needCellSizeUpdate = true;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Platform.iOS
 			nativeView.Frame = new CGRect(CGPoint.Empty, size);
 			VisualElementRenderer.Element.Layout(nativeView.Frame.ToRectangle());
 
-			layoutAttributes.Frame = VisualElementRenderer.NativeView.Frame;
+			layoutAttributes.Frame = nativeView.Frame;
 
 			return layoutAttributes;
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/VerticalTemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/VerticalTemplatedCell.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using CoreGraphics;
 using Foundation;


### PR DESCRIPTION
### Description of Change ###

Normally the CollectionView on iOS uses the first available cell as a prototype to determine the estimated size (or exact size) of subsequent cells. But if there is no first available cell when the CollectionView first appears, the estimates remain zero and new cells are added, but are not visible. 

These changes allow the CollectionView to use the first available cell even if there is no data when the CollectionView first appears.

### Issues Resolved ### 

- fixes #4600

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Added an automated test; for manual testing, in Control Gallery navigate to CollectionView Gallery -> Observable Collection Galleries -> Add/Remove Items (Grid, Initially Empty) and click the Insert button; an item should appear. Click the button again; another item should appear, and both items should be the same size.

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
