### PR TITLE
Properly detect SDK style projects

### DIFF
--- a/.nuspec/Xamarin.Forms.props
+++ b/.nuspec/Xamarin.Forms.props
@@ -1,5 +1,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+	<PropertyGroup>
+		<!-- Sdk.props imports Microsoft.NET.Sdk.props which defines Configurations and Platforms, which is the SDK-style way -->
+		<IsSdkStyle Condition="'$(IsSdkStyle)' == '' and '$(Configurations)' != '' and '$(Platforms)' != ''">true</IsSdkStyle>
+	</PropertyGroup>
+
 	<!--
 	When using Sdk-style projects and default embedded resource items are enabled, automatically
 	add the XAML files and fix up item metadata to pair them with code files.
@@ -10,6 +15,6 @@
 	The actual item groups are in a separate conditionally-imported file as they use constructs that
 	are not compatible with older MSBuild versions.
 	-->
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.props" Condition="'$(MSBuildSDKsPath)'!=''" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.props" Condition="'$(IsSdkStyle)' == 'true'" />
 
 </Project>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -17,7 +17,7 @@
 		<_DefaultCssItemsEnabled>False</_DefaultCssItemsEnabled>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.targets" Condition="'$(MSBuildSDKsPath)'!=''" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.targets" Condition="'$(IsSdkStyle)' != 'true'" />
 
 	<ItemGroup>
 		<ProjectCapability Include="XamarinForms" />


### PR DESCRIPTION
The `$(MSBuildSDKsPath)` is actually *always* set whenever there are MSBuild SDKs 
*installed*, not necessarily when the current project is an SDK-style project itself. 

This means that we're potentially adding duplicate items and otherwise disrupting 
normal operation of the non-SDK style projects with this import. 

So use the well-known properties that are set by the .NET [Sdk.props](https://github.com/dotnet/sdk/blob/master/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L22-L27) file instead, 
which is the first imported target even before nuget-provided .props files.