### PR TITLE
[C, iOS, AND, UWP] Color for Picker.Title

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
@@ -23,9 +23,16 @@ namespace Xamarin.Forms.Controls
 			var titleContainer = new ViewContainer<Picker>(Test.Picker.Title, new Picker());
 			titleContainer.View.Title = "Title";
 
-			var titleColorContainer = new ViewContainer<Picker>(Test.Picker.Title, new Picker());
-			titleColorContainer.View.Title = "Title";
+			var titleColorContainer = new ViewContainer<Picker>(Test.Picker.TitleColor, new Picker());
+			titleColorContainer.View.Title = "Title Color";
 			titleColorContainer.View.TitleColor = Color.Red;
+
+			var button = new Button() { Text = "Reset color to default" };
+			button.Clicked += (o, a) => {
+				titleColorContainer.View.ClearValue(Picker.TitleColorProperty);
+			};
+
+			titleColorContainer.ContainerLayout.Children.Add(button);
 
 			var textColorContainer = new ViewContainer<Picker>(Test.Picker.TextColor, new Picker());
 			textColorContainer.View.Items.Add("Item 1");

--- a/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
@@ -23,6 +23,10 @@ namespace Xamarin.Forms.Controls
 			var titleContainer = new ViewContainer<Picker>(Test.Picker.Title, new Picker());
 			titleContainer.View.Title = "Title";
 
+			var titleColorContainer = new ViewContainer<Picker>(Test.Picker.Title, new Picker());
+			titleColorContainer.View.Title = "Title";
+			titleColorContainer.View.TitleColor = Color.Red;
+
 			var textColorContainer = new ViewContainer<Picker>(Test.Picker.TextColor, new Picker());
 			textColorContainer.View.Items.Add("Item 1");
 			textColorContainer.View.Items.Add("Item 2");
@@ -62,6 +66,7 @@ namespace Xamarin.Forms.Controls
 			Add(itemsContainer);
 			Add(selectedIndexContainer);
 			Add(titleContainer);
+			Add(titleColorContainer);
 			Add(textColorContainer);
 			Add(fontAttributesContainer);
 			Add(fontFamilyContainer);

--- a/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
@@ -27,12 +27,13 @@ namespace Xamarin.Forms.Controls
 			titleColorContainer.View.Title = "Title Color";
 			titleColorContainer.View.TitleColor = Color.Red;
 
-			var button = new Button() { Text = "Reset color to default" };
-			button.Clicked += (o, a) => {
-				titleColorContainer.View.ClearValue(Picker.TitleColorProperty);
-			};
+			var buttonReset = new Button() { Text = "Reset color to default" };
+			var buttonChange = new Button() { Text = "Change color" };
+			buttonReset.Clicked += (o, a) => titleColorContainer.View.ClearValue(Picker.TitleColorProperty);
+			buttonChange.Clicked += (o, a) => titleColorContainer.View.TitleColor = Color.Green;
 
-			titleColorContainer.ContainerLayout.Children.Add(button);
+			titleColorContainer.ContainerLayout.Children.Add(buttonReset);
+			titleColorContainer.ContainerLayout.Children.Add(buttonChange);
 
 			var textColorContainer = new ViewContainer<Picker>(Test.Picker.TextColor, new Picker());
 			textColorContainer.View.Items.Add("Item 1");

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -18,6 +18,9 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty TitleProperty =
 			BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
 
+		public static readonly BindableProperty TitleColorProperty =
+			BindableProperty.Create(nameof(TitleColor), typeof(Color), typeof(Picker), default(Color));
+
 		public static readonly BindableProperty SelectedIndexProperty =
 			BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
 									propertyChanged: OnSelectedIndexChanged, coerceValue: CoerceSelectedIndex);
@@ -105,6 +108,12 @@ namespace Xamarin.Forms
 		public string Title {
 			get { return (string)GetValue(TitleProperty); }
 			set { SetValue(TitleProperty, value); }
+		}
+
+		public Color TitleColor
+		{
+			get { return (Color)GetValue(TitleColorProperty); }
+			set { SetValue(TitleColorProperty, value); }
 		}
 
 		BindingBase _itemDisplayBinding;

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -766,6 +766,7 @@ namespace Xamarin.Forms.CustomAttributes
 		public enum Picker
 		{
 			Title,
+			TitleColor,
 			Items,
 			SelectedIndex,
 			Focus,

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using Android.Content;
 using Android.Widget;
 using AColor = Android.Graphics.Color;
+using Android.Text;
+using Android.Text.Style;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -108,7 +110,18 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				using (var builder = new AlertDialog.Builder(Context))
 				{
-					builder.SetTitle(model.Title ?? "");
+					if (!Element.IsSet(Picker.TitleColorProperty))
+					{
+						builder.SetTitle(model.Title ?? "");
+					}
+					else
+					{
+						var title = new SpannableString(model.Title ?? "");
+						title.SetSpan(new ForegroundColorSpan(model.TitleColor.ToAndroid()), 0, title.Length(), SpanTypes.ExclusiveExclusive);
+
+						builder.SetTitle(title);
+					}
+
 					string[] items = model.Items.ToArray();
 					builder.SetItems(items, (s, e) => ((IElementController)model).SetValueFromRenderer(Picker.SelectedIndexProperty, e.Which));
 
@@ -144,7 +157,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdatePicker()
 		{
 			Control.Hint = Element.Title;
-			
+
 			if (Element.IsSet(Picker.TitleColorProperty))
 				Control.SetHintTextColor(Element.TitleColor.ToAndroid());
 			else

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using Android.Content;
 using Android.Widget;
+using AColor = Android.Graphics.Color;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -14,6 +15,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		AlertDialog _dialog;
 		bool _disposed;
 		TextColorSwitcher _textColorSwitcher;
+		int _originalHintTextColor;
 
 		public PickerRenderer(Context context) : base(context)
 		{
@@ -59,6 +61,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors, useLegacyColorManagement);
 
 					SetNativeControl(textField);
+
+					_originalHintTextColor = Control.CurrentHintTextColor;
 				}
 				UpdateFont();
 				UpdatePicker();
@@ -140,9 +144,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdatePicker()
 		{
 			Control.Hint = Element.Title;
-
-			if (Element.TitleColor != default(Color))
+			
+			if (Element.IsSet(Picker.TitleColorProperty))
 				Control.SetHintTextColor(Element.TitleColor.ToAndroid());
+			else
+				Control.SetHintTextColor(new AColor(_originalHintTextColor));
 
 			if (Element.SelectedIndex == -1 || Element.Items == null || Element.SelectedIndex >= Element.Items.Count)
 				Control.Text = null;

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == Picker.TitleProperty.PropertyName)
+			if (e.PropertyName == Picker.TitleProperty.PropertyName || e.PropertyName == Picker.TitleColorProperty.PropertyName)
 				UpdatePicker();
 			else if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 				UpdatePicker();
@@ -140,6 +140,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdatePicker()
 		{
 			Control.Hint = Element.Title;
+
+			if (Element.TitleColor != default(Color))
+				Control.SetHintTextColor(Element.TitleColor.ToAndroid());
 
 			if (Element.SelectedIndex == -1 || Element.Items == null || Element.SelectedIndex >= Element.Items.Count)
 				Control.Text = null;

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using Orientation = Android.Widget.Orientation;
 using Android.Content;
 using AColor = Android.Graphics.Color;
+using Android.Text;
+using Android.Text.Style;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -126,7 +128,19 @@ namespace Xamarin.Forms.Platform.Android
 
 			var builder = new AlertDialog.Builder(Context);
 			builder.SetView(layout);
-			builder.SetTitle(model.Title ?? "");
+
+			if (!Element.IsSet(Picker.TitleColorProperty))
+			{
+				builder.SetTitle(model.Title ?? "");
+			}
+			else
+			{
+				var title = new SpannableString(model.Title ?? "");
+				title.SetSpan(new ForegroundColorSpan(model.TitleColor.ToAndroid()), 0, title.Length(), SpanTypes.ExclusiveExclusive);
+
+				builder.SetTitle(title);
+			}
+
 			builder.SetNegativeButton(global::Android.Resource.String.Cancel, (s, a) =>
 			{
 				ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == Picker.TitleProperty.PropertyName)
+			if (e.PropertyName == Picker.TitleProperty.PropertyName || e.PropertyName == Picker.TitleColorProperty.PropertyName)
 				UpdatePicker();
 			else if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 				UpdatePicker();
@@ -164,6 +164,9 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdatePicker()
 		{
 			Control.Hint = Element.Title;
+
+			if (Element.TitleColor != default(Color))
+				Control.SetHintTextColor(Element.TitleColor.ToAndroid());
 
 			string oldText = Control.Text;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Linq;
 using Orientation = Android.Widget.Orientation;
 using Android.Content;
+using AColor = Android.Graphics.Color;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -16,6 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 		AlertDialog _dialog;
 		bool _isDisposed;
 		TextColorSwitcher _textColorSwitcher;
+		int _originalHintTextColor;
 
 		public PickerRenderer(Context context) : base(context)
 		{
@@ -62,6 +64,8 @@ namespace Xamarin.Forms.Platform.Android
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors, useLegacyColorManagement);
 
 					SetNativeControl(textField);
+
+					_originalHintTextColor = Control.CurrentHintTextColor;
 				}
 
 				UpdateFont();
@@ -165,8 +169,10 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Control.Hint = Element.Title;
 
-			if (Element.TitleColor != default(Color))
+			if (Element.IsSet(Picker.TitleColorProperty))
 				Control.SetHintTextColor(Element.TitleColor.ToAndroid());
+			else
+				Control.SetHintTextColor(new AColor(_originalHintTextColor));
 
 			string oldText = Control.Text;
 

--- a/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
@@ -210,8 +210,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateTitle()
 		{
-			if (Element.TitleColor == default(Color))
+			if (!Element.IsSet(Picker.TitleColorProperty))
 			{
+				Control.HeaderTemplate = null;
 				Control.Header = Element.Title;
 			}
 			else

--- a/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
@@ -217,6 +217,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 			else
 			{
+				Control.Header = null;
 				Control.HeaderTemplate = (Windows.UI.Xaml.DataTemplate)Windows.UI.Xaml.Application.Current.Resources["ComboBoxHeader"];
 				Control.DataContext = Element;
 			}

--- a/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 				UpdateSelectedIndex();
-			else if (e.PropertyName == Picker.TitleProperty.PropertyName)
+			else if (e.PropertyName == Picker.TitleProperty.PropertyName || e.PropertyName == Picker.TitleColorProperty.PropertyName)
 				UpdateTitle();
 			else if (e.PropertyName == Picker.TextColorProperty.PropertyName)
 				UpdateTextColor();
@@ -210,7 +210,15 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateTitle()
 		{
-			Control.Header = Element.Title;
+			if (Element.TitleColor == default(Color))
+			{
+				Control.Header = Element.Title;
+			}
+			else
+			{
+				Control.HeaderTemplate = (Windows.UI.Xaml.DataTemplate)Windows.UI.Xaml.Application.Current.Resources["ComboBoxHeader"];
+				Control.DataContext = Element;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -349,5 +349,8 @@
 	<Style TargetType="ToggleSwitch">
 		<Setter Property="MinWidth" Value="0"/>
 	</Style>
-    
+
+    <DataTemplate x:Key="ComboBoxHeader">
+        <TextBlock Text="{Binding Title}" Foreground="{Binding TitleColor,Converter={StaticResource ColorConverter},ConverterParameter=DefaultTextForegroundThemeBrush}" />
+    </DataTemplate>
 </ResourceDictionary>

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -142,8 +142,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var selectedIndex = Element.SelectedIndex;
 			var items = Element.Items;
 
-			if (Element.TitleColor == default(Color))
+			if (!Element.IsSet(Picker.TitleColorProperty))
 			{
+				Control.AttributedPlaceholder = null;
 				Control.Placeholder = Element.Title;
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -92,7 +92,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-			if (e.PropertyName == Picker.TitleProperty.PropertyName)
+			if (e.PropertyName == Picker.TitleProperty.PropertyName || e.PropertyName == Picker.TitleColorProperty.PropertyName)
 				UpdatePicker();
 			else if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 				UpdatePicker();
@@ -141,7 +141,19 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var selectedIndex = Element.SelectedIndex;
 			var items = Element.Items;
-			Control.Placeholder = Element.Title;
+
+			if (Element.TitleColor == default(Color))
+			{
+				Control.Placeholder = Element.Title;
+			}
+			else
+			{
+				Control.AttributedPlaceholder = new NSAttributedString(Element.Title, new UIStringAttributes
+				{
+					ForegroundColor = Element.TitleColor.ToUIColor()
+				});
+			}
+
 			var oldText = Control.Text;
 			Control.Text = selectedIndex == -1 || items == null || selectedIndex >= items.Count ? "" : items[selectedIndex];
 			UpdatePickerNativeSize(oldText);


### PR DESCRIPTION
### Description of Change ###

The user is now able to set a color for the Picker.Title property.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4669

### API Changes ###

Added:
 - Color Picker.TitleColor { get; set; } //Bindable Property

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

As far as I can tell, other platforms do not show a title/placeholder at this time

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

When using this new property, the title, as visible on the respective platform, will adhere to the color set by the user.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

![Android](https://user-images.githubusercontent.com/939291/49801692-26323800-fd4b-11e8-81e6-d12747cd7741.png)

![Android popup](https://user-images.githubusercontent.com/939291/50086344-01333e80-01fd-11e9-9229-d3ade481fc62.png)

![UWP](https://user-images.githubusercontent.com/939291/49801814-81fcc100-fd4b-11e8-8f5c-b984d8a114ff.png)

![iOS](https://user-images.githubusercontent.com/939291/49802501-54b11280-fd4d-11e8-9e3d-2b3f1ea72af6.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
