### PR TITLE
[iOS] Added RowAnimationsEnabled platform specific to control row animations

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -50,7 +50,6 @@
 			return config;
 		}
 
-		#region RowAnimationsEnabled
 		public static readonly BindableProperty RowAnimationsEnabledProperty = BindableProperty.Create(nameof(RowAnimationsEnabled), typeof(bool), typeof(ListView), true);
 
 		public static bool GetRowAnimationsEnabled(BindableObject element)
@@ -73,6 +72,5 @@
 		{
 			return GetRowAnimationsEnabled(config.Element);
 		}
-		#endregion
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -40,6 +40,11 @@ namespace Xamarin.Forms.Platform.iOS
 		protected UITableViewRowAnimation InsertRowsAnimation { get; set; } = UITableViewRowAnimation.Automatic;
 		protected UITableViewRowAnimation DeleteRowsAnimation { get; set; } = UITableViewRowAnimation.Automatic;
 		protected UITableViewRowAnimation ReloadRowsAnimation { get; set; } = UITableViewRowAnimation.Automatic;
+		protected UITableViewRowAnimation ReloadSectionsAnimation
+		{
+			get { return _dataSource.ReloadSectionsAnimation; }
+			set { _dataSource.ReloadSectionsAnimation = value; }
+		}
 
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
@@ -971,6 +976,7 @@ namespace Xamarin.Forms.Platform.iOS
 			bool _isDragging;
 			bool _selectionFromNative;
 			bool _disposed;
+			public UITableViewRowAnimation ReloadSectionsAnimation { get; set; } = UITableViewRowAnimation.Automatic;
 
 			public ListViewDataSource(ListViewDataSource source)
 			{


### PR DESCRIPTION
### Description of Change ###

An explanation as to why this is needed is discussed in the issue ticket. Essentially, this allows the developer to turn off row animations on demand instead of relying on `UITableViewRowAnimation` which does not work in certain cases. Currently, I'm setting `UIView.AnimationsEnabled` to false as a workaround, but this has very bad side effects like turning off status bar animations as well as soft keyboard animations.

PS: I'd like to be able to test this in my project, but I can't create a nuget package with `.create-nuget.bat` since it's looking for `..\Xamarin.Forms.Platform.Android\bin\debug\MonoAndroid81` and I have Android 9 installed. Does your script need to be updated?

You could try testing this in `60699` by turning off the platform specific.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4199

### API Changes ###

Added:

bool RowAnimationsEnabled platform specific

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
