### PR TITLE
[Android] fixes Right-to-Left Hamburger icon in MasterDetailPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2818.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2818.cs
@@ -1,0 +1,46 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2818, "Right-to-Left MasterDetail in Xamarin.Forms Hamburger icon issue", PlatformAffected.Android)]
+	public class Issue2818 : MasterDetailPage
+	{
+		public Issue2818()
+		{
+			FlowDirection = FlowDirection.RightToLeft;
+
+			Master = new ContentPage
+			{
+				Title = "Master",
+				BackgroundColor = Color.SkyBlue,
+				Icon = "menuIcon"
+			};
+
+			Detail = new NavigationPage(new ContentPage
+			{
+				Title = "Detail",
+				Content = new StackLayout
+				{
+					Children = {
+						new Label
+						{
+							Text = "The page must be with RightToLeft FlowDirection. Hamburger icon in main page must be going to right side."
+						},
+						new Button
+						{
+							Text = "Set RightToLeft",
+							Command = new Command(() => FlowDirection = FlowDirection.RightToLeft)
+						},
+						new Button
+						{
+							Text = "Set LeftToRight",
+							Command = new Command(() => FlowDirection = FlowDirection.LeftToRight)
+						}
+					}
+				}
+			});
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -843,6 +843,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3525.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3275.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3884.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2818.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2831.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4040.xaml.cs">
       <DependentUpon>Issue4040.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailContainer.cs
@@ -57,6 +57,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 		}
 
+		public void UpdateFlowDirection() => _pageContainer?.UpdateFlowDirection(_parent);
+
 		protected override void AddChildView(VisualElement childView)
 		{
 			_pageContainer = null;
@@ -100,6 +102,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				fc?.SetOnCreateCallback(pc =>
 				{
 					_pageContainer = pc;
+					UpdateFlowDirection();
 					SetDefaultBackgroundColor(pc.Child);
 				});
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -398,6 +398,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdateFlowDirection()
 		{
 			this.UpdateFlowDirection(Element);
+			_detailLayout.UpdateFlowDirection();
 		}
 
 		void UpdateIsPresented()


### PR DESCRIPTION
### Description of Change ###

fixes Right-to-Left Hamburger icon in MasterDetailPage 

### Issues Resolved ### 

- fixes #2818

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

**Before**
![screenshot_5](https://user-images.githubusercontent.com/27482193/49878230-1fcdba00-fe38-11e8-9823-ba028d4dc6a7.png)

**After**
![screenshot_4](https://user-images.githubusercontent.com/27482193/49878197-147a8e80-fe38-11e8-8d61-5ce45f4ba5a5.png)


### Testing Procedure ###

- In ControllGalery run UItest 2818
- Hamburger icon on the main page should be on the right

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
