### PR TITLE
[Android] fixes pop-up dialog in Pickers when you call Focus()

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/IPopupTrigger.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/IPopupTrigger.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms.Platform.Android
+{
+	public interface IPopupTrigger
+	{
+		bool ShowPopupOnFocus { get; set; }
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
@@ -9,7 +9,7 @@ using Android.Runtime;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class PickerEditText : EditText
+	public class PickerEditText : EditText, IPopupTrigger
 	{
 		readonly static HashSet<Keycode> availableKeys = new HashSet<Keycode>(new[] {
 			Keycode.Tab, Keycode.Forward, Keycode.Back, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		System.WeakReference<IPickerRenderer> rendererRef;
 
-		internal bool ShowPopupWhenFocus;
+		public bool ShowPopupOnFocus { get; set; }
 
 		public PickerEditText(Context context, IPickerRenderer pickerRenderer) : base(context)
 		{
@@ -32,9 +32,9 @@ namespace Xamarin.Forms.Platform.Android
 		protected override void OnFocusChanged(bool gainFocus, [GeneratedEnum] FocusSearchDirection direction, Rect previouslyFocusedRect)
 		{
 			base.OnFocusChanged(gainFocus, direction, previouslyFocusedRect);
-			if (gainFocus && ShowPopupWhenFocus)
+			if (gainFocus && ShowPopupOnFocus)
 				CallOnClick();
-			ShowPopupWhenFocus = false;
+			ShowPopupOnFocus = false;
 		}
 
 		void OnKeyPress(object sender, KeyEventArgs e)

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		System.WeakReference<IPickerRenderer> rendererRef;
 
-		internal bool FromFocusSearch;
+		internal bool ShowPopupWhenFocus;
 
 		public PickerEditText(Context context, IPickerRenderer pickerRenderer) : base(context)
 		{
@@ -32,9 +32,9 @@ namespace Xamarin.Forms.Platform.Android
 		protected override void OnFocusChanged(bool gainFocus, [GeneratedEnum] FocusSearchDirection direction, Rect previouslyFocusedRect)
 		{
 			base.OnFocusChanged(gainFocus, direction, previouslyFocusedRect);
-			if (gainFocus && FromFocusSearch)
+			if (gainFocus && ShowPopupWhenFocus)
 				CallOnClick();
-			FromFocusSearch = false;
+			ShowPopupWhenFocus = false;
 		}
 
 		void OnKeyPress(object sender, KeyEventArgs e)

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -261,6 +261,9 @@ namespace Xamarin.Forms.Platform.Android
 				var handler = new Handler(looper);
 				handler.Post(() =>
 				{
+					var pickerEdit = Control as PickerEditText;
+					if (pickerEdit != null)
+						pickerEdit.ShowPopupWhenFocus = true;
 					Control?.RequestFocus();
 				});
 			}

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -261,9 +261,8 @@ namespace Xamarin.Forms.Platform.Android
 				var handler = new Handler(looper);
 				handler.Post(() =>
 				{
-					var pickerEdit = Control as PickerEditText;
-					if (pickerEdit != null)
-						pickerEdit.ShowPopupWhenFocus = true;
+					if (Control is IPopupTrigger popupElement)
+						popupElement.ShowPopupOnFocus = true;
 					Control?.RequestFocus();
 				});
 			}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -167,7 +167,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			// when the user focuses on picker show a popup dialog
 			if (control is PickerEditText picker)
-				picker.FromFocusSearch = true;
+				picker.ShowPopupWhenFocus = true;
 
 			return control;
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -166,8 +166,8 @@ namespace Xamarin.Forms.Platform.Android
 			} while (!(control?.Focusable == true || ++attempt >= maxAttempts));
 
 			// when the user focuses on picker show a popup dialog
-			if (control is PickerEditText picker)
-				picker.ShowPopupWhenFocus = true;
+			if (control is IPopupTrigger popupElement)
+				popupElement.ShowPopupOnFocus = true;
 
 			return control;
 		}

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Extensions\ImageViewExtensions.cs" />
     <Compile Include="Extensions\TextViewExtensions.cs" />
     <Compile Include="SwipeGestureHandler.cs" />
+    <Compile Include="Renderers\IPopupTrigger.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
### Description of Change ###

fixes pop-up dialog in Pickers when you call `Focus()`

### Issues Resolved ### 

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###

None


### Testing Procedure ###

- test Bugzilla41424 should passes.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
