### PR TITLE
delay ui test a bit so elements can vanish first

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Controls.Issues
 						_button.Image = null;
 						_imageButton.Source = null;
 						_listView.ItemsSource = new string[] { null };
-						button.Text = _appearText;
+						Device.BeginInvokeOnMainThread(() => button.Text = _appearText);
 					}
 					else
 					{
@@ -73,7 +73,7 @@ namespace Xamarin.Forms.Controls.Issues
 						_button.Image = _fileName;
 						_imageButton.Source = _fileName;
 						_listView.ItemsSource = new string[] { _fileName };
-						button.Text = _disappearText;
+						Device.BeginInvokeOnMainThread(() => button.Text = _disappearText);
 					}
 				})
 			};
@@ -109,6 +109,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Assert.IsNotNull(imageCell);
 
 			RunningApp.Tap("ClickMe");
+			RunningApp.WaitForElement(_appearText);
 			var elementsAfter = RunningApp.WaitForElement(_fileName);
 			var imageCellAfter = RunningApp.Query(app => app.Marked(_theListView).Descendant()).Where(x => x.Class.Contains("Image")).FirstOrDefault();
 			Assert.IsNull(imageCellAfter);


### PR DESCRIPTION
### Description of Change ###
Add some delay before testing if images vanished on iOS

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
