### PR TITLE
update support libraries to preview9 and uncomment no longer broken interface

### DIFF
--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -24,8 +24,8 @@
       </group>
       <group targetFramework="MonoAndroid90">
         <dependency id="Xamarin.GooglePlayServices.Maps" version="60.1142.1"/>
-        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0-preview8"/>
-        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0-preview8"/>
+        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0-preview9"/>
+        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0-preview9"/>
         <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
       <group targetFramework="tizen40">

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -21,12 +21,12 @@
         <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="27.0.2"/>
       </group>
       <group targetFramework="MonoAndroid90">
-        <dependency id="Xamarin.Android.Support.v4" version="28.0.0-preview8"/>
-        <dependency id="Xamarin.Android.Support.Design" version="28.0.0-preview8"/>
-        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0-preview8"/>
-        <dependency id="Xamarin.Android.Support.v7.CardView" version="28.0.0-preview8"/>
-        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0-preview8"/>
-        <dependency id="Xamarin.Android.Support.CustomTabs" version="28.0.0-preview8"/>
+        <dependency id="Xamarin.Android.Support.v4" version="28.0.0-preview9"/>
+        <dependency id="Xamarin.Android.Support.Design" version="28.0.0-preview9"/>
+        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0-preview9"/>
+        <dependency id="Xamarin.Android.Support.v7.CardView" version="28.0.0-preview9"/>
+        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0-preview9"/>
+        <dependency id="Xamarin.Android.Support.CustomTabs" version="28.0.0-preview9"/>
       </group>
       <group targetFramework="uap10.0">
         <dependency id="NETStandard.Library" version="2.0.1"/>

--- a/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
+++ b/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
@@ -112,10 +112,10 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">

--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -270,55 +270,55 @@
   
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Annotations">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Compat">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Core.UI">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Core.Utils">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.CustomTabs">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Design">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Fragment">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Media.Compat">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Transition">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.CardView">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.Palette">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -74,10 +74,10 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -330,55 +330,55 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Annotations">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Compat">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Core.UI">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Core.Utils">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.CustomTabs">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Design">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Fragment">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Media.Compat">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Transition">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.CardView">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.Palette">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -88,10 +88,10 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -70,7 +70,7 @@
   </ItemGroup>  
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
   </ItemGroup>  
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -14,9 +14,7 @@ using LP = Android.Views.ViewGroup.LayoutParams;
 namespace Xamarin.Forms.Platform.Android
 {
     public class ShellFlyoutTemplatedContentRenderer : Java.Lang.Object, IShellFlyoutContentRenderer
-#if __ANDROID81__
 		, AppBarLayout.IOnOffsetChangedListener
-#endif
     {
         #region IShellFlyoutContentRenderer
 
@@ -46,9 +44,7 @@ namespace Xamarin.Forms.Platform.Android
 
             _rootView = coordinator;
 
-            #if __ANDROID81__
             appBar.AddOnOffsetChangedListener(this);
-			#endif
 
             int actionBarHeight = (int)context.ToPixels(56);
 

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -329,13 +329,13 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
     <PackageReference Include="Xamarin.Android.Support.Design">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.CardView">
-      <Version>28.0.0-preview8</Version>
+      <Version>28.0.0-preview9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v8.1' ">


### PR DESCRIPTION
### Description of Change ###
Update android support libraries to the latest preview9. These also fixed an issue with *IOnOffsetChangedListener* which could now be added back in 

### Platforms Affected ### 
- Android

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
