### PR TITLE
[Android] Fix first navigation race condition with main page affectation

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -303,16 +303,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			// If the Appearing handler changed the application's main page for some reason,
 			// this page may no longer be part of the hierarchy; if so, we need to skip
-			// updating the toolbar and pushing the pages to avoid crashing the app
+			// updating the toolbar to avoid crashing the app
 			if (!Element.IsAttachedToRoot())
 				return;
 
 			RegisterToolbar();
 
-			// If there is already stuff on the stack we need to push it
-			PushCurrentPages();
-
 			UpdateToolbar();
+
 			_isAttachedToWindow = true;
 		}
 
@@ -368,12 +366,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				navController.PopToRootRequested += OnPoppedToRoot;
 				navController.InsertPageBeforeRequested += OnInsertPageBeforeRequested;
 				navController.RemovePageRequested += OnRemovePageRequested;
-
-				if (_isAttachedToWindow && Element.IsAttachedToRoot())
-				{
-					PushCurrentPages();
-				}
 			}
+
+			// If there is already stuff on the stack we need to push it
+			PushCurrentPages();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###
Wait for initial page to be loaded before push new pages inside the navigation stack.

### Issues Resolved ### 
- Fix #4729
- Fix #3528
- Fix #3923

### Platforms Affected ### 
- Android

### PR Checklist ###

- [ ] Has automated tests => Only manuel test is possible
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
