### PR TITLE
[macOS] Only the first Navigating event of WebView can be triggered

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/WebViewRenderer.cs
@@ -66,6 +66,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					decisionToken.Use();
 				}
+				
+				_sentNavigating = false;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fix the problem that only the first Navigating event of WebView can be triggered

### Platforms Affected ### 

- macOS