### PR TITLE
[X] Design time properties

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -264,22 +264,24 @@ namespace Xamarin.Forms.Build.Tasks
 
 					//First using the ResourceLoader
 					var nop = Instruction.Create(Nop);
-					var getResourceProvider = module.ImportPropertyGetterReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "ResourceLoader"), "ResourceProvider", isStatic: true);
-					il.Emit(Call, getResourceProvider);
-					il.Emit(Brfalse, nop);
-					il.Emit(Call, getResourceProvider);
 
+					il.Emit(Newobj, module.ImportCtorReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "ResourceLoader/ResourceLoadingQuery"), 0));
+					il.Emit(Dup); //dup the RLQ
+
+					//AssemblyName
 					il.Emit(Ldtoken, module.ImportReference(initComp.DeclaringType));
 					il.Emit(Call, module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", parameterTypes: new[] { ("mscorlib", "System", "RuntimeTypeHandle") }, isStatic: true));
 					il.Emit(Call, module.ImportMethodReference(("mscorlib", "System.Reflection", "IntrospectionExtensions"), methodName: "GetTypeInfo", parameterTypes: new[] { ("mscorlib", "System", "Type") }, isStatic: true));
 					il.Emit(Callvirt, module.ImportPropertyGetterReference(("mscorlib", "System.Reflection", "TypeInfo"), propertyName: "Assembly", flatten: true));
 					il.Emit(Callvirt, module.ImportMethodReference(("mscorlib", "System.Reflection", "Assembly"), methodName: "GetName", parameterTypes: null)); //assemblyName
 
+					il.Emit(Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "ResourceLoader/ResourceLoadingQuery"), "AssemblyName"));
+					il.Emit(Dup); //dup the RLQ
+
 					il.Emit(Ldstr, resourcePath);   //resourcePath
-					il.Emit(Callvirt, module.ImportMethodReference(("mscorlib", "System", "Func`3"),
-																   methodName: "Invoke",
-																   paramCount: 2,
-																   classArguments: new[] { ("mscorlib", "System.Reflection", "AssemblyName"), ("mscorlib", "System", "String"), ("mscorlib", "System", "String") }));
+					il.Emit(Callvirt, module.ImportPropertySetterReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "ResourceLoader/ResourceLoadingQuery"), "ResourcePath"));
+					
+					il.Emit(Call, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "ResourceLoader"), "CanProvideContentFor", 1, isStatic: true));
 					il.Emit(Brfalse, nop);
 					il.Emit(Ldarg_0);
 					il.Emit(Call, initCompRuntime);

--- a/Xamarin.Forms.Core/Internals/ResourceLoader.cs
+++ b/Xamarin.Forms.Core/Internals/ResourceLoader.cs
@@ -1,19 +1,54 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Reflection;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class ResourceLoader
 	{
 		static Func<AssemblyName, string, string> resourceProvider;
 
+		[Obsolete("You shouldn't have used this one to begin with, don't use the other one either")]
 		//takes a resource path, returns string content
 		public static Func<AssemblyName, string, string> ResourceProvider {
 			get => resourceProvider;
 			internal set {
-				DesignMode.IsDesignModeEnabled = true;
 				resourceProvider = value;
+				if (value != null)
+					ResourceProvider2 = rlq => new ResourceLoadingResponse { ResourceContent = value(rlq.AssemblyName, rlq.ResourcePath) };
+				else
+					ResourceProvider2 = null;
 			}
+		}
+
+		static Func<ResourceLoadingQuery, ResourceLoadingResponse> _resourceProvider2;
+		public static Func<ResourceLoadingQuery, ResourceLoadingResponse> ResourceProvider2 {
+			get => _resourceProvider2;
+			internal set {
+				DesignMode.IsDesignModeEnabled = value != null;
+				_resourceProvider2 = value;
+			}
+		}
+
+		[Obsolete("Can't touch this")]
+		public static bool CanProvideContentFor(ResourceLoadingQuery rlq)
+		{
+			if (_resourceProvider2 == null)
+				return false;
+			return _resourceProvider2(rlq) != null;
+		}
+
+		public class ResourceLoadingQuery
+		{
+			public AssemblyName AssemblyName { get; set; }
+			public string ResourcePath { get; set; }
+		}
+
+		public class ResourceLoadingResponse
+		{
+			public string ResourceContent { get; set; }
+			public bool UseDesignProperties { get; set; }
 		}
 
 		internal static Action<Exception> ExceptionHandler { get; set; }

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -38,6 +38,7 @@ using Xamarin.Forms.StyleSheets;
 [assembly: Preserve]
 
 [assembly: XmlnsDefinition("http://xamarin.com/schemas/2014/forms", "Xamarin.Forms")]
+[assembly: XmlnsDefinition("http://xamarin.com/schemas/2014/forms/design", "Xamarin.Forms")]
 
 [assembly: StyleProperty("background-color", typeof(VisualElement), nameof(VisualElement.BackgroundColorProperty))]
 [assembly: StyleProperty("background-image", typeof(Page), nameof(Page.BackgroundImageProperty))]

--- a/Xamarin.Forms.Xaml.UnitTests/DesignPropertiesTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignPropertiesTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[TestFixture]
+	public class DesignPropertiesTests
+	{
+		[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+		[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+		[Test]
+		public void DesignProperties()
+		{
+			var xaml = @"
+				<ContentPage
+						xmlns=""http://xamarin.com/schemas/2014/forms""
+						xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+						xmlns:d=""http://xamarin.com/schemas/2014/forms/design""
+						xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+						mc:Ignorable=""d"">
+					<Label  d:Text=""Bar"" Text=""Foo"" x:Name=""label"" />
+				</ContentPage>";
+
+			var view = new ContentPage();
+			XamlLoader.Load(view, xaml, useDesignProperties: true); //this is equiv as LoadFromXaml, but with the bool set
+
+			var label = ((Forms.Internals.INameScope)view).FindByName("label") as Label;
+
+			Assert.That(label.Text, Is.EqualTo("Bar"));
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/ResourceLoader.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/ResourceLoader.xaml.cs
@@ -29,7 +29,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			public void TearDown()
 			{
 				Device.PlatformServices = null;
+#pragma warning disable CS0618 // Type or member is obsolete
 				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = null;
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			[TestCase(false), TestCase(true)]
@@ -38,7 +40,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				var layout = new ResourceLoader(useCompiledXaml);
 				Assert.That(layout.label.TextColor, Is.EqualTo(Color.FromHex("#368F95")));
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = (asmName, path) => {
+#pragma warning restore CS0618 // Type or member is obsolete
 					if (path == "ResourceLoader.xaml")
 						return @"
 <ContentPage 
@@ -52,7 +56,63 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				};
 				layout = new ResourceLoader(useCompiledXaml);
 				Assert.That(layout.label.TextColor, Is.EqualTo(Color.Pink));
+			}
 
+			[Test]
+			public void XamlLoadingUsesResourceProvider2([Values (false, true)]bool useCompiledXaml)
+			{
+				var layout = new ResourceLoader(useCompiledXaml);
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.FromHex("#368F95")));
+
+				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider2 = (rlq) => {
+					if (rlq.ResourcePath == "ResourceLoader.xaml")
+						return new Forms.Internals.ResourceLoader.ResourceLoadingResponse {
+							ResourceContent = @"
+<ContentPage 
+	xmlns=""http://xamarin.com/schemas/2014/forms""
+	xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+	x:Class=""Xamarin.Forms.Xaml.UnitTests.ResourceLoader""
+	xmlns:d=""http://xamarin.com/schemas/2014/forms/design""
+	xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+	mc:Ignorable=""d"" >
+  
+	<Label x:Name = ""label"" TextColor = ""Pink"" d:TextColor = ""HotPink"" />
+</ContentPage >"};
+					return null;
+				}; 
+
+
+				layout = new ResourceLoader(useCompiledXaml);
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.Pink));
+			}
+
+			[Test]
+			public void XamlLoadingUsesResourceProvider2WithDesignProperties([Values(false, true)]bool useCompiledXaml)
+			{
+				var layout = new ResourceLoader(useCompiledXaml);
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.FromHex("#368F95")));
+
+				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider2 = (rlq) => {
+					if (rlq.ResourcePath == "ResourceLoader.xaml")
+						return new Forms.Internals.ResourceLoader.ResourceLoadingResponse {
+							UseDesignProperties = true,
+							ResourceContent = @"
+<ContentPage 
+	xmlns=""http://xamarin.com/schemas/2014/forms""
+	xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+	x:Class=""Xamarin.Forms.Xaml.UnitTests.ResourceLoader""
+	xmlns:d=""http://xamarin.com/schemas/2014/forms/design""
+	xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+	mc:Ignorable=""d"" >
+  
+	<Label x:Name = ""label"" TextColor = ""Pink"" d:TextColor = ""HotPink"" />
+</ContentPage >"};
+					return null;
+				};
+
+
+				layout = new ResourceLoader(useCompiledXaml);
+				Assert.That(layout.label.TextColor, Is.EqualTo(Color.HotPink));
 			}
 
 			[TestCase(false), TestCase(true)]
@@ -61,7 +121,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				var layout = new ResourceLoader(useCompiledXaml);
 				Assert.That(layout.label.TextColor, Is.EqualTo(Color.FromHex("#368F95")));
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				Xamarin.Forms.Internals.ResourceLoader.ResourceProvider = (asmName, path) => {
+#pragma warning restore CS0618 // Type or member is obsolete
 					if (path == "AppResources/Colors.xaml")
 						return @"
 <ResourceDictionary

--- a/Xamarin.Forms.Xaml/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Xaml/Properties/AssemblyInfo.cs
@@ -13,6 +13,7 @@ using Xamarin.Forms.Xaml;
 [assembly: Preserve]
 
 [assembly: XmlnsDefinition("http://xamarin.com/schemas/2014/forms", "Xamarin.Forms.Xaml")]
+[assembly: XmlnsDefinition("http://xamarin.com/schemas/2014/forms/design", "Xamarin.Forms.Xaml")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "Xamarin.Forms.Xaml")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System", AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System", AssemblyName = "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]

--- a/Xamarin.Forms.Xaml/RemoveDuplicateDesignNodes.cs
+++ b/Xamarin.Forms.Xaml/RemoveDuplicateDesignNodes.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+
+namespace Xamarin.Forms.Xaml
+{
+	class RemoveDuplicateDesignNodes : IXamlNodeVisitor
+	{
+		public TreeVisitingMode VisitingMode => TreeVisitingMode.TopDown;
+		public bool StopOnDataTemplate => false;
+		public bool StopOnResourceDictionary => false;
+		public bool VisitNodeOnDataTemplate => true;
+		public bool SkipChildren(INode node, INode parentNode) => false;
+		public bool IsResourceDictionary(ElementNode node) => false;
+
+		public void Visit(ValueNode node, INode parentNode)
+		{
+		}
+
+		public void Visit(MarkupNode node, INode parentNode)
+		{
+		}
+
+		public void Visit(ElementNode node, INode parentNode)
+		{
+			if (node.Properties == null || node.Properties.Count == 0)
+				return;
+			var props = node.Properties.ToList();
+			for (var i = 0; i < props.Count; i++) {
+				var key = props[i].Key;
+				if (key.NamespaceURI != XamlParser.XFDesignUri)
+					continue;
+				var k = new XmlName(XamlParser.XFUri, key.LocalName);
+				if (node.Properties.Remove(k))
+					continue;
+				if (node.NamespaceResolver.LookupPrefix(XamlParser.XFUri) == "")
+					node.Properties.Remove(new XmlName("", k.LocalName));
+			}
+		}
+
+		public void Visit(RootNode node, INode parentNode)
+		{
+			Visit((ElementNode)node, parentNode);
+		}
+
+		public void Visit(ListNode node, INode parentNode)
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -38,9 +38,11 @@ namespace Xamarin.Forms.Xaml
 	static class XamlParser
 	{
 		public const string XFUri = "http://xamarin.com/schemas/2014/forms";
+		public const string XFDesignUri = "http://xamarin.com/schemas/2014/forms/design";
 		public const string X2006Uri = "http://schemas.microsoft.com/winfx/2006/xaml";
 		public const string X2009Uri = "http://schemas.microsoft.com/winfx/2009/xaml";
 		public const string McUri = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+
 
 		public static void ParseXaml(RootNode rootNode, XmlReader reader)
 		{


### PR DESCRIPTION
An alternate xaml resource file provider can request the XamlLoader to
_not_ ignore normally ignored properties in prebuilt XF design xmlns, as
in the following snippet:

```xaml
<ContentPage
    xmlns="http://xamarin.com/schemas/2014/forms"
    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
    mc:Ignorable="d">
  <Label d:Text="Bar" Text="Foo" x:Name="label" />
</ContentPage>
```

The `d:` should be the prefix used by default for this, but any other
prefix will do too.

The `d:Text` property maps to the exact same property as `Text`, as the
XmllnsDefinitionAttributes are identical (that's convenient from a Intelisense
point of view), but, when (and only when) instructed by a provided Xaml resource
loader, the `d:Text` will override the `Text` property.

This works with virtually all properties defined on built-in Xamarin.Forms
controls, but it doesn't mean it's a sane idea to try to assign design value
to all existing properties.

The API for setting the ResourceLoader had to change, and instead of taking
pre-defined arguments, it accepts and returns query and response types. This
is slightly less convenient to invoke through reflection, but way more easy
to extend in the future.

As a side note, I'm quite proud, and thankful, of the work done by that 5-people
2-hours brainstorming-meeting that came up with the new name for the now
deprecated `ResourceProvider`.