### PR TITLE
Condition default items on the UsingMicrosoftNETSdk property for SDK projects 

### DIFF
--- a/.nuspec/Xamarin.Forms.DefaultItems.props
+++ b/.nuspec/Xamarin.Forms.DefaultItems.props
@@ -1,10 +1,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <ItemGroup Condition="'$(EnableDefaultItems)'=='True' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
+  <ItemGroup Condition="'$(UsingMicrosoftNETSdk)'=='True' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
     <EmbeddedResource Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(EnableDefaultItems)'=='True' And '$(EnableDefaultCssItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
+  <ItemGroup Condition="'$(UsingMicrosoftNETSdk)'=='True' And '$(EnableDefaultCssItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
     <EmbeddedResource Include="**\*.css" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
 </Project>

--- a/.nuspec/Xamarin.Forms.DefaultItems.targets
+++ b/.nuspec/Xamarin.Forms.DefaultItems.targets
@@ -7,11 +7,11 @@
 	Unfortunately there is no way to work around this without adding a new extension point to
 	the sdk props.
 	-->
-	<ItemGroup Condition="'$(EnableDefaultItems)'=='True' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
+	<ItemGroup Condition="'$(UsingMicrosoftNETSdk)'=='True' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
 		<Compile Update="**\*.xaml$(DefaultLanguageSourceExtension)" DependentUpon="%(Filename)" SubType="Code" />
 		<None Remove="**\*.xaml" Condition="'$(EnableDefaultNoneItems)'=='True'" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(EnableDefaultItems)'=='True' And '$(EnableDefaultCssItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
+	<ItemGroup Condition="'$(UsingMicrosoftNETSdk)'=='True' And '$(EnableDefaultCssItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
 		<None Remove="**\*.css" Condition="'$(EnableDefaultNoneItems)'=='True'" />
 	</ItemGroup>
 

--- a/.nuspec/Xamarin.Forms.props
+++ b/.nuspec/Xamarin.Forms.props
@@ -1,10 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<PropertyGroup>
-		<!-- Sdk.props imports Microsoft.NET.Sdk.props which defines Configurations and Platforms, which is the SDK-style way -->
-		<IsSdkStyle Condition="'$(IsSdkStyle)' == '' and '$(Configurations)' != '' and '$(Platforms)' != ''">true</IsSdkStyle>
-	</PropertyGroup>
-
 	<!--
 	When using Sdk-style projects and default embedded resource items are enabled, automatically
 	add the XAML files and fix up item metadata to pair them with code files.
@@ -15,6 +10,6 @@
 	The actual item groups are in a separate conditionally-imported file as they use constructs that
 	are not compatible with older MSBuild versions.
 	-->
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.props" Condition="'$(IsSdkStyle)' == 'true'" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.props" Condition="'$(UsingMicrosoftNETSdk)' == 'true'" />
 
 </Project>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -17,7 +17,7 @@
 		<_DefaultCssItemsEnabled>False</_DefaultCssItemsEnabled>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.targets" Condition="'$(IsSdkStyle)' != 'true'" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Forms.DefaultItems.targets" Condition="'$(UsingMicrosoftNETSdk)' != 'true'" />
 
 	<ItemGroup>
 		<ProjectCapability Include="XamarinForms" />


### PR DESCRIPTION
https://github.com/dotnet/sdk/blob/master/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props#L26

If someone only has pre 2.0 sdk installed then this property doesn't work
Not sure if that means this won't work

Compiling works on VSMac

Here's the binlog from compiling a PCL library
![image](https://user-images.githubusercontent.com/5375137/50037612-78d05600-ffd0-11e8-9e27-dc9bc27e25c1.png)
