### PR TITLE
Added case in GTK listviewrender for change of SelectedItem property

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4748.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4748.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4748, "Setting SelectedItem property of GTK ListView does not reflected in UI", PlatformAffected.Default)]
+	public class Issue4748 : TestContentPage 
+	{
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+			var lastItem = "Item3";
+			var listView = new ListView
+			{
+				ItemsSource = new List<string>
+				{
+					"Item1",
+					"Item2",
+					lastItem
+				}
+			};
+
+			var button = new Button
+			{
+				Text = "Select last item",
+				AutomationId = "SelectLastItem"
+			};
+
+			button.Clicked += (_, __) => listView.SelectedItem = lastItem;
+			layout.Children.Add(listView);
+			layout.Children.Add(button);
+
+			Content = layout;
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -547,6 +547,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3988.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4026.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4748.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
@@ -95,6 +95,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				UpdateIsRefreshing();
 			else if (e.PropertyName == ListView.IsPullToRefreshEnabledProperty.PropertyName)
 				UpdatePullToRefreshEnabled();
+			else if (e.PropertyName == ListView.SelectedItemProperty.PropertyName)
+				UpdateSelectedItem();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -434,6 +436,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			{
 				_listView.UpdatePullToRefreshEnabled(isPullToRefreshEnabled);
 			}
+		}
+
+		private void UpdateSelectedItem()
+		{
+			_listView?.SetSeletedItem(Element.SelectedItem);
 		}
 
 		private void UpdateGrouping()


### PR DESCRIPTION
### Description of Change ###

Added case in GTK listviewrender for change of SelectedItem property.

### Issues Resolved ### 

- fixes #4748


### API Changes ###
none

### Platforms Affected ### 
- GTK

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
I've added Issue4748.cs with basic example. Without fix, clicking button does not update selected item highlight in list. With fix, last item in list become highlighted, as it should.
I didn't understand, how to run UI tests locally, so I didn't made one.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
