### PR TITLE
Add Device.IsVirtual property

### DIFF
--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -72,6 +72,10 @@ namespace Xamarin.Forms
 		public static FlowDirection FlowDirection { get; internal set; }
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetIsVirtual(bool value) => IsVirtual = value;
+		public static bool IsVirtual { get; internal set; }
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool IsInvokeRequired
 		{
 			get { return PlatformServices.IsInvokeRequired; }

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -14,6 +14,7 @@ using Android.App;
 using Android.Content;
 using Android.Content.Res;
 using Android.OS;
+using Android.Provider;
 using Android.Util;
 using Android.Views;
 using Xamarin.Forms.Internals;
@@ -182,6 +183,20 @@ namespace Xamarin.Forms
 			// This could change as a result of a config change, so we need to check it every time
 			int minWidthDp = activity.Resources.Configuration.SmallestScreenWidthDp;
 			Device.SetIdiom(minWidthDp >= TabletCrossover ? TargetIdiom.Tablet : TargetIdiom.Phone);
+
+			// From https://github.com/xamarin/Essentials/blob/master/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
+			var isEmulator =
+				Build.Fingerprint.StartsWith("generic", StringComparison.InvariantCulture) ||
+				Build.Fingerprint.StartsWith("unknown", StringComparison.InvariantCulture) ||
+				Build.Model.Contains("google_sdk") ||
+				Build.Model.Contains("Emulator") ||
+				Build.Model.Contains("Android SDK built for x86") ||
+				Build.Manufacturer.Contains("Genymotion") ||
+				(Build.Brand.StartsWith("generic", StringComparison.InvariantCulture) && Build.Device.StartsWith("generic", StringComparison.InvariantCulture)) ||
+				Build.Product.Equals("google_sdk", StringComparison.InvariantCulture);
+
+			if (isEmulator)
+				Device.SetIsVirtual(true);
 
 			if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1)
 				Device.SetFlowDirection(activity.Resources.Configuration.LayoutDirection.ToFlowDirection());

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Foundation;
+using ObjCRuntime;
 #if __MOBILE__
 using UIKit;
 using Xamarin.Forms.Platform.iOS;
@@ -94,6 +95,8 @@ namespace Xamarin.Forms
 #if __MOBILE__
 			Device.SetIdiom(UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad ? TargetIdiom.Tablet : TargetIdiom.Phone);
 			Device.SetFlowDirection(UIApplication.SharedApplication.UserInterfaceLayoutDirection.ToFlowDirection());
+			if (Runtime.Arch == Arch.SIMULATOR)
+				Device.SetIsVirtual(true);
 #else
 			Device.SetIdiom(TargetIdiom.Desktop);
 			Device.SetFlowDirection(NSApplication.SharedApplication.UserInterfaceLayoutDirection.ToFlowDirection());


### PR DESCRIPTION
Sometimes (especially for tooling and/or telemetry purposes) it's
useful to know if your code is running on a physical device or an
emulator/simulator. Xamarin.Essentials provides this information
via the DeviceInfo class, but it requires its own separate initialization
in addition to what XF already does.

For a library targeting XF, depending on Xamarin.Essentials to provide
this information would mean taking a dependency on its package.
Consumers of the library would need to now know to initialize Essentials
properly or otherwise the library will fail. Since it would be a
transitive dependency, it wouldn't be easy to figure out what's
required to make it work.

So in order to make this information available in the easiest
possible way, a new `IsVirtual` property is added to the `Device`
class, which is set for Android and iOS in the same way Essentials does,
but using a simple boolean instead to reduce the added API surface.

### API Changes ###
Added:
 - bool IsVirtual { get; } 

### Platforms Affected ### 
- iOS
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Since this code is already tested as part of Xamarin.Essentials, likely not needed again here?

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
