### PR TITLE
[C] WeakEventManager minor changes

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/WeakEventManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/WeakEventManagerTests.cs
@@ -55,8 +55,8 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			internal event EventHandler TestEvent
 			{
-				add { _weakEventManager.AddEventHandler(nameof(TestEvent), value); }
-				remove { _weakEventManager.RemoveEventHandler(nameof(TestEvent), value); }
+				add { _weakEventManager.AddEventHandler(value); }
+				remove { _weakEventManager.RemoveEventHandler(value); }
 			}
 
 			void OnTestEvent()
@@ -82,21 +82,21 @@ namespace Xamarin.Forms.Core.UnitTests
 		public void AddHandlerWithEmptyEventNameThrowsException()
 		{
 			var wem = new WeakEventManager();
-			Assert.Throws<ArgumentNullException>(() => wem.AddEventHandler("", (sender, args) => { }));
+			Assert.Throws<ArgumentNullException>(() => wem.AddEventHandler((sender, args) => { }, ""));
 		}
 
 		[Test]
 		public void AddHandlerWithNullEventHandlerThrowsException()
 		{
 			var wem = new WeakEventManager();
-			Assert.Throws<ArgumentNullException>(() => wem.AddEventHandler("test", null));
+			Assert.Throws<ArgumentNullException>(() => wem.AddEventHandler(null, "test"));
 		}
 
 		[Test]
 		public void AddHandlerWithNullEventNameThrowsException()
 		{
 			var wem = new WeakEventManager();
-			Assert.Throws<ArgumentNullException>(() => wem.AddEventHandler(null, (sender, args) => { }));
+			Assert.Throws<ArgumentNullException>(() => wem.AddEventHandler((sender, args) => { }, null));
 		}
 
 		[Test]
@@ -164,29 +164,29 @@ namespace Xamarin.Forms.Core.UnitTests
 		public void RemoveHandlerWithEmptyEventNameThrowsException()
 		{
 			var wem = new WeakEventManager();
-			Assert.Throws<ArgumentNullException>(() => wem.RemoveEventHandler("", (sender, args) => { }));
+			Assert.Throws<ArgumentNullException>(() => wem.RemoveEventHandler((sender, args) => { }, ""));
 		}
 
 		[Test]
 		public void RemoveHandlerWithNullEventHandlerThrowsException()
 		{
 			var wem = new WeakEventManager();
-			Assert.Throws<ArgumentNullException>(() => wem.RemoveEventHandler("test", null));
+			Assert.Throws<ArgumentNullException>(() => wem.RemoveEventHandler(null, "test"));
 		}
 
 		[Test]
 		public void RemoveHandlerWithNullEventNameThrowsException()
 		{
 			var wem = new WeakEventManager();
-			Assert.Throws<ArgumentNullException>(() => wem.RemoveEventHandler(null, (sender, args) => { }));
+			Assert.Throws<ArgumentNullException>(() => wem.RemoveEventHandler((sender, args) => { }, null));
 		}
 
 		[Test]
 		public void RemovingNonExistentHandlersShouldNotThrow()
 		{
 			var wem = new WeakEventManager();
-			wem.RemoveEventHandler("fake", (sender, args) => { });
-			wem.RemoveEventHandler("alsofake", Handler);
+			wem.RemoveEventHandler((sender, args) => { }, "fake");
+			wem.RemoveEventHandler(Handler, "alsofake");
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Command.cs
+++ b/Xamarin.Forms.Core/Command.cs
@@ -103,8 +103,8 @@ namespace Xamarin.Forms
 
 		public event EventHandler CanExecuteChanged
 		{
-			add { _weakEventManager.AddEventHandler(nameof(CanExecuteChanged), value); }
-			remove { _weakEventManager.RemoveEventHandler(nameof(CanExecuteChanged), value); }
+			add { _weakEventManager.AddEventHandler(value); }
+			remove { _weakEventManager.RemoveEventHandler(value); }
 		}
 
 		public void Execute(object parameter)

--- a/Xamarin.Forms.Core/ImageSource.cs
+++ b/Xamarin.Forms.Core/ImageSource.cs
@@ -145,8 +145,8 @@ namespace Xamarin.Forms
 
 		internal event EventHandler SourceChanged
 		{
-			add { _weakEventManager.AddEventHandler(nameof(SourceChanged), value); }
-			remove { _weakEventManager.RemoveEventHandler(nameof(SourceChanged), value); }
+			add { _weakEventManager.AddEventHandler(value); }
+			remove { _weakEventManager.RemoveEventHandler(value); }
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

As pointed in https://github.com/xamarin/Xamarin.Forms/issues/4750#issuecomment-447673540,
internal WeakEventManager usage can be simplified.

This also updates the code to ValueTuple, throw expressions, ...

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

/

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
