### PR TITLE
[XamlC] instantiate generic parameter on base types

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -824,8 +824,7 @@ namespace Xamarin.Forms.Build.Tasks
 		{
 			var module = context.Body.Method.Module;
 			var localName = propertyName.LocalName;
-			bool attached;
-			var bpRef = GetBindablePropertyReference(parent, propertyName.NamespaceURI, ref localName, out attached, context, iXmlLineInfo);
+			var bpRef = GetBindablePropertyReference(parent, propertyName.NamespaceURI, ref localName, out System.Boolean attached, context, iXmlLineInfo);
 
 			//If the target is an event, connect
 			if (CanConnectEvent(parent, localName, attached))
@@ -1001,12 +1000,10 @@ namespace Xamarin.Forms.Build.Tasks
 
 			if (bpRef == null)
 				return false;
-			var elementNode = valueNode as IElementNode;
-			if (elementNode == null)
+			if (!(valueNode is IElementNode elementNode))
 				return false;
 
-			VariableDefinition varValue;
-			if (!context.Variables.TryGetValue(valueNode as IElementNode, out varValue))
+			if (!context.Variables.TryGetValue(valueNode as IElementNode, out VariableDefinition varValue))
 				return false;
 			var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference(("Xamarin.Forms.Core","Xamarin.Forms","BindingBase")), module);
 			if (implicitOperator != null)

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4760.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4760.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4760">
+	<Label x:Name="label" Text="Foo" Scale="{local:Gh4760Multiply Base=2, By=3}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4760.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4760.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+using NUnit.Framework;
+
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public abstract class Gh4760Base<T> : IMarkupExtension<T>
+	{
+		public abstract T ProvideValue();
+		public T ProvideValue(IServiceProvider serviceProvider) => ProvideValue();
+		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) =>
+		  ProvideValue(serviceProvider);
+	}
+
+	public class Gh4760MultiplyExtension : Gh4760Base<double>
+	{
+		public double Base { get; set; }
+		public double By { get; set; }
+
+		public override double ProvideValue() => Base * By;
+	}
+
+	public partial class Gh4760 : ContentPage
+	{
+		public Gh4760() => InitializeComponent();
+		public Gh4760(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void GenericBaseClassForMarkups([Values (false, true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh4760)));
+				var layout = new Gh4760(useCompiledXaml);
+				Assert.That(layout.label.Scale, Is.EqualTo(6));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.XamlcUnitTests
 			public abstract void Method<T>(T t);
 		}
 
-		abstract class Garply<T>
+		abstract class Garply<T> : Grault<T>
 		{
 			public abstract void Method(T t);
 		}
@@ -56,6 +56,14 @@ namespace Xamarin.Forms.XamlcUnitTests
 		abstract class Waldo<T>
 		{
 			public abstract void Method(Foo<T> t);
+		}
+
+		interface IGrault<T>
+		{
+		}
+
+		class Grault<T> : IGrault<T>
+		{
 		}
 
 		ModuleDefinition module;
@@ -177,6 +185,21 @@ namespace Xamarin.Forms.XamlcUnitTests
 			var resolved = method.Parameters[0].ParameterType.ResolveGenericParameters(method);
 
 			Assert.That(TypeRefComparer.Default.Equals(module.ImportReference(returnType), resolved));
+		}
+		
+		[Test]
+		public void TestImplementsGenericInterface()
+		{
+			GenericInstanceType igrault;
+			IList<TypeReference> arguments;
+			var garply = module.ImportReference(typeof(Garply<System.Byte>));
+
+			Assert.That(garply.ImplementsGenericInterface("Xamarin.Forms.XamlcUnitTests.TypeReferenceExtensionsTests/IGrault`1<T>", out igrault, out arguments));
+
+			Assert.AreEqual("System", igrault.GenericArguments[0].Namespace);
+			Assert.AreEqual("Byte", igrault.GenericArguments[0].Name);
+			Assert.AreEqual("System", arguments[0].Namespace);
+			Assert.AreEqual("Byte", arguments[0].Name);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

See #4047 for full description. This PR cherry-pick the commit from #4047 and adds a Xaml unit test.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4760
- closes #4047

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
