### PR TITLE
[Android] Avoid acting on a disposed reference

### DIFF
--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -266,9 +266,13 @@ namespace Xamarin.Forms.Platform.Android
 				var handler = new Handler(looper);
 				handler.Post(() =>
 				{
+					if (Control == null || Control.IsDisposed())
+						return;
+
 					if (Control is IPopupTrigger popupElement)
 						popupElement.ShowPopupOnFocus = true;
-					Control?.RequestFocus();
+
+					Control.RequestFocus();
 				});
 			}
 			else


### PR DESCRIPTION
### Description of Change ###

Fixes a UI test crash in 30935.

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Xamarin.Forms.Platform.Android.FormsEditText'.
12-17 13:17:21.290 I/MonoDroid(15560):   at Android.Views.View.RequestFocus () [0x0000a] in <0266c7f7d18f4d3580215846af2399e2>:0 
12-17 13:17:21.290 I/MonoDroid(15560):   at Xamarin.Forms.Platform.Android.ViewRenderer`2[TView,TNativeView].<OnFocusChangeRequested>b__30_0 () [0x00031] in <e7fd999147d542de8f25a4543d0d9869>:0 
12-17 13:17:21.290 I/MonoDroid(15560):   at Java.Lang.Thread+RunnableImplementor.Run () [0x00008] in <0266c7f7d18f4d3580215846af2399e2>:0 
12-17 13:17:21.290 I/MonoDroid(15560):   at Java.Lang.IRunnableInvoker.n_Run (System.IntPtr jnienv, System.IntPtr native__this) [0x00009] in <0266c7f7d18f4d3580215846af2399e2>:0 
12-17 13:17:21.290 I/MonoDroid(15560):   at (wrapper dynamic-method) System.Object.26(intptr,intptr)```
```

### Issues Resolved ### 

N/A

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
1. Run B30935 test in Control Gallery
2. No crash? Success!

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
