### PR TITLE
[Android] Check if Drawable is null in Draw override on ImageButton

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -39,6 +39,7 @@ using Xamarin.Forms.Controls.Issues;
 [assembly: ExportRenderer(typeof(Issue1683.EditorKeyboardFlags), typeof(EditorRendererKeyboardFlags))]
 //[assembly: ExportRenderer(typeof(AndroidHelpText.HintLabel), typeof(HintLabel))]
 [assembly: ExportRenderer(typeof(QuickCollectNavigationPage), typeof(QuickCollectNavigationPageRenderer))]
+[assembly: ExportRenderer(typeof(Issue4782.Issue4782ImageButton), typeof(Issue4782ImageButtonImageButtonRenderer))]
 
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.NoFlashTestNavigationPage), typeof(Xamarin.Forms.ControlGallery.Android.NoFlashTestNavigationPage))]
@@ -626,6 +627,19 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			Control.SetKeyboardFlags(FlagsToSet);
 			Control.TestKeyboardFlags(FlagsToTestFor);
+		}
+	}
+
+	public class Issue4782ImageButtonImageButtonRenderer : ImageButtonRenderer
+	{
+		public Issue4782ImageButtonImageButtonRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<ImageButton> e)
+		{
+			base.OnElementChanged(e);
+			SetImageDrawable(null);
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4782.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4782.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4782, "[Android] Null drawable crashes Image Button",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ImageButton)]
+#endif
+	public class Issue4782 : TestContentPage
+	{
+		const string _success = "Success";
+		public class Issue4782ImageButton : ImageButton { }
+
+		protected override void Init()
+		{
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						Text = "If app didn't crash then test passed",
+						AutomationId = _success
+					},
+					new Issue4782ImageButton()
+				}
+			};
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void ImageButtonNullDrawable()
+		{
+			RunningApp.WaitForElement(_success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -17,6 +17,7 @@
       <DependentUpon>Issue1588.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4782.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4484.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3509.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4597.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -17,6 +17,7 @@
 		public const string Entry = "Entry";
 		public const string Frame = "Frame";
 		public const string Image = "Image";
+		public const string ImageButton = "ImageButton";
 		public const string Label = "Label";
 		public const string ListView = "ListView";
 		public const string UwpIgnore = "UwpIgnore";

--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -189,42 +189,42 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			var backgroundDrawable = _backgroundTracker?.BackgroundDrawable;
-
 			RectF drawableBounds = null;
 
-			if ((int)Build.VERSION.SdkInt >= 18 && backgroundDrawable != null)
+			if(Drawable != null)
 			{
-				var outlineBounds = backgroundDrawable.GetPaddingBounds(canvas.Width, canvas.Height);
-				var width = (float)MeasuredWidth;
-				var height = (float)MeasuredHeight;
-
-				var widthRatio = 1f;
-				var heightRatio = 1f;
-
-				if (Element.Aspect == Aspect.AspectFill && OnThisPlatform().GetIsShadowEnabled())
-					Internals.Log.Warning(nameof(ImageButtonRenderer), "AspectFill isn't fully supported when using shadows. Image may be clipped incorrectly to Border");
-
-				switch (Element.Aspect)
+				if ((int)Build.VERSION.SdkInt >= 18 && backgroundDrawable != null)
 				{
-					case Aspect.Fill:
-						break;
-					case Aspect.AspectFill:
-					case Aspect.AspectFit:
-						heightRatio = (float)Drawable.IntrinsicHeight / height;
-						widthRatio = (float)Drawable.IntrinsicWidth / width;
-						break;
+					var outlineBounds = backgroundDrawable.GetPaddingBounds(canvas.Width, canvas.Height);
+					var width = (float)MeasuredWidth;
+					var height = (float)MeasuredHeight;
+
+					var widthRatio = 1f;
+					var heightRatio = 1f;
+
+					if (Element.Aspect == Aspect.AspectFill && OnThisPlatform().GetIsShadowEnabled())
+						Internals.Log.Warning(nameof(ImageButtonRenderer), "AspectFill isn't fully supported when using shadows. Image may be clipped incorrectly to Border");
+
+					switch (Element.Aspect)
+					{
+						case Aspect.Fill:
+							break;
+						case Aspect.AspectFill:
+						case Aspect.AspectFit:
+							heightRatio = (float)Drawable.IntrinsicHeight / height;
+							widthRatio = (float)Drawable.IntrinsicWidth / width;
+							break;
+					}
+
+					drawableBounds = new RectF(outlineBounds.Left * widthRatio, outlineBounds.Top * heightRatio, outlineBounds.Right * widthRatio, outlineBounds.Bottom * heightRatio);
 				}
 
-				drawableBounds = new RectF(outlineBounds.Left * widthRatio, outlineBounds.Top * heightRatio, outlineBounds.Right * widthRatio, outlineBounds.Bottom * heightRatio);
+				if (drawableBounds != null)
+					Drawable.SetBounds((int)drawableBounds.Left, (int)drawableBounds.Top, (int)drawableBounds.Right, (int)drawableBounds.Bottom);
 			}
 
-			if (drawableBounds != null)
-				Drawable.SetBounds((int)drawableBounds.Left, (int)drawableBounds.Top, (int)drawableBounds.Right, (int)drawableBounds.Bottom);
-
-
-
 			base.Draw(canvas);
-			if (_backgroundTracker.BackgroundDrawable != null)
+			if (_backgroundTracker?.BackgroundDrawable != null)
 				_backgroundTracker.BackgroundDrawable.DrawOutline(canvas, canvas.Width, canvas.Height);
 		}
 


### PR DESCRIPTION
### Description of Change ###
Forms just sets the default Drawable to "Transparent" so the Drawable is never null. 3rd party libraries that implement their own handlers won't do this though so need to check if Drawable is null. 

### Issues Resolved ### 
- fixes #4782

### Platforms Affected ### 
- Android

### Testing Procedure ###
There aren't any.  I added a custom renderer UI test to replicate setting Drawable to null but there's no way to manually test outside of just making sure changes don't appear to cause more breaks.
You can check the ImageButtonGallery just to makes sure all seems correct

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
