### PR TITLE
[Tizen] Supports SwitchCell.OnColor

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/SwitchCellRenderer.cs
@@ -38,10 +38,11 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				var toggle = new Switch()
 				{
+					BindingContext = cell,
+					Parent = cell.Parent
 				};
 				toggle.SetBinding(Switch.IsToggledProperty, new Binding(SwitchCell.OnProperty.PropertyName));
-				toggle.BindingContext = cell;
-				toggle.Parent = cell.Parent;
+				toggle.SetBinding(Switch.OnColorProperty, new Binding(SwitchCell.OnColorProperty.PropertyName));
 				var nativeView = Platform.GetOrCreateRenderer(toggle).NativeView;
 
 				if (Device.Idiom == TargetIdiom.Watch)


### PR DESCRIPTION
### Description of Change ###
Added `OnColor` property for changing color of `SwitchCell` on Tizen. This PR is an addendum to the changes in #4036.

### Issues Resolved ### 
- implements tizen part of #4027

### API Changes ###
None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
![switchcell](https://user-images.githubusercontent.com/1029134/50141576-37e78280-02eb-11e9-9b1c-4b6d3deed6e5.gif)

### Testing Procedure ###
Use [SwitchCellListPages](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Controls/GalleryPages/CellsGalleries/SwitchCellListPage.cs)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard