### PR TITLE
[X] throw XPE on missing element .ctor

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
@@ -148,6 +148,9 @@ namespace Xamarin.Forms.Build.Tasks
 				md.IsSpecialName &&
 				md.Name == "op_Implicit" && md.Parameters [0].ParameterType.FullName == "System.String");
 
+			if (!typedef.IsValueType && ctorInfo == null && factoryMethodInfo == null)
+				throw new XamlParseException($"Missing default constructor for '{typedef.FullName}'.", node);
+
 			if (ctorinforef != null || factorymethodinforef != null || typedef.IsValueType) {
 				VariableDefinition vardef = new VariableDefinition(typeref);
 				Context.Variables [node] = vardef;

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4751.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4751.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh4751">
+	<ContentPage.BindingContext>
+		<local:Gh4751VM />
+	</ContentPage.BindingContext>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4751.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh4751.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh4751VM
+	{
+		public string Title { get; }
+		public Gh4751VM(string title = null) => Title = title; //a .ctor with a default value IS NOT a default .ctor
+	}
+
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh4751 : ContentPage
+	{
+		public Gh4751() => InitializeComponent();
+		public Gh4751(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void ErrorOnMissingDefaultCtor([Values (false, true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<XamlParseException>(() => MockCompiler.Compile(typeof(Gh4751)));
+				else
+					Assert.Throws<XamlParseException>(() => new Gh4751(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -83,10 +83,11 @@ namespace Xamarin.Forms.Xaml
 					if (value == null)
 						value = Activator.CreateInstance(type);
 				}
-				catch (TargetInvocationException e) {
-					if (e.InnerException is XamlParseException || e.InnerException is XmlException)
-						throw e.InnerException;
-					throw;
+				catch (TargetInvocationException e) when (e.InnerException is XamlParseException || e.InnerException is XmlException) {
+					throw e.InnerException;
+				}
+				catch (MissingMethodException mme) {
+					throw new XamlParseException(mme.Message, node, mme);
 				}
 			}
 

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Xaml
 				catch (TargetInvocationException e) when (e.InnerException is XamlParseException || e.InnerException is XmlException) {
 					throw e.InnerException;
 				}
-				catch (MissingMethodException mme) {
+				catch (MissingMemberException mme) {
 					throw new XamlParseException(mme.Message, node, mme);
 				}
 			}


### PR DESCRIPTION
### Description of Change ###

In case of runtime parse, wrap the MissingMethodException in a
XamlParseException, to get lineInfo. In case of XamlC, detect missing
constructor and fail early.

### Issues Resolved ### 

- fixes #4751

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
