### PR TITLE
[A] only clip to bounds on API 18 and up

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Android.Content;
 using Android.Graphics;
 using Android.Support.V7.Widget;
+using Android.OS;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
@@ -45,7 +46,8 @@ namespace Xamarin.Forms.Platform.Android
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			base.OnLayout(changed, l, t, r, b);
-			ClipBounds = new Rect(0,0, Width, Height);
+			if ((int)Build.VERSION.SdkInt >= 18)
+				ClipBounds = new Rect(0,0, Width, Height);
 
 			// After a direct (non-animated) scroll operation, we may need to make adjustments
 			// to align the target item; if an adjustment is pending, execute it here.

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Threading.Tasks;
+using Android.OS;
 using Android.Widget;
 using AScaleType = Android.Widget.ImageView.ScaleType;
 using ARect = Android.Graphics.Rect;
@@ -19,8 +20,11 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		static void OnLayoutChange(object sender, global::Android.Views.View.LayoutChangeEventArgs e)
 		{
-			if(sender is IVisualElementRenderer renderer && renderer.View is ImageView imageView)
-				imageView.ClipBounds = imageView.GetScaleType() == AScaleType.CenterCrop ? new ARect(0, 0, e.Right - e.Left, e.Bottom - e.Top) : null;
+			if ((int)Build.VERSION.SdkInt >= 18)
+			{
+				if (sender is IVisualElementRenderer renderer && renderer.View is ImageView imageView)
+					imageView.ClipBounds = imageView.GetScaleType() == AScaleType.CenterCrop ? new ARect(0, 0, e.Right - e.Left, e.Bottom - e.Top) : null;
+			}
 		}
 
 		public static void Dispose(IVisualElementRenderer renderer)


### PR DESCRIPTION
### Description of Change ###

[A] only clip to bounds on API 18 and up

### Issues Resolved ### 

- fixes #4789
- fixes #4790

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
