### PR TITLE
Adds some tests around different ways instantiating a type can throw

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -355,7 +355,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					<local:SettingPropertyThrows TestValue=""Test"" />
 				</ContentPage>";
 
+			var exceptions = new List<Exception>();
+			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
+
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+
+			// Assuming we use ResourceLoader.ExceptionHandler to handle exceptions like this... if we use a different approach,
+			// we'll need to change this assertion...
+			Assert.That(exceptions.Count, Is.EqualTo(1));
 		}
 
 		[Test]

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -303,7 +303,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void InstantiateWithDefaultConstructorThrows()
+		public void CanReplaceTypeWhenDefaultConstructorThrows()
 		{
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -316,7 +316,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void InstantiateWithFactoryMethodThrows()
+		public void CanReplaceTypeWhenFactoryMethodThrows()
 		{
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -329,7 +329,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void InstantiateWithNonDefaultConstructorThrows()
+		public void CanReplaceTypeWhenNonDefaultConstructorThrows()
 		{
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -340,6 +340,19 @@ namespace Xamarin.Forms.Xaml.UnitTests
 							<x:Int32>1</x:Int32>
 						</x:Arguments>
 					</local:InstantiateThrows>
+				</ContentPage>";
+
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+		}
+
+		[Test]
+		public void CanIgnoreSettingPropertyThatThrows()
+		{
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
+					<local:SettingPropertyThrows TestValue=""Test"" />
 				</ContentPage>";
 
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
@@ -528,6 +541,16 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public InstantiateThrows(int value)
 		{
 			throw new InvalidOperationException();
+		}
+	}
+
+	public class SettingPropertyThrows : BindableObject
+	{
+		public static readonly BindableProperty TestValueProperty = BindableProperty.Create("TestValue", typeof(string), typeof(SettingPropertyThrows), "", propertyChanged: TestValuePropertyChanged);
+
+		static void TestValuePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			throw new InvalidOperationException("Setting this property throws an exception.");
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using Xamarin.Forms.Core.UnitTests;
 
@@ -304,6 +303,68 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
+		public void InstantiateWithDefaultConstructorThrows()
+		{
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
+					<local:InstantiateThrows />
+				</ContentPage>";
+
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+		}
+
+		[Test]
+		public void InstantiateWithFactoryMethodThrows()
+		{
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
+					<local:InstantiateThrows x:FactoryMethod=""CreateInstance"" />
+				</ContentPage>";
+
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+		}
+
+		[Test]
+		public void InstantiateWithNonDefaultConstructorThrows()
+		{
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
+					<local:InstantiateThrows>
+						<x:Arguments>
+							<x:Int32>1</x:Int32>
+						</x:Arguments>
+					</local:InstantiateThrows>
+				</ContentPage>";
+
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+		}
+
+		[Test]
+		public void FormsFallbackWithUnsupportedNonDefaultConstructor()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
+					<local:Test>
+						<x:Arguments>
+							<x:Int32>1</x:Int32>
+						</x:Arguments>
+					</local:Test>
+				</ContentPage>";
+
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+		}
+
+		[Test]
 		public void StaticResourceKeyInApp()
 		{
 			var app = @"
@@ -449,6 +510,24 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var myButton = (Button)page.Content;
 
 			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Blue));
+		}
+	}
+
+	public class InstantiateThrows
+	{
+		public InstantiateThrows()
+		{
+			throw new InvalidOperationException();
+		}
+
+		public static InstantiateThrows CreateInstance()
+		{
+			throw new InvalidOperationException();
+		}
+
+		public InstantiateThrows(int value)
+		{
+			throw new InvalidOperationException();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

@StephaneDelcroix ... For the Forms Previewer, we'll need someway to handle this scenario. Perhaps another callback that lets us provide a replacement type when instantiating a type fails?

However, simply providing a replacement type won't be enough to sort this. For example:

1. The scenario covered by the `FormsFallbackWithUnsupportedNonDefaultConstructor` test: If we have provided a fallback type in response to the `FallbackTypeResolver` callback, it is very likely that instantiation of that fallback type will fail in non-default constructor scenarios (for example, using `x:FactoryMethod` or `x:Arguments`). In such a case, if we have a callback to handle instantiation throwing an exception, what should it return? Ultimately we probably just instantiate the fallback type using its default constructor.

2. Similarly if we allow a custom type to be created, and it throws an exception while being instantiated, and `x:FactoryMethod` or `x:Arguments` was used to instantiate it, simply returning providing a replacement type in response to that failure will very likely fail again. I can't add a test for this scenario until we have a callback that handles instantiation failures.

The possibility also exists, of course, that instantiating the replacement type will work in the above scenario (for example, the user type might derive from a Forms type and have a constructor parameter that it bases to the base type constructor). So perhaps the best approach would be that the Previewer provides Forms with a replacement type (when instantiation fails) and Forms tries to instantiate that replacement type using the standard mechanism... then if *that* still fails, simply try to instantiate using the default constructor (if that wasn't already what we were doing). And if *that* fails, I think we'd simply throw 😄 

FYI @alanmcgovern, @drewgillies 