### PR TITLE
[Flex] fix Padding on the FlexLayout

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/FlexLayoutTests.cs
@@ -454,5 +454,36 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.That(layout.Children[2].Bounds, Is.EqualTo(new Rectangle(0, 200, 300, 100)));
 		}
+
+		[Test]
+		public void PaddingOnLayout()
+		//https://github.com/xamarin/Xamarin.Forms/issues/2663
+		{
+			var label0 = new Label {
+				IsPlatformEnabled = true,
+			};
+			var label1 = new Label {
+				IsPlatformEnabled = true,
+			};
+			var label2 = new Label {
+				IsPlatformEnabled = true,
+			};
+			var layout = new FlexLayout {
+				IsPlatformEnabled = true,
+				JustifyContent = FlexJustify.SpaceBetween,
+				AlignItems = FlexAlignItems.Start,
+
+				Padding = new Thickness(20,10,20,0),
+				Children = {
+					label0,
+					label1,
+					label2,
+				}
+			};
+
+			layout.Layout(new Rectangle(0, 0, 500, 300));
+			Assert.That(layout.Children[0].Bounds, Is.EqualTo(new Rectangle(20, 10, 100, 20)));
+			Assert.That(layout.Children[2].Bounds, Is.EqualTo(new Rectangle(380, 10, 100, 20)));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -391,7 +391,7 @@ namespace Xamarin.Forms
 			if (_root == null)
 				return;
 			
-			Layout(x, y, width, height);
+			Layout(width, height);
 			foreach (var child in Children) {
 				var frame = GetFlexItem(child).GetFrame();
 				if (double.IsNaN(frame.X)
@@ -399,7 +399,8 @@ namespace Xamarin.Forms
 					|| double.IsNaN(frame.Width)
 					|| double.IsNaN(frame.Height))
 					throw new Exception("something is deeply wrong");
-				child.Layout(GetFlexItem(child).GetFrame());
+				frame = frame.Offset(x, y); //flex doesn't support offset on _root
+				child.Layout(frame);
 			}
 		}
 
@@ -418,7 +419,7 @@ namespace Xamarin.Forms
 				item.Shrink = 0;
 				item.AlignSelf = Flex.AlignSelf.Start;
 			}
-			Layout(0, 0, widthConstraint, heightConstraint);
+			Layout(widthConstraint, heightConstraint);
 
 			//2. look at the children location
 			if (double.IsPositiveInfinity(widthConstraint)) {
@@ -442,12 +443,10 @@ namespace Xamarin.Forms
 			return new SizeRequest(new Size(widthConstraint, heightConstraint));
 		}
 
-		void Layout(double x, double y, double width, double height)
+		void Layout(double width, double height)
 		{
 			if (_root.Parent != null)	//Layout is only computed at root level
 				return;
-			_root.Left = (float)x;
-			_root.Top = (float)y;
 			_root.Width = !double.IsPositiveInfinity((width)) ? (float)width : 0;
 			_root.Height = !double.IsPositiveInfinity((height)) ? (float)height : 0;
 			_root.Layout();


### PR DESCRIPTION
### Description of Change ###

As the flex engine doesn't handle x,y offset on the root layout,
handle that at the XF.FlexLayout level.

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2663

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
