### PR TITLE
Disable suggestions for all Pickers

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -75,10 +75,6 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateMinimumDate();
 			UpdateTextColor();
 			UpdateFlowDirection();
-
-			Control.SpellCheckingType = UITextSpellCheckingType.No;
-			Control.AutocorrectionType = UITextAutocorrectionType.No;
-			Control.AutocapitalizationType = UITextAutocapitalizationType.None;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -11,6 +11,9 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		public NoCaretField() : base(new RectangleF())
 		{
+			SpellCheckingType = UITextSpellCheckingType.No;
+			AutocorrectionType = UITextAutocorrectionType.No;
+			AutocapitalizationType = UITextAutocapitalizationType.None;
 		}
 
 		public override RectangleF GetCaretRectForPosition(UITextPosition position)
@@ -72,6 +75,10 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateMinimumDate();
 			UpdateTextColor();
 			UpdateFlowDirection();
+
+			Control.SpellCheckingType = UITextSpellCheckingType.No;
+			Control.AutocorrectionType = UITextAutocorrectionType.No;
+			Control.AutocapitalizationType = UITextAutocapitalizationType.None;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Disables all spellchecking and correction suggestions on iOS for the different Picker controls

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4629

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

The user might've seen red squigglies before but won't now(?)

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
