### PR TITLE
[Tizen] Supports Picker.TitleColor, FontSize, FontFamily and FontAttr

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/Dialog.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Dialog.cs
@@ -1,6 +1,7 @@
 using System;
 using ElmSharp;
 using EButton = ElmSharp.Button;
+using EColor = ElmSharp.Color;
 
 namespace Xamarin.Forms.Platform.Tizen.Native
 {
@@ -27,6 +28,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		EvasObject _content;
 		string _title;
 		string _message;
+		EColor _titleColor = EColor.Default;
 
 		/// <summary>
 		///  Creates a dialog window.
@@ -71,6 +73,22 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				{
 					_title = value;
 					ApplyTitle(value);
+				}
+			}
+		}
+
+		public EColor TitleColor
+		{
+			get
+			{
+				return _titleColor;
+			}
+			set
+			{
+				if (_titleColor != value)
+				{
+					_titleColor = value;
+					ApplyTitleColor(value);
 				}
 			}
 		}
@@ -219,6 +237,11 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		protected virtual void ApplyTitle(string title)
 		{
 			SetPartText("title,text", title);
+		}
+
+		protected virtual void ApplyTitleColor(EColor color)
+		{
+			SetPartColor(Device.Idiom == TargetIdiom.TV ? "text_title" : "text_maintitle", color);
 		}
 
 		/// <summary>

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDialog.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDialog.cs
@@ -78,6 +78,11 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 			_popupLayout.SetPartText("elm.text.title", title);
 		}
 
+		protected override void ApplyTitleColor(EColor color)
+		{
+			_popupLayout.SetPartColor("text_title", color);
+		}
+
 		protected override void ApplyMessage(string message)
 		{
 			_popupLayout.SetPartText("elm.text", message);


### PR DESCRIPTION
### Description of Change ###
Added `TitleColor` property for setting color for the  `Picker.Title`  and `FontSize`/`FontFamily`/`FontAttributes` as well. This PR is an addendum to the changes in #4701 and #662.

### Issues Resolved ### 
- implements tizen part of #4669 
- implements tizen part of #662 (for Picker)

### API Changes ###
None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
Just like other platforms, on Tizen, the visual representation of a Picker is now similar to a `Entry` (not a `Button`). Plus, `Title` is shown as a placeholder.

### Before/After Screenshots ### 

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/1029134/50319643-c1759b00-050b-11e9-816d-71e535e822a0.gif" width="300">  | <img src="https://user-images.githubusercontent.com/1029134/50319671-dd793c80-050b-11e9-834f-1d8ba89073be.gif" width="300">  |

### Testing Procedure ###
Use `ControlGallery` (Picker Gallery)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard