### PR TITLE
Make ListView CachingStrategy property visible to Intellisense

### DIFF
--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -248,7 +248,6 @@ namespace Xamarin.Forms
 			set { SetValue(VerticalScrollBarVisibilityProperty, value); }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public ListViewCachingStrategy CachingStrategy { get; private set; }
 
 		[EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
### Description of Change ###

Remove `[EditorBrowsable(EditorBrowsableState.Never)]` attribute from `ListView.CachingStrategy` property. This will make it visible to Intellisense for auto-completion in XAML in Visual Studio.

### Issues Resolved ### 

- fixes #4738 (partially)

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Create a new ContentPage; add a ListView in XAML; CachingStrategy should show up in Intellisense.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
