### PR TITLE
[Android] fixes issue content set after an await is not visible

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1760.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1760.cs
@@ -3,6 +3,10 @@ using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+#if UITEST
+using NUnit.Framework;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
@@ -90,5 +94,18 @@ namespace Xamarin.Forms.Controls.Issues
 				};
 			}
 		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void Issue1760Test()
+		{
+			RunningApp.WaitForElement(Before);
+			RunningApp.WaitForElement(After);
+
+			RunningApp.Tap("Test Page 1");
+			RunningApp.WaitForElement(Before);
+			RunningApp.WaitForElement(After);
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -165,6 +165,20 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (ElementController.LogicalChildren.LastOrDefault() != view)
 				EnsureChildOrder();
+
+			MaybeRequestLayoutOnParent(ElementController.RealParent as Layout);
+		}
+
+		void MaybeRequestLayoutOnParent(Layout layout)
+		{
+			if (layout == null)
+				return;
+
+			var view = layout.GetRenderer().View;
+			if (!view.IsInLayout && !view.IsLayoutRequested)
+				view.RequestLayout();
+
+			MaybeRequestLayoutOnParent(layout.RealParent as Layout);
 		}
 
 		void OnChildRemoved(object sender, ElementEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Added calling `RequestLayout` on parent Layout when adding child in current Layout.

### Issues Resolved ### 

- fixes #1760

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 

before
![screenshot_2](https://user-images.githubusercontent.com/27482193/50448738-ee72e500-0933-11e9-97ab-153ef5f41b0e.png)

after
![screenshot_1](https://user-images.githubusercontent.com/27482193/50448737-ee72e500-0933-11e9-96a7-b6bfc346ceed.png)

### Testing Procedure ###

- run UItest 1760

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
