### PR TITLE
[Android] Only post DisableTimer to the queue if it's not on the UI thread

### DIFF
--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -58,10 +58,17 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void DisableTimer()
 		{
-			Device.BeginInvokeOnMainThread(new Action(() =>
+			if (Device.IsInvokeRequired)
+			{
+				Device.BeginInvokeOnMainThread(new Action(() =>
+				{
+					_val?.Cancel();
+				}));
+			}
+			else
 			{
 				_val?.Cancel();
-			}));
+			}
 		}
 
 		protected override void EnableTimer()


### PR DESCRIPTION
### Description of Change ###

PR #4177 attempts to fix an issue with disabling the Android timer on a non-UI thread by using BeginInvokeOnMainThread, which posts the action to the main looper to be run later on the UI thread. 

But if the call to DisableTimer is happening because the Ticker itself has finished all of the pending actions, DisableTimer needs to be called immediately in order to end the animations so that awaited animation calls can return. Since the animations are running on the UI thread to begin with, these calls to DisableTimer are _already_ on the UI thread; they don't _need_ to be posted there for later invocation.

This change adds a check in DisableTimer to see if it's already on the UI thread; if so, it is executed immediately. Otherwise, it is posted to the UI thread.

### Issues Resolved ### 

- fixes bug where awaited animations never finish (UI Test 39821)

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run UI Test 39821; without the fix, it will never finish (i.e., the "Success" label will never be displayed).

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
