### PR TITLE
[Android] Avoid acting on a disposed SpannableString in LabelRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -74,18 +74,18 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static void RecalculateSpanPositions(this TextView textView, Label element, SpannableString spannableString, SizeRequest finalSize)
 		{
-			if (element?.FormattedText?.Spans == null
-				|| element.FormattedText.Spans.Count == 0)
+			var layout = textView.Layout;
+			if (layout == null)
+				return;
+
+			if (element?.FormattedText?.Spans == null || element.FormattedText.Spans.Count == 0)
+				return;
+
+			if (spannableString == null || spannableString.IsDisposed())
 				return;
 
 			var labelWidth = finalSize.Request.Width;
-
 			if (labelWidth <= 0 || finalSize.Request.Height <= 0)
-				return;
-
-			var layout = textView.Layout;
-
-			if (layout == null)
 				return;
 
 			var text = spannableString.ToString();


### PR DESCRIPTION
### Description of Change ###

Fixes an `ObjectDisposedException` thrown by `LabelRenderer` due to the `SpannableString` object being disposed in certain cases.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- Fixes #4864

### API Changes ###
None

### Platforms Affected ### 
Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
1. Use a Label inside a ViewCell DataTemplate for a ListView.
2. Add 10 or more rows of data.
3. Rotate the device between portrait and landscape.
4. No crash? Success!

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard