### PR TITLE
[UWP] Implementation of Switch.OnColor

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/SwitchCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/SwitchCoreGalleryPage.cs
@@ -19,7 +19,25 @@ namespace Xamarin.Forms.Controls
 			base.Build (stackLayout);
 
 			var isToggledContainer = new ValueViewContainer<Switch> (Test.Switch.IsToggled, new Switch (), "IsToggled", value => value.ToString ());
-			Add (isToggledContainer);
+
+			var onColoredSwitch = new Switch() { OnColor = Color.HotPink };
+
+			var onColorContainer = new ValueViewContainer<Switch>(Test.Switch.OnColor, onColoredSwitch, "OnColor", value => value.ToString());
+			var changeOnColorButton = new Button
+			{
+				Text = "Change OnColor"
+			};
+			var clearOnColorButton = new Button
+			{
+				Text = "Clear OnColor"
+			};
+			changeOnColorButton.Clicked += (s, a) => { onColoredSwitch.OnColor = Color.Red; };
+			clearOnColorButton.Clicked += (s, a) => { onColoredSwitch.OnColor = Color.Default; };
+			onColorContainer.ContainerLayout.Children.Add(changeOnColorButton);
+			onColorContainer.ContainerLayout.Children.Add(clearOnColorButton);
+
+			Add(isToggledContainer);
+			Add(onColorContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -709,7 +709,8 @@ namespace Xamarin.Forms.CustomAttributes
 
 		public enum Switch
 		{
-			IsToggled
+			IsToggled,
+			OnColor
 		}
 
 		public enum TimePicker

--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -16,7 +16,6 @@ namespace Xamarin.Forms.Platform.UWP
 		protected override void OnElementChanged(ElementChangedEventArgs<Switch> e)
 		{
 			base.OnElementChanged(e);
-			
 			if (e.NewElement != null)
 			{
 				if (Control == null)

--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -10,8 +10,8 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public class SwitchRenderer : ViewRenderer<Switch, ToggleSwitch>
 	{
-		private object _originalOnColor;
-		private Brush _originalOnColorBrush;
+		object _originalOnColor;
+		Brush _originalOnColorBrush;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Switch> e)
 		{
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					var control = new ToggleSwitch();
 					control.Toggled += OnNativeToggled;
-					control.Loaded += Control_Loaded;
+					control.Loaded += OnControlLoaded;
 					control.ClearValue(ToggleSwitch.OnContentProperty);
 					control.ClearValue(ToggleSwitch.OffContentProperty);
 
@@ -34,12 +34,6 @@ namespace Xamarin.Forms.Platform.UWP
 
 				UpdateFlowDirection();
 			}
-		}
-
-		private void Control_Loaded(object sender, RoutedEventArgs e)
-		{
-			UpdateOnColor();
-			Control.Loaded -= Control_Loaded;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -59,6 +53,12 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 		protected override bool PreventGestureBubbling { get; set; } = true;
+
+		void OnControlLoaded(object sender, RoutedEventArgs e)
+		{
+			UpdateOnColor();
+			Control.Loaded -= OnControlLoaded;
+		}
 
 		void OnNativeToggled(object sender, RoutedEventArgs routedEventArgs)
 		{
@@ -98,7 +98,7 @@ namespace Xamarin.Forms.Platform.UWP
 							if (_originalOnColor == null)
 								_originalOnColor = frame.Value;
 
-							if (Element.IsSet(Switch.OnColorProperty) && !Element.OnColor.IsDefault)
+							if (!Element.OnColor.IsDefault)
 								frame.Value = new SolidColorBrush(Element.OnColor.ToWindowsColor()) { Opacity = .7 };
 							else
 								frame.Value = _originalOnColor;
@@ -108,12 +108,12 @@ namespace Xamarin.Forms.Platform.UWP
 				}
 			}
 
-			var rect = Control.GetDescendantsByName<Windows.UI.Xaml.Shapes.Rectangle>("SwitchKnobBounds").FirstOrDefault();
+			var rect = Control.GetDescendantsByName<Windows.UI.Xaml.Shapes.Rectangle>("SwitchKnobBounds").First();
 
 			if (_originalOnColorBrush == null)
 				_originalOnColorBrush = rect.Fill;
 
-			if (Element.IsSet(Switch.OnColorProperty) && !Element.OnColor.IsDefault)
+			if (!Element.OnColor.IsDefault)
 				rect.Fill = new SolidColorBrush(Element.OnColor.ToWindowsColor());
 			else
 				rect.Fill = _originalOnColorBrush;

--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public class SwitchRenderer : ViewRenderer<Switch, ToggleSwitch>
 	{
-		object _originalOnColor;
+		Brush _originalOnHoverColor;
 		Brush _originalOnColorBrush;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Switch> e)
@@ -95,13 +95,13 @@ namespace Xamarin.Forms.Platform.UWP
 						{
 							var frame = timeline.KeyFrames.First();
 
-							if (_originalOnColor == null)
-								_originalOnColor = frame.Value;
+							if (_originalOnHoverColor == null)
+								_originalOnHoverColor = (Brush)frame.Value;
 
 							if (!Element.OnColor.IsDefault)
-								frame.Value = new SolidColorBrush(Element.OnColor.ToWindowsColor()) { Opacity = .7 };
+								frame.Value = new SolidColorBrush(Element.OnColor.ToWindowsColor()) { Opacity = _originalOnHoverColor.Opacity };
 							else
-								frame.Value = _originalOnColor;
+								frame.Value = _originalOnHoverColor;
 							break;
 						}
 					}

--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -1,21 +1,29 @@
 ﻿using System.ComponentModel;
+using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Shapes;
 
 namespace Xamarin.Forms.Platform.UWP
 {
 	public class SwitchRenderer : ViewRenderer<Switch, ToggleSwitch>
 	{
+		private object _originalOnColor;
+		private Brush _originalOnColorBrush;
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Switch> e)
 		{
 			base.OnElementChanged(e);
-
+			
 			if (e.NewElement != null)
 			{
 				if (Control == null)
 				{
 					var control = new ToggleSwitch();
 					control.Toggled += OnNativeToggled;
+					control.Loaded += Control_Loaded;
 					control.ClearValue(ToggleSwitch.OnContentProperty);
 					control.ClearValue(ToggleSwitch.OffContentProperty);
 
@@ -26,6 +34,12 @@ namespace Xamarin.Forms.Platform.UWP
 
 				UpdateFlowDirection();
 			}
+		}
+
+		private void Control_Loaded(object sender, RoutedEventArgs e)
+		{
+			UpdateOnColor();
+			Control.Loaded -= Control_Loaded;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -40,6 +54,8 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateFlowDirection();
 			}
+			else if (e.PropertyName == Switch.OnColorProperty.PropertyName)
+				UpdateOnColor();
 		}
 
 		protected override bool PreventGestureBubbling { get; set; } = true;
@@ -52,6 +68,55 @@ namespace Xamarin.Forms.Platform.UWP
 		void UpdateFlowDirection()
 		{
 			Control.UpdateFlowDirection(Element);
+		}
+
+		void UpdateOnColor()
+		{
+			if (Control == null)
+				return;
+
+			var grid = Control.GetChildren<Windows.UI.Xaml.Controls.Grid>().FirstOrDefault();
+			var groups = Windows.UI.Xaml.VisualStateManager.GetVisualStateGroups(grid);
+			foreach (var group in groups)
+			{
+				if (group.Name != "CommonStates")
+					continue;
+
+				foreach (var state in group.States)
+				{
+					if (state.Name != "PointerOver")
+						continue;
+
+					foreach (var timeline in state.Storyboard.Children.OfType<ObjectAnimationUsingKeyFrames>())
+					{
+						var property = Storyboard.GetTargetProperty(timeline);
+						var target = Storyboard.GetTargetName(timeline);
+						if ((target == "SwitchKnobBounds") && (property == "Fill"))
+						{
+							var frame = timeline.KeyFrames.First();
+
+							if (_originalOnColor == null)
+								_originalOnColor = frame.Value;
+
+							if (Element.IsSet(Switch.OnColorProperty) && !Element.OnColor.IsDefault)
+								frame.Value = new SolidColorBrush(Element.OnColor.ToWindowsColor()) { Opacity = .7 };
+							else
+								frame.Value = _originalOnColor;
+							break;
+						}
+					}
+				}
+			}
+
+			var rect = Control.GetDescendantsByName<Windows.UI.Xaml.Shapes.Rectangle>("SwitchKnobBounds").FirstOrDefault();
+
+			if (_originalOnColorBrush == null)
+				_originalOnColorBrush = rect.Fill;
+
+			if (Element.IsSet(Switch.OnColorProperty) && !Element.OnColor.IsDefault)
+				rect.Fill = new SolidColorBrush(Element.OnColor.ToWindowsColor());
+			else
+				rect.Fill = _originalOnColorBrush;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Forms.Platform.UWP
 					{
 						var property = Storyboard.GetTargetProperty(timeline);
 						var target = Storyboard.GetTargetName(timeline);
-						if ((target == "SwitchKnobBounds") && (property == "Fill"))
+						if (target == "SwitchKnobBounds" && property == "Fill")
 						{
 							var frame = timeline.KeyFrames.First();
 


### PR DESCRIPTION
### Description of Change ###

Implements the `Switch.OnColor` for UWP which was reported as a bug to be not working

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4460

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

`Switch.OnColor` now actually works on UWP!

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

After: 

![screenshot 2019-01-02 15 38 41](https://user-images.githubusercontent.com/939291/50596407-8298fb00-0ea4-11e9-874a-23be523d4542.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Added a case for this in the Switch Gallery app

![untitled](https://user-images.githubusercontent.com/939291/50596546-f76c3500-0ea4-11e9-800e-d2c364f0391c.gif)


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
