### PR TITLE
[Android] wire up the correct toolbar to SetSupportActionBar

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -10,6 +10,7 @@ using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms.Platform.Android.AppLinks;
 using System.Linq;
+using System;
 
 namespace Xamarin.Forms.ControlGallery.Android
 {
@@ -96,6 +97,16 @@ namespace Xamarin.Forms.ControlGallery.Android
 		public bool IsPreAppCompat()
 		{
 			return false;
+		}
+
+
+
+		public override bool OnOptionsItemSelected(global::Android.Views.IMenuItem item)
+		{
+			if (_app.GetVisiblePage() is Issue4827 && item.ItemId == global::Android.Resource.Id.Home)
+				OnBackPressed();
+
+			return base.OnOptionsItemSelected(item);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4827.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4827.cs
@@ -14,16 +14,21 @@ using Xamarin.Forms.Core.UITests;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+	// This test only passes because of an override in FormsAppCompatActivity passes the 
+	// software back button press to the OnBackButtonPressed Command
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 4827, "[Android] Software backbutton doesn't work",
+	[Issue(IssueTracker.Github, 4827, "[Android] Software backbutton doesn't continue on device rotation",
 		PlatformAffected.iOS)]
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.Navigation)]
 #endif
 	public class Issue4827 : TestNavigationPage
 	{
+
+
 		Label results = new Label();
 		const string _success = "Success";
+		const string _pushPageButton = "Push Page";
 
 		public void Success()
 		{
@@ -43,7 +48,7 @@ namespace Xamarin.Forms.Controls.Issues
 						results,
 						new Button()
 						{
-							Text = "Push Page",
+							Text = _pushPageButton,
 							Command = new Command(PushSecondPage)
 						}
 					}
@@ -76,7 +81,7 @@ namespace Xamarin.Forms.Controls.Issues
 					{
 						new Label()
 						{
-							Text = "Click back. If you see text that says Success then test has passed"
+							Text = "Click back. If you see text that says Success then this test has passed"
 						}
 					}
 				};
@@ -92,9 +97,17 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST && __ANDROID__
 		[Test]
-		public void UpdatingSourceOfDisposedListViewDoesNotCrash()
+		public void TestForSoftwareBackButtonTriggeringOnBackButtonPressed()
 		{
-
+			RunningApp.WaitForElement(_pushPageButton);
+			RunningApp.Tap(_pushPageButton);
+			RunningApp.WaitForElement(_success);
+			RunningApp.SetOrientationLandscape();
+			RunningApp.Tap(_pushPageButton);
+			RunningApp.WaitForElement(_success);
+			RunningApp.SetOrientationPortrait();
+			RunningApp.Tap(_pushPageButton);
+			RunningApp.WaitForElement(_success);
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4827.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4827.cs
@@ -105,15 +105,15 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var softwareBackButton = RunningApp.Query(app => app.Marked("toolbar").Descendant()).Where(x=> x.Class.Contains("AppCompatImageButton")).FirstOrDefault();
 
-			RunningApp.TapCoordinates(softwareBackButton.Rect.X, softwareBackButton.Rect.Y);
+			RunningApp.Tap(PlatformQueries.NavigationBarBackButton);
 			RunningApp.WaitForElement(_success);
 			RunningApp.SetOrientationLandscape();
 			RunningApp.Tap(_pushPageButton);
-			RunningApp.TapCoordinates(softwareBackButton.Rect.X, softwareBackButton.Rect.Y);
+			RunningApp.Tap(PlatformQueries.NavigationBarBackButton);
 			RunningApp.WaitForElement(_success);
 			RunningApp.SetOrientationPortrait();
 			RunningApp.Tap(_pushPageButton);
-			RunningApp.TapCoordinates(softwareBackButton.Rect.X, softwareBackButton.Rect.Y);
+			RunningApp.Tap(PlatformQueries.NavigationBarBackButton);
 			RunningApp.WaitForElement(_success);
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4827.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4827.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 using System.Text;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-
+using System.Linq;
 
 #if UITEST
 using Xamarin.UITest;
@@ -29,6 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 		Label results = new Label();
 		const string _success = "Success";
 		const string _pushPageButton = "Push Page";
+		const string _instructionsLabel = "_instructionsLabel";
 
 		public void Success()
 		{
@@ -81,7 +82,8 @@ namespace Xamarin.Forms.Controls.Issues
 					{
 						new Label()
 						{
-							Text = "Click back. If you see text that says Success then this test has passed"
+							Text = "Click back. If you see text that says Success then this test has passed",
+							AutomationId = _instructionsLabel
 						}
 					}
 				};
@@ -99,14 +101,19 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void TestForSoftwareBackButtonTriggeringOnBackButtonPressed()
 		{
-			RunningApp.WaitForElement(_pushPageButton);
-			RunningApp.Tap(_pushPageButton);
+			RunningApp.WaitForElement(_instructionsLabel);
+
+			var softwareBackButton = RunningApp.Query(app => app.Marked("toolbar").Descendant()).Where(x=> x.Class.Contains("AppCompatImageButton")).FirstOrDefault();
+
+			RunningApp.TapCoordinates(softwareBackButton.Rect.X, softwareBackButton.Rect.Y);
 			RunningApp.WaitForElement(_success);
 			RunningApp.SetOrientationLandscape();
 			RunningApp.Tap(_pushPageButton);
+			RunningApp.TapCoordinates(softwareBackButton.Rect.X, softwareBackButton.Rect.Y);
 			RunningApp.WaitForElement(_success);
 			RunningApp.SetOrientationPortrait();
 			RunningApp.Tap(_pushPageButton);
+			RunningApp.TapCoordinates(softwareBackButton.Rect.X, softwareBackButton.Rect.Y);
 			RunningApp.WaitForElement(_success);
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4827.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4827.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4827, "[Android] Software backbutton doesn't work",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Navigation)]
+#endif
+	public class Issue4827 : TestNavigationPage
+	{
+		Label results = new Label();
+		const string _success = "Success";
+
+		public void Success()
+		{
+			results.Text = _success;
+		}
+
+		protected override void Init()
+		{
+			results.Text = "Testing...";
+
+			PushAsync(new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						results,
+						new Button()
+						{
+							Text = "Push Page",
+							Command = new Command(PushSecondPage)
+						}
+					}
+				}
+			});
+
+			PushSecondPage();
+		}
+
+		void PushSecondPage()
+		{
+			results.Text = "Testing... (If you're reading this the test has failed)";
+			if(Device.RuntimePlatform == Device.iOS)
+				results.Text = "This test doesn't work on iOS";
+
+			PushAsync(new BackTestContentPage(this));
+		}
+
+
+		[Preserve(AllMembers = true)]
+		public class BackTestContentPage : ContentPage
+		{
+			private readonly Issue4827 _issue4827;
+
+			public BackTestContentPage(Issue4827 issue4827)
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "Click back. If you see text that says Success then test has passed"
+						}
+					}
+				};
+				_issue4827 = issue4827;
+			}
+
+			protected override bool OnBackButtonPressed()
+			{
+				_issue4827.Success();
+				return base.OnBackButtonPressed();
+			}
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void UpdatingSourceOfDisposedListViewDoesNotCrash()
+		{
+
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -14,6 +14,7 @@
       <DependentUpon>Bugzilla60787.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4827.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2102.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1588.xaml.cs">
       <DependentUpon>Issue1588.xaml</DependentUpon>

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -245,5 +245,15 @@ namespace Xamarin.Forms.Controls
 		{
 			SetMainPage(CreateDefaultMainPage());
 		}
+
+		public Page GetVisiblePage()
+		{
+			int modalIndex = Current.MainPage.Navigation.ModalStack.Count;
+			if (modalIndex > 0)
+				return Current.MainPage.Navigation.ModalStack[modalIndex - 1];
+
+
+			return Current.MainPage;
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -66,14 +66,6 @@ namespace Xamarin.Forms.Platform.Android
 			ConfigurationChanged?.Invoke(this, new EventArgs());
 		}
 
-		public override bool OnOptionsItemSelected(IMenuItem item)
-		{
-			if (item.ItemId == global::Android.Resource.Id.Home)
-				BackPressed?.Invoke(this, EventArgs.Empty);
-
-			return base.OnOptionsItemSelected(item);
-		}
-
 		public void SetStatusBarColor(AColor color)
 		{
 			if (Forms.IsLollipopOrNewer)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -378,9 +378,12 @@ namespace Xamarin.Forms.Platform.Android
 			else
 				bar = new AToolbar(this);
 
-			SetSupportActionBar(bar);
+			// don't change the order of this and SetSupportActionBar otherwise
+			// OnOptionsItemSelected won't fire anymore
 			if (onClickListener != null)
 				bar.SetNavigationOnClickListener(onClickListener);
+
+			SetSupportActionBar(bar);
 
 			return bar;
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -157,18 +157,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			base.OnCreate(savedInstanceState);
 
-			AToolbar bar;
-			if (ToolbarResource != 0)
-			{
-				bar = LayoutInflater.Inflate(ToolbarResource, null).JavaCast<AToolbar>();
-				if (bar == null)
-					throw new InvalidOperationException("ToolbarResource must be set to a Android.Support.V7.Widget.Toolbar");
-			}
-			else
-				bar = new AToolbar(this);
-
-			SetSupportActionBar(bar);
-
 			_layout = new ARelativeLayout(BaseContext);
 			SetContentView(_layout);
 
@@ -389,6 +377,22 @@ namespace Xamarin.Forms.Platform.Android
 		internal class DefaultApplication : Application
 		{
 		}
+
+		internal AToolbar CreateNewToolbar(global::Android.Views.View.IOnClickListener onClickListener)
+		{
+			AToolbar bar;
+			if (ToolbarResource != 0)
+				bar = LayoutInflater.Inflate(ToolbarResource, null).JavaCast<AToolbar>();
+			else
+				bar = new AToolbar(this);
+
+			SetSupportActionBar(bar);
+			if (onClickListener != null)
+				bar.SetOnClickListener(onClickListener);
+
+			return bar;
+		}
+
 
 		#region Statics
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -380,7 +380,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			SetSupportActionBar(bar);
 			if (onClickListener != null)
-				bar.SetOnClickListener(onClickListener);
+				bar.SetNavigationOnClickListener(onClickListener);
 
 			return bar;
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -744,18 +744,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void SetupToolbar()
 		{
 			Context context = Context;
-			var activity = (FormsAppCompatActivity)context;
-
-			AToolbar bar;
-			if (FormsAppCompatActivity.ToolbarResource != 0)
-				bar = activity.LayoutInflater.Inflate(FormsAppCompatActivity.ToolbarResource, null).JavaCast<AToolbar>();
-			else
-				bar = new AToolbar(context);
-
-			bar.SetNavigationOnClickListener(this);
-
-			AddView(bar);
-			_toolbar = bar;
+			if(context is FormsAppCompatActivity activity)
+			{
+				_toolbar = activity.CreateNewToolbar(this);
+				AddView(_toolbar);
+			}
 		}
 
 		Task<bool> SwitchContentAsync(Page page, bool animated, bool removed = false, bool popToRoot = false)


### PR DESCRIPTION
### Description of Change ###
I finished up this PR knowing it would be slightly breaking but then realized it causes the back button on Android to operate differently than iOS which maybe was intentional?

is the purpose of this code
https://github.com/xamarin/Xamarin.Forms/blob/78385f9fc1fc56dc88bd98e73bf9c8f2f2d0a90a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs#L160-L170

To make it so that the software back button doesn't fire the *OnBackButtonPressed* of the contentpage on Android?

The Visible toolbar is created on the NavigationRenderer
https://github.com/xamarin/Xamarin.Forms/blob/ceb25378059c35fcec55e18bbbbe9c58d71b01e6/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs#L744-L759

So SetSupportActionBar(bar); isn't using the right toolbar which means this code never runs
https://github.com/xamarin/Xamarin.Forms/blob/78385f9fc1fc56dc88bd98e73bf9c8f2f2d0a90a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs#L69

I came across this while investigating
https://github.com/xamarin/Xamarin.Forms/issues/4827

I'll fill out the rest if this PR seems valid

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4827 

Possibly fixes
https://github.com/xamarin/Xamarin.Forms/issues/2118
Need to research a bit further

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
Clicking the software backbutton on Android will now fire the *OnBackButtonPressed* on Android

Also now on startup we're only inflating the toolbar view once opposed to twice


### Testing Procedure ###
Run the included Issue

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard