### PR TITLE
[Android] If drawable specified on shell doesn't exist don't dispose of it

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutContentRenderer.cs
@@ -112,6 +112,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var drawable = await Context.GetFormsDrawable(source);
 			menuItem.SetIcon(drawable);
+			drawable?.Dispose();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -362,7 +362,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			var drawable = await Context.GetFormsDrawable(source);
 			menuItem.SetIcon(drawable);
-			drawable.Dispose();
+			drawable?.Dispose();
 		}
 
 		void SetupMenu()


### PR DESCRIPTION
### Description of Change ###
If an Icon is specified on a ShellSection that doesn't exist it was causing an NRE when trying to dispose of it

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
