### PR TITLE
[UWP] Fixed disappearing Switch on SwitchCell in TableView

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CellControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CellControl.cs
@@ -103,8 +103,9 @@ namespace Xamarin.Forms.Platform.UWP
 			if (lv != null)
 			{
 				lv.SetValue(MeasuredEstimateProperty, result.Height);
-				SetDafaultColor();
 			}
+
+			SetDefaultSwitchColor();
 
 			return result;
 		}
@@ -202,7 +203,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		void SetDafaultColor()
+		void SetDefaultSwitchColor()
 		{
 			if (_defaultOnColor == null && Cell is SwitchCell)
 			{


### PR DESCRIPTION
### Description of Change ###

Fixed bug where the switch in a `SwitchCell` in a `TableView` would disappear on UWP. The method for setting the default color was only called when it was in a `ListView`. Also renamed the method to be more clear.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4903

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
