### PR TITLE
[Android] Allow the page background to be reset

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -379,6 +379,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			string backgroundImage = view.BackgroundImage;
 			if (!string.IsNullOrEmpty(backgroundImage))
 				this.SetBackground(Context.GetDrawable(backgroundImage));
+			else
+				this.SetBackground(null);
 		}
 
 		void UpdateDetail()

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -120,6 +120,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (!string.IsNullOrEmpty(view.BackgroundImage))
 				this.SetBackground(Context.GetDrawable(view.BackgroundImage));
+			else
+				this.SetBackground(null);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Once a background is set on the page, it can never be unset.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Setting a page background to an image, and then setting it to null will now actually set the page to no image. Previously, the image stayed.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

 - Create a page
 - Set the background to a valid image
 - _observe the image_
 - Set the background to null
 - _observe the blank page_

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
