### PR TITLE
[Android] Fix for ListViewRenderer causing ObjectDisposedException

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -386,7 +386,7 @@ namespace Xamarin.Forms.Platform.Android
 					_refresh.Refreshing = false;
 					_refresh.Post(() =>
 					{
-					    if(Control == null || Control.IsDisposed())
+					    if(_refresh.IsDisposed())
 						    return;
 						
 						_refresh.Refreshing = true;

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -386,6 +386,9 @@ namespace Xamarin.Forms.Platform.Android
 					_refresh.Refreshing = false;
 					_refresh.Post(() =>
 					{
+					    if(Control == null || Control.IsDisposed())
+						    return;
+						
 						_refresh.Refreshing = true;
 					});
 				}


### PR DESCRIPTION
### Description of Change ###

ListViewRenderer has in the method "UpdateIsRefreshing" that has part that is run asynchronously using post. There is no check in the action if the control has been disposed in the meantime. 

### Issues Resolved ### 

Stacktrace:

JniPeerMembers.AssertSelf (Java.Interop.IJavaPeerable self)
JniPeerMembers+JniInstanceMethods.InvokeVirtualVoidMethod (System.String encodedMember, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters)
SwipeRefreshLayout.set_Refreshing (System.Boolean value)
ListViewRenderer.<UpdateIsRefreshing>b__28_0 ()
Thread+RunnableImplementor.Run ()
IRunnableInvoker.n_Run (System.IntPtr jnienv, System.IntPtr native__this)

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None (less crashes)

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Be very unlucky. (We just see this happen in our crash reports sometimes)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
