### PR TITLE
Update VisualElementTracker.cs

### DIFF
--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -177,7 +177,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		void HandleRedrawNeeded(object sender, EventArg<VisualElement> e)
 		{
-			foreach (string propertyName in _batchedProperties)
+			// local version of _batchedProperties created to prevent 'Collection was modified' error
+			var batchedProperties = _batchedProperties as List<string>;
+		
+			foreach (string propertyName in batchedProperties)
 				HandlePropertyChanged(this, new PropertyChangedEventArgs(propertyName));
 			_batchedProperties.Clear();
 

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -8,6 +8,7 @@ using Android.Views;
 using AView = Android.Views.View;
 using Object = Java.Lang.Object;
 using Xamarin.Forms.Internals;
+using System.Linq;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -177,10 +178,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void HandleRedrawNeeded(object sender, EventArg<VisualElement> e)
 		{
-			// local version of _batchedProperties created to prevent 'Collection was modified' error
-			var batchedProperties = _batchedProperties as List<string>;
-		
-			foreach (string propertyName in batchedProperties)
+			foreach (string propertyName in _batchedProperties.ToList())
 				HandlePropertyChanged(this, new PropertyChangedEventArgs(propertyName));
 			_batchedProperties.Clear();
 


### PR DESCRIPTION
### Description of Change ###

.ToList() operation on _batchedProperties IList in HandleRedrawNeeded method. Used to prevent 'Collection was modified' error seen in issue #4917

### Issues Resolved ### 
- fixes #4917

### API Changes ###
None

Changed:
- Added reference to System.Linq
 - running .ToList() on _batchedProperties object

### Platforms Affected ### 
- Android

- [ ] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
