### PR TITLE
[tests] UWP requires file extensions

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Controls.Issues
 		string _disappearText = "You should see 4 images. Clicking this should cause the images to all disappear";
 		string _appearText = "Clicking this should cause the images to all appear";
 		string _theListView = "theListViewAutomationId";
-		string _fileName = "coffee";
+		string _fileName = "coffee.png";
 
 		protected override void Init()
 		{


### PR DESCRIPTION
This should also be fine on iOS/Android as the extension is used in the other tests.