### PR TITLE
Makes iOS ImageButton opaque when pressed

### DIFF
--- a/.create-nuget.bat
+++ b/.create-nuget.bat
@@ -9,7 +9,8 @@ set NUGET_EXE=%NUGET_DIR%NuGet.exe
 
 mkdir Xamarin.Forms.Platform.MacOS\bin\debug\
 mkdir Xamarin.Forms.Platform.Tizen\bin\debug\tizen40\
-mkdir Xamarin.Forms.Platform.MacOS\bin\debug\
+mkdir Xamarin.Forms.Maps.Tizen\bin\debug\Tizen40
+mkdir Xamarin.Forms.Maps.MacOS\bin\debug
 mkdir Xamarin.Forms.Platform.UAP\bin\debug\
 mkdir Xamarin.Forms.Platform.ios\bin\debug\
 mkdir Stubs\Xamarin.Forms.Platform.iOS\bin\iPhone\debug\
@@ -97,9 +98,11 @@ echo foo > Stubs\Xamarin.Forms.Platform.iOS\bin\iPhone\debug\Xamarin.Forms.Platf
 
 echo foo > Xamarin.Forms.Platform.MacOS\bin\debug\Xamarin.forms.Platform.macOS.dll
 echo foo > Xamarin.Forms.Platform.MacOS\bin\debug\Xamarin.forms.Platform.dll
+echo foo > Xamarin.Forms.Maps.MacOS\bin\debug\Xamarin.Forms.Maps.macOS.dll
 
 mkdir Stubs\Xamarin.Forms.Platform.Tizen\bin\debug\tizen40
 echo foo > Stubs\Xamarin.Forms.Platform.Tizen\bin\debug\tizen40\Xamarin.Forms.Platform.dll
+echo foo > Xamarin.Forms.Maps.Tizen\bin\debug\Tizen40\Xamarin.Forms.Maps.Tizen.dll
 
 mkdir Xamarin.Forms.Platform.Tizen\bin\debug\tizen40
 echo foo > Xamarin.Forms.Platform.Tizen\bin\debug\tizen40\Xamarin.forms.Platform.tizen.dll

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
@@ -76,6 +76,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (Control == null)
 				{
 					SetNativeControl(CreateNativeControl());
+					Control.AdjustsImageWhenHighlighted = false;
 
 					Debug.Assert(Control != null, "Control != null");
 				}
@@ -112,7 +113,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override UIButton CreateNativeControl()
 		{
-			return new UIButton(UIButtonType.System);
+			return new UIButton(UIButtonType.Custom);
 		}
 
 		protected override void SetAccessibilityLabel()


### PR DESCRIPTION
### Description of Change ###

Makes iOS ImageButton opaque when pressed.

### Issues Resolved ### 
- fixes #4947 
### Platforms Affected ### 
- iOS
### Testing
Use update `.create-nuget.bat` to create private nuget to run AllLittleThings sample.
### Before/After Screenshots ### 
![image](https://user-images.githubusercontent.com/4120386/50999059-65c87d00-14cd-11e9-8d5f-b7ce8331dc62.png)


