### PR TITLE
[Android] set ClipBounds to use ViewCompat.SetClipBounds

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
@@ -5,6 +5,7 @@ using AScaleType = Android.Widget.ImageView.ScaleType;
 using ARect = Android.Graphics.Rect;
 using System;
 using Xamarin.Forms.Internals;
+using AViewCompat = Android.Support.V4.View.ViewCompat;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
@@ -20,7 +21,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		static void OnLayoutChange(object sender, global::Android.Views.View.LayoutChangeEventArgs e)
 		{
 			if(sender is IVisualElementRenderer renderer && renderer.View is ImageView imageView)
-				imageView.ClipBounds = imageView.GetScaleType() == AScaleType.CenterCrop ? new ARect(0, 0, e.Right - e.Left, e.Bottom - e.Top) : null;
+				AViewCompat.SetClipBounds(imageView, imageView.GetScaleType() == AScaleType.CenterCrop ? new ARect(0, 0, e.Right - e.Left, e.Bottom - e.Top) : null);
 		}
 
 		public static void Dispose(IVisualElementRenderer renderer)


### PR DESCRIPTION
### Description of Change ###

- Due to a regression modify *ImageElementManager* to use *ViewCompat.SetClipBounds* so as to not cause crashing

I realize that there is a ClipBounds here in CollectionView code
https://github.com/xamarin/Xamarin.Forms/blob/154c2d088a385513e2819e524040b8afff8f6f7a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs#L48

But CollectionView is new code that only supports >= 19 so it wouldn't set a good precedence to fix CV to be compatible pre api 19

### Issues Resolved ### 
- fixes #4789


### Platforms Affected ### 
- Android


### Testing Procedure ###
Run ImageButton Gallery on pre api 18 device

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
