### PR TITLE
[Android] Fix ObjectDisposedException on MasterDetailPageRenderer update

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -387,7 +387,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (_detailLayout.ChildView == null)
 				Update();
 			else
-				new Handler(Looper.MainLooper).Post(() => Update());
+				new Handler(Looper.MainLooper).Post(() =>
+				{
+					if (_detailLayout == null || _detailLayout.IsDisposed())
+						return;
+
+					Update();
+				});
 
 			void Update()
 			{
@@ -412,9 +418,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void UpdateMaster()
 		{
-
 			if (_masterLayout.ChildView == null)
-				new Handler(Looper.MainLooper).Post(() => Update());
+				new Handler(Looper.MainLooper).Post(() =>
+				{
+					if (_masterLayout == null || _masterLayout.IsDisposed())
+						return;
+
+					Update();
+				});
 			else
 				Update();
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -419,6 +419,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdateMaster()
 		{
 			if (_masterLayout.ChildView == null)
+				Update();
+			else
 				new Handler(Looper.MainLooper).Post(() =>
 				{
 					if (_masterLayout == null || _masterLayout.IsDisposed())
@@ -426,23 +428,17 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 					Update();
 				});
-			else
-				Update();
 
 			void Update()
 			{
-				Android.MasterDetailContainer masterContainer = _masterLayout;
-				if (masterContainer == null)
-					return;
+				if (_masterLayout.ChildView != null)
+					_masterLayout.ChildView.PropertyChanged -= HandleMasterPropertyChanged;
 
-				if (masterContainer.ChildView != null)
-					masterContainer.ChildView.PropertyChanged -= HandleMasterPropertyChanged;
+				_masterLayout.ChildView = Element.Master;
 
-				masterContainer.ChildView = Element.Master;
-				if (Element.Master != null)
-					Element.Master.PropertyChanged += HandleMasterPropertyChanged;
+				if (_masterLayout.ChildView != null)
+					_masterLayout.ChildView.PropertyChanged += HandleMasterPropertyChanged;
 			}
-
 		}
 
 		void UpdateSplitViewLayout()

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
@@ -227,6 +226,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				if (_masterLayout != null)
 				{
+					if (_masterLayout.ChildView != null)
+						_masterLayout.ChildView.PropertyChanged -= HandleMasterPropertyChanged;
+
 					RemoveView(_masterLayout);
 					_masterLayout.Dispose();
 					_masterLayout = null;
@@ -387,16 +389,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (_detailLayout.ChildView == null)
 				Update();
 			else
-				new Handler(Looper.MainLooper).Post(() =>
-				{
-					if (_detailLayout == null || _detailLayout.IsDisposed())
-						return;
-
-					Update();
-				});
+				// Queue up disposal of the previous renderers after the current layout updates have finished
+				new Handler(Looper.MainLooper).Post(Update);
 
 			void Update()
 			{
+				if (_detailLayout == null || _detailLayout.IsDisposed())
+					return;
+
 				Context.HideKeyboard(this);
 				_detailLayout.ChildView = Element.Detail;
 			}
@@ -421,16 +421,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (_masterLayout.ChildView == null)
 				Update();
 			else
-				new Handler(Looper.MainLooper).Post(() =>
-				{
-					if (_masterLayout == null || _masterLayout.IsDisposed())
-						return;
-
-					Update();
-				});
+				// Queue up disposal of the previous renderers after the current layout updates have finished
+				new Handler(Looper.MainLooper).Post(Update);
 
 			void Update()
 			{
+				if (_masterLayout == null || _masterLayout.IsDisposed())
+					return;
+
 				if (_masterLayout.ChildView != null)
 					_masterLayout.ChildView.PropertyChanged -= HandleMasterPropertyChanged;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
@@ -6,7 +6,6 @@ using Android.Content;
 using Android.Support.V4.Widget;
 using Android.Views;
 using AView = Android.Views.View;
-using AColor = Android.Graphics.Drawables.ColorDrawable;
 using Android.OS;
 using Xamarin.Forms.Platform.Android.FastRenderers;
 
@@ -168,7 +167,7 @@ namespace Xamarin.Forms.Platform.Android
 				element.SendViewInitialized(this);
 
 			if (element != null && !string.IsNullOrEmpty(element.AutomationId))
-					SetAutomationId(element.AutomationId);
+				SetAutomationId(element.AutomationId);
 
 			SetContentDescription();
 		}
@@ -361,7 +360,13 @@ namespace Xamarin.Forms.Platform.Android
 				Update();
 			else
 				// Queue up disposal of the previous renderers after the current layout updates have finished
-				new Handler(Looper.MainLooper).Post(() => Update());
+				new Handler(Looper.MainLooper).Post(() =>
+				{
+					if (_detailLayout == null || _detailLayout.IsDisposed())
+						return;
+
+					Update();
+				});
 
 			void Update()
 			{
@@ -384,13 +389,22 @@ namespace Xamarin.Forms.Platform.Android
 				Update();
 			else
 				// Queue up disposal of the previous renderers after the current layout updates have finished
-				new Handler(Looper.MainLooper).Post(() => Update());
+				new Handler(Looper.MainLooper).Post(() =>
+				{
+					if (_masterLayout == null || _masterLayout.IsDisposed())
+						return;
+
+					Update();
+				});
 
 			void Update()
 			{
-				if (_masterLayout != null && _masterLayout.ChildView != null)
+				if (_masterLayout?.ChildView != null)
 					_masterLayout.ChildView.PropertyChanged -= HandleMasterPropertyChanged;
-				_masterLayout.ChildView = _page.Master;
+
+				if (_masterLayout != null)
+					_masterLayout.ChildView = _page.Master;
+
 				if (_page.Master != null)
 					_page.Master.PropertyChanged += HandleMasterPropertyChanged;
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
@@ -208,6 +208,9 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (_masterLayout != null)
 				{
+					if (_masterLayout.ChildView != null)
+						_masterLayout.ChildView.PropertyChanged -= HandleMasterPropertyChanged;
+
 					_masterLayout.Dispose();
 					_masterLayout = null;
 				}
@@ -360,16 +363,13 @@ namespace Xamarin.Forms.Platform.Android
 				Update();
 			else
 				// Queue up disposal of the previous renderers after the current layout updates have finished
-				new Handler(Looper.MainLooper).Post(() =>
-				{
-					if (_detailLayout == null || _detailLayout.IsDisposed())
-						return;
-
-					Update();
-				});
+				new Handler(Looper.MainLooper).Post(Update);
 
 			void Update()
 			{
+				if (_detailLayout == null || _detailLayout.IsDisposed())
+					return;
+
 				Context.HideKeyboard(this);
 				_detailLayout.ChildView = _page.Detail;
 			}
@@ -389,24 +389,20 @@ namespace Xamarin.Forms.Platform.Android
 				Update();
 			else
 				// Queue up disposal of the previous renderers after the current layout updates have finished
-				new Handler(Looper.MainLooper).Post(() =>
-				{
-					if (_masterLayout == null || _masterLayout.IsDisposed())
-						return;
-
-					Update();
-				});
+				new Handler(Looper.MainLooper).Post(Update);
 
 			void Update()
 			{
-				if (_masterLayout?.ChildView != null)
+				if (_masterLayout == null || _masterLayout.IsDisposed())
+					return;
+
+				if (_masterLayout.ChildView != null)
 					_masterLayout.ChildView.PropertyChanged -= HandleMasterPropertyChanged;
 
-				if (_masterLayout != null)
-					_masterLayout.ChildView = _page.Master;
+				_masterLayout.ChildView = _page.Master;
 
-				if (_page.Master != null)
-					_page.Master.PropertyChanged += HandleMasterPropertyChanged;
+				if (_masterLayout.ChildView != null)
+					_masterLayout.ChildView.PropertyChanged += HandleMasterPropertyChanged;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###
Fix ObjectDisposedException, same thing as PR #4931 but for MasterDetailPage.

### Issues Resolved ### 
When changing the mainPage from a MasterDetailPage sometime a ObjectDisposedException because the update is delayed and the page had changed.

- Fixes : https://github.com/xamarin/xamarin-android/issues/2604

### API Changes ###
 
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Have a MasterDetailPage as MainPage change it, repeat it enough times to trigger the issue


### PR Checklist ###

- [ ] Has automated tests => Only manual test is possible
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
