### PR TITLE
[macOS] BoxView binding to BackgroundColor broken

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Controls/FormsBoxView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Controls/FormsBoxView.cs
@@ -44,6 +44,7 @@ namespace Xamarin.Forms.Platform.macOS.Controls
 		public void SetColor (NSColor color)
 		{
 			_colorToRenderer = color;
+			SetNeedsDisplayInRect(Bounds);
 		}
 
 		public void SetCornerRadius (float topLeft, float topRight, float bottomLeft, float bottomRight)
@@ -52,6 +53,7 @@ namespace Xamarin.Forms.Platform.macOS.Controls
 			_topRight = topRight;
 			_bottomLeft = bottomLeft;
 			_bottomRight = bottomRight;
+			SetNeedsDisplayInRect(Bounds);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Force BoxViewRenderer to redraw itself after color/corners updates

### Issues Resolved ### 
fixes #4338 

### API Changes ###
None

### Platforms Affected ### 
- MacOs

### Behavioral/Visual Changes ###
Possible to change background color / color of boxView with bindings

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Here is test scenario: https://github.com/Abhijit-Revamp/XamIssues

