### PR TITLE
BoxView.BackgroundColor binding does not work on WPF

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/BoxViewRenderer.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Platform.WPF
 					SetNativeControl(rectangle);
 				}
 
-				UpdateColor();
+				UpdateBackground();
 				UpdateCornerRadius();
 			}
 
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.WPF
 			base.OnElementPropertyChanged(sender, e);
 
 			if (e.PropertyName == BoxView.ColorProperty.PropertyName)
-				UpdateColor();
+				UpdateBackground();
 			else if (e.PropertyName == BoxView.CornerRadiusProperty.PropertyName)
 				UpdateCornerRadius();
 		}
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Platform.WPF
 			UpdateSize();
 		}
 
-		void UpdateColor()
+		protected override void UpdateBackground()
 		{
 			Color color = Element.Color != Color.Default ? Element.Color : Element.BackgroundColor;
 			_border.UpdateDependencyColor(Border.BackgroundProperty, color);


### PR DESCRIPTION
### Description of Change ###
As was mentioned, that BoxView works fine with **Color** but doesn't with **BackgroundColor**
Set the same renderer's handler for both properties.

### Issues Resolved ### 
- fixes #4788 

### API Changes ###
None

### Platforms Affected ### 
- WPF

### Behavioral/Visual Changes ###
Can update BackgroundColor with bindings

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

Try to bind BackgroundColor of BoxView to VM's property

```xml
<BoxView
    BackgroundColor="{Binding Color}"
    HeightRequest="100"
    WidthRequest="100" />
```