### PR TITLE
[ios] Clear perfect size on Labels so reused renderers will resize correctly

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3652.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3652.cs
@@ -2,6 +2,13 @@
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
@@ -49,7 +56,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				var label = new Label();
 				label.SetBinding(Label.TextProperty, "Description");
-
+				label.AutomationId = "pandabear";
 				var menu = new MenuItem { Text = "Remove" };
 				menu.Command = new Command(() => ((ListItemViewModel)BindingContext).Remove.Execute((this, BindingContext)));
 				ContextActions.Add(menu);
@@ -102,5 +109,41 @@ namespace Xamarin.Forms.Controls.Issues
 			public Command Remove =>
 				new Command(() => MessagingCenter.Send(this, "Remove", this));
 		}
+
+#if UITEST && !__WINDOWS__
+		[Test]
+		public void TestRemovingContextMenuItems()
+		{
+			for(int i = 1; i <= 3; i++)
+			{
+				string searchFor = $"Remove me using the context menu. #{i}";
+				RunningApp.WaitForElement(searchFor);
+
+				RunningApp.ActivateContextMenu(searchFor);
+				RunningApp.WaitForElement(c => c.Marked("Remove"));
+				RunningApp.Tap(c => c.Marked("Remove"));
+			}
+
+
+			for (int i = 4; i <= 6; i++)
+			{
+				RunningApp.Tap("Add an item");
+				string searchFor = $"Remove me using the context menu. #{i}";
+
+				RunningApp.ActivateContextMenu(searchFor);
+				RunningApp.WaitForElement(c => c.Marked("Remove"));
+				RunningApp.Tap(c => c.Marked("Remove"));
+			}
+
+
+			for (int i = 1; i <= 6; i++)
+			{
+				string searchFor = $"Remove me using the context menu. #{i}";
+				RunningApp.WaitForNoElement(c => c.Marked("Remove"));
+			}
+
+		}
+#endif
+
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -142,6 +142,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
 		{
+			_perfectSizeValid = false;
+
 			if (e.OldElement != null)
 			{
 				e.OldElement.PropertyChanging -= ElementPropertyChanging;


### PR DESCRIPTION
### Description of Change ###
Because ListViews reuse renderers we need to clear the *_perfectSizeValid* value so that the size gets updated when the renderer is reused

### Issues Resolved ### 
- fixes #4957  

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Testing Procedure ###
Run Issue3652 in the control gallery and follow the steps there

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard