### PR TITLE
[Android] Correctly dispose TabbedPageRenderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
@@ -157,7 +157,6 @@ namespace Xamarin.Forms.Controls.Issues
 				protected override void OnAppearing() => Debug.WriteLine($"OnAppearing: {_permutations}");
 				protected override void OnDisappearing() => Debug.WriteLine($"OnDisappearing: {_permutations}");
 			}
-
 		}
 
 		[Preserve(AllMembers = true)]
@@ -170,7 +169,6 @@ namespace Xamarin.Forms.Controls.Issues
 				PushAsync(new InternalPage(30));
 
 				var otherPage = new InternalPage(40);
-				PushAsync(otherPage);
 
 				otherPage.Appearing += async (object sender, EventArgs e) =>
 				{
@@ -182,7 +180,9 @@ namespace Xamarin.Forms.Controls.Issues
 					Application.Current.MainPage.BindingContext = new object();
 				};
 
+				PushAsync(otherPage);
 			}
+
 			protected override void OnAppearing() => Debug.WriteLine($"OnAppearing: Issue2338");
 			protected override void OnDisappearing() => Debug.WriteLine($"OnDisappearing: Issue2338");
 
@@ -336,10 +336,6 @@ namespace Xamarin.Forms.Controls.Issues
 					await Task.Delay(500);
 					var contentPage = new ContentPage();
 
-#pragma warning disable 4014
-					Detail.Navigation.PushAsync(contentPage);
-#pragma warning restore 4014
-
 					contentPage.Appearing += (_, __) =>
 					{
 						var navPage = new NavigationPage(new ContentPage() { Title = "Details" });
@@ -350,6 +346,10 @@ namespace Xamarin.Forms.Controls.Issues
 
 						navPage.PushAsync(new ContentPage() { Title = "Details 2" });
 					};
+
+#pragma warning disable 4014
+					Detail.Navigation.PushAsync(contentPage);
+#pragma warning restore 4014
 				}
 			}
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4973.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4973.cs
@@ -1,0 +1,75 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using System;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4973, "TabbedPage nav tests", PlatformAffected.Android)]
+	public class Issue4973 : TestTabbedPage
+	{
+		protected override void Init()
+		{
+			Children.Add(new TabbedPage
+			{
+				Title = "Tab1",
+				Children =
+				{
+					new ContentPage
+					{
+						Title = "InnerTab1"
+					},
+					new ContentPage
+					{
+						Title = "InnerTab2"
+					}
+				}
+			});
+
+			Children.Add(new ContentPage
+			{
+				Title = "Tab2"
+			});
+
+			Children.Add(new ContentPage
+			{
+				Title = "Tab3"
+			});
+
+			Children.Add(new ContentPage
+			{
+				Title = "Tab4"
+			});
+
+			Children.Add(new ContentPage
+			{
+				Title = "Tab5",
+				Content = new Label
+				{
+					Text = "Test"
+				}
+			});
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void TabbedPageWithModalIssueTestsAllElementsPresent()
+		{
+			RunningApp.Tap(q => q.Text("Tab5"));
+
+			RunningApp.WaitForElement(q => q.Text("Test"));
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			RunningApp.Tap(q => q.Text("Tab1"));
+
+			RunningApp.Tap(q => q.Text("Tab2"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4973.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4973.cs
@@ -1,4 +1,4 @@
-﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
 #if UITEST
@@ -57,14 +57,13 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST && __ANDROID__
 		[Test]
-		public void TabbedPageWithModalIssueTestsAllElementsPresent()
+		public void Issue4973Test()
 		{
 			RunningApp.Tap(q => q.Text("Tab5"));
 
 			RunningApp.WaitForElement(q => q.Text("Test"));
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			GarbageCollectionHelper.Collect();
 
 			RunningApp.Tap(q => q.Text("Tab1"));
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -497,6 +497,8 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue4600.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4973.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5252.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5057.xaml.cs">
       <DependentUpon>Issue5057.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
@@ -78,7 +78,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				RemoveAllViews();
 
 				_previousPage = null;
-			
+				_fragmentManager = null;
+
 				if (Element?.Children != null)
 				{
 					foreach (ContentPage pageToRemove in Element.Children)

--- a/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		IPageController PageController => Element as IPageController;
 
-		FragmentManager FragmentManager => _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
+		FragmentManager FragmentManager => _fragmentManager ?? (_fragmentManager = Context.GetFragmentManager());
 
 		void IManageFragments.SetFragmentManager(FragmentManager childFragmentManager)
 		{

--- a/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/CarouselPageRenderer.cs
@@ -2,16 +2,18 @@ using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using Android.Content;
+using Android.Support.V4.App;
 using Android.Support.V4.View;
 using Android.Views;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
-	public class CarouselPageRenderer : VisualElementRenderer<CarouselPage>, ViewPager.IOnPageChangeListener
+	public class CarouselPageRenderer : VisualElementRenderer<CarouselPage>, ViewPager.IOnPageChangeListener, IManageFragments
 	{
 		bool _disposed;
 		FormsViewPager _viewPager;
 		Page _previousPage;
+		FragmentManager _fragmentManager;
 
 		public CarouselPageRenderer(Context context) : base(context)
 		{
@@ -34,6 +36,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		}
 
 		IPageController PageController => Element as IPageController;
+
+		FragmentManager FragmentManager => _fragmentManager ?? (_fragmentManager = ((FormsAppCompatActivity)Context).SupportFragmentManager);
+
+		void IManageFragments.SetFragmentManager(FragmentManager childFragmentManager)
+		{
+			if (_fragmentManager == null)
+				_fragmentManager = childFragmentManager;
+		}
 
 		void ViewPager.IOnPageChangeListener.OnPageSelected(int position)
 		{
@@ -117,15 +127,22 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (e.NewElement != null)
 			{
-				FormsViewPager pager =
-					_viewPager =
-					new FormsViewPager(activity)
-					{
-						OverScrollMode = OverScrollMode.Never,
-						EnableGesture = true,
-						LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent),
-						Adapter = new FormsFragmentPagerAdapter<ContentPage>(e.NewElement, activity.SupportFragmentManager) { CountOverride = e.NewElement.Children.Count }
-					};
+				if (_viewPager != null)
+				{
+					_viewPager.RemoveOnPageChangeListener(this);
+
+					ViewGroup.RemoveView(_viewPager);
+
+					_viewPager.Dispose();
+				}
+
+				FormsViewPager pager = _viewPager = new FormsViewPager(activity)
+				{
+					OverScrollMode = OverScrollMode.Never,
+					EnableGesture = true,
+					LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent),
+					Adapter = new FormsFragmentPagerAdapter<ContentPage>(e.NewElement, FragmentManager) { CountOverride = e.NewElement.Children.Count }
+				};
 				pager.Id = Platform.GenerateViewId();
 				pager.AddOnPageChangeListener(this);
 
@@ -145,7 +162,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == "CurrentPage")
+			if (e.PropertyName == nameof(Element.CurrentPage))
 				ScrollToCurrentPage();
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsFragmentPagerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsFragmentPagerAdapter.cs
@@ -10,9 +10,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 	internal class FormsFragmentPagerAdapter<T> : FragmentPagerAdapter where T : Page
 	{
 		MultiPage<T> _page;
+		FragmentManager _fragmentManager;
 		bool _disposed;
-
-		readonly FragmentManager _fragmentManager;
 
 		public FormsFragmentPagerAdapter(MultiPage<T> page, FragmentManager fragmentManager) : base(fragmentManager)
 		{
@@ -79,6 +78,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				_disposed = true;
 
 				_page = null;
+				_fragmentManager = null;
 			}
 
 			base.Dispose(disposing);

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsFragmentPagerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsFragmentPagerAdapter.cs
@@ -42,12 +42,17 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		public override int GetItemPosition(Object objectValue)
 		{
 			var fragContainer = objectValue as FragmentContainer;
+			
 			if (fragContainer?.Page != null)
 			{
 				int index = _page.Children.IndexOf(fragContainer.Page);
+				
 				if (index >= 0)
 					return index;
 			}
+
+			_fragments.Remove(fragContainer);
+
 			return PositionNone;
 		}
 


### PR DESCRIPTION
### Description of Change ###
Fix the disposing of the TabbedPageRenderer.

There are several problems with the current implementation of the dispose :
- The fragments created by the FragmentPagerAdapter was not removed
- The TabSelected listeners are not correctly cleared
- The PageChange listeners are not cleared

### Issues Resolved ### 
- Fixes #4973

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
- Install the repro App : [issue4973.zip](https://github.com/xamarin/Xamarin.Forms/files/2752742/issue4973.zip)
- Go to the tab of the right
- Go to another tab

### PR Checklist ###
- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
