### PR TITLE
[UWP] fixes crashing ActivityIndicator with COMException

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsProgressBar.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsProgressBar.cs
@@ -16,7 +16,8 @@ namespace Xamarin.Forms.Platform.UWP
 		protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
 		{
 			var result = base.MeasureOverride(availableSize);
-			result.Width = availableSize.Width;
+			if (!double.IsInfinity(availableSize.Width))
+				result.Width = availableSize.Width;
 			return result;
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Native size crashes with infinity values.

### Issues Resolved ### 

- fixes #4982

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Testing Procedure ###

- Run Activity Indicator Gallery
- Select "Input Transparent View"
- App doesn't crash

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
