### PR TITLE
[Core] Fix dynamic resources in merged dictionaries #3661

### DIFF
--- a/Xamarin.Forms.Core/ResourcesExtensions.cs
+++ b/Xamarin.Forms.Core/ResourcesExtensions.cs
@@ -15,14 +15,19 @@ namespace Xamarin.Forms
 				{
 					resources = resources ?? new Dictionary<string, object>();
 					foreach (KeyValuePair<string, object> res in ve.Resources.MergedResources)
-						if (!resources.ContainsKey(res.Key))
-							resources.Add(res.Key, res.Value);
+					{
+						// If a MergedDictionary value is overridden for a DynamicResource, 
+						// it comes out later in the enumeration of MergedResources
+						// TryGetValue ensures we pull the up-to-date value for the key
+						if (!resources.ContainsKey(res.Key) && ve.Resources.TryGetValue(res.Key, out object value))
+							resources.Add(res.Key, value);
 						else if (res.Key.StartsWith(Style.StyleClassPrefix, StringComparison.Ordinal))
 						{
 							var mergedClassStyles = new List<Style>(resources[res.Key] as List<Style>);
 							mergedClassStyles.AddRange(res.Value as List<Style>);
 							resources[res.Key] = mergedClassStyles;
 						}
+					}
 				}
 				var app = element as Application;
 				if (app != null && app.SystemResources != null)


### PR DESCRIPTION
### Description of Change ###

Dynamic resources do not work with merged ResourceDictionaries. When an Element has its parent set, the original stale resource values are used and updated values ignored. This change uses `ResourceDictionary.TryGetValue` to ensure that dictionaries are checked in the correct order to get the most recent value.

Tested manually using the repro in #3661, on iOS.  I couldn't find any unit tests for this extension method, so none have been added/changed.  Happy to go back and amend if you point out what I've missed.

### Issues Resolved ### 

- fixes #3661

### API Changes ###

- None
 
### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Before
![before](https://user-images.githubusercontent.com/9745915/51185401-ecff6180-18ce-11e9-90b6-d1269124c584.png)

After
![after](https://user-images.githubusercontent.com/9745915/51185411-f092e880-18ce-11e9-83e8-8b5148d1ba01.png)


### Testing Procedure ###

I have a branch, 'repro-3661' which is essentially the repro uploaded in #3661, with the addition of using dynamic resources in a style setter, both defined in merged dictionaries.  I've manually tested on iOS only, and unit tests are passing (equivalent to master).

### PR Checklist ###

- [ ] Has automated tests 
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
