### PR TITLE
Removed redundant ItemTemplateSelector prop from BindableLayout

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
@@ -166,27 +166,10 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
 			BindableLayout.SetItemsSource(layout, itemsSource);
-			BindableLayout.SetItemTemplateSelector(layout, new DataTemplateSelectorFrame());
+			BindableLayout.SetItemTemplate(layout, new DataTemplateSelectorFrame());
 
 			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
 			Assert.AreEqual(itemsSource.Count, layout.Children.Cast<Frame>().Count());
-		}
-
-		[Test]
-		public void ItemTemplateTakesPrecendenceOverItemTemplateSelector()
-		{
-			var layout = new StackLayout
-			{
-				IsPlatformEnabled = true,
-			};
-
-			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
-			BindableLayout.SetItemsSource(layout, itemsSource);
-			BindableLayout.SetItemTemplate(layout, new DataTemplateBoxView());
-			BindableLayout.SetItemTemplateSelector(layout, new DataTemplateSelectorFrame());
-
-			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
-			Assert.AreEqual(itemsSource.Count, layout.Children.Cast<BoxView>().Count());
 		}
 
 		[Test]
@@ -309,8 +292,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			int i = 0;
 			foreach (object item in itemsSource)
 			{
-				if (BindableLayout.GetItemTemplate(layout) is DataTemplate dataTemplate ||
-					BindableLayout.GetItemTemplateSelector(layout) is DataTemplateSelector dataTemplateSelector)
+				if (BindableLayout.GetItemTemplate(layout) is DataTemplate)
 				{
 					if (!Equals(item, layout.Children[i].BindingContext))
 					{

--- a/Xamarin.Forms.Core/BindableLayout.cs
+++ b/Xamarin.Forms.Core/BindableLayout.cs
@@ -14,9 +14,6 @@ namespace Xamarin.Forms
 			BindableProperty.CreateAttached("ItemTemplate", typeof(DataTemplate), typeof(Layout<View>), default(DataTemplate),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemTemplate = (DataTemplate)n; });
 
-		[Obsolete("ItemTemplateSelectorProperty is obsolete. Please use ItemTemplateProperty instead.")]
-		public static readonly BindableProperty ItemTemplateSelectorProperty = ItemTemplateProperty;
-
 		static readonly BindableProperty BindableLayoutControllerProperty =
 			 BindableProperty.CreateAttached("BindableLayoutController", typeof(BindableLayoutController), typeof(Layout<View>), default(BindableLayoutController),
 				 defaultValueCreator: (b) => new BindableLayoutController((Layout<View>)b),
@@ -40,18 +37,6 @@ namespace Xamarin.Forms
 		public static DataTemplate GetItemTemplate(BindableObject b)
 		{
 			return (DataTemplate)b.GetValue(ItemTemplateProperty);
-		}
-
-		[Obsolete("SetItemTemplateSelector is obsolete. Please use SetItemTemplate instead.")]
-		public static void SetItemTemplateSelector(BindableObject b, DataTemplateSelector value)
-		{
-			b.SetValue(ItemTemplateProperty, value);
-		}
-
-		[Obsolete("GetItemTemplateSelector is obsolete. Please use GetItemTemplate instead.")]
-		public static DataTemplateSelector GetItemTemplateSelector(BindableObject b)
-		{
-			return (DataTemplateSelector)b.GetValue(ItemTemplateProperty);
 		}
 
 		static BindableLayoutController GetBindableLayoutController(BindableObject b)


### PR DESCRIPTION
### Description of Change ###

Hi guys. From my point of view ItemTemplateSelectorProperty will confuse developers as it is not clear what it the priority of choosing ItemTemplate and ItemTemplateSelector.
Besides **DataTemplateSelector** inherits **DataTemplate** and definitely there is no need in ItemTemplateSelectorProperty (Like we have in **ListView** control)

Since **BindableLayout** is fresh class, i suggest to mark this property as obsolete and remove in further releases.


### API Changes ###
Suggest to remove BindableLayout.**ItemTemplateSelectorProperty**


### Platforms Affected ### 
- Core

None

### Before/After Screenshots ### 
Not applicable
