### PR TITLE
[Android] fixes TabStop on Stepper Control

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/StepperRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/StepperRenderer.cs
@@ -27,7 +27,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override LinearLayout CreateNativeControl()
 		{
-			return new LinearLayout(Context) { Orientation = Orientation.Horizontal };
+			return new LinearLayout(Context)
+			{
+				Orientation = Orientation.Horizontal,
+				Focusable = true,
+				DescendantFocusability = DescendantFocusability.AfterDescendants
+			};
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Stepper> e)
@@ -36,15 +41,17 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (e.OldElement == null)
 			{
-				_downButton = new AButton(Context) { Text = "-", Gravity = GravityFlags.Center, Tag = this };
+				_downButton = new AButton(Context) { Text = "-", Gravity = GravityFlags.Center, Tag = this, Focusable = true };
 				_downButton.SetHeight((int)Context.ToPixels(10.0));
 
 				_downButton.SetOnClickListener(StepperListener.Instance);
 
-				_upButton = new AButton(Context) { Text = "+", Tag = this };
+				_upButton = new AButton(Context) { Text = "+", Tag = this, Focusable = true };
 
 				_upButton.SetOnClickListener(StepperListener.Instance);
 				_upButton.SetHeight((int)Context.ToPixels(10.0));
+
+				_downButton.NextFocusForwardId = _upButton.Id = Platform.GenerateViewId();
 
 				var layout = CreateNativeControl();
 


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 

partially fixes #4956 [Android]

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Stepper don't skipped from with TabStop

### Testing Procedure ###

- Run Issue3872
- Tab Over controls
- You're able to tab to stepper

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
