### PR TITLE
[iOS] Fixed updating Label TextDecorations when no Text is set

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5003.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5003.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Controls.Issues"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue5003">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <local:StrikeThroughIfTrueConverter x:Key="StrikeThroughIfTrueConverter"/>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Content>
+    <Label  Text="{Binding MyNullString}" 
+                TextDecorations="{Binding SomeBoolean, Converter={StaticResource StrikeThroughIfTrueConverter}}"/>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5003.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5003.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Globalization;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5003, "iOS StrikeThrough applied to null string throws error", PlatformAffected.iOS)]
+	public partial class Issue5003 : ContentPage
+	{
+
+		public Issue5003()
+		{
+#if APP
+			InitializeComponent();
+#endif
+			BindingContext = new VM();
+		}
+
+		[Preserve(AllMembers = true)]
+		class VM
+		{
+			public string MyNullString { get; set; }
+			public bool SomeBoolean { get; set; }
+		}
+	}
+
+	public class StrikeThroughIfTrueConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is bool b)
+			{
+				if (b)
+					return TextDecorations.Strikethrough;
+			}
+
+			return TextDecorations.None;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -427,6 +427,10 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue4600.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5003.xaml.cs">
+      <DependentUpon>Issue5003.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />
@@ -1087,6 +1091,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4360.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5003.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.Dispose(disposing);
 			if (disposing)
 			{
-				if(Element != null)
+				if (Element != null)
 				{
 					Element.PropertyChanging -= ElementPropertyChanging;
 				}
@@ -215,6 +215,14 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (!Element.IsSet(Label.TextDecorationsProperty))
 				return;
+
+#if __MOBILE__
+			if (!(Control.AttributedText?.Length > 0))
+				return;
+#else
+			if (!(Control.AttributedStringValue?.Length > 0))
+				return;
+#endif
 
 			var textDecorations = Element.TextDecorations;
 #if __MOBILE__


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5003 
- fixes #5149
- fixes #5258

### API Changes ###
<!-- List all API changes here (or just put None), example:

None

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
