### PR TITLE
[Control Gallery] Basic Search + Visual Selector

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -399,6 +399,8 @@ namespace Xamarin.Forms.Controls
 				_pages.Insert(1, new GalleryPageFactory(() => new TitleView(true), "TitleView"));
 			}
 
+			_pages.Sort((x, y) => string.Compare(x.Title, y.Title, true));
+
 			var template = new DataTemplate(() =>
 			{
 				var cell = new TextCell();

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -399,7 +399,27 @@ namespace Xamarin.Forms.Controls
 				_pages.Insert(1, new GalleryPageFactory(() => new TitleView(true), "TitleView"));
 			}
 
-			var template = new DataTemplate(typeof(TextCell));
+			var template = new DataTemplate(() =>
+			{
+				var cell = new TextCell();
+				cell.ContextActions.Add(new MenuItem
+				{
+					Text = "Select Visual",
+					Command = new Command(async () =>
+					{
+						var buttons = typeof(VisualMarker).GetProperties().Select(p => p.Name);
+						var selection = await rootPage.DisplayActionSheet("Select Visual", "Cancel", null, buttons.ToArray());
+						if (cell.BindingContext is GalleryPageFactory pageFactory)
+						{
+							var page = pageFactory.Realize();
+							if (typeof(VisualMarker).GetProperty(selection)?.GetValue(null) is IVisual visual)
+								page.Visual = visual;
+							await PushPage(page);
+						}
+					})
+				});
+				return cell;
+			});
 			template.SetBinding(TextCell.TextProperty, "Title");
 
 			BindingContext = _pages;

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -448,6 +448,14 @@ namespace Xamarin.Forms.Controls
 
 			await PushPage(page);
 		}
+
+		public void FilterPages(string filter)
+		{
+			if (string.IsNullOrWhiteSpace(filter))
+				ItemsSource = _pages;
+			else
+				ItemsSource = _pages.Where(p => p.Title.IndexOf(filter, StringComparison.InvariantCultureIgnoreCase) != -1);
+		}
 	}
 	[Preserve(AllMembers = true)]
 	internal class CoreRootPage : ContentPage
@@ -465,6 +473,11 @@ namespace Xamarin.Forms.Controls
 			var searchBar = new SearchBar()
 			{
 				AutomationId = "SearchBar"
+			};
+
+			searchBar.TextChanged += (sender, e) =>
+			{
+				corePageView.FilterPages(e.NewTextValue);
 			};
 
 			var testCasesButton = new Button


### PR DESCRIPTION
### Description of Change ###

This PR does 3 things:
 - Adds basic search on the gallery home page _(there is that search box, there are those hundreds of pages, there is a need to find a particular page)_
 - Adds context menus to allow the visual to be defined when navigating _(because we really don't want to rewrite all the tests)_
 - Adds sorting to the pages list _(to help us find things)_

### Issues Resolved ### 

None.

### API Changes ###
 
None.

### Platforms Affected ### 

None.

### Behavioral/Visual Changes ###

None.

### Before/After Screenshots ### 

| Android | iOS |
| :-: | :-: |
| <img src="https://user-images.githubusercontent.com/1096616/51383923-71e2b900-1b23-11e9-8d34-5772e7b7c1ec.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1096616/51385340-a2c4ed00-1b27-11e9-97b0-65604e87bdf7.png" width="300" /> |


### Testing Procedure ###

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
