### PR TITLE
[Core] Add some Device.InvokeOnMainThread helpers

### DIFF
--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -104,6 +104,57 @@ namespace Xamarin.Forms
 			PlatformServices.BeginInvokeOnMainThread(action);
 		}
 
+		public static Task<T> InvokeOnMainThreadAsync<T>(Func<T> func)
+		{
+			var tcs = new TaskCompletionSource<T>();
+			BeginInvokeOnMainThread(() =>
+			{
+				try
+				{
+					var result = func();
+					tcs.SetResult(result);
+				}
+				catch (Exception ex)
+				{
+					tcs.SetException(ex);
+				}
+			});
+			return tcs.Task;
+		}
+
+		public static Task InvokeOnMainThreadAsync(Action action)
+		{
+			Func<object> dummyFunc = () => { action(); return null; };
+			return InvokeOnMainThreadAsync(dummyFunc);
+		}
+
+		public static Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask)
+		{
+			var tcs = new TaskCompletionSource<T>();
+			BeginInvokeOnMainThread(
+				async() =>
+				{
+					try
+					{
+						var ret = await funcTask().ConfigureAwait(false);
+						tcs.SetResult(ret);
+					}
+					catch (Exception e)
+					{
+						tcs.SetException(e);
+					}
+				}
+			);
+
+			return tcs.Task;
+		}
+
+		public static Task InvokeOnMainThreadAsync(Func<Task> funcTask)
+		{
+			Func<Task<object>> dummyFunc = () => { funcTask(); return null; };
+			return InvokeOnMainThreadAsync(dummyFunc);
+		}
+
 		public static double GetNamedSize(NamedSize size, Element targetElement)
 		{
 			return GetNamedSize(size, targetElement.GetType());

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -155,6 +155,15 @@ namespace Xamarin.Forms
 			return InvokeOnMainThreadAsync(dummyFunc);
 		}
 
+		public static async Task<SynchronizationContext> GetMainThreadSynchronizationContextAsync()
+		{
+			SynchronizationContext ret = null;
+			await InvokeOnMainThreadAsync(() =>
+				ret = SynchronizationContext.Current
+			).ConfigureAwait(false);
+			return ret;
+		}
+
 		public static double GetNamedSize(NamedSize size, Element targetElement)
 		{
 			return GetNamedSize(size, targetElement.GetType());


### PR DESCRIPTION
These helpers keep popping up on forums/stackoverflow[1][2],
would be nice to include them out of the box.

[1] https://forums.xamarin.com/discussion/51720/wait-for-device-begininvokeonmainthread
[2] https://stackoverflow.com/a/47941859
