### PR TITLE
Implement FlowDirection propagation to items in CollectionView

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 					GalleryBuilder.NavButton("CarouselView Galleries", () => new CarouselViewGallery(), Navigation),
 					GalleryBuilder.NavButton("EmptyView Galleries", () => new EmptyViewGallery(), Navigation),
 					GalleryBuilder.NavButton("Selection Galleries", () => new SelectionGallery(), Navigation),
+					GalleryBuilder.NavButton("Propagation Galleries", () => new PropagationGallery(), Navigation),
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
@@ -224,6 +224,48 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			});
 		}
 
+		public static DataTemplate PropagationTemplate()
+		{
+			return new DataTemplate(() =>
+			{
+				var templateLayout = new Grid
+				{
+					BackgroundColor = Color.Bisque,
+					RowDefinitions = new RowDefinitionCollection { new RowDefinition { Height = GridLength.Auto } },
+					WidthRequest = 100,
+					HeightRequest = 140
+				};
+
+				var buttonLayout = new StackLayout { Orientation = StackOrientation.Horizontal };
+
+				var button1 = new Button
+				{
+					Margin = new Thickness(5),
+					Text = "Button 1"
+				};
+
+				var button2 = new Button
+				{
+					Margin = new Thickness(5),
+					Text = "Button 2"
+				};
+
+				var button3 = new Button
+				{
+					Margin = new Thickness(5),
+					Text = "Button 3"
+				};
+
+				buttonLayout.Children.Add(button1);
+				buttonLayout.Children.Add(button2);
+				buttonLayout.Children.Add(button3);
+
+				templateLayout.Children.Add(buttonLayout);
+
+				return templateLayout;
+			});
+		}
+		
 		public static DataTemplate VariableSizeTemplate()
 		{
 			var indexHeightConverter = new IndexRequestConverter(3, 50, 150);

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagateCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagateCodeGallery.cs
@@ -15,7 +15,8 @@
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Star }
 				},
-				FlowDirection = FlowDirection.RightToLeft
+				FlowDirection = FlowDirection.RightToLeft,
+				Visual = VisualMarker.Material
 			};
 
 			var itemTemplate = ExampleTemplates.PropagationTemplate();

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagateCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagateCodeGallery.cs
@@ -1,0 +1,69 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
+{
+	internal class PropagateCodeGallery : ContentPage
+	{
+		public PropagateCodeGallery(IItemsLayout itemsLayout)
+		{
+			Title = $"Propagate FlowDirection=RTL";
+
+			var layout = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Star }
+				},
+				FlowDirection = FlowDirection.RightToLeft
+			};
+
+			var itemTemplate = ExampleTemplates.PropagationTemplate();
+
+			var collectionView = new CollectionView
+			{
+				ItemsLayout = itemsLayout,
+				ItemTemplate = itemTemplate,
+			};
+
+			var generator = new ItemsSourceGenerator(collectionView, initialItems: 2);
+			layout.Children.Add(generator);
+			var instructions = new Label();
+			UpdateInstructions(layout, instructions);
+			Grid.SetRow(instructions, 2);
+			layout.Children.Add(instructions);
+
+			var switchLabel = new Label { Text = "Toggle FlowDirection" };
+			var switchLayout = new StackLayout { Orientation = StackOrientation.Horizontal };
+			var updateSwitch = new Switch { };
+
+			updateSwitch.Toggled += (sender, args) => 
+			{
+				layout.FlowDirection = layout.FlowDirection == FlowDirection.RightToLeft 
+					? FlowDirection.LeftToRight 
+					: FlowDirection.RightToLeft;
+
+				UpdateInstructions(layout, instructions);
+			};
+
+			switchLayout.Children.Add(switchLabel);
+			switchLayout.Children.Add(updateSwitch);
+
+			Grid.SetRow(switchLayout, 1);
+			layout.Children.Add(switchLayout);
+
+			layout.Children.Add(collectionView);
+			
+			Grid.SetRow(collectionView, 3);
+
+			Content = layout;
+
+			generator.GenerateItems();
+		}
+
+		static void UpdateInstructions(Layout layout, Label instructions)
+		{
+			instructions.Text = $"The buttons in each item should be in order from {layout.FlowDirection}.";
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagationGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagationGallery.cs
@@ -1,0 +1,26 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
+{
+	internal class PropagationGallery : ContentPage
+	{
+		public PropagationGallery()
+		{
+			var descriptionLabel =
+				new Label { Text = "Property Propagation Galleries", Margin = new Thickness(2, 2, 2, 2) };
+
+			Title = "Property Propagation Galleries";
+
+			Content = new ScrollView
+			{
+				Content = new StackLayout
+				{
+					Children =
+					{
+						descriptionLabel,
+						GalleryBuilder.NavButton("Propagate FlowDirection", () =>
+							new PropagateCodeGallery(ListItemsLayout.VerticalList), Navigation),
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Internals/PropertyPropagationExtensions.cs
+++ b/Xamarin.Forms.Core/Internals/PropertyPropagationExtensions.cs
@@ -21,5 +21,17 @@ namespace Xamarin.Forms.Internals
 					view.PropagatePropertyChanged(propertyName);
 			}
 		}
+
+		internal static void PropagatePropertyChanged(string propertyName, Element element)
+		{
+			if (propertyName == null || propertyName == VisualElement.FlowDirectionProperty.PropertyName)
+				Element.SetFlowDirectionFromParent(element);
+
+			if (propertyName == null || propertyName == VisualElement.VisualProperty.PropertyName)
+				Element.SetVisualfromParent(element);
+
+			if (element is IPropertyPropagationController view)
+					view.PropagatePropertyChanged(propertyName);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 
@@ -7,6 +9,8 @@ namespace Xamarin.Forms
 {
 	public class ItemsView : View
 	{
+		List<Element> _logicalChildren = new List<Element>();
+
 		protected internal ItemsView()
 		{
 			CollectionView.VerifyCollectionViewFlagEnabled(constructorHint: nameof(ItemsView));
@@ -38,6 +42,26 @@ namespace Xamarin.Forms
 			get => (IEnumerable)GetValue(ItemsSourceProperty);
 			set => SetValue(ItemsSourceProperty, value);
 		}
+
+		public void AddLogicalChild(Element element)
+		{
+			_logicalChildren.Add(element);
+			element.Parent = this;
+		}
+
+		public void RemoveLogicalChild(Element element)
+		{
+			element.Parent = null;
+			_logicalChildren.Remove(element);
+		}
+
+#if NETSTANDARD1_0
+		ReadOnlyCollection<Element> _readOnlyLogicalChildren;
+		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _readOnlyLogicalChildren ?? 
+			(_readOnlyLogicalChildren = new ReadOnlyCollection<Element>(_logicalChildren));
+#else
+		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildren.AsReadOnly();
+#endif
 
 		// TODO hartez 2018/08/29 17:35:10 Should ItemsView be abstract? With ItemsLayout as an interface?
 		// Trying to come up with a reasonable way to restrict CarouselView to ListItemsLayout(LinearLayout) 

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
@@ -46,6 +47,9 @@ namespace Xamarin.Forms
 		public void AddLogicalChild(Element element)
 		{
 			_logicalChildren.Add(element);
+
+			PropertyPropagationExtensions.PropagatePropertyChanged(null, element);
+
 			element.Parent = this;
 		}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -48,7 +48,6 @@ namespace Xamarin.Forms.Platform.Android
 					textViewHolder.TextView.Text = ItemsSource[position].ToString();
 					break;
 				case TemplatedItemViewHolder templatedItemViewHolder:
-					ItemsView.AddLogicalChild(templatedItemViewHolder.View);
 					BindableObject.SetInheritedBindingContext(templatedItemViewHolder.View, ItemsSource[position]);
 					break;
 			}
@@ -69,6 +68,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			// Realize the content, create a renderer out of it, and use that
 			var templateElement = (View)template.CreateContent();
+			ItemsView.AddLogicalChild(templateElement);
 			var itemContentControl = _createView(CreateRenderer(templateElement, context), context);
 
 			return new TemplatedItemViewHolder(itemContentControl, templateElement);

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (holder is TemplatedItemViewHolder templatedItemViewHolder)
 			{
-				templatedItemViewHolder.View.Parent = null;
+				ItemsView.RemoveLogicalChild(templatedItemViewHolder.View);
 			}
 
 			base.OnViewRecycled(holder);
@@ -47,9 +47,9 @@ namespace Xamarin.Forms.Platform.Android
 				case TextViewHolder textViewHolder:
 					textViewHolder.TextView.Text = ItemsSource[position].ToString();
 					break;
-				case TemplatedItemViewHolder templateViewHolder:
-					templateViewHolder.View.Parent = ItemsView;
-					BindableObject.SetInheritedBindingContext(templateViewHolder.View, ItemsSource[position]);
+				case TemplatedItemViewHolder templatedItemViewHolder:
+					ItemsView.AddLogicalChild(templatedItemViewHolder.View);
+					BindableObject.SetInheritedBindingContext(templatedItemViewHolder.View, ItemsSource[position]);
 					break;
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using CoreGraphics;
 using Foundation;
 using UIKit;
 
@@ -38,7 +35,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// If we're updating from a previous layout, we should keep any settings for the SelectableItemsViewController around
 			var selectableItemsViewController = Delegator?.SelectableItemsViewController;
-			Delegator = new UICollectionViewDelegator(_layout)
+			Delegator = new UICollectionViewDelegator(_layout, this);
 			{
 				SelectableItemsViewController = selectableItemsViewController
 			};
@@ -163,15 +160,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void ApplyTemplateAndDataContext(TemplatedCell cell, NSIndexPath indexPath)
 		{
-			var oldView = cell.VisualElementRenderer?.Element;
-			if (oldView != null)
-			{
-				// This is not the ideal place to handle this, but it will have to do until  
-				// we get the selection stuff merged and we can properly use CellDisplayingEnded
-				// TODO When the selection stuff is merged, move this to CellDisplayingEnded
-				_itemsView.RemoveLogicalChild(oldView);
-			}
-
 			// We need to create a renderer, which means we need a template
 			var templateElement = _itemsView.ItemTemplate.CreateContent() as View;
 			IVisualElementRenderer renderer = CreateRenderer(templateElement);
@@ -181,6 +169,18 @@ namespace Xamarin.Forms.Platform.iOS
 				_itemsView.AddLogicalChild(renderer.Element);
 				BindableObject.SetInheritedBindingContext(renderer.Element, _itemsSource[indexPath.Row]);
 				cell.SetRenderer(renderer);
+			}
+		}
+
+		internal void RemoveLogicalChild(UICollectionViewCell cell)
+		{
+			if (cell is TemplatedCell templatedCell)
+			{
+				var oldView = templatedCell.VisualElementRenderer?.Element;
+				if (oldView != null)
+				{
+					_itemsView.RemoveLogicalChild(oldView);
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -163,12 +163,22 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void ApplyTemplateAndDataContext(TemplatedCell cell, NSIndexPath indexPath)
 		{
+			var oldView = cell.VisualElementRenderer?.Element;
+			if (oldView != null)
+			{
+				// This is not the ideal place to handle this, but it will have to do until  
+				// we get the selection stuff merged and we can properly use CellDisplayingEnded
+				// TODO When the selection stuff is merged, move this to CellDisplayingEnded
+				_itemsView.RemoveLogicalChild(oldView);
+			}
+
 			// We need to create a renderer, which means we need a template
 			var templateElement = _itemsView.ItemTemplate.CreateContent() as View;
 			IVisualElementRenderer renderer = CreateRenderer(templateElement);
 
 			if (renderer != null)
 			{
+				_itemsView.AddLogicalChild(renderer.Element);
 				BindableObject.SetInheritedBindingContext(renderer.Element, _itemsSource[indexPath.Row]);
 				cell.SetRenderer(renderer);
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -161,15 +161,11 @@ namespace Xamarin.Forms.Platform.iOS
 		void ApplyTemplateAndDataContext(TemplatedCell cell, NSIndexPath indexPath)
 		{
 			// We need to create a renderer, which means we need a template
-			var templateElement = _itemsView.ItemTemplate.CreateContent() as View;
-			IVisualElementRenderer renderer = CreateRenderer(templateElement);
-
-			if (renderer != null)
-			{
-				_itemsView.AddLogicalChild(renderer.Element);
-				BindableObject.SetInheritedBindingContext(renderer.Element, _itemsSource[indexPath.Row]);
-				cell.SetRenderer(renderer);
-			}
+			var view = _itemsView.ItemTemplate.CreateContent() as View;
+			_itemsView.AddLogicalChild(view);
+			var renderer = CreateRenderer(view);
+			BindableObject.SetInheritedBindingContext(view, _itemsSource[indexPath.Row]);
+			cell.SetRenderer(renderer);
 		}
 
 		internal void RemoveLogicalChild(UICollectionViewCell cell)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -36,9 +36,6 @@ namespace Xamarin.Forms.Platform.iOS
 			// If we're updating from a previous layout, we should keep any settings for the SelectableItemsViewController around
 			var selectableItemsViewController = Delegator?.SelectableItemsViewController;
 			Delegator = new UICollectionViewDelegator(_layout, this);
-			{
-				SelectableItemsViewController = selectableItemsViewController
-			};
 
 			CollectionView.Delegate = Delegator;
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/SelectableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/SelectableItemsViewController.cs
@@ -12,7 +12,6 @@ namespace Xamarin.Forms.Platform.iOS
 			: base(selectableItemsView, layout)
 		{
 			SelectableItemsView = selectableItemsView;
-			Delegator.SelectableItemsViewController = this;
 		}
 
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection

--- a/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
@@ -7,9 +7,17 @@ namespace Xamarin.Forms.Platform.iOS
 	public class UICollectionViewDelegator : UICollectionViewDelegateFlowLayout
 	{
 		public ItemsViewLayout ItemsViewLayout { get; private set; }
-		public SelectableItemsViewController SelectableItemsViewController { get; set; }
+		public ItemsViewController ItemsViewController { get; private set; }
+		public SelectableItemsViewController SelectableItemsViewController
+		{
+			get => ItemsViewController as SelectableItemsViewController;
+		}
 
-		public UICollectionViewDelegator(ItemsViewLayout itemsViewLayout) => ItemsViewLayout = itemsViewLayout;
+		public UICollectionViewDelegator(ItemsViewLayout itemsViewLayout, ItemsViewController itemsViewController)
+		{
+			ItemsViewLayout = itemsViewLayout;
+			ItemsViewController = itemsViewController;
+		}
 
 		public override void WillDisplayCell(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath path)
 		{
@@ -57,6 +65,11 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
 			SelectableItemsViewController?.ItemDeselected(collectionView, indexPath);
+		}
+
+		public override void CellDisplayingEnded(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath indexPath)
+		{
+			ItemsViewController.RemoveLogicalChild(cell);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Attach/detach templated Views as logical child elements of the CollectionView so that the EffectiveFlowDirection (and other properties) propagate down to them.

### Issues Resolved ### 

- fixes #4583 

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

In Control Gallery, navigate to CollectionView Gallery -> Propagation Galleries -> Propagate FlowDirection. Toggle the FlowDirection switch and verify that the description below it matches the behavior of the CollectionView.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
