### PR TITLE
[iOS] CollectionView multi-item Add/Remove/Replace/Move

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/MultiItemRemover.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/MultiItemRemover.cs
@@ -29,16 +29,15 @@
 			var index1 = indexes[0];
 			var index2 = indexes[1];
 
-			if (index1 > -1 && index2 > -1 && index1 < observableCollection.Count &&
-				index2 < observableCollection.Count && index1 < index2)
+			if (index1 > -1 && index2 < observableCollection.Count && index1 <= index2)
 			{
 				if (_withIndex)
 				{
-					observableCollection.TestRemoveWithListAndIndex(index1, index2 - index1);
+					observableCollection.TestRemoveWithListAndIndex(index1, (index2 - index1) + 1);
 				}
 				else
 				{
-					observableCollection.TestRemoveWithList(index1, index2 - index1);
+					observableCollection.TestRemoveWithList(index1, (index2 - index1) + 1);
 				}
 			}
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/MultiItemReplacer.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/MultiItemReplacer.cs
@@ -32,8 +32,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			var index1 = indexes[0];
 			var index2 = indexes[1];
 
-			if (index1 > -1 && index2 > -1 && index1 < observableCollection.Count &&
-				index2 < observableCollection.Count && index1 <= index2)
+			if (index1 > -1 && index2 < observableCollection.Count && index1 <= index2)
 			{
 				var newItems = new List<CollectionViewGalleryTestItem>();
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/MultiItemReplacer.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/MultiItemReplacer.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			var index2 = indexes[1];
 
 			if (index1 > -1 && index2 > -1 && index1 < observableCollection.Count &&
-				index2 < observableCollection.Count && index1 < index2)
+				index2 < observableCollection.Count && index1 <= index2)
 			{
 				var newItems = new List<CollectionViewGalleryTestItem>();
 
@@ -45,11 +45,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 
 				if (_withIndex)
 				{
-					observableCollection.TestReplaceWithListAndIndex(index1, index2 - index1, newItems);
+					observableCollection.TestReplaceWithListAndIndex(index1, index2 - index1 + 1, newItems);
 				}
 				else
 				{
-					observableCollection.TestReplaceWithList(index1, index2 - index1, newItems);
+					observableCollection.TestReplaceWithList(index1, index2 - index1 + 1, newItems);
 				}
 			}
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCollectionResetGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCollectionResetGallery.cs
@@ -1,0 +1,39 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
+{
+	internal class ObservableCollectionResetGallery : ContentPage
+	{
+		public ObservableCollectionResetGallery()
+		{
+			var layout = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Star }
+				}
+			};
+
+			var itemsLayout = new GridItemsLayout(3, ItemsLayoutOrientation.Vertical) as IItemsLayout;
+
+			var itemTemplate = ExampleTemplates.PhotoTemplate();
+
+			var collectionView = new CollectionView { ItemsLayout = itemsLayout, ItemTemplate = itemTemplate };
+
+			var generator = new ItemsSourceGenerator(collectionView, 100, ItemsSourceType.MultiTestObservableCollection);
+
+			layout.Children.Add(generator);
+
+			var resetter = new Resetter(collectionView);
+			layout.Children.Add(resetter);
+			Grid.SetRow(resetter, 1);
+
+			layout.Children.Add(collectionView);
+			Grid.SetRow(collectionView, 2);
+
+			Content = layout;
+
+			generator.GenerateItems();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableMultiItemCollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableMultiItemCollectionViewGallery.cs
@@ -56,41 +56,4 @@
 			generator.GenerateItems();
 		}
 	}
-
-	internal class ObservableCollectionResetGallery : ContentPage
-	{
-		public ObservableCollectionResetGallery()
-		{
-			var layout = new Grid
-			{
-				RowDefinitions = new RowDefinitionCollection
-				{
-					new RowDefinition { Height = GridLength.Auto },
-					new RowDefinition { Height = GridLength.Auto },
-					new RowDefinition { Height = GridLength.Star }
-				}
-			};
-
-			var itemsLayout = new GridItemsLayout(3, ItemsLayoutOrientation.Vertical) as IItemsLayout;
-
-			var itemTemplate = ExampleTemplates.PhotoTemplate();
-
-			var collectionView = new CollectionView { ItemsLayout = itemsLayout, ItemTemplate = itemTemplate };
-
-			var generator = new ItemsSourceGenerator(collectionView, 100, ItemsSourceType.MultiTestObservableCollection);
-
-			layout.Children.Add(generator);
-
-			var resetter = new Resetter(collectionView);
-			layout.Children.Add(resetter);
-			Grid.SetRow(resetter, 1);
-
-			layout.Children.Add(collectionView);
-			Grid.SetRow(collectionView, 2);
-
-			Content = layout;
-
-			generator.GenerateItems();
-		}
-	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -104,9 +104,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void Remove(NotifyCollectionChangedEventArgs args)
 		{
-			var startIndex = args.OldStartingIndex > -1 ? args.OldStartingIndex : _itemsSource.IndexOf(args.OldItems[0]);
-			var count = args.OldItems.Count;
+			var startIndex = args.OldStartingIndex;
 
+			if (startIndex < 0)
+			{
+				// INCC implementation isn't giving us enough information to know where the removed items were in the
+				// collection. So the best we can do is a ReloadData()
+				_collectionView.ReloadData();
+				return;
+			}
+
+			// If we have a start index, we can be more clever about removing the item(s) (and get the nifty animations)
+			var count = args.OldItems.Count;
 			_collectionView.DeleteItems(CreateIndexesFrom(startIndex, count));
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -44,10 +44,21 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void Move(NotifyCollectionChangedEventArgs args)
 		{
-			var oldPath = NSIndexPath.Create(0, args.OldStartingIndex);
-			var newPath = NSIndexPath.Create(0, args.NewStartingIndex);
+			var count = args.NewItems.Count;
 
-			_collectionView.MoveItem(oldPath, newPath);
+			if (count == 1)
+			{
+				// For a single item, we can use MoveItem and get the animation
+				var oldPath = NSIndexPath.Create(0, args.OldStartingIndex);
+				var newPath = NSIndexPath.Create(0, args.NewStartingIndex);
+
+				_collectionView.MoveItem(oldPath, newPath);
+				return;
+			}
+
+			var start = Math.Min(args.OldStartingIndex, args.NewStartingIndex);
+			var end = Math.Max(args.OldStartingIndex, args.NewStartingIndex) + count;
+			_collectionView.ReloadItems(CreateIndexesFrom(start, end));
 		}
 		
 		private void Replace(NotifyCollectionChangedEventArgs args)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -67,11 +67,12 @@ namespace Xamarin.Forms.Platform.iOS
 		
 		private void Replace(NotifyCollectionChangedEventArgs args)
 		{
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 			var newCount = args.NewItems.Count;
 
 			if (newCount == args.OldItems.Count)
 			{
+				var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
+
 				// We are replacing one set of items with a set of equal size; we can do a simple item range update
 				_collectionView.ReloadItems(CreateIndexesFrom(startIndex, newCount));
 				return;


### PR DESCRIPTION
### Description of Change ###

Update INotifyCollectionChanged handling for CollectionView on iOS to handle mutli-item Add, Remove, Replace, and Move notifications. 

### Issues Resolved ### 

- partially implements #3172 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

In Control Gallery, navigate to CollectionView Gallery -> Observable Collection Galleries -> [Multi-item add/remove, no index|Multi-item add/remove, with index].

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
