### PR TITLE
[iOS] Fix ScrollTo MakeVisible positioning

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ScrollToPositionExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ScrollToPositionExtensions.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Forms.Platform.iOS
 			switch (scrollToPosition)
 			{
 				case ScrollToPosition.MakeVisible:
+					return UICollectionViewScrollPosition.None;
 				case ScrollToPosition.Start:
 					return isLtr ? UICollectionViewScrollPosition.Right : UICollectionViewScrollPosition.Left;
 				case ScrollToPosition.End:
@@ -41,6 +42,7 @@ namespace Xamarin.Forms.Platform.iOS
 			switch (scrollToPosition)
 			{
 				case ScrollToPosition.MakeVisible:
+					return UICollectionViewScrollPosition.None;
 				case ScrollToPosition.Start:
 					return UICollectionViewScrollPosition.Top;
 				case ScrollToPosition.End:


### PR DESCRIPTION
### Description of Change ###

Using `MakeVisible` with `ScrollTo` methods on iOS positions the item at the start of the CollectionView (instead of merely getting it onto the screen). This change makes the scrolling behave as expected.

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
In Control Gallery, navigate to CollectionView Gallery -> ScrollTo Galleries and select any of the options.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
