### PR TITLE
Prevent snap helpers from snapping until the user interacts with scro…

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/CenterSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CenterSnapHelper.cs
@@ -1,0 +1,18 @@
+﻿using Android.Support.V7.Widget;
+using AView = Android.Views.View;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal class CenterSnapHelper : NongreedySnapHelper
+	{
+		public override AView FindSnapView(RecyclerView.LayoutManager layoutManager)
+		{
+			if (!CanSnap)
+			{
+				return null;
+			}
+
+			return base.FindSnapView(layoutManager);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/CollectionView/EdgeSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EdgeSnapHelper.cs
@@ -3,7 +3,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal abstract class EdgeSnapHelper : LinearSnapHelper
+	internal abstract class EdgeSnapHelper : NongreedySnapHelper
 	{
 		protected static OrientationHelper CreateOrientationHelper(RecyclerView.LayoutManager layoutManager)
 		{

--- a/Xamarin.Forms.Platform.Android/CollectionView/EndSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EndSnapHelper.cs
@@ -13,6 +13,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override AView FindSnapView(RecyclerView.LayoutManager layoutManager)
 		{
+			if (!CanSnap)
+			{
+				return null;
+			}
+
 			if (layoutManager.ItemCount == 0)
 			{
 				return null;
@@ -23,7 +28,7 @@ namespace Xamarin.Forms.Platform.Android
 				// Don't snap to anything if this isn't a LinearLayoutManager;
 				return null;
 			}
-
+			
 			int span = 1;
 			if (layoutManager is GridLayoutManager gridLayoutManager)
 			{

--- a/Xamarin.Forms.Platform.Android/CollectionView/NongreedySnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/NongreedySnapHelper.cs
@@ -8,16 +8,44 @@ namespace Xamarin.Forms.Platform.Android
 		// (otherwise, this would start trying to snap the view as soon as we attached it to the RecyclerView)
 		protected bool CanSnap { get; set; }
 
-		public override int FindTargetSnapPosition(RecyclerView.LayoutManager layoutManager, int velocityX, int velocityY)
+		bool _disposed;
+		RecyclerView _recyclerView;
+
+		public override void AttachToRecyclerView(RecyclerView recyclerView)
 		{
-			CanSnap = true;
-			return base.FindTargetSnapPosition(layoutManager, velocityX, velocityY);
+			base.AttachToRecyclerView(recyclerView);
+
+			_recyclerView = recyclerView;
+
+			if (_recyclerView != null)
+			{
+				_recyclerView.ScrollChange += RecyclerView_ScrollChange;
+			}
 		}
 
-		public override int[] CalculateScrollDistance(int velocityX, int velocityY)
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				if (_recyclerView != null)
+				{
+					_recyclerView.ScrollChange -= RecyclerView_ScrollChange;
+				}
+			}
+
+			base.Dispose(disposing);
+		}
+
+		void RecyclerView_ScrollChange(object sender, global::Android.Views.View.ScrollChangeEventArgs e)
 		{
 			CanSnap = true;
-			return base.CalculateScrollDistance(velocityX, velocityY);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/NongreedySnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/NongreedySnapHelper.cs
@@ -1,0 +1,23 @@
+﻿using Android.Support.V7.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal abstract class NongreedySnapHelper : LinearSnapHelper
+	{
+		// Flag to indicate that the user has scrolled the view, so we can start snapping
+		// (otherwise, this would start trying to snap the view as soon as we attached it to the RecyclerView)
+		protected bool CanSnap { get; set; }
+
+		public override int FindTargetSnapPosition(RecyclerView.LayoutManager layoutManager, int velocityX, int velocityY)
+		{
+			CanSnap = true;
+			return base.FindTargetSnapPosition(layoutManager, velocityX, velocityY);
+		}
+
+		public override int[] CalculateScrollDistance(int velocityX, int velocityY)
+		{
+			CanSnap = true;
+			return base.CalculateScrollDistance(velocityX, velocityY);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/CollectionView/NongreedySnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/NongreedySnapHelper.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (_recyclerView != null)
 			{
-				_recyclerView.ScrollChange += RecyclerView_ScrollChange;
+				_recyclerView.ScrollChange += RecyclerViewScrollChange;
 			}
 		}
 
@@ -36,14 +36,14 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (_recyclerView != null)
 				{
-					_recyclerView.ScrollChange -= RecyclerView_ScrollChange;
+					_recyclerView.ScrollChange -= RecyclerViewScrollChange;
 				}
 			}
 
 			base.Dispose(disposing);
 		}
 
-		void RecyclerView_ScrollChange(object sender, global::Android.Views.View.ScrollChangeEventArgs e)
+		void RecyclerViewScrollChange(object sender, global::Android.Views.View.ScrollChangeEventArgs e)
 		{
 			CanSnap = true;
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/SnapManager.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SnapManager.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Forms.Platform.Android
 					case SnapPointsAlignment.Start:
 						return new StartSnapHelper();
 					case SnapPointsAlignment.Center:
-						return new LinearSnapHelper();
+						return new CenterSnapHelper();
 					case SnapPointsAlignment.End:
 						return new EndSnapHelper();
 					default:
@@ -75,8 +75,8 @@ namespace Xamarin.Forms.Platform.Android
 				}
 			}
 
-			// The default LinearSnapHelper snaps to center
-			return new LinearSnapHelper();
+			// Use center snapping as the default
+			return new CenterSnapHelper();
 		}
 
 		public void Dispose()

--- a/Xamarin.Forms.Platform.Android/CollectionView/SnapManager.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SnapManager.cs
@@ -26,8 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 			var snapPointsType = itemsLayout.SnapPointsType;
 
 			// Clear our the existing snap helper (if any)
-			_snapHelper?.AttachToRecyclerView(null);
-			_snapHelper = null;
+			DetachSnapHelper();
 
 			if (snapPointsType == SnapPointsType.None)
 			{
@@ -79,10 +78,16 @@ namespace Xamarin.Forms.Platform.Android
 			return new CenterSnapHelper();
 		}
 
+		void DetachSnapHelper()
+		{
+			_snapHelper?.AttachToRecyclerView(null);
+			_snapHelper?.Dispose();
+			_snapHelper = null;
+		}
+
 		public void Dispose()
 		{
-			_recyclerView?.Dispose();
-			_snapHelper?.Dispose();
+			DetachSnapHelper();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/StartSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/StartSnapHelper.cs
@@ -12,6 +12,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override AView FindSnapView(RecyclerView.LayoutManager layoutManager)
 		{
+			if (!CanSnap)
+			{
+				return null;
+			}
+
 			if (layoutManager.ItemCount == 0)
 			{
 				return null;

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -69,8 +69,10 @@
     <Compile Include="AppCompat\ShellFragmentContainer.cs" />
     <Compile Include="BorderBackgroundManager.cs" />
     <Compile Include="CollectionView\CarouselViewRenderer.cs" />
+    <Compile Include="CollectionView\CenterSnapHelper.cs" />
     <Compile Include="CollectionView\DataChangeObserver.cs" />
     <Compile Include="CollectionView\EmptySource.cs" />
+    <Compile Include="CollectionView\NongreedySnapHelper.cs" />
     <Compile Include="CollectionView\SingleSnapHelper.cs" />
     <Compile Include="CollectionView\EmptyViewAdapter.cs" />
     <Compile Include="CollectionView\EndSingleSnapHelper.cs" />


### PR DESCRIPTION
### Description of Change ###

 By default, the LinearSnapHelper on Android snaps to the appropriate view immediately after being attached to the RecyclerView. However, the other platforms (and the single snap helpers) don't work this way. So to bring everything into line behaviorally, this change prevents the snap helpers on Android from snapping until the user interacts with the CollectionView.

### Issues Resolved ### 

- fixes #4935 

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
