### PR TITLE
[iOS,Android] Add status bar height to DeviceInfo

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/StatusBarHeight.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/StatusBarHeight.cs
@@ -2,17 +2,8 @@
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
-#if UITEST
-using Xamarin.Forms.Core.UITests;
-using Xamarin.UITest;
-using NUnit.Framework;
-#endif
-
 namespace Xamarin.Forms.Controls.Issues
 {
-#if UITEST
-	[Category(UITestCategories.ManualReview)]
-#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 20090125, "Get height of the status bar", PlatformAffected.iOS | PlatformAffected.Android)]
 	public class StatusBarHeightTest : TestContentPage // or TestMasterDetailPage, etc ...
@@ -25,21 +16,10 @@ namespace Xamarin.Forms.Controls.Issues
 				AutomationId = "StatusBarHeight",
 				Text = $"The status bar is {Device.Info.StatusBarHeight} units tall. "
 					+ Environment.NewLine + "iOS should be 44."
-					+ Environment.NewLine + "Android should be 24.,
+					+ Environment.NewLine + "Android should be 24.",
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.Center
 			};
 		}
-
-#if UITEST
-		[Test]
-		public void StatusBarHeightTest() 
-		{
-			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
-			RunningApp.Screenshot ("I am at Issue 1");
-			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
-			RunningApp.Screenshot ("I see the Label");
-		}
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/StatusBarHeight.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/StatusBarHeight.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 20090125, "Get height of the status bar", PlatformAffected.iOS | PlatformAffected.Android)]
+	public class StatusBarHeightTest : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			// Initialize ui here instead of ctor
+			Content = new Label
+			{
+				AutomationId = "StatusBarHeight",
+				Text = $"The status bar is {Device.Info.StatusBarHeight} units tall. "
+					+ Environment.NewLine + "iOS should be 44."
+					+ Environment.NewLine + "Android should be 24.,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void StatusBarHeightTest() 
+		{
+			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
+			RunningApp.Screenshot ("I am at Issue 1");
+			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
+			RunningApp.Screenshot ("I see the Label");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -895,6 +895,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue4493.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5172.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5204.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)StatusBarHeight.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/DeviceInfo.cs
+++ b/Xamarin.Forms.Core/DeviceInfo.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Forms.Internals
 
 		public abstract double ScalingFactor { get; }
 
+		public abstract double StatusBarHeight { get; }
+
 		public void Dispose()
 		{
 			Dispose(true);

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -286,7 +286,7 @@ namespace Xamarin.Forms
 			bool _disposed;
 			readonly Context _formsActivity;
 			readonly Size _pixelScreenSize;
-			readonly double _scalingFactor;
+			readonly double _scalingFactor, _statusBarHeight;
 
 			Orientation _previousOrientation = Orientation.Undefined;
 
@@ -297,6 +297,7 @@ namespace Xamarin.Forms
 					_scalingFactor = display.Density;
 					_pixelScreenSize = new Size(display.WidthPixels, display.HeightPixels);
 					ScaledScreenSize = new Size(_pixelScreenSize.Width / _scalingFactor, _pixelScreenSize.Height / _scalingFactor);
+					_statusBarHeight = formsActivity.Resources.GetDimensionPixelSize(formsActivity.Resources.GetIdentifier("status_bar_height", "dimen", "android")) / _scalingFactor;
 				}
 
 				CheckOrientationChanged(formsActivity.Resources.Configuration.Orientation);
@@ -322,6 +323,8 @@ namespace Xamarin.Forms
 			{
 				get { return _scalingFactor; }
 			}
+
+			public override double StatusBarHeight => _statusBarHeight;
 
 
 			public override double DisplayRound(double value) =>

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -155,7 +155,7 @@ namespace Xamarin.Forms
 			readonly NSObject _notification;
 #endif
 			readonly Size _scaledScreenSize;
-			readonly double _scalingFactor;
+			readonly double _scalingFactor, _statusBarHeight;
 
 			public IOSDeviceInfo()
 			{
@@ -168,6 +168,7 @@ namespace Xamarin.Forms
 				_scaledScreenSize = new Size(NSScreen.MainScreen.Frame.Width, NSScreen.MainScreen.Frame.Height);
 #endif
 				PixelScreenSize = new Size(_scaledScreenSize.Width * _scalingFactor, _scaledScreenSize.Height * _scalingFactor);
+				_statusBarHeight = UIKit.UIApplication.SharedApplication.StatusBarFrame.Height;
 			}
 
 			public override Size PixelScreenSize { get; }
@@ -175,6 +176,8 @@ namespace Xamarin.Forms
 			public override Size ScaledScreenSize => _scaledScreenSize;
 
 			public override double ScalingFactor => _scalingFactor;
+
+			public override double StatusBarHeight => _statusBarHeight;
 
 			protected override void Dispose(bool disposing)
 			{


### PR DESCRIPTION
### Description of Change ###

On iOS and Android it can be helpful to know how tall the status bar is when doing things like layout and animation

### API Changes ###

Added:
DeviceInfo.cs
public abstract double StatusBarHeight { get; }


### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Testing Procedure ###

Run new `StatusBarHeight`  test and manually verify the reported  height.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
