### PR TITLE
Cake build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ AndroidNative/gradlew.bat
 *.swp
 tools/
 !tools/mdoc/**/*
+caketools/

--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,4 @@ AndroidNative/gradlew.bat
 *.pdb
 # temporary vim files
 *.swp
-tools/
+caketools/

--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,5 @@ AndroidNative/gradlew.bat
 *.pdb
 # temporary vim files
 *.swp
-caketools/
+tools/
+!tools/mdoc/**/*

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ AndroidNative/gradlew.bat
 *.pdb
 # temporary vim files
 *.swp
+tools/

--- a/build.cake
+++ b/build.cake
@@ -2,6 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
+// examples
+/*
+
+./build.ps1 -Target NugetPack -ScriptArgs '-version="9.9.9-custom"'
+./build.sh --target NugetPack --version="9.9.9-custom"
+
+
+
+ */
 //////////////////////////////////////////////////////////////////////
 // ADDINS
 //////////////////////////////////////////////////////////////////////
@@ -20,10 +30,7 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
-
-//////////////////////////////////////////////////////////////////////
-// PREPARATION
-//////////////////////////////////////////////////////////////////////
+var version = Argument("version", "9.9.9-beta");
 
 
 //////////////////////////////////////////////////////////////////////
@@ -35,53 +42,80 @@ Task("Clean")
 {
     CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor"));
     CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor"));
- 
     Information(MakeAbsolute(Directory("./")));
 
+    // this doesn't work
     GitClean(MakeAbsolute(Directory("./")));
 });
 
+Task("NuGetPack")
+    .IsDependentOn("Build")
+    .Does(() =>
+    {
+        var nugetFilePaths = GetFiles("./.nuspec/*.nuspec");
+        var nugetPackageDir = Directory("./artifacts");
+
+        var nuGetPackSettings = new NuGetPackSettings
+        {   
+            OutputDirectory = nugetPackageDir,
+            Version = version
+        };
+
+        nuGetPackSettings.Properties.Add("configuration", configuration);
+        nuGetPackSettings.Properties.Add("platform", "anycpu");
+        // nuGetPackSettings.Verbosity = NuGetVerbosity.Detailed;
+        NuGetPack(nugetFilePaths, nuGetPackSettings);
+    });
+
+Task("BuildHack")
+    .Does(() =>
+    {
+        if(!IsRunningOnWindows())
+        {
+            MSBuild("./Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj", settings =>
+            {
+                settings.SetConfiguration(configuration);
+            });
+        }
+    });
+
 Task("Build")
+    .IsDependentOn("BuildHack")
     .Does(() =>
 { 
-    
     try
     {
         MSBuild("./Xamarin.Forms.sln", settings =>
         {
-            settings.Restore = true;
+            settings
+                .SetPlatformTarget(PlatformTarget.MSIL)
+                .SetConfiguration(configuration)
+                .WithProperty("CreateAllAndroidTargets", "true")
+                .WithRestore();
+
+            settings.ToolVersion = MSBuildToolVersion.VS2017;
+            settings.MSBuildPlatform = (Cake.Common.Tools.MSBuild.MSBuildPlatform)1;
+
         });
     }
     catch(Exception)
     {
         // ignore exceptions for now
     }
-
-    if(!IsRunningOnWindows())
-    {
-        MSBuild("./Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj", settings =>
-        {
-            settings.SetConfiguration(configuration);
-        });
-    }
 });
+
 
 Task("Deploy")
     .IsDependentOn("DeployiOS")
     .IsDependentOn("DeployAndroid")
     .Does(() =>
     { 
-        /* BuildAndroidApk("./Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj", sign:true, configuration:"Debug");
-        AdbUninstall("AndroidControlGallery.AndroidControlGallery");
-        AdbInstall("./Xamarin.Forms.ControlGallery.Android/bin/Debug/AndroidControlGallery.AndroidControlGallery-Signed.apk");
-        AmStartActivity("AndroidControlGallery.AndroidControlGallery/md546303760447087909496d02dc7b17ae8.Activity1");
-    */
-
         // not sure how to get this to deploy to iOS
         BuildiOSIpa("./Xamarin.Forms.sln", platform:"iPhoneSimulator", configuration:"Debug");
 
     });
 
+// TODO? Not sure how to make this work
 Task("DeployiOS")
     .Does(() =>
     { 
@@ -97,7 +131,7 @@ Task("DeployAndroid")
         AdbUninstall("AndroidControlGallery.AndroidControlGallery");
         AdbInstall("./Xamarin.Forms.ControlGallery.Android/bin/Debug/AndroidControlGallery.AndroidControlGallery-Signed.apk");
 
-        // does this md5 randomly change?
+        // how to grab this dynamically?
         AmStartActivity("AndroidControlGallery.AndroidControlGallery/md546303760447087909496d02dc7b17ae8.Activity1");
 
     });

--- a/build.cake
+++ b/build.cake
@@ -39,8 +39,8 @@ var nugetversion = Argument<string>("packageVersion", "9.9.9-beta");
 Task("Clean")
     .Does(() =>
 {
-    CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
-    CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
+    //CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
+    //CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
 
     Information(MakeAbsolute(Directory("./")));
 
@@ -127,16 +127,6 @@ Task("Android81")
                         .WithProperty("AndroidTargetFrameworkVersion", "v8.1"));
     });
 
-Task("Deploy")
-    .IsDependentOn("DeployiOS")
-    .IsDependentOn("DeployAndroid")
-    .Does(() =>
-    { 
-        // not sure how to get this to deploy to iOS
-        BuildiOSIpa("./Xamarin.Forms.sln", platform:"iPhoneSimulator", configuration:"Debug");
-
-    });
-
 Task("VSMAC")
     .IsDependentOn("BuildHack")
     .Does(() =>
@@ -144,6 +134,11 @@ Task("VSMAC")
         StartProcess("open", new ProcessSettings{ Arguments = "Xamarin.Forms.sln" });
         
     });
+
+Task("Deploy")
+    .IsDependentOn("DeployiOS")
+    .IsDependentOn("DeployAndroid");
+
 
 // TODO? Not sure how to make this work
 Task("DeployiOS")
@@ -157,7 +152,9 @@ Task("DeployiOS")
 Task("DeployAndroid")
     .Does(() =>
     { 
-        BuildAndroidApk("./Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj", sign:true, configuration:"Debug");
+        MSBuild("./Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj", GetMSBuildSettings().WithRestore());
+        MSBuild("./Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj", GetMSBuildSettings().WithRestore());
+        BuildAndroidApk("./Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj", sign:true, configuration:configuration);
         AdbUninstall("AndroidControlGallery.AndroidControlGallery");
         AdbInstall("./Xamarin.Forms.ControlGallery.Android/bin/Debug/AndroidControlGallery.AndroidControlGallery-Signed.apk");
 

--- a/build.cake
+++ b/build.cake
@@ -6,6 +6,7 @@
 // examples
 /*
 
+./build.ps1 -Target NugetPack
 ./build.ps1 -Target NugetPack -ScriptArgs '-packageVersion="9.9.9-custom"'
 
 
@@ -106,7 +107,7 @@ Task("Build")
     .Does(() =>
 { 
     try{
-        MSBuild("./Xamarin.Forms.sln", GetMSBuildSettings());
+        MSBuild("./Xamarin.Forms.sln", GetMSBuildSettings().WithRestore());
     }
     catch(Exception)
     {
@@ -195,7 +196,6 @@ MSBuildSettings GetMSBuildSettings()
 {
     var msbuildSettings =  new MSBuildSettings();
 
-    msbuildSettings.ToolVersion = MSBuildToolVersion.VS2017;
     msbuildSettings.PlatformTarget = PlatformTarget.MSIL;
     msbuildSettings.MSBuildPlatform = (Cake.Common.Tools.MSBuild.MSBuildPlatform)1;
     msbuildSettings.Configuration = configuration;

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//////////////////////////////////////////////////////////////////////
+// ADDINS
+//////////////////////////////////////////////////////////////////////
+#addin "nuget:?package=Cake.Xamarin&version=3.0.0"
+#addin "nuget:?package=Cake.Android.Adb&version=3.0.0"
+#addin "nuget:?package=Cake.Git&version=0.19.0"
+
+//////////////////////////////////////////////////////////////////////
+// TOOLS
+//////////////////////////////////////////////////////////////////////
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.4.0
+
+//////////////////////////////////////////////////////////////////////
+// ARGUMENTS
+//////////////////////////////////////////////////////////////////////
+
+var target = Argument("target", "Default");
+var configuration = Argument("configuration", "Debug");
+
+//////////////////////////////////////////////////////////////////////
+// PREPARATION
+//////////////////////////////////////////////////////////////////////
+
+
+//////////////////////////////////////////////////////////////////////
+// TASKS
+//////////////////////////////////////////////////////////////////////
+
+Task("Clean")
+    .Does(() =>
+{
+    CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor"));
+    CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor"));
+ 
+    Information(MakeAbsolute(Directory("./")));
+
+    GitClean(MakeAbsolute(Directory("./")));
+});
+
+Task("Build")
+    .Does(() =>
+{ 
+    
+    try
+    {
+        MSBuild("./Xamarin.Forms.sln", settings =>
+        {
+            settings.Restore = true;
+        });
+    }
+    catch(Exception)
+    {
+        // ignore exceptions for now
+    }
+
+    if(!IsRunningOnWindows())
+    {
+        MSBuild("./Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj", settings =>
+        {
+            settings.SetConfiguration(configuration);
+        });
+    }
+});
+
+Task("Deploy")
+    .IsDependentOn("DeployiOS")
+    .IsDependentOn("DeployAndroid")
+    .Does(() =>
+    { 
+        /* BuildAndroidApk("./Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj", sign:true, configuration:"Debug");
+        AdbUninstall("AndroidControlGallery.AndroidControlGallery");
+        AdbInstall("./Xamarin.Forms.ControlGallery.Android/bin/Debug/AndroidControlGallery.AndroidControlGallery-Signed.apk");
+        AmStartActivity("AndroidControlGallery.AndroidControlGallery/md546303760447087909496d02dc7b17ae8.Activity1");
+    */
+
+        // not sure how to get this to deploy to iOS
+        BuildiOSIpa("./Xamarin.Forms.sln", platform:"iPhoneSimulator", configuration:"Debug");
+
+    });
+
+Task("DeployiOS")
+    .Does(() =>
+    { 
+        // not sure how to get this to deploy to iOS
+        BuildiOSIpa("./Xamarin.Forms.sln", platform:"iPhoneSimulator", configuration:"Debug");
+
+    });
+
+Task("DeployAndroid")
+    .Does(() =>
+    { 
+        BuildAndroidApk("./Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj", sign:true, configuration:"Debug");
+        AdbUninstall("AndroidControlGallery.AndroidControlGallery");
+        AdbInstall("./Xamarin.Forms.ControlGallery.Android/bin/Debug/AndroidControlGallery.AndroidControlGallery-Signed.apk");
+
+        // does this md5 randomly change?
+        AmStartActivity("AndroidControlGallery.AndroidControlGallery/md546303760447087909496d02dc7b17ae8.Activity1");
+
+    });
+
+Task("Run-Unit-Tests")
+    .IsDependentOn("Build")
+    .Does(() =>
+{
+    NUnit3("./src/**/bin/" + configuration + "/*.Tests.dll", new NUnit3Settings {
+        NoResults = true
+        });
+});
+
+//////////////////////////////////////////////////////////////////////
+// TASK TARGETS
+//////////////////////////////////////////////////////////////////////
+
+Task("Default")
+    .IsDependentOn("Build")
+    //.IsDependentOn("Run-Unit-Tests")
+    ;
+
+//////////////////////////////////////////////////////////////////////
+// EXECUTION
+//////////////////////////////////////////////////////////////////////
+
+RunTarget(target);

--- a/build.cake
+++ b/build.cake
@@ -39,8 +39,8 @@ var nugetversion = Argument<string>("packageVersion", "9.9.9-beta");
 Task("Clean")
     .Does(() =>
 {
-    //CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
-    //CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
+    CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
+    CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
 
     Information(MakeAbsolute(Directory("./")));
 

--- a/build.cake
+++ b/build.cake
@@ -17,11 +17,11 @@
 #addin "nuget:?package=Cake.Xamarin&version=3.0.0"
 #addin "nuget:?package=Cake.Android.Adb&version=3.0.0"
 #addin "nuget:?package=Cake.Git&version=0.19.0"
-
 //////////////////////////////////////////////////////////////////////
 // TOOLS
 //////////////////////////////////////////////////////////////////////
 #tool nuget:?package=NUnit.ConsoleRunner&version=3.4.0
+#tool nuget:?package=GitVersion.CommandLine&version=4.0.0
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
@@ -29,8 +29,12 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
-var nugetversion = Argument<string>("packageVersion", "9.9.9-beta");
 
+var gitVersion = GitVersion();
+var majorMinorPatch = gitVersion.MajorMinorPatch;
+var informationalVersion = gitVersion.InformationalVersion;
+var buildVersion = gitVersion.FullBuildMetaData;
+var nugetversion = Argument<string>("packageVersion", gitVersion.NuGetVersion);
 
 //////////////////////////////////////////////////////////////////////
 // TASKS
@@ -50,13 +54,14 @@ Task("Clean")
 
 Task("NuGetPack")
     .IsDependentOn("Build")
-    .IsDependentOn("Android81")
     .IsDependentOn("_NuGetPack");
 
 
 Task("_NuGetPack")
     .Does(() =>
     {
+        Information("Nuget Version: {0}", nugetversion);
+        
         var nugetPackageDir = Directory("./artifacts");
         var nuGetPackSettings = new NuGetPackSettings
         {   
@@ -83,6 +88,7 @@ Task("BuildHack")
 
 Task("Build")
     .IsDependentOn("BuildHack")
+    .IsDependentOn("Android81")
     .Does(() =>
 { 
     try

--- a/build.cake
+++ b/build.cake
@@ -40,8 +40,9 @@ var version = Argument("version", "9.9.9-beta");
 Task("Clean")
     .Does(() =>
 {
-    CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor"));
-    CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor"));
+    CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
+    CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
+
     Information(MakeAbsolute(Directory("./")));
 
     // this doesn't work

--- a/build.cake
+++ b/build.cake
@@ -6,8 +6,7 @@
 // examples
 /*
 
-./build.ps1 -Target NugetPack -ScriptArgs '-version="9.9.9-custom"'
-./build.sh --target NugetPack --version="9.9.9-custom"
+./build.ps1 -Target NugetPack -ScriptArgs '-packageVersion="9.9.9-custom"'
 
 
 
@@ -30,7 +29,7 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
-var version = Argument("version", "9.9.9-beta");
+var nugetversion = Argument<string>("packageVersion", "9.9.9-beta");
 
 
 //////////////////////////////////////////////////////////////////////
@@ -62,7 +61,7 @@ Task("_NuGetPack")
         var nuGetPackSettings = new NuGetPackSettings
         {   
             OutputDirectory = nugetPackageDir,
-            Version = version
+            Version = nugetversion
         };
 
         var nugetFilePaths = 

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,234 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+<#
+
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+
+.PARAMETER Script
+The build script to execute.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER ShowDescription
+Shows description about tasks.
+.PARAMETER DryRun
+Performs a dry run.
+.PARAMETER Experimental
+Uses the nightly builds of the Roslyn script engine.
+.PARAMETER Mono
+Uses the Mono Compiler rather than the Roslyn script engine.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+
+.LINK
+https://cakebuild.net
+
+#>
+
+[CmdletBinding()]
+Param(
+    [string]$Script = "build.cake",
+    [string]$Target,
+    [string]$Configuration,
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity,
+    [switch]$ShowDescription,
+    [Alias("WhatIf", "Noop")]
+    [switch]$DryRun,
+    [switch]$Experimental,
+    [switch]$Mono,
+    [switch]$SkipToolPackageRestore,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs
+)
+
+[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
+function MD5HashFile([string] $filePath)
+{
+    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
+    {
+        return $null
+    }
+
+    [System.IO.Stream] $file = $null;
+    [System.Security.Cryptography.MD5] $md5 = $null;
+    try
+    {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $file = [System.IO.File]::OpenRead($filePath)
+        return [System.BitConverter]::ToString($md5.ComputeHash($file))
+    }
+    finally
+    {
+        if ($file -ne $null)
+        {
+            $file.Dispose()
+        }
+    }
+}
+
+function GetProxyEnabledWebClient
+{
+    $wc = New-Object System.Net.WebClient
+    $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials        
+    $wc.Proxy = $proxy
+    return $wc
+}
+
+Write-Host "Preparing to run build script..."
+
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
+$MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
+$ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
+$MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+
+# Make sure tools folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type directory | out-null
+}
+
+# Make sure that packages.config exist.
+if (!(Test-Path $PACKAGES_CONFIG)) {
+    Write-Verbose -Message "Downloading packages.config..."    
+    try {        
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile("https://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
+        Throw "Could not download packages.config."
+    }
+}
+
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
+    }
+}
+
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
+}
+
+# Save nuget.exe path to environment to be available to child processed
+$ENV:NUGET_EXE = $NUGET_EXE
+
+# Restore tools from NuGet?
+if(-Not $SkipToolPackageRestore.IsPresent) {
+    Push-Location
+    Set-Location $TOOLS_DIR
+
+    # Check for changes in packages.config and remove installed tools if true.
+    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
+      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        Write-Verbose -Message "Missing or changed package.config hash..."
+        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+    }
+
+    Write-Verbose -Message "Restoring tools from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet tools."
+    }
+    else
+    {
+        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
+    }
+    Write-Verbose -Message ($NuGetOutput | out-string)
+
+    Pop-Location
+}
+
+# Restore addins from NuGet
+if (Test-Path $ADDINS_PACKAGES_CONFIG) {
+    Push-Location
+    Set-Location $ADDINS_DIR
+
+    Write-Verbose -Message "Restoring addins from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$ADDINS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet addins."
+    }
+
+    Write-Verbose -Message ($NuGetOutput | out-string)
+
+    Pop-Location
+}
+
+# Restore modules from NuGet
+if (Test-Path $MODULES_PACKAGES_CONFIG) {
+    Push-Location
+    Set-Location $MODULES_DIR
+
+    Write-Verbose -Message "Restoring modules from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$MODULES_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet modules."
+    }
+
+    Write-Verbose -Message ($NuGetOutput | out-string)
+
+    Pop-Location
+}
+
+# Make sure that Cake has been installed.
+if (!(Test-Path $CAKE_EXE)) {
+    Throw "Could not find Cake.exe at $CAKE_EXE"
+}
+
+
+
+# Build Cake arguments
+$cakeArguments = @("$Script");
+if ($Target) { $cakeArguments += "-target=$Target" }
+if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
+if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
+if ($ShowDescription) { $cakeArguments += "-showdescription" }
+if ($DryRun) { $cakeArguments += "-dryrun" }
+if ($Experimental) { $cakeArguments += "-experimental" }
+if ($Mono) { $cakeArguments += "-mono" }
+$cakeArguments += $ScriptArgs
+
+# Start Cake
+Write-Host "Running build script..."
+&$CAKE_EXE $cakeArguments
+exit $LASTEXITCODE

--- a/build.ps1
+++ b/build.ps1
@@ -96,7 +96,7 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$TOOLS_DIR = Join-Path $PSScriptRoot "caketools"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"

--- a/build.ps1
+++ b/build.ps1
@@ -96,7 +96,7 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "caketools"
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+##########################################################################
+# This is the Cake bootstrapper script for Linux and OS X.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+# Define directories.
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+TOOLS_DIR=$SCRIPT_DIR/tools
+NUGET_EXE=$TOOLS_DIR/nuget.exe
+CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
+PACKAGES_CONFIG=$TOOLS_DIR/packages.config
+PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
+
+# Define md5sum or md5 depending on Linux/OSX
+MD5_EXE=
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    MD5_EXE="md5 -r"
+else
+    MD5_EXE="md5sum"
+fi
+
+# Define default arguments.
+SCRIPT="build.cake"
+TARGET="Default"
+CONFIGURATION="Release"
+VERBOSITY="verbose"
+DRYRUN=
+SHOW_VERSION=false
+SCRIPT_ARGUMENTS=()
+
+# Parse arguments.
+for i in "$@"; do
+    case $1 in
+        -s|--script) SCRIPT="$2"; shift ;;
+        -t|--target) TARGET="$2"; shift ;;
+        -c|--configuration) CONFIGURATION="$2"; shift ;;
+        -v|--verbosity) VERBOSITY="$2"; shift ;;
+        -d|--dryrun) DRYRUN="-dryrun" ;;
+        --version) SHOW_VERSION=true ;;
+        --) shift; SCRIPT_ARGUMENTS+=("$@"); break ;;
+        *) SCRIPT_ARGUMENTS+=("$1") ;;
+    esac
+    shift
+done
+
+# Make sure the tools folder exist.
+if [ ! -d "$TOOLS_DIR" ]; then
+  mkdir "$TOOLS_DIR"
+fi
+
+# Make sure that packages.config exist.
+if [ ! -f "$TOOLS_DIR/packages.config" ]; then
+    echo "Downloading packages.config..."
+    curl -Lsfo "$TOOLS_DIR/packages.config" https://cakebuild.net/download/bootstrapper/packages
+    if [ $? -ne 0 ]; then
+        echo "An error occurred while downloading packages.config."
+        exit 1
+    fi
+fi
+
+# Download NuGet if it does not exist.
+if [ ! -f "$NUGET_EXE" ]; then
+    echo "Downloading NuGet..."
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    if [ $? -ne 0 ]; then
+        echo "An error occurred while downloading nuget.exe."
+        exit 1
+    fi
+fi
+
+# Restore tools from NuGet.
+pushd "$TOOLS_DIR" >/dev/null
+if [ ! -f $PACKAGES_CONFIG_MD5 ] || [ "$( cat $PACKAGES_CONFIG_MD5 | sed 's/\r$//' )" != "$( $MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' )" ]; then
+    find . -type d ! -name . | xargs rm -rf
+fi
+
+mono "$NUGET_EXE" install -ExcludeVersion
+if [ $? -ne 0 ]; then
+    echo "Could not restore NuGet packages."
+    exit 1
+fi
+
+$MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' >| $PACKAGES_CONFIG_MD5
+
+popd >/dev/null
+
+# Make sure that Cake has been installed.
+if [ ! -f "$CAKE_EXE" ]; then
+    echo "Could not find Cake.exe at '$CAKE_EXE'."
+    exit 1
+fi
+
+# Start Cake
+if $SHOW_VERSION; then
+    exec mono "$CAKE_EXE" -version
+else
+    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
+fi

--- a/build.sh
+++ b/build.sh
@@ -24,8 +24,6 @@ fi
 
 # Define default arguments.
 SCRIPT="build.cake"
-TARGET="Default"
-CONFIGURATION="Release"
 VERBOSITY="verbose"
 DRYRUN=
 SHOW_VERSION=false

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@
 
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-TOOLS_DIR=$SCRIPT_DIR/tools
+TOOLS_DIR=$SCRIPT_DIR/caketools
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
 PACKAGES_CONFIG=$TOOLS_DIR/packages.config

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@
 
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-TOOLS_DIR=$SCRIPT_DIR/caketools
+TOOLS_DIR=$SCRIPT_DIR/tools
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
 PACKAGES_CONFIG=$TOOLS_DIR/packages.config

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -57,6 +57,7 @@ steps:
           Xamarin.Forms.Platform.iOS/bin/$(BuildConfiguration)/**/*.pdb
           Xamarin.Forms.Platform.iOS/bin/$(BuildConfiguration)/**/*.mdb
           Xamarin.Forms.Platform.WP8/bin/$(BuildConfiguration)/**/*.dll
+          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pdb
           Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pri
           Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xr.xml
@@ -72,6 +73,7 @@ steps:
           Xamarin.Forms.Maps.MacOS/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Maps.WP8/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.dll
+          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pdb
           Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pri
           Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.xbf
           Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.dll


### PR DESCRIPTION
### Description of Change ###
Set of cake targets for easily building/packaging/deploying Forms

### Targets
- Clean for removing bin/objs
- Build for just building SLN
- NugetPack for packing into nugets 
  - ./build.ps1 -Target NugetPack -ScriptArgs '-packageVersion="9.9.9-custom"'
  - Currently only works on windows but could create a nuspec for ios or could convert nuspec files to nuspecsettings in cake
  - ./build.ps1 -Target NugetPack  uses GitVersion.CommandLine to generate the version from the tag or the branch name if you haven't specified a package version at the command line
- VSMAC builds the correct multi targeted projects and opens the SLN in vmac.
  - Currently there's a multi targeting bug with VSM that doesn't let it be opened
- DeployAndroid builds an apk and deploys it to a connected device and starts the gallery. 
  - useful for putting up a new apk when running ui tests

### Testing scenarios

#### Windows

```ps1
# Generates nuget based on branch
 ./build.ps1 -Target NugetPack

# Deploy to whatever android emulator you have running
 ./build.ps1 -Target DeployAndroid

# Deletes all the bin/obj folders
 ./build.ps1 -Target Clean
```


#### Mac

```sh
# Builds necessary projects to run CG on mac and opens sln on vsmac
 ./build.sh1 --target vsmac
```


