### PR TITLE
Correctly load addresses of intermediate values in compiled binding paths

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -526,6 +526,8 @@ namespace Xamarin.Forms.Build.Tasks
 				il.Emit(Ret);
 			}
 			else {
+				var locs = new Dictionary<TypeReference, VariableDefinition>();
+
 				if (tSourceRef.IsValueType)
 					il.Emit(Ldarga_S, (byte)0);
 				else
@@ -533,6 +535,19 @@ namespace Xamarin.Forms.Build.Tasks
 
 				for (int i = 0; i < properties.Count; i++) {
 					(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg) = properties[i];
+
+					if (i > 0 && propDeclTypeRef.IsValueType) {
+						var importedPropDeclTypeRef = module.ImportReference(propDeclTypeRef);
+
+						if (!locs.TryGetValue(importedPropDeclTypeRef, out var loc)) {
+							loc = new VariableDefinition(importedPropDeclTypeRef);
+							getter.Body.Variables.Add(loc);
+							locs[importedPropDeclTypeRef] = loc;
+						}
+
+						il.Emit(Stloc, loc);
+						il.Emit(Ldloca, loc);
+					}
 
 					if (!property.PropertyType.IsValueType) { //if part of the path is null, return (default(T), false)
 						var nop = Create(Nop);
@@ -542,8 +557,14 @@ namespace Xamarin.Forms.Build.Tasks
 						il.Emit(Brfalse, nop);
 						il.Emit(Pop);
 						if (tPropertyRef.IsValueType) {
-							var defaultValueVarDef = new VariableDefinition(tPropertyRef);
-							getter.Body.Variables.Add(defaultValueVarDef);
+							var importedTPropertyRef = module.ImportReference(tPropertyRef);
+
+							if (!locs.TryGetValue(importedTPropertyRef, out var defaultValueVarDef)) {
+								defaultValueVarDef = new VariableDefinition(tPropertyRef);
+								getter.Body.Variables.Add(defaultValueVarDef);
+								locs[importedTPropertyRef] = defaultValueVarDef;
+							}
+
 							il.Emit(Ldloca_S, defaultValueVarDef);
 							il.Emit(Initobj, tPropertyRef);
 							il.Emit(Ldloc, defaultValueVarDef);

--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
@@ -18,6 +18,7 @@
 			<Entry Text="{Binding Text, Mode=TwoWay}" x:Name="entry0"/>
             <Label Text="{Binding .}" x:Name="label7" x:DataType="sys:Int32"/>
             <Label Text="{Binding Text, Mode=OneTime}" x:Name="label8" />
+			<Label Text="{Binding StructModel.Text}" x:Name="label9" />
 		</StackLayout>
 		<Label Text="{Binding Text}" x:Name="labelWithUncompiledBinding" />
 	</StackLayout>

--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -49,6 +49,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					Model = new MockViewModel {
 						Text = "Text1"
 					},
+					StructModel = new MockStructViewModel {
+						Text = "Text9"
+					}
 				};
 				vm.Model [3] = "TextIndex";
 
@@ -70,6 +73,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				//value types
 				Assert.That(layout.label5.Text, Is.EqualTo("42"));
 				Assert.That(layout.label6.Text, Is.EqualTo("text6"));
+				Assert.AreEqual("Text9", layout.label9.Text);
 
 				//testing selfPath
 				layout.label4.BindingContext = "Self";
@@ -141,6 +145,15 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				if (_model == value)
 					return;
 				_model = value;
+				OnPropertyChanged();
+			}
+		}
+
+		MockStructViewModel _structModel;
+		public MockStructViewModel StructModel {
+			get { return _structModel; }
+			set {
+				_structModel = value;
 				OnPropertyChanged();
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

The intermediate values in compiled binding paths must be loaded as addresses when calling the subsequent property getter. However, the preceding property getters directly return the values if they are value types. This change adds a code to convert those values into addresses.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
