### PR TITLE
[iOS] Implement ItemSizingStrategy hint property for CollectionView

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
@@ -24,6 +24,10 @@
 							new TemplateCodeCollectionViewGridGallery (), Navigation),
 						GalleryBuilder.NavButton("Horizontal Grid (Code)", () => 
 							new TemplateCodeCollectionViewGridGallery (ItemsLayoutOrientation.Horizontal), Navigation),
+
+						GalleryBuilder.NavButton("ItemSizing Strategy", () => 
+							new VariableSizeTemplateGridGallery (ItemsLayoutOrientation.Horizontal), Navigation),
+						
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
@@ -1,4 +1,6 @@
-﻿namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
+﻿using System;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 {
 	internal class ExampleTemplates
 	{
@@ -218,6 +220,33 @@
 				Grid.SetRow(caption, 1);
 
 				return templateLayout;
+			});
+		}
+
+		public static DataTemplate VariableSizeTemplate()
+		{
+			var height1 = 50;
+			var width1 = 100;
+
+			var height2 = 150;
+			var width2 = 300;
+
+			var index = 0;
+
+			return new DataTemplate(() =>
+			{
+				var image = new Image
+				{
+					HeightRequest = index == 0 ? height1 : height2,
+					WidthRequest = index == 0 ? width1 : width2,
+					Aspect = Aspect.AspectFit
+				};
+
+				image.SetBinding(Image.SourceProperty, new Binding("Image"));
+
+				index += 1;
+
+				return image;
 			});
 		}
 	}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 {
@@ -225,29 +226,68 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 
 		public static DataTemplate VariableSizeTemplate()
 		{
-			var height1 = 50;
-			var width1 = 100;
-
-			var height2 = 150;
-			var width2 = 300;
-
-			var index = 0;
+			var indexHeightConverter = new IndexRequestConverter(3, 50, 150);
+			var indexWidthConverter = new IndexRequestConverter(3, 100, 300);
+			var colorConverter = new IndexColorConverter();
 
 			return new DataTemplate(() =>
 			{
+				var layout = new Frame();
+
+				layout.SetBinding(VisualElement.HeightRequestProperty, new Binding("Index", converter: indexHeightConverter));
+				layout.SetBinding(VisualElement.WidthRequestProperty, new Binding("Index", converter: indexWidthConverter));
+				layout.SetBinding(VisualElement.BackgroundColorProperty, new Binding("Index", converter: colorConverter));
+
 				var image = new Image
 				{
-					HeightRequest = index == 0 ? height1 : height2,
-					WidthRequest = index == 0 ? width1 : width2,
 					Aspect = Aspect.AspectFit
 				};
 
+				image.SetBinding(VisualElement.HeightRequestProperty, new Binding("Index", converter: indexHeightConverter));
+				image.SetBinding(VisualElement.WidthRequestProperty, new Binding("Index", converter: indexWidthConverter));
+
 				image.SetBinding(Image.SourceProperty, new Binding("Image"));
 
-				index += 1;
+				layout.Content = image;
 
-				return image;
+				return layout;
 			});
+		}
+
+		private class IndexRequestConverter : IValueConverter
+		{
+			private readonly int _cutoff;
+			private readonly int _lowValue;
+			private readonly int _highValue;
+
+			public IndexRequestConverter(int cutoff, int lowValue, int highValue)
+			{
+				_cutoff = cutoff;
+				_lowValue = lowValue;
+				_highValue = highValue;
+			}
+
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				var index = (int)value;
+
+				return index < _cutoff ? _lowValue : (object)_highValue;
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+		}
+
+		private class IndexColorConverter : IValueConverter
+		{
+			Color[] _colors = new Color[] { Color.Red, Color.Green, Color.Blue, Color.Orange, Color.BlanchedAlmond };
+
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				var index = (int)value;
+				return _colors[index % _colors.Length];
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
@@ -254,11 +254,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			});
 		}
 
-		private class IndexRequestConverter : IValueConverter
+		class IndexRequestConverter : IValueConverter
 		{
-			private readonly int _cutoff;
-			private readonly int _lowValue;
-			private readonly int _highValue;
+			readonly int _cutoff;
+			readonly int _lowValue;
+			readonly int _highValue;
 
 			public IndexRequestConverter(int cutoff, int lowValue, int highValue)
 			{
@@ -277,7 +277,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
 		}
 
-		private class IndexColorConverter : IValueConverter
+		class IndexColorConverter : IValueConverter
 		{
 			Color[] _colors = new Color[] { Color.Red, Color.Green, Color.Blue, Color.Orange, Color.BlanchedAlmond };
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/VariableSizeTemplateGridGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/VariableSizeTemplateGridGallery.cs
@@ -1,0 +1,44 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
+{
+	internal class VariableSizeTemplateGridGallery : ContentPage
+	{
+		public VariableSizeTemplateGridGallery(ItemsLayoutOrientation orientation = ItemsLayoutOrientation.Vertical)
+		{
+			var layout = new Grid
+			{ 
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Star }
+				}
+			};
+
+			var itemsLayout = new GridItemsLayout(2, orientation);
+
+			var itemTemplate = ExampleTemplates.VariableSizeTemplate();
+
+			var collectionView = new CollectionView {ItemsLayout = itemsLayout, ItemTemplate = itemTemplate,
+				ItemSizingStrategy = ItemSizingStrategy.MeasureFirstItem };
+
+			var generator = new ItemsSourceGenerator(collectionView, 100);
+			var sizingStrategySelector = new EnumSelector<ItemSizingStrategy>(() => collectionView.ItemSizingStrategy,
+				mode => {
+					// Setting the template again so the "first" item is small, making the transition between 
+					// "MeasureFirstItem" and "MeasureAllItems" obvious
+					collectionView.ItemTemplate = ExampleTemplates.VariableSizeTemplate();
+					collectionView.ItemSizingStrategy = mode;
+				});
+
+			layout.Children.Add(generator);
+			layout.Children.Add(sizingStrategySelector );
+			Grid.SetRow(sizingStrategySelector , 1);
+			layout.Children.Add(collectionView);
+			Grid.SetRow(collectionView, 2);
+
+			Content = layout;
+
+			generator.GenerateItems();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/VariableSizeTemplateGridGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/VariableSizeTemplateGridGallery.cs
@@ -10,6 +10,7 @@
 				{
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Star }
 				}
 			};
@@ -22,23 +23,43 @@
 				ItemSizingStrategy = ItemSizingStrategy.MeasureFirstItem };
 
 			var generator = new ItemsSourceGenerator(collectionView, 100);
+
+			var explanation = new Label();
+			UpdateExplanation(explanation, collectionView.ItemSizingStrategy);
+
 			var sizingStrategySelector = new EnumSelector<ItemSizingStrategy>(() => collectionView.ItemSizingStrategy,
 				mode => {
-					// Setting the template again so the "first" item is small, making the transition between 
-					// "MeasureFirstItem" and "MeasureAllItems" obvious
-					collectionView.ItemTemplate = ExampleTemplates.VariableSizeTemplate();
 					collectionView.ItemSizingStrategy = mode;
+					UpdateExplanation(explanation, collectionView.ItemSizingStrategy);
 				});
 
 			layout.Children.Add(generator);
+
 			layout.Children.Add(sizingStrategySelector );
 			Grid.SetRow(sizingStrategySelector , 1);
+
+			layout.Children.Add(explanation);
+			Grid.SetRow(explanation, 2);
+
 			layout.Children.Add(collectionView);
-			Grid.SetRow(collectionView, 2);
+			Grid.SetRow(collectionView, 3);
 
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		static void UpdateExplanation(Label explanation, ItemSizingStrategy strategy)
+		{
+			switch (strategy)
+			{
+				case ItemSizingStrategy.MeasureAllItems:
+					explanation.Text = "Each item is individually measured.";
+					break;
+				case ItemSizingStrategy.MeasureFirstItem:
+					explanation.Text = "The first item is measured, and that size is given to all subsequent cells.";
+					break;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Items/ItemSizingStrategy.cs
+++ b/Xamarin.Forms.Core/Items/ItemSizingStrategy.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.Forms
+{
+	public enum ItemSizingStrategy
+	{
+		MeasureAllItems,
+		MeasureFirstItem
+	}
+}

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -65,6 +65,15 @@ namespace Xamarin.Forms
 			set => SetValue(ItemTemplateProperty, value);
 		}
 
+		public static readonly BindableProperty ItemSizingStrategyProperty =
+			BindableProperty.Create(nameof(ItemSizingStrategy), typeof(ItemSizingStrategy), typeof(ItemsView));
+
+		public ItemSizingStrategy ItemSizingStrategy
+		{
+			get => (ItemSizingStrategy)GetValue(ItemSizingStrategyProperty);
+			set => SetValue(ItemSizingStrategyProperty, value);
+		}
+
 		public void ScrollTo(int index, int groupIndex = -1,
 			ScrollToPosition position = ScrollToPosition.MakeVisible, bool animate = true)
 		{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -51,7 +51,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void LayoutOnPropertyChanged(object sender, PropertyChangedEventArgs propertyChanged)
 		{
-			HandlePropertyChanged(propertyChanged);
 		}
 
 		protected virtual void HandlePropertyChanged(PropertyChangedEventArgs propertyChanged)
@@ -62,8 +61,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public Func<UICollectionViewCell> GetPrototype { get; set; }
 
-		// TODO hartez 2018/09/14 17:24:22 Long term, this needs to use the ItemSizingStrategy enum and not be locked into bool	
-		public bool UniformSize { get; set; }
+		internal ItemSizingStrategy ItemSizingStrategy { get; set; }
 
 		public abstract void ConstrainTo(CGSize size);
 
@@ -124,7 +122,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return shouldInvalidate;
 		}
 
-		protected void DetermineCellSize()
+		protected internal void DetermineCellSize()
 		{
 			if (GetPrototype == null)
 			{
@@ -140,7 +138,7 @@ namespace Xamarin.Forms.Platform.iOS
 			//		has at least one item), Autolayout will kick in for the first cell and size it correctly
 			// If GetPrototype() _can_ return a cell, this estimate will be updated once that cell is measured
 			EstimatedItemSize = new CGSize(1, 1);
-			
+
 			if (!(GetPrototype() is ItemsViewCell prototype))
 			{
 				_determiningCellSize = false;
@@ -152,7 +150,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var measure = prototype.Measure();
 
-			if (UniformSize)
+			if (ItemSizingStrategy == ItemSizingStrategy.MeasureFirstItem)
 			{
 				// This is the size we'll give all of our cells from here on out
 				ItemSize = measure;
@@ -212,7 +210,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			_needCellSizeUpdate = true;
 		}
-		
+
 		public override CGPoint TargetContentOffset(CGPoint proposedContentOffset, CGPoint scrollingVelocity)
 		{
 			var snapPointsType = _itemsLayout.SnapPointsType;
@@ -254,12 +252,12 @@ namespace Xamarin.Forms.Platform.iOS
 			// closest to the relevant part of the viewport while being sufficiently visible
 
 			// Find the spot in the viewport we're trying to align with
-			var alignmentTarget = SnapHelpers.FindAlignmentTarget(alignment, proposedContentOffset, 
+			var alignmentTarget = SnapHelpers.FindAlignmentTarget(alignment, proposedContentOffset,
 				CollectionView, ScrollDirection);
 
 			// Find the closest sufficiently visible candidate
 			var bestCandidate = SnapHelpers.FindBestSnapCandidate(visibleElements, viewport, alignmentTarget);
-			
+
 			if (bestCandidate != null)
 			{
 				return SnapHelpers.AdjustContentOffset(proposedContentOffset, bestCandidate.Frame, viewport, alignment,
@@ -277,7 +275,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// Get the viewport of the UICollectionView at the current content offset
 			var contentOffset = CollectionView.ContentOffset;
 			var viewport = new CGRect(contentOffset, CollectionView.Bounds.Size);
-								
+
 			// Find the spot in the viewport we're trying to align with
 			var alignmentTarget = SnapHelpers.FindAlignmentTarget(alignment, contentOffset, CollectionView, ScrollDirection);
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -122,7 +122,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return shouldInvalidate;
 		}
 
-		protected internal void DetermineCellSize()
+		protected void DetermineCellSize()
 		{
 			if (GetPrototype == null)
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -43,6 +43,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				ItemsViewController.UpdateEmptyView();
 			}
+			else if (changedProperty.Is(ItemsView.ItemSizingStrategyProperty))
+			{
+				UpdateItemSizingStrategy();
+			}
 		}
 
 		protected virtual ItemsViewLayout SelectLayout(IItemsLayout layoutSpecification)
@@ -79,7 +83,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 			}
 
-			_layout = SelectLayout(newElement.ItemsLayout);
+			UpdateLayout();
 			ItemsViewController = CreateController(newElement, _layout);
 			SetNativeControl(ItemsViewController.View);
 			ItemsViewController.CollectionView.BackgroundColor = UIColor.Clear;
@@ -87,6 +91,32 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// Listen for ScrollTo requests
 			newElement.ScrollToRequested += ScrollToRequested;
+		}
+
+		protected virtual void UpdateLayout()
+		{
+			_layout = SelectLayout(Element.ItemsLayout);
+			_layout.ItemSizingStrategy = Element.ItemSizingStrategy;
+
+			if (ItemsViewController != null)
+			{
+				ItemsViewController.UpdateLayout(_layout);
+			}
+		}
+
+		protected virtual void UpdateItemSizingStrategy()
+		{
+			if (ItemsViewController?.CollectionView?.VisibleCells.Length == 0)
+			{
+				// The CollectionView isn't really up and running yet, so we can just set the strategy and move on
+				_layout.ItemSizingStrategy = Element.ItemSizingStrategy;
+			}
+			else
+			{
+				// We're changing the strategy for a CollectionView mid-stream; 
+				// we'll just have to swap out the whole UICollectionViewLayout
+				UpdateLayout();
+			}
 		}
 
 		protected virtual ItemsViewController CreateController(ItemsView newElement, ItemsViewLayout layout)


### PR DESCRIPTION
### Description of Change ###

Add ItemSizingStrategy to CollectionView in Core; 
Create test harness for ItemSizingStrategy changes; 
Handle ItemSizingStrategy and ItemSizingStrategy changes on iOS;

### Issues Resolved ### 

- partially implements #3172

### API Changes ###

Added:

public enum ItemSizingStrategy;

ItemsView.ItemSizingStrategy // Bindable Property

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Navigate to  CollectionView Gallery -> DataTemplate Galleries -> ItemSizing Strategy, select the different ItemSizingStrategies to see them in action.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
