### PR TITLE
Allow the previewer to use design flag on RDs

### DIFF
--- a/Xamarin.Forms.Xaml/ResourcesLoader.cs
+++ b/Xamarin.Forms.Xaml/ResourcesLoader.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 using Xamarin.Forms;
 using System.Xml;
@@ -11,10 +10,15 @@ namespace Xamarin.Forms.Xaml
 	{
 		public T CreateFromResource<T>(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo) where T: new()
 		{
-			var alternateResource = Xamarin.Forms.Internals.ResourceLoader.ResourceProvider?.Invoke(assembly.GetName(), resourcePath);
+			var resourceLoadingResponse = Forms.Internals.ResourceLoader.ResourceProvider2?.Invoke(new Forms.Internals.ResourceLoader.ResourceLoadingQuery {
+				AssemblyName = assembly.GetName(),
+				ResourcePath = resourcePath
+			});
+
+			var alternateResource = resourceLoadingResponse?.ResourceContent;
 			if (alternateResource != null) {
 				var rd = new T();
-				rd.LoadFromXaml(alternateResource);
+				XamlLoader.Load(rd, alternateResource, resourceLoadingResponse.UseDesignProperties);
 				return rd;
 			}
 
@@ -35,7 +39,12 @@ namespace Xamarin.Forms.Xaml
 
 		public string GetResource(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo)
 		{
-			var alternateResource = Xamarin.Forms.Internals.ResourceLoader.ResourceProvider?.Invoke(assembly.GetName(), resourcePath);
+			var resourceLoadingResponse = Forms.Internals.ResourceLoader.ResourceProvider2?.Invoke(new Forms.Internals.ResourceLoader.ResourceLoadingQuery {
+				AssemblyName = assembly.GetName(),
+				ResourcePath = resourcePath
+			});
+
+			var alternateResource = resourceLoadingResponse?.ResourceContent;
 			if (alternateResource != null)
 				return alternateResource;
 


### PR DESCRIPTION
### Description of Change ###

Allow the previewer to use design flag on RDs

This is very unlikely to happen, but why not.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

/

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

> VS bug [#783307](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/783307)