### PR TITLE
[Xaml] Better handling of exception on properties

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -480,6 +480,22 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var o = XamlLoader.Create(xaml, true);
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
 		}
+
+		[Test]
+		public void CanIgnoreSettingPropertyThatThrows()
+		{
+			var xaml = @"
+					<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+						xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
+						<local:SettingPropertyThrows TestValue=""Test"" TestBP=""bar""/>
+					</ContentPage>";
+
+			var exceptions = new List<Exception>();
+			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+			Assert.That(exceptions.Count, Is.EqualTo(2));
+		}
 	}
 
 	public class InstantiateThrows
@@ -487,5 +503,17 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public InstantiateThrows() => throw new InvalidOperationException();
 		public static InstantiateThrows CreateInstance() => throw new InvalidOperationException();
 		public InstantiateThrows(int value) => throw new InvalidOperationException();
+	}
+
+	public class SettingPropertyThrows : View
+	{
+		public static readonly BindableProperty TestBPProperty =
+			BindableProperty.Create("TestBP", typeof(string), typeof(SettingPropertyThrows), default(string),
+				propertyChanged: (b,o,n)=>throw new Exception());
+
+		public string TestValue {
+			get { return null; }
+			set { throw new InvalidOperationException(); }
+		}
 	}
 }

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -505,8 +505,14 @@ namespace Xamarin.Forms.Xaml
 							   property.ReturnTypeInfo.GetGenericTypeDefinition() == typeof(Nullable<>);
 				if ((convertedValue == null && (!property.ReturnTypeInfo.IsValueType || nullable)) ||
 					(property.ReturnType.IsInstanceOfType(convertedValue))) {
-					bindable.SetValue(property, convertedValue);
-					return true;
+					try {
+						bindable.SetValue(property, convertedValue);
+						return true;
+					}
+					catch (Exception e) {
+						exception = e;
+						return false;
+					}
 				}
 
 				// This might be a collection; see if we can add to it
@@ -558,8 +564,14 @@ namespace Xamarin.Forms.Xaml
 			if (convertedValue != null && !propertyInfo.PropertyType.IsInstanceOfType(convertedValue))
 				return false;
 
-			setter.Invoke(element, new object [] { convertedValue });
-			return true;
+			try {
+				setter.Invoke(element, new object[] { convertedValue });
+				return true;
+			}
+			catch (Exception e) {
+				exception = e;
+				return false;
+			}
 		}
 
 		static bool TryGetProperty(object element, string localName, out object value, IXmlLineInfo lineInfo, HydrationContext context, out Exception exception, out object targetProperty)


### PR DESCRIPTION
### Description of Change ###

Allow the previewer to recover and continue on throwing property setters
or BindableProperties.

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

/

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

> VS bug [#783306](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/783306)