### PR TITLE
[X] add callback for previewer on failing ctor

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/FactoryMethodMissingCtor.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/FactoryMethodMissingCtor.xaml.cs
@@ -7,11 +7,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 	[XamlCompilation(XamlCompilationOptions.Skip)]
 	public partial class FactoryMethodMissingCtor : MockView
 	{
-		public FactoryMethodMissingCtor()
-		{
-			InitializeComponent();
-		}
-
+		public FactoryMethodMissingCtor() => InitializeComponent();
 		public FactoryMethodMissingCtor(bool useCompiledXaml)
 		{
 			//this stub will be replaced at compile time
@@ -20,15 +16,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		public class Tests
 		{
-			[SetUp]
-			public void SetUp()
-			{
-				Device.PlatformServices = new MockPlatformServices();
-			}
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
 
-			[TestCase(false)]
-			[TestCase(true)]
-			public void Throw(bool useCompiledXaml)
+			[Test]
+			public void Throw([Values(false, true)]bool useCompiledXaml)
 			{
 				if (useCompiledXaml)
 					Assert.Throws(new XamlParseExceptionConstraint(7, 4), () => MockCompiler.Compile(typeof(FactoryMethodMissingCtor)));

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -80,8 +80,14 @@ namespace Xamarin.Forms.Xaml
 						if (converted != null && converted.GetType() == type)
 							value = converted;
 					}
-					if (value == null)
-						value = Activator.CreateInstance(type);
+					if (value == null) {
+						try {
+							value = Activator.CreateInstance(type);
+						}
+						catch (TargetInvocationException tie) {
+							value = XamlLoader.InstantiationFailedCallback?.Invoke(new XamlLoader.CallbackTypeInfo { XmlNamespace = node.XmlType.NamespaceUri, XmlTypeName = node.XmlType.Name }) ?? throw tie;
+						}
+					}
 				}
 				catch (TargetInvocationException e) when (e.InnerException is XamlParseException || e.InnerException is XmlException) {
 					throw e.InnerException;
@@ -181,7 +187,13 @@ namespace Xamarin.Forms.Xaml
 							ci.GetParameters().Length != 0 && ci.IsPublic &&
 							ci.GetParameters().All(pi => pi.CustomAttributes.Any(attr => attr.AttributeType == typeof (ParameterAttribute))));
 			object[] arguments = CreateArgumentsArray(node, ctorInfo);
-			return ctorInfo.Invoke(arguments);
+			try {
+				return ctorInfo.Invoke(arguments);
+			}
+			catch (Exception e) when (e is TargetInvocationException || e is MissingMemberException) {
+				return XamlLoader.InstantiationFailedCallback?.Invoke(new XamlLoader.CallbackTypeInfo { XmlNamespace = node.XmlType.NamespaceUri, XmlTypeName = node.XmlType.Name }) ?? throw e;
+			}
+
 		}
 
 		public object CreateFromFactory(Type nodeType, IElementNode node)
@@ -191,7 +203,12 @@ namespace Xamarin.Forms.Xaml
 			if (!node.Properties.ContainsKey(XmlName.xFactoryMethod))
 			{
 				//non-default ctor
-				return Activator.CreateInstance(nodeType, arguments);
+				try {
+					return Activator.CreateInstance(nodeType, arguments);
+				}
+				catch (Exception e) when (e is TargetInvocationException || e is MissingMemberException) {
+					return XamlLoader.InstantiationFailedCallback?.Invoke(new XamlLoader.CallbackTypeInfo { XmlNamespace = node.XmlType.NamespaceUri, XmlTypeName = node.XmlType.Name }) ?? throw e;
+				}
 			}
 
 			var factoryMethod = ((string)((ValueNode)node.Properties[XmlName.xFactoryMethod]).Value);
@@ -219,7 +236,12 @@ namespace Xamarin.Forms.Xaml
 			var mi = nodeType.GetRuntimeMethods().FirstOrDefault(isMatch);
 			if (mi == null)
 				throw new MissingMemberException($"No static method found for {nodeType.FullName}::{factoryMethod} ({string.Join(", ", types.Select(t => t.FullName))})");
-			return mi.Invoke(null, arguments);
+			try {
+				return mi.Invoke(null, arguments);
+			}
+			catch (TargetInvocationException tie) {
+				return XamlLoader.InstantiationFailedCallback?.Invoke(new XamlLoader.CallbackTypeInfo { XmlNamespace = node.XmlType.NamespaceUri, XmlTypeName = node.XmlType.Name}) ?? throw tie;
+			}
 		}
 
 		public object[] CreateArgumentsArray(IElementNode enode)

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -317,5 +317,6 @@ namespace Xamarin.Forms.Xaml
 
 		internal static Func<IList<FallbackTypeInfo>, Type, Type> FallbackTypeResolver { get; set; }
 		internal static Action<CallbackTypeInfo, object> ValueCreatedCallback  { get; set; }
+		internal static Func<CallbackTypeInfo, object> InstantiationFailedCallback { get; set; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->
Add a callback when object instantiation or creation fails, so the
previewer can replace it by an educated guess

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

/
### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

> VS bug [#783305](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/783305)