### PR TITLE
Test covering FactoryMethod invalid on replaced type

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -453,8 +453,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void CanReplaceTypeWhenInstantiationThrows()
+		public void CanProvideInstanceWhenInstantiationThrows()
 		{
+			int instantiationFailedCallbackCalled = 0;
 			var xaml = @"
 					<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
 						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
@@ -476,9 +477,35 @@ namespace Xamarin.Forms.Xaml.UnitTests
 						</StackLayout>
 					</ContentPage>";
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
-			XamlLoader.InstantiationFailedCallback = (type) => new Button();
-			var o = XamlLoader.Create(xaml, true);
+			XamlLoader.InstantiationFailedCallback = type =>
+			{
+				instantiationFailedCallbackCalled++;
+				return new Button();
+			};
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+			Assert.That(instantiationFailedCallbackCalled, Is.EqualTo(4));
+		}
+
+		[Test]
+		public void CanProvideInstanceWhenReplacedTypeConstructorInvalid()
+		{
+			int instantiationFailedCallbackCalled = 0;
+			var xaml = @"
+					<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+						xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
+						<StackLayout>
+							<local:ReplacedType x:FactoryMethod=""CreateInstance"" />
+						</StackLayout>
+					</ContentPage>";
+			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
+			XamlLoader.InstantiationFailedCallback = type =>
+			{
+				instantiationFailedCallbackCalled++;
+				return new Button();
+			};
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+			Assert.That(instantiationFailedCallbackCalled, Is.EqualTo(1));
 		}
 
 		[Test]


### PR DESCRIPTION
### Description of Change ###

If the Forms Previewer replaces a type with a Forms base type, it is possible a valid factory method specified on the original type is invalid on the Forms base type, and Forms will throw an exception. `XamlLoader.InstantiationFailedCallback()` should be called in this scenario if it has been set.

FYI @alanmcgovern

> VS bug [#788354](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/788354)