### PR TITLE
[Android] Include default proguard file so user doesn't have to create rules for XF

### DIFF
--- a/.nuspec/Xamarin.Forms.Android.targets
+++ b/.nuspec/Xamarin.Forms.Android.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)proguard.cfg" />
+  </ItemGroup>
+</Project>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -155,6 +155,7 @@
     
     <!--Android 10-->
     <file src="Xamarin.Forms.Android.targets" target="build\MonoAndroid10\Xamarin.Forms.targets" />
+    <file src="proguard.cfg" target="build\MonoAndroid10\proguard.cfg" />
     
     <!--Android 81-->
     <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid81\Xamarin.Forms.Platform.Android.dll" target="lib\MonoAndroid81" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -153,6 +153,9 @@
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\tizen40\Design" />   
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\tizen40\Design" />
     
+    <!--Android 10-->
+    <file src="Xamarin.Forms.Android.targets" target="build\MonoAndroid10\Xamarin.Forms.targets" />
+    
     <!--Android 81-->
     <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid81\Xamarin.Forms.Platform.Android.dll" target="lib\MonoAndroid81" />
     <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid81\Xamarin.Forms.Platform.Android.*pdb" target="lib\MonoAndroid81" />

--- a/.nuspec/proguard.cfg
+++ b/.nuspec/proguard.cfg
@@ -1,0 +1,2 @@
+-keep class android.support.v7.widget.FitWindowsFrameLayout { *; }
+-dontwarn android.support.v7.widget.FitWindowsFrameLayout

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.Xaml.UnitTest
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuspec", ".nuspec", "{7E12C50D-A570-4DF1-94E1-8599843FA87C}"
 	ProjectSection(SolutionItems) = preProject
+		.nuspec\proguard.cfg = .nuspec\proguard.cfg
+		.nuspec\Xamarin.Forms.Android.targets = .nuspec\Xamarin.Forms.Android.targets
 		.nuspec\Xamarin.Forms.AppLinks.nuspec = .nuspec\Xamarin.Forms.AppLinks.nuspec
 		.nuspec\Xamarin.Forms.Debug.targets = .nuspec\Xamarin.Forms.Debug.targets
 		.nuspec\Xamarin.Forms.DefaultItems.props = .nuspec\Xamarin.Forms.DefaultItems.props


### PR DESCRIPTION
### Description of Change ###
Add a default proguard configuration file for when the user enables proguard.  With support 28 projects are hitting the DEX limit a lot faster now. Adding this file will mean that our library works with proguard and the user doesn't have to add any rules themselves.  I'm targeting 3.6.0 since this will help remove some friction with support 28

### Issues Resolved ### 
- fixes #2709

### Platforms Affected ### 
- Android


### Testing Procedure ###
- Enable proguard and full linking on an XF project
- Install this nuget
- Run Android project and it shouldn't crash

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
