### PR TITLE
[UWP] fix  ListView renderer

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/ListView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/WindowsSpecific/ListView.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.PlatformConfiguration.WindowsSpecific
 		#region SelectionMode
 
 		public static readonly BindableProperty SelectionModeProperty =
-			BindableProperty.CreateAttached("SelectionMode", typeof(ListViewSelectionMode),
+			BindableProperty.CreateAttached("WindowsSelectionMode", typeof(ListViewSelectionMode),
 				typeof(ListView), ListViewSelectionMode.Accessible);
 
 		public static ListViewSelectionMode GetSelectionMode(BindableObject element)

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -231,7 +231,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				ClearSizeEstimate();
 			}
-			else if (e.PropertyName == Specifics.SelectionModeProperty.PropertyName)
+			else if (e.PropertyName == ListView.SelectionModeProperty.PropertyName)
 			{
 				UpdateSelectionMode();
 			}


### PR DESCRIPTION
### Description of Change ###

`UpdateWindowsSpecificSelectionMode` method could not be fired when the `Specifics.SelectionModeProperty` changed. Because the property names `Specifics.SelectionModeProperty` and  `ListView.SelectionModeProperty` were equal.

### Issues Resolved ### 

none

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

Can change `Windows.Specifics.SelectionModeProperty`.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
