### PR TITLE
[iOS] fix accessibility of Picker

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PickerGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PickerGallery.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Controls
 			p1.SelectedIndexChanged += (sender, e) => {
 				testLabel.Text = "Selected Index Changed";
 			};
+			p1.SetAutomationPropertiesName("Title picker");
 
 			Content = new ScrollView { 
 				Content = new StackLayout {

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -81,6 +81,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
 
+				entry.AccessibilityTraits = UIAccessibilityTrait.Button;
+
 				SetNativeControl(entry);
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -85,8 +85,10 @@ namespace Xamarin.Forms.Platform.iOS
 					entry.InputAssistantItem.TrailingBarButtonGroups = null;
 
 					_defaultTextColor = entry.TextColor;
-					
+
 					_useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
+
+					entry.AccessibilityTraits = UIAccessibilityTrait.Button;
 
 					SetNativeControl(entry);
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -91,6 +91,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 					_picker.ValueChanged += OnValueChanged;
 
+					entry.AccessibilityTraits = UIAccessibilityTrait.Button;
+
 					SetNativeControl(entry);
 				}
 


### PR DESCRIPTION
### Description of Change ###

Pickers reads like a Button. This is part of PR #3955

### Issues Resolved ### 

- partially fixes #3454

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Before
![screenshot_20](https://user-images.githubusercontent.com/27482193/52339356-e96a8080-2a1d-11e9-8f8b-f5356b01814b.png)

After
![screenshot_19](https://user-images.githubusercontent.com/27482193/52338214-cee2d800-2a1a-11e9-8abd-f3d235538a40.png)


### Testing Procedure ###

- start `PickerGallery - Legacy` in ControlGallery
- run `Accessibility Inspector` or `VoiceOver`
- picker type should be like a button


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
