### PR TITLE
[Android CollectionView] Fixes crash when ItemSource Changed

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGallery.cs
@@ -23,7 +23,9 @@
 						GalleryBuilder.NavButton("EmptyView (View)", () =>
 							new EmptyViewViewGallery(), Navigation),
 						GalleryBuilder.NavButton("EmptyView (Template View)", () =>
-							new EmptyViewTemplateGallery(), Navigation)
+							new EmptyViewTemplateGallery(), Navigation),
+						GalleryBuilder.NavButton("EmptyView (load simulation)", () =>
+							new EmptyViewLoadSimulateGallery(), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewLoadSimulateGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewLoadSimulateGallery.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.EmptyViewGalleries.EmptyViewLoadSimulateGallery">
+    <ContentPage.Content>
+		<Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="*"></RowDefinition>
+            </Grid.RowDefinitions>
+            <CollectionView x:Name="CollectionView" Grid.Row="1">
+				<CollectionView.ItemsLayout>
+					<GridItemsLayout Span="3" Orientation="Vertical"></GridItemsLayout>
+				</CollectionView.ItemsLayout>
+				<CollectionView.EmptyView>
+					Items loading simulation...
+				</CollectionView.EmptyView>
+			</CollectionView>
+		</Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewLoadSimulateGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewLoadSimulateGallery.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.EmptyViewGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class EmptyViewLoadSimulateGallery : ContentPage
+	{
+		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource();
+
+		public EmptyViewLoadSimulateGallery()
+		{
+			InitializeComponent();
+
+			CollectionView.ItemTemplate = ExampleTemplates.PhotoTemplate();
+
+			new Thread(() =>
+			{
+				Thread.Sleep(1000);
+				Device.BeginInvokeOnMainThread(() => CollectionView.ItemsSource = _demoFilteredItemSource.Items);
+			}).Start();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -43,6 +43,9 @@
     <Compile Update="GalleryPages\BindableLayoutGalleryPage.xaml.cs">
       <DependentUpon>BindableLayoutGalleryPage.xaml</DependentUpon>
     </Compile>
+    <Compile Update="GalleryPages\CollectionViewGalleries\EmptyViewGalleries\EmptyViewLoadSimulateGallery.xaml.cs">
+      <DependentUpon>EmptyViewLoadSimulateGallery.xaml</DependentUpon>
+    </Compile>
     <Compile Update="GalleryPages\VisualStateManagerGalleries\OnPlatformExample.xaml.cs">
       <DependentUpon>OnPlatformExample.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -213,7 +213,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			// Stop watching the old adapter to see if it's empty (if we _are_ watching)
-			Unwatch(GetAdapter());
+			Unwatch(ItemsViewAdapter ?? GetAdapter());
 			
 			UpdateAdapter();
 


### PR DESCRIPTION
### Description of Change ###

The function `GetAdapter` generated a new instance of the `adapter` that is not registered with `DataObserver`. At the same time, when trying to `Unwatch` from it, a exception was thrown.

### Issues Resolved ### 

- fixes #5110

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- run CollectionView Gallery > EmptyView Galleies > EmptyView (load simulation)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
