### PR TITLE
Rethinking the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Xamarin.Forms provides a way to quickly build native apps for iOS, Android, Windows and macOS, completely in C#.
 
-Read more about the platform at https://www.xamarin.com/forms.
+For quick starts, documentation, and guides read more at https://docs.microsoft.com/en-us/xamarin/xamarin-forms/.
 
 ## Build Status ##
 
@@ -13,7 +13,7 @@ Read more about the platform at https://www.xamarin.com/forms.
 
 ## Packages ##
 
-Platform/Feature               | Package name                              | Stable (3.0.0 branch)     |Nightly Feed [MyGet](https://www.myget.org/F/xamarinforms-ci/api/v2)  (master branch)
+Platform/Feature               | Package name                              | Stable (3.5.0 branch)     |Nightly Feed [MyGet](https://www.myget.org/F/xamarinforms-ci/api/v2)  (master branch)
 -----------------------|-------------------------------------------|-----------------------------|-------------------------
 Core             | `Xamarin.Forms` | [![NuGet](https://img.shields.io/nuget/v/Xamarin.Forms.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms/)| [![MyGet](https://img.shields.io/myget/xamarinforms-ci/vpre/Xamarin.Forms.svg?style=flat-square&label=myget)](https://myget.org/feed/xamarinforms-ci/package/nuget/Xamarin.Forms)
 Maps                 | `Xamarin.Forms.Maps`    | [![NuGet](https://img.shields.io/nuget/v/Xamarin.Forms.Maps.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms.Maps/) | [![MyGet](https://img.shields.io/myget/xamarinforms-ci/vpre/Xamarin.Forms.Maps.svg?style=flat-square&label=myget)](https://myget.org/feed/xamarinforms-ci/package/nuget/Xamarin.Forms.Maps)
@@ -38,7 +38,7 @@ If you want to use the latest dev build then you should read [this blog post](ht
 
 - Change your application's dependencies to have a `*` to get the latest version.
 
-## Getting Started ##
+## Getting Started for Contributors ##
 
 ##### Install Visual Studio 2017 #####
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For quick starts, documentation, and guides read more at https://docs.microsoft.
 
 ## Packages ##
 
-Platform/Feature               | Package name                              | Stable (3.5.0 branch)     |Nightly Feed [MyGet](https://www.myget.org/F/xamarinforms-ci/api/v2)  (master branch)
+Platform/Feature               | Package name                              | Stable (3.6.0 branch)     |Nightly Feed [MyGet](https://www.myget.org/F/xamarinforms-ci/api/v2)  (master branch)
 -----------------------|-------------------------------------------|-----------------------------|-------------------------
 Core             | `Xamarin.Forms` | [![NuGet](https://img.shields.io/nuget/v/Xamarin.Forms.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms/)| [![MyGet](https://img.shields.io/myget/xamarinforms-ci/vpre/Xamarin.Forms.svg?style=flat-square&label=myget)](https://myget.org/feed/xamarinforms-ci/package/nuget/Xamarin.Forms)
 Maps                 | `Xamarin.Forms.Maps`    | [![NuGet](https://img.shields.io/nuget/v/Xamarin.Forms.Maps.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms.Maps/) | [![MyGet](https://img.shields.io/myget/xamarinforms-ci/vpre/Xamarin.Forms.Maps.svg?style=flat-square&label=myget)](https://myget.org/feed/xamarinforms-ci/package/nuget/Xamarin.Forms.Maps)


### PR DESCRIPTION
The readme is heavily focused on contributors. How might we provide a more high level landing page introduction to Xamarin.Forms for both app developers and contributors?

