### PR TITLE
[X] only require escaping if starts with '{'

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2756.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2756.xaml
@@ -3,5 +3,8 @@
         xmlns="http://xamarin.com/schemas/2014/forms"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         x:Class="Xamarin.Forms.Xaml.UnitTests.Gh2756">
-    <Label Text="{Binding Path=StartTime, StringFormat='{0:yy-MM-dd}'}"/>
+    <StackLayout>
+        <Label Text="{Binding Color.R, StringFormat='R = {0:F2}'}"/> <!-- should parse -->
+        <Label Text="{Binding Path=StartTime, StringFormat='{0:yy-MM-dd}'}"/> <!-- should throw -->
+    </StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2756.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2756.xaml.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 
 using Xamarin.Forms.Core.UnitTests;
 
@@ -25,9 +25,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			public void UnescapedBraces([Values(false, true)]bool useCompiledXaml)
 			{
 				if (useCompiledXaml)
-					Assert.Throws<XamlParseException>(() => MockCompiler.Compile(typeof(Gh2756)));
+					Assert.Throws(new XamlParseExceptionConstraint(8, 16), () => MockCompiler.Compile(typeof(Gh2756)));
 				else
-					Assert.Throws<XamlParseException>(() => new Gh2756(useCompiledXaml));
+					Assert.Throws(new XamlParseExceptionConstraint(8, 16), () => new Gh2756(useCompiledXaml));
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3539.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh3539.xaml
@@ -12,11 +12,11 @@
         <StackLayout Margin="10, 0">
             <Label Text="{Binding Name}" />
             <Slider Value="{Binding Hue}" />
-            <Label Text="{Binding Hue, StringFormat='{}Hue = {0:F2}'}" />
+            <Label Text="{Binding Hue, StringFormat='Hue = {0:F2}'}" />
             <Slider Value="{Binding Saturation}" />
-            <Label Text="{Binding Saturation, StringFormat='{}Saturation = {0:F2}'}" />
+            <Label Text="{Binding Saturation, StringFormat='Saturation = {0:F2}'}" />
             <Slider Value="{Binding Luminosity}" />
-            <Label Text="{Binding Luminosity, StringFormat='{}Luminosity = {0:F2}'}" />
+            <Label Text="{Binding Luminosity, StringFormat='Luminosity = {0:F2}'}" />
         </StackLayout>
     </StackLayout> 
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Issue1438.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Issue1438.xaml
@@ -5,7 +5,7 @@
 	<StackLayout>
 		<Label BindingContext="{x:Reference slider}"
 			   x:Name="label"
-			   Text="{Binding Value, StringFormat='{}Slider value is {0:F3}'}"
+			   Text="{Binding Value, StringFormat='Slider value is {0:F3}'}"
 			   Font="Large"
 			   HorizontalOptions="Center"
 			   VerticalOptions="CenterAndExpand" />

--- a/Xamarin.Forms.Xaml.UnitTests/MarkupExpressionParserTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MarkupExpressionParserTests.cs
@@ -248,11 +248,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void BracesNeedsToBeEscaped()
+		public void NonStartingBracesDoNotNeedToBeEscaped()
 		{
 			var bindingString = "{Binding Foo, StringFormat='Hello {0}'}";
 
-			Assert.Throws<XamlParseException>(() => new MarkupExtensionParser().ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			Assert.DoesNotThrow(() => new MarkupExtensionParser().ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
 			{
 				IXamlTypeResolver = typeResolver,
 			}));

--- a/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
+++ b/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
@@ -141,10 +141,10 @@ namespace Xamarin.Forms.Xaml
 			else
 				str_value = GetNextPiece(ref remaining, out var next);
 
-			if (str_value != null && !str_value.StartsWith("{}", StringComparison.Ordinal) && str_value.Length > 2 && str_value.IndexOf('{') != -1)
+			if (str_value != null && !str_value.StartsWith("{}", StringComparison.Ordinal) && str_value.Length > 2 && str_value.StartsWith("{", StringComparison.Ordinal))
 			{
 				var lineInfo = (serviceProvider.GetService(typeof(IXmlLineInfoProvider)) as IXmlLineInfoProvider != null) ? (serviceProvider.GetService(typeof(IXmlLineInfoProvider)) as IXmlLineInfoProvider).XmlLineInfo : new XmlLineInfo();
-				throw new XamlParseException("Strings containing `{` needs to be escaped. Start the string with `{}`", lineInfo);
+				throw new XamlParseException("Strings starting with `{` needs to be escaped. Start the string with `{}`", lineInfo);
 			}
 
 			SetPropertyValue(prop, str_value, value, serviceProvider);


### PR DESCRIPTION
### Description of Change ###

escaping required only if the string starts with `{`

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5152

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
