### PR TITLE
Missing visual not falling back to registered default renderer

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -152,6 +152,8 @@
     <ProjectReference Include="..\Xamarin.Forms.Material.iOS\Xamarin.Forms.Material.iOS.csproj">
       <Project>{8A75B1DC-CEED-4B1B-8675-A7DFFD1E6DE4}</Project>
       <Name>Xamarin.Forms.Material.iOS</Name>
+      <IsAppExtension>false</IsAppExtension>
+      <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Core.UnitTests
 	internal class RenderWith { }
 	internal class RenderWithChild : RenderWith { }
 	internal class RenderWithChildTarget : IRegisterable { }
+	internal class RenderWithSetAsNewDefault : IRegisterable { }
 
 	internal class VisualButtonTarget : IRegisterable { }
 	internal class VisualSliderTarget : IRegisterable { }
@@ -58,6 +59,16 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			base.TearDown();
 			Device.PlatformServices = null;
+		}
+
+
+		[Test]
+		public void RegisteringANewDefaultShouldReplaceRenderWithAttributeForFallbackVisual()
+		{
+			Internals.Registrar.Registered.Register(typeof(RenderWith), typeof(RenderWithSetAsNewDefault));
+			var renderWithTarget = Internals.Registrar.Registered.GetHandler(typeof(RenderWith), typeof(VisualMarkerUnitTests));
+
+			Assert.That(renderWithTarget, Is.InstanceOf<RenderWithSetAsNewDefault>());
 		}
 
 

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms.Internals
 			for (int i = 0; i < supportedVisuals.Length; i++)
 				visualRenderers[supportedVisuals[i]] = trender;
 		}
-		
+
 		public void Register(Type tview, Type trender) => Register(tview, trender, _defaultVisualRenderers);
 
 		internal TRegistrable GetHandler(Type type) => GetHandler(type, _defaultVisualType);
@@ -126,7 +126,7 @@ namespace Xamarin.Forms.Internals
 				else if (visualType == _materialVisualType)
 					VisualMarker.MaterialCheck();
 
-			if (visualType != _defaultVisualType && _handlers.TryGetValue(_defaultVisualType, out visualRenderers))
+			if (visualType != _defaultVisualType && visualRenderers != null)
 				if (visualRenderers.TryGetValue(_defaultVisualType, out Type specificTypeRenderer))
 					return specificTypeRenderer;
 
@@ -163,7 +163,7 @@ namespace Xamarin.Forms.Internals
 					if (visualRenderers.TryGetValue(visualType, out handlerType))
 						return true;
 
-				if (visualType != _defaultVisualType && _handlers.TryGetValue(viewType, out visualRenderers))
+				if (visualType != _defaultVisualType && visualRenderers != null)
 					if (visualRenderers.TryGetValue(_defaultVisualType, out handlerType))
 						return true;
 

--- a/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
+++ b/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
@@ -72,6 +72,8 @@
     <ProjectReference Include="..\Xamarin.Forms.Platform.iOS\Xamarin.Forms.Platform.iOS.csproj">
       <Project>{271193C1-6E7C-429C-A36D-3F1BE5267231}</Project>
       <Name>Xamarin.Forms.Platform.iOS</Name>
+      <IsAppExtension>false</IsAppExtension>
+      <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
       <Project>{57B8B73D-C3B5-4C42-869E-7B2F17D354AC}</Project>


### PR DESCRIPTION
### Description of Change ###
The code was using the wrong key type when accessing the handler dictionary when checking for a default registered renderer.


### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Options ###
- There's a UI Test
- Set Visual on Button to some random type (that's not a VisualMarker) and make sure it loads the AppCompatButton
- Download nuget and install it into an Android 8.1 project and set one button to visual and the other not. Make sure they both load appcompat

### PR Checklist ###
- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
