### PR TITLE
Add AllowMultiple=true to QueryPropertyAttribute

### DIFF
--- a/Xamarin.Forms.Core/Shell/QueryPropertyAttribute.cs
+++ b/Xamarin.Forms.Core/Shell/QueryPropertyAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms
 {
-	[AttributeUsage(AttributeTargets.Class)]
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 	public class QueryPropertyAttribute : Attribute
 	{
 		public string Name { get;  }


### PR DESCRIPTION
### Description of Change ###

Added `AllowMultiple=true` to the `QueryPropertyAttribute`.

### Issues Resolved ### 

In the process of building a demo app (https://github.com/matthewrdev/xamarin-forms-4), I discovered that I could not apply multiple parameters; doing so would cause a compile-time error.

![image](https://user-images.githubusercontent.com/3260473/52514753-a3edc380-2c68-11e9-856b-83391996b10c.png)

The usage of this property in [ShellContent.ApplyQueryAttributes](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Core/Shell/ShellContent.cs#L171) indicates that the intended behaviour is to allow users to specify multiple URL arguments that will be applied onto the page. Changing AllowMultiple to true fixes this.

For reference, when AllowMultiple is not explicitly set, it's default value is false. See: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/attributes/attributeusage.

### API Changes ###

Added `AllowMultiple=true` to the [`QueryPropertyAttribute`]().

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

 1. Define a page that uses multiple the `QueryPropertyAttribute` to apply URL arguments to properties
 2. Prior to this change, this will result in a compilation error.
 3. After this change, there will be no compilation error.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
