### PR TITLE
Reinstate and obsolete IPlatform, et al

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewTemplateGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewTemplateGallery.xaml
@@ -20,7 +20,7 @@
 						<StackLayout> 
 							<Label FontAttributes="Bold" FontSize="18" Margin="10,25,10,10"
 									HorizontalOptions="Fill" HorizontalTextAlignment="Center" 
-									Text="{Binding Filter, StringFormat='Your filter term of {0} did not match any records'}"></Label>
+									Text="{Binding Filter, StringFormat='{}Your filter term of {0} did not match any records'}"></Label>
 						</StackLayout>
 					</DataTemplate>
 				</CollectionView.EmptyViewTemplate>

--- a/Xamarin.Forms.Core.UnitTests/PreviewerReflectionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PreviewerReflectionTests.cs
@@ -2,12 +2,21 @@ using System;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
 	[TestFixture]
 	public class PreviewerReflectionTests
 	{
+		class FakePlatform : IPlatform
+		{
+			public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
 		[Test]
 		public void PageHasPlatformProperty()
 		{
@@ -16,7 +25,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var setPlatform = page.GetType ().GetProperty ("Platform", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 			Assert.That(setPlatform, Is.Not.Null, "Previewer requires that Page have a property called 'Platform'");
 
-			TestDelegate setValue = () => setPlatform.SetValue(page, new object(), null);
+			TestDelegate setValue = () => setPlatform.SetValue(page, new FakePlatform(), null);
 			Assert.That(setValue, Throws.Nothing, "'Page.Platform' must have a setter");
 		}
 

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -614,7 +614,7 @@ namespace Xamarin.Forms
 
 		// Platform isn't needed anymore, but the Previewer will still try to set it via reflection
 		// and throw an NRE if it's not available
-		// So even if this property eventuall gets removed, we still need to keep something settable on
+		// So even if this property eventually gets removed, we still need to keep something settable on
 		// Page called Platform
 
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -228,6 +228,10 @@ namespace Xamarin.Forms
 			}
 		}
 
+		[EditorBrowsable(EditorBrowsableState.Never)]	
+		[Obsolete("IPlatform is obsolete as of 3.5.0. Do not use this property.")]
+		public IPlatform Platform { get; set; }
+
 		void IElementController.SetValueFromRenderer(BindableProperty property, object value) => SetValueFromRenderer(property, value);
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetValueFromRenderer(BindableProperty property, object value)

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -44,6 +44,7 @@ namespace Xamarin.Forms
 		Element _parentOverride;
 
 		string _styleId;
+		
 
 		public string AutomationId
 		{
@@ -228,10 +229,6 @@ namespace Xamarin.Forms
 			}
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]	
-		[Obsolete("IPlatform is obsolete as of 3.5.0. Do not use this property.")]
-		public IPlatform Platform { get; set; }
-
 		void IElementController.SetValueFromRenderer(BindableProperty property, object value) => SetValueFromRenderer(property, value);
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetValueFromRenderer(BindableProperty property, object value)
@@ -310,7 +307,7 @@ namespace Xamarin.Forms
 		{
 			child.Parent = this;
 
-			child.ApplyBindings(skipBindingContext: false, fromBindingContextChanged:true);
+			child.ApplyBindings(skipBindingContext: false, fromBindingContextChanged: true);
 
 			ChildAdded?.Invoke(this, new ElementEventArgs(child));
 
@@ -583,7 +580,8 @@ namespace Xamarin.Forms
 		internal INameScope GetNameScope()
 		{
 			var element = this;
-			do {
+			do
+			{
 				var ns = NameScope.GetNameScope(element);
 				if (ns != null)
 					return ns;
@@ -607,5 +605,41 @@ namespace Xamarin.Forms
 		{
 			SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearTwoWayBindings);
 		}
+
+		#region Obsolete IPlatform Stuff
+
+#pragma warning disable CS0618 // Type or member is obsolete
+		private IPlatform _platform;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+		// Platform isn't needed anymore, but the Previewer will still try to set it via reflection
+		// and throw an NRE if it's not available
+		// So even if this property eventuall gets removed, we still need to keep something settable on
+		// Page called Platform
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("IPlatform is obsolete as of 3.5.0. Do not use this property.")]
+		public IPlatform Platform
+		{
+			get => _platform;
+			set
+			{
+				if (_platform == value)	
+					return;	
+				_platform = value;	
+				PlatformSet?.Invoke(this, EventArgs.Empty);	
+				foreach (Element descendant in Descendants())
+				{	
+					descendant._platform = _platform;	
+					descendant.PlatformSet?.Invoke(this, EventArgs.Empty);	
+				}
+			}
+		}
+
+		[Obsolete("PlatformSet is obsolete as of 3.5.0. Do not use this event.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public event EventHandler PlatformSet;
+
+		#endregion
 	}
 }

--- a/Xamarin.Forms.Core/IElementController.cs
+++ b/Xamarin.Forms.Core/IElementController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
@@ -17,7 +18,12 @@ namespace Xamarin.Forms
 		Element RealParent { get; }
 		IEnumerable<Element> Descendants();
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Obsolete("IPlatform is obsolete as of 3.5.0. Do not use this property.")]
 		IPlatform Platform { get; set; }
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("PlatformSet is obsolete as of 3.5.0. Do not use this event.")]
+		event EventHandler PlatformSet;
 	}
 }

--- a/Xamarin.Forms.Core/IElementController.cs
+++ b/Xamarin.Forms.Core/IElementController.cs
@@ -16,5 +16,8 @@ namespace Xamarin.Forms
 		ReadOnlyCollection<Element> LogicalChildren { get; }
 		Element RealParent { get; }
 		IEnumerable<Element> Descendants();
+
+		[Obsolete("IPlatform is obsolete as of 3.5.0. Do not use this property.")]
+		IPlatform Platform { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/IMenuItemController.cs
+++ b/Xamarin.Forms.Core/IMenuItemController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 
 namespace Xamarin.Forms
@@ -7,5 +8,8 @@ namespace Xamarin.Forms
 	{
 		bool IsEnabled { get; set; }
 		void Activate();
+
+		[Obsolete("This property is obsolete as of 3.5.0. Please use MenuItem.IsEnabledProperty.PropertyName instead.")]
+		string IsEnabledPropertyName { get; }
 	}
 }

--- a/Xamarin.Forms.Core/Internals/IPlatform.cs
+++ b/Xamarin.Forms.Core/Internals/IPlatform.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.ComponentModel;	
+
+ namespace Xamarin.Forms.Internals	
+{	
+	[EditorBrowsable(EditorBrowsableState.Never)]	
+	[Obsolete("This interface is obsolete as of 3.5.0. Do not use it.")]
+	public interface IPlatform	
+	{	
+		SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint);	
+	}	
+}

--- a/Xamarin.Forms.Core/Internals/IPlatform.cs
+++ b/Xamarin.Forms.Core/Internals/IPlatform.cs
@@ -7,6 +7,8 @@ using System.ComponentModel;
 	[Obsolete("This interface is obsolete as of 3.5.0. Do not use it.")]
 	public interface IPlatform	
 	{	
+		[Obsolete("This method is obsolete as of 3.5.0. Please use the static Platform.GetNativeSize(VisualElement " +
+			"view, double widthConstraint, double heightConstraint) method instead")]
 		SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint);	
 	}	
 }

--- a/Xamarin.Forms.Core/Internals/NavigationRequestedEventArgs.cs
+++ b/Xamarin.Forms.Core/Internals/NavigationRequestedEventArgs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
@@ -16,6 +17,12 @@ namespace Xamarin.Forms.Internals
 			BeforePage = before;
 		}
 
+		[Obsolete("This constructor is obsolete as of 3.5.0. Please use NavigationRequestedEventArgs(Page page, " +
+			"bool animated) instead.")]
+		public NavigationRequestedEventArgs(Page page, bool animated, bool realize = true) : this(page, animated)
+		{
+		}
+
 		public bool Animated { get; set; }
 
 		public Page BeforePage { get; set; }
@@ -23,5 +30,8 @@ namespace Xamarin.Forms.Internals
 		public Task<bool> Task { get; set; }
 
 		public NavigationRequestType RequestType { get; set; } = NavigationRequestType.Unknown;
+
+		[Obsolete("This property is obsolete as of 3.5.0.")]
+		public bool Realize { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/MenuItem.cs
+++ b/Xamarin.Forms.Core/MenuItem.cs
@@ -69,6 +69,9 @@ namespace Xamarin.Forms
 			set => SetValueCore(IsEnabledPropertyKey, value);
 		}
 
+		[Obsolete("This property is obsolete as of 3.5.0. Please use MenuItem.IsEnabledProperty.PropertyName instead.")]
+		public string IsEnabledPropertyName => MenuItem.IsEnabledProperty.PropertyName;
+
 		public event EventHandler Clicked;
 
 		protected virtual void OnClicked() => Clicked?.Invoke(this, EventArgs.Empty);

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -450,12 +450,5 @@ namespace Xamarin.Forms
 
 			_titleView = newTitleView;
 		}
-
-		// This is a dummy property for the Previewer
-		// Platform isn't needed anymore, but the Previewer will still try to set it via reflection
-		// and throw an NRE if it's not available; this fake property keeps it happy.
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		[Obsolete("This property is no longer used as of version 3.4.")]
-		internal new object Platform { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -456,6 +456,6 @@ namespace Xamarin.Forms
 		// and throw an NRE if it's not available; this fake property keeps it happy.
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Obsolete("This property is no longer used as of version 3.4.")]
-		internal object Platform { get; set; }
+		internal new object Platform { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/ToolbarItem.cs
+++ b/Xamarin.Forms.Core/ToolbarItem.cs
@@ -17,12 +17,12 @@ namespace Xamarin.Forms
 		{
 		}
 
-		public ToolbarItem(string text, string icon, Action activated, ToolbarItemOrder order = ToolbarItemOrder.Default, int priority = 0)
+		public ToolbarItem(string name, string icon, Action activated, ToolbarItemOrder order = ToolbarItemOrder.Default, int priority = 0)
 		{
 			if (activated == null)
 				throw new ArgumentNullException("activated");
 
-			Text = text;
+			Text = name;
 			Icon = icon;
 			Clicked += (s, e) => activated();
 			Order = order;

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -155,6 +155,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			_navModel.PushModal(modal);
 
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			modal.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			Task presentModal = PresentModal(modal, animated);
 
 			await presentModal;

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -13,6 +13,9 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
 	internal class Platform : BindableObject, IPlatformLayout, INavigation, IDisposable
+#pragma warning disable CS0618
+		, IPlatform
+#pragma warning restore
 	{
 		readonly Context _context;
 		readonly PlatformRenderer _renderer;
@@ -468,6 +471,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		public static implicit operator ViewGroup(Platform canvas)
 		{
 			return canvas._renderer;
+		}
+
+		#endregion
+
+		#region Obsolete 
+
+		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		{
+			return GetNativeSize(view, widthConstraint, heightConstraint);
 		}
 
 		#endregion

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -251,7 +251,16 @@ namespace Xamarin.Forms.Platform.Android
 			PopupManager.ResetBusyCount(this);
 
 			Platform = new Platform(this);
-			
+
+			if (_application != null)
+			{
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			_application.Platform = Platform;
+#pragma warning restore CS0618 // Type or member is obsolete
+			}
+
 			Platform.SetPage(page);
 			_layout.AddView(Platform.GetViewGroup());
 		}

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -284,6 +284,12 @@ namespace Xamarin.Forms.Platform.Android
 
 			_navModel.PushModal(modal);
 
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			modal.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			await PresentModal(modal, animated);
 
 			// Verify that the modal is still on the stack
@@ -469,6 +475,13 @@ namespace Xamarin.Forms.Platform.Android
 			_navModel.Push(newRoot, null);
 
 			Page = newRoot;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			Page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			AddChild(Page, layout);
 
 			Application.Current.NavigationProxy.Inner = this;

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -22,6 +22,9 @@ using AView = Android.Views.View;
 namespace Xamarin.Forms.Platform.Android
 {
 	public class Platform : BindableObject, INavigation, IDisposable, IPlatformLayout
+#pragma warning disable CS0618
+		, IPlatform
+#pragma warning restore
 	{
 		internal const string CloseContextActionsSignalName = "Xamarin.CloseContextActions";
 
@@ -1154,6 +1157,15 @@ namespace Xamarin.Forms.Platform.Android
 
 			// If a page is found, return the PageContext set by the previewer for that page (if any)
 			return (parent as Page)?.GetValue(PageContextProperty) as Context;
+		}
+
+		#endregion
+
+		#region Obsolete 
+
+		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		{
+			return GetNativeSize(view, widthConstraint, heightConstraint);
 		}
 
 		#endregion

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -250,9 +250,11 @@ namespace Xamarin.Forms.Platform.Android
 				}
 				cell = (Cell)boxedCell.Element;
 
-				// We are going to re-set the Platform here because in some cases (headers mostly) its possible this is unset and
-				// when the binding context gets updated the measure passes will all fail. By applying this here the Update call
-				// further down will result in correct layouts.
+#pragma warning disable CS0618 // Type or member is obsolete
+				// The Platform property is no longer necessary, but we have to set it because some third-party
+				// library might still be retrieving it and using it
+				cell.Platform = _listView.Platform;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				ICellController cellController = cell;
 				cellController.SendDisappearing();

--- a/Xamarin.Forms.Platform.GTK/Platform.cs
+++ b/Xamarin.Forms.Platform.GTK/Platform.cs
@@ -10,6 +10,9 @@ using Xamarin.Forms.Platform.GTK.Renderers;
 namespace Xamarin.Forms.Platform.GTK
 {
 	public class Platform : BindableObject, INavigation, IDisposable
+#pragma warning disable CS0618
+		, IPlatform
+#pragma warning restore
 	{
 		private bool _disposed;
 		readonly List<Page> _modals;
@@ -251,5 +254,14 @@ namespace Xamarin.Forms.Platform.GTK
 		{
 
 		}
+
+		#region Obsolete 
+
+		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		{
+			return GetNativeSize(view, widthConstraint, heightConstraint);
+		}
+
+		#endregion
 	}
 }

--- a/Xamarin.Forms.Platform.GTK/Platform.cs
+++ b/Xamarin.Forms.Platform.GTK/Platform.cs
@@ -125,6 +125,12 @@ namespace Xamarin.Forms.Platform.GTK
 
 			Page = newRoot;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			Page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			AddChild(Page);
 
 			Application.Current.NavigationProxy.Inner = this;
@@ -218,6 +224,13 @@ namespace Xamarin.Forms.Platform.GTK
 		Task INavigation.PushModalAsync(Page modal, bool animated)
 		{
 			_modals.Add(modal);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			modal.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			modal.DescendantRemoved += HandleChildRemoved;
 
 			var modalRenderer = GetRenderer(modal);

--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -202,6 +202,12 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (_appeared == false)
 				return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			Page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			AddChild(Page);
 
 			Page.DescendantRemoved += HandleChildRemoved;
@@ -220,6 +226,12 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (_appeared)
 				return;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			Page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			AddChild(Page);
 

--- a/Xamarin.Forms.Platform.MacOS/Platform.cs
+++ b/Xamarin.Forms.Platform.MacOS/Platform.cs
@@ -7,6 +7,9 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Platform.MacOS
 {
 	public class Platform : BindableObject, IDisposable
+#pragma warning disable CS0618
+		, IPlatform
+#pragma warning restore
 	{
 		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer",
 			typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),
@@ -273,5 +276,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			var view = e.Element;
 			DisposeModelAndChildrenRenderers(view);
 		}
+
+		#region Obsolete 
+
+		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		{
+			return GetNativeSize(view, widthConstraint, heightConstraint);
+		}
+
+		#endregion
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/PlatformNavigation.cs
+++ b/Xamarin.Forms.Platform.MacOS/PlatformNavigation.cs
@@ -72,6 +72,12 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		Task INavigation.PushModalAsync(Page modal, bool animated)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
+				// The Platform property is no longer necessary, but we have to set it because some third-party
+				// library might still be retrieving it and using it
+				modal.Platform = _platformRenderer.Platform;
+#pragma warning restore CS0618 // Type or member is obsolete
+			
 			return _modalTracker.PushAsync(modal, _animateModals && animated);
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
+++ b/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
@@ -131,6 +131,15 @@ namespace Xamarin.Forms.Platform.Tizen
 				throw new InvalidOperationException("Call Forms.Init (UIApplication) before this");
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			if (_application != null)	
+			{	
+				_application.Platform = _platform;	
+			}
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			_platform.HasAlpha = MainWindow.Alpha;
 			_platform.SetPage(page);
 		}

--- a/Xamarin.Forms.Platform.Tizen/LightweightPlatform.cs
+++ b/Xamarin.Forms.Platform.Tizen/LightweightPlatform.cs
@@ -49,6 +49,12 @@ namespace Xamarin.Forms.Platform.Tizen
 
 			if (_page == null) return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			_page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			var renderer = Platform.CreateRenderer(_page);
 			_rootView = renderer.NativeView;
 			RootNativeViewChanged?.Invoke(this, new RootNativeViewChangedEventArgs(_rootView));
@@ -75,6 +81,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				SetPage(null);
 			}
 			_disposed = true;
+		}
+
+		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		{
+			return Platform.GetNativeSize(view, widthConstraint, heightConstraint);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Platform.cs
+++ b/Xamarin.Forms.Platform.Tizen/Platform.cs
@@ -77,6 +77,9 @@ namespace Xamarin.Forms.Platform.Tizen
 
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface ITizenPlatform : IDisposable
+#pragma warning disable CS0618 // Type or member is obsolete
+		, IPlatform
+#pragma warning restore CS0618 // Type or member is obsolete
 	{
 		void SetPage(Page page);
 		bool SendBackButtonPressed();
@@ -166,6 +169,12 @@ namespace Xamarin.Forms.Platform.Tizen
 			_navModel.Push(newRoot, null);
 
 			Page = newRoot;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			Page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			IVisualElementRenderer pageRenderer = Platform.CreateRenderer(Page);
 			var naviItem = _internalNaviframe.Push(pageRenderer.NativeView);
@@ -552,6 +561,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				page = (Page)page.RealParent;
 
 			return Page == page || _navModel.Roots.Contains(page);
+		}
+
+		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		{
+			return Platform.GetNativeSize(view, widthConstraint, heightConstraint);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -223,7 +223,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 		}
 
-		public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 		{
 			return Platform.GetNativeSize(view, widthConstraint, heightConstraint);
 		}

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -223,7 +223,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 		}
 
-		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 		{
 			return Platform.GetNativeSize(view, widthConstraint, heightConstraint);
 		}

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -17,6 +17,9 @@ using NativeAutomationProperties = Windows.UI.Xaml.Automation.AutomationProperti
 namespace Xamarin.Forms.Platform.UWP
 {
 	public abstract class Platform : INavigation
+#pragma warning disable CS0618 // Type or member is obsolete
+		, IPlatform
+#pragma warning restore CS0618 // Type or member is obsolete
 	{
 		static Task<bool> s_currentAlert;
 
@@ -181,6 +184,11 @@ namespace Xamarin.Forms.Platform.UWP
 			return tcs.Task;
 		}
 
+		SizeRequest IPlatform.GetNativeSize(VisualElement element, double widthConstraint, double heightConstraint)
+		{
+			return Platform.GetNativeSize(element, widthConstraint, heightConstraint);
+		} 
+
 		public static SizeRequest GetNativeSize(VisualElement element, double widthConstraint, double heightConstraint)
 		{
 			// Hack around the fact that Canvas ignores the child constraints.
@@ -273,6 +281,12 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (newPage == _currentPage)
 				return;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			newPage.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (_currentPage != null)
 			{
@@ -517,5 +531,7 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 			e.Handled = BackButtonPressed();
 		}
+
+
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/Platform.cs
+++ b/Xamarin.Forms.Platform.WPF/Platform.cs
@@ -164,6 +164,13 @@ namespace Xamarin.Forms.Platform.WPF
 				return;
 
 			Page = newRoot;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			Page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			_page.StartupPage = Page;
 			Application.Current.NavigationProxy.Inner = this;
 		}
@@ -237,6 +244,13 @@ namespace Xamarin.Forms.Platform.WPF
 				throw new ArgumentNullException(nameof(page));
 
 			var tcs = new TaskCompletionSource<bool>();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+				// The Platform property is no longer necessary, but we have to set it because some third-party
+				// library might still be retrieving it and using it
+				page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			_page.PushModal(page, animated);
 			tcs.SetResult(true);
 			return tcs.Task;

--- a/Xamarin.Forms.Platform.WPF/Platform.cs
+++ b/Xamarin.Forms.Platform.WPF/Platform.cs
@@ -10,6 +10,9 @@ using Xamarin.Forms.Platform.WPF.Controls;
 namespace Xamarin.Forms.Platform.WPF
 {
 	public class Platform : BindableObject, INavigation
+#pragma warning disable CS0618
+		, IPlatform
+#pragma warning restore
 	{
 		readonly FormsApplicationPage _page;
 		Page Page { get; set; }
@@ -246,5 +249,14 @@ namespace Xamarin.Forms.Platform.WPF
 			tcs.SetResult(page); 
 			return tcs.Task;
 		}
+
+		#region Obsolete 
+
+		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		{
+			return GetNativeSize(view, widthConstraint, heightConstraint);
+		}
+
+		#endregion
 	}
 } 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -166,6 +166,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_modals.Add(modal);
 
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			modal.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			modal.DescendantRemoved += HandleChildRemoved;
 
 			if (_appeared)
@@ -245,6 +251,12 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_appeared == false)
 				return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+			// The Platform property is no longer necessary, but we have to set it because some third-party
+			// library might still be retrieving it and using it
+			Page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 			AddChild(Page);
 
 			Page.DescendantRemoved += HandleChildRemoved;
@@ -259,6 +271,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_renderer.View.BackgroundColor = UIColor.White;
 			_renderer.View.ContentMode = UIViewContentMode.Redraw;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+				// The Platform property is no longer necessary, but we have to set it because some third-party
+				// library might still be retrieving it and using it
+				Page.Platform = this;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			AddChild(Page);
 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -11,6 +11,9 @@ using RectangleF = CoreGraphics.CGRect;
 namespace Xamarin.Forms.Platform.iOS
 {
 	public class Platform : BindableObject, INavigation, IDisposable
+#pragma warning disable CS0618
+		, IPlatform
+#pragma warning restore
 	{
 		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer", typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),
 			propertyChanged: (bindable, oldvalue, newvalue) =>
@@ -487,5 +490,14 @@ namespace Xamarin.Forms.Platform.iOS
 				return result;
 			}
 		}
+
+		#region Obsolete 
+
+		SizeRequest IPlatform.GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
+		{
+			return GetNativeSize(view, widthConstraint, heightConstraint);
+		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Reinstate and obsolete various internals that were modified in 3.5.

### Issues Resolved ### 

- fixes https://github.com/xamarin/Xamarin.Forms/pull/4235#issuecomment-461511061

### API Changes ###

This, but in reverse: https://github.com/xamarin/Xamarin.Forms/pull/4235#issuecomment-461689943
 
### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable
