### PR TITLE
DetectPlatform Fixed for UWP

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -40,18 +40,22 @@ namespace Xamarin.Forms
 			Device.SetFlags(s_flags);
 			Device.Info = new WindowsDeviceInfo();
 
-			switch (DetectPlatform())
+			switch (Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily)
 			{
-				case Windows.Foundation.Metadata.Platform.Windows:
+				case "Windows.Desktop":
 					Device.SetIdiom(TargetIdiom.Desktop);
 					break;
-				case Windows.Foundation.Metadata.Platform.WindowsPhone:
+				case "Windows.Mobile":
 					Device.SetIdiom(TargetIdiom.Phone);
+					break;
+				case "Windows.Xbox":
+					Device.SetIdiom(TargetIdiom.TV);
 					break;
 				default:
 					Device.SetIdiom(TargetIdiom.Tablet);
 					break;
 			}
+
 			ExpressionSearch.Default = new WindowsExpressionSearch();
 
 			Registrar.ExtraAssemblies = rendererAssemblies?.ToArray();
@@ -63,16 +67,7 @@ namespace Xamarin.Forms
 
 			Platform.UWP.Platform.SubscribeAlertsAndActionSheets();
 		}
-
-		static Windows.Foundation.Metadata.Platform DetectPlatform()
-		{
-			bool isHardwareButtonsAPIPresent = ApiInformation.IsTypePresent("Windows.Phone.UI.Input.HardwareButtons");
-
-			if (isHardwareButtonsAPIPresent)
-				return Windows.Foundation.Metadata.Platform.WindowsPhone;
-			return Windows.Foundation.Metadata.Platform.Windows;
-		}
-
+		 
 		static FlowDirection GetFlowDirection()
 		{
 			string resourceFlowDirection = ResourceContext.GetForCurrentView().QualifierValues["LayoutDirection"];

--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Forms
 					Device.SetIdiom(TargetIdiom.TV);
 					break;
 				default:
-					Device.SetIdiom(TargetIdiom.Tablet);
+					Device.SetIdiom(TargetIdiom.Unsupported);
 					break;
 			}
 

--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -43,7 +43,11 @@ namespace Xamarin.Forms
 			switch (Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily)
 			{
 				case "Windows.Desktop":
-					Device.SetIdiom(TargetIdiom.Desktop);
+					if (Windows.UI.ViewManagement.UIViewSettings.GetForCurrentView().UserInteractionMode ==
+						Windows.UI.ViewManagement.UserInteractionMode.Touch)
+						Device.SetIdiom(TargetIdiom.Tablet);
+					else
+						Device.SetIdiom(TargetIdiom.Desktop);
 					break;
 				case "Windows.Mobile":
 					Device.SetIdiom(TargetIdiom.Phone);


### PR DESCRIPTION
…onInfo.DeviceFamily

UWP-Xbox sets TV...Surface tablets sets Desktop intead of Phone

### Description of Change ###

fixes #4852

### Issues Resolved ### 

Using previous code, it was missing platforms like Xbox which should be set as TV.
Beside that Surface tablet PCs were getting Idiom as phone. Because ApiInformation.IsTypePresent("Windows.Phone.UI.Input.HardwareButtons")  returns false for Surface. It supposed to be Desktop not Phone as confirmed in the msdn question below. Using DeviceFamily returns Desktop. 

https://social.msdn.microsoft.com/Forums/windowsapps/en-US/0b75ea16-1d2a-4997-bfa2-8cb6f73ff1e8/uwp-what-device-family-is-a-surface-tablet?forum=wpdevelop#39c5d17a-4706-4c24-b3c0-9b17ca60dd4f


- fixes #

### API Changes ###
Running UWP app on Xbox returns Idiom as TV, Surface returns as Desktop
 
### Platforms Affected ### 

- UWP
 