### PR TITLE
[Core] Incorrect increments in Stepper

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/StepperUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/StepperUnitTests.cs
@@ -144,6 +144,73 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True (fired);
 		}
 
+		[Test]
+		public void TestValueDecimalPlacesNotSet()
+		{
+			var stepper = new Stepper
+			{
+				Minimum = 0,
+				Maximum = 10,
+				Increment = 1.55
+			};
+
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(1.55, stepper.Value);
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(3.1, stepper.Value);
+		}
+
+		[Test]
+		public void TestValueDecimalPlacesSetTo0()
+		{
+			var stepper = new Stepper
+			{
+				Minimum = 0,
+				Maximum = 10,
+				Increment = 1.55,
+				DecimalPlaces = 0
+			};
+
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(2, stepper.Value);
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(4, stepper.Value);
+		}
+
+		[Test]
+		public void TestValueDecimalPlacesSetTo1()
+		{
+			var stepper = new Stepper
+			{
+				Minimum = 0,
+				Maximum = 10,
+				Increment = 1.55,
+				DecimalPlaces = 1
+			};
+
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(1.6, stepper.Value);
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(3.2, stepper.Value);
+		}
+
+		[Test]
+		public void TestValueDecimalPlacesSetToIntMax()
+		{
+			var stepper = new Stepper
+			{
+				Minimum = 0,
+				Maximum = 10,
+				Increment = 1.55,
+				DecimalPlaces = int.MaxValue
+			};
+
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(1.55, stepper.Value);
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(3.1, stepper.Value);
+		}
+
 		[TestCase (100.0, 0.5)]
 		[TestCase (10.0, 25.0)]
 		[TestCase (0, 39.5)]

--- a/Xamarin.Forms.Core/Stepper.cs
+++ b/Xamarin.Forms.Core/Stepper.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms
 			var stepper = (Stepper)bindable;
 			var clampedValue = ((double)value).Clamp(stepper.Minimum, stepper.Maximum);
 			var decimalPlaces = stepper.DecimalPlaces;
-			return decimalPlaces >= 0 && decimalPlaces <= 15
+			return decimalPlaces >= 0
 				? Math.Round(clampedValue, decimalPlaces)
 				: clampedValue;
 		}, propertyChanged: (bindable, oldValue, newValue) =>

--- a/Xamarin.Forms.Core/Stepper.cs
+++ b/Xamarin.Forms.Core/Stepper.cs
@@ -32,7 +32,11 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty ValueProperty = BindableProperty.Create("Value", typeof(double), typeof(Stepper), 0.0, BindingMode.TwoWay, coerceValue: (bindable, value) =>
 		{
 			var stepper = (Stepper)bindable;
-			return Math.Round(((double)value).Clamp(stepper.Minimum, stepper.Maximum), stepper.ValueRoundDigits);
+			var clampedValue = ((double)value).Clamp(stepper.Minimum, stepper.Maximum);
+			var decimalPlaces = stepper.DecimalPlaces;
+			return decimalPlaces >= 0 && decimalPlaces <= 15
+				? Math.Round(clampedValue, decimalPlaces)
+				: clampedValue;
 		}, propertyChanged: (bindable, oldValue, newValue) =>
 		{
 			var stepper = (Stepper)bindable;
@@ -43,7 +47,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty IncrementProperty = BindableProperty.Create("Increment", typeof(double), typeof(Stepper), 1.0);
 
-		public static readonly BindableProperty ValueRoundDigitsProperty = BindableProperty.Create("ValueRoundDigits", typeof(int), typeof(Stepper), 10);
+		public static readonly BindableProperty DecimalPlacesProperty = BindableProperty.Create("DecimalPlaces", typeof(int), typeof(Stepper), -1);
 
 		readonly Lazy<PlatformConfigurationRegistry<Stepper>> _platformConfigurationRegistry;
 
@@ -77,10 +81,10 @@ namespace Xamarin.Forms
 			set { SetValue(IncrementProperty, value); }
 		}
 
-		public int ValueRoundDigits
+		public int DecimalPlaces
 		{
-			get { return (int)GetValue(ValueRoundDigitsProperty); }
-			set { SetValue(ValueRoundDigitsProperty, value); }
+			get { return (int)GetValue(DecimalPlacesProperty); }
+			set { SetValue(DecimalPlacesProperty, value); }
 		}
 
 		public double Maximum

--- a/Xamarin.Forms.Core/Stepper.cs
+++ b/Xamarin.Forms.Core/Stepper.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms
 			var clampedValue = ((double)value).Clamp(stepper.Minimum, stepper.Maximum);
 			var decimalPlaces = stepper.DecimalPlaces;
 			return decimalPlaces >= 0
-				? Math.Round(clampedValue, decimalPlaces)
+				? Math.Round(clampedValue, Math.Min(decimalPlaces, 15)) // double has 15 decimal places. But we don't want to throw exception even though user set DecimalPlaces > 15
 				: clampedValue;
 		}, propertyChanged: (bindable, oldValue, newValue) =>
 		{

--- a/Xamarin.Forms.Core/Stepper.cs
+++ b/Xamarin.Forms.Core/Stepper.cs
@@ -32,11 +32,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty ValueProperty = BindableProperty.Create("Value", typeof(double), typeof(Stepper), 0.0, BindingMode.TwoWay, coerceValue: (bindable, value) =>
 		{
 			var stepper = (Stepper)bindable;
-			var result = ((double)value).Clamp(stepper.Minimum, stepper.Maximum);
-			var increment = stepper.Increment;
-			return Math.Abs(increment) > double.Epsilon
-				? Math.Round(result / increment) * increment
-				: result;
+			return Math.Round(((double)value).Clamp(stepper.Minimum, stepper.Maximum), stepper.ValueRoundDigits);
 		}, propertyChanged: (bindable, oldValue, newValue) =>
 		{
 			var stepper = (Stepper)bindable;
@@ -46,6 +42,8 @@ namespace Xamarin.Forms
 		});
 
 		public static readonly BindableProperty IncrementProperty = BindableProperty.Create("Increment", typeof(double), typeof(Stepper), 1.0);
+
+		public static readonly BindableProperty ValueRoundDigitsProperty = BindableProperty.Create("ValueRoundDigits", typeof(int), typeof(Stepper), 10);
 
 		readonly Lazy<PlatformConfigurationRegistry<Stepper>> _platformConfigurationRegistry;
 
@@ -77,6 +75,12 @@ namespace Xamarin.Forms
 		{
 			get { return (double)GetValue(IncrementProperty); }
 			set { SetValue(IncrementProperty, value); }
+		}
+
+		public int ValueRoundDigits
+		{
+			get { return (int)GetValue(ValueRoundDigitsProperty); }
+			set { SetValue(ValueRoundDigitsProperty, value); }
 		}
 
 		public double Maximum

--- a/Xamarin.Forms.Core/Stepper.cs
+++ b/Xamarin.Forms.Core/Stepper.cs
@@ -32,7 +32,11 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty ValueProperty = BindableProperty.Create("Value", typeof(double), typeof(Stepper), 0.0, BindingMode.TwoWay, coerceValue: (bindable, value) =>
 		{
 			var stepper = (Stepper)bindable;
-			return ((double)value).Clamp(stepper.Minimum, stepper.Maximum);
+			var result = ((double)value).Clamp(stepper.Minimum, stepper.Maximum);
+			var increment = stepper.Increment;
+			return Math.Abs(increment) > double.Epsilon
+				? Math.Round(result / increment) * increment
+				: result;
 		}, propertyChanged: (bindable, oldValue, newValue) =>
 		{
 			var stepper = (Stepper)bindable;


### PR DESCRIPTION
### Description of Change ###

Stepper control with a small increment may sets incorrect value.
So we need to avoid values which aren't in STEP (Increment) sequence.

### Issues Resolved ### 

- fixes #5168 

### API Changes ###

None

### Platforms Affected ### 
- Core

### Behavioral/Visual Changes ###
Stepper works properly with small Increment value

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

* run Control Gallery > Stepper Gallery - Legacy
* click 3 times on latest `+` button
* click 3 times on `-` button

