### PR TITLE
[Material] [Android, iOS] Added Slider and ProgressBar

### DIFF
--- a/Xamarin.Forms.Controls/Controls/ColorPicker.cs
+++ b/Xamarin.Forms.Controls/Controls/ColorPicker.cs
@@ -1,0 +1,171 @@
+using System;
+
+namespace Xamarin.Forms.Controls
+{
+	public class ColorPicker : ContentView
+	{
+		public static readonly BindableProperty UseDefaultProperty = BindableProperty.Create(nameof(UseDefault), typeof(bool), typeof(ColorPicker), false,
+			propertyChanged: OnColorChanged);
+
+		public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(ColorPicker), Color.Default,
+			propertyChanged: OnColorChanged);
+
+		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(ColorPicker), "Pick a color:",
+			propertyChanged: OnTitleChanged);
+
+		static readonly string[] _components = { "R", "G", "B", "A" };
+
+		Label _titleLabel;
+		Slider[] _sliders;
+		BoxView _box;
+		Label _hexLabel;
+		Switch _useDefault;
+
+		public ColorPicker()
+		{
+			var grid = new Grid
+			{
+				Padding = 0,
+				RowSpacing = 3,
+				ColumnSpacing = 3,
+				ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = 20 },
+					new ColumnDefinition { Width = GridLength.Star },
+					new ColumnDefinition { Width = 60 },
+				},
+			};
+
+			_titleLabel = new Label { Text = (string)TitleProperty.DefaultValue };
+			grid.AddChild(_titleLabel, 0, 0, 2);
+
+			_useDefault = new Switch
+			{
+				IsToggled = true,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+			_useDefault.Toggled += OnUseDefaultToggled;
+			grid.AddChild(_useDefault, 2, 0);
+
+			_sliders = new Slider[_components.Length];
+			for (var i = 0; i < _components.Length; i++)
+			{
+				_sliders[i] = new Slider
+				{
+					VerticalOptions = LayoutOptions.Center,
+					Minimum = 0,
+					Maximum = 255,
+					Value = 255
+				};
+				_sliders[i].ValueChanged += OnColorSliderChanged;
+				var label = new Label
+				{
+					Text = _components[i],
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center
+				};
+				grid.AddChild(label, 0, i + 1);
+				grid.AddChild(_sliders[i], 1, i + 1);
+			}
+
+			_box = new BoxView
+			{
+				Color = Color,
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+			};
+			grid.AddChild(_box, 2, 1, 1, 3);
+
+			_hexLabel = new Label
+			{
+				Text = ColorToHex(Color),
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				FontSize = 10,
+			};
+			grid.AddChild(_hexLabel, 2, 4);
+
+			Content = grid;
+		}
+
+		public string Title
+		{
+			get => (string)GetValue(TitleProperty);
+			set => SetValue(TitleProperty, value);
+		}
+
+		public bool UseDefault
+		{
+			get => (bool)GetValue(UseDefaultProperty);
+			set => SetValue(UseDefaultProperty, value);
+		}
+
+		public Color Color
+		{
+			get => (Color)GetValue(ColorProperty);
+			set => SetValue(ColorProperty, value);
+		}
+
+		public event EventHandler<ColorPickedEventArgs> ColorPicked;
+
+		void OnColorSliderChanged(object sender, ValueChangedEventArgs e)
+		{
+			var color = Color.FromRgba(
+				(int)_sliders[0].Value,
+				(int)_sliders[1].Value,
+				(int)_sliders[2].Value,
+				(int)_sliders[3].Value);
+			Color = color;
+		}
+
+		private void OnUseDefaultToggled(object sender, ToggledEventArgs e)
+		{
+			UseDefault = !e.Value;
+
+			foreach (var slider in _sliders)
+				slider.IsEnabled = e.Value;
+		}
+
+		static void OnColorChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is ColorPicker picker)
+			{
+				var color = picker.UseDefault ? Color.Default : picker.Color;
+				picker._hexLabel.Text = color.IsDefault ? "<default>" : ColorToHex(color);
+				picker._box.Color = color;
+				picker.ColorPicked?.Invoke(picker, new ColorPickedEventArgs(color));
+			}
+		}
+
+		static void OnTitleChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is ColorPicker picker)
+			{
+				picker._titleLabel.Text = picker.Title;
+			}
+		}
+
+		static string ColorToHex(Color color)
+		{
+			var a = (int)(color.A * 255);
+			var r = (int)(color.R * 255);
+			var g = (int)(color.G * 255);
+			var b = (int)(color.B * 255);
+
+			var value = a << 24 | r << 16 | g << 8 | b;
+
+			return "#" + value.ToString("X");
+		}
+	}
+
+	public class ColorPickedEventArgs : EventArgs
+	{
+		public ColorPickedEventArgs(Color color)
+		{
+			Color = color;
+		}
+
+		public Color Color { get; }
+	}
+}

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -321,6 +321,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new OpenGLViewCoreGalleryPage(), "OpenGLView Gallery"),
 				new GalleryPageFactory(() => new PickerCoreGalleryPage(), "Picker Gallery"),
 				new GalleryPageFactory(() => new ProgressBarCoreGalleryPage(), "ProgressBar Gallery"),
+				new GalleryPageFactory(() => new MaterialProgressBarGallery(), "[Material] ProgressBar Gallery"),
 				new GalleryPageFactory(() => new ScrollGallery(), "ScrollView Gallery"),
 				new GalleryPageFactory(() => new ScrollGallery(ScrollOrientation.Horizontal), "ScrollView Gallery Horizontal"),
 				new GalleryPageFactory(() => new ScrollGallery(ScrollOrientation.Both), "ScrollView Gallery 2D"),

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -321,7 +321,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new OpenGLViewCoreGalleryPage(), "OpenGLView Gallery"),
 				new GalleryPageFactory(() => new PickerCoreGalleryPage(), "Picker Gallery"),
 				new GalleryPageFactory(() => new ProgressBarCoreGalleryPage(), "ProgressBar Gallery"),
-				new GalleryPageFactory(() => new MaterialProgressBarGallery(), "[Material] ProgressBar Gallery"),
+				new GalleryPageFactory(() => new MaterialProgressBarGallery(), "[Material] ProgressBar & Slider Gallery"),
 				new GalleryPageFactory(() => new ScrollGallery(), "ScrollView Gallery"),
 				new GalleryPageFactory(() => new ScrollGallery(ScrollOrientation.Horizontal), "ScrollView Gallery Horizontal"),
 				new GalleryPageFactory(() => new ScrollGallery(ScrollOrientation.Both), "ScrollView Gallery 2D"),

--- a/Xamarin.Forms.Controls/GalleryPages/MaterialProgressBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MaterialProgressBarGallery.cs
@@ -1,0 +1,102 @@
+﻿namespace Xamarin.Forms.Controls
+{
+	public class MaterialProgressBarGallery : ContentPage
+	{
+		public MaterialProgressBarGallery()
+		{
+			Visual = VisualMarker.Material;
+
+			var progressBar = new ProgressBar();
+
+			Slider[] ColorSlider =
+			{
+				new Slider(0, 1, 0.5),
+				new Slider(0, 1, 0.5),
+				new Slider(0, 1, 0.5),
+				new Slider(0, 1, 0.5)
+			};
+			Slider[] BackColorSlider =
+			{
+				new Slider(0, 1, 0.5),
+				new Slider(0, 1, 0.5),
+				new Slider(0, 1, 0.5),
+				new Slider(0, 1, 0.5)
+			};
+
+			var actions = new Grid()
+			{
+				ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = 10 },
+					new ColumnDefinition { Width = GridLength.Star },
+					new ColumnDefinition { Width = 30 },
+					new ColumnDefinition { Width = 10 },
+					new ColumnDefinition { Width = GridLength.Star },
+					new ColumnDefinition { Width = 30 },
+				}
+			};
+
+			actions.AddChild(new Label { Text = "Primary color" }, 0, 0, 3);
+			for (int i = 0; i < ColorSlider.Length; i++)
+			{
+				var valueLabel = new Label();
+				ColorSlider[i].ValueChanged += (_, e) =>
+				{
+					progressBar.ProgressColor = Color.FromRgba(ColorSlider[0].Value, ColorSlider[1].Value, ColorSlider[2].Value, ColorSlider[3].Value);
+					valueLabel.Text = ((int)(e.NewValue * 255)).ToString();
+				};
+				actions.AddChild(new Label { Text = GetColorLetter(i) }, 0, i + 1);
+				actions.AddChild(ColorSlider[i], 1, i + 1);
+				actions.AddChild(valueLabel, 2, i + 1);
+			}
+
+			actions.AddChild(new Label { Text = "Background color" }, 3, 0, 3);
+			for (int i = 0; i < BackColorSlider.Length; i++)
+			{
+				var valueLabel = new Label();
+				BackColorSlider[i].ValueChanged += (_, e) =>
+				{
+					progressBar.BackgroundColor = Color.FromRgba(BackColorSlider[0].Value, BackColorSlider[1].Value, BackColorSlider[2].Value, BackColorSlider[3].Value);
+					valueLabel.Text = ((int)(e.NewValue * 255)).ToString();
+				};
+				actions.AddChild(new Label { Text = GetColorLetter(i) }, 3, i + 1);
+				actions.AddChild(BackColorSlider[i], 4, i + 1);
+				actions.AddChild(valueLabel, 5, i + 1);
+			}
+
+			var valueSlider = new Slider(0, 1, progressBar.Progress);
+			valueSlider.ValueChanged += (_, e) => progressBar.Progress = e.NewValue;
+			actions.AddChild(new Label { Text = "Value" }, 0, 5, 6);
+			actions.AddChild(valueSlider, 0, 6, 6);
+
+			var heightSlider = new Slider(0, 100, 4);
+			heightSlider.ValueChanged += (_, e) => progressBar.HeightRequest = e.NewValue;
+			actions.AddChild(new Label { Text = "HeightRequest" }, 0, 7, 6);
+			actions.AddChild(heightSlider, 0, 8, 6);
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					actions,
+					progressBar
+				}
+			};
+		}
+
+		string GetColorLetter(int index)
+		{
+			switch (index)
+			{
+				case 0:
+					return "R";
+				case 1:
+					return "G";
+				case 2:
+					return "B";
+				default:
+					return "A";
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/MaterialProgressBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MaterialProgressBarGallery.cs
@@ -1,4 +1,6 @@
-﻿namespace Xamarin.Forms.Controls
+using System;
+
+namespace Xamarin.Forms.Controls
 {
 	public class MaterialProgressBarGallery : ContentPage
 	{
@@ -6,97 +8,111 @@
 		{
 			Visual = VisualMarker.Material;
 
-			var progressBar = new ProgressBar();
+			var progressBar = new ProgressBar { Progress = 0.5 };
+			var slider = new Slider { Value = 0.5 };
 
-			Slider[] ColorSlider =
+			var primaryPicker = new ColorPicker { Title = "Primary Color" };
+			primaryPicker.ColorPicked += (_, e) =>
 			{
-				new Slider(0, 1, 0.5),
-				new Slider(0, 1, 0.5),
-				new Slider(0, 1, 0.5),
-				new Slider(0, 1, 0.5)
+				progressBar.ProgressColor = e.Color;
+				slider.MinimumTrackColor = e.Color;
 			};
-			Slider[] BackColorSlider =
+			var backgroundPicker = new ColorPicker { Title = "Background Color" };
+			backgroundPicker.ColorPicked += (_, e) =>
 			{
-				new Slider(0, 1, 0.5),
-				new Slider(0, 1, 0.5),
-				new Slider(0, 1, 0.5),
-				new Slider(0, 1, 0.5)
+				progressBar.BackgroundColor = e.Color;
+				slider.MaximumTrackColor = e.Color;
 			};
-
-			var actions = new Grid()
+			var thumbPicker = new ColorPicker { Title = "Thumb Color" };
+			thumbPicker.ColorPicked += (_, e) =>
 			{
-				ColumnDefinitions =
-				{
-					new ColumnDefinition { Width = 10 },
-					new ColumnDefinition { Width = GridLength.Star },
-					new ColumnDefinition { Width = 30 },
-					new ColumnDefinition { Width = 10 },
-					new ColumnDefinition { Width = GridLength.Star },
-					new ColumnDefinition { Width = 30 },
-				}
+				slider.ThumbColor = e.Color;
 			};
 
-			actions.AddChild(new Label { Text = "Primary color" }, 0, 0, 3);
-			for (int i = 0; i < ColorSlider.Length; i++)
+			var valuePicker = CreateValuePicker("Value / Progress", value =>
 			{
-				var valueLabel = new Label();
-				ColorSlider[i].ValueChanged += (_, e) =>
-				{
-					progressBar.ProgressColor = Color.FromRgba(ColorSlider[0].Value, ColorSlider[1].Value, ColorSlider[2].Value, ColorSlider[3].Value);
-					valueLabel.Text = ((int)(e.NewValue * 255)).ToString();
-				};
-				actions.AddChild(new Label { Text = GetColorLetter(i) }, 0, i + 1);
-				actions.AddChild(ColorSlider[i], 1, i + 1);
-				actions.AddChild(valueLabel, 2, i + 1);
-			}
-
-			actions.AddChild(new Label { Text = "Background color" }, 3, 0, 3);
-			for (int i = 0; i < BackColorSlider.Length; i++)
+				progressBar.Progress = value / 100.0;
+				slider.Value = value / 100.0;
+			});
+			var heightPicker = CreateValuePicker("Height", value =>
 			{
-				var valueLabel = new Label();
-				BackColorSlider[i].ValueChanged += (_, e) =>
-				{
-					progressBar.BackgroundColor = Color.FromRgba(BackColorSlider[0].Value, BackColorSlider[1].Value, BackColorSlider[2].Value, BackColorSlider[3].Value);
-					valueLabel.Text = ((int)(e.NewValue * 255)).ToString();
-				};
-				actions.AddChild(new Label { Text = GetColorLetter(i) }, 3, i + 1);
-				actions.AddChild(BackColorSlider[i], 4, i + 1);
-				actions.AddChild(valueLabel, 5, i + 1);
-			}
-
-			var valueSlider = new Slider(0, 1, progressBar.Progress);
-			valueSlider.ValueChanged += (_, e) => progressBar.Progress = e.NewValue;
-			actions.AddChild(new Label { Text = "Value" }, 0, 5, 6);
-			actions.AddChild(valueSlider, 0, 6, 6);
-
-			var heightSlider = new Slider(0, 100, 4);
-			heightSlider.ValueChanged += (_, e) => progressBar.HeightRequest = e.NewValue;
-			actions.AddChild(new Label { Text = "HeightRequest" }, 0, 7, 6);
-			actions.AddChild(heightSlider, 0, 8, 6);
+				progressBar.HeightRequest = value;
+				slider.HeightRequest = value;
+			});
 
 			Content = new StackLayout
 			{
+				Padding = 10,
+				Spacing = 10,
 				Children =
 				{
-					actions,
-					progressBar
+					new ScrollView
+					{
+						Margin = new Thickness(-10, 0),
+						Content = new StackLayout
+						{
+							Padding = 10,
+							Spacing = 10,
+							Children =
+							{
+								primaryPicker,
+								backgroundPicker,
+								thumbPicker,
+								valuePicker,
+								heightPicker,
+							}
+						}
+					},
+
+					new BoxView
+					{
+						HeightRequest = 1,
+						Margin = new Thickness(-10, 0),
+						Color = Color.Black
+					},
+
+					progressBar,
+					slider
 				}
 			};
 		}
 
-		string GetColorLetter(int index)
+		Grid CreateValuePicker(string title, Action<double> changed)
 		{
-			switch (index)
+			// 50%
+			Slider slider = new Slider(0, 100, 50);
+
+			var actions = new Grid
 			{
-				case 0:
-					return "R";
-				case 1:
-					return "G";
-				case 2:
-					return "B";
-				default:
-					return "A";
-			}
+				Padding = 0,
+				ColumnSpacing = 6,
+				RowSpacing = 6,
+				ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = 10 },
+					new ColumnDefinition { Width = GridLength.Star },
+					new ColumnDefinition { Width = 30 }
+				}
+			};
+
+			actions.AddChild(new Label { Text = title }, 0, 0, 3);
+
+			var valueLabel = new Label
+			{
+				Text = slider.Value.ToString(),
+				HorizontalOptions = LayoutOptions.End
+			};
+
+			slider.ValueChanged += (_, e) =>
+			{
+				changed?.Invoke(slider.Value);
+				valueLabel.Text = e.NewValue.ToString("0");
+			};
+			actions.AddChild(new Label { Text = "V" }, 0, 1);
+			actions.AddChild(slider, 1, 1);
+			actions.AddChild(valueLabel, 2, 1);
+
+			return actions;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Slider.cs
+++ b/Xamarin.Forms.Core/Slider.cs
@@ -38,9 +38,7 @@ namespace Xamarin.Forms
 		}, propertyChanged: (bindable, oldValue, newValue) =>
 		{
 			var slider = (Slider)bindable;
-			EventHandler<ValueChangedEventArgs> eh = slider.ValueChanged;
-			if (eh != null)
-				eh(slider, new ValueChangedEventArgs((double)oldValue, (double)newValue));
+			slider.ValueChanged?.Invoke(slider, new ValueChangedEventArgs((double)oldValue, (double)newValue));
 		});
 
 		public static readonly BindableProperty MinimumTrackColorProperty = BindableProperty.Create(nameof(MinimumTrackColor), typeof(Color), typeof(Slider), Color.Default);

--- a/Xamarin.Forms.Material.iOS/MaterialProgressBarRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialProgressBarRenderer.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.iOS.Material
 {
 	public class MaterialProgressBarRenderer : ViewRenderer<ProgressBar, MProgressView>
 	{
-		const float BackgroundAlpha = 0.3f;
+		const float BackgroundAlpha = 0.6f;
 
 		BasicColorScheme _defaultColorScheme;
 		BasicColorScheme _colorScheme;

--- a/Xamarin.Forms.Material.iOS/MaterialProgressBarRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialProgressBarRenderer.cs
@@ -10,8 +10,6 @@ namespace Xamarin.Forms.Platform.iOS.Material
 {
 	public class MaterialProgressBarRenderer : ViewRenderer<ProgressBar, MProgressView>
 	{
-		const float BackgroundAlpha = 0.6f;
-
 		BasicColorScheme _defaultColorScheme;
 		BasicColorScheme _colorScheme;
 
@@ -51,7 +49,7 @@ namespace Xamarin.Forms.Platform.iOS.Material
 			var cs = MaterialColors.Light.CreateColorScheme();
 			return new BasicColorScheme(
 				cs.PrimaryColor,
-				cs.PrimaryColor.ColorWithAlpha(BackgroundAlpha),
+				cs.PrimaryColor.ColorWithAlpha(MaterialColors.SliderTrackAlpha),
 				cs.PrimaryColor);
 		}
 
@@ -123,9 +121,6 @@ namespace Xamarin.Forms.Platform.iOS.Material
 
 		void UpdateAllColors()
 		{
-			// TODO: Fix this once Google implements the new way.
-			//       Right now, copy what is done with the activity indicator.
-
 			Color progressColor = Element.ProgressColor;
 			Color backgroundColor = Element.BackgroundColor;
 
@@ -144,8 +139,6 @@ namespace Xamarin.Forms.Platform.iOS.Material
 					// handle the case where only the background is set
 					var background = backgroundColor.ToUIColor();
 
-					// TODO: Potentially override background alpha to match material design.
-					// TODO: Potentially override primary color to match material design.
 					_colorScheme = new BasicColorScheme(
 						_defaultColorScheme.PrimaryColor,
 						background,
@@ -160,9 +153,10 @@ namespace Xamarin.Forms.Platform.iOS.Material
 					// handle the case where only the progress is set
 					var progress = progressColor.ToUIColor();
 
+					progress.GetRGBA(out _, out _, out _, out var alpha);
 					_colorScheme = new BasicColorScheme(
 						progress,
-						progress.ColorWithAlpha(BackgroundAlpha),
+						progress.ColorWithAlpha(alpha * MaterialColors.SliderTrackAlpha),
 						progress);
 				}
 				else
@@ -171,7 +165,6 @@ namespace Xamarin.Forms.Platform.iOS.Material
 					var background = backgroundColor.ToUIColor();
 					var progress = progressColor.ToUIColor();
 
-					// TODO: Potentially override alpha to match material design.
 					_colorScheme = new BasicColorScheme(
 						progress,
 						background,

--- a/Xamarin.Forms.Material.iOS/MaterialSliderRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialSliderRenderer.cs
@@ -141,15 +141,19 @@ namespace Xamarin.Forms.Platform.iOS.Material
 			if (minColor.IsDefault && maxColor.IsDefault && thumbColor.IsDefault)
 				return;
 
-			// TODO: Potentially override alpha to match material design.
-
 			if (!minColor.IsDefault)
 			{
 				Control.SetTrackFillColor(minColor.ToUIColor(), UIControlState.Normal);
 
 				// if no max color was specified, then use a shade of the min
 				if (maxColor.IsDefault)
-					Control.SetTrackBackgroundColor(MatchAlpha(minColor, Control.GetTrackBackgroundColor(UIControlState.Normal)), UIControlState.Normal);
+				{
+					Control.GetTrackBackgroundColor(UIControlState.Normal).GetRGBA(out _, out _, out _, out var baseAlpha);
+					Control.SetTrackBackgroundColor(minColor.MultiplyAlpha(baseAlpha).ToUIColor(), UIControlState.Normal);
+				}
+
+				if (thumbColor.IsDefault)
+					Control.SetThumbColor(minColor.ToUIColor(), UIControlState.Normal);
 			}
 
 			if (!maxColor.IsDefault)
@@ -157,12 +161,6 @@ namespace Xamarin.Forms.Platform.iOS.Material
 
 			if (!thumbColor.IsDefault)
 				Control.SetThumbColor(thumbColor.ToUIColor(), UIControlState.Normal);
-
-			UIColor MatchAlpha(Color color, UIColor alphaColor)
-			{
-				alphaColor.GetRGBA(out _, out _, out _, out var a);
-				return color.ToUIColor().ColorWithAlpha(a);
-			}
 		}
 
 		void OnControlValueChanged(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.Android/Resources/color/white_disabled_material.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/color/white_disabled_material.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@android:color/white"
+          android:alpha="?android:attr/disabledAlpha" />
+</selector>

--- a/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialProgressBar.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialProgressBar.xml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+From original drawable https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/res/res/drawable/progress_horizontal_material.xml
+with removed rounded corners.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:id="@android:id/background"
+        android:gravity="center_vertical|fill_horizontal">
+    <shape android:shape="rectangle"
+           android:tint="#000">
+      <corners android:radius="0dp" />
+      <solid android:color="#000" />
+    </shape>
+  </item>
+  <item android:id="@android:id/secondaryProgress"
+        android:gravity="center_vertical|fill_horizontal">
+    <scale android:scaleWidth="100%">
+      <shape android:shape="rectangle"
+             android:tint="#000">
+        <corners android:radius="0dp" />
+        <solid android:color="#000" />
+      </shape>
+    </scale>
+  </item>
+  <item android:id="@android:id/progress"
+        android:gravity="center_vertical|fill_horizontal">
+    <scale android:scaleWidth="100%">
+      <shape android:shape="rectangle"
+             android:tint="#000">
+        <corners android:radius="0dp" />
+        <solid android:color="#000" />
+      </shape>
+    </scale>
+  </item>
+</layer-list>

--- a/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialProgressBar.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialProgressBar.xml
@@ -1,35 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- 
 From original drawable https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/res/res/drawable/progress_horizontal_material.xml
-with removed rounded corners.
+with removed rounded corners. And, following some of the drawable/color links.
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:id="@android:id/background"
-        android:gravity="center_vertical|fill_horizontal">
-    <shape android:shape="rectangle"
-           android:tint="#000">
-      <corners android:radius="0dp" />
-      <solid android:color="#000" />
-    </shape>
-  </item>
-  <item android:id="@android:id/secondaryProgress"
-        android:gravity="center_vertical|fill_horizontal">
-    <scale android:scaleWidth="100%">
-      <shape android:shape="rectangle"
-             android:tint="#000">
-        <corners android:radius="0dp" />
-        <solid android:color="#000" />
-      </shape>
-    </scale>
-  </item>
-  <item android:id="@android:id/progress"
-        android:gravity="center_vertical|fill_horizontal">
-    <scale android:scaleWidth="100%">
-      <shape android:shape="rectangle"
-             android:tint="#000">
-        <corners android:radius="0dp" />
-        <solid android:color="#000" />
-      </shape>
-    </scale>
-  </item>
+    <item android:id="@android:id/background"
+          android:gravity="center_vertical|fill_horizontal">
+        <shape android:shape="rectangle"
+               android:tint="?android:attr/colorControlNormal">
+            <corners android:radius="0dp" />
+            <solid android:color="@color/white_disabled_material" />
+        </shape>
+    </item>
+    <item android:id="@android:id/secondaryProgress"
+          android:gravity="center_vertical|fill_horizontal">
+        <scale android:scaleWidth="100%">
+            <shape android:shape="rectangle"
+                   android:tint="?android:attr/colorControlActivated">
+                <corners android:radius="0dp" />
+                <solid android:color="@color/white_disabled_material" />
+            </shape>
+        </scale>
+    </item>
+    <item android:id="@android:id/progress"
+          android:gravity="center_vertical|fill_horizontal">
+        <scale android:scaleWidth="100%">
+            <shape android:shape="rectangle"
+                   android:tint="?android:attr/colorControlActivated">
+                <corners android:radius="0dp" />
+                <solid android:color="@android:color/white" />
+            </shape>
+        </scale>
+    </item>
 </layer-list>

--- a/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
@@ -6,6 +6,10 @@
     <item name="materialButtonStyle">@style/XamarinFormsMaterialButton</item>
   </style>
 
+  <!-- Material Sliders -->
+  <style name="XamarinFormsMaterialSlider" parent="Widget.AppCompat.SeekBar">
+  </style>
+
   <!-- Material Progress Bars -->
   <style name="XamarinFormsMaterialProgressBarHorizontal" parent="Widget.AppCompat.ProgressBar.Horizontal">
     <item name="android:indeterminateOnly">false</item>
@@ -14,6 +18,7 @@
   <style name="XamarinFormsMaterialProgressBarCircular" parent="Widget.AppCompat.ProgressBar">
     <item name="android:background">@drawable/MaterialActivityIndicatorBackground</item>
   </style>
+
   <!-- Material Buttons (All Styles) -->
   <style name="XamarinFormsMaterialButton" parent="Widget.MaterialComponents.Button">
     <item name="android:insetTop">0dp</item>
@@ -25,4 +30,5 @@
   <style name="XamarinFormsMaterialEntryFilled" parent="Widget.MaterialComponents.TextInputLayout.FilledBox">
     <item name="boxCollapsedPaddingTop">8dp</item>
   </style>
+
 </resources>

--- a/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
@@ -8,6 +8,8 @@
 
   <!-- Material Progress Bars -->
   <style name="XamarinFormsMaterialProgressBarHorizontal" parent="Widget.AppCompat.ProgressBar.Horizontal">
+    <item name="android:indeterminateOnly">false</item>
+    <item name="android:progressDrawable">@drawable/MaterialProgressBar</item>
   </style>
   <style name="XamarinFormsMaterialProgressBarCircular" parent="Widget.AppCompat.ProgressBar">
     <item name="android:background">@drawable/MaterialActivityIndicatorBackground</item>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -313,6 +313,8 @@
     <Compile Include="ButtonElementManager.cs" />
     <Compile Include="IButtonLayoutRenderer.cs" />
     <Compile Include="ButtonLayoutManager.cs" />
+    <Compile Include="Material\MaterialSliderRenderer.cs" />
+    <AndroidResource Include="Resources\color\white_disabled_material.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
@@ -405,6 +407,9 @@
     <AndroidResource Include="Resources\drawable\MaterialProgressBar.xml">
       <SubType>Designer</SubType>
     </AndroidResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\color\" />
   </ItemGroup>
   <Target Name="BeforeBuild" Condition=" '$(CreateAllAndroidTargets)' == 'true' ">
     <!--  create 8.1 binaries-->

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -401,6 +401,11 @@
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\drawable\MaterialProgressBar.xml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
   <Target Name="BeforeBuild" Condition=" '$(CreateAllAndroidTargets)' == 'true' ">
     <!--  create 8.1 binaries-->
     <MSBuild Targets="Restore" Projects="@(ProjectToBuild)">


### PR DESCRIPTION
### Description of Change ###

Added the Material versions of the ProgressBar and Slider.

### Issues Resolved ### 

 - fixes #5008 
 - fixes #5079 
 - fixes #5018 

### API Changes ###

Added the Material renderers for Slider and ProgressBar for Android and iOS.

The rules for the coloring are as follows:

 - All default colors, then use the defaults
 - A single color for `ProgressBar.ProgressColor` or `Slider.MinimumTrackColor`, then follow material: a single color throughout (including the slider thumb), but the background has an alpha
 - A single background color for `ProgressBar.BackgroundColor` or `Slider.MaximumTrackColor`, then just set the background color
 - Both progress and background, then throw material out and set colors explicitly
 - A default slider thumb, then fall back to the primary color
 - A specific thumb, then use that explicitly

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

New Material renderers.

### Before/After Screenshots ### 

|   |  Android  |  iOS  |
|-:| :-: | :-: |
| Defaults | <img src="https://user-images.githubusercontent.com/1096616/52608751-8a749380-2e83-11e9-95d7-494284d6ed50.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1096616/52608763-919ba180-2e83-11e9-934d-b7ccd2a84095.png" width="300" /> |
| Height of 50 | <img src="https://user-images.githubusercontent.com/1096616/52608752-8a749380-2e83-11e9-86f9-d1bfcdbb3386.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1096616/52608764-919ba180-2e83-11e9-90be-c6007ab17f46.png" width="300" /> |
| Primary color of Red | <img src="https://user-images.githubusercontent.com/1096616/52608753-8a749380-2e83-11e9-959c-1b6bb9aaa9c5.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1096616/52608765-92343800-2e83-11e9-968d-d3e4bfe8b207.png" width="300" /> |
| Primary and Background | <img src="https://user-images.githubusercontent.com/1096616/52608754-8b0d2a00-2e83-11e9-82be-dfae35f0e710.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1096616/52608766-92343800-2e83-11e9-8b60-935fc16bf5ce.png" width="300" /> |
| All | <img src="https://user-images.githubusercontent.com/1096616/52608755-8b0d2a00-2e83-11e9-9286-89d6d1c0f30b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1096616/52608767-92343800-2e83-11e9-83f0-f86ebff90b43.png" width="300" /> |
| All with 50% alpha | <img src="https://user-images.githubusercontent.com/1096616/52608757-8b0d2a00-2e83-11e9-8254-ca84cb17c096.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1096616/52608768-92ccce80-2e83-11e9-968f-666a85bb9cbd.png" width="300" /> |

### Testing Procedure ###

Loads of buttons and switches on the `MaterialProgressBarGallery` gallery or "[Material] ProgressBar & Slider Gallery".

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
