### PR TITLE
Add DesignerInterface

### DIFF
--- a/Xamarin.Forms.Xaml/DesignerInterface.cs
+++ b/Xamarin.Forms.Xaml/DesignerInterface.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Xaml
+{
+	// IMPORTANT!!
+	//  READ BEFORE MODIFYING!!
+	// This class represents the API that the Forms previewer will use
+	//  via reflection. Adding members or changing implementations is fine, but
+	//  DO NOT break this API unless you know what you're doing and/or are
+	//  coordinating with the designer team.
+	// Thanks!
+	static class DesignerInterface
+	{
+		const int LatestSupportedVersion = 1;
+		static int Version => LatestSupportedVersion;
+
+		// These types are used via reflection for type checks..
+		static Type IMarkupExtensionType => typeof (IMarkupExtension);
+		static Type ViewType => typeof (Xamarin.Forms.View);
+		static Type BoxViewType => typeof (Xamarin.Forms.BoxView);
+		static Type VisualElementType => typeof (Xamarin.Forms.VisualElement);
+		static Type ApplicationType => typeof (Xamarin.Forms.Application);
+
+		static Func<ResourceLoader.ResourceLoadingQuery, ResourceLoader.ResourceLoadingResponse> ResourceProvider2 {
+			get => ResourceLoader.ResourceProvider2;
+			set => ResourceLoader.ResourceProvider2 = value;
+		}
+
+		static Action<Exception> ExceptionHandler {
+			get => ResourceLoader.ExceptionHandler;
+			set => ResourceLoader.ExceptionHandler = value;
+		}
+
+		static Func<IList<XamlLoader.FallbackTypeInfo>, Type, Type> FallbackTypeResolver {
+			get => XamlLoader.FallbackTypeResolver;
+			set => XamlLoader.FallbackTypeResolver = value;
+		}
+
+		static Action<XamlLoader.CallbackTypeInfo, object> ValueCreatedCallback  {
+			get => XamlLoader.ValueCreatedCallback;
+			set => XamlLoader.ValueCreatedCallback = value;
+		}
+
+		static void SetIdiom(TargetIdiom idiom) => Device.SetIdiom(idiom);
+
+		static void SetLayout(Page page, Rectangle layout)
+			=> page.Layout(layout);
+
+		static TXaml LoadFromXaml<TXaml>(TXaml view, string xaml)
+			=> Extensions.LoadFromXaml(view, xaml);
+
+		static object CreateFromXaml(string xaml, bool doNotThrow, bool useDesignProperties)
+			=> XamlLoader.Create(xaml, doNotThrow, useDesignProperties);
+
+		static string GetPathForType(Type type)
+			=> XamlResourceIdAttribute.GetPathForType(type);
+
+		static void RegisterAll(Type[] attrTypes)
+			=> Xamarin.Forms.Internals.Registrar.RegisterAll (attrTypes);
+
+		static Page GetPage (object obj)
+		{
+			switch (obj) {
+
+			case null: return null;
+			case Page p: return p;
+			case View v: return new ContentPage { Content = v };
+			case ViewCell cell:
+				return new ContentPage { Content = cell.View ?? throw new EmptyViewCellException () };
+			default:
+				throw new UnsupportedTypeException (obj.GetType ());
+			}
+		}
+
+		public class EmptyViewCellException : Exception
+		{
+		}
+
+		public class UnsupportedTypeException : Exception
+		{
+			public UnsupportedTypeException (Type type)
+				: base (type.FullName)
+			{
+			}
+		}
+	}
+
+	// Platform assembly members that are reflected:
+	//  Note that visibility is irrelevant to our concerns; they may be made non-public
+	//  without breaking this contract.
+
+	// All platforms:
+	//
+	//  Xamarin.Forms.ExportRendererAttribute
+	//  Xamarin.Forms.ExportCellAttribute
+	//  Xamarin.Forms.ExportImageSourceHandlerAttribute
+	//
+	//  static void Forms.SetFlags(string[] flags)
+	//  static IVisualElementRenderer Platform.CreateRenderer(VisualElement element)
+	//  static void Platform.SetRenderer(VisualElement bindable, IVisualElementRenderer value)
+
+	// iOS:
+	//
+	//  static void Forms.Init()
+	//  UIView IVisualElementRenderer.NativeView { get; }
+
+	// Android:
+	//
+	//  static bool Forms.IsInitialized { get; }
+	//  static void ResourceManager.Init(Assembly masterAssembly)
+	//  static bool FileImageSourceHandler.DecodeSynchronously { set; }
+	//  static void Platform.SetPageContext(BindableObject bindable, Context context)
+	//  void IVisualElementRenderer.UpdateLayout()
+	//  ViewGroup IVisualElementRenderer.ViewGroup { get; }*
+	//  static void Forms.Init(Context activity, Bundle bundle)*
+}


### PR DESCRIPTION
### Description of Change ###

Adds an API contract for the Forms previewer.

For Core and Xaml assemblies, members have been added to the `DesignerInterface` class. If some API surface changes in Forms, we can catch it and update the `DesignerInterface` implementation without changing its API surface, allowing older versions of the previewer to work with newer versions of Forms. If we cannot keep the `DesignerInterface` backward compatible, there is now a version that we can bump, so older versions of the previewer can fail gracefully with a helpful error message.

For the platform-specific assemblies, it was not possible to reference their types directly here, so a list is added at the end for reference.

fixes #4429

### API Changes ###

Added:
 -  Xamarin.Forms.Xaml.DesignerInterface

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard

> VS bug [#790714](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/790714)