### PR TITLE
[iOS] Fix the layout of the button

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ButtonLayoutGalleryPage.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/ButtonLayoutGalleryPage.xaml
@@ -24,6 +24,10 @@
 				<Button Text="Some Text" />
 				<Button Image="bank.png" />
 				<Button Text="Some Text" Image="bank.png" />
+				<Button Text="Some Text" Image="bank.png" ContentLayout="Top, 8" />
+				<Button Text="Some Text" Image="bank.png" ContentLayout="Right, 8" />
+				<Button Text="Some Text" Image="bank.png" ContentLayout="Bottom, 8" />
+				<Button Text="Some Text" Image="bank.png" ContentLayout="Left, 8" />
 			</StackLayout>
 
 			<Label Text="Autosized:" Margin="0,0,0,-5" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonLayoutManager.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
 using CoreGraphics;
+using Foundation;
 using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -263,9 +264,15 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				// TODO: Do not use the title label as it is not yet updated and
 				//       if we move the image, then we technically have more
-				//       space and will require a new laoyt pass.
+				//       space and will require a new layout pass.
 
-				var titleRect = control.TitleLabel.Bounds.Size;
+				var title =
+					control.CurrentAttributedTitle ??
+					new NSAttributedString(control.CurrentTitle, new UIStringAttributes { Font = control.TitleLabel.Font });
+				var titleRect = title.GetBoundingRect(
+					control.Bounds.Size,
+					NSStringDrawingOptions.UsesLineFragmentOrigin | NSStringDrawingOptions.UsesFontLeading,
+					null);
 
 				var titleWidth = titleRect.Width;
 				var titleHeight = titleRect.Height;


### PR DESCRIPTION
### Description of Change ###
It appears that iOS has a nice little delay when setting the title to the layout, so we have to use manual measuring.

### Issues Resolved ### 

- fixes #5160

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

The images are correctly laid out.

### Before/After Screenshots ### 

|   | Classic | Material |
| -: | :-: | :-: |
| Before | <img src="https://user-images.githubusercontent.com/1096616/52660484-6eff9c00-2f08-11e9-87f6-885dcbce9b5e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1096616/52660398-4081c100-2f08-11e9-864d-4008977967e6.png" width="300" /> |
| After | <img src="https://user-images.githubusercontent.com/1096616/52660601-b423ce00-2f08-11e9-93ee-b12681565a26.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1096616/52660446-5b543580-2f08-11e9-934e-4b87ad03755a.png" width="300" /> |

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
