### PR TITLE
[iOS] Fix ImageRenderer dispose

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -60,16 +60,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override async void OnElementChanged(ElementChangedEventArgs<Image> e)
 		{
-			if (Control == null)
-			{
-				var imageView = new UIImageView(RectangleF.Empty);
-				imageView.ContentMode = UIViewContentMode.ScaleAspectFit;
-				imageView.ClipsToBounds = true;
-				SetNativeControl(imageView);
-			}
-
 			if (e.NewElement != null)
 			{
+				if (Control == null)
+				{
+					var imageView = new UIImageView(RectangleF.Empty);
+					imageView.ContentMode = UIViewContentMode.ScaleAspectFit;
+					imageView.ClipsToBounds = true;
+					SetNativeControl(imageView);
+				}
+
 				await TrySetImage(e.OldElement as Image);
 			}
 

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -107,9 +107,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void Dispose(bool disposing)
 		{
-			//this needs to be here
-			base.Dispose(disposing);
-
 			if (disposing)
 			{
 				_elementPropertyChanged = null;
@@ -124,6 +121,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				}
 			}
 
+			base.Dispose(disposing);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<TView> e)

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -107,6 +107,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void Dispose(bool disposing)
 		{
+			//this needs to be here
+			base.Dispose(disposing);
+
 			if (disposing)
 			{
 				_elementPropertyChanged = null;
@@ -121,7 +124,6 @@ namespace Xamarin.Forms.Platform.MacOS
 				}
 			}
 
-			base.Dispose(disposing);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<TView> e)


### PR DESCRIPTION
### Description of Change ###

When a ViewRenderer is disposed it sets Element to Null, the Control on the ImageRender was always being created even if the `NewElement` was null.

### Issues Resolved ### 

- fixes failing tests on IOS

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard