### PR TITLE
[Android] fixes redraw element when changing renderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1332.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1332.cs
@@ -1,0 +1,73 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 1332, "Frame inside frame does not resize after visibility changed", PlatformAffected.Android)]
+	public class Issue1332: TestContentPage
+	{
+		protected override void Init()
+		{
+			double layoutWidth = 0.6;
+			double layoutHeight = 150;
+
+			var red = new Frame
+			{
+				BackgroundColor = Color.Red,
+				Content = new Frame
+				{
+					BorderColor = Color.Black,
+					HeightRequest = layoutHeight,
+					BackgroundColor = Color.Transparent
+				}
+			};
+			AbsoluteLayout.SetLayoutBounds(red, new Rectangle(0, 0, layoutWidth, layoutHeight));
+			AbsoluteLayout.SetLayoutFlags(red, AbsoluteLayoutFlags.XProportional | AbsoluteLayoutFlags.WidthProportional);
+
+			var stack = new StackLayout
+			{
+				Children =
+				{
+					new Button
+					{
+						Text = "visibility",
+						Padding = 10,
+						Command = new Command(() => red.IsVisible = !red.IsVisible)
+					},
+					new Button
+					{
+						Text = "width",
+						Padding = 10,
+						Command = new Command(() => {
+							layoutWidth = layoutWidth == 0.3 ? 0.6 : 0.3;
+							red.IsVisible = false;
+							AbsoluteLayout.SetLayoutBounds(red, new Rectangle(0, 0, layoutWidth, 150));
+							red.IsVisible = true;
+						})
+					}
+				}
+			};
+			AbsoluteLayout.SetLayoutBounds(stack, new Rectangle(1, 0, layoutWidth / 2, 1));
+			AbsoluteLayout.SetLayoutFlags(stack, AbsoluteLayoutFlags.All);
+
+			var desc = new Label
+			{
+				Text = "Click on Visibility, then click on Width button few times." +
+					"The layout of the second frame must be updated to match the first."
+			};
+			AbsoluteLayout.SetLayoutBounds(desc, new Rectangle(0, 0.5, 1, 0.5));
+			AbsoluteLayout.SetLayoutFlags(desc, AbsoluteLayoutFlags.All);
+
+			Content = new AbsoluteLayout
+			{
+				Children =
+				{
+					red,
+					stack,
+					desc
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1760_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1760_1.cs
@@ -1,0 +1,34 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1760, "Content set after an await is not visible", PlatformAffected.Android, issueTestNumber: 1)]
+	public class Issue1760_1 : TestMasterDetailPage
+	{
+		protected override void Init()
+		{
+			Master = new Issue1760._1760Master(false);
+			Detail = new Issue1760._1760TestPage(false);
+			IsPresented = true;
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void Issue1760_1Test()
+		{
+			RunningApp.WaitForElement(Issue1760.Before);
+			RunningApp.WaitForElement(Issue1760.After);
+
+			RunningApp.Tap("Test Page 1");
+			RunningApp.WaitForElement(Issue1760.Before);
+			RunningApp.WaitForElement(Issue1760.After);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5184.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5184.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	public class ListViewEntry
+	{
+		public int Number { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ListViewGroup : List<ListViewEntry>
+	{
+		public string Heading { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class MainPageViewModel
+	{
+		List<ListViewGroup> _groups = new List<ListViewGroup>();
+
+		public MainPageViewModel()
+		{
+			for (int i = 0; i < 20; ++i)
+			{
+				var group = new ListViewGroup
+				{
+					Heading = $"Group {i * 5} - {(i + 1) * 5 - 1}"
+				};
+
+				for (int j = 0; j < 5; ++j)
+				{
+					group.Add(new ListViewEntry { Number = i * 5 + j });
+				}
+
+				_groups.Add(group);
+			}
+		}
+
+		public IReadOnlyList<ListViewGroup> Groups
+		{
+			get { return _groups; }
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5184, "Items get mixed up when fast scrolling", PlatformAffected.Android)]
+	public class Issue5184 : TestContentPage
+	{
+		protected override void Init()
+		{
+			BindingContext = new MainPageViewModel();
+			var listView = new ListView
+			{
+				Margin = 20,
+				IsGroupingEnabled = true,
+				GroupHeaderTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, nameof(ListViewGroup.Heading));
+					var grid = new Grid {
+						HorizontalOptions = LayoutOptions.FillAndExpand,
+						ColumnDefinitions = new ColumnDefinitionCollection {
+							new ColumnDefinition { Width = GridLength.Star }
+						},
+						Children = { label }
+					};
+					return new ViewCell { View = grid };
+				}),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, nameof(ListViewEntry.Number));
+					var grid = new Grid
+					{
+						HorizontalOptions = LayoutOptions.FillAndExpand,
+						ColumnDefinitions = new ColumnDefinitionCollection {
+							new ColumnDefinition { Width = GridLength.Star }
+						},
+						Children = { label }
+					};
+					return new ViewCell { View = grid };
+				})
+			};
+			listView.SetBinding(ListView.ItemsSourceProperty, nameof(MainPageViewModel.Groups));
+
+			Content = new StackLayout
+			{
+				Children = {
+					new Label { Text = "Quickly scroll down and back. Check that all items are correct." },
+					listView
+				}
+			};
+		} 
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -295,6 +295,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2617.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3139.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3087.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1760_1.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1332.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5184.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3089.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1342.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2482.cs" />

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -261,6 +261,8 @@ namespace Xamarin.Forms
 			for (var i = 0; i < LogicalChildrenInternal.Count; i++)
 				CompressedLayout.SetHeadlessOffset((VisualElement)LogicalChildrenInternal[i], isHeadless ? new Point(headlessOffset.X + Bounds.X, headlessOffset.Y + Bounds.Y) : new Point());
 
+			_lastLayoutSize = new Size(width, height);
+
 			LayoutChildren(x, y, w, h);
 
 			for (var i = 0; i < oldBounds.Length; i++)
@@ -273,8 +275,6 @@ namespace Xamarin.Forms
 					return;
 				}
 			}
-
-			_lastLayoutSize = new Size(width, height);
 		}
 
 		internal static void LayoutChildIntoBoundingRegion(View child, Rectangle region, SizeRequest childSizeRequest)

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -115,6 +115,8 @@ namespace Xamarin.Forms.Platform.Android
 			//On Width or Height changes, the anchors needs to be updated
 			UpdateAnchorX();
 			UpdateAnchorY();
+
+			MaybeRequestLayout();
 		}
 
 		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -127,6 +129,12 @@ namespace Xamarin.Forms.Platform.Android
 			if (e.PropertyName == Layout.IsClippedToBoundsProperty.PropertyName)
 			{
 				UpdateClipToBounds();
+				return;
+			}
+
+			if (e.Is(Platform.RendererProperty))
+			{
+				_renderer.View.Invalidate();
 				return;
 			}
 


### PR DESCRIPTION
### Description of Change ###

Added calling `RequestLayout` on parent Layout when adding child in current Layout.
Related PR https://github.com/xamarin/Xamarin.Forms/pull/4861

### Issues Resolved ### 

- fixes #1760

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- run UItest 1760
- run UItest 1760 (1)
- run UItest 1332
- run UItest 5184

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
