### PR TITLE
[Android] Fix ImageRenderer URI

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5172.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5172.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5172, "ImageCell does not load image from URI - Android", PlatformAffected.Android)]
+	public class Issue5172 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			Label header = new Label
+			{
+				Text = "Please make sure a image is shown in the ImageCell bellow",
+				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label)),
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			TableView tableView = new TableView
+			{
+				Intent = TableIntent.Form,
+				Root = new TableRoot
+				{
+					new TableSection
+					{
+						new ImageCell
+						{
+                            // Some differences with loading images in initial release.
+                            ImageSource = ImageSource.FromUri(new Uri("https://i0.wp.com/www.thedudes.com.br/wp-content/uploads/2018/06/Vitrine-Perfil-dos-Dudes-04.png")),
+							Text = "This is an ImageCell",
+							Detail = "This is some detail text",
+						}
+					}
+				}
+			};
+
+			Padding = new Thickness(10, 20, 10, 5);
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					header,
+					tableView
+				}
+			};
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5172.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5172.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Controls.Issues
 						new ImageCell
 						{
                             // Some differences with loading images in initial release.
-                            ImageSource = ImageSource.FromUri(new Uri("https://i0.wp.com/www.thedudes.com.br/wp-content/uploads/2018/06/Vitrine-Perfil-dos-Dudes-04.png")),
+                            ImageSource = ImageSource.FromUri(new Uri("https://raw.githubusercontent.com/xamarin/Xamarin.Forms/543da8aec914efc6ce98794302792ef948cc28c8/Xamarin.Forms.ControlGallery.Android/Resources/drawable/coffee.png")),
 							Text = "This is an ImageCell",
 							Detail = "This is some detail text",
 						}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -868,6 +868,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3622.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4138.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4314.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5172.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			// Check if the source on the new image has changed since the image was loaded
-			if (!Equals(newView?.Source, newImageSource))
+			if (newView != null && !Equals(newView?.Source, newImageSource))
 			{
 				bitmap?.Dispose();
 				return;


### PR DESCRIPTION
### Description of Change ###

Don't dispose if newImage set is null. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5172

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
