### PR TITLE
Add AllowMultiple=true to QueryPropertyAttribute (#5180)

### DIFF
--- a/Xamarin.Forms.Core/Shell/QueryPropertyAttribute.cs
+++ b/Xamarin.Forms.Core/Shell/QueryPropertyAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms
 {
-	[AttributeUsage(AttributeTargets.Class)]
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 	public class QueryPropertyAttribute : Attribute
 	{
 		public string Name { get;  }


### PR DESCRIPTION
#5180 targeted at 3.6.0

In the process of building a demo app (https://github.com/matthewrdev/xamarin-forms-4), I discovered that I could not apply multiple parameters; doing so would cause a compile-time error.

The usage of this property in ShellContent, specifically in ApplyQueryAttributes, indicates that the intended behaviour is to allow users to specify multiple URL arguments that will be applied onto the page. Changing AllowMultiple to true fixes this.

For reference, when AllowMultiple is not explicitly set, it's default value is false. See: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/attributes/attributeusage.