### PR TITLE
[C] Binding null on nullable

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -429,7 +429,7 @@ namespace Xamarin.Forms
 		internal static bool TryConvert(ref object value, BindableProperty targetProperty, Type convertTo, bool toTarget)
 		{
 			if (value == null)
-				return !convertTo.GetTypeInfo().IsValueType;
+				return !convertTo.GetTypeInfo().IsValueType || Nullable.GetUnderlyingType(convertTo) != null;
 			if ((toTarget && targetProperty.TryConvert(ref value)) || (!toTarget && convertTo.IsInstanceOfType(value)))
 				return true;
 

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5242.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5242.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5242"
+        NullableInt="{Binding Value}" x:DataType="local:Gh5242VM">
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5242.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5242.xaml.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh5242VM
+	{
+		public int? Value {get;set;}
+	}
+
+	public partial class Gh5242 : ContentPage
+	{
+		public static readonly BindableProperty NullableIntProperty = BindableProperty.Create("NullableInt", typeof(int?), typeof(Gh5242), defaultValue:-1);
+		public int? NullableInt { get => (int?)GetValue(NullableIntProperty); }
+
+		public Gh5242() => InitializeComponent();
+		public Gh5242(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void BindingToNullable([Values (false, true)]bool useCompiledXaml)
+			{
+				var layout = new Gh5242(useCompiledXaml) {BindingContext = new Gh5242VM {Value = 42}};
+				Assert.That(layout.NullableInt, Is.EqualTo(42));
+
+				layout.BindingContext = new Gh5242VM { Value = null };
+				Assert.That(layout.NullableInt, Is.Null);
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
### Description of Change ###

[C] Binding null on nullable
    
@kicsiede's fix for #5242, plus unit test, targetted to 3.6.0
    
### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

 - closes #5242

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
