### PR TITLE
iOS: Color of Editor Placeholder is different than Entry

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5252.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5252.cs
@@ -1,0 +1,49 @@
+﻿using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5252, "iOS: The Editor and Entry placeholder default color should be the same", PlatformAffected.iOS)]
+
+	class Issue5252 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var sl = new StackLayout();
+			sl.Children.Add(new Label()
+			{
+				Text = "iOS: The Editor and Entry placeholder default color should be the same for consistency"
+			});
+
+			var entry = new Entry()
+			{
+				Placeholder = "Entry placeholder",
+			};
+			sl.Children.Add(entry);
+
+			var editor = new Editor()
+			{
+				Placeholder = "Editor placeholder",
+			};
+			sl.Children.Add(editor);
+
+			sl.Children.Add(new Button()
+			{
+				Text = "Toggle placeholder color",
+				Command = new Command(() =>
+				{
+					entry.PlaceholderColor = entry.PlaceholderColor.IsDefault ? Color.Red : (Color)Entry.PlaceholderColorProperty.DefaultValue;
+					editor.PlaceholderColor = editor.PlaceholderColor.IsDefault ? Color.Red : (Color)Editor.PlaceholderColorProperty.DefaultValue;
+				})
+			});
+
+
+			Content = new ScrollView()
+			{
+				Content = sl
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -429,6 +429,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue4600.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5252.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5057.xaml.cs">
       <DependentUpon>Issue5057.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -9,6 +9,9 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class EditorRenderer : EditorRendererBase<UITextView>
 	{
+		// Using same placeholder color as for the Entry
+		readonly UIColor _defaultPlaceholderColor = ColorExtensions.SeventyPercentGrey;
+
 		UILabel _placeholderLabel;
 
 		public EditorRenderer()
@@ -63,10 +66,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected internal override void UpdatePlaceholderColor()
 		{
-			if (Element.PlaceholderColor == Color.Default)
-				_placeholderLabel.TextColor = UIColor.DarkGray;
+			Color placeholderColor = Element.PlaceholderColor;
+			if (placeholderColor.IsDefault)
+				_placeholderLabel.TextColor = _defaultPlaceholderColor;
 			else
-				_placeholderLabel.TextColor = Element.PlaceholderColor.ToUIColor();
+				_placeholderLabel.TextColor = placeholderColor.ToUIColor();
 		}
 
 		void CreatePlaceholderLabel()


### PR DESCRIPTION
### Description of Change ###

On iOS, Entry and Editor should have same default placeholder color for consistency

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5252

### API Changes ###

 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before:

![image](https://user-images.githubusercontent.com/743918/52803310-7fd81b00-308a-11e9-81bc-a46b6471efb1.png)

After:

![image](https://user-images.githubusercontent.com/743918/52802983-b2cddf00-3089-11e9-943e-f060105d94dd.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
