### PR TITLE
[macOS] NavigationRenderer internal stack reversed after RemovePage

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
@@ -305,15 +305,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			target?.Dispose();
 			if (removeFromStack)
 			{
-				var newStack = new Stack<NavigationChildPageWrapper>();
-				foreach (var stack in _currentStack)
-				{
-					if (stack.Page != page)
-					{
-						newStack.Push(stack);
-					}
-				}
-				_currentStack = newStack;
+				var newSource = _currentStack.Reverse().Where(w => w.Page != page);
+				_currentStack = new Stack<NavigationChildPageWrapper>(newSource);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fixed RemovePage method for navigation in MacOs

### Issues Resolved ### 

- fixes #5257

### API Changes ###

None

### Platforms Affected ### 
- MacOs

### Behavioral/Visual Changes ###

No crash during navigation

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
* Add 3 pages to a NavigationPage stack (A, B, C)
* Remove the page in the middle  (B)
* Pop the last page form the stack (C)

```csharp
		private Page _page1 = new ContentPage { BackgroundColor = Color.Red };
		private Page _page2 = new ContentPage();
		private Page _page3 = new ContentPage { BackgroundColor = Color.Green };

		public App()
		{
			MainPage = new NavigationPage(_page1);
		}

		protected override async void OnStart()
		{
			await Task.Delay(3000);

			MainPage.Navigation.InsertPageBefore(_page2, _page1);
			MainPage.Navigation.InsertPageBefore(_page3, _page2);

			await Task.Delay(2000);
			MainPage.Navigation.RemovePage(_page2);
			await _page1.Navigation.PopAsync();
		}
```
