### PR TITLE
[XamlC] avoid cast exception on overriden members

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -827,7 +827,7 @@ namespace Xamarin.Forms.Build.Tasks
 			var bpRef = GetBindablePropertyReference(parent, propertyName.NamespaceURI, ref localName, out System.Boolean attached, context, iXmlLineInfo);
 
 			//If the target is an event, connect
-			if (CanConnectEvent(parent, localName, attached))
+			if (CanConnectEvent(parent, localName, valueNode, attached))
 				return ConnectEvent(parent, localName, valueNode, iXmlLineInfo, context);
 
 			//If Value is DynamicResource, SetDynamicResource
@@ -890,9 +890,9 @@ namespace Xamarin.Forms.Build.Tasks
 			return bpRef;
 		}
 
-		static bool CanConnectEvent(VariableDefinition parent, string localName, bool attached)
+		static bool CanConnectEvent(VariableDefinition parent, string localName, INode valueNode, bool attached)
 		{
-			return !attached && parent.VariableType.GetEvent(ed => ed.Name == localName, out _) != null;
+			return !attached && valueNode is ValueNode && parent.VariableType.GetEvent(ed => ed.Name == localName, out _) != null;
 		}
 
 		static IEnumerable<Instruction> ConnectEvent(VariableDefinition parent, string localName, INode valueNode, IXmlLineInfo iXmlLineInfo, ILContext context)

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5242.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5242.xaml.cs
@@ -40,6 +40,5 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.That(layout.NullableInt, Is.Null);
 			}
 		}
-
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5256.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5256.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5256">
+    <local:Gh5256Entry x:Name="entry" Completed="{Binding CompletedCommand}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5256.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5256.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System.Windows.Input;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh5256Entry : Entry
+	{
+		public Gh5256Entry()
+		{
+			base.Completed += (o,e) => this.Completed?.Execute(o);
+		}
+		public static readonly BindableProperty CompletedProperty =
+			BindableProperty.Create("Completed", typeof(ICommand), typeof(Gh5256Entry), default(ICommand));
+
+		public new ICommand Completed {
+			get => (ICommand)GetValue(CompletedProperty);
+			set => SetValue(CompletedProperty, value);
+		}
+	}
+
+	//[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh5256 : ContentPage
+	{
+		public Gh5256() => InitializeComponent();
+		public Gh5256(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void EventOverriding([Values(false, true)]bool useCompiledXaml)
+			{
+				var layout = new Gh5256(useCompiledXaml) { BindingContext = new { CompletedCommand = new Command(() => Assert.Pass()) } };
+				layout.entry.SendCompleted();
+				Assert.Fail();
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
### Description of Change ###

avoid InvalidCastException if an event is overriden with the new keyword
to a bindableproperty. Kids, DO NOT EVER DO THIS AT HOME.


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5256 for XamlC

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
