### PR TITLE
[XamlC] compiled binding to int indexers

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5254.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5254.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5254">
+    <Label x:Name="label" Text="{Binding Answer[0].Title}" x:DataType="local:Gh5254VM" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5254.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5254.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh5254VM
+	{
+		public string Title { get; set; }
+		public List<Gh5254VM> Answer { get; set; }
+	}
+
+	public partial class Gh5254 : ContentPage
+	{
+		public Gh5254() => InitializeComponent();
+		public Gh5254(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void BindToIntIndexer([Values(false, true)]bool useCompiledXaml)
+			{
+				var layout = new Gh5254(useCompiledXaml)
+				{
+					BindingContext = new Gh5254VM {
+						Answer = new List<Gh5254VM> {
+							new Gh5254VM { Title = "Foo"},
+							new Gh5254VM { Title = "Bar"},
+						}
+					}
+				};
+				Assert.That(layout.label.Text, Is.EqualTo("Foo"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Compiled Bindings with Int32 indexers weren't working correctly... this should be a bit better

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5254

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
