### PR TITLE
[Android iOS Visual] fixes background in ActivityIndicator

### DIFF
--- a/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
@@ -31,18 +31,23 @@
                 <ActivityIndicator Color="{StaticResource PrimaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
             </StackLayout>
 
-            <Label Text="Custom Background Color" Margin="0,0,0,-10" />
+            <Label Text="Custom Background Color + Height 200" Margin="0,0,0,-10" />
             <StackLayout Orientation="Horizontal">
-                <ActivityIndicator BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
-                <ActivityIndicator BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
+                <ActivityIndicator HeightRequest="200" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
+                <ActivityIndicator HeightRequest="200" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
             </StackLayout>
 
-            <Label Text="Custom" Margin="0,0,0,-10" />
+            <Label Text="Custom + Height 150" Margin="0,0,0,-10" />
+            <StackLayout Orientation="Horizontal">
+                <ActivityIndicator HeightRequest="150" Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
+                <ActivityIndicator HeightRequest="150" Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
+            </StackLayout>
+
+            <Label Text="Default size" Margin="0,0,0,-10" />
             <StackLayout Orientation="Horizontal">
                 <ActivityIndicator Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
                 <ActivityIndicator Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
             </StackLayout>
-
 
             <Label Text="Progress Bars" FontSize="Large" />
 

--- a/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/VisualGallery.xaml
@@ -38,13 +38,13 @@
             </StackLayout>
 
             <Label Text="Custom + Height 144 (Max)" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
+            <StackLayout Orientation="Horizontal" BackgroundColor="Lime">
                 <ActivityIndicator HeightRequest="144" Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
                 <ActivityIndicator HeightRequest="144" Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
             </StackLayout>
 
             <Label Text="Default size" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
+            <StackLayout Orientation="Horizontal" BackgroundColor="Yellow">
                 <ActivityIndicator Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
                 <ActivityIndicator Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
             </StackLayout>

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -322,6 +322,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new PickerCoreGalleryPage(), "Picker Gallery"),
 				new GalleryPageFactory(() => new ProgressBarCoreGalleryPage(), "ProgressBar Gallery"),
 				new GalleryPageFactory(() => new MaterialProgressBarGallery(), "[Material] ProgressBar & Slider Gallery"),
+				new GalleryPageFactory(() => new MaterialActivityIndicatorGallery(), "[Material] ActivityIndicator Gallery"),
 				new GalleryPageFactory(() => new ScrollGallery(), "ScrollView Gallery"),
 				new GalleryPageFactory(() => new ScrollGallery(ScrollOrientation.Horizontal), "ScrollView Gallery Horizontal"),
 				new GalleryPageFactory(() => new ScrollGallery(ScrollOrientation.Both), "ScrollView Gallery 2D"),

--- a/Xamarin.Forms.Controls/GalleryPages/MaterialActivityIndicatorGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MaterialActivityIndicatorGallery.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.Controls
 			var activityIndicator = new ActivityIndicator()
 			{
 				IsRunning = false,
+				BackgroundColor = Color.Red,
 				HeightRequest = 50
 			};
 

--- a/Xamarin.Forms.Controls/GalleryPages/MaterialActivityIndicatorGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MaterialActivityIndicatorGallery.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Xamarin.Forms.Controls
 {
 	public class MaterialActivityIndicatorGallery : ContentPage
@@ -14,8 +12,26 @@ namespace Xamarin.Forms.Controls
 				HeightRequest = 50
 			};
 
-			var isRunSwitch = new Switch { IsToggled = activityIndicator.IsRunning };
+			var IsRunGrid = new Grid
+			{
+				Padding = 0,
+				ColumnSpacing = 6,
+				RowSpacing = 6,
+				ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = GridLength.Star },
+					new ColumnDefinition { Width = 50 }
+				}
+			};
+
+			IsRunGrid.AddChild(new Label { Text = "Is Running" }, 0, 0);
+			var isRunSwitch = new Switch {
+				IsToggled = activityIndicator.IsRunning,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
 			isRunSwitch.Toggled += (_, e) => activityIndicator.IsRunning = e.Value;
+			IsRunGrid.AddChild(isRunSwitch, 1, 0);
 
 			var primaryPicker = new ColorPicker { Title = "Primary Color", Color = activityIndicator.Color };
 			primaryPicker.ColorPicked += (_, e) =>
@@ -24,7 +40,17 @@ namespace Xamarin.Forms.Controls
 			};
 			var backgroundPicker = new ColorPicker { Title = "Background Color", Color = activityIndicator.BackgroundColor };
 			backgroundPicker.ColorPicked += (_, e) => activityIndicator.BackgroundColor = e.Color;
+			
 			var heightPicker = MaterialProgressBarGallery.CreateValuePicker("Height", value => activityIndicator.HeightRequest = value);
+
+			var content = new StackLayout
+			{
+				Children = { activityIndicator },
+				BackgroundColor = Color.Blue
+			};
+
+			var backgroundPanelPicker = new ColorPicker { Title = "Back panel Color", Color = content.BackgroundColor };
+			backgroundPanelPicker.ColorPicked += (_, e) => content.BackgroundColor = e.Color;
 
 			Content = new StackLayout
 			{
@@ -41,9 +67,10 @@ namespace Xamarin.Forms.Controls
 							Spacing = 10,
 							Children =
 							{
-								isRunSwitch,
+								IsRunGrid,
 								primaryPicker,
 								backgroundPicker,
+								backgroundPanelPicker,
 								heightPicker,
 							}
 						}
@@ -56,14 +83,7 @@ namespace Xamarin.Forms.Controls
 						Color = Color.Black
 					},
 
-					new StackLayout
-					{
-						Children =
-						{
-							activityIndicator
-						},
-						BackgroundColor = Color.Blue
-					}
+					content
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/MaterialActivityIndicatorGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MaterialActivityIndicatorGallery.cs
@@ -1,0 +1,71 @@
+using System;
+
+namespace Xamarin.Forms.Controls
+{
+	public class MaterialActivityIndicatorGallery : ContentPage
+	{
+		public MaterialActivityIndicatorGallery()
+		{
+			Visual = VisualMarker.Material;
+
+			var activityIndicator = new ActivityIndicator()
+			{
+				IsRunning = false,
+				HeightRequest = 50
+			};
+
+			var isRunSwitch = new Switch { IsToggled = activityIndicator.IsRunning };
+			isRunSwitch.Toggled += (_, e) => activityIndicator.IsRunning = e.Value;
+
+			var primaryPicker = new ColorPicker { Title = "Primary Color", Color = activityIndicator.Color };
+			primaryPicker.ColorPicked += (_, e) =>
+			{
+				activityIndicator.Color = e.Color;
+			};
+			var backgroundPicker = new ColorPicker { Title = "Background Color", Color = activityIndicator.BackgroundColor };
+			backgroundPicker.ColorPicked += (_, e) => activityIndicator.BackgroundColor = e.Color;
+			var heightPicker = MaterialProgressBarGallery.CreateValuePicker("Height", value => activityIndicator.HeightRequest = value);
+
+			Content = new StackLayout
+			{
+				Padding = 10,
+				Spacing = 10,
+				Children =
+				{
+					new ScrollView
+					{
+						Margin = new Thickness(-10, 0),
+						Content = new StackLayout
+						{
+							Padding = 10,
+							Spacing = 10,
+							Children =
+							{
+								isRunSwitch,
+								primaryPicker,
+								backgroundPicker,
+								heightPicker,
+							}
+						}
+					},
+
+					new BoxView
+					{
+						HeightRequest = 1,
+						Margin = new Thickness(-10, 0),
+						Color = Color.Black
+					},
+
+					new StackLayout
+					{
+						Children =
+						{
+							activityIndicator
+						},
+						BackgroundColor = Color.Blue
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/MaterialProgressBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MaterialProgressBarGallery.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Controls
 			};
 		}
 
-		Grid CreateValuePicker(string title, Action<double> changed)
+		internal static Grid CreateValuePicker(string title, Action<double> changed)
 		{
 			// 50%
 			Slider slider = new Slider(0, 100, 50);

--- a/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using CoreAnimation;
 using CoreGraphics;
@@ -39,7 +40,7 @@ namespace Xamarin.Forms.Platform.iOS.Material
 
 					_backgroundLayer = new CAShapeLayer
 					{
-						LineWidth = 4,
+						LineWidth = Control.StrokeWidth,
 						FillColor = UIColor.Clear.CGColor,
 						Hidden = true
 					};
@@ -80,9 +81,22 @@ namespace Xamarin.Forms.Platform.iOS.Material
 			if (_center != Control.Center)
 			{
 				_center = Control.Center;
-				_backgroundLayer.Path = UIBezierPath.FromArc(_center, Control.Radius - 2, 0, 360, true).CGPath;
+				_backgroundLayer.LineWidth = Control.StrokeWidth;
+				var pathRadius = Control.Radius - Control.StrokeWidth / 2;
+				_backgroundLayer.Path = UIBezierPath.FromArc(_center, pathRadius, 0, 360, true).CGPath;
 			}
 			SetBackgroundColor(Element.BackgroundColor);
+		}
+
+		public override CGSize SizeThatFits(CGSize size)
+		{
+			var radius = NMath.Min(size.Width, size.Height) / 2;
+			if (!nfloat.IsInfinity(radius))
+			{
+				Control.Radius = radius;
+				Control.StrokeWidth = Control.Radius / 6;
+			}
+			return base.SizeThatFits(size);
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
@@ -12,8 +12,10 @@ namespace Xamarin.Forms.Platform.iOS.Material
 {
 	public class MaterialActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, MActivityIndicator>
 	{
-		const float _minimumSize = 12;
-		const float _defaultRadius = 24;
+		// by Material spec the stroke width is 1/12 of the diameter, 
+		// but Android's native progress indicator is 1/10 of the diameter.
+		const float _strokeRatio = 10;
+		const float _defaultRadius = 22;
 		const float _defaultStrokeWidth = 4;
 		const float _defaultSize = 2 * _defaultRadius + _defaultStrokeWidth;
 
@@ -85,12 +87,12 @@ namespace Xamarin.Forms.Platform.iOS.Material
 
             // try get the radius for this size
 			var min = NMath.Min(Control.Bounds.Width, Control.Bounds.Height);
-			var stroke = min / 12;
+			var stroke = min / _strokeRatio;
 			var radius = min / 2 - stroke;
 
             // but, in the end use the limit set by the control
 			Control.Radius = radius;
-			Control.StrokeWidth = Control.Radius / 6;
+			Control.StrokeWidth = Control.Radius / (_strokeRatio / 2);
 
 			_backgroundLayer.LineWidth = Control.StrokeWidth;
 			_backgroundLayer.Path = UIBezierPath.FromArc(Control.Center, Control.Radius - Control.StrokeWidth / 2, 0, 360, true).CGPath;

--- a/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
@@ -85,12 +85,12 @@ namespace Xamarin.Forms.Platform.iOS.Material
 		{
 			base.LayoutSubviews();
 
-            // try get the radius for this size
+			// try get the radius for this size
 			var min = NMath.Min(Control.Bounds.Width, Control.Bounds.Height);
 			var stroke = min / _strokeRatio;
-			var radius = min / 2 - stroke;
+			var radius = min / 2;
 
-            // but, in the end use the limit set by the control
+			// but, in the end use the limit set by the control
 			Control.Radius = radius;
 			Control.StrokeWidth = Control.Radius / (_strokeRatio / 2);
 

--- a/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
@@ -26,7 +26,6 @@ namespace Xamarin.Forms.Platform.Android.Material
 		bool _disposed;
 
 		ActivityIndicator _element;
-		AProgressBar _control;
 
 		VisualElementTracker _visualElementTracker;
 		VisualElementRenderer _visualElementRenderer;
@@ -40,22 +39,14 @@ namespace Xamarin.Forms.Platform.Android.Material
 		{
 			VisualElement.VerifyVisualFlagEnabled();
 
-			_control = new AProgressBar(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular)
-			{
-				Indeterminate = true
-			};
-			var squareLayout = new SquareLayout(context)
-			{
-				LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, GravityFlags.Center)
-			};
-			squareLayout.AddView(_control);
-			AddView(squareLayout);
+			Control = new CircularProgress(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular);
+			AddView(Control, new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, GravityFlags.Center));
 
 			_visualElementRenderer = new VisualElementRenderer(this);
 			_motionEventHelper = new MotionEventHelper();
 		}
 
-		protected AProgressBar Control => _control;
+		protected AProgressBar Control { get; private set; }
 
 		protected ActivityIndicator Element
 		{
@@ -150,21 +141,21 @@ namespace Xamarin.Forms.Platform.Android.Material
 			var background = Element.BackgroundColor.IsDefault 
 				? AColor.Transparent 
 				: Element.BackgroundColor.ToAndroid();
-			(_control.Background as GradientDrawable)?.SetColor(background);
+			(Control.Background as GradientDrawable)?.SetColor(background);
 
 			if (Element.IsRunning)
 			{
 				var progress = Element.Color.IsDefault 
 					? MaterialColors.Light.PrimaryColor 
 					: Element.Color.ToAndroid();
-				_control.IndeterminateTintList = ColorStateList.ValueOf(progress);
+				Control.IndeterminateTintList = ColorStateList.ValueOf(progress);
 			}
 			else
 			{
-				_control.Visibility = Element.BackgroundColor.IsDefault 
+				Control.Visibility = Element.BackgroundColor.IsDefault 
 					? ViewStates.Gone 
 					: ViewStates.Visible;
-				_control.IndeterminateTintList = ColorStateList.ValueOf(AColor.Transparent);
+				Control.IndeterminateTintList = ColorStateList.ValueOf(AColor.Transparent);
 			}
 		}
 
@@ -180,7 +171,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 
 		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
-			_control.Measure(widthConstraint, heightConstraint);
+			Control.Measure(widthConstraint, heightConstraint);
 			return new SizeRequest(new Size(Control.MeasuredWidth, Control.MeasuredHeight), new Size());
 		}
 
@@ -202,11 +193,11 @@ namespace Xamarin.Forms.Platform.Android.Material
 		// IViewRenderer
 
 		void IViewRenderer.MeasureExactly() =>
-			ViewRenderer.MeasureExactly(_control, Element, Context);
+			ViewRenderer.MeasureExactly(Control, Element, Context);
 
 		// ITabStop
 
-		AView ITabStop.TabStop => _control;
+		AView ITabStop.TabStop => Control;
 	}
 }
 #endif

--- a/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
@@ -40,9 +40,16 @@ namespace Xamarin.Forms.Platform.Android.Material
 		{
 			VisualElement.VerifyVisualFlagEnabled();
 
-			_control = new AProgressBar(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular);
-			_control.Indeterminate = true;
-			AddView(_control);
+			_control = new AProgressBar(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular)
+			{
+				Indeterminate = true
+			};
+			var squareLayout = new SquareLayout(context)
+			{
+				LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, GravityFlags.Center)
+			};
+			squareLayout.AddView(_control);
+			AddView(squareLayout);
 
 			_visualElementRenderer = new VisualElementRenderer(this);
 			_motionEventHelper = new MotionEventHelper();

--- a/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 			VisualElement.VerifyVisualFlagEnabled();
 
 			Control = new CircularProgress(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular);
-			AddView(Control, new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, GravityFlags.Center));
+			AddView(Control);
 
 			_visualElementRenderer = new VisualElementRenderer(this);
 			_motionEventHelper = new MotionEventHelper();

--- a/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
@@ -2,15 +2,12 @@
 using System;
 using System.ComponentModel;
 using Android.Content;
-using Android.Content.Res;
-using Android.Graphics.Drawables;
 using Android.Support.V4.View;
 using Android.Views;
 using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android.FastRenderers;
 using Xamarin.Forms.Platform.Android.Material;
-using AColor = Android.Graphics.Color;
 using AProgressBar = Android.Widget.ProgressBar;
 using AView = Android.Views.View;
 
@@ -26,6 +23,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 		bool _disposed;
 
 		ActivityIndicator _element;
+		CircularProgress _control;
 
 		VisualElementTracker _visualElementTracker;
 		VisualElementRenderer _visualElementRenderer;
@@ -39,12 +37,13 @@ namespace Xamarin.Forms.Platform.Android.Material
 		{
 			VisualElement.VerifyVisualFlagEnabled();
 
-			Control = new CircularProgress(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular)
+			Control = _control = new CircularProgress(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular)
 			{
 				// limiting size to compare iOS realization
 				// https://github.com/material-components/material-components-ios/blob/develop/components/ActivityIndicator/src/MDCActivityIndicator.m#L425
 				MinSize = (int)Context.ToPixels(10),
-				MaxSize = (int)Context.ToPixels(144)
+				MaxSize = (int)Context.ToPixels(144),
+				DefaultColor = MaterialColors.Light.PrimaryColor
 			};
 			AddView(Control);
 
@@ -117,7 +116,9 @@ namespace Xamarin.Forms.Platform.Android.Material
 
 				e.NewElement.PropertyChanged += OnElementPropertyChanged;
 
-				UpdateColorsAndRuning();
+				UpdateColor();
+				UpdateBackgroundColor();
+				UpdateIsRunning();
 
 				ElevationHelper.SetElevation(this, e.NewElement);
 			}
@@ -127,8 +128,12 @@ namespace Xamarin.Forms.Platform.Android.Material
 		{
 			ElementPropertyChanged?.Invoke(this, e);
 
-			if (e.IsOneOf(ActivityIndicator.IsRunningProperty, ActivityIndicator.ColorProperty, VisualElement.BackgroundColorProperty))
-				UpdateColorsAndRuning();
+			if (e.Is(ActivityIndicator.IsRunningProperty))
+				UpdateIsRunning();
+			else if (e.Is(ActivityIndicator.ColorProperty))
+				UpdateColor();
+			else if (e.Is(VisualElement.BackgroundColorProperty))
+				UpdateBackgroundColor();
 		}
 
 		public override bool OnTouchEvent(MotionEvent e)
@@ -139,30 +144,22 @@ namespace Xamarin.Forms.Platform.Android.Material
 			return _motionEventHelper.HandleMotionEvent(Parent, e);
 		}
 
-		void UpdateColorsAndRuning()
+		void UpdateIsRunning()
 		{
-			if (Element == null || Control == null)
-				return;
+			if (Element != null && Control != null)
+				_control.IsRunning = Element.IsRunning;
+		}
 
-			var background = Element.BackgroundColor.IsDefault 
-				? AColor.Transparent 
-				: Element.BackgroundColor.ToAndroid();
-			(Control.Background as GradientDrawable)?.SetColor(background);
+		void UpdateColor()
+		{
+			if (Element != null && Control != null)
+				_control.SetColor(Element.Color);
+		}
 
-			if (Element.IsRunning)
-			{
-				var progress = Element.Color.IsDefault 
-					? MaterialColors.Light.PrimaryColor 
-					: Element.Color.ToAndroid();
-				Control.IndeterminateTintList = ColorStateList.ValueOf(progress);
-			}
-			else
-			{
-				Control.Visibility = Element.BackgroundColor.IsDefault 
-					? ViewStates.Gone 
-					: ViewStates.Visible;
-				Control.IndeterminateTintList = ColorStateList.ValueOf(AColor.Transparent);
-			}
+		void UpdateBackgroundColor()
+		{
+			if (Element != null && Control != null)
+				_control.SetBackgroundColor(Element.BackgroundColor);
 		}
 
 		// IVisualElementRenderer

--- a/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Material/MaterialActivityIndicatorRenderer.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 		{
 			VisualElement.VerifyVisualFlagEnabled();
 
-			Control = _control = new CircularProgress(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular)
+			_control = new CircularProgress(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular)
 			{
 				// limiting size to compare iOS realization
 				// https://github.com/material-components/material-components-ios/blob/develop/components/ActivityIndicator/src/MDCActivityIndicator.m#L425
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 			_motionEventHelper = new MotionEventHelper();
 		}
 
-		protected AProgressBar Control { get; private set; }
+		protected AProgressBar Control => _control;
 
 		protected ActivityIndicator Element
 		{
@@ -146,19 +146,19 @@ namespace Xamarin.Forms.Platform.Android.Material
 
 		void UpdateIsRunning()
 		{
-			if (Element != null && Control != null)
+			if (Element != null && _control != null)
 				_control.IsRunning = Element.IsRunning;
 		}
 
 		void UpdateColor()
 		{
-			if (Element != null && Control != null)
+			if (Element != null && _control != null)
 				_control.SetColor(Element.Color);
 		}
 
 		void UpdateBackgroundColor()
 		{
-			if (Element != null && Control != null)
+			if (Element != null && _control != null)
 				_control.SetBackgroundColor(Element.BackgroundColor);
 		}
 
@@ -174,7 +174,7 @@ namespace Xamarin.Forms.Platform.Android.Material
 
 		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
-			Control.Measure(widthConstraint, heightConstraint);
+			_control.Measure(widthConstraint, heightConstraint);
 			return new SizeRequest(new Size(Control.MeasuredWidth, Control.MeasuredHeight), new Size());
 		}
 
@@ -196,11 +196,11 @@ namespace Xamarin.Forms.Platform.Android.Material
 		// IViewRenderer
 
 		void IViewRenderer.MeasureExactly() =>
-			ViewRenderer.MeasureExactly(Control, Element, Context);
+			ViewRenderer.MeasureExactly(_control, Element, Context);
 
 		// ITabStop
 
-		AView ITabStop.TabStop => Control;
+		AView ITabStop.TabStop => _control;
 	}
 }
 #endif

--- a/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
@@ -1,51 +1,25 @@
 using System;
 using Android.Content;
 using Android.Util;
-using Android.Views;
 using AProgressBar = Android.Widget.ProgressBar;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal class CircularProgress : AProgressBar, ViewTreeObserver.IOnPreDrawListener
+	internal class CircularProgress : AProgressBar
 	{
 		public CircularProgress(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
 		{
-			ViewTreeObserver.AddOnPreDrawListener(this);
 			Indeterminate = true;
 		}
 
-		protected override void Dispose(bool disposing)
+		public override void Layout(int l, int t, int r, int b)
 		{
-			base.Dispose(disposing);
-			if (disposing && !this.IsDisposed())
-				ViewTreeObserver.RemoveOnPreDrawListener(this);
-		}
-
-		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
-		{
-			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-
-			if (IsInEditMode)
-			{
-				if (Math.Abs(heightMeasureSpec) < Math.Abs(widthMeasureSpec))
-					OnMeasure(heightMeasureSpec, heightMeasureSpec);
-				else
-					OnMeasure(widthMeasureSpec, widthMeasureSpec);
-			}
-		}
-
-		public bool OnPreDraw()
-		{
-			if (Width != Height)
-			{
-				var squareSize = Math.Min(Width, Height);
-				var lp = LayoutParameters;
-				lp.Width = squareSize;
-				lp.Height = squareSize;
-				RequestLayout();
-				return false;
-			}
-			return true;
+			var width = r - l;
+			var height = b - t;
+			var squareSize = Math.Min(width, height);
+			l += (width - squareSize) / 2;
+			t += (height - squareSize) / 2;
+			base.Layout(l, t, l + squareSize, t + squareSize);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
@@ -1,20 +1,17 @@
 using System;
 using Android.Content;
-using Android.Runtime;
+using Android.Util;
 using Android.Views;
-using Android.Widget;
+using AProgressBar = Android.Widget.ProgressBar;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal class SquareLayout : FrameLayout, ViewTreeObserver.IOnPreDrawListener
+	internal class CircularProgress : AProgressBar, ViewTreeObserver.IOnPreDrawListener
 	{
-		public SquareLayout(Context context) : base(context)
+		public CircularProgress(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
 		{
 			ViewTreeObserver.AddOnPreDrawListener(this);
-		}
-
-		protected SquareLayout(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
-		{
+			Indeterminate = true;
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
@@ -7,6 +7,7 @@ using Android.Graphics.Drawables;
 using AColor = Android.Graphics.Color;
 using Android.Content.Res;
 using Android.Views;
+using Android.Graphics;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -31,6 +32,13 @@ namespace Xamarin.Forms.Platform.Android
 			Indeterminate = true;
 		}
 
+		public override void Draw(Canvas canvas)
+		{
+			base.Draw(canvas);
+			if (_isRunning != IsRunning)
+				IsRunning = _isRunning;
+		}
+
 		public void SetColor(Color color)
 		{
 			var progress = color.IsDefault ? DefaultColor : color.ToAndroid();
@@ -41,13 +49,6 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			_backgroudColor = color.IsDefault ? AColor.Transparent : color.ToAndroid();
 			(Background as GradientDrawable)?.SetColor(_backgroudColor);
-		}
-
-		public override ViewStates Visibility {
-			get => !_isRunning && _backgroudColor == AColor.Transparent 
-				? ViewStates.Invisible 
-				: base.Visibility;
-			set => base.Visibility = value;
 		}
 
 		AnimatedVectorDrawable CurrentDrawable => IndeterminateDrawable.Current as AnimatedVectorDrawable;

--- a/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
@@ -1,21 +1,65 @@
 using System;
 using Android.Content;
+using Android.OS;
 using Android.Util;
 using AProgressBar = Android.Widget.ProgressBar;
+using Android.Graphics.Drawables;
+using AColor = Android.Graphics.Color;
+using Android.Content.Res;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	internal class CircularProgress : AProgressBar
 	{
+		bool _lastIsRunning = false;
+
 		public int MaxSize { get; set; } = int.MaxValue;
 
 		public int MinSize { get; set; } = 0;
 
+		public AColor DefaultColor { get; set; }
+
 		const int _paddingRatio = 10;
+
+		const int _paddingRatio23 = 14;
 
 		public CircularProgress(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
 		{
 			Indeterminate = true;
+		}
+
+		public void SetColor(Color color)
+		{
+			var progress = color.IsDefault
+				? DefaultColor
+				: color.ToAndroid();
+			IndeterminateTintList = ColorStateList.ValueOf(progress);
+		}
+
+		public void SetBackgroundColor(Color color)
+		{
+			var background = color.IsDefault
+				? AColor.Transparent
+				: color.ToAndroid();
+			(Background as GradientDrawable)?.SetColor(background);
+		}
+
+		AnimatedVectorDrawable CurrentDrawable => IndeterminateDrawable.Current as AnimatedVectorDrawable;
+
+		public bool IsRunning
+		{
+			get => CurrentDrawable?.IsRunning ?? false;
+			set
+			{
+				if (CurrentDrawable == null)
+					return;
+
+				_lastIsRunning = value;
+				if (_lastIsRunning && !CurrentDrawable.IsRunning)
+					CurrentDrawable.Start();
+				else if (!_lastIsRunning && CurrentDrawable.IsRunning)
+					CurrentDrawable.Stop();
+			}
 		}
 
 		public override void Layout(int l, int t, int r, int b)
@@ -25,7 +69,12 @@ namespace Xamarin.Forms.Platform.Android
 			var squareSize = Math.Min(Math.Max(Math.Min(width, height), MinSize), MaxSize);
 			l += (width - squareSize) / 2;
 			t += (height - squareSize) / 2;
-			var strokeWidth = squareSize / _paddingRatio;
+			int strokeWidth;
+			if (Build.VERSION.SdkInt < BuildVersionCodes.N)
+				strokeWidth = squareSize / _paddingRatio23;
+			else
+				strokeWidth = squareSize / _paddingRatio;
+
 			squareSize += strokeWidth;
 			base.Layout(l - strokeWidth, t - strokeWidth, l + squareSize, t + squareSize);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/SquareLayout.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SquareLayout.cs
@@ -1,0 +1,54 @@
+using System;
+using Android.Content;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal class SquareLayout : FrameLayout, ViewTreeObserver.IOnPreDrawListener
+	{
+		public SquareLayout(Context context) : base(context)
+		{
+			ViewTreeObserver.AddOnPreDrawListener(this);
+		}
+
+		protected SquareLayout(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+		{
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+			if (disposing && !this.IsDisposed())
+				ViewTreeObserver.RemoveOnPreDrawListener(this);
+		}
+
+		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+
+			if (IsInEditMode)
+			{
+				if (Math.Abs(heightMeasureSpec) < Math.Abs(widthMeasureSpec))
+					OnMeasure(heightMeasureSpec, heightMeasureSpec);
+				else
+					OnMeasure(widthMeasureSpec, widthMeasureSpec);
+			}
+		}
+
+		public bool OnPreDraw()
+		{
+			if (Width != Height)
+			{
+				var squareSize = Math.Min(Width, Height);
+				var lp = LayoutParameters;
+				lp.Width = squareSize;
+				lp.Height = squareSize;
+				RequestLayout();
+				return false;
+			}
+			return true;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Resources/drawable-v24/MaterialActivityIndicatorBackground.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/drawable-v24/MaterialActivityIndicatorBackground.xml
@@ -5,7 +5,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="ring"
     android:thicknessRatio="12"
-    android:innerRadiusRatio="2.8"
+    android:innerRadiusRatio="3"
     android:useLevel="false">
   <solid android:color="#000" />
 </shape>

--- a/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialActivityIndicatorBackground.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialActivityIndicatorBackground.xml
@@ -3,8 +3,7 @@
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="ring"
-    android:innerRadius="16dp" 
-    android:thickness="4dp"
+    android:thicknessRatio="12"
     android:useLevel="false">
   <solid android:color="#000" />
 </shape>

--- a/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialActivityIndicatorBackground.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialActivityIndicatorBackground.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- innerRadius = (diameter / 2) - (thickness * 2) = 16dp -->
+<!--  thickness = width / thicknessRatio = 48 / 12 = 4
+      thicknessRatio = width / thickness = 48 / 4 = 12 -->
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="ring"

--- a/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialActivityIndicatorBackground.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/drawable/MaterialActivityIndicatorBackground.xml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--  thickness = width / thicknessRatio = 48 / 12 = 4
-      thicknessRatio = width / thickness = 48 / 4 = 12 -->
+<!-- API23 and less
+magic innerRadiusRatio = 90% pi -->
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="ring"
     android:thicknessRatio="12"
-    android:innerRadiusRatio="2.8"
+    android:innerRadiusRatio="2.8274333882308139146163790449516"
     android:useLevel="false">
   <solid android:color="#000" />
 </shape>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -152,7 +152,7 @@
     <Compile Include="Material\MaterialEntryRenderer.cs" />
     <Compile Include="Material\MaterialProgressBarRenderer.cs" />
     <Compile Include="IPickerRenderer.cs" />
-    <Compile Include="Renderers\SquareLayout.cs" />
+    <Compile Include="Renderers\CircularProgress.cs" />
     <Compile Include="Renderers\PickerEditText.cs" />
     <Compile Include="Renderers\FontImageSourceHandler.cs" />
     <Compile Include="Renderers\FormsWebViewClient.cs" />

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Material\MaterialEntryRenderer.cs" />
     <Compile Include="Material\MaterialProgressBarRenderer.cs" />
     <Compile Include="IPickerRenderer.cs" />
+    <Compile Include="Renderers\SquareLayout.cs" />
     <Compile Include="Renderers\PickerEditText.cs" />
     <Compile Include="Renderers\FontImageSourceHandler.cs" />
     <Compile Include="Renderers\FormsWebViewClient.cs" />

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -400,9 +400,14 @@
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\MaterialActivityIndicatorBackground.xml">
+      <Generator>MSBuild:UpdateGeneratedFiles</Generator>
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\drawable-v24\MaterialActivityIndicatorBackground.xml">
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>
@@ -411,9 +416,7 @@
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Resources\color\" />
-  </ItemGroup>
+  <ItemGroup />
   <Target Name="BeforeBuild" Condition=" '$(CreateAllAndroidTargets)' == 'true' ">
     <!--  create 8.1 binaries-->
     <MSBuild Targets="Restore" Projects="@(ProjectToBuild)">


### PR DESCRIPTION
### Description of Change ###

Fixed the back circle of the activation indicator when resizing. The `ThicknessRatio` of the activator indicator is tied to the width so that the width and height are the same, it is added to the square layout.
![image](https://user-images.githubusercontent.com/27482193/52898977-99e23c80-31f5-11e9-8516-9871b4df540a.png)

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5261

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Before/After Screenshots ### 

After
**Android**
![screenshot_2](https://user-images.githubusercontent.com/27482193/52900115-2ba47680-3203-11e9-88cc-94f4515f9882.png)
![](http://g.recordit.co/XPUXjB7t5s.gif)

**iOS**
![screenshot_3](https://user-images.githubusercontent.com/27482193/52900116-2ba47680-3203-11e9-9360-051764699440.png) |

### Testing Procedure ###

- run VisualGallery

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
