### PR TITLE
[visual] Add extra parameter to android visual constructors

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/DependencyResolutionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DependencyResolutionTests.cs
@@ -173,7 +173,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var context = "Pretend this is an Android context";
 
-			var result = Internals.Registrar.Registered.GetHandler(typeof(MockElement), null, context);
+			var result = Internals.Registrar.Registered.GetHandler(typeof(MockElement), null, null, context);
 			var typedRenderer = (MockRendererWithParam)result;
 
 			Assert.That(typedRenderer, Is.InstanceOf(typeof(MockRendererWithParam)));

--- a/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			
 		}
 	}
+
 	public class VisualMarkerUnitTests : IVisual { }
 	public class RegisteredWithNobodyMarker : IVisual { }
 
@@ -30,7 +31,18 @@ namespace Xamarin.Forms.Core.UnitTests
 	internal class RenderWithChildTarget : IRegisterable { }
 	internal class RenderWithSetAsNewDefault : IRegisterable { }
 
-	internal class VisualButtonTarget : IRegisterable { }
+	internal class VisualButtonTarget : IRegisterable
+	{
+		public object Param1 { get; }
+		public object Param2 { get; }
+
+		public VisualButtonTarget() { }
+		public VisualButtonTarget(object param1, object param2) {
+			Param1 = param1;
+			Param2 = param2;
+		}
+	}
+
 	internal class VisualSliderTarget : IRegisterable { }
 	internal class ButtonChildTarget : IRegisterable { }
 	internal class ButtonChild : Button, IRegisterable { }
@@ -113,6 +125,18 @@ namespace Xamarin.Forms.Core.UnitTests
 			buttonTarget = Internals.Registrar.Registered.GetHandler(typeof(Button));
 			Assert.IsNotNull(buttonTarget);
 			Assert.That(buttonTarget, Is.InstanceOf<ButtonTarget>());
+
+
+			Button button = new Button();
+			object someObject = new object();
+			buttonTarget = Internals.Registrar.Registered.GetHandler(typeof(Button), button, new VisualMarkerUnitTests(), someObject);
+			Assert.IsNotNull(buttonTarget);
+			Assert.That(buttonTarget, Is.InstanceOf<VisualButtonTarget>());
+
+			var visualButtonTarget = (VisualButtonTarget)buttonTarget;
+			Assert.AreEqual(visualButtonTarget.Param1, someObject);
+			Assert.AreEqual(visualButtonTarget.Param2, button);
+
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/DependencyResolver.cs
+++ b/Xamarin.Forms.Core/DependencyResolver.cs
@@ -33,7 +33,9 @@ namespace Xamarin.Forms.Internals
 			return result;
 		}
 
-		internal static object ResolveOrCreate(Type type, params object[] args)
+		internal static object ResolveOrCreate(Type type) => ResolveOrCreate(type, null, null);
+
+		internal static object ResolveOrCreate(Type type, object source, Type visualType, params object[] args)
 		{
 			var result = Resolve(type, args);
 
@@ -41,6 +43,10 @@ namespace Xamarin.Forms.Internals
 
 			if (args.Length > 0)
 			{
+				if(visualType != typeof(VisualRendererMarker.Default))
+					if (type.GetTypeInfo().DeclaredConstructors.Any(info => info.GetParameters().Length == 2))
+						return Activator.CreateInstance(type, new[] { args[0], source });
+
 				// This is by no means a general solution to matching with the correct constructor, but it'll
 				// do for finding Android renderers which need Context (vs older custom renderers which may still use
 				// parameterless constructors)

--- a/Xamarin.Forms.Core/DependencyResolver.cs
+++ b/Xamarin.Forms.Core/DependencyResolver.cs
@@ -6,6 +6,7 @@ namespace Xamarin.Forms.Internals
 {
 	public static class DependencyResolver
 	{
+		static Type _defaultVisualType = typeof(VisualMarker.DefaultVisual);
 		static Func<Type, object[], object> Resolver { get; set; }
 
 		public static void ResolveUsing(Func<Type, object[], object> resolver)
@@ -37,13 +38,15 @@ namespace Xamarin.Forms.Internals
 
 		internal static object ResolveOrCreate(Type type, object source, Type visualType, params object[] args)
 		{
+			visualType = visualType ?? _defaultVisualType;
+
 			var result = Resolve(type, args);
 
 			if (result != null) return result;
 
 			if (args.Length > 0)
 			{
-				if(visualType != typeof(VisualRendererMarker.Default))
+				if(visualType != _defaultVisualType)
 					if (type.GetTypeInfo().DeclaredConstructors.Any(info => info.GetParameters().Length == 2))
 						return Activator.CreateInstance(type, new[] { args[0], source });
 

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Internals
 			return (TRegistrable)handler;
 		}
 
-		internal TRegistrable GetHandler(Type type, IVisual visual, params object[] args)
+		internal TRegistrable GetHandler(Type type, object source, IVisual visual, params object[] args)
 		{
 			if (args.Length == 0)
 			{
@@ -67,7 +67,8 @@ namespace Xamarin.Forms.Internals
 			if (handlerType == null)
 				return null;
 
-			return (TRegistrable)DependencyResolver.ResolveOrCreate(handlerType, args);
+			
+			return (TRegistrable)DependencyResolver.ResolveOrCreate(handlerType, source, visual?.GetType(), args);
 		}
 
 		public TOut GetHandler<TOut>(Type type) where TOut : class, TRegistrable
@@ -77,7 +78,7 @@ namespace Xamarin.Forms.Internals
 
 		public TOut GetHandler<TOut>(Type type, params object[] args) where TOut : class, TRegistrable
 		{
-			return GetHandler(type, null, args) as TOut;
+			return GetHandler(type, null, null, args) as TOut;
 		}
 
 		public TOut GetHandlerForObject<TOut>(object obj) where TOut : class, TRegistrable
@@ -99,19 +100,9 @@ namespace Xamarin.Forms.Internals
 			var reflectableType = obj as IReflectableType;
 			var type = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : obj.GetType();
 
-			return GetHandler(type, (obj as IVisualController)?.EffectiveVisual, args) as TOut;
+			return GetHandler(type, obj, (obj as IVisualController)?.EffectiveVisual, args) as TOut;
 		}
-
-		TOut GetHandlerForObject<TOut>(object obj, IVisual visual, params object[] args) where TOut : class, TRegistrable
-		{
-			if (obj == null)
-				throw new ArgumentNullException(nameof(obj));
-
-			var reflectableType = obj as IReflectableType;
-			var type = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : obj.GetType();
-
-			return GetHandler(type, visual, args) as TOut;
-		}
+		
 
 		public Type GetHandlerType(Type viewType) => GetHandlerType(viewType, _defaultVisualType);
 

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -40,8 +40,10 @@ namespace Xamarin.Forms.Material.Android
 		VisualElementRenderer _visualElementRenderer;
 		ButtonLayoutManager _buttonLayoutManager;
 		readonly AutomationPropertiesProvider _automationPropertiesProvider;
-		
-		public MaterialButtonRenderer(Context context)
+
+		public MaterialButtonRenderer(Context context) : this(context, null) { }
+
+		public MaterialButtonRenderer(Context context, BindableObject element)
 			: base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialTheme))
 		{
 			_automationPropertiesProvider = new AutomationPropertiesProvider(this);


### PR DESCRIPTION
### Description of Change ###
Material Android renderers need to know the style they are being set to on creation so they can be set to the correct style id.  The style on an android element isn't settable at runtime post inception.

The idea is being able to do this via the constructor
```C#
static int getThemeId(BindableObject element)
		{
			var style = Xamarin.Forms.Material.Button.GetStyle(element);
			int themeId = Resource.Style.XamarinFormsMaterialTheme;
			switch (style)
			{
				case Xamarin.Forms.Material.Style.Outline:
					themeId = Resource.Style.XamarinFormsMaterialOutlinedButtonTheme;
					break;
				case Xamarin.Forms.Material.Style.Text:
					themeId = Resource.Style.XamarinFormsMaterialTextButtonTheme;
					break;
			}

			return themeId;
		}

		public MaterialButtonRenderer(Context context, BindableObject element)
			: base(new ContextThemeWrapper(context, getThemeId(element)))
		{
			VisualElement.VerifyVisualFlagEnabled();
```
 
### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms
- Android

### Behavioral/Visual Changes ###
If a constructor isn't found with two arguments it will just default back to the previous behavior which just uses the constructor that takes a context

### Testing Procedure ###
Unit Test Added

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
