### PR TITLE
Fix NRE in Android ResourceManager when reference resource in Previewer

### DIFF
--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -138,6 +138,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		static int GetId(Type type, string memberName)
 		{
+			// This may legitimately be null in designer scenarios
+			if (type == null)
+				return 0;
+
 			object value = null;
 			var fields = type.GetFields();
 			for (int i = 0; i < fields.Length; i++)


### PR DESCRIPTION
### Description of Change ###

When running in the Forms Previewer, `Xamarin.Forms.Platform.Android.ResourceManager.Init()` won't find the expected types if the project has not been built, and `GetId()` will fail with an NRE.

Add a null check to `GetId()` and return 0.

### Issues Resolved ### 

Fixes part of #5300 

### API Changes ###
 
None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

A sample app sets `ContentPage.BackgroundImage` in a `Style` in `App.xaml`. If the project is not built, currently every page fails to render in the Previewer (Android) as follows:

![image](https://user-images.githubusercontent.com/9665847/52984420-13b73780-343b-11e9-94dc-dcb11dead1bd.png)

With this fix in place, all pages render as expected, for example...

![image](https://user-images.githubusercontent.com/9665847/52984545-a657d680-343b-11e9-83ec-2e075878cbe5.png)

### Testing Procedure ###

Verified Forms XAML pages that failed to render in Previewer now render successfully.

### PR Checklist ###

- [ ] Has automated tests - we will add tests on the previewer side to cover this scenario
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
