### PR TITLE
Use a better way of finding the Android root assembly

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms
 		// Why is bundle a param if never used?
 		public static void Init(Context activity, Bundle bundle)
 		{
-			Assembly resourceAssembly = Assembly.GetCallingAssembly();
+			Assembly resourceAssembly = Assembly.GetEntryAssembly ();
 			SetupInit(activity, resourceAssembly);
 		}
 


### PR DESCRIPTION
If you want a foolproof way of getting a reference to the assembly from
the Android/iOS/whatever project, then just use the EntryAssembly.