### PR TITLE
[XamlC] Identify generic instance types correctly when importing ctor

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/ModuleDefinitionExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/ModuleDefinitionExtensionsTests.cs
@@ -1,0 +1,62 @@
+using System;
+using NUnit.Framework;
+using Mono.Cecil;
+using Xamarin.Forms.Build.Tasks;
+
+namespace Xamarin.Forms.XamlcUnitTests
+{
+	[TestFixture]
+	public class ModuleDefinitionExtensionsTests
+	{
+		class WithGenericInstanceCtorParameter
+		{
+			public WithGenericInstanceCtorParameter(Tuple<byte> argument)
+			{
+			}
+
+			public WithGenericInstanceCtorParameter(Tuple<short> argument)
+			{
+			}
+		}
+
+		ModuleDefinition module;
+
+		[SetUp]
+		public void SetUp()
+		{
+			var resolver = new XamlCAssemblyResolver();
+			resolver.AddAssembly(Uri.UnescapeDataString((new UriBuilder(typeof(ModuleDefinitionExtensionsTests).Assembly.CodeBase)).Path));
+			resolver.AddAssembly(Uri.UnescapeDataString((new UriBuilder(typeof(byte).Assembly.CodeBase)).Path));
+
+			module = ModuleDefinition.CreateModule("foo", new ModuleParameters {
+				AssemblyResolver = resolver,
+				Kind = ModuleKind.Dll
+			});
+		}
+
+		[Test]
+		public void TestImportCtorReferenceWithGenericInstanceCtorParameter()
+		{
+			var type = module.ImportReference(typeof(WithGenericInstanceCtorParameter));
+			var byteTuple = module.ImportReference(typeof(Tuple<byte>));
+			var byteTupleCtor = module.ImportCtorReference(type, new[] { byteTuple });
+			var int16Tuple = module.ImportReference(typeof(Tuple<short>));
+			var int16TupleCtor = module.ImportCtorReference(type, new[] { int16Tuple });
+
+			Assert.AreEqual("System.Tuple`1<System.Byte>", byteTupleCtor.Parameters[0].ParameterType.FullName);
+			Assert.AreEqual("System.Tuple`1<System.Int16>", int16TupleCtor.Parameters[0].ParameterType.FullName);
+		}
+
+		[Test]
+		public void TestImportCtorReferenceWithGenericInstanceTypeParameter()
+		{
+			var byteTuple = module.ImportReference(typeof(Tuple<byte>));
+			var byteTupleCtor = module.ImportCtorReference(("mscorlib", "System", "Tuple`1"), 1, new[] { byteTuple });
+			var in16Tuple = module.ImportReference(typeof(Tuple<short>));
+			var int16TupleCtor = module.ImportCtorReference(("mscorlib", "System", "Tuple`1"), 1, new[] { in16Tuple });
+
+			Assert.AreEqual("System.Tuple`1<System.Byte>", ((GenericInstanceType)byteTupleCtor.DeclaringType).GenericArguments[0].FullName);
+			Assert.AreEqual("System.Tuple`1<System.Int16>", ((GenericInstanceType)int16TupleCtor.DeclaringType).GenericArguments[0].FullName);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

The old implementation fails to identify generic instance types for typed binding getter, whose type is:
System.Func`2<TSource, ValueTuple<TProperty, bool>>

This fixes the issue by taking generic arguments into account.

### Issues Resolved ### 

None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run the automated test.

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
