### PR TITLE
[C] deprecate GetValues

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -1,9 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xamarin.Forms.Internals;
 
@@ -11,52 +9,91 @@ namespace Xamarin.Forms
 {
 	public abstract class BindableObject : INotifyPropertyChanged, IDynamicResourceHandler
 	{
+		readonly Dictionary<BindableProperty, BindablePropertyContext> _properties = new Dictionary<BindableProperty, BindablePropertyContext>(4);
+		bool _applying;
+		object _inheritedContext;
+
 		public static readonly BindableProperty BindingContextProperty =
 			BindableProperty.Create("BindingContext", typeof(object), typeof(BindableObject), default(object),
 									BindingMode.OneWay, null, BindingContextPropertyChanged, null, null, BindingContextPropertyBindingChanging);
 
-		readonly Dictionary<BindableProperty, BindablePropertyContext> _properties = new Dictionary<BindableProperty, BindablePropertyContext>(4);
-
-		bool _applying;
-		object _inheritedContext;
-
 		public object BindingContext
 		{
-			get { return _inheritedContext ?? GetValue(BindingContextProperty); }
-			set { SetValue(BindingContextProperty, value); }
-		}
-
-		void IDynamicResourceHandler.SetDynamicResource(BindableProperty property, string key)
-		{
-			SetDynamicResource(property, key, false);
+			get => _inheritedContext ?? GetValue(BindingContextProperty);
+			set => SetValue(BindingContextProperty, value);
 		}
 
 		public event PropertyChangedEventHandler PropertyChanged;
-
+		public event PropertyChangingEventHandler PropertyChanging;
 		public event EventHandler BindingContextChanged;
 
-		internal void ClearValue(BindableProperty property, bool fromStyle)
-		{
-			ClearValue(property, fromStyle: fromStyle, checkAccess: true);
-		}
+		public void ClearValue(BindableProperty property) => ClearValue(property, fromStyle: false, checkAccess: true);
 
-		public void ClearValue(BindableProperty property)
-		{
-			ClearValue(property, fromStyle: false, checkAccess: true);
-		}
+		internal void ClearValue(BindableProperty property, bool fromStyle) => ClearValue(property, fromStyle: fromStyle, checkAccess: true);
 
 		public void ClearValue(BindablePropertyKey propertyKey)
 		{
 			if (propertyKey == null)
-				throw new ArgumentNullException("propertyKey");
+				throw new ArgumentNullException(nameof(propertyKey));
 
 			ClearValue(propertyKey.BindableProperty, fromStyle:false, checkAccess: false);
+		}
+
+		void ClearValue(BindableProperty property, bool fromStyle, bool checkAccess)
+		{
+			if (property == null)
+				throw new ArgumentNullException(nameof(property));
+
+			if (checkAccess && property.IsReadOnly)
+				throw new InvalidOperationException($"The BindableProperty \"{property.PropertyName}\" is readonly.");
+
+			BindablePropertyContext bpcontext = GetContext(property);
+			if (bpcontext == null)
+				return;
+
+			if (fromStyle && !CanBeSetFromStyle(property))
+				return;
+
+			object original = bpcontext.Value;
+
+			object newValue = property.GetDefaultValue(this);
+
+			bool same = Equals(original, newValue);
+			if (!same)
+			{
+				property.PropertyChanging?.Invoke(this, original, newValue);
+
+				OnPropertyChanging(property.PropertyName);
+			}
+
+			bpcontext.Attributes &= ~BindableContextAttributes.IsManuallySet;
+			bpcontext.Value = newValue;
+			if (property.DefaultValueCreator == null)
+				bpcontext.Attributes |= BindableContextAttributes.IsDefaultValue;
+			else
+				bpcontext.Attributes |= BindableContextAttributes.IsDefaultValueCreated;
+
+			if (!same)
+			{
+				OnPropertyChanged(property.PropertyName);
+				property.PropertyChanged?.Invoke(this, original, newValue);
+			}
+		}
+
+		public object GetValue(BindableProperty property)
+		{
+			if (property == null)
+				throw new ArgumentNullException(nameof(property));
+
+			var context = property.DefaultValueCreator != null ? GetOrCreateContext(property) : GetContext(property);
+
+			return context == null ? property.DefaultValue : context.Value;
 		}
 
 		internal (bool IsSet, T Value)[] GetValues<T>(BindableProperty[] propArray)
 		{
 			Dictionary<BindableProperty, BindablePropertyContext> properties = _properties;
-			var resultArray = new(bool IsSet, T Value)[propArray.Length];
+			var resultArray = new (bool IsSet, T Value)[propArray.Length];
 
 			for (int i = 0; i < propArray.Length; i++)
 			{
@@ -75,59 +112,55 @@ namespace Xamarin.Forms
 			return resultArray;
 		}
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("There's no perf gain(anymore), but more allocation. use GetValue()")]
+		public object[] GetValues(BindableProperty property0, BindableProperty property1) => new object[] { GetValue(property0), GetValue(property1) };
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("There's no perf gain(anymore), but more allocation. use GetValue()")]
+		public object[] GetValues(BindableProperty property0, BindableProperty property1, BindableProperty property2) => new object[] { GetValue(property0), GetValue(property1), GetValue(property2) };
+
 		public bool IsSet(BindableProperty targetProperty)
 		{
-			if (targetProperty == null)
-				throw new ArgumentNullException(nameof(targetProperty));
-
-			var bpcontext = GetContext(targetProperty);
+			var bpcontext = GetContext(targetProperty ?? throw new ArgumentNullException(nameof(targetProperty)));
 			return bpcontext != null
 				&& (bpcontext.Attributes & BindableContextAttributes.IsDefaultValue) == 0;
 		}
 
-		public object GetValue(BindableProperty property)
-		{
-			if (property == null)
-				throw new ArgumentNullException("property");
-
-			BindablePropertyContext context = property.DefaultValueCreator != null ? GetOrCreateContext(property) : GetContext(property);
-
-			if (context == null)
-				return property.DefaultValue;
-
-			return context.Value;
-		}
-
-		public event PropertyChangingEventHandler PropertyChanging;
 
 		public void RemoveBinding(BindableProperty property)
 		{
-			if (property == null)
-				throw new ArgumentNullException("property");
+			BindablePropertyContext context = GetContext(property ?? throw new ArgumentNullException(nameof(property)));
 
-			BindablePropertyContext context = GetContext(property);
-			if (context == null || context.Binding == null)
+			if (context?.Binding != null)
+				RemoveBinding(property, context);
+		}
+
+		public void SetBinding(BindableProperty targetProperty, BindingBase binding) => SetBinding(targetProperty, binding, false);
+
+		internal void SetBinding(BindableProperty targetProperty, BindingBase binding, bool fromStyle)
+		{
+			if (targetProperty == null)
+				throw new ArgumentNullException(nameof(targetProperty));
+
+			if (fromStyle && !CanBeSetFromStyle(targetProperty))
 				return;
 
-			RemoveBinding(property, context);
-		}
+			var context = GetOrCreateContext(targetProperty);
+			if (fromStyle)
+				context.Attributes |= BindableContextAttributes.IsSetFromStyle;
+			else
+				context.Attributes &= ~BindableContextAttributes.IsSetFromStyle;
 
-		public void SetBinding(BindableProperty targetProperty, BindingBase binding)
-		{
-			SetBinding(targetProperty, binding, false);
-		}
+			if (context.Binding != null)
+				context.Binding.Unapply();
 
-		public void SetValue(BindableProperty property, object value)
-		{
-			SetValue(property, value, false, true);
-		}
+			BindingBase oldBinding = context.Binding;
+			context.Binding = binding ?? throw new ArgumentNullException(nameof(binding));
 
-		public void SetValue(BindablePropertyKey propertyKey, object value)
-		{
-			if (propertyKey == null)
-				throw new ArgumentNullException("propertyKey");
+			targetProperty.BindingChanging?.Invoke(this, oldBinding, binding);
 
-			SetValue(propertyKey.BindableProperty, value, false, false);
+			binding.Apply(BindingContext, this, targetProperty);
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
@@ -159,15 +192,9 @@ namespace Xamarin.Forms
 			bindable.OnBindingContextChanged();
 		}
 
-		protected void ApplyBindings()
-		{
-			ApplyBindings(skipBindingContext: false, fromBindingContextChanged: false);
-		}
+		protected void ApplyBindings() => ApplyBindings(skipBindingContext: false, fromBindingContextChanged: false);
 
-		protected virtual void OnBindingContextChanged()
-		{
-			BindingContextChanged?.Invoke(this, EventArgs.Empty);
-		}
+		protected virtual void OnBindingContextChanged() => BindingContextChanged?.Invoke(this, EventArgs.Empty);
 
 		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
 			=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -194,78 +221,7 @@ namespace Xamarin.Forms
 			return bpcontext != null && bpcontext.Binding != null;
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public object[] GetValues(BindableProperty property0, BindableProperty property1)
-		{
-			var values = new object[2];
 
-			if (_properties.TryGetValue(property0, out var context0))
-			{
-				values[0] = context0.Value;
-				property0 = null;
-			}
-
-			if (_properties.TryGetValue(property1, out var context1))
-			{
-				values[1] = context1.Value;
-				property1 = null;
-			}
-
-			if (!ReferenceEquals(property0, null))
-				values[0] = property0.DefaultValueCreator == null ? property0.DefaultValue : CreateAndAddContext(property0).Value;
-			if (!ReferenceEquals(property1, null))
-				values[1] = property1.DefaultValueCreator == null ? property1.DefaultValue : CreateAndAddContext(property1).Value;
-
-			return values;
-		}
-
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public object[] GetValues(BindableProperty property0, BindableProperty property1, BindableProperty property2)
-		{
-			var values = new object[3];
-
-			if (_properties.TryGetValue(property0, out var context0))
-			{
-				values[0] = context0.Value;
-				property0 = null;
-			}
-
-			if (_properties.TryGetValue(property1, out var context1))
-			{
-				values[1] = context1.Value;
-				property1 = null;
-			}
-
-			if (_properties.TryGetValue(property2, out var context2))
-			{
-				values[2] = context2.Value;
-				property2 = null;
-			}
-
-			if (!ReferenceEquals(property0, null))
-				values[0] = property0.DefaultValueCreator == null ? property0.DefaultValue : CreateAndAddContext(property0).Value;
-			if (!ReferenceEquals(property1, null))
-				values[1] = property1.DefaultValueCreator == null ? property1.DefaultValue : CreateAndAddContext(property1).Value;
-			if (!ReferenceEquals(property2, null))
-				values[2] = property2.DefaultValueCreator == null ? property2.DefaultValue : CreateAndAddContext(property2).Value;
-
-			return values;
-		}
-
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		internal object[] GetValues(params BindableProperty[] properties)
-		{
-			var values = new object[properties.Length];
-			for (var i = 0; i < properties.Length; i++) {
-				var prop = properties[i];
-				if (_properties.TryGetValue(prop, out var context))
-					values[i] = context.Value;
-				else
-					values[i] = prop.DefaultValueCreator == null ? prop.DefaultValue : CreateAndAddContext(prop).Value;
-			}
-
-			return values;
-		}
 
 		internal virtual void OnRemoveDynamicResource(BindableProperty property)
 		{
@@ -278,38 +234,11 @@ namespace Xamarin.Forms
 		internal void RemoveDynamicResource(BindableProperty property)
 		{
 			if (property == null)
-				throw new ArgumentNullException("property");
+				throw new ArgumentNullException(nameof(property));
 
 			OnRemoveDynamicResource(property);
 			BindablePropertyContext context = GetOrCreateContext(property);
 			context.Attributes &= ~BindableContextAttributes.IsDynamicResource;
-		}
-
-		internal void SetBinding(BindableProperty targetProperty, BindingBase binding, bool fromStyle)
-		{
-			if (targetProperty == null)
-				throw new ArgumentNullException("targetProperty");
-			if (binding == null)
-				throw new ArgumentNullException("binding");
-
-			if (fromStyle && !CanBeSetFromStyle(targetProperty))
-				return;
-
-			var context = GetOrCreateContext(targetProperty);
-			if (fromStyle)
-				context.Attributes |= BindableContextAttributes.IsSetFromStyle;
-			else
-				context.Attributes &= ~BindableContextAttributes.IsSetFromStyle;
-
-			if (context.Binding != null)
-				context.Binding.Unapply();
-
-			BindingBase oldBinding = context.Binding;
-			context.Binding = binding;
-
-			targetProperty.BindingChanging?.Invoke(this, oldBinding, binding);
-
-			binding.Apply(BindingContext, this, targetProperty);
 		}
 
 		bool CanBeSetFromStyle(BindableProperty property)
@@ -326,10 +255,9 @@ namespace Xamarin.Forms
 			return false;
 		}
 
-		internal void SetDynamicResource(BindableProperty property, string key)
-		{
-			SetDynamicResource(property, key, false);
-		}
+		void IDynamicResourceHandler.SetDynamicResource(BindableProperty property, string key) => SetDynamicResource(property, key, false);
+
+		internal void SetDynamicResource(BindableProperty property, string key) => SetDynamicResource(property, key, false);
 
 		internal void SetDynamicResource(BindableProperty property, string key, bool fromStyle)
 		{
@@ -351,21 +279,39 @@ namespace Xamarin.Forms
 			OnSetDynamicResource(property, key);
 		}
 
-		internal void SetValue(BindableProperty property, object value, bool fromStyle)
+		public void SetValue(BindableProperty property, object value) => SetValue(property, value, false, true);
+
+		public void SetValue(BindablePropertyKey propertyKey, object value)
 		{
-			SetValue(property, value, fromStyle, true);
+			if (propertyKey == null)
+				throw new ArgumentNullException(nameof(propertyKey));
+
+			SetValue(propertyKey.BindableProperty, value, false, false);
+		}
+
+		internal void SetValue(BindableProperty property, object value, bool fromStyle) => SetValue(property, value, fromStyle, true);
+
+		void SetValue(BindableProperty property, object value, bool fromStyle, bool checkAccess)
+		{
+			if (property == null)
+				throw new ArgumentNullException(nameof(property));
+
+			if (checkAccess && property.IsReadOnly)
+				throw new InvalidOperationException($"The BindableProperty \"{property.PropertyName}\" is readonly.");
+
+			if (fromStyle && !CanBeSetFromStyle(property))
+				return;
+
+			SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource,
+				(fromStyle ? SetValuePrivateFlags.FromStyle : SetValuePrivateFlags.ManuallySet) | (checkAccess ? SetValuePrivateFlags.CheckAccess : 0));
 		}
 
 		internal void SetValueCore(BindablePropertyKey propertyKey, object value, SetValueFlags attributes = SetValueFlags.None)
-		{
-			SetValueCore(propertyKey.BindableProperty, value, attributes, SetValuePrivateFlags.None);
-		}
+			=> SetValueCore(propertyKey.BindableProperty, value, attributes, SetValuePrivateFlags.None);
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetValueCore(BindableProperty property, object value, SetValueFlags attributes = SetValueFlags.None)
-		{
-			SetValueCore(property, value, attributes, SetValuePrivateFlags.Default);
-		}
+			=> SetValueCore(property, value, attributes, SetValuePrivateFlags.Default);
 
 		internal void SetValueCore(BindableProperty property, object value, SetValueFlags attributes, SetValuePrivateFlags privateAttributes)
 		{
@@ -379,18 +325,18 @@ namespace Xamarin.Forms
 				throw new ArgumentNullException(nameof(property));
 			if (checkAccess && property.IsReadOnly)
 			{
-				Log.Warning("BindableObject", "Can not set the BindableProperty \"{0}\" because it is readonly.", property.PropertyName);
+				Log.Warning("BindableObject", $"Can not set the BindableProperty \"{property.PropertyName}\" because it is readonly.");
 				return;
 			}
 
 			if (!converted && !property.TryConvert(ref value))
 			{
-				Log.Warning("SetValue", "Can not convert {0} to type '{1}'", value, property.ReturnType);
+				Log.Warning("SetValue", $"Can not convert {value} to type '{property.ReturnType}'");
 				return;
 			}
 
 			if (property.ValidateValue != null && !property.ValidateValue(this, value))
-				throw new ArgumentException("Value was an invalid value for " + property.PropertyName, "value");
+				throw new ArgumentException($"Value is an invalid value for {property.PropertyName}", nameof(value));
 
 			if (property.CoerceValue != null)
 				value = property.CoerceValue(this, value);
@@ -435,142 +381,6 @@ namespace Xamarin.Forms
 
 				context.Attributes &= ~BindableContextAttributes.IsBeingSet;
 			}
-		}
-
-		internal void ApplyBindings(bool skipBindingContext, bool fromBindingContextChanged)
-		{
-			var prop = _properties.Values.ToArray();
-			for (int i = 0, propLength = prop.Length; i < propLength; i++) {
-				BindablePropertyContext context = prop [i];
-				BindingBase binding = context.Binding;
-				if (binding == null)
-					continue;
-
-				if (skipBindingContext && ReferenceEquals(context.Property, BindingContextProperty))
-					continue;
-
-				binding.Unapply(fromBindingContextChanged: fromBindingContextChanged);
-				binding.Apply(BindingContext, this, context.Property, fromBindingContextChanged: fromBindingContextChanged);
-			}
-		}
-
-		static void BindingContextPropertyBindingChanging(BindableObject bindable, BindingBase oldBindingBase, BindingBase newBindingBase)
-		{
-			object context = bindable._inheritedContext;
-			var oldBinding = oldBindingBase as Binding;
-			var newBinding = newBindingBase as Binding;
-
-			if (context == null && oldBinding != null)
-				context = oldBinding.Context;
-			if (context != null && newBinding != null)
-				newBinding.Context = context;
-		}
-
-		static void BindingContextPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
-		{
-			bindable._inheritedContext = null;
-			bindable.ApplyBindings(skipBindingContext: true, fromBindingContextChanged:true);
-			bindable.OnBindingContextChanged();
-		}
-
-		void ClearValue(BindableProperty property, bool fromStyle, bool checkAccess)
-		{
-			if (property == null)
-				throw new ArgumentNullException(nameof(property));
-
-			if (checkAccess && property.IsReadOnly)
-				throw new InvalidOperationException(string.Format("The BindableProperty \"{0}\" is readonly.", property.PropertyName));
-
-			BindablePropertyContext bpcontext = GetContext(property);
-			if (bpcontext == null)
-				return;
-
-			if (fromStyle && !CanBeSetFromStyle(property))
-				return;
-
-			object original = bpcontext.Value;
-
-			object newValue = property.GetDefaultValue(this);
-
-			bool same = Equals(original, newValue);
-			if (!same)
-			{
-				property.PropertyChanging?.Invoke(this, original, newValue);
-
-				OnPropertyChanging(property.PropertyName);
-			}
-
-			bpcontext.Attributes &= ~BindableContextAttributes.IsManuallySet;
-			bpcontext.Value = newValue;
-			if (property.DefaultValueCreator == null)
-				bpcontext.Attributes |= BindableContextAttributes.IsDefaultValue;
-			else
-				bpcontext.Attributes |= BindableContextAttributes.IsDefaultValueCreated;
-
-			if (!same)
-			{
-				OnPropertyChanged(property.PropertyName);
-				property.PropertyChanged?.Invoke(this, original, newValue);
-			}
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		BindablePropertyContext CreateAndAddContext(BindableProperty property)
-		{
-			var defaultValueCreator = property.DefaultValueCreator;
-			var context = new BindablePropertyContext { Property = property, Value = defaultValueCreator != null ? defaultValueCreator(this) : property.DefaultValue };
-
-			if (defaultValueCreator == null)
-				context.Attributes = BindableContextAttributes.IsDefaultValue;
-			else
-				context.Attributes = BindableContextAttributes.IsDefaultValueCreated;
-
-			_properties.Add(property, context);
-			return context;
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		BindablePropertyContext GetContext(BindableProperty property)
-		{
-			if (_properties.TryGetValue(property, out var result))
-				return result;
-			return null;
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		BindablePropertyContext GetOrCreateContext(BindableProperty property)
-		{
-			BindablePropertyContext context = GetContext(property);
-			if (context == null)
-			{
-				context = CreateAndAddContext(property);
-			}
-
-			return context;
-		}
-
-		void RemoveBinding(BindableProperty property, BindablePropertyContext context)
-		{
-			context.Binding.Unapply();
-
-			property.BindingChanging?.Invoke(this, context.Binding, null);
-
-			context.Binding = null;
-		}
-
-		void SetValue(BindableProperty property, object value, bool fromStyle, bool checkAccess)
-		{
-			if (property == null)
-				throw new ArgumentNullException("property");
-
-			if (checkAccess && property.IsReadOnly)
-				throw new InvalidOperationException(string.Format("The BindableProperty \"{0}\" is readonly.", property.PropertyName));
-
-			if (fromStyle && !CanBeSetFromStyle(property))
-				return;
-
-			SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource,
-				(fromStyle ? SetValuePrivateFlags.FromStyle : SetValuePrivateFlags.ManuallySet) | (checkAccess ? SetValuePrivateFlags.CheckAccess : 0));
 		}
 
 		void SetValueActual(BindableProperty property, BindablePropertyContext context, object value, bool currentlyApplying, SetValueFlags attributes, bool silent = false)
@@ -623,6 +433,72 @@ namespace Xamarin.Forms
 
 				property.PropertyChanged?.Invoke(this, original, value);
 			}
+		}
+
+		internal void ApplyBindings(bool skipBindingContext, bool fromBindingContextChanged)
+		{
+			var prop = _properties.Values.ToArray();
+			for (int i = 0, propLength = prop.Length; i < propLength; i++) {
+				BindablePropertyContext context = prop [i];
+				BindingBase binding = context.Binding;
+				if (binding == null)
+					continue;
+
+				if (skipBindingContext && ReferenceEquals(context.Property, BindingContextProperty))
+					continue;
+
+				binding.Unapply(fromBindingContextChanged: fromBindingContextChanged);
+				binding.Apply(BindingContext, this, context.Property, fromBindingContextChanged: fromBindingContextChanged);
+			}
+		}
+
+		static void BindingContextPropertyBindingChanging(BindableObject bindable, BindingBase oldBindingBase, BindingBase newBindingBase)
+		{
+			object context = bindable._inheritedContext;
+			var oldBinding = oldBindingBase as Binding;
+			var newBinding = newBindingBase as Binding;
+
+			if (context == null && oldBinding != null)
+				context = oldBinding.Context;
+			if (context != null && newBinding != null)
+				newBinding.Context = context;
+		}
+
+		static void BindingContextPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+		{
+			bindable._inheritedContext = null;
+			bindable.ApplyBindings(skipBindingContext: true, fromBindingContextChanged:true);
+			bindable.OnBindingContextChanged();
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		BindablePropertyContext CreateAndAddContext(BindableProperty property)
+		{
+			var defaultValueCreator = property.DefaultValueCreator;
+			var context = new BindablePropertyContext { Property = property, Value = defaultValueCreator != null ? defaultValueCreator(this) : property.DefaultValue };
+
+			if (defaultValueCreator == null)
+				context.Attributes = BindableContextAttributes.IsDefaultValue;
+			else
+				context.Attributes = BindableContextAttributes.IsDefaultValueCreated;
+
+			_properties.Add(property, context);
+			return context;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		BindablePropertyContext GetContext(BindableProperty property) => _properties.TryGetValue(property, out var result) ? result : null;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		BindablePropertyContext GetOrCreateContext(BindableProperty property) => GetContext(property) ?? CreateAndAddContext(property);
+
+		void RemoveBinding(BindableProperty property, BindablePropertyContext context)
+		{
+			context.Binding.Unapply();
+
+			property.BindingChanging?.Invoke(this, context.Binding, null);
+
+			context.Binding = null;
 		}
 
 		[Flags]

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -113,11 +113,11 @@ namespace Xamarin.Forms
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		[Obsolete("There's no perf gain(anymore), but more allocation. use GetValue()")]
+		[Obsolete("GetValues is obsolete as of 4.0.0. Please use GetValue instead.")]
 		public object[] GetValues(BindableProperty property0, BindableProperty property1) => new object[] { GetValue(property0), GetValue(property1) };
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		[Obsolete("There's no perf gain(anymore), but more allocation. use GetValue()")]
+		[Obsolete("GetValues is obsolete as of 4.0.0. Please use GetValue instead.")]
 		public object[] GetValues(BindableProperty property0, BindableProperty property1, BindableProperty property2) => new object[] { GetValue(property0), GetValue(property1), GetValue(property2) };
 
 		public bool IsSet(BindableProperty targetProperty)

--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -244,16 +244,11 @@ namespace Xamarin.Forms
 
 		void InitLayoutProperties(Flex.Item item)
 		{
-			var values = GetValues(AlignContentProperty,
-								   AlignItemsProperty,
-								   DirectionProperty,
-								   JustifyContentProperty,
-								   WrapProperty);
-			item.AlignContent = (Flex.AlignContent)(FlexAlignContent)values[0];
-			item.AlignItems = (Flex.AlignItems)(FlexAlignItems)values[1];
-			item.Direction = (Flex.Direction)(FlexDirection)values[2];
-			item.JustifyContent = (Flex.Justify)(FlexJustify)values[3];
-			item.Wrap = (Flex.Wrap)(FlexWrap)values[4];
+			item.AlignContent = (Flex.AlignContent)(FlexAlignContent)GetValue(AlignContentProperty);
+			item.AlignItems = (Flex.AlignItems)(FlexAlignItems)GetValue(AlignItemsProperty);
+			item.Direction = (Flex.Direction)(FlexDirection)GetValue(DirectionProperty);
+			item.JustifyContent = (Flex.Justify)(FlexJustify)GetValue(JustifyContentProperty);
+			item.Wrap = (Flex.Wrap)(FlexWrap)GetValue(WrapProperty);
 		}
 
 		void ClearLayout()
@@ -300,33 +295,27 @@ namespace Xamarin.Forms
 
 		void InitItemProperties(View view, Flex.Item item)
 		{
-			var values = view.GetValues(OrderProperty,
-										GrowProperty,
-										ShrinkProperty,
-										BasisProperty,
-										AlignSelfProperty,
-										MarginProperty,
-										WidthRequestProperty,
-										HeightRequestProperty,
-										IsVisibleProperty);
-			item.Order = (int)values[0];
-			item.Grow = (float)values[1];
-			item.Shrink = (float)values[2];
-			item.Basis = ((FlexBasis)values[3]).ToFlexBasis();
-			item.AlignSelf = (Flex.AlignSelf)(FlexAlignSelf)values[4];
-			item.MarginLeft = (float)((Thickness)values[5]).Left;
-			item.MarginTop = (float)((Thickness)values[5]).Top;
-			item.MarginRight = (float)((Thickness)values[5]).Right;
-			item.MarginBottom = (float)((Thickness)values[5]).Bottom;
-			item.Width = (double)values[6] < 0 ? float.NaN : (float)(double)values[6];
-			item.Height = (double)values[7] < 0 ? float.NaN : (float)(double)values[7];
-			item.IsVisible = (bool)values[8];
+			item.Order = (int)view.GetValue(OrderProperty);
+			item.Grow = (float)view.GetValue(GrowProperty);
+			item.Shrink = (float)view.GetValue(ShrinkProperty);
+			item.Basis = ((FlexBasis)view.GetValue(BasisProperty)).ToFlexBasis();
+			item.AlignSelf = (Flex.AlignSelf)(FlexAlignSelf)view.GetValue(AlignSelfProperty);
+			var (mleft, mtop, mright, mbottom) = (Thickness)view.GetValue(MarginProperty);
+			item.MarginLeft = (float)mleft;
+			item.MarginTop = (float)mtop;
+			item.MarginRight = (float)mright;
+			item.MarginBottom = (float)mbottom;
+			var width = (double)view.GetValue(WidthRequestProperty);
+			item.Width = width < 0 ? float.NaN : (float)width;
+			var height = (double)view.GetValue(HeightRequestProperty);
+			item.Height = height < 0 ? float.NaN : (float)height;
+			item.IsVisible = (bool)view.GetValue(IsVisibleProperty);
 			if (view is FlexLayout) {
-				var padding = view.GetValue(PaddingProperty);
-				item.PaddingLeft = (float)((Thickness)padding).Left;
-				item.PaddingTop = (float)((Thickness)padding).Top;
-				item.PaddingRight = (float)((Thickness)padding).Right;
-				item.PaddingBottom = (float)((Thickness)padding).Bottom;
+				var (pleft, ptop, pright, pbottom) = (Thickness)view.GetValue(PaddingProperty);
+				item.PaddingLeft = (float)pleft;
+				item.PaddingTop = (float)ptop;
+				item.PaddingRight = (float)pright;
+				item.PaddingBottom = (float)pbottom;
 			}
 		}
 

--- a/Xamarin.Forms.Core/FontElement.cs
+++ b/Xamarin.Forms.Core/FontElement.cs
@@ -60,9 +60,8 @@ namespace Xamarin.Forms
 
 			SetCancelEvents(bindable, true);
 
-			var values = bindable.GetValues(FontSizeProperty, FontAttributesProperty);
-			var fontSize = (double)values[0];
-			var fontAttributes = (FontAttributes)values[1];
+			var fontSize = (double)bindable.GetValue(FontSizeProperty);
+			var fontAttributes = (FontAttributes)bindable.GetValue(FontAttributesProperty);
 			var fontFamily = (string)newValue;
 
 			if (fontFamily != null)
@@ -81,10 +80,9 @@ namespace Xamarin.Forms
 
 			SetCancelEvents(bindable, true);
 
-			var values = bindable.GetValues(FontFamilyProperty, FontAttributesProperty);
 			var fontSize = (double)newValue;
-			var fontAttributes = (FontAttributes)values[1];
-			var fontFamily = (string)values[0];
+			var fontAttributes = (FontAttributes)bindable.GetValue(FontAttributesProperty);
+			var fontFamily = (string)bindable.GetValue(FontFamilyProperty);
 
 			if (fontFamily != null)
 				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize).WithAttributes(fontAttributes));
@@ -107,10 +105,9 @@ namespace Xamarin.Forms
 
 			SetCancelEvents(bindable, true);
 
-			var values = bindable.GetValues(FontFamilyProperty, FontSizeProperty);
-			var fontSize = (double)values[1];
+			var fontSize = (double)bindable.GetValue(FontSizeProperty);
 			var fontAttributes = (FontAttributes)newValue;
-			var fontFamily = (string)values[0];
+			var fontFamily = (string)bindable.GetValue(FontFamilyProperty);
 
 			if (fontFamily != null)
 				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize).WithAttributes(fontAttributes));

--- a/Xamarin.Forms.Platform.iOS/Renderers/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FontExtensions.cs
@@ -145,8 +145,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		internal static UIFont ToNSFont(this Label label)
 #endif
 		{
-			var values = label.GetValues(Label.FontFamilyProperty, Label.FontSizeProperty, Label.FontAttributesProperty);
-			return ToUIFont((string)values[0], (float)(double)values[1], (FontAttributes)values[2]) ??
+			return ToUIFont(label.FontFamily, (float)label.FontSize, label.FontAttributes) ??
 					UIFont.SystemFontOfSize(UIFont.LabelFontSize);
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -347,11 +347,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateText()
 		{
-			var values = Element.GetValues(Label.FormattedTextProperty, Label.TextProperty);
-
-			_formatted = values[0] as FormattedString;
+			_formatted = Element.FormattedText;
 			if (_formatted == null && Element.LineHeight >= 0)
-				_formatted = (string)values[1];
+				_formatted = Element.Text;
 
 			if (IsTextFormatted)
 			{
@@ -360,9 +358,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			else
 			{
 #if __MOBILE__
-				Control.Text = (string)values[1];
+				Control.Text = Element.Text;
 #else
-				Control.StringValue = (string)values[1] ?? "";
+				Control.StringValue = Element.Text ?? "";
 #endif
 			}
 			UpdateLayout();


### PR DESCRIPTION
### Description of Change ###

Deprecate GetValues, as it no longer make snes now that the properties
store is a Dictionary and no longer a List.

Update the code to be C#7-ish.

Take this refactoring opportunity to move similar method next to each other.

### Issues Resolved ### 

- fixes #5015

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
