### PR TITLE
[Android] Fix SearchBar renderer height on API24

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Platform.Android
 		InputTypes _inputType;
 		TextColorSwitcher _textColorSwitcher;
 		TextColorSwitcher _hintColorSwitcher;
+		float _defaultHeight => Context.ToPixels(42);
 
 		public SearchBarRenderer(Context context) : base(context)
 		{
@@ -43,6 +44,16 @@ namespace Xamarin.Forms.Platform.Android
 			((ISearchBarController)Element).OnSearchButtonPressed();
 			ClearFocus(Control);
 			return true;
+		}
+
+		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
+		{
+			var sizerequest = base.GetDesiredSize(widthConstraint, heightConstraint);
+			if (Build.VERSION.SdkInt == BuildVersionCodes.N && heightConstraint == 0 && sizerequest.Request.Height == 0)
+			{
+				sizerequest.Request = new Size(sizerequest.Request.Width, _defaultHeight);
+			}
+			return sizerequest;
 		}
 
 		protected override SearchView CreateNativeControl()


### PR DESCRIPTION
### Description of Change ###

For some crazy reason Android isn't measuring the SearchBar widget height correctly on API24, when we pass a HeightRequest of 0 (so the item provides its own size.  So we give it a default height based on running on the same device on API27.

This should fix UITests on API24

### Issues Resolved ### 

- fixes #5328 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 

![screenshot_1550687566](https://user-images.githubusercontent.com/1235097/53121334-e908d400-354b-11e9-9df3-89af985860b8.png)
![screenshot_1550687314](https://user-images.githubusercontent.com/1235097/53121335-e908d400-354b-11e9-88d6-827428440ea6.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard