### PR TITLE
Fix NRE in Android ResourceManager when reference resource in Previewer

### DIFF
--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -138,6 +138,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		static int GetId(Type type, string memberName)
 		{
+			// This may legitimately be null in designer scenarios
+			if (type == null)
+				return 0;
+
 			object value = null;
 			var fields = type.GetFields();
 			for (int i = 0; i < fields.Length; i++)


### PR DESCRIPTION
Backport from fix in 3.6.0

(cherry picked from commit fb59591580ea474e7f48e5941854fd790dc5a8cb)