### PR TITLE
[Material] rename iOS assembly to be non platform specific

### DIFF
--- a/.nuspec/Xamarin.Forms.Visual.Material.nuspec
+++ b/.nuspec/Xamarin.Forms.Visual.Material.nuspec
@@ -30,8 +30,8 @@
     <file src="_._" target="lib\MonoAndroid10\_._" />
     <file src="Xamarin.Forms.Visual.Material.targets" target="build\MonoAndroid10\Xamarin.Forms.Visual.Material.targets" />  
        
-    <file src="..\Xamarin.Forms.Material.iOS\bin\$Configuration$\Xamarin.Forms.Material.iOS.dll" target="lib\Xamarin.iOS10" />
-    <file src="..\Xamarin.Forms.Material.iOS\bin\$Configuration$\Xamarin.Forms.Material.iOS.*pdb" target="lib\Xamarin.iOS10" />
-    <file src="..\Xamarin.Forms.Material.iOS\bin\$Configuration$\Xamarin.Forms.Material.iOS.*mdb" target="lib\Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Material.iOS\bin\$Configuration$\Xamarin.Forms.Material.dll" target="lib\Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Material.iOS\bin\$Configuration$\Xamarin.Forms.Material.*pdb" target="lib\Xamarin.iOS10" />
+    <file src="..\Xamarin.Forms.Material.iOS\bin\$Configuration$\Xamarin.Forms.Material.*mdb" target="lib\Xamarin.iOS10" />
   </files>
 </package>

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using Xamarin.Forms.StyleSheets;
 [assembly: InternalsVisibleTo("Xamarin.Forms.Xaml.UnitTests")]
 [assembly: InternalsVisibleTo("Xamarin.Forms.UITests")]
 [assembly: InternalsVisibleTo("Xamarin.Forms.FlexLayout.UnitTests")]
-[assembly: InternalsVisibleTo("Xamarin.Forms.Material.iOS")]
+[assembly: InternalsVisibleTo("Xamarin.Forms.Material")]
 
 [assembly: InternalsVisibleTo("Xamarin.Forms.Core.iOS.UITests")]
 [assembly: InternalsVisibleTo("Xamarin.Forms.Core.Android.UITests")]

--- a/Xamarin.Forms.Material.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Material.iOS/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using Xamarin.Forms.Internals;
 using System.Runtime.InteropServices;
 using Xamarin.Forms;
 
-[assembly: AssemblyTitle("Xamarin.Forms.Material.iOS")]
+[assembly: AssemblyTitle("Xamarin.Forms.Material")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCulture("")]

--- a/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
+++ b/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
@@ -7,7 +7,7 @@
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Forms.Material.iOS</RootNamespace>
-    <AssemblyName>Xamarin.Forms.Material.iOS</AssemblyName>
+    <AssemblyName>Xamarin.Forms.Material</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
@@ -65,7 +65,7 @@ using UIKit;
 [assembly: ExportImageSourceHandler(typeof(FontImageSource), typeof(FontImageSourceHandler))]
 [assembly: InternalsVisibleTo("iOSUnitTests")]
 [assembly: InternalsVisibleTo("Xamarin.Forms.Platform")]
-[assembly: InternalsVisibleTo("Xamarin.Forms.Material.iOS")]
+[assembly: InternalsVisibleTo("Xamarin.Forms.Material")]
 [assembly: Xamarin.Forms.Dependency(typeof(Deserializer))]
 [assembly: Xamarin.Forms.Dependency(typeof(ResourcesProvider))]
 [assembly: ResolutionGroupName("Xamarin")]


### PR DESCRIPTION
### Description of Change ###
It doesn't make any sense to have platform specific dlls
If we create Material dlls for netstandard or android then we should just bait and switch them not create multiple dlls

### Platforms Affected ### 
- iOS

