### PR TITLE
[XamlC] throw on invalid DataType

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -378,8 +378,12 @@ namespace Xamarin.Forms.Build.Tasks
 					break;
 				n = n.Parent as IElementNode;
 			}
+
+			if (dataTypeNode is null)
+				yield break;
+
 			if (!((dataTypeNode as ValueNode)?.Value is string dataType))
-				yield break; //throw
+				throw new XamlParseException("x:DataType expects a string literal", dataTypeNode as IXmlLineInfo);
 
 			var prefix = dataType.Contains(":") ? dataType.Substring(0, dataType.IndexOf(":", StringComparison.Ordinal)) : "";
 			var namespaceuri = node.NamespaceResolver.LookupNamespace(prefix) ?? "";

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5330.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5330.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5330"
+        x:DataType="{x:Type Button}">
+    <Label Text="{Binding foo}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5330.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5330.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh5330 : ContentPage
+	{
+		public Gh5330() => InitializeComponent();
+		public Gh5330(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void FailOnUnresolvedDataType([Values(true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<XamlParseException>(() => MockCompiler.Compile(typeof(Gh5330)));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Invalid x:DataType was ignored up to now. Change the behavior so it
throws a XPE.

### Issues Resolved ### 

- fixes #5330

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
