### PR TITLE
previewer; PageRenderer trap for missing bg image

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -32,6 +32,15 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 		}
 
+		public static UIColor FromPatternImageFromBundle(string bgImage)
+		{
+			var image = UIImage.FromBundle(bgImage);
+			if (image == null)
+				return UIColor.White;
+
+			return UIColor.FromPatternImage(image);
+		}
+
 		public static Color ToColor(this UIColor color)
 		{
 			nfloat red;

--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 		}
 
+#if __MOBILE__
 		public static UIColor FromPatternImageFromBundle(string bgImage)
 		{
 			var image = UIImage.FromBundle(bgImage);
@@ -40,6 +41,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			return UIColor.FromPatternImage(image);
 		}
+#endif
 
 		public static Color ToColor(this UIColor color)
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
@@ -361,7 +361,7 @@ namespace Xamarin.Forms.Platform.iOS
 			string bgImage = ((Page)Element).BackgroundImage;
 			if (!string.IsNullOrEmpty(bgImage))
 			{
-				View.BackgroundColor = UIColor.FromPatternImage(UIImage.FromBundle(bgImage));
+				View.BackgroundColor = ColorExtensions.FromPatternImageFromBundle(bgImage);
 				return;
 			}
 			Color bgColor = Element.BackgroundColor;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -322,7 +322,9 @@ namespace Xamarin.Forms.Platform.iOS
 			string bgImage = ((Page)Element).BackgroundImage;
 			if (!string.IsNullOrEmpty(bgImage))
 			{
-				View.BackgroundColor = UIColor.FromPatternImage(UIImage.FromBundle(bgImage) ?? throw new Exception($"Image: File '{bgImage}' not found in app bundle"));
+				var image = UIImage.FromBundle(bgImage);
+				if (image != null)
+					View.BackgroundColor = UIColor.FromPatternImage(image);
 				return;
 			}
 			Color bgColor = Element.BackgroundColor;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -322,9 +322,7 @@ namespace Xamarin.Forms.Platform.iOS
 			string bgImage = ((Page)Element).BackgroundImage;
 			if (!string.IsNullOrEmpty(bgImage))
 			{
-				var image = UIImage.FromBundle(bgImage);
-				if (image != null)
-					View.BackgroundColor = UIColor.FromPatternImage(image);
+				View.BackgroundColor = ColorExtensions.FromPatternImageFromBundle(bgImage);
 				return;
 			}
 			Color bgColor = Element.BackgroundColor;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -302,7 +302,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateBackground()
 		{
 			if (!string.IsNullOrEmpty(((Page)Element).BackgroundImage))
-				View.BackgroundColor = UIColor.FromPatternImage(UIImage.FromBundle(((Page)Element).BackgroundImage));
+				View.BackgroundColor = ColorExtensions.FromPatternImageFromBundle(((Page)Element).BackgroundImage);
 			else if (Element.BackgroundColor == Color.Default)
 				View.BackgroundColor = UIColor.White;
 			else

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -319,7 +319,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateBackground()
 		{
 			if (!string.IsNullOrEmpty(((Page)Element).BackgroundImage))
-				View.BackgroundColor = UIColor.FromPatternImage(UIImage.FromBundle(((Page)Element).BackgroundImage));
+				View.BackgroundColor = ColorExtensions.FromPatternImageFromBundle(((Page)Element).BackgroundImage);
 			else if (Element.BackgroundColor == Color.Default)
 				View.BackgroundColor = UIColor.White;
 			else


### PR DESCRIPTION
Previewer team opened https://github.com/xamarin/Xamarin.Forms/issues/5300 which asks we scrub for all places where we throw if an image is not found. So, these change simply ignore missing images.
