### PR TITLE
[Android] Allow Renderer/Adapter to deselect ViewHolders not in child collection

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/PreselectedItemGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/PreselectedItemGallery.xaml
@@ -15,11 +15,8 @@
 
 			<Label x:Name="SelectedItemsCommand" Grid.Row="2"/>
 
-			<CollectionView x:Name="CollectionView" Grid.Row="3">
-				<CollectionView.ItemsLayout>
-					<GridItemsLayout Span="3" Orientation="Vertical"></GridItemsLayout>
-				</CollectionView.ItemsLayout>
-			</CollectionView>
-		</Grid>
+            <CollectionView x:Name="CollectionView" Grid.Row="3" />
+
+        </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewAdapter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Android.Content;
 using Android.Support.V7.Widget;
 using Object = Java.Lang.Object;
@@ -8,6 +9,7 @@ namespace Xamarin.Forms.Platform.Android
 	public class SelectableItemsViewAdapter : ItemsViewAdapter
 	{
 		protected readonly SelectableItemsView SelectableItemsView;
+		List<SelectableViewHolder> _currentViewHolders = new List<SelectableViewHolder>();
 
 		internal SelectableItemsViewAdapter(SelectableItemsView selectableItemsView, 
 			Func<IVisualElementRenderer, Context, global::Android.Views.View> createView = null) : base(selectableItemsView, createView)
@@ -27,6 +29,9 @@ namespace Xamarin.Forms.Platform.Android
 			// Watch for clicks so the user can select the item held by this ViewHolder
 			selectable.Clicked += SelectableOnClicked;
 
+			// Keep track of the view holders here so we can clear the native selection
+			_currentViewHolders.Add(selectable);
+
 			var selectedItem = SelectableItemsView.SelectedItem;
 			if (selectedItem == null)
 			{
@@ -44,11 +49,20 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (holder is SelectableViewHolder selectable)
 			{
+				_currentViewHolders.Remove(selectable);
 				selectable.Clicked -= SelectableOnClicked;
 				selectable.IsSelected = false;
 			}
 
 			base.OnViewRecycled(holder);
+		}
+
+		internal void ClearNativeSelection()
+		{
+			for (int i = 0; i < _currentViewHolders.Count; i++)
+			{
+				_currentViewHolders[i].IsSelected = false;
+			}
 		}
 
 		void SelectableOnClicked(object sender, int adapterPosition)

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewRenderer.cs
@@ -42,19 +42,6 @@ namespace Xamarin.Forms.Platform.Android
 			SwapAdapter(ItemsViewAdapter, true);
 		}
 
-		void ClearSelection()
-		{
-			for (int i = 0, size = ChildCount; i < size; i++)
-			{
-				var holder = GetChildViewHolder(GetChildAt(i));
-				
-				if (holder is SelectableViewHolder selectable)
-				{
-					selectable.IsSelected = false;
-				}
-			}
-		}
-
 		void MarkItemSelected(object selectedItem)
 		{
 			var position = ItemsViewAdapter.GetPositionForItem(selectedItem);
@@ -79,7 +66,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (mode == SelectionMode.None || mode == SelectionMode.Single)
 				{
-					ClearSelection();
+					SelectableItemsViewAdapter.ClearNativeSelection();
 				}
 
 				// If the mode is Multiple and SelectedItem is set to null, don't do anything
@@ -88,7 +75,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (mode != SelectionMode.Multiple)
 			{
-				ClearSelection();
+				SelectableItemsViewAdapter.ClearNativeSelection();
 				MarkItemSelected(selectedItem);
 			}
 


### PR DESCRIPTION
### Description of Change ###

ViewHolders which are just off screen do not show up in the RecyclerView's child collection, but have not yet been recycled. So they are not visible to the ClearSelection method, nor are they de-selected during the recycling process.

These changes add tracking of the active ViewHolders so they can be directly de-selected, rather than iterating over the RecyclerView's child collection. 

### Issues Resolved ### 

- fixes #5078

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Before/After Screenshots ### 

Before:

![5078_before](https://user-images.githubusercontent.com/538025/53293003-27d79d80-3789-11e9-9997-cd6bafa9a433.GIF)

After:

![5078_after](https://user-images.githubusercontent.com/538025/53293010-43db3f00-3789-11e9-886f-dbd0fd830259.GIF)


### Testing Procedure ###

In Control Gallery, navigate to CollectionView Gallery -> Selection Galleries -> Preselected Item. Scroll down until the selected item is just off screen. Select another item. When you scroll back up, the original item should no longer be selected. 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
