### PR TITLE
Fix WPFResources, EntryCell

### DIFF
--- a/Xamarin.Forms.Platform.WPF/WPFResources.xaml
+++ b/Xamarin.Forms.Platform.WPF/WPFResources.xaml
@@ -382,7 +382,7 @@
 
 	<DataTemplate x:Key="EntryCell">
 
-		<wpf:FormsTextBox Grid.Column="1" Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
+		<wpf:FormsTextBox Grid.Column="1" Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" IsEnabled="{Binding IsEnabled}"/>
 
 	</DataTemplate>
 


### PR DESCRIPTION
Also bind IsEnabled

### Description of Change ###

Bind EntryCell.IsEnabled to the rendered FormsTextBox. 

### Issues Resolved ### 

- fixes #5360

### API Changes ###
None

### Platforms Affected ### 
- WPF

### Behavioral/Visual Changes ###
The Rendered FormsTextBox now gets the IsEnabled property data-bound to the EntryCell's IsEnabled property, which fixes that functionality. 

None

### Before/After Screenshots ### 
Before:
![image](https://user-images.githubusercontent.com/114143/53299764-4dbf7980-383f-11e9-99a6-0a64b9f5418d.png)

After:
![image](https://user-images.githubusercontent.com/114143/53299745-076a1a80-383f-11e9-902d-ad5fc569aaee.png)


### Testing Procedure ###

1. Put a TableView on a page, containing an EntryCell. Set its IsEnabled property to false
2. You will notice that the control at runtime, in WPF is enabled.
3. Now fix things
4. You'll notice that the edit is disabled now.

### PR Checklist ###

- [ ] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
