### PR TITLE
[macOS] Image crashes App during disposing its renderer

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
@@ -31,14 +31,13 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
 		{
-			if (Control == null)
-			{
-				var imageView = new FormsNSImageView();
-				SetNativeControl(imageView);
-			}
-
 			if (e.NewElement != null)
 			{
+				if (Control == null)
+				{
+					var imageView = new FormsNSImageView();
+					SetNativeControl(imageView);
+				}
 				SetAspect();
 				SetImage(e.OldElement);
 				SetOpacity();


### PR DESCRIPTION
### Description of Change ###
Prevent creating new native controls if XF Element equals **NULL**

### API Changes ###
None

### Platforms Affected ### 
- MacOS
### Behavioral/Visual Changes ###
No crash

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

Open ControlGallery and search Issue342. Open it, then try to navigate back.

Actual behavior: crash in ViewRenderer.

