### PR TITLE
[previewer] resilience on createvalue

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void ContentPageWithMissingType()
+		public void ContentPageWithMissingTypeMockviewReplacement()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(MockView);
 
@@ -66,6 +66,28 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			var page = (ContentPage) XamlLoader.Create(xaml, true);
 			Assert.That(page.Content, Is.TypeOf<MockView>());
+		}
+
+		[Test]
+		public void ContentPageWithMissingTypeNoReplacement()
+		{
+			XamlLoader.FallbackTypeResolver = (p, type) => type;
+
+			var xaml = @"
+					<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+						xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly""
+						xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+						<ContentPage.Content>
+							<local:MyCustomButton Foo=""Bar"">
+								<local:MyCustomButton.Qux>
+									<Label />
+								</local:MyCustomButton.Qux>
+							</local:MyCustomButton>
+						</ContentPage.Content>
+					</ContentPage>";
+
+			var page = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.That(page.Content, Is.Null);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -43,12 +43,15 @@ namespace Xamarin.Forms.Xaml
 		{
 			object value = null;
 
-			XamlParseException xpe;
 			var type = XamlParser.GetElementType(node.XmlType, node, Context.RootElement?.GetType().GetTypeInfo().Assembly,
-				out xpe);
-			if (xpe != null)
+				out XamlParseException xpe);
+			if (xpe != null) {
+				if (Context.ExceptionHandler != null) {
+					Context.ExceptionHandler(xpe);
+					return;
+				}
 				throw xpe;
-
+			}
 			Context.Types[node] = type;
 			if (IsXaml2009LanguagePrimitive(node))
 				value = CreateLanguagePrimitive(type, node);


### PR DESCRIPTION
### Description of Change ###

Up to now, we were resilient on missing properties(value assignment) for the previewer, This adds supports for resilience on unsupported types (object creation).

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5171

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

> VS bug [#802254](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/802254)