### PR TITLE
[iOS] Load specified Font Family or PostScript Font

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -202,9 +202,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var iconcolor = fontsource.Color != Color.Default ? fontsource.Color : Color.White;
 				var imagesize = new SizeF((float)fontsource.Size, (float)fontsource.Size);
-				var hasFontFamily = fontsource.FontFamily != null && UIFont.FamilyNames.Contains(fontsource.FontFamily);
-				var font = hasFontFamily ?
-					UIFont.FromName(fontsource.FontFamily, (float)fontsource.Size) :
+				var font = UIFont.FromName(fontsource.FontFamily ?? string.Empty, (float)fontsource.Size) ??
 					UIFont.SystemFontOfSize((float)fontsource.Size);
 
 				UIGraphics.BeginImageContextWithOptions(imagesize, false, 0f);


### PR DESCRIPTION
### Description of Change ###

Fixes the iOS FontImageSourceHandler to use any valid UIFont Name which could be the Font Family Name or the Post Script name thereby allowing users to specify the exact font when using multiple Icon fonts within the same Font Family i.e. Font Awesome.

### Issues Resolved ### 

- fixes #5372 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

The FontImageSourceHandler will now locate valid Fonts by PostScript name and not just use the default font for a specified Font Family.

### Testing Procedure ###

Visual Studio nearly crashed my system just loading Xamarin Forms... I did test the UIFont loading in a separate project though and validated that this will work without throwing exceptions. The `fontsource.FontFamily` is guarded from providing a null value which would throw a NullReferenceException rather than simply providing a null UIFont.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
