### PR TITLE
[iOS] Cell.DefaultBackgroundColor iOS platform-specific only works for header cells

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
@@ -51,6 +51,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public virtual void SetBackgroundColor(UITableViewCell tableViewCell, Cell cell, UIColor color)
 		{
+			tableViewCell.TextLabel.BackgroundColor = color;
+			tableViewCell.ContentView.BackgroundColor = color;
 			tableViewCell.BackgroundColor = color;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Modified SetBackgroundColor method.
Instead of https://github.com/xamarin/Xamarin.Forms/pull/5365

```csharp
public virtual void SetBackgroundColor(UITableViewCell tableViewCell, Cell cell, UIColor color)
{
    tableViewCell.TextLabel.BackgroundColor = color; // New line
    tableViewCell.ContentView.BackgroundColor = color; // New line
    tableViewCell.BackgroundColor = color;
}
```

### Issues Resolved ### 
- fixes #5346 

### API Changes ###
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###
Actual behavior: you cannot change background color of non-header cell by setting platform-specific property


### Testing Procedure ###

* Open original issue #5346 
* Run the attached sample on iOS.
* Browse to the ListView/Cell Platform-Specifics page.

