### PR TITLE
[iOS, Android] Prevent NREs in ScrollViews

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
@@ -1,4 +1,5 @@
 using Android.Content;
+using Android.Support.V4.Widget;
 using Android.Views;
 using Android.Widget;
 
@@ -52,7 +53,7 @@ namespace Xamarin.Forms.Platform.Android
 				_renderer.LastX = ev.RawX;
 				if (ev.Action == MotionEventActions.Move)
 				{
-					var parent = (global::Android.Widget.ScrollView)Parent;
+					var parent = (NestedScrollView)Parent;
 					parent.ScrollBy(0, (int)dY);
 					// Fall through to base.OnTouchEvent, it'll take care of the X scrolling 					
 				}

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -247,7 +247,7 @@ namespace Xamarin.Forms.Platform.Android
 			bool requestContainerLayout = bottom > _previousBottom;
 			_previousBottom = bottom;
 
-			_container.Measure(MeasureSpecFactory.MakeMeasureSpec(right - left, MeasureSpecMode.Unspecified),
+			_container?.Measure(MeasureSpecFactory.MakeMeasureSpec(right - left, MeasureSpecMode.Unspecified),
 				MeasureSpecFactory.MakeMeasureSpec(bottom - top, MeasureSpecMode.Unspecified));
 			base.OnLayout(changed, left, top, right, bottom);
 			if (_view.Content != null && _hScrollView != null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void LayoutSubviews()
 		{
-			_shellScrollTracker.OnLayoutSubviews();
+			_shellScrollTracker?.OnLayoutSubviews();
 
 			base.LayoutSubviews();
 


### PR DESCRIPTION
### Description of Change ###

#4522 added some new code paths to ScrollView renderers for Shell that can possibly cause NREs.

### Issues Resolved ### 

- fixes #5161
- fixes #5247

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android


### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- For #5161, not quite sure how to repro, but the changes seem self-explanatory.
- For #5247, run Bugzilla 41415 and try to manually scroll the yellow/red ScrollView. If it doesn't crash, success!

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
