### PR TITLE
[X] wrap typeconverter exceptions in XPE

### DIFF
--- a/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
+++ b/Xamarin.Forms.Core/Xaml/TypeConversionExtensions.cs
@@ -114,8 +114,14 @@ namespace Xamarin.Forms.Xaml
 				var xfExtendedTypeConverter = xfTypeConverter as IExtendedTypeConverter;
 				if (xfExtendedTypeConverter != null)
 					return value = xfExtendedTypeConverter.ConvertFromInvariantString(str, serviceProvider);
-				if (xfTypeConverter != null)
-					return value = xfTypeConverter.ConvertFromInvariantString(str);
+				if (xfTypeConverter != null) {
+					try {
+						return value = xfTypeConverter.ConvertFromInvariantString(str);
+					}
+					catch (Exception e) {
+						throw new XamlParseException("Type conversion failed", serviceProvider, e);
+					}
+				}
 				var converterType = converter?.GetType();
 				if (converterType != null)
 				{

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_1.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_1.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5378_1">
+    <Label Margin="1,2,3," />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_1.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_1.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh5378_1 : ContentPage
+	{
+		public Gh5378_1() => InitializeComponent();
+		public Gh5378_1(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture] class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void ReportSyntaxError([Values(false, true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<XamlParseException>(() => MockCompiler.Compile(typeof(Gh5378_1)));
+				else
+					Assert.Throws<XamlParseException>(() => new Gh5378_1(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_2.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_2.xaml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5378_2">
+    <Button Clicked="{Binding FooBar}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_2.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_2.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh5378_2 : ContentPage
+	{
+		public Gh5378_2()
+		{
+			InitializeComponent();
+		}
+
+		public Gh5378_2(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture] class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void ReportSyntaxError([Values(false, true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<XamlParseException>(() => MockCompiler.Compile(typeof(Gh5378_2)));
+				else
+					Assert.Throws<XamlParseException>(() => new Gh5378_2(useCompiledXaml));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

[X] wrap typeconverter exceptions in XPE

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5378

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
