### PR TITLE
[Visual] Check if assembly is dynamic before calling GetExportedTypes

### DIFF
--- a/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
+++ b/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml;
@@ -64,7 +65,11 @@ namespace Xamarin.Forms
 			}
 			catch(NotSupportedException)
 			{
-				Log.Warning("Visual", $"Can't scan {assembly.FullName} for Visual types.");
+				Log.Warning("Visual", $"Cannot scan assembly {assembly.FullName} for Visual types.");
+			}
+			catch (FileNotFoundException)
+			{
+				Log.Warning("Visual", $"Unable to load a dependent assembly for {assembly.FullName}. It cannot be scanned for Visual types.");
 			}
 		}
 

--- a/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
+++ b/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
@@ -53,9 +53,19 @@ namespace Xamarin.Forms
 
 		static void Register(Assembly assembly, Dictionary<string, IVisual> mappings)
 		{
-			foreach (var type in assembly.GetExportedTypes())
-				if (typeof(IVisual).IsAssignableFrom(type) && type != typeof(IVisual))
-					Register(type, mappings);
+			if (assembly.IsDynamic)
+				return;
+
+			try
+			{
+				foreach (var type in assembly.GetExportedTypes())
+					if (typeof(IVisual).IsAssignableFrom(type) && type != typeof(IVisual))
+						Register(type, mappings);
+			}
+			catch(NotSupportedException)
+			{
+				Log.Warning("Visual", $"Can't scan {assembly.FullName} for Visual types.");
+			}
 		}
 
 		static void Register(Type visual, Dictionary<string, IVisual> mappings)


### PR DESCRIPTION
### Description of Change ###

GetExportedTypes can't be called on a dynamic assembly. I also added a catch for NotSupportException and FileNotFoundException since those are the possible exception that GetExportedTypes can throw

### Testing Procedure ###
Run Visual Gallery on Windows

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
