### PR TITLE
Catch exceptions thrown by TypeConverter when setting properties

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -505,12 +505,13 @@ namespace Xamarin.Forms.Xaml.UnitTests
 						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 						xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
 						<local:SettingPropertyThrows TestValue=""Test"" TestBP=""bar""/>
+						<Button BackgroundColor=""InvalidColor""/>
 					</ContentPage>";
 
 			var exceptions = new List<Exception>();
 			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
-			Assert.That(exceptions.Count, Is.EqualTo(2));
+			Assert.That(exceptions.Count, Is.EqualTo(3));
 		}
 	}
 

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -497,7 +497,15 @@ namespace Xamarin.Forms.Xaml
 						throw new XamlParseException($"Multiple properties with name '{property.DeclaringType}.{property.PropertyName}' found.", lineInfo, innerException: e);
 					}
 				};
-			var convertedValue = value.ConvertTo(property.ReturnType, minforetriever, serviceProvider);
+
+			object convertedValue;
+			try {
+				convertedValue = value.ConvertTo(property.ReturnType, minforetriever, serviceProvider);
+			}
+			catch (Exception e) {
+				exception = e;
+				return false;
+			}
 
 			if (bindable != null) {
 				//SetValue doesn't throw on mismatching type, so check before to get a chance to try the property setting or the collection adding


### PR DESCRIPTION
### Description of Change ###

In `ApplyPropertiesVisitor.TrySetValue()`, catch and record any exception thrown by the TypeConverter and return false, rather than letting it throw.

The exception will later be thrown by `ApplyPropertiesVisitor.SetPropertyValue()`, but this change means `HydrationContext.ExceptionHandler` will be called if it has been set (rather than throwing the exception).

### Issues Resolved ### 

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/802696

### API Changes ###

None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

* Manually tested exception is now passed to ExceptionHandler when running in the Previewer
* Added a test to verify the above scenario
* Manually tested exception still throws in non-Previewer scenarios.

### PR Checklist ###

- [x] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
