### PR TITLE
[Android] Remove changes to IVisualElementRenderer so it remains backwards compatible

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -21,7 +21,8 @@ namespace Xamarin.Forms.Platform.Android
 		IImageRendererController,
 		AView.IOnFocusChangeListener,
 		AView.IOnClickListener,
-		AView.IOnTouchListener
+		AView.IOnTouchListener,
+		ILayoutChanges
 	{
 		bool _inputTransparent;
 		bool _disposed;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
@@ -15,7 +15,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			renderer.ElementPropertyChanged += OnElementPropertyChanged;
 			renderer.ElementChanged += OnElementChanged;
-			renderer.LayoutChange += OnLayoutChange;
+
+			if(renderer is ILayoutChanges layoutChanges)
+				layoutChanges.LayoutChange += OnLayoutChange;
 		}
 
 		static void OnLayoutChange(object sender, global::Android.Views.View.LayoutChangeEventArgs e)
@@ -28,7 +30,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			renderer.ElementPropertyChanged -= OnElementPropertyChanged;
 			renderer.ElementChanged -= OnElementChanged;
-			renderer.LayoutChange -= OnLayoutChange;
+			if (renderer is ILayoutChanges layoutChanges)
+				layoutChanges.LayoutChange -= OnLayoutChange;
 
 			if (renderer.View is ImageView imageView)
 				imageView.SetImageDrawable(null);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -11,7 +11,8 @@ using Android.Support.V4.View;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
-	internal sealed class ImageRenderer : AImageView, IVisualElementRenderer, IImageRendererController, IViewRenderer, ITabStop
+	internal sealed class ImageRenderer : AImageView, IVisualElementRenderer, IImageRendererController, IViewRenderer, ITabStop,
+		ILayoutChanges
 	{
 		bool _disposed;
 		Image _element;

--- a/Xamarin.Forms.Platform.Android/ILayoutChanges.cs
+++ b/Xamarin.Forms.Platform.Android/ILayoutChanges.cs
@@ -3,7 +3,7 @@ using ALayoutChangeEventArgs = Android.Views.View.LayoutChangeEventArgs;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public interface ILayoutChanges
+	internal interface ILayoutChanges
 	{
 		event EventHandler<ALayoutChangeEventArgs> LayoutChange;
 	}

--- a/Xamarin.Forms.Platform.Android/ILayoutChanges.cs
+++ b/Xamarin.Forms.Platform.Android/ILayoutChanges.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using ALayoutChangeEventArgs = Android.Views.View.LayoutChangeEventArgs;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	public interface ILayoutChanges
+	{
+		event EventHandler<ALayoutChangeEventArgs> LayoutChange;
+	}
+}

--- a/Xamarin.Forms.Platform.Android/IVisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/IVisualElementRenderer.cs
@@ -29,7 +29,5 @@ namespace Xamarin.Forms.Platform.Android
 		void SetLabelFor(int? id);
 
 		void UpdateLayout();
-
-		event EventHandler<ALayoutChangeEventArgs> LayoutChange;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
@@ -31,12 +31,6 @@ namespace Xamarin.Forms.Platform.Android
 			remove { _elementPropertyChanged -= value; }
 		}
 
-		event EventHandler<AView.LayoutChangeEventArgs> IVisualElementRenderer.LayoutChange
-		{
-			add =>_flyoutRenderer.AndroidView.LayoutChange += value;
-			remove => _flyoutRenderer.AndroidView.LayoutChange -= value;
-		}
-
 		VisualElement IVisualElementRenderer.Element => Element;
 
 		VisualElementTracker IVisualElementRenderer.Tracker => null;

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -144,6 +144,7 @@
     <Compile Include="GetDesiredSizeDelegate.cs" />
     <Compile Include="IBorderVisualElementRenderer.cs" />
     <Compile Include="IDeviceInfoProvider.cs" />
+    <Compile Include="ILayoutChanges.cs" />
     <Compile Include="ITabStop.cs" />
     <Compile Include="Material\MaterialEditorRenderer.cs" />
     <Compile Include="Material\MaterialFormsTextInputLayoutBase.cs" />


### PR DESCRIPTION
### Description of Change ###
Added a new interface to handle LayoutChanges so that IVisualElementRenderer can stay the same and not break older libraries 

### Platforms Affected ### 
- Android

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
