### PR TITLE
Adds a test to verify root node FallbackTypeInfos

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -550,6 +550,34 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
 			Assert.That(exceptions.Count, Is.EqualTo(1));
 		}
+
+		[Test]
+		public void CanResolveRootNode()
+		{
+			string assemblyName = null;
+			string clrNamespace = null;
+			string typeName = null;
+
+
+			XamlLoader.FallbackTypeResolver = (fallbackTypeInfos, type) =>
+			{
+				assemblyName = fallbackTypeInfos?[1].AssemblyName;
+				clrNamespace = fallbackTypeInfos?[1].ClrNamespace;
+				typeName = fallbackTypeInfos?[1].TypeName;
+				return type ?? typeof(MockView);
+			};
+
+			var xaml = @"
+					<local:MissingType xmlns=""http://xamarin.com/schemas/2014/forms""
+						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+						xmlns:local=""clr-namespace:my.namespace;assembly=my.assembly"">
+					</local:MissingType>";
+
+			XamlLoader.Create(xaml, true);
+			Assert.That(assemblyName, Is.EqualTo("my.assembly"));
+			Assert.That(clrNamespace, Is.EqualTo("my.namespace"));
+			Assert.That(typeName, Is.EqualTo("MissingType"));
+		}
 	}
 
 	public class InstantiateThrows


### PR DESCRIPTION
If the root tag is something like `<local:Foo>`, Forms doesn't generate any `FallbackTypeInfos`, so the previewer has no way to process the type.

This seems to be because of [these lines](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Xaml/XamlParser.cs#L422) in `XamlParser.GetTypeReference()`...
```
	if (defaultAssemblyName == null)
		return null;
```
When determining the type of the root tag, `defaultAssemblyName` is null because `Context.RootElement` (referenced in `CreateValuesVisitor.Visit()` to get the root assembly) has not yet been set.