### PR TITLE
[X] bubble markup exception to previewer

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -24,6 +24,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			XamlLoader.ValueCreatedCallback = null;
 			XamlLoader.InstantiationFailedCallback = null;
 			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = null;
+#pragma warning disable 0618
+			Xamarin.Forms.Xaml.Internals.XamlLoader.DoNotThrowOnExceptions = false;
+#pragma warning restore 0618
 		}
 
 		[Test]
@@ -549,6 +552,21 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
 			Assert.That(exceptions.Count, Is.EqualTo(1));
+		}
+
+		[Test]
+		public void IgnoreMarkupExtensionException()
+		{
+			var xaml = @"
+						<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
+							<ListView ItemsSource=""{x:Static Foo}"" />
+						</ContentPage>";
+
+			var exceptions = new List<Exception>();
+			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+			Assert.That(exceptions.Count, Is.GreaterThan(1));
 		}
 	}
 

--- a/Xamarin.Forms.Xaml.UnitTests/XStaticException.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XStaticException.xaml.cs
@@ -33,6 +33,12 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			public void Setup()
 			{
 				Device.PlatformServices = new MockPlatformServices();
+
+				//there's a test not resetting the values correctly, but can't find which one...
+				Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = null;
+#pragma warning disable 0618
+				Xamarin.Forms.Xaml.Internals.XamlLoader.DoNotThrowOnExceptions = false;
+#pragma warning restore 0618
 			}
 
 			[TearDown]

--- a/Xamarin.Forms.Xaml.UnitTests/XamlLoaderCreateTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlLoaderCreateTests.cs
@@ -10,6 +10,17 @@ namespace Xamarin.Forms.Xaml.UnitTests
 	[TestFixture]
 	public class XamlLoaderCreateTests
 	{
+		[TearDown]
+		public void TearDown()
+		{
+			Device.PlatformServices = null;
+			XamlLoader.FallbackTypeResolver = null;
+			XamlLoader.ValueCreatedCallback = null;
+			XamlLoader.InstantiationFailedCallback = null;
+			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = null;
+			Xamarin.Forms.Xaml.Internals.XamlLoader.DoNotThrowOnExceptions = false;
+		}
+
 		[Test]
 		public void CreateFromXaml ()
 		{

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -118,8 +118,17 @@ namespace Xamarin.Forms.Xaml
 				foreach (var cnode in node.CollectionItems)
 					cnode.Accept(visitor, node);
 
-				value = markup.ProvideValue(serviceProvider);
-
+				try {
+					value = markup.ProvideValue(serviceProvider);
+				}
+				catch (Exception e) {
+					var xamlpe = e as XamlParseException ?? new XamlParseException("Markup extension failed", serviceProvider, e);
+					if (Context.ExceptionHandler != null) {
+						Context.ExceptionHandler(xamlpe);
+					}
+					else
+						throw xamlpe;
+				}
 				if (!node.Properties.TryGetValue(XmlName.xKey, out INode xKey))
 					xKey = null;
 


### PR DESCRIPTION
### Description of Change ###

[X] bubble markup exception to previewer

### Issues Resolved ### 

- fixes #5407

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard