### PR TITLE
[X] allow previewer fallback on rootnode

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -550,6 +550,34 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
 			Assert.That(exceptions.Count, Is.EqualTo(1));
 		}
+
+		[Test]
+		public void CanResolveRootNode()
+		{
+			string assemblyName = null;
+			string clrNamespace = null;
+			string typeName = null;
+
+
+			XamlLoader.FallbackTypeResolver = (fallbackTypeInfos, type) =>
+			{
+				assemblyName = fallbackTypeInfos?[1].AssemblyName;
+				clrNamespace = fallbackTypeInfos?[1].ClrNamespace;
+				typeName = fallbackTypeInfos?[1].TypeName;
+				return type ?? typeof(MockView);
+			};
+
+			var xaml = @"
+						<local:MissingType xmlns=""http://xamarin.com/schemas/2014/forms""
+							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+							xmlns:local=""clr-namespace:my.namespace;assembly=my.assembly"">
+						</local:MissingType>";
+
+			XamlLoader.Create(xaml, true);
+			Assert.That(assemblyName, Is.EqualTo("my.assembly"));
+			Assert.That(clrNamespace, Is.EqualTo("my.namespace"));
+			Assert.That(typeName, Is.EqualTo("MissingType"));
+		}
 	}
 
 	public class InstantiateThrows

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -578,6 +578,34 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(clrNamespace, Is.EqualTo("my.namespace"));
 			Assert.That(typeName, Is.EqualTo("MissingType"));
 		}
+
+		[Test]
+		public void CanResolveRootNodeWithoutAssembly()
+		{
+			string assemblyName = null;
+			string clrNamespace = null;
+			string typeName = null;
+
+
+			XamlLoader.FallbackTypeResolver = (fallbackTypeInfos, type) =>
+			{
+				assemblyName = fallbackTypeInfos?[1].AssemblyName;
+				clrNamespace = fallbackTypeInfos?[1].ClrNamespace;
+				typeName = fallbackTypeInfos?[1].TypeName;
+				return type ?? typeof(MockView);
+			};
+
+			var xaml = @"
+						<local:MissingType xmlns=""http://xamarin.com/schemas/2014/forms""
+							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+							xmlns:local=""using:my.namespace"">
+						</local:MissingType>";
+
+			XamlLoader.Create(xaml, true);
+			Assert.That(assemblyName, Is.EqualTo(null));
+			Assert.That(clrNamespace, Is.EqualTo("my.namespace"));
+			Assert.That(typeName, Is.EqualTo("MissingType"));
+		}
 	}
 
 	public class InstantiateThrows

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -419,8 +419,6 @@ namespace Xamarin.Forms.Xaml
 			if (lookupAssemblies.Count == 0) {
 				XmlnsHelper.ParseXmlns(namespaceURI, out _, out var ns, out var asmstring, out _);
 				asmstring = asmstring ?? defaultAssemblyName;
-				if (asmstring == null)
-					return null;
 				if (namespaceURI != null && ns != null)
 					lookupAssemblies.Add(new XmlnsDefinitionAttribute(namespaceURI, ns) { AssemblyName = asmstring });
 			}
@@ -441,7 +439,7 @@ namespace Xamarin.Forms.Xaml
 			
 			potentialTypes = new List<XamlLoader.FallbackTypeInfo>();
 			foreach (string typeName in lookupNames)
-				foreach (XmlnsDefinitionAttribute xmlnsDefinitionAttribute in lookupAssemblies)				
+				foreach (XmlnsDefinitionAttribute xmlnsDefinitionAttribute in lookupAssemblies)	
 					potentialTypes.Add(new XamlLoader.FallbackTypeInfo {
 						ClrNamespace = xmlnsDefinitionAttribute.ClrNamespace,
 						TypeName = typeName,

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -408,41 +408,29 @@ namespace Xamarin.Forms.Xaml
 			var namespaceURI = xmlType.NamespaceUri;
 			var elementName = xmlType.Name;
 			var typeArguments = xmlType.TypeArguments;
-			potentialTypes = null;			
+			potentialTypes = null;
 
-			foreach (var xmlnsDef in xmlnsDefinitions)
-			{
+			foreach (var xmlnsDef in xmlnsDefinitions) {
 				if (xmlnsDef.XmlNamespace != namespaceURI)
 					continue;
 				lookupAssemblies.Add(xmlnsDef);
 			}
 
-			if (lookupAssemblies.Count == 0)
-			{
-				if (defaultAssemblyName == null)
-					return null;
-
-				string ns;
-				string typename;
-				string asmstring;
-				string targetPlatform;
-
-				XmlnsHelper.ParseXmlns(namespaceURI, out typename, out ns, out asmstring, out targetPlatform);
+			if (lookupAssemblies.Count == 0) {
+				XmlnsHelper.ParseXmlns(namespaceURI, out _, out var ns, out var asmstring, out _);
 				asmstring = asmstring ?? defaultAssemblyName;
+				if (asmstring == null)
+					return null;
 				if (namespaceURI != null && ns != null)
-					lookupAssemblies.Add(new XmlnsDefinitionAttribute(namespaceURI, ns)
-					{
-						AssemblyName = asmstring
-					});
+					lookupAssemblies.Add(new XmlnsDefinitionAttribute(namespaceURI, ns) { AssemblyName = asmstring });
 			}
 
 			var lookupNames = new List<string>();
-			if (elementName != "DataTemplate" && !elementName.EndsWith("Extension"))
+			if (elementName != "DataTemplate" && !elementName.EndsWith("Extension", StringComparison.Ordinal))
 				lookupNames.Add(elementName + "Extension");
 			lookupNames.Add(elementName);
 
-			for (var i = 0; i < lookupNames.Count; i++)
-			{
+			for (var i = 0; i < lookupNames.Count; i++) {
 				var name = lookupNames[i];
 				if (name.Contains(":"))
 					name = name.Substring(name.LastIndexOf(':') + 1);
@@ -454,8 +442,7 @@ namespace Xamarin.Forms.Xaml
 			potentialTypes = new List<XamlLoader.FallbackTypeInfo>();
 			foreach (string typeName in lookupNames)
 				foreach (XmlnsDefinitionAttribute xmlnsDefinitionAttribute in lookupAssemblies)				
-					potentialTypes.Add(new XamlLoader.FallbackTypeInfo
-					{
+					potentialTypes.Add(new XamlLoader.FallbackTypeInfo {
 						ClrNamespace = xmlnsDefinitionAttribute.ClrNamespace,
 						TypeName = typeName,
 						AssemblyName = xmlnsDefinitionAttribute.AssemblyName,


### PR DESCRIPTION
### Description of Change ###

[X] allow previewer fallback on rootnode

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5410

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard