### PR TITLE
[Android] fixes ListView pull-to-refresh gesture in non-data areas

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue5268">
+    <ListView x:Name="MyListView"
+              IsPullToRefreshEnabled="True"
+              IsRefreshing="{Binding IsBusy, Mode=OneWay}"
+              ItemsSource="{Binding Sources}"
+              BackgroundColor="Blue"
+              RefreshCommand="{Binding Command}">
+        <ListView.ItemTemplate>
+            <DataTemplate>
+                <TextCell Text="{Binding Val}" />
+            </DataTemplate>
+        </ListView.ItemTemplate>
+    </ListView>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml
@@ -10,8 +10,12 @@
               RefreshCommand="{Binding Command}">
         <ListView.ItemTemplate>
             <DataTemplate>
-                <TextCell Text="{Binding Val}" />
-            </DataTemplate>
+				<ViewCell>
+					<ScrollView>
+						<Label Text="{Binding Val}" MaxLines="100" HorizontalTextAlignment="Center" TextColor="White" FontSize="14" />
+					</ScrollView>
+				</ViewCell>
+			</DataTemplate>
         </ListView.ItemTemplate>
     </ListView>
 </ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml
@@ -7,15 +7,21 @@
               IsRefreshing="{Binding IsBusy, Mode=OneWay}"
               ItemsSource="{Binding Sources}"
               BackgroundColor="Blue"
-              RefreshCommand="{Binding Command}">
+              RefreshCommand="{Binding Command}" RowHeight="100">
         <ListView.ItemTemplate>
             <DataTemplate>
-				<ViewCell>
-					<ScrollView>
-						<Label Text="{Binding Val}" MaxLines="100" HorizontalTextAlignment="Center" TextColor="White" FontSize="14" />
-					</ScrollView>
-				</ViewCell>
-			</DataTemplate>
+                <ViewCell>
+                    <ScrollView>
+                        <StackLayout>
+                            <Label Text="{Binding Val}" MaxLines="100" HorizontalTextAlignment="Center" TextColor="White" FontSize="14" />
+                            <Label Text="{Binding Val}" MaxLines="100" HorizontalTextAlignment="Center" TextColor="White" FontSize="14" />
+                            <Label Text="{Binding Val}" MaxLines="100" HorizontalTextAlignment="Center" TextColor="White" FontSize="14" />
+                            <Label Text="{Binding Val}" MaxLines="100" HorizontalTextAlignment="Center" TextColor="White" FontSize="14" />
+                            <Label Text="{Binding Val}" MaxLines="100" HorizontalTextAlignment="Center" TextColor="White" FontSize="14" />
+                        </StackLayout>
+                    </ScrollView>
+                </ViewCell>
+            </DataTemplate>
         </ListView.ItemTemplate>
     </ListView>
 </ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml.cs
@@ -1,0 +1,39 @@
+﻿#if APP
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5268, "ListView with PullToRefresh enabled gestures conflict", PlatformAffected.Android)]
+	public partial class Issue5268 : ContentPage
+	{
+		[Preserve(AllMembers = true)]
+		public class SrcItem
+		{
+			public string Val { get; set; }
+		}
+
+		public ObservableCollection<SrcItem> Sources { get; }
+		public ICommand Command { get; }
+
+		public Issue5268()
+		{
+			InitializeComponent();
+			Sources = new ObservableCollection<SrcItem>();
+			Command = new Command(AddData);
+			Sources.Add(new SrcItem { Val = "gstql!! - " + Sources.Count });
+			MyListView.BindingContext = this;
+		}
+
+		void AddData()
+		{
+			IsBusy = true;
+			Sources.Add(new SrcItem { Val = "gstql!! - " + Sources.Count });
+			IsBusy = false;
+		}
+	}
+}
+#endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5268.xaml.cs
@@ -1,5 +1,6 @@
 ﻿#if APP
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows.Input;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
@@ -16,6 +17,8 @@ namespace Xamarin.Forms.Controls.Issues
 			public string Val { get; set; }
 		}
 
+		string GenerateLongString() => string.Join(" \n", Enumerable.Range(0, 50).Select(i => $"{Sources.Count} item"));
+
 		public ObservableCollection<SrcItem> Sources { get; }
 		public ICommand Command { get; }
 
@@ -24,14 +27,14 @@ namespace Xamarin.Forms.Controls.Issues
 			InitializeComponent();
 			Sources = new ObservableCollection<SrcItem>();
 			Command = new Command(AddData);
-			Sources.Add(new SrcItem { Val = "gstql!! - " + Sources.Count });
+			Sources.Add(new SrcItem { Val = GenerateLongString() });
 			MyListView.BindingContext = this;
 		}
 
 		void AddData()
 		{
 			IsBusy = true;
-			Sources.Add(new SrcItem { Val = "gstql!! - " + Sources.Count });
+			Sources.Add(new SrcItem { Val = GenerateLongString() });
 			IsBusy = false;
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -433,6 +433,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5003.xaml.cs">
       <DependentUpon>Issue5003.xaml</DependentUpon>
       <SubType>Code</SubType>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5268.xaml.cs">
+      <DependentUpon>Issue5268.xaml</DependentUpon>
+      <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
@@ -1115,6 +1118,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5003.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5268.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -433,6 +433,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5003.xaml.cs">
       <DependentUpon>Issue5003.xaml</DependentUpon>
       <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue5268.xaml.cs">
       <DependentUpon>Issue5268.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -152,11 +152,9 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					var ctx = Context;
 					nativeListView = CreateNativeControl();
-					if (Forms.IsLollipopOrNewer)
-						nativeListView.NestedScrollingEnabled = true;
 					_refresh = new SwipeRefreshLayout(ctx);
 					_refresh.SetOnRefreshListener(this);
-					_refresh.AddView(nativeListView, LayoutParams.MatchParent);
+					_refresh.AddView(nativeListView, new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent));
 					SetNativeControl(nativeListView, _refresh);
 
 					_headerView = new Container(ctx);

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool _isAttached;
 		ScrollToRequestedEventArgs _pendingScrollTo;
 
-		SwipeRefreshLayoutWithFixedNestedScrolling _refresh;
+		SwipeRefreshLayout _refresh;
 		IListViewController Controller => Element;
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
 
@@ -103,6 +103,9 @@ namespace Xamarin.Forms.Platform.Android
 			return new Size(40, 40);
 		}
 
+		protected virtual SwipeRefreshLayout CreateNativePullToRefresh(Context context)
+			=> new SwipeRefreshLayoutWithFixedNestedScrolling(context);
+
 		protected override void OnAttachedToWindow()
 		{
 			base.OnAttachedToWindow();
@@ -155,7 +158,7 @@ namespace Xamarin.Forms.Platform.Android
 					nativeListView = CreateNativeControl();
 					if (Forms.IsLollipopOrNewer)
 						nativeListView.NestedScrollingEnabled = true;
-					_refresh = new SwipeRefreshLayoutWithFixedNestedScrolling(ctx);
+					_refresh = CreateNativePullToRefresh(ctx);
 					_refresh.SetOnRefreshListener(this);
 					_refresh.AddView(nativeListView, new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent));
 					SetNativeControl(nativeListView, _refresh);


### PR DESCRIPTION
### Description of Change ###

Caused by #4522 

Enabling `NestedScrollEnabled` for some reason turned off the work `SwipeRefreshLayout` on empty areas of ListView.

### Issues Resolved ### 

- fixes #5268

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Refreshing is activated on all areas of ListView

### Testing Procedure ###

- run UItest 5268
- try refreshing the ListView in a blank area by swiping down

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
