### PR TITLE
Uwp restart uitests on crash

### DIFF
--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Core.UITests
 			{ "button", "ControlType.Button" }
 		};
 
-		readonly WindowsDriver<WindowsElement> _session;
+		WindowsDriver<WindowsElement> _session;
 
 		readonly Dictionary<string, string> _translatePropertyAccessor = new Dictionary<string, string>
 		{
@@ -43,8 +43,18 @@ namespace Xamarin.Forms.Core.UITests
 
 		public WinDriverApp(WindowsDriver<WindowsElement> session)
 		{
+			Init(session);
+		}
+
+		void Init(WindowsDriver<WindowsElement> session)
+		{
 			_session = session;
-			TestServer = new WindowsTestServer(_session);
+			TestServer = new WindowsTestServer(_session, this);
+		}
+
+		public void RestartFromCrash()
+		{
+			Init(WindowsTestBase.ReConfigureAppFromCrash());
 		}
 
 		public void Back()
@@ -511,7 +521,7 @@ namespace Xamarin.Forms.Core.UITests
 			MouseClickAt(x, y);
 		}
 
-		public ITestServer TestServer { get; }
+		public ITestServer TestServer { get; private set; }
 
 		public void TouchAndHold(Func<AppQuery, AppQuery> query)
 		{

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		public void RestartFromCrash()
 		{
-			Init(WindowsTestBase.ReConfigureAppFromCrash());
+			Init(WindowsTestBase.CreateWindowsDriver());
 		}
 
 		public void Back()

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
@@ -39,6 +39,19 @@ namespace Xamarin.Forms.Core.UITests
 			return new WinDriverApp(Session);
 		}
 
+		public static WindowsDriver<WindowsElement> ReConfigureAppFromCrash()
+		{
+			AppiumOptions options = new AppiumOptions();
+			options.AddAdditionalCapability("app", "0d4424f6-1e29-4476-ac00-ba22c3789cb6_ph1m9x8skttmg!App");
+			options.AddAdditionalCapability("appArguments", "RunningAsUITests");
+			Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), options);
+			Assert.IsNotNull(Session);
+			Session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1);
+			Reset();
+
+			return Session;
+		}
+
 		internal static void HandleAppClosed(Exception ex)
 		{
 			if (ex is InvalidOperationException && ex.Message == "Currently selected window has been closed")

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
@@ -1,20 +1,11 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Resources;
-using System.Text;
 using NUnit.Framework;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Appium.MultiTouch;
-using OpenQA.Selenium.Appium.Windows;
-using OpenQA.Selenium.Interactions.Internal;
-using OpenQA.Selenium.Remote;
-using Xamarin.Forms.Xaml;
-using Xamarin.UITest;
 using OpenQA.Selenium.Appium;
-using System.Collections.Generic;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Interactions;
-using OpenQA.Selenium.Appium.Windows.Enums;
-using System.Windows.Input;
+using Xamarin.UITest;
 
 namespace Xamarin.Forms.Core.UITests
 {
@@ -26,20 +17,12 @@ namespace Xamarin.Forms.Core.UITests
 		public static IApp ConfigureApp()
 		{
 			if (Session == null)
-			{
-				AppiumOptions options = new AppiumOptions();
-				options.AddAdditionalCapability("app", "0d4424f6-1e29-4476-ac00-ba22c3789cb6_ph1m9x8skttmg!App");
-				options.AddAdditionalCapability("appArguments", "RunningAsUITests");
-				Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), options);
-				Assert.IsNotNull(Session);
-				Session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1);
-				Reset();
-			}
+				Session = CreateWindowsDriver();
 
 			return new WinDriverApp(Session);
 		}
 
-		public static WindowsDriver<WindowsElement> ReConfigureAppFromCrash()
+		public static WindowsDriver<WindowsElement> CreateWindowsDriver()
 		{
 			AppiumOptions options = new AppiumOptions();
 			options.AddAdditionalCapability("app", "0d4424f6-1e29-4476-ac00-ba22c3789cb6_ph1m9x8skttmg!App");

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestServer.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestServer.cs
@@ -7,10 +7,12 @@ namespace Xamarin.Forms.Core.UITests
 	internal class WindowsTestServer : ITestServer
 	{
 		readonly WindowsDriver<WindowsElement> _session;
+		readonly WinDriverApp _winDriverApp;
 
-		public WindowsTestServer(WindowsDriver<WindowsElement> session)
+		public WindowsTestServer(WindowsDriver<WindowsElement> session, WinDriverApp winDriverApp)
 		{
 			_session = session;
+			_winDriverApp = winDriverApp;
 		}
 
 		public string Post(string endpoint, object arguments = null)
@@ -30,6 +32,11 @@ namespace Xamarin.Forms.Core.UITests
 				try
 				{
 					return _session.CurrentWindowHandle;
+				}
+				catch (OpenQA.Selenium.WebDriverException we)
+				when (we.Message.Contains("Currently selected window has been closed"))
+				{
+					_winDriverApp.RestartFromCrash();
 				}
 				catch (Exception exception)
 				{


### PR DESCRIPTION
### Description of Change ###
If a UI Tests causes the UWP window to crash this will restart it when it tries to run the next test.
Currently if a tests fails all subsequent tests will just fail because the window is closed

### Platforms Affected ### 
- UWP

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
