### PR TITLE
[Android] fixes an exception when calling entry.Focus()

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5202.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5202.cs
@@ -1,0 +1,28 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 5202, "Entry.Focus() throws ObjectDisposedException", PlatformAffected.Android)]
+	public class Issue5202 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+			var entry = new Entry();
+			var button = new Button { Text = "Click me" };
+			button.Clicked += (_, __) =>
+			{
+				layout.Children.Clear();
+				layout.Children.Add(entry);
+				layout.Children.Add(button);
+				entry.Focus();
+			};
+
+			layout.Children.Add(entry);
+			layout.Children.Add(button);
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5202.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5202.cs
@@ -1,8 +1,15 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[Category(Core.UITests.UITestCategories.Entry)]
+#endif
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 5202, "Entry.Focus() throws ObjectDisposedException", PlatformAffected.Android)]
 	public class Issue5202 : TestContentPage
@@ -24,5 +31,13 @@ namespace Xamarin.Forms.Controls.Issues
 			layout.Children.Add(button);
 			Content = layout;
 		}
+#if UITEST
+		[Test]
+		public void Issue5202Test()
+		{
+			RunningApp.WaitForElement("Click me");
+			RunningApp.Tap("Click me");
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -232,6 +232,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla45743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46494.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5202.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla44476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla46630.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla47923.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -92,6 +92,32 @@ namespace Xamarin.Forms.Platform.Android
 
 			((IElementController)Element).SetValueFromRenderer(Entry.TextProperty, s.ToString());
 		}
+
+		// -- fix for 3.5 only --
+		internal override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
+		{
+			if (Control == null || Control.IsDisposed() || EditText == null || EditText.IsDisposed())
+				return;
+
+			e.Result = true;
+			if (e.Focus)
+			{
+				Device.BeginInvokeOnMainThread(() => {
+					if (Control == null || Control.IsDisposed() || EditText == null || EditText.IsDisposed())
+						return;
+
+					Control.RequestFocus();
+					EditText.ShowKeyboard();
+				});
+			}
+			else
+			{
+				Control.ClearFocus();
+				EditText.HideKeyboard();
+			}
+		}
+		// -- end fix for 3.5 --
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
 		{
 			base.OnElementChanged(e);


### PR DESCRIPTION
### Description of Change ###

In the master branch, this issue was solved by multiple changes in the `EntryRenderer`, `ViewRenderer` and `KeyboardManager`. This PR contains only the needful code to fix the bug.

### Issues Resolved ### 

- fixes #5202

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- run uitest 5202
- click on button
- application should't crash

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
