### PR TITLE
[iOS] Fix tapping a ViewCell after close ContextActionMenu

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextScrollViewDelegate.cs
@@ -179,7 +179,7 @@ namespace Xamarin.Forms.Platform.iOS
 							table.AddGestureRecognizer(_globalCloser);
 
 							_closer = new UITapGestureRecognizer(close);
-							contentCell.AddGestureRecognizer(_closer);
+							contentCell.ContentCell.AddGestureRecognizer(_closer);
 						}
 					}
 				}


### PR DESCRIPTION
### Description of Change ###

Changed view to which the `TabGesture` is added. Now it corresponds to the view from which this gesture will be removed after close ContextAction.

### Issues Resolved ### 

- fixes #4987

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

### Testing Procedure ###

- run UITest 4314
- open and close menu action
- try to select this cell (they are highlighted)
- remove both cells

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
