### PR TITLE
Handle DataTemplateSelector on iOS/Android CollectionView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBindingErrors.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBindingErrors.xaml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.CollectionViewBindingErrors">
+        <StackLayout>
+            <Label Text="The label below should read 'Binding Errors: 0'; if the number of binding errors is greater than zero, this test has failed."></Label>
+
+            <Label x:Name="BindingErrorCount" Text="Binding Errors: 0"></Label>
+
+            <CollectionView x:Name="CollectionView" ItemsSource="{Binding ItemsList}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <StackLayout>
+                            <Image Source="{Binding Image}" WidthRequest="100" HeightRequest="100"/>
+                            <Label Text="{Binding Caption}"></Label>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBindingErrors.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBindingErrors.xaml.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 68000, "Binding errors when CollectionView ItemsSource is set with a binding",
+		PlatformAffected.Android)]
+	public partial class CollectionViewBindingErrors : TestContentPage
+	{
+		public CollectionViewBindingErrors()
+		{
+#if APP
+			InitializeComponent();
+
+			var listener = new CountBindingErrors(BindingErrorCount);
+			Log.Listeners.Add(listener);
+			Disappearing += (obj, args) => { Log.Listeners.Remove(listener); };
+
+			BindingContext = new BindingErrorsViewModel();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+
+#if UITEST
+		[Test]
+		public void CollectionViewBindingErrorsShouldBeZero()
+		{
+			RunningApp.WaitForElement("Binding Errors: 0");
+		}
+#endif
+		}
+
+	[Preserve(AllMembers = true)]
+	public class CollectionViewGalleryTestItem
+	{
+		public DateTime Date { get; set; }
+		public string Caption { get; set; }
+		public string Image { get; set; }
+		public int Index { get; set; }
+
+		public CollectionViewGalleryTestItem(DateTime date, string caption, string image, int index)
+		{
+			Date = date;
+			Caption = caption;
+			Image = image;
+			Index = index;
+		}
+
+		public override string ToString()
+		{
+			return $"Item: {Index}";
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	internal class CountBindingErrors : LogListener
+	{
+		private readonly Label _errorCount;
+		int _count;
+
+		public CountBindingErrors(Label errorCount)
+		{
+			_errorCount = errorCount;
+		}
+
+		public override void Warning(string category, string message)
+		{
+			if (category == "Binding")
+			{
+				_count += 1;
+			}
+
+			_errorCount.Text = $"Binding Errors: {_count}";
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	internal class BindingErrorsViewModel
+	{
+		readonly string[] _imageOptions = {
+			"cover1.jpg",
+			"oasis.jpg",
+			"photo.jpg",
+			"Vegetables.jpg",
+			"Fruits.jpg",
+			"FlowerBuds.jpg",
+			"Legumes.jpg"
+		};
+
+		List<CollectionViewGalleryTestItem> GenerateList()
+		{
+			var items = new List<CollectionViewGalleryTestItem>();
+			var images = _imageOptions;
+
+			for (int n = 0; n < 100; n++)
+			{
+				items.Add(new CollectionViewGalleryTestItem(DateTime.Now.AddDays(n),
+					$"Item: {n}", images[n % images.Length], n));
+			}
+
+			return items;
+		}
+
+		List<CollectionViewGalleryTestItem> _items;
+
+		public List<CollectionViewGalleryTestItem> ItemsList
+		{
+			get
+			{
+				if (_items == null)
+				{
+					_items = GenerateList();
+				}
+
+				return _items;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBindingErrors.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBindingErrors.xaml.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Forms.Controls.Issues
 		public CollectionViewBindingErrors()
 		{
 #if APP
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+
 			InitializeComponent();
 
 			var listener = new CountBindingErrors(BindingErrorCount);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -17,6 +17,10 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue4919.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5461.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBindingErrors.xaml.cs">
+      <DependentUpon>CollectionViewBindingErrors.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue2102.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1588.xaml.cs">
       <DependentUpon>Issue1588.xaml</DependentUpon>
@@ -1133,6 +1137,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5003.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)CollectionViewBindingErrors.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGalleryTestItem.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGalleryTestItem.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
+{
+	[Preserve(AllMembers = true)]
+	public class CollectionViewGalleryTestItem
+	{
+		public DateTime Date { get; set; }
+		public string Caption { get; set; }
+		public string Image { get; set; }
+		public int Index { get; set; }
+
+		public CollectionViewGalleryTestItem(DateTime date, string caption, string image, int index)
+		{
+			Date = date;
+			Caption = caption;
+			Image = image;
+			Index = index;
+		}
+
+		public override string ToString()
+		{
+			return $"Item: {Index}";
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
@@ -27,9 +27,11 @@
 
 						GalleryBuilder.NavButton("ItemSizing Strategy", () => 
 							new VariableSizeTemplateGridGallery (ItemsLayoutOrientation.Horizontal), Navigation),
-						
-					}
-				}
+
+                        GalleryBuilder.NavButton("DataTemplateSelector", () =>
+                            new DataTemplateSelectorGallery(), Navigation),
+                    }
+                }
 			};
 		}
 	}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
@@ -30,7 +30,7 @@
 
                         GalleryBuilder.NavButton("DataTemplateSelector", () =>
                             new DataTemplateSelectorGallery(), Navigation),
-                    }
+					}
                 }
 			};
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries;assembly=Xamarin.Forms.Controls"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.DataTemplateSelectorGallery">
+
+    
+    
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="DefaultTemplate">
+                <Grid HeightRequest="100">
+                    <Grid.RowDefinitions>
+                        <RowDefinition></RowDefinition>
+                        <RowDefinition></RowDefinition>
+                    </Grid.RowDefinitions>
+
+                    <Image Source="coffee.png"/>
+
+                    <Label Grid.Row="1" Text="{Binding Date, StringFormat='{}{0:d}'}"></Label>
+                </Grid>
+            </DataTemplate>
+            <DataTemplate x:Key="FridayTemplate">
+                <Grid HeightRequest="100">
+                    <Grid.RowDefinitions>
+                        <RowDefinition></RowDefinition>
+                        <RowDefinition></RowDefinition>
+                    </Grid.RowDefinitions>
+                    
+                    <Image Source="oasis.jpg"/>
+
+                    <Label Grid.Row="1" Text="Friday! Woot!"></Label>
+                </Grid>
+            </DataTemplate>
+            <local:TGIFDataTemplateSelector x:Key="tgifDataTemplateSelector"
+                    DefaultTemplate="{StaticResource DefaultTemplate}"
+                    FridayTemplate="{StaticResource FridayTemplate}" />
+
+            <DataTemplate x:Key="EmptyTemplate">
+
+                <!-- TODO This needs datattemplateselector for Empty View so we can verify it works -->
+                
+                <StackLayout>
+                    <Label Text="{Binding ., StringFormat='({0}) does not match any day of the week.'}"></Label>
+                </StackLayout>
+                
+            </DataTemplate>
+            
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <ContentPage.Content>
+
+        <StackLayout>
+
+            <SearchBar x:Name="SearchBar" Placeholder="Day of Week Filter" />
+
+            <CollectionView x:Name="CollectionView" ItemTemplate="{StaticResource tgifDataTemplateSelector}" 
+                            EmptyViewTemplate="{StaticResource EmptyTemplate}"/>
+
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml
@@ -7,25 +7,25 @@
     <ContentPage.Resources>
         <ResourceDictionary>
             <DataTemplate x:Key="DefaultTemplate">
-                <Grid HeightRequest="100">
+                <Grid HeightRequest="50">
                     <Grid.RowDefinitions>
                         <RowDefinition></RowDefinition>
                         <RowDefinition></RowDefinition>
                     </Grid.RowDefinitions>
 
-                    <Image Source="coffee.png"/>
+                    <Image Source="coffee.png" AutomationId="weekday"/>
 
                     <Label Grid.Row="1" Text="{Binding Date, StringFormat='{}{0:dddd}'}"></Label>
                 </Grid>
             </DataTemplate>
             <DataTemplate x:Key="WeekendTemplate">
-                <Grid HeightRequest="100">
+                <Grid HeightRequest="50">
                     <Grid.RowDefinitions>
                         <RowDefinition></RowDefinition>
                         <RowDefinition></RowDefinition>
                     </Grid.RowDefinitions>
-                    
-                    <Image Source="oasis.jpg"/>
+
+                    <Image Source="oasis.jpg" AutomationId="weekend"/>
 
                     <Label Grid.Row="1" Text="It's the weekend! Woot!"></Label>
                 </Grid>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml
@@ -3,8 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries;assembly=Xamarin.Forms.Controls"
              x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.DataTemplateSelectorGallery">
-
-    
     
     <ContentPage.Resources>
         <ResourceDictionary>
@@ -17,10 +15,10 @@
 
                     <Image Source="coffee.png"/>
 
-                    <Label Grid.Row="1" Text="{Binding Date, StringFormat='{}{0:d}'}"></Label>
+                    <Label Grid.Row="1" Text="{Binding Date, StringFormat='{}{0:dddd}'}"></Label>
                 </Grid>
             </DataTemplate>
-            <DataTemplate x:Key="FridayTemplate">
+            <DataTemplate x:Key="WeekendTemplate">
                 <Grid HeightRequest="100">
                     <Grid.RowDefinitions>
                         <RowDefinition></RowDefinition>
@@ -29,23 +27,30 @@
                     
                     <Image Source="oasis.jpg"/>
 
-                    <Label Grid.Row="1" Text="Friday! Woot!"></Label>
+                    <Label Grid.Row="1" Text="It's the weekend! Woot!"></Label>
                 </Grid>
             </DataTemplate>
-            <local:TGIFDataTemplateSelector x:Key="tgifDataTemplateSelector"
-                    DefaultTemplate="{StaticResource DefaultTemplate}"
-                    FridayTemplate="{StaticResource FridayTemplate}" />
-
+            
             <DataTemplate x:Key="EmptyTemplate">
-
-                <!-- TODO This needs datattemplateselector for Empty View so we can verify it works -->
-                
                 <StackLayout>
                     <Label Text="{Binding ., StringFormat='({0}) does not match any day of the week.'}"></Label>
                 </StackLayout>
-                
             </DataTemplate>
-            
+
+            <DataTemplate x:Key="SymbolsTemplate">
+                <StackLayout BackgroundColor="Red">
+                    <Label Text="{Binding ., StringFormat='({0}) _definitely_ does not match any day of the week.'}"></Label>
+                </StackLayout>
+            </DataTemplate>
+
+            <local:WeekendSelector x:Key="WeekendSelector"
+                    DefaultTemplate="{StaticResource DefaultTemplate}"
+                    FridayTemplate="{StaticResource WeekendTemplate}" />
+
+            <local:SearchTermSelector x:Key="SearchTermSelector"
+                    DefaultTemplate="{StaticResource EmptyTemplate}"
+                    SymbolsTemplate="{StaticResource SymbolsTemplate}" />
+
         </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -55,8 +60,8 @@
 
             <SearchBar x:Name="SearchBar" Placeholder="Day of Week Filter" />
 
-            <CollectionView x:Name="CollectionView" ItemTemplate="{StaticResource tgifDataTemplateSelector}" 
-                            EmptyViewTemplate="{StaticResource EmptyTemplate}"/>
+            <CollectionView x:Name="CollectionView" ItemTemplate="{StaticResource WeekendSelector}" 
+                            EmptyViewTemplate="{StaticResource SearchTermSelector}"/>
 
         </StackLayout>
     </ContentPage.Content>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml.cs
@@ -40,16 +40,33 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 		}
 	}
 
-    public class TGIFDataTemplateSelector : DataTemplateSelector
+    public class WeekendSelector : DataTemplateSelector
     {
         public DataTemplate FridayTemplate { get; set; }
         public DataTemplate DefaultTemplate { get; set; }
 
         protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
         {
-            return ((CollectionViewGalleryTestItem)item).Date.DayOfWeek == DayOfWeek.Friday
+			var dow = ((CollectionViewGalleryTestItem)item).Date.DayOfWeek;
+
+			return dow == DayOfWeek.Saturday || dow == DayOfWeek.Sunday
                 ? FridayTemplate 
 				: DefaultTemplate;
         }
     }
+
+	public class SearchTermSelector : DataTemplateSelector
+	{
+		public DataTemplate DefaultTemplate { get; set; }
+		public DataTemplate SymbolsTemplate { get; set; }
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			var search = ((string)item);
+
+			return search.Any(c => !char.IsLetter(c))
+				? SymbolsTemplate
+				: DefaultTemplate;
+		}
+	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class DataTemplateSelectorGallery : ContentPage
+    {
+		DemoFilteredItemSource _demoFilteredItemSource;
+
+        public DataTemplateSelectorGallery()
+        {
+            InitializeComponent();
+
+			_demoFilteredItemSource = new DemoFilteredItemSource(filter: ItemMatches);
+
+			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
+
+			SearchBar.SearchCommand = new Command(() =>
+			{
+				_demoFilteredItemSource.FilterItems(SearchBar.Text);
+				CollectionView.EmptyView = SearchBar.Text;
+			});
+		}
+
+		private bool ItemMatches(string filter, CollectionViewGalleryTestItem item)
+		{
+			if (String.IsNullOrEmpty(filter))
+			{
+				return true;
+			}
+
+			return item.Date.DayOfWeek.ToString().ToLower().Contains(filter.ToLower());
+		}
+	}
+
+    public class TGIFDataTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate FridayTemplate { get; set; }
+        public DataTemplate DefaultTemplate { get; set; }
+
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+        {
+            return ((CollectionViewGalleryTestItem)item).Date.DayOfWeek == DayOfWeek.Friday
+                ? FridayTemplate 
+				: DefaultTemplate;
+        }
+    }
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DemoFilteredItemSource.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DemoFilteredItemSource.cs
@@ -8,10 +8,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 	internal class DemoFilteredItemSource
 	{
 		readonly List<CollectionViewGalleryTestItem> _source;
+		private readonly Func<string, CollectionViewGalleryTestItem, bool> _filter;
 
 		public ObservableCollection<CollectionViewGalleryTestItem> Items { get; }
 
-		public DemoFilteredItemSource(int count = 50)
+		public DemoFilteredItemSource(int count = 50, Func<string, CollectionViewGalleryTestItem, bool> filter = null)
 		{
 			_source = new List<CollectionViewGalleryTestItem>();
 			
@@ -32,11 +33,18 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 					$"{images[n % images.Length]}, {n}", images[n % images.Length], n));
 			}
 			Items = new ObservableCollection<CollectionViewGalleryTestItem>(_source);
+
+			_filter = filter ?? ItemMatches;
+		}
+
+		private bool ItemMatches(string filter, CollectionViewGalleryTestItem item)
+		{
+			return item.Caption.ToLower().Contains(filter.ToLower());
 		}
 
 		public void FilterItems(string filter)
 		{
-			var filteredItems = _source.Where(item => item.Caption.ToLower().Contains(filter.ToLower())).ToList();
+			var filteredItems = _source.Where(item => _filter(filter, item)).ToList();
 
 			foreach (CollectionViewGalleryTestItem collectionViewGalleryTestItem in _source)
 			{

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGalleryFilterInfo.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGalleryFilterInfo.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.EmptyViewGalleries
+{
+	[Preserve(AllMembers = true)]
+	public class EmptyViewGalleryFilterInfo : INotifyPropertyChanged
+	{
+		string _filter;
+
+		public string Filter
+		{
+			get => _filter;
+			set
+			{
+				_filter = value; 
+				OnPropertyChanged();
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewTemplateGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewTemplateGallery.xaml.cs
@@ -1,7 +1,4 @@
-﻿using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using Xamarin.Forms.Internals;
-using Xamarin.Forms.Xaml;
+﻿using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.EmptyViewGalleries
 {
@@ -25,29 +22,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.EmptyViewG
 				_demoFilteredItemSource.FilterItems(SearchBar.Text);
 				_emptyViewGalleryFilterInfo.Filter = SearchBar.Text;
 			});
-		}
-	}
-
-	[Preserve(AllMembers = true)]
-	public class EmptyViewGalleryFilterInfo : INotifyPropertyChanged
-	{
-		string _filter;
-
-		public string Filter
-		{
-			get => _filter;
-			set
-			{
-				_filter = value; 
-				OnPropertyChanged();
-			}
-		}
-
-		public event PropertyChangedEventHandler PropertyChanged;
-
-		void OnPropertyChanged([CallerMemberName] string propertyName = null)
-		{
-			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemsSourceGenerator.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemsSourceGenerator.cs
@@ -1,33 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 {
-	[Preserve(AllMembers = true)]
-	public class CollectionViewGalleryTestItem
-	{
-		public DateTime Date { get; set; }
-		public string Caption { get; set; }
-		public string Image { get; set; }
-		public int Index { get; set; }
-
-		public CollectionViewGalleryTestItem(DateTime date, string caption, string image, int index)
-		{
-			Date = date;
-			Caption = caption;
-			Image = image;
-			Index = index;
-		}
-
-		public override string ToString()
-		{
-			return $"Item: {Index}";
-		}
-	}
-
-	internal enum ItemsSourceType
+    internal enum ItemsSourceType
 	{
 		List,
 		ObservableCollection,

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -57,6 +57,9 @@
 	<Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\SelectionGalleries\PreselectedItemsGallery.xaml">
+       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\DataTemplateSelectorGallery.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\MapWithItemsSourceGallery.xaml">

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
@@ -280,7 +280,7 @@ namespace Xamarin.Forms.Core.UITests
 			}
 		}
 
-        [TestCase("EmptyView", "EmptyView (load simulation)", "photo")]
+		[TestCase("EmptyView", "EmptyView (load simulation)", "photo")]
         public void VisitAndCheckItem(string collectionTestName, string subgallery, string item)
         {
             VisitInitialGallery(collectionTestName);
@@ -290,5 +290,18 @@ namespace Xamarin.Forms.Core.UITests
 
             App.WaitForElement(t => t.Marked(item));
         }
+		
+        [TestCase("DataTemplate Galleries", "DataTemplateSelector")]
+        void VisitAndCheckForItems(string collectionTestName, string subGallery)
+        {
+            VisitInitialGallery(collectionTestName);
+            
+            App.WaitForElement(t => t.Marked(subGallery));
+            App.Tap(t => t.Marked(subGallery));
+
+            App.WaitForElement("weekend");
+            App.WaitForElement("weekday");
+        }
+        
     }
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.Android
 			// So we give it an alternate delegate for creating the views
 
 			ItemsViewAdapter = new ItemsViewAdapter(ItemsView, 
-				(renderer, context) => new SizedItemContentView(renderer, context, () => Width, () => Height));
+				(view, context) => new SizedItemContentView(context, () => Width, () => Height));
 
 			SwapAdapter(ItemsViewAdapter, false);
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -8,14 +8,14 @@ using ViewGroup = Android.Views.ViewGroup;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	// TODO hartez 2018/07/25 14:43:04 Experiment with an ItemSource property change as _adapter.notifyDataSetChanged
+	// TODO hartez 2018/07/25 14:43:04 Experiment with an ItemSource property change as _adapter.notifyDataSetChanged	
 
 	public class ItemsViewAdapter : RecyclerView.Adapter
 	{
 		protected readonly ItemsView ItemsView;
-		bool _disposed;
 		readonly Func<View, Context, ItemContentView> _createItemContentView;
 		internal readonly IItemsViewSource ItemsSource;
+		bool _disposed;
 
 		internal ItemsViewAdapter(ItemsView itemsView, Func<View, Context, ItemContentView> createItemContentView = null)
 		{
@@ -67,12 +67,20 @@ namespace Xamarin.Forms.Platform.Android
 				return new TextViewHolder(view);
 			}
 
-			// Realize the content, create a renderer out of it, and use that
-			var templateElement = (View)template.CreateContent();
-			ItemsView.AddLogicalChild(templateElement);
-			var itemContentControl = _createView(CreateRenderer(templateElement, context), context);
+			var itemContentView = new ItemContentView(parent.Context);
+			return new TemplatedItemViewHolder(itemContentView, template);
+		}
 
-			return new TemplatedItemViewHolder(itemContentControl, templateElement);
+		public override int ItemCount => ItemsSource.Count;
+
+		public override int GetItemViewType(int position)
+		{
+			// TODO hartez We might be able to turn this to our own purposes
+			// We might be able to have the CollectionView signal the adapter if the ItemTemplate property changes
+			// And as long as it's null, we return a value to that effect here
+			// Then we don't have to check _itemsView.ItemTemplate == null in OnCreateViewHolder, we can just use
+			// the viewType parameter.
+			return 42;
 		}
 
 		protected override void Dispose(bool disposing)
@@ -88,38 +96,6 @@ namespace Xamarin.Forms.Platform.Android
 
 				base.Dispose(disposing);
 			}
-		}
-
-		static IVisualElementRenderer CreateRenderer(View view, Context context)
-		{
-			if (view == null)
-			{
-				throw new ArgumentNullException(nameof(view));
-			}
-
-			if (context == null)
-			{
-				throw new ArgumentNullException(nameof(context));
-			}
-
-			var renderer = Platform.CreateRenderer(view, context);
-			Platform.SetRenderer(view, renderer);
-
-			return renderer;
-			var itemContentView = new ItemContentView(parent.Context);
-			return new TemplatedItemViewHolder(itemContentView, template);
-		}
-
-		public override int ItemCount => ItemsSource.Count;
-
-		public override int GetItemViewType(int position)
-		{
-			// TODO hartez We might be able to turn this to our own purposes
-			// We might be able to have the CollectionView signal the adapter if the ItemTemplate property changes
-			// And as long as it's null, we return a value to that effect here
-			// Then we don't have to check _itemsView.ItemTemplate == null in OnCreateViewHolder, we can just use
-			// the viewType parameter.
-			return 42;
 		}
 
 		public virtual int GetPositionForItem(object item)

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewAdapter.cs
@@ -11,8 +11,8 @@ namespace Xamarin.Forms.Platform.Android
 		protected readonly SelectableItemsView SelectableItemsView;
 		List<SelectableViewHolder> _currentViewHolders = new List<SelectableViewHolder>();
 
-		internal SelectableItemsViewAdapter(SelectableItemsView selectableItemsView, 
-			Func<IVisualElementRenderer, Context, global::Android.Views.View> createView = null) : base(selectableItemsView, createView)
+		internal SelectableItemsViewAdapter(SelectableItemsView selectableItemsView,
+			Func<View, Context, ItemContentView> createView = null) : base(selectableItemsView, createView)
 		{
 			SelectableItemsView = selectableItemsView;
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/SizedItemContentView.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SizedItemContentView.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Forms.Platform.Android
 		readonly Func<int> _width;
 		readonly Func<int> _height;
 
-		public SizedItemContentView(IVisualElementRenderer content, Context context, Func<int> width, Func<int> height) 
-			: base(content, context)
+		public SizedItemContentView(Context context, Func<int> width, Func<int> height) 
+			: base(context)
 		{
 			_width = width;
 			_height = height;
@@ -17,6 +17,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{
+			if (Content == null)
+			{
+				SetMeasuredDimension(0, 0);
+				return;
+			}
+
 			var targetWidth = _width();
 			var targetHeight = _height();
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
@@ -1,21 +1,52 @@
+using System;
+using Android.Content;
+using Xamarin.Forms.Internals;
+
 namespace Xamarin.Forms.Platform.Android
 {
 	internal class TemplatedItemViewHolder : SelectableViewHolder
 	{
-		public View View { get; }
+		private readonly ItemContentView _itemContentView;
+		private readonly DataTemplate _template;
 
-		public TemplatedItemViewHolder(global::Android.Views.View itemView, View rootElement) : base(itemView)
+		public View View { get; private set; }
+
+		public TemplatedItemViewHolder(ItemContentView itemContentView, DataTemplate template) : base(itemContentView)
 		{
-			View = rootElement;
+			_itemContentView = itemContentView;
+			_template = template;
 		}
 
 		protected override void OnSelectedChanged()
 		{
 			base.OnSelectedChanged();
 
+			if (View == null)
+			{
+				return;
+			}
+
 			VisualStateManager.GoToState(View, IsSelected 
 				? VisualStateManager.CommonStates.Selected 
 				: VisualStateManager.CommonStates.Normal);
+		}
+
+		public void Recycle(ItemsView itemsView)
+		{
+			itemsView.RemoveLogicalChild(View);
+			_itemContentView.Recycle();
+		}
+
+		public void Bind(object itemBindingContext, ItemsView itemsView)
+		{
+			var template = _template.SelectDataTemplate(itemBindingContext, itemsView);
+
+			// Realize the content, create a renderer out of it, and use that
+			View = (View)template.CreateContent();
+			itemsView.AddLogicalChild(View);
+			_itemContentView.RealizeContent(View);
+
+			BindableObject.SetInheritedBindingContext(View, itemBindingContext);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
@@ -41,12 +41,14 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var template = _template.SelectDataTemplate(itemBindingContext, itemsView);
 
-			// Realize the content, create a renderer out of it, and use that
 			View = (View)template.CreateContent();
-			itemsView.AddLogicalChild(View);
 			_itemContentView.RealizeContent(View);
 
-			BindableObject.SetInheritedBindingContext(View, itemBindingContext);
+			// Set the binding context before we add it as a child of the ItemsView; otherwise, it will
+			// inherit the ItemsView's binding context
+			View.BindingContext = itemBindingContext;
+
+			itemsView.AddLogicalChild(View);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Foundation;
 using UIKit;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -227,8 +228,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void ApplyTemplateAndDataContext(TemplatedCell cell, NSIndexPath indexPath)
 		{
+			var template = _itemsView.ItemTemplate;
+			var item = _itemsSource[indexPath.Row];
+
+			// Run this through the extension method in case it's really a DataTemplateSelector
+			template = template.SelectDataTemplate(item, _itemsView);
+
 			// We need to create a renderer, which means we need a template
-			var view = _itemsView.ItemTemplate.CreateContent() as View;
+			var view = template.CreateContent() as View;
 			_itemsView.AddLogicalChild(view);
 			var renderer = CreateRenderer(view);
 			BindableObject.SetInheritedBindingContext(view, _itemsSource[indexPath.Row]);
@@ -357,6 +364,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (emptyViewTemplate != null)
 			{
+				// Run this through the extension method in case it's really a DataTemplateSelector
+				emptyViewTemplate = emptyViewTemplate.SelectDataTemplate(emptyView, _itemsView);
+
 				// We have a template; turn it into a Forms view 
 				var templateElement = emptyViewTemplate.CreateContent() as View;
 				var renderer = CreateRenderer(templateElement);

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -234,12 +234,16 @@ namespace Xamarin.Forms.Platform.iOS
 			// Run this through the extension method in case it's really a DataTemplateSelector
 			template = template.SelectDataTemplate(item, _itemsView);
 
-			// We need to create a renderer, which means we need a template
+			// Create the content and renderer for the view and 
 			var view = template.CreateContent() as View;
-			_itemsView.AddLogicalChild(view);
 			var renderer = CreateRenderer(view);
-			BindableObject.SetInheritedBindingContext(view, _itemsSource[indexPath.Row]);
 			cell.SetRenderer(renderer);
+
+			// Bind the view to the data item
+			view.BindingContext = _itemsSource[indexPath.Row];
+
+			// And make sure it's a "child" of the ItemsView
+			_itemsView.AddLogicalChild(view);
 		}
 
 		internal void RemoveLogicalChild(UICollectionViewCell cell)

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -72,7 +72,9 @@ namespace Xamarin.Forms.Platform.iOS
 		void CreatePlaceholderLabel()
 		{
 			if (Control == null)
+			{
 				return;
+			}
 
 			Control.AddSubview(_placeholderLabel);
 


### PR DESCRIPTION
### Description of Change ###

Modifies the CollectionView on Android and iOS to handle DataTemplateSelectors for ItemTemplate and EmptyViewTemplate.

### Issues Resolved ### 

- fixes #4826

### API Changes ###

 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
