### PR TITLE
[iOS] Check new element before creating placeholder label

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -31,11 +31,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
 		{
-			// create label so it can get updated during the initial setup loop
-			_placeholderLabel = new UILabel
+			if (e.NewElement != null)
 			{
-				BackgroundColor = UIColor.Clear
-			};
+				// create label so it can get updated during the initial setup loop
+				_placeholderLabel = new UILabel
+				{
+					BackgroundColor = UIColor.Clear
+				};
+			}
 
 			base.OnElementChanged(e);
 
@@ -66,6 +69,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CreatePlaceholderLabel()
 		{
+			if (Control == null)
+				return;
+
 			Control.AddSubview(_placeholderLabel);
 
 			var edgeInsets = TextView.TextContainerInset;

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -39,7 +39,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			base.OnElementChanged(e);
 
-			CreatePlaceholderLabel();
+			if (e.NewElement != null)
+			{
+				CreatePlaceholderLabel();
+			}
 		}
 
 		protected internal override void UpdateFont()

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -31,8 +31,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
 		{
-			if (e.NewElement != null)
+			bool initializing = false;
+			if (e.NewElement != null && _placeholderLabel == null)
 			{
+				initializing = true;
 				// create label so it can get updated during the initial setup loop
 				_placeholderLabel = new UILabel
 				{
@@ -42,7 +44,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			base.OnElementChanged(e);
 
-			if (e.NewElement != null)
+			if (e.NewElement != null && initializing)
 			{
 				CreatePlaceholderLabel();
 			}


### PR DESCRIPTION
### Description of Change ###

CreatePlaceholderLabel is being called even if the new Element is null, which causes a crash on on dispose.

### Issues Resolved ### 

- fixes crash when disposing Editor

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
