### PR TITLE
remove covariant out on IElementConfiguration

### DIFF
--- a/Xamarin.Forms.Core/IElementConfiguration.cs
+++ b/Xamarin.Forms.Core/IElementConfiguration.cs
@@ -1,7 +1,8 @@
 
 namespace Xamarin.Forms
 {
-	public interface IElementConfiguration<out TElement> where TElement : Element
+	// Don't make this generic covariant as it causes UWP performance to tank
+	public interface IElementConfiguration<TElement> where TElement : Element
 	{
 		IPlatformElementConfiguration<T, TElement> On<T>() where T : IConfigPlatform;
 	}


### PR DESCRIPTION
### Description of Change ###
Currently there appears to be an issue with UWP where a DataContext that implements a covariant generic constrained interface performs very poorly

If you create a native UWP app and use the following ViewModel structure
```C#
	public class ViewModel : IElementConfiguration<Element>
	{
		public string CompositionName { get; set; } = "test class";
	}

	public class Element
	{

	}

	// Remove the out on the generic or the constraint on the generic and rerun the application
	public interface IElementConfiguration<out TElement> where TElement : Element
	{
	}


	uwpListView.ItemsSource = Enumerable.Range(0,1000).Select(x=> new ViewModel()).ToList();
```

You will see the same performance degradation

- Closes #5235


### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Testing Procedure ###
- Verify you can run UWP UI Tests

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
