### PR TITLE
ContextCompat.getColor if API < 23

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Forms
 		const int TabletCrossover = 600;
 
 		static bool? s_isLollipopOrNewer;
+		static bool? s_isMarshmallowOrNewer;
 
 		[Obsolete("Context is obsolete as of version 2.5. Please use a local context instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
@@ -52,6 +53,16 @@ namespace Xamarin.Forms
 				if (!s_isLollipopOrNewer.HasValue)
 					s_isLollipopOrNewer = (int)Build.VERSION.SdkInt >= 21;
 				return s_isLollipopOrNewer.Value;
+			}
+		}
+
+		internal static bool IsMarshmallowOrNewer
+		{
+			get
+			{
+				if (!s_isMarshmallowOrNewer.HasValue)
+					s_isMarshmallowOrNewer = (int)Build.VERSION.SdkInt >= 23;
+				return s_isMarshmallowOrNewer.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -1,6 +1,9 @@
 using System;
 using System.ComponentModel;
 using Android.Content;
+using Android.Support.V4.Content;
+using AColor = Android.Graphics.Color;
+using AColorRes = Android.Resource.Color;
 using Android.Views;
 
 namespace Xamarin.Forms.Platform.Android
@@ -117,7 +120,9 @@ namespace Xamarin.Forms.Platform.Android
 				bool isDefaultBkgndColor = bkgndColor.IsDefault;
 				if (page.Parent is BaseShellItem && isDefaultBkgndColor)
 				{
-					var color = Context.Resources.GetColor(global::Android.Resource.Color.BackgroundLight, Context.Theme);
+					var color = Forms.IsMarshmallowOrNewer ?
+						Context.Resources.GetColor(AColorRes.BackgroundLight, Context.Theme) :
+						new AColor(ContextCompat.GetColor(Context, global::Android.Resource.Color.BackgroundLight));
 					SetBackgroundColor(color);
 				}
 				else if (!isDefaultBkgndColor || setBkndColorEvenWhenItsDefault)


### PR DESCRIPTION
### Description of Change ###

Use `ContextCompat.getColor` if API < 23 per https://stackoverflow.com/questions/31590714/getcolorint-id-deprecated-on-android-6-0-marshmallow-api-23

### Issues Resolved ### 

- fixes part of #5071

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None; Without this change, XF Shell throws on load for API under 23

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Load Shell Template

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
