### PR TITLE
Fix [Android] WebView Navigating Cancel property not working with custom scheme

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4891.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4891.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4891, "[Android] WebView Navigating Cancel property not working with custom scheme", PlatformAffected.Android)]
+	public class Issue4891 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		Button _back;
+		WebView _myWebView;
+		Label _log;
+		ScrollView _logScrollView;
+		
+		protected override void Init()
+		{
+
+			_back = new Button
+			{
+				Text = "Back"
+			};
+			_back.Clicked += Back_Clicked;
+
+			_myWebView = new WebView
+			{
+				HorizontalOptions = LayoutOptions.StartAndExpand,
+				VerticalOptions = LayoutOptions.Start,
+				HeightRequest = 240
+			};
+			_myWebView.Navigating += MyWebView_Navigating;
+			_myWebView.Navigated += MyWebView_Navigated;
+			_myWebView.Source = new HtmlWebViewSource()
+			{
+				Html = "<html><body>Click on the link below. Expected results:<br/>1. Navigating event logged.<br/>2. Navigated event NOT logged.<br/>3. This page stays loaded in the WebView control.<br/><br/><a href='xamforms4223://custom'>Navigate to Custom xamforms4223 scheme</a></body></html>"
+			};
+
+			_log = new Label
+			{
+				VerticalOptions = LayoutOptions.StartAndExpand,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Text = ""
+			};
+
+			_logScrollView = new ScrollView
+			{
+				VerticalOptions = LayoutOptions.StartAndExpand,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Content = _log
+			};
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					_myWebView,
+					_back,
+					_logScrollView
+				}
+			};
+		}
+
+
+		void MyWebView_Navigating(object sender, WebNavigatingEventArgs e)
+		{
+			LogToScreen($"Navigating: {e.Url}");
+			if (e.Url.StartsWith("xamforms4223", StringComparison.OrdinalIgnoreCase))
+			{
+				LogToScreen("Caught custom scheme, cancelling navigation.");
+				e.Cancel = true;
+			}
+		}
+
+		void MyWebView_Navigated(object sender, WebNavigatedEventArgs e)
+		{
+			LogToScreen($"Navigated: ({e.Result}) {e.Url}");
+		}
+
+		void LogToScreen(string text)
+		{
+			_log.Text += $"{text}\n";
+
+			InvalidateMeasure();
+			_logScrollView.ScrollToAsync(_log, ScrollToPosition.End, false);
+		}
+
+		void Back_Clicked(object sender, EventArgs e)
+		{
+			if (_myWebView.CanGoBack)
+			{
+				_myWebView.GoBack();
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
Updates Xamarin.Forms.Platform.Android.FormsWebViewClient

This was broken with release 3.3.0.

Notes:
Depending on the API version, Android's StopLoading does not work as expected/consistently which is used to cancel the load in OnPageStarted. This is why 3.3.0 created this 'custom scheme' problem.

In addition, Android's ShouldOverrideUrlLoading is NOT executed when the WebView.Source is explicitly set. This is why 3.3.0 fixed the problem of Navigating not firing when the Source is set.

### Issues Resolved ###
fixes #4891 
fixes #4919

### API Changes ###
None

### Platforms Affected ###
Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ###
Not applicable

### Testing Procedure ###
see Issue4891.cs
