### PR TITLE
[Android] ensure scrollbar has been initialized

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -63,7 +63,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 	{
 		public ScrollbarFadingEnabledFalseScrollViewRenderer(Context context) : base(context)
 		{
-			// I do a cast here just so this will fail just to be sure we don't chance the base types
+			// I do a cast here just so this will fail just to be sure we don't change the base types
 			var castingTest = (global::Android.Support.V4.Widget.NestedScrollView)this;
 			castingTest.ScrollbarFadingEnabled = false;
 		}

--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -25,6 +25,7 @@ using Android.Text.Method;
 using Xamarin.Forms.Controls.Issues;
 
 
+[assembly: ExportRenderer(typeof(Issue5461.ScrollbarFadingEnabledFalseScrollView), typeof(ScrollbarFadingEnabledFalseScrollViewRenderer))]
 [assembly: ExportRenderer(typeof(Issue1942.CustomGrid), typeof(Issue1942GridRenderer))]
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Effects.AttachedStateEffectLabel), typeof(AttachedStateEffectLabelRenderer))]
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.LegacyComponents.NonAppCompatSwitch), typeof(NonAppCompatSwitchRenderer))]
@@ -55,6 +56,16 @@ namespace Xamarin.Forms.ControlGallery.Android
 	{
 		public NonAppCompatSwitchRenderer(Context context) : base(context)
 		{
+		}
+	}
+
+	public class ScrollbarFadingEnabledFalseScrollViewRenderer : ScrollViewRenderer
+	{
+		public ScrollbarFadingEnabledFalseScrollViewRenderer(Context context) : base(context)
+		{
+			// I do a cast here just so this will fail just to be sure we don't chance the base types
+			var castingTest = (global::Android.Support.V4.Widget.NestedScrollView)this;
+			castingTest.ScrollbarFadingEnabled = false;
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5461.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5461.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5461, "[Android] ScrollView crashes when setting ScrollbarFadingEnabled to false in Custom Renderer",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ScrollView)]
+#endif
+	public class Issue5461 : TestContentPage
+	{
+		const string Success = "If you can see this, the test has passed";
+		protected override void Init()
+		{
+			ScrollView scrollView = new ScrollbarFadingEnabledFalseScrollView()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = Success
+						}
+					},
+					HeightRequest = 2000
+				}
+			};
+
+			Content = scrollView;
+		}
+
+		public class ScrollbarFadingEnabledFalseScrollView : ScrollView { }
+
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void ScrollViewWithScrollbarFadingEnabledFalseDoesntCrash()
+		{
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -14,6 +14,7 @@
       <DependentUpon>Bugzilla60787.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5461.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2102.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1588.xaml.cs">
       <DependentUpon>Issue1588.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal static class ScrollViewExtensions
+	{
+		internal static void HandleScrollBarVisibilityChange(this IScrollView scrollView)
+		{
+
+			//// According to the Android Documentation
+			//// * <p>AwakenScrollBars method should be invoked every time a subclass directly updates
+			//// *the scroll parameters.</ p >
+
+			//// If AwakenScrollBars is never called there are cases where the ScrollDrawable is never called
+			//// which causes a crash during draw
+
+			if(scrollView.ScrollBarsInitialized)
+				scrollView.AwakenScrollBars();
+
+			//// The scrollbar drawable won't initialize if ScrollbarFadingEnabled == false
+			if (!scrollView.ScrollbarFadingEnabled)
+			{
+				scrollView.ScrollbarFadingEnabled = true;
+				scrollView.AwakenScrollBars();
+				scrollView.ScrollbarFadingEnabled = false;
+			}
+			else
+			{
+				scrollView.AwakenScrollBars();
+			}
+
+			scrollView.ScrollBarsInitialized = true;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
@@ -17,17 +17,17 @@ namespace Xamarin.Forms.Platform.Android
 		internal static void HandleScrollBarVisibilityChange(this IScrollView scrollView)
 		{
 
-			//// According to the Android Documentation
-			//// * <p>AwakenScrollBars method should be invoked every time a subclass directly updates
-			//// *the scroll parameters.</ p >
+			// According to the Android Documentation
+			// * <p>AwakenScrollBars method should be invoked every time a subclass directly updates
+			// *the scroll parameters.</ p >
 
-			//// If AwakenScrollBars is never called there are cases where the ScrollDrawable is never called
-			//// which causes a crash during draw
+			// If AwakenScrollBars is never called there are cases where the ScrollDrawable is never called
+			// which causes a crash during draw
 
-			if(scrollView.ScrollBarsInitialized)
+			if (scrollView.ScrollBarsInitialized)
 				scrollView.AwakenScrollBars();
 
-			//// The scrollbar drawable won't initialize if ScrollbarFadingEnabled == false
+			// The scrollbar drawable won't initialize if ScrollbarFadingEnabled == false
 			if (!scrollView.ScrollbarFadingEnabled)
 			{
 				scrollView.ScrollbarFadingEnabled = true;

--- a/Xamarin.Forms.Platform.Android/IScrollView.cs
+++ b/Xamarin.Forms.Platform.Android/IScrollView.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal interface IScrollView
+	{
+		bool ScrollBarsInitialized { get; set; }
+		bool ScrollbarFadingEnabled { get; set; }
+		void AwakenScrollBars();
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
@@ -1,11 +1,12 @@
 using Android.Content;
 using Android.Support.V4.Widget;
+using Android.Graphics;
 using Android.Views;
 using Android.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class AHorizontalScrollView : HorizontalScrollView
+	public class AHorizontalScrollView : HorizontalScrollView, IScrollView
 	{
 		readonly ScrollViewRenderer _renderer;
 
@@ -68,5 +69,38 @@ namespace Xamarin.Forms.Platform.Android
 
 			_renderer.UpdateScrollPosition(Context.FromPixels(l), Context.FromPixels(t));
 		}
+
+		public override void Draw(Canvas canvas)
+		{
+			try
+			{
+				base.Draw(canvas);
+			}
+			catch (Java.Lang.NullPointerException npe)
+			when (npe.Message.Contains("ScrollBarDrawable.mutate()"))
+			{
+				// This will most likely never run since UpdateScrollBars is called 
+				// when the scrollbars visibilities are updated but I left it here
+				// just in case there's an edge case that causes an exception
+				this.HandleScrollBarVisibilityChange();
+			}
+		}
+
+		public override bool HorizontalScrollBarEnabled
+		{
+			get { return base.HorizontalScrollBarEnabled; }
+			set
+			{
+				base.HorizontalScrollBarEnabled = value;
+				this.HandleScrollBarVisibilityChange();
+			}
+		}
+
+		void IScrollView.AwakenScrollBars()
+		{
+			base.AwakenScrollBars();
+		}
+
+		bool IScrollView.ScrollBarsInitialized { get; set; } = false;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -247,8 +247,6 @@ namespace Xamarin.Forms.Platform.Android
 			EventHandler<VisualElementChangedEventArgs> changed = ElementChanged;
 			if (changed != null)
 				changed(this, e);
-
-			ScrollbarFadingEnabled = false;
 		}
 
 		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -8,12 +8,11 @@ using Android.Support.V4.Widget;
 using Android.Views;
 using Android.Widget;
 using Xamarin.Forms.Internals;
-using AScrollView = Android.Widget.ScrollView;
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class ScrollViewRenderer : NestedScrollView, IVisualElementRenderer, IEffectControlProvider
+	public class ScrollViewRenderer : NestedScrollView, IVisualElementRenderer, IEffectControlProvider, IScrollView
 	{
 		ScrollViewContainer _container;
 		HorizontalScrollView _hScrollView;
@@ -138,9 +137,20 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override void Draw(Canvas canvas)
 		{
-			canvas.ClipRect(canvas.ClipBounds);
+			try
+			{
+				canvas.ClipRect(canvas.ClipBounds);
 
-			base.Draw(canvas);
+				base.Draw(canvas);
+			}
+			catch (Java.Lang.NullPointerException npe)
+			when(npe.Message.Contains("ScrollBarDrawable.mutate()"))
+			{
+				// This will most likely never run since UpdateScrollBars is called 
+				// when the scrollbars visibilities are updated but I left it here
+				// just in case there's an edge case that causes an exception
+				this.HandleScrollBarVisibilityChange();
+			}
 		}
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)
@@ -237,6 +247,8 @@ namespace Xamarin.Forms.Platform.Android
 			EventHandler<VisualElementChangedEventArgs> changed = ElementChanged;
 			if (changed != null)
 				changed(this, e);
+
+			ScrollbarFadingEnabled = false;
 		}
 
 		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
@@ -498,7 +510,7 @@ namespace Xamarin.Forms.Platform.Android
 					newHorizontalScrollVisiblility = _defaultHorizontalScrollVisibility;
 				}
 
-				_hScrollView.HorizontalScrollBarEnabled = newHorizontalScrollVisiblility == ScrollBarVisibility.Always;
+				_hScrollView.HorizontalScrollBarEnabled = newHorizontalScrollVisiblility == ScrollBarVisibility.Always;				
 			}
 		}
 
@@ -513,6 +525,15 @@ namespace Xamarin.Forms.Platform.Android
 				newVerticalScrollVisibility = _defaultVerticalScrollVisibility;
 
 			VerticalScrollBarEnabled = newVerticalScrollVisibility == ScrollBarVisibility.Always;
+
+			this.HandleScrollBarVisibilityChange();
 		}
+
+		void IScrollView.AwakenScrollBars()
+		{
+			base.AwakenScrollBars();
+		}
+
+		bool IScrollView.ScrollBarsInitialized { get; set; } = false;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Elevation.cs" />
     <Compile Include="Extensions\EntryRendererExtensions.cs" />
     <Compile Include="Extensions\FragmentManagerExtensions.cs" />
+    <Compile Include="Extensions\ScrollViewExtensions.cs" />
     <Compile Include="FastRenderers\AutomationPropertiesProvider.cs" />
     <Compile Include="AppCompat\PageExtensions.cs" />
     <Compile Include="Extensions\JavaObjectExtensions.cs" />
@@ -145,6 +146,7 @@
     <Compile Include="IBorderVisualElementRenderer.cs" />
     <Compile Include="IDeviceInfoProvider.cs" />
     <Compile Include="ILayoutChanges.cs" />
+    <Compile Include="IScrollView.cs" />
     <Compile Include="ITabStop.cs" />
     <Compile Include="IPickerRenderer.cs" />
     <Compile Include="PickerManager.cs" />


### PR DESCRIPTION
### Description of Change ###
Added code to force the underlying scrollbars on a NestedScrollView control to initialize to avoid crashes during the draw phase 

### Issues Resolved ### 

- fixes #5461

### Platforms Affected ### 
- Android

### Testing Procedure ###
- there are automated tests

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
