### PR TITLE
Fix build break when building on command line

### DIFF
--- a/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
+++ b/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
@@ -14,6 +14,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <RuntimeIdentifiers>win</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Maps.Design/Xamarin.Forms.Maps.Design.csproj
+++ b/Xamarin.Forms.Maps.Design/Xamarin.Forms.Maps.Design.csproj
@@ -14,6 +14,7 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <RuntimeIdentifiers>win</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Xaml.Design/Xamarin.Forms.Xaml.Design.csproj
+++ b/Xamarin.Forms.Xaml.Design/Xamarin.Forms.Xaml.Design.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <RuntimeIdentifiers>win</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
### Description of Change ###

Fix build break when using command line that gums up my `.create-nuget.bat` file (and prob any other tools that builds from the cmd line in order to build a private nuget package):

> C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets(1
86,5): error : Your project file doesn't list 'win' as a "RuntimeIdentifier". You should add 'win' to the "RuntimeIdent
ifiers" property in your project file and then re-run NuGet restore. [X:\git\forms0\Xamarin.Forms.Core.Design\Xamarin.F
orms.Core.Design.csproj]

> C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets(1
86,5): error : Your project file doesn't list 'win' as a "RuntimeIdentifier". You should add 'win' to the "RuntimeIdent
ifiers" property in your project file and then re-run NuGet restore. [X:\git\forms0\Xamarin.Forms.Maps.Design\Xamarin.F
orms.Maps.Design.csproj]

> C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets(1
86,5): error : Your project file doesn't list 'win' as a "RuntimeIdentifier". You should add 'win' to the "RuntimeIdent
ifiers" property in your project file and then re-run NuGet restore. [X:\git\forms0\Xamarin.Forms.Xaml.Design\Xamarin.F
orms.Xaml.Design.csproj]
