### PR TITLE
[UWP] Roll back PR 3400 so the correct context is passed into Tapped

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue935.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue935.cs
@@ -68,9 +68,8 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			Title = "List Page";
 
-			var items = new object [] {
-				new CustomViewCellBindingContext(),
-				new object()
+			var items = new [] {
+				new CustomViewCellBindingContext()
 			};
 				
 			var cellTemplate = new DataTemplate (typeof(CustomViewCell));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue935.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue935.cs
@@ -24,7 +24,6 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	public class CustomViewCell : ViewCell 
 	{
-
 		public CustomViewCell ()
 		{
 			int tapsFired = 0;
@@ -35,14 +34,29 @@ namespace Xamarin.Forms.Controls.Issues
 				Text = "I have been selected:"
 			};
 
+			if (this is CustomViewCellBindingContext)
+				label.Text = "If you can read this text the UI Test has failed";
+
 			Tapped += (s, e) => {
 				tapsFired++;
 				label.Text = "I have been selected:" + tapsFired;
+
+				var cell = (CustomViewCell)s;
 			};
 
 			View = label;
 		}
 	}
+
+
+	[Preserve(AllMembers = true)]
+	public class CustomViewCellBindingContext : CustomViewCell
+	{
+		public CustomViewCellBindingContext()
+		{
+		}
+	}
+
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
@@ -54,8 +68,9 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			Title = "List Page";
 
-			var items = new [] {
-				new CustomViewCell (),
+			var items = new object [] {
+				new CustomViewCellBindingContext(),
+				new object()
 			};
 				
 			var cellTemplate = new DataTemplate (typeof(CustomViewCell));

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -722,9 +722,9 @@ namespace Xamarin.Forms.Platform.UWP
 			List.SelectedIndex = index;
 		}
 
-		void OnListItemClicked(int index, Cell cell = null)
+		void OnListItemClicked(int index)
 		{
-			Element.NotifyRowTapped(index, cell);
+			Element.NotifyRowTapped(index);
 			_itemWasClicked = true;
 		}
 
@@ -735,7 +735,7 @@ namespace Xamarin.Forms.Platform.UWP
 				var templatedItems = TemplatedItemsView.TemplatedItems;
 				var selectedItemIndex = templatedItems.GetGlobalIndexOfItem(e.ClickedItem);
 
-				OnListItemClicked(selectedItemIndex, e.ClickedItem as Cell);
+				OnListItemClicked(selectedItemIndex);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

The description of why is summarized here
https://github.com/xamarin/Xamarin.Forms/issues/5465

### Platforms Affected ### 
- UWP


### Testing Procedure ###
- run Issue2927Test and it will no longer crash

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
