### PR TITLE
[Maps] move design dll to the design folder

### DIFF
--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -65,8 +65,8 @@
     <file src="..\docs\Xamarin.Forms.Maps.xml" target="lib\tizen40" />
 
     <!-- Xaml Design-time Stuff -->
-    <file src="..\Xamarin.Forms.Maps.Design\bin\$Configuration$\Xamarin.Forms.Maps.Design.dll" target="lib\netstandard2.0" />
-    <file src="..\Xamarin.Forms.Maps.Design\bin\$Configuration$\Xamarin.Forms.Maps.Design.dll" target="lib\netstandard1.0" />
+    <file src="..\Xamarin.Forms.Maps.Design\bin\$Configuration$\Xamarin.Forms.Maps.Design.dll" target="lib\netstandard2.0\Design" />
+    <file src="..\Xamarin.Forms.Maps.Design\bin\$Configuration$\Xamarin.Forms.Maps.Design.dll" target="lib\netstandard1.0\Design" />
 
 </files>
 </package>


### PR DESCRIPTION
### Description of Change ###

Put the design.dll for Maps into the Design folder for consistency.

### Issues Resolved ### 

- fixes #5472

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

None

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
