### PR TITLE
[Tizen] Fix CarouselPage focus issue

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/CarouselPageRenderer.cs
@@ -142,10 +142,10 @@ namespace Xamarin.Forms.Platform.Tizen
 			// To update TabIndex order
 			CustomFocusManager.StartReorderTabIndex();
 
+			Element.UpdateFocusTreePolicy();
+
 			if (IsChangedByScroll())
 				return;
-
-			Element.UpdateFocusTreePolicy();
 
 			if (Element.CurrentPage != Element.Children[_pageIndex])
 			{


### PR DESCRIPTION
### Description of Change ###
 * Fix bug of CarouselPage focusing
    We disallow focus on page that outside of screen, So When CurrentPage was changed on MultPage, We change `AllowTreeFocus` property to false on all others page
    We have mistake on this code, so can't change policy when CurrentPage was changed by scrolling
    This PR is fix it

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
