### PR TITLE
[X] recover from missing markup type

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -559,8 +559,12 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		{
 			var xaml = @"
 						<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
-							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
-							<ListView ItemsSource=""{x:Static Foo}"" />
+							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+								xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
+								<StackLayout>
+									<ListView ItemsSource=""{x:Static Foo}"" />
+									<ListView ItemsSource=""{local:Missing Test}"" />
+								</StackLayout>
 						</ContentPage>";
 
 			var exceptions = new List<Exception>();

--- a/Xamarin.Forms.Xaml/XamlServiceProvider.cs
+++ b/Xamarin.Forms.Xaml/XamlServiceProvider.cs
@@ -201,19 +201,13 @@ namespace Xamarin.Forms.Xaml.Internals
 			Assembly currentAssembly)
 		{
 			this.currentAssembly = currentAssembly;
-			if (namespaceResolver == null)
-				throw new ArgumentNullException();
-			if (getTypeFromXmlName == null)
-				throw new ArgumentNullException();
-
-			this.namespaceResolver = namespaceResolver;
-			this.getTypeFromXmlName = getTypeFromXmlName;
+			this.namespaceResolver = namespaceResolver ?? throw new ArgumentNullException();
+			this.getTypeFromXmlName = getTypeFromXmlName ?? throw new ArgumentNullException();
 		}
 
 		Type IXamlTypeResolver.Resolve(string qualifiedTypeName, IServiceProvider serviceProvider)
 		{
-			XamlParseException e;
-			var type = Resolve(qualifiedTypeName, serviceProvider, out e);
+			var type = Resolve(qualifiedTypeName, serviceProvider, out XamlParseException e);
 			if (e != null)
 				throw e;
 			return type;
@@ -221,8 +215,7 @@ namespace Xamarin.Forms.Xaml.Internals
 
 		bool IXamlTypeResolver.TryResolve(string qualifiedTypeName, out Type type)
 		{
-			XamlParseException exception;
-			type = Resolve(qualifiedTypeName, null, out exception);
+			type = Resolve(qualifiedTypeName, null, out XamlParseException exception);
 			return exception == null;
 		}
 
@@ -234,28 +227,23 @@ namespace Xamarin.Forms.Xaml.Internals
 				return null;
 
 			string prefix, name;
-			if (split.Length == 2)
-			{
+			if (split.Length == 2) {
 				prefix = split[0];
 				name = split[1];
 			}
-			else
-			{
+			else {
 				prefix = "";
 				name = split[0];
 			}
 
 			IXmlLineInfo xmlLineInfo = null;
-			if (serviceProvider != null)
-			{
-				var lineInfoProvider = serviceProvider.GetService(typeof (IXmlLineInfoProvider)) as IXmlLineInfoProvider;
-				if (lineInfoProvider != null)
+			if (serviceProvider != null) {
+				if (serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider)
 					xmlLineInfo = lineInfoProvider.XmlLineInfo;
 			}
 
 			var namespaceuri = namespaceResolver.LookupNamespace(prefix);
-			if (namespaceuri == null)
-			{
+			if (namespaceuri == null) {
 				exception = new XamlParseException(string.Format("No xmlns declaration for prefix \"{0}\"", prefix), xmlLineInfo);
 				return null;
 			}


### PR DESCRIPTION
### Description of Change ###

[X] recover from missing markup type

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5484

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

> VS bug [#813561](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/813561), VS bug [#816607](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/816607)