### PR TITLE
Centralize Theme Wrapper and fix sandbox to work with previewer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml
@@ -69,6 +69,9 @@
             <Label Text="Custom" Margin="0,0,0,-10" />
             <ProgressBar Progress="0.5" ProgressColor="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" />
 
+            <Label Text="Height 20" Margin="0,0,0,-10" />
+            <ProgressBar Progress="0.5" HeightRequest="20" ProgressColor="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" />
+
 
             <Label Text="Buttons" FontSize="Large" />
 

--- a/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Material.Android
 		public MaterialActivityIndicatorRenderer(Context context)
 			: base(context)
 		{
-			_control = new CircularProgress(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular)
+			_control = new CircularProgress(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular)
 			{
 				// limiting size to compare iOS realization
 				// https://github.com/material-components/material-components-ios/blob/develop/components/ActivityIndicator/src/MDCActivityIndicator.m#L425

--- a/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Material.Android
 		public MaterialActivityIndicatorRenderer(Context context)
 			: base(context)
 		{
-			_control = new CircularProgress(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialProgressBarCircular), null, Resource.Style.XamarinFormsMaterialProgressBarCircular)
+			_control = new CircularProgress(MaterialContextThemeWrapper.Create(context), null, Resource.Attribute.materialProgressBarCircularStyle)
 			{
 				// limiting size to compare iOS realization
 				// https://github.com/material-components/material-components-ios/blob/develop/components/ActivityIndicator/src/MDCActivityIndicator.m#L425

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Material.Android
 		readonly AutomationPropertiesProvider _automationPropertiesProvider;
 		
 		public MaterialButtonRenderer(Context context)
-			: base(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialTheme))
+			: base(MaterialContextThemeWrapper.Create(context))
 		{
 			_automationPropertiesProvider = new AutomationPropertiesProvider(this);
 			_buttonLayoutManager = new ButtonLayoutManager(this,

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Material.Android
 		readonly AutomationPropertiesProvider _automationPropertiesProvider;
 		
 		public MaterialButtonRenderer(Context context)
-			: base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialTheme))
+			: base(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialTheme))
 		{
 			_automationPropertiesProvider = new AutomationPropertiesProvider(this);
 			_buttonLayoutManager = new ButtonLayoutManager(this,

--- a/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
+++ b/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Material.Android
 		{
 		}
 
-		private MaterialContextThemeWrapper(Context context, int themeResId) : base(context, themeResId)
+		MaterialContextThemeWrapper(Context context, int themeResId) : base(context, themeResId)
 		{
 
 		}

--- a/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
+++ b/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
@@ -2,20 +2,30 @@
 using Android.Content;
 using Android.Views;
 using Xamarin.Forms.Platform.Android;
+using AndroidAppCompat = Android.Support.V7.Content.Res.AppCompatResources;
 
 namespace Xamarin.Forms.Material.Android
 {
 	public class MaterialContextThemeWrapper : ContextThemeWrapper
 	{
-		public MaterialContextThemeWrapper(Context context) : base(context, Resource.Style.XamarinFormsMaterialTheme)
+		private MaterialContextThemeWrapper(Context context) : this(context, Resource.Style.XamarinFormsMaterialTheme)
 		{
 		}
 
-
-		public static Context Create(Context context)
+		private MaterialContextThemeWrapper(Context context, int themeResId) : base(context, themeResId)
 		{
-			if (context is MaterialContextThemeWrapper)
-				return context;
+
+		}
+
+		public static MaterialContextThemeWrapper Create(Context context, int themeResId)
+		{
+			return new MaterialContextThemeWrapper(context, themeResId);
+		}
+
+		public static MaterialContextThemeWrapper Create(Context context)
+		{
+			if (context is MaterialContextThemeWrapper materialContext)
+				return materialContext;
 
 			return new MaterialContextThemeWrapper(context);
 		}

--- a/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
+++ b/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Material.Android
 {
 	public class MaterialContextThemeWrapper : ContextThemeWrapper
 	{
-		private MaterialContextThemeWrapper(Context context) : this(context, Resource.Style.XamarinFormsMaterialTheme)
+		MaterialContextThemeWrapper(Context context) : this(context, Resource.Style.XamarinFormsMaterialTheme)
 		{
 		}
 

--- a/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
+++ b/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
@@ -17,11 +17,6 @@ namespace Xamarin.Forms.Material.Android
 
 		}
 
-		public static MaterialContextThemeWrapper Create(Context context, int themeResId)
-		{
-			return new MaterialContextThemeWrapper(context, themeResId);
-		}
-
 		public static MaterialContextThemeWrapper Create(Context context)
 		{
 			if (context is MaterialContextThemeWrapper materialContext)

--- a/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
+++ b/Xamarin.Forms.Material.Android/MaterialContextThemeWrapper.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Material.Android
 {
 	public class MaterialContextThemeWrapper : ContextThemeWrapper
 	{
-		MaterialContextThemeWrapper(Context context) : this(context, Resource.Style.XamarinFormsMaterialTheme)
+		public MaterialContextThemeWrapper(Context context) : this(context, Resource.Style.XamarinFormsMaterialTheme)
 		{
 		}
 

--- a/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Material.Android
 		readonly MotionEventHelper _motionEventHelper;
 
 		public MaterialFrameRenderer(Context context)
-			: base(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialTheme))
+			: base(MaterialContextThemeWrapper.Create(context))
 		{
 			_gestureManager = new GestureManager(this);
 			_effectControlProvider = new EffectControlProvider(this);

--- a/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Material.Android
 		readonly MotionEventHelper _motionEventHelper;
 
 		public MaterialFrameRenderer(Context context)
-			: base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialTheme))
+			: base(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialTheme))
 		{
 			_gestureManager = new GestureManager(this);
 			_effectControlProvider = new EffectControlProvider(this);

--- a/Xamarin.Forms.Material.Android/MaterialProgressBarRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialProgressBarRenderer.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Material.Android
 		MotionEventHelper _motionEventHelper;
 		
 		public MaterialProgressBarRenderer(Context context)
-			: base(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialProgressBarHorizontal), null, Resource.Style.XamarinFormsMaterialProgressBarHorizontal)
+			: base(MaterialContextThemeWrapper.Create(context), null, Resource.Attribute.materialProgressBarHorizontalStyle)
 		{
 			Indeterminate = false;
 			Max = MaximumValue;

--- a/Xamarin.Forms.Material.Android/MaterialProgressBarRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialProgressBarRenderer.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Material.Android
 		MotionEventHelper _motionEventHelper;
 		
 		public MaterialProgressBarRenderer(Context context)
-			: base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialProgressBarHorizontal), null, Resource.Style.XamarinFormsMaterialProgressBarHorizontal)
+			: base(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialProgressBarHorizontal), null, Resource.Style.XamarinFormsMaterialProgressBarHorizontal)
 		{
 			Indeterminate = false;
 			Max = MaximumValue;

--- a/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Material.Android
 		double _min = 0.0;
 
 		public MaterialSliderRenderer(Context context)
-			: base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialSlider), null, Resource.Style.XamarinFormsMaterialSlider)
+			: base(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialSlider), null, Resource.Style.XamarinFormsMaterialSlider)
 		{
 			SetOnSeekBarChangeListener(this);
 			Max = (int)MaximumValue;

--- a/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Material.Android
 		double _min = 0.0;
 
 		public MaterialSliderRenderer(Context context)
-			: base(MaterialContextThemeWrapper.Create(context, Resource.Style.XamarinFormsMaterialSlider), null, Resource.Style.XamarinFormsMaterialSlider)
+			: base(MaterialContextThemeWrapper.Create(context), null, Resource.Attribute.materialSliderStyle)
 		{
 			SetOnSeekBarChangeListener(this);
 			Max = (int)MaximumValue;

--- a/Xamarin.Forms.Material.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.Material.Android/Resources/values/styles.xml
@@ -2,11 +2,17 @@
 <resources>
 
   <attr name="materialOutlinedButtonStyle" format="reference"/>
+  <attr name="materialSliderStyle" format="reference"/>
+  <attr name="materialProgressBarHorizontalStyle" format="reference"/>
+  <attr name="materialProgressBarCircularStyle" format="reference"/>
 
   <!-- Material Base Theme -->
   <style name="XamarinFormsMaterialTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
     <item name="materialButtonStyle">@style/XamarinFormsMaterialButton</item>
     <item name="materialOutlinedButtonStyle">@style/XamarinFormsMaterialButtonOutlined</item>
+    <item name="materialSliderStyle">@style/XamarinFormsMaterialSlider</item>
+    <item name="materialProgressBarHorizontalStyle">@style/XamarinFormsMaterialProgressBarHorizontal</item>
+    <item name="materialProgressBarCircularStyle">@style/XamarinFormsMaterialProgressBarCircular</item>
   </style>
 
   <!-- Material Sliders -->


### PR DESCRIPTION
### Description of Change ###

- Moved the ContextThemeWrapper creation to a factory method which will centralize the wrapper creation plus it won't double wrap things
- Also modified sandbox slightly so that iOS will render with previewer


### Platforms Affected ### 
- Android


### Testing Procedure ###
- run Visual Gallery in Control Gallery

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
