### PR TITLE
[Android] NamedSize now returns defaultValue instead of -1 if parsing from resource fails

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -549,9 +549,9 @@ namespace Xamarin.Forms
 			{
 				double myValue;
 
-				if (TryGetTextAppearance(themeDefault, out myValue))
+				if (TryGetTextAppearance(themeDefault, out myValue) && myValue > 0)
 					return myValue;
-				if (TryGetTextAppearance(deviceDefault, out myValue))
+				if (TryGetTextAppearance(deviceDefault, out myValue) && myValue > 0)
 					return myValue;
 				return defaultValue;
 			}


### PR DESCRIPTION
### Description of Change ###

In the previewer, `TryGetTextAppearance()` returns `-0.5` for all values. Return default value if we get a size of 0 or less.

### Issues Resolved ### 

- fixes https://devdiv.visualstudio.com/DevDiv/_queries/edit/763877

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Before:

![image](https://user-images.githubusercontent.com/9665847/54012828-eef4eb00-41c2-11e9-931d-0c72dbb34ec9.png)

After:

![image](https://user-images.githubusercontent.com/9665847/54012737-ac331300-41c2-11e9-9d2a-495fdc9bf37d.png)


### Testing Procedure ###
Manual testing in previewer.

### PR Checklist ###

- [ ] Has automated tests (we will test this in the previewer)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
