### PR TITLE
Fix up Sandbox to work with previewer and add android material reference in

### DIFF
--- a/Xamarin.Forms.Sandbox.Android/MainActivity.cs
+++ b/Xamarin.Forms.Sandbox.Android/MainActivity.cs
@@ -18,8 +18,9 @@ namespace Xamarin.Forms.Sandbox.Droid
             ToolbarResource = Resource.Layout.Toolbar;
 
             base.OnCreate(savedInstanceState);
-            global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
-            LoadApplication(new App());
+			global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
+			global::Xamarin.Forms.FormsMaterial.Init(this, savedInstanceState);
+			LoadApplication(new App());
         }
     }
 }

--- a/Xamarin.Forms.Sandbox.Android/Xamarin.Forms.Sandbox.Android.csproj
+++ b/Xamarin.Forms.Sandbox.Android/Xamarin.Forms.Sandbox.Android.csproj
@@ -101,6 +101,10 @@
       <Project>{6e53feb1-1100-46ae-8013-17bba35cc197}</Project>
       <Name>Xamarin.Forms.Platform.Android (Forwarders)</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Xamarin.Forms.Material.Android\Xamarin.Forms.Material.Android.csproj">
+      <Project>{e1586ce6-8eac-4388-a15a-1aabf108b5f8}</Project>
+      <Name>Xamarin.Forms.Material.Android</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Xamarin.Forms.Platform.Android.FormsViewGroup\Xamarin.Forms.Platform.Android.FormsViewGroup.csproj">
       <Project>{3b72465b-acae-43ae-9327-10f372fe5f80}</Project>
       <Name>Xamarin.Forms.Platform.Android.FormsViewGroup</Name>

--- a/Xamarin.Forms.Sandbox.iOS/Xamarin.Forms.Sandbox.iOS.csproj
+++ b/Xamarin.Forms.Sandbox.iOS/Xamarin.Forms.Sandbox.iOS.csproj
@@ -184,6 +184,10 @@
       <Project>{e155c410-e5de-464d-9ed7-2b1e672438ed}</Project>
       <Name>Xamarin.Forms.Sandbox</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj">
+      <Project>{9db2f292-8034-4e06-89ad-98bbda4306b9}</Project>
+      <Name>Xamarin.Forms.Xaml</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.iOS.MaterialComponents">

--- a/Xamarin.Forms.Sandbox/App.StartHere.cs
+++ b/Xamarin.Forms.Sandbox/App.StartHere.cs
@@ -9,11 +9,8 @@ namespace Xamarin.Forms.Sandbox
 		// This code is called from the App Constructor so just initialize the main page of the application here
 		void InitializeMainPage()
 		{
-			/*MainPage = new ContentPage()
-			{
-				Content = CreateStackLayout(new[] { new Button() { Text = "text" } })
-			};
-			MainPage.Visual = VisualMarker.Material;*/
+			//MainPage = CreateStackLayoutPage(new[] { new Button() { Text = "text" } });
+			//MainPage.Visual = VisualMarker.Material;
 			MainPage = new MainPage();
 		}
 	}

--- a/Xamarin.Forms.Sandbox/MainPage.xaml
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml
@@ -4,7 +4,7 @@
              x:Class="Xamarin.Forms.Sandbox.MainPage">
     <ContentPage.Content>
         <StackLayout>
-            <Button Text="Material text" Visual="MaTeRiAl" />
+            <Button Text="Material text"  />
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Sandbox/MainPage.xaml
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.Forms.Sandbox.MainPage">
+             x:Class="Xamarin.Forms.Sandbox.MainPage"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core" 
+             ios:Page.UseSafeArea="true">
     <ContentPage.Content>
         <StackLayout>
-            <Button Text="Material text"  />
+            <Button Text="I am a Button"  />
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Sandbox/Xamarin.Forms.Sandbox.csproj
+++ b/Xamarin.Forms.Sandbox/Xamarin.Forms.Sandbox.csproj
@@ -16,17 +16,13 @@
   
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
+    <ProjectReference ReferenceOutputAssembly="False" Include="..\Xamarin.Forms.Build.Tasks\Xamarin.Forms.Build.Tasks.csproj" />
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj" />
     <ProjectReference Include="..\Xamarin.Forms.CustomAttributes\Xamarin.Forms.CustomAttributes.csproj" />
     <ProjectReference Include="..\Xamarin.Forms.Maps\Xamarin.Forms.Maps.csproj" />
     <ProjectReference Include="..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <EmbeddedResource Update="Page1.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
+
   <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
   <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 </Project>


### PR DESCRIPTION
### Description of Change ###

- add material reference to android sandbox
- add a XAML dll reference to ios so it runs on previewer
- Add build tasks as non referenced assembly to sandbox can compile XAML files off a clean build
