### PR TITLE
Parsing now throws XamlParseExceptions here

### DIFF
--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -142,10 +142,7 @@ namespace Xamarin.Forms.Xaml
 					return;
 				}
 				xpe = xpe ?? new XamlParseException($"Can not set the content of {((IElementNode)parentNode).XmlType.Name} as it doesn't have a ContentPropertyAttribute", node);
-				if (Context.ExceptionHandler != null)
-					Context.ExceptionHandler(xpe);
-				else
-					throw xpe;
+				ExceptionHelper.ThrowUnhandledException(Context, xpe);
 			}
 			else if (IsCollectionItem(node, parentNode) && parentNode is ListNode) {
 				if (!Values.TryGetValue(parentNode.Parent, out var source) && Context.ExceptionHandler != null)
@@ -171,10 +168,7 @@ namespace Xamarin.Forms.Xaml
 					return;
 				}
 				xpe = xpe ?? new XamlParseException($"Value of {parentList.XmlName.LocalName} does not have a Add() method", node);
-				if (Context.ExceptionHandler != null)
-					Context.ExceptionHandler(xpe);
-				else
-					throw xpe;
+				ExceptionHelper.ThrowUnhandledException(Context, xpe);
 			}
 		}
 
@@ -243,10 +237,7 @@ namespace Xamarin.Forms.Xaml
 				else if (valueProvider != null)
 					value = valueProvider.ProvideValue(serviceProvider);
 			} catch (Exception e) {
-				if (Context.ExceptionHandler != null)
-					Context.ExceptionHandler(e);
-				else
-					throw e;
+				ExceptionHelper.ThrowUnhandledException(Context, e);
 			}
 		}
 
@@ -357,10 +348,7 @@ namespace Xamarin.Forms.Xaml
 				return;
 
 			xpe = xpe ?? new XamlParseException($"Cannot assign property \"{localName}\": Property does not exist, or is not assignable, or mismatching type between value and property", lineInfo);
-			if (context.ExceptionHandler != null)
-				context.ExceptionHandler(xpe);
-			else
-				throw xpe;
+			ExceptionHelper.ThrowUnhandledException(context, xpe);
 		}
 
 		public static object GetPropertyValue(object xamlElement, XmlName propertyName, HydrationContext context, IXmlLineInfo lineInfo, out object targetProperty)
@@ -384,10 +372,7 @@ namespace Xamarin.Forms.Xaml
 				return value;
 
 			xpe = xpe ?? new XamlParseException($"Property {localName} is not found or does not have an accessible getter", lineInfo);
-			if (context.ExceptionHandler != null)
-				context.ExceptionHandler(xpe);
-			else
-				throw xpe;
+			ExceptionHelper.ThrowUnhandledException(context, xpe);
 
 			return null;
 		}

--- a/Xamarin.Forms.Xaml/ExceptionHelper.cs
+++ b/Xamarin.Forms.Xaml/ExceptionHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Xaml
 {
@@ -6,11 +7,20 @@ namespace Xamarin.Forms.Xaml
 	{
 		internal static void ThrowUnhandledException(HydrationContext context, Exception e)
 		{
-			if (context.ExceptionHandler != null)
-				context.ExceptionHandler(e);
+			ThrowUnhandledException(context?.ExceptionHandler, e);
+		}
+
+		internal static void ThrowUnhandledException(Exception e)
+		{
+			ThrowUnhandledException(ResourceLoader.ExceptionHandler, e);
+		}
+
+		internal static void ThrowUnhandledException(Action<Exception> exceptionHandler, Exception e)
+		{
+			if (exceptionHandler != null)
+				exceptionHandler(e);
 			else
 				throw (e);
 		}
-
 	}
 }

--- a/Xamarin.Forms.Xaml/ExceptionHelper.cs
+++ b/Xamarin.Forms.Xaml/ExceptionHelper.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Xamarin.Forms.Xaml
+{
+	static class ExceptionHelper
+	{
+		internal static void ThrowUnhandledException(HydrationContext context, Exception e)
+		{
+			if (context.ExceptionHandler != null)
+				context.ExceptionHandler(e);
+			else
+				throw (e);
+		}
+
+	}
+}

--- a/Xamarin.Forms.Xaml/ExpandMarkupsVisitor.cs
+++ b/Xamarin.Forms.Xaml/ExpandMarkupsVisitor.cs
@@ -79,15 +79,15 @@ namespace Xamarin.Forms.Xaml
 				return new ValueNode(expression.Substring(2), null);
 
 			if (expression[expression.Length - 1] != '}')
-				throw new Exception("Expression must end with '}'");
+				ExceptionHelper.ThrowUnhandledException(Context, new XamlParseException("Expression must end with '}'"));
 
 			int len;
 			string match;
 			if (!MarkupExpressionParser.MatchMarkup(out match, expression, out len))
-				throw new Exception();
+				ExceptionHelper.ThrowUnhandledException(Context, new XamlParseException());
 			expression = expression.Substring(len).TrimStart();
 			if (expression.Length == 0)
-				throw new Exception("Expression did not end in '}'");
+				ExceptionHelper.ThrowUnhandledException(Context, new XamlParseException("Expression did not end in '}'"));
 
 			var serviceProvider = new XamlServiceProvider(node, Context);
 			serviceProvider.Add(typeof (IXmlNamespaceResolver), nsResolver);

--- a/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
+++ b/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Xaml
 				return expression.Substring(2);
 
 			if (expression[expression.Length - 1] != '}')
-				throw new Exception("Expression must end with '}'");
+				ExceptionHelper.ThrowUnhandledException(new XamlParseException("Expression must end with '}'"));
 
 			int len;
 			string match;
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Xaml
 				return false;
 			expression = expression.Substring(len).TrimStart();
 			if (expression.Length == 0)
-				throw new Exception("Expression did not end in '}'");
+				ExceptionHelper.ThrowUnhandledException(new XamlParseException("Expression did not end in '}'"));
 
 			var parser = Activator.CreateInstance(GetType()) as IExpressionParser;
 			return parser.Parse(match, ref expression, serviceProvider);
@@ -193,10 +193,10 @@ namespace Xamarin.Forms.Xaml
 			}
 
 			if (inString && end == remaining.Length)
-				throw new Exception("Unterminated quoted string");
+				ExceptionHelper.ThrowUnhandledException(new XamlParseException("Unterminated quoted string"));
 
 			if (end == remaining.Length && !remaining.EndsWith("}", StringComparison.Ordinal))
-				throw new Exception("Expression did not end with '}'");
+				ExceptionHelper.ThrowUnhandledException(new XamlParseException("Expression did not end with '}'"));
 
 			if (end == 0)
 			{

--- a/Xamarin.Forms.Xaml/MarkupExtensionParser.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensionParser.cs
@@ -32,12 +32,13 @@ namespace Xamarin.Forms.Xaml
 
 				//The order of lookup is to look for the Extension-suffixed class name first and then look for the class name without the Extension suffix.
 				if (!typeResolver.TryResolve(match + "Extension", out type) && !typeResolver.TryResolve(match, out type))
-					throw new XamlParseException($"MarkupExtension not found for {match}", serviceProvider);
+					ExceptionHelper.ThrowUnhandledException(new XamlParseException($"MarkupExtension not found for {match}", serviceProvider));
 				markupExtension = Activator.CreateInstance(type) as IMarkupExtension;
 			}
 
 			if (markupExtension == null)
-				throw new XamlParseException($"Missing public default constructor for MarkupExtension {match}", serviceProvider);
+				ExceptionHelper.ThrowUnhandledException(
+					new XamlParseException($"Missing public default constructor for MarkupExtension {match}", serviceProvider));
 
 			if (remaining == "}")
 				return markupExtension.ProvideValue(serviceProvider);
@@ -62,7 +63,8 @@ namespace Xamarin.Forms.Xaml
 					setter = t.GetRuntimeProperty(prop).SetMethod;
 				}
 				catch (AmbiguousMatchException e) {
-					throw new XamlParseException($"Multiple properties with name  '{t}.{prop}' found.", serviceProvider, innerException: e);
+					ExceptionHelper.ThrowUnhandledException(
+						new XamlParseException($"Multiple properties with name  '{t}.{prop}' found.", serviceProvider, innerException: e));
 				}
 			}
 			else {
@@ -70,7 +72,8 @@ namespace Xamarin.Forms.Xaml
 					setter = markupExtension.GetType().GetRuntimeProperty(prop).SetMethod;
 				}
 				catch (AmbiguousMatchException e) {
-					throw new XamlParseException($"Multiple properties with name  '{markupExtension.GetType()}.{prop}' found.", serviceProvider, innerException: e);
+					ExceptionHelper.ThrowUnhandledException(
+						new XamlParseException($"Multiple properties with name  '{_markupExtension.GetType()}.{prop}' found.", serviceProvider, innerException: e));
 				}
 
 			}
@@ -82,7 +85,8 @@ namespace Xamarin.Forms.Xaml
 						throw converterException;
 				}
 				catch (AmbiguousMatchException e) {
-					throw new XamlParseException($"Multiple properties with name  '{markupExtension.GetType()}.{prop}' found.", serviceProvider, innerException: e);
+					ExceptionHelper.ThrowUnhandledException(
+						new XamlParseException($"Multiple properties with name  '{_markupExtension.GetType()}.{prop}' found.", serviceProvider, innerException: e));
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

Changes generic Exception throws to XamlParseExceptions, so that tooling can ignore them when failing silently.

### Issues Resolved ### 
fixes #5508

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Per repro in issue

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
