### PR TITLE
[Android] fix focus event on android and add UI Tests

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -246,6 +246,7 @@ namespace Xamarin.Forms.Controls
 	[Preserve(AllMembers = true)]
 	internal class CorePageView : ListView
 	{
+		[Preserve(AllMembers = true)]
 		internal class GalleryPageFactory
 		{
 			public GalleryPageFactory(Func<Page> create, string title)
@@ -258,10 +259,17 @@ namespace Xamarin.Forms.Controls
 				};
 
 				Title = title;
+				TitleAutomationId = $"{Title}AutomationId";
 			}
 
 			public Func<Page> Realize { get; set; }
 			public string Title { get; set; }
+
+			public string TitleAutomationId
+			{
+				get;
+				set;
+			}
 
 			public override string ToString()
 			{
@@ -287,7 +295,6 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new CellForceUpdateSizeGalleryPage(), "Cell Force Update Size Gallery"),
 				new GalleryPageFactory(() => new AppearingGalleryPage(), "Appearing Gallery"),
 				new GalleryPageFactory(() => new EntryCoreGalleryPage(), "Entry Gallery"),
-				new GalleryPageFactory(() => new EntryCoreGalleryPage{ Visual = VisualMarker.Material }, "Entry Gallery (Material)"),
 				new GalleryPageFactory(() => new MaterialEntryGalleryPage(), "Entry Material Demos"),
 				new GalleryPageFactory(() => new NavBarTitleTestPage(), "Titles And Navbar Windows"),
 				new GalleryPageFactory(() => new PanGestureGalleryPage(), "Pan gesture Gallery"),
@@ -389,7 +396,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new TableViewGallery(), "TableView Gallery - Legacy"),
 				new GalleryPageFactory(() => new TemplatedCarouselGallery(), "TemplatedCarouselPage Gallery - Legacy"),
 				new GalleryPageFactory(() => new TemplatedTabbedGallery(), "TemplatedTabbedPage Gallery - Legacy"),
-				 new GalleryPageFactory(() => new UnevenViewCellGallery(), "UnevenViewCell Gallery - Legacy"),
+				new GalleryPageFactory(() => new UnevenViewCellGallery(), "UnevenViewCell Gallery - Legacy"),
 				new GalleryPageFactory(() => new UnevenListGallery(), "UnevenList Gallery - Legacy"),
 				new GalleryPageFactory(() => new ViewCellGallery(), "ViewCell Gallery - Legacy"),
 				new GalleryPageFactory(() => new WebViewGallery(), "WebView Gallery - Legacy"),
@@ -428,9 +435,12 @@ namespace Xamarin.Forms.Controls
 						}
 					})
 				});
+
 				return cell;
 			});
+
 			template.SetBinding(TextCell.TextProperty, "Title");
+			template.SetBinding(TextCell.AutomationIdProperty, "TitleAutomationId");
 
 			BindingContext = _pages;
 			ItemTemplate = template;

--- a/Xamarin.Forms.Controls/CoreGalleryPages/CoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/CoreGalleryPage.cs
@@ -98,6 +98,19 @@ namespace Xamarin.Forms.Controls
 				_isVisibleStateViewContainer.View.IsVisible = !_isVisibleStateViewContainer.View.IsVisible;
 			});
 
+
+			_isFocusedStateViewContainer.StateChangeButton.Command = new Command(() => {
+				
+				if ((bool)isFocusedView.GetValue(VisualElement.IsFocusedProperty))
+				{
+					isFocusedView.SetValueCore(IsFocusedPropertyKey, false);
+				}
+				else
+				{
+					isFocusedView.SetValueCore(IsFocusedPropertyKey, true);
+				}
+			});
+
 			_focusStateViewContainer.StateChangeButton.Command = new Command (() => {
 				if (_focusStateViewContainer.View.IsFocused) {
 					_focusStateViewContainer.View.Unfocus ();

--- a/Xamarin.Forms.Controls/ViewContainers/StateViewContainer.cs
+++ b/Xamarin.Forms.Controls/ViewContainers/StateViewContainer.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Controls
 				AutomationId = name + "StateLabel"
 			};
 
-			if(name == "Focus" || name == "Unfocused" || name == "Focus")
+			if(name == "Focus" || name == "Unfocused" || name == "Focused")
 				stateValueLabel.SetBinding(Label.TextProperty, "IsFocused", converter: new GenericValueConverter(o => o.ToString()));
 			else
 				stateValueLabel.SetBinding (Label.TextProperty, name, converter: new GenericValueConverter (o => o.ToString()));			

--- a/Xamarin.Forms.Controls/ViewContainers/StateViewContainer.cs
+++ b/Xamarin.Forms.Controls/ViewContainers/StateViewContainer.cs
@@ -24,8 +24,11 @@ namespace Xamarin.Forms.Controls
 				BindingContext = view,
 				AutomationId = name + "StateLabel"
 			};
-			if (name != "Focus")
-				stateValueLabel.SetBinding (Label.TextProperty, name, converter: new GenericValueConverter (o => o.ToString()));
+
+			if(name == "Focus" || name == "Unfocused" || name == "Focus")
+				stateValueLabel.SetBinding(Label.TextProperty, "IsFocused", converter: new GenericValueConverter(o => o.ToString()));
+			else
+				stateValueLabel.SetBinding (Label.TextProperty, name, converter: new GenericValueConverter (o => o.ToString()));			
 
 			StateChangeButton = new Button {
 				Text = "Change State: " + name,

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
@@ -1,8 +1,10 @@
 using NUnit.Framework;
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.CustomAttributes;
 
 namespace Xamarin.Forms.Core.UITests
 {
+
 	[TestFixture]
 	[Category(UITestCategories.Entry)]
 	internal class EntryUITests : _ViewUITests
@@ -17,9 +19,20 @@ namespace Xamarin.Forms.Core.UITests
 			App.NavigateToGallery(GalleryQueries.EntryGallery);
 		}
 
-		// TODO
+		[Test]
+		[UiTest(typeof(Entry), "Focus")]
 		public override void _Focus()
 		{
+			var remote = new StateViewContainerRemote(App, Test.VisualElement.Focus, PlatformViewType);
+			remote.GoTo();
+			bool isFocused = System.Convert.ToBoolean( App.Query("FocusStateLabel")[0].ReadText());
+			Assert.IsFalse(isFocused);
+			remote.TapView();
+			isFocused = System.Convert.ToBoolean(App.Query("FocusStateLabel")[0].ReadText());
+			Assert.IsTrue(isFocused);
+			App.Tap("FocusStateLabel");
+			isFocused = System.Convert.ToBoolean(App.Query("FocusStateLabel")[0].ReadText());
+			Assert.IsFalse(isFocused);
 		}
 
 		[UiTestExempt(ExemptReason.CannotTest, "Invalid interaction")]
@@ -27,7 +40,6 @@ namespace Xamarin.Forms.Core.UITests
 		{
 		}
 
-		// TODO
 		public override void _IsFocused()
 		{
 		}
@@ -37,6 +49,8 @@ namespace Xamarin.Forms.Core.UITests
 		{
 		}
 
+
+		
 		// TODO
 		// Implement control specific ui tests
 		[Test]

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/MaterialEntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/MaterialEntryUITests.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms.CustomAttributes;
 namespace Xamarin.Forms.Core.UITests
 {
 
-#if __ANDROID__ || _iOS
+#if __ANDROID__ || __IOS__
 	[TestFixture]
 	[Category(UITestCategories.Entry)]
 	[Category(UITestCategories.Visual)]

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/MaterialEntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/MaterialEntryUITests.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Core.UITests
+{
+
+#if __ANDROID__ || _iOS
+	[TestFixture]
+	[Category(UITestCategories.Entry)]
+	[Category(UITestCategories.Visual)]
+	internal class MaterialEntryUITests : EntryUITests
+	{
+		protected override void NavigateToGallery()
+		{
+			App.NavigateToGallery(GalleryQueries.EntryGallery, "Material");
+		}
+
+		[Test]
+		[UiTest(typeof(Entry), "Focus")]
+		public override void _Focus()
+		{
+			base._Focus();
+		}
+	}
+#endif
+}

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -9,29 +9,44 @@ namespace Xamarin.Forms.Core.UITests
 {
 	internal static class AppExtensions
 	{
-		public static AppRect ScreenBounds (this IApp app)
+		public static AppRect ScreenBounds(this IApp app)
 		{
-			return app.Query (Queries.Root ()).First().Rect;
+			return app.Query(Queries.Root()).First().Rect;
 		}
 
-		public static void NavigateBack (this IApp app)
+		public static void NavigateBack(this IApp app)
 		{
 			app.Back();
 		}
 
-		public static void NavigateToGallery (this IApp app, string page)
+		public static void NavigateToGallery(this IApp app, string page)
+		{
+			NavigateToGallery(app, page, null);
+		}
+
+		public static void NavigateToGallery(this IApp app, string page, string visual)
 		{
 			const string goToTestButtonQuery = "* marked:'GoToTestButton'";
 
 			app.WaitForElement(q => q.Raw(goToTestButtonQuery), "Timed out waiting for Go To Test button to disappear", TimeSpan.FromSeconds(10));
 
-			var text = Regex.Match (page, "'(?<text>[^']*)'").Groups["text"].Value;
+			var text = Regex.Match(page, "'(?<text>[^']*)'").Groups["text"].Value;
 
 			app.WaitForElement("SearchBar");
-			app.EnterText (q => q.Raw ("* marked:'SearchBar'"), text);
+			app.EnterText(q => q.Raw("* marked:'SearchBar'"), text);
 
-			app.Tap (q => q.Raw (goToTestButtonQuery));
-			app.WaitForNoElement (o => o.Raw (goToTestButtonQuery), "Timed out waiting for Go To Test button to disappear", TimeSpan.FromMinutes(2));
+			if(!String.IsNullOrWhiteSpace(visual))
+			{
+				app.ActivateContextMenu($"{text}AutomationId");
+				app.Tap("Select Visual");
+				app.Tap("Material");
+			}
+			else
+			{
+				app.Tap(q => q.Raw(goToTestButtonQuery));
+			}
+
+			app.WaitForNoElement(o => o.Raw(goToTestButtonQuery), "Timed out waiting for Go To Test button to disappear", TimeSpan.FromMinutes(2));
 		}
 
 
@@ -43,7 +58,8 @@ namespace Xamarin.Forms.Core.UITests
 			{
 				elements = app.Query(elementQuery);
 				tryCount++;
-				if (elements.Length == 0 && onFail != null) onFail();
+				if (elements.Length == 0 && onFail != null)
+					onFail();
 			}
 
 			return elements;

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -37,6 +37,7 @@ namespace Xamarin.Forms.Core.UITests
 
 			if(!String.IsNullOrWhiteSpace(visual))
 			{
+				app.DismissKeyboard();
 				app.ActivateContextMenu($"{text}AutomationId");
 				app.Tap("Select Visual");
 				app.Tap("Material");

--- a/Xamarin.Forms.Core.UITests.Shared/Xamarin.Forms.Core.UITests.projitems
+++ b/Xamarin.Forms.Core.UITests.Shared/Xamarin.Forms.Core.UITests.projitems
@@ -35,6 +35,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Tests\Legacy-CellsUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\Legacy-UnevenListTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\MapUITests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tests\MaterialEntryUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\PickerUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\ProgressBarUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\RootGalleryUITests.cs" />

--- a/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
@@ -6,6 +6,8 @@ using Android.Runtime;
 using Android.Util;
 using Android.Support.V4.View;
 using Android.Content.Res;
+using AView = Android.Views.View;
+using Xamarin.Forms.Platform.Android.AppCompat;
 
 namespace Xamarin.Forms.Material.Android
 {
@@ -94,8 +96,15 @@ namespace Xamarin.Forms.Material.Android
 		 * and this is the only way to set it away from that and to whatever the user specified
 		 * 2) The HintTextColor has a different alpha when focused vs not focused
 		 * */
-		void OnFocusChange(object sender, FocusChangeEventArgs e) => 
+		void OnFocusChange(object sender, FocusChangeEventArgs e)
+		{
 			Device.BeginInvokeOnMainThread(() => ApplyTheme());
+
+			// propagate the focus changed event to the View Renderer base class
+			if (Parent is AView.IOnFocusChangeListener focusChangeListener)
+				focusChangeListener.OnFocusChange(EditText, e.HasFocus);
+
+		}
 
 		internal void SetHint(string hint, VisualElement element)
 		{

--- a/Xamarin.Forms.Platform.Android/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/TextCellRenderer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using Android.Content;
 using Android.Views;
@@ -20,6 +21,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateHeight();
 			UpdateIsEnabled();
 			UpdateFlowDirection();
+			UpdateAutomationId();
 			View.SetImageVisible(false);
 
 			return View;
@@ -37,6 +39,13 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateHeight();
 			else if (args.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
+			else if (args.PropertyName == VisualElement.AutomationIdProperty.PropertyName)
+				UpdateAutomationId();
+		}
+
+		void UpdateAutomationId()
+		{
+			View.ContentDescription = Cell.AutomationId;
 		}
 
 		void UpdateDetailText()

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 		[Obsolete("This constructor is obsolete as of version 2.5. Please use ViewRenderer(Context) instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		protected ViewRenderer()
+
 		{
 		}
 	}
@@ -37,6 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		protected ViewRenderer() 
 		{
+			
 		}
 
 		protected virtual TNativeView CreateNativeControl()

--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -236,7 +236,7 @@
     </Style>
 
     <DataTemplate x:Key="TextCell">
-		<StackPanel>
+		<StackPanel AutomationProperties.AutomationId="{Binding AutomationId}">
 			<TextBlock
 				Text="{Binding Text}"
 				Style="{ThemeResource BaseTextBlockStyle}"

--- a/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateBackground(tvc, item);
 
 			SetAccessibility(tvc, item);
+			UpdateAutomationId(tvc, textCell);
 
 			return tvc;
 		}
@@ -59,8 +60,14 @@ namespace Xamarin.Forms.Platform.iOS
 				tvc.DetailTextLabel.TextColor = textCell.DetailColor.ToUIColor(DefaultTextColor);
 			else if (args.PropertyName == Cell.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled(tvc, textCell);
+			else if (args.PropertyName == TextCell.AutomationIdProperty.PropertyName)
+				UpdateAutomationId(tvc, textCell);
 
 			HandlePropertyChanged(tvc, args);
+		}
+		void UpdateAutomationId(CellTableViewCell tvc, TextCell cell)
+		{
+			tvc.AccessibilityIdentifier = cell.AutomationId;
 		}
 
 		protected virtual void HandlePropertyChanged(object sender, PropertyChangedEventArgs args)


### PR DESCRIPTION
### Description of Change ###
- propagate focus event on nested edit text with material up to parent
- Add automationid to TextCell so that I can use it during UI Test
- Add Material UI Test abilities to Core Gallery Pages

### Issues Resolved ### 
- fixes #5509 

### Platforms Affected ### 
- iOS
- Android

### Testing Procedure ###
Run Entry Control gallery and test focus pages

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard