### PR TITLE
[X] resilience on markup

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -564,22 +564,21 @@ namespace Xamarin.Forms.Xaml.UnitTests
 								<StackLayout>
 									<ListView ItemsSource=""{x:Static Foo}"" />
 									<ListView ItemsSource=""{local:Missing Test}"" />
+									<Label Text=""{Binding Foo"" />
 								</StackLayout>
 						</ContentPage>";
-
 			var exceptions = new List<Exception>();
 			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
 			Assert.That(exceptions.Count, Is.GreaterThan(1));
-    }
+		}
 
-    [Test]
+		[Test]
 		public void CanResolveRootNode()
 		{
 			string assemblyName = null;
 			string clrNamespace = null;
 			string typeName = null;
-
 
 			XamlLoader.FallbackTypeResolver = (fallbackTypeInfos, type) =>
 			{

--- a/Xamarin.Forms.Xaml/ExpandMarkupsVisitor.cs
+++ b/Xamarin.Forms.Xaml/ExpandMarkupsVisitor.cs
@@ -78,17 +78,28 @@ namespace Xamarin.Forms.Xaml
 			if (expression.StartsWith("{}", StringComparison.Ordinal))
 				return new ValueNode(expression.Substring(2), null);
 
-			if (expression[expression.Length - 1] != '}')
-				throw new Exception("Expression must end with '}'");
+			if (expression[expression.Length - 1] != '}') {
+				var ex = new XamlParseException("Expression must end with '}'", xmlLineInfo);
+				if (Context.ExceptionHandler != null) {
+					Context.ExceptionHandler(ex);
+					return null;
+				}
+				throw ex;
+			}
 
-			int len;
-			string match;
-			if (!MarkupExpressionParser.MatchMarkup(out match, expression, out len))
+			if (!MarkupExpressionParser.MatchMarkup(out var match, expression, out var len))
 				throw new Exception();
-			expression = expression.Substring(len).TrimStart();
-			if (expression.Length == 0)
-				throw new Exception("Expression did not end in '}'");
 
+			expression = expression.Substring(len).TrimStart();
+			if (expression.Length == 0) {
+				var ex = new XamlParseException("Expression did not end in '}'", xmlLineInfo);
+				if (Context.ExceptionHandler != null)
+				{
+					Context.ExceptionHandler(ex);
+					return null;
+				}
+				throw ex;
+			}
 			var serviceProvider = new XamlServiceProvider(node, Context);
 			serviceProvider.Add(typeof (IXmlNamespaceResolver), nsResolver);
 


### PR DESCRIPTION
### Description of Change ###

let the previewer intercepts and recover from misformatted markups

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5508
- closes #5527

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
