### PR TITLE
[Mac] disregard the Dark mode

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -97,6 +97,9 @@ namespace Xamarin.Forms
 #else
 			Device.SetIdiom(TargetIdiom.Desktop);
 			Device.SetFlowDirection(NSApplication.SharedApplication.UserInterfaceLayoutDirection.ToFlowDirection());
+			var mojave = new NSOperatingSystemVersion(10, 14, 0);
+			if (NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(mojave))
+				NSApplication.SharedApplication.Appearance = NSAppearance.GetAppearance(NSAppearance.NameAqua);
 #endif
 			Device.SetFlags(s_flags);
 			Device.PlatformServices = new IOSPlatformServices();


### PR DESCRIPTION
### Description of Change ###

The application usable in dark mode.

### Issues Resolved ### 

- fixes #3777

### API Changes ###
 
 None

### Platforms Affected ### 

Mac

### Behavioral/Visual Changes ###

The application will never go to the dark side.

### Before/After Screenshots ### 

Before
![image](https://user-images.githubusercontent.com/27482193/54304087-7d0f0e00-45d5-11e9-8749-3ea37997df1d.png)

After
![image](https://user-images.githubusercontent.com/27482193/54304343-00306400-45d6-11e9-8ad2-f8d59a4b9747.png)


### Testing Procedure ###

- run Control Gallery in Dark mode 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
