### PR TITLE
[iOS] CarouselView - System.InvalidCastException: Specified cast is not valid.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5488.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5488.xaml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Controls.Issues"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue5488">
+    <ContentPage.BindingContext>
+        <local:TestPageViewModel></local:TestPageViewModel>
+    </ContentPage.BindingContext>
+    <StackLayout HorizontalOptions="CenterAndExpand">
+        <Label Text="Trying carousel view" HorizontalOptions="CenterAndExpand"></Label>
+        <CarouselView ItemsSource="{Binding Users}" HeightRequest="300">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <StackLayout BackgroundColor="#80000000" Padding="12">
+                        <Label TextColor="White" Text="{Binding Id}" FontSize="16" HorizontalOptions="Center" VerticalOptions="CenterAndExpand"/>
+                        <Label TextColor="White" Text="{Binding Name}" FontSize="16" HorizontalOptions="Center" VerticalOptions="CenterAndExpand"/>
+                    </StackLayout>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5488.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5488.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5488, "CarouselView on iOS in XamarinForms 3.6: System.InvalidCastException: Specified cast is not valid.", PlatformAffected.iOS)]
+	public partial class Issue5488 : ContentPage
+	{
+		public Issue5488()
+		{
+			InitializeComponent();
+		}
+	}
+
+	public class TestPageViewModel
+	{
+		public ObservableCollection<User> Users { get; set; }
+		public TestPageViewModel()
+		{
+			Users = new ObservableCollection<User>(Enumerable.Range(1, 10).Select(_ =>
+				new User
+				{
+					Id = _,
+					Name = $"User_{_}"
+				}
+			));
+		}
+	}
+
+	public class User
+	{
+		public int Id { get; set; }
+		public string Name { get; set; }
+	}
+}
+

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -438,6 +438,10 @@
       <DependentUpon>Issue5003.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5488.xaml.cs">
+      <DependentUpon>Issue5488.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />
@@ -1118,6 +1122,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5003.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5488.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.Platform.iOS
 {
-	public class CarouselViewRenderer
+	public class CarouselViewRenderer : ItemsViewRenderer
 	{
 		public CarouselViewRenderer()
 		{


### PR DESCRIPTION
### Description of Change ###
Extend CaroselView renderer in iOS from ItemsViewRenderer

### Issues Resolved ### 
- fixes #5488 

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
CaroselView in iOS does not crash on InvalidCastException anymore.

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Go to issue 5488 page, app should not crash

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
