### PR TITLE
Missing type with x:Name throws exception that isn't caught

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -628,6 +628,22 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(clrNamespace, Is.EqualTo("my.namespace"));
 			Assert.That(typeName, Is.EqualTo("MissingType"));
 		}
+
+		[Test]
+		public void IgnoreNamedMissingTypeException()
+		{
+			var xaml = @"
+				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
+
+					<Missing x:Name=""MyName"" />
+				</ContentPage>";
+
+			var exceptions = new List<Exception>();
+			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+		}
 	}
 
 	public class InstantiateThrows


### PR DESCRIPTION
`x:Name` attribute on a non-existent type throws an exception that isn't passed to the `ExceptionHandler`...

``` xml
<ContentPage 
    xmlns="http://xamarin.com/schemas/2014/forms" 
    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" >

    <Missing x:Name="MyName" />

</ContentPage>
```
Exception:
```
System.Collections.Generic.KeyNotFoundException: The given key 'Xamarin.Forms.Xaml.ElementNode' was not present in the dictionary.
   at Xamarin.Forms.Xaml.RegisterXNamesVisitor.Visit(Xamarin.Forms.Xaml.ValueNode node, Xamarin.Forms.Xaml.INode parentNode) Line 35
   at Xamarin.Forms.Xaml.ValueNode.Accept(Xamarin.Forms.Xaml.IXamlNodeVisitor visitor, Xamarin.Forms.Xaml.INode parentNode) Line 86
   at Xamarin.Forms.Xaml.ElementNode.Accept(Xamarin.Forms.Xaml.IXamlNodeVisitor visitor, Xamarin.Forms.Xaml.INode parentNode) Line 143
   at Xamarin.Forms.Xaml.RootNode.Accept(Xamarin.Forms.Xaml.IXamlNodeVisitor visitor, Xamarin.Forms.Xaml.INode parentNode) Line 202
   at Xamarin.Forms.Xaml.XamlLoader.Visit(Xamarin.Forms.Xaml.RootNode rootnode, Xamarin.Forms.Xaml.HydrationContext visitorContext, bool useDesignProperties) Line 148
   at Xamarin.Forms.Xaml.XamlLoader.Create(string xaml, bool doNotThrow, bool useDesignProperties) Line 132
   at Xamarin.Forms.Xaml.XamlLoader.Create(string xaml, bool doNotThrow) Line 102
```

See #5546
