### PR TITLE
[X] resilient to untyped x:Name

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -627,6 +627,25 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(clrNamespace, Is.EqualTo("my.namespace"));
 			Assert.That(typeName, Is.EqualTo("MissingType"));
 		}
+
+		[Test]
+		public void IgnoreNamedMissingTypeException()
+		{
+			var xaml = @"
+					<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+						xmlns:local=""clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests"">
+						<StackLayout>
+							<local:Missing x:Name=""MyName"" />
+							<Button x:Name=""button"" />
+							<Button x:Name=""button"" />
+						</StackLayout>
+					</ContentPage>";
+			var exceptions = new List<Exception>();
+			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
+			Assert.That(exceptions.Count, Is.GreaterThan(1));
+		}
 	}
 
 	public class InstantiateThrows

--- a/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
+++ b/Xamarin.Forms.Xaml/RegisterXNamesVisitor.cs
@@ -30,18 +30,29 @@ namespace Xamarin.Forms.Xaml
 		{
 			if (!IsXNameProperty(node, parentNode))
 				return;
-			try
-			{
+
+			try {
 				((IElementNode)parentNode).Namescope.RegisterName((string)node.Value, Values[parentNode]);
 			}
-			catch (ArgumentException ae)
-			{
+			catch (ArgumentException ae) {
 				if (ae.ParamName != "name")
 					throw ae;
-				throw new XamlParseException($"An element with the name \"{(string)node.Value}\" already exists in this NameScope", node);
+				var xpe = new XamlParseException($"An element with the name \"{(string)node.Value}\" already exists in this NameScope", node);
+				if (Context.ExceptionHandler != null) {
+					Context.ExceptionHandler(xpe);
+					return;
+				}
+				throw xpe;
 			}
-			var element = Values[parentNode] as Element;
-			if (element != null)
+			catch (KeyNotFoundException knfe) {
+				if (Context.ExceptionHandler != null) {
+					Context.ExceptionHandler(knfe);
+					return;
+				}
+				throw knfe;
+			}
+
+			if (Values[parentNode] is Element element)
 				element.StyleId = element.StyleId ?? (string)node.Value;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Allow the previewer to recover from an x:Name attribute on a element
with unresolved type.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5546
- closes #5547

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
