### PR TITLE
[Xaml] Throw XamlParseException when a duplicate property is detected

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DuplicatePropertyElements.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/DuplicatePropertyElements.xaml
@@ -1,0 +1,4 @@
+<BindableObject xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.DuplicatePropertyElements">
+	<BindableObject.BindingContext>0</BindableObject.BindingContext>
+	<BindableObject.BindingContext>0</BindableObject.BindingContext>
+</BindableObject>

--- a/Xamarin.Forms.Xaml.UnitTests/DuplicatePropertyElements.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DuplicatePropertyElements.xaml.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class DuplicatePropertyElements : BindableObject
+	{
+		public DuplicatePropertyElements(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public static class Tests
+		{
+			[TestCase(false)]
+			[TestCase(true)]
+			public static void ThrowXamlParseException(bool useCompiledXaml)
+			{
+				Assert.Throws<XamlParseException>(useCompiledXaml ?
+					(TestDelegate)(() => MockCompiler.Compile(typeof(DuplicatePropertyElements))) :
+					() => new DuplicatePropertyElements(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/DuplicateXArgumentsElements.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/DuplicateXArgumentsElements.xaml
@@ -1,0 +1,8 @@
+<BindableObject xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib.dll" x:Class="Xamarin.Forms.Xaml.UnitTests.DuplicateXArgumentsElements">
+	<BindableObject.BindingContext>
+        <system:Uri>
+            <x:Arguments>https://example.com/</x:Arguments>
+            <x:Arguments>https://example.com/</x:Arguments>
+        </system:Uri>
+    </BindableObject.BindingContext>
+</BindableObject>

--- a/Xamarin.Forms.Xaml.UnitTests/DuplicateXArgumentsElements.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DuplicateXArgumentsElements.xaml.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class DuplicateXArgumentsElements : BindableObject
+	{
+		public DuplicateXArgumentsElements(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public static class Tests
+		{
+			[TestCase(false)]
+			[TestCase(true)]
+			public static void ThrowXamlParseException(bool useCompiledXaml)
+			{
+				Assert.Throws<XamlParseException>(useCompiledXaml ?
+					(TestDelegate)(() => MockCompiler.Compile(typeof(DuplicateXArgumentsElements))) :
+					() => new DuplicateXArgumentsElements(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/MultipleDataTemplateChildElements.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/MultipleDataTemplateChildElements.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<BindableObject xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.MultipleDataTemplateChildElements">
+	<BindableObject.BindingContext>
+		<DataTemplate>
+			<Page />
+			<Page />
+		</DataTemplate>
+	</BindableObject.BindingContext>
+</BindableObject>

--- a/Xamarin.Forms.Xaml.UnitTests/MultipleDataTemplateChildElements.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MultipleDataTemplateChildElements.xaml.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class MultipleDataTemplateChildElements : BindableObject
+	{
+		public MultipleDataTemplateChildElements(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public static class Tests
+		{
+			[TestCase(false)]
+			[TestCase(true)]
+			public static void ThrowXamlParseException(bool useCompiledXaml)
+			{
+				Assert.Throws<XamlParseException>(useCompiledXaml ?
+					(TestDelegate)(() => MockCompiler.Compile(typeof(MultipleDataTemplateChildElements))) :
+					() => new MultipleDataTemplateChildElements(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -80,16 +80,23 @@ namespace Xamarin.Forms.Xaml
 							else //Attached BP
 								name = new XmlName(reader.NamespaceURI, reader.LocalName);
 
+							if (node.Properties.ContainsKey(name))
+								throw new XamlParseException($"'{reader.Name}' is a duplicate property name.", (IXmlLineInfo)reader);
+
 							INode prop = null;
 							if (reader.IsEmptyElement)
 								Debug.WriteLine($"Unexpected empty element '<{reader.Name} />'", (IXmlLineInfo)reader);
 							else
 								prop = ReadNode(reader);
+
 							if (prop != null)
 								node.Properties.Add(name, prop);
 						}
 						// 2. Xaml2009 primitives, x:Arguments, ...
 						else if (reader.NamespaceURI == X2009Uri && reader.LocalName == "Arguments") {
+							if (node.Properties.ContainsKey(XmlName.xArguments))
+								throw new XamlParseException($"'x:Arguments' is a duplicate directive name.", (IXmlLineInfo)reader);
+
 							var prop = ReadNode(reader);
 							if (prop != null)
 								node.Properties.Add(XmlName.xArguments, prop);
@@ -97,6 +104,9 @@ namespace Xamarin.Forms.Xaml
 						// 3. DataTemplate (should be handled by 4.)
 						else if (node.XmlType.NamespaceUri == XFUri &&
 								 (node.XmlType.Name == "DataTemplate" || node.XmlType.Name == "ControlTemplate")) {
+							if (node.Properties.ContainsKey(XmlName._CreateContent))
+								throw new XamlParseException($"Multiple child elements in {node.XmlType.Name}", (IXmlLineInfo)reader);
+
 							var prop = ReadNode(reader, true);
 							if (prop != null)
 								node.Properties.Add(XmlName._CreateContent, prop);


### PR DESCRIPTION
### Description of Change ###

Throw XamlParseException when a duplicate property is detected.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
