### PR TITLE
[Android] Fix issue when Message is null on Android API19

### DIFF
--- a/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
@@ -41,5 +41,13 @@ namespace Xamarin.Forms.Platform.Android
 
 			scrollView.ScrollBarsInitialized = true;
 		}
+
+		internal static bool HandleDrawException(this Java.Lang.NullPointerException npe)
+		{
+			if(Build.VERSION.SdkInt <= BuildVersionCodes.Kitkat)
+				return true;
+
+			return npe.Message?.Contains("ScrollBarDrawable.mutate()") == true;
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		internal static void HandleScrollBarVisibilityChange(this IScrollView scrollView)
 		{
+			if (Build.VERSION.SdkInt <= BuildVersionCodes.Kitkat)
+				return;
 
 			// According to the Android Documentation
 			// * <p>AwakenScrollBars method should be invoked every time a subclass directly updates
@@ -40,14 +42,6 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			scrollView.ScrollBarsInitialized = true;
-		}
-
-		internal static bool HandleDrawException(this Java.Lang.NullPointerException npe)
-		{
-			if(Build.VERSION.SdkInt <= BuildVersionCodes.Kitkat)
-				return true;
-
-			return npe.Message?.Contains("ScrollBarDrawable.mutate()") == true;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.Android
 				base.Draw(canvas);
 			}
 			catch (Java.Lang.NullPointerException npe)
-			when (npe.Message.Contains("ScrollBarDrawable.mutate()"))
+			when (npe.HandleDrawException())
 			{
 				// This will most likely never run since UpdateScrollBars is called 
 				// when the scrollbars visibilities are updated but I left it here

--- a/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AHorizontalScrollView.cs
@@ -76,8 +76,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				base.Draw(canvas);
 			}
-			catch (Java.Lang.NullPointerException npe)
-			when (npe.HandleDrawException())
+			catch (Java.Lang.NullPointerException)
 			{
 				// This will most likely never run since UpdateScrollBars is called 
 				// when the scrollbars visibilities are updated but I left it here

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Android.Animation;
 using Android.Content;
 using Android.Graphics;
+using Android.OS;
 using Android.Support.V4.Widget;
 using Android.Views;
 using Android.Widget;
@@ -144,7 +145,7 @@ namespace Xamarin.Forms.Platform.Android
 				base.Draw(canvas);
 			}
 			catch (Java.Lang.NullPointerException npe)
-			when(npe.Message == null || npe.Message.Contains("ScrollBarDrawable.mutate()"))
+			when(npe.HandleDrawException())
 			{
 				// This will most likely never run since UpdateScrollBars is called 
 				// when the scrollbars visibilities are updated but I left it here

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -144,8 +144,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				base.Draw(canvas);
 			}
-			catch (Java.Lang.NullPointerException npe)
-			when(npe.HandleDrawException())
+			catch (Java.Lang.NullPointerException)
 			{
 				// This will most likely never run since UpdateScrollBars is called 
 				// when the scrollbars visibilities are updated but I left it here

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -144,7 +144,7 @@ namespace Xamarin.Forms.Platform.Android
 				base.Draw(canvas);
 			}
 			catch (Java.Lang.NullPointerException npe)
-			when(npe.Message.Contains("ScrollBarDrawable.mutate()"))
+			when(npe.Message == null || npe.Message.Contains("ScrollBarDrawable.mutate()"))
 			{
 				// This will most likely never run since UpdateScrollBars is called 
 				// when the scrollbars visibilities are updated but I left it here

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Android.Animation;
 using Android.Content;
 using Android.Graphics;
-using Android.OS;
 using Android.Support.V4.Widget;
 using Android.Views;
 using Android.Widget;


### PR DESCRIPTION
### Description of Change ###

Fix issue when Message is null on Android API19 introduced on PR #5462 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->



### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run gallery and go to test #5461 or a test with a Scrollview on API19 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
