### PR TITLE
Ignore FindByName exception when running in previewer

### DIFF
--- a/Xamarin.Forms.Core/NameScopeExtensions.cs
+++ b/Xamarin.Forms.Core/NameScopeExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
@@ -5,7 +6,16 @@ namespace Xamarin.Forms
 	public static class NameScopeExtensions
 	{
 		public static T FindByName<T>(this Element element, string name)
-		=> (T)element.FindByName(name);
+		{
+			try {
+				return (T)element.FindByName(name);
+			}
+			catch (InvalidCastException) {
+				if (DesignMode.IsDesignModeEnabled)
+					return default(T);
+				throw;
+			}
+		}
 
 		internal static T FindByName<T>(this INameScope namescope, string name)
 			=> (T)namescope.FindByName(name);

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using Xamarin.Forms.Core.UnitTests;
 
@@ -645,6 +644,24 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
 			Assert.That(exceptions.Count, Is.GreaterThan(1));
+		}
+
+		[Test]
+		public void IgnoreFindByNameInvalidCastException()
+		{
+			// The previewer might replace MyButton with Replaced.MyButton, which could result in generated calls to
+			// FindByName() failing with an InvalidCastException. This tests that such a call doesn't fail when
+			// IsDesignModeEnabled is true.
+
+			var xaml = @"
+					<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
+						<Label x:Name=""MyName"" />
+					</ContentPage>";
+
+			DesignMode.IsDesignModeEnabled = true;
+			var content = (ContentPage)XamlLoader.Create(xaml, true);
+			Assert.DoesNotThrow(() => content.FindByName<Button>("MyName"));
 		}
 	}
 


### PR DESCRIPTION
### Description of Change ###

When running in the previewer, some types are replaced.

If a replaced type has an `x:Name` attribute, this will result in an `InvalidCastException` when `FindByName()` tries to cast it to the original type. So return `default(T)` in this scenario (this may just result in an exception later trying to use the result of this call, but it is at least less likely to be in the constructor).

### Issues Resolved ### 

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/821129

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Tested in previewer. Added unit test that covers the scenario.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
