### PR TITLE
Fix BindableLayout's incorrect layout.children.add -> use insert

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
@@ -49,10 +49,10 @@ namespace Xamarin.Forms.Core.UnitTests
 				IsPlatformEnabled = true,
 			};
 
-			var itemsSource = new ObservableCollection<int>();
+			var itemsSource = new ObservableCollection<int>() { 0, 1, 2, 3, 4 };
 			BindableLayout.SetItemsSource(layout, itemsSource);
 
-			itemsSource.Insert(0, 1);
+			itemsSource.Insert(2, 5);
 			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
 		}
 
@@ -413,8 +413,8 @@ namespace Xamarin.Forms.Core.UnitTests
 				OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
 				OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, changedItems, 0));
 			}
- 		}     
-      
+		}
+
 		class MyDataTemplateSelectorTest : DataTemplateSelector
 		{
 			readonly Func<object, BindableObject, DataTemplate> _func;


### PR DESCRIPTION
### Description of Change ###

In the BindableLayout, when bound to a collection that implements INotifyCollectionChanged,
item inserts are always handled as Add

There is an extension method in Xamarin.Forms.Internals.NotifyCollectionChangedEventArgsExtensions that handles all the events correctly when you pass the callbacks.
I changed BindableLayout.cs to use this extension method when the collection changes.

Also, I removed passing the index to CreateView, since createview doesn't do anything with that.
And, in the reset, I replaced layout.children.clear() with CreateChildren().
CreateChildren clears the layout.children and then checks if it needs to create new ones.
Some libraries (eg DynamicData/ReactiveUI) trigger the reset after a batch update of the collection. It can be disputed if this correct behaviour, but Xamarin's listviews on all platforms support this behavior also, so I thought it would be fair to have BindableLayout support it as well. (It's a real small extra check)

### Issues Resolved ### 

- fixes #5579

### API Changes ###
None

### Platforms Affected ### 
All

### Behavioral/Visual Changes ###
Items will appear on the correct place instead of always at the end of the list

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Modified BindableLayoutTests.TracksInsert to simulate this situation

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
