### PR TITLE
- Move renderer registration to Assembly Info

### DIFF
--- a/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
@@ -12,7 +12,6 @@ using AProgressBar = Android.Widget.ProgressBar;
 using AView = Android.Views.View;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(ActivityIndicator), typeof(MaterialActivityIndicatorRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
 namespace Xamarin.Forms.Material.Android
 {

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -18,7 +18,6 @@ using AView = Android.Views.View;
 using MButton = Android.Support.Design.Button.MaterialButton;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(Xamarin.Forms.Button), typeof(MaterialButtonRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
 namespace Xamarin.Forms.Material.Android
 {

--- a/Xamarin.Forms.Material.Android/MaterialDatePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialDatePickerRenderer.cs
@@ -6,7 +6,6 @@ using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(Xamarin.Forms.DatePicker), typeof(MaterialDatePickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
 namespace Xamarin.Forms.Material.Android
 {

--- a/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
@@ -7,7 +7,6 @@ using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(Xamarin.Forms.Editor), typeof(MaterialEditorRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 namespace Xamarin.Forms.Material.Android
 {
 	public class MaterialEditorRenderer : EditorRendererBase<MaterialFormsTextInputLayout>

--- a/Xamarin.Forms.Material.Android/MaterialEntryRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEntryRenderer.cs
@@ -7,7 +7,6 @@ using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(Xamarin.Forms.Entry), typeof(MaterialEntryRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 namespace Xamarin.Forms.Material.Android
 {
 	public sealed class MaterialEntryRenderer : EntryRendererBase<MaterialFormsTextInputLayout>

--- a/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
@@ -11,7 +11,6 @@ using AView = Android.Views.View;
 using MaterialCardView = Android.Support.Design.Card.MaterialCardView;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(Xamarin.Forms.Frame), typeof(MaterialFrameRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
 namespace Xamarin.Forms.Material.Android
 {

--- a/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
@@ -6,7 +6,6 @@ using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(Xamarin.Forms.Picker), typeof(MaterialPickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
 namespace Xamarin.Forms.Material.Android
 {

--- a/Xamarin.Forms.Material.Android/MaterialProgressBarRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialProgressBarRenderer.cs
@@ -11,7 +11,6 @@ using AProgressBar = Android.Widget.ProgressBar;
 using AView = Android.Views.View;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(ProgressBar), typeof(MaterialProgressBarRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
 namespace Xamarin.Forms.Material.Android
 {

--- a/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
@@ -11,7 +11,6 @@ using Xamarin.Forms.Material.Android;
 using AView = Android.Views.View;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(Xamarin.Forms.Slider), typeof(MaterialSliderRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
 namespace Xamarin.Forms.Material.Android
 {

--- a/Xamarin.Forms.Material.Android/MaterialStepperRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialStepperRenderer.cs
@@ -9,7 +9,6 @@ using Xamarin.Forms.Platform.Android;
 using AButton = Android.Widget.Button;
 using MButton = Android.Support.Design.Button.MaterialButton;
 
-[assembly: ExportRenderer(typeof(Xamarin.Forms.Stepper), typeof(MaterialStepperRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
 namespace Xamarin.Forms.Material.Android
 {

--- a/Xamarin.Forms.Material.Android/MaterialTimePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialTimePickerRenderer.cs
@@ -6,7 +6,6 @@ using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(Xamarin.Forms.TimePicker), typeof(MaterialTimePickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
 namespace Xamarin.Forms.Material.Android
 {

--- a/Xamarin.Forms.Material.Android/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Material.Android/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using Xamarin.Forms;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.Material.Android;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -16,3 +18,15 @@ using Xamarin.Forms.Internals;
 [assembly: Preserve]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
+
+[assembly: ExportRenderer(typeof(ActivityIndicator), typeof(MaterialActivityIndicatorRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(Button), typeof(MaterialButtonRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(DatePicker), typeof(MaterialDatePickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(Editor), typeof(MaterialEditorRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(Entry), typeof(MaterialEntryRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(Frame), typeof(MaterialFrameRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(Picker), typeof(MaterialPickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(ProgressBar), typeof(MaterialProgressBarRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(Slider), typeof(MaterialSliderRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(Stepper), typeof(MaterialStepperRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(TimePicker), typeof(MaterialTimePickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]


### PR DESCRIPTION
### Description of Change ###
Move all default material renderer registration to AssemblyInfo in order to stay consistent
