### PR TITLE
[Android] fall back to using native get identifier if reflection fails to retrieve drawable

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -63,9 +63,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal Platform(Context context, bool embedded)
 		{
-			PackageName = context.PackageName;
 			_embedded = embedded;
 			_context = context ?? throw new ArgumentNullException(nameof(context), "Somehow we're getting a null context passed in");
+			PackageName = context.PackageName;
 			_activity = context as Activity;
 
 			if (!embedded)

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Forms.Platform.Android
 		, IPlatform
 #pragma warning restore
 	{
+
+		internal static string PackageName { get; private set; }
 		internal const string CloseContextActionsSignalName = "Xamarin.CloseContextActions";
 
 		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer", typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),
@@ -61,6 +63,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal Platform(Context context, bool embedded)
 		{
+			PackageName = context.PackageName;
 			_embedded = embedded;
 			_context = context ?? throw new ArgumentNullException(nameof(context), "Somehow we're getting a null context passed in");
 			_activity = context as Activity;

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -10,8 +10,6 @@ using Path = System.IO.Path;
 using Xamarin.Forms.Internals;
 using AndroidAppCompat = Android.Support.V7.Content.Res.AppCompatResources;
 using System.ComponentModel;
-using System.Collections.Generic;
-using System.IO;
 
 namespace Xamarin.Forms.Platform.Android
 {

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -152,42 +152,34 @@ namespace Xamarin.Forms.Platform.Android
 
 		static int IdFromTitle(string title, Type type, Resources resource)
 		{
-			int id = 0;
-
-			if (title == null)
-				return id;
-
-			string name = Path.GetFileNameWithoutExtension(title);
-
-			if (id == 0)
-				id = GetId(type, name);
-
-			if (_resourceTypeNames.TryGetValue(type, out string value))
-				id = resource.GetIdentifier(name, value, Platform.PackageName);
-
-			if (id == 0)
-				id = resource.GetIdentifier(name, value, null);
-
-			return id;
-
+			return IdFromTitle(title, type, resource, Platform.PackageName);
 		}
 
 		static int IdFromTitle(string title, Type type, Context context)
+		{
+			return IdFromTitle(title, type, context.Resources, context.PackageName);
+		}
+
+		static int IdFromTitle(string title, Type type, Resources resource, string packageName)
 		{
 			int id = 0;
 			if (title == null)
 				return id;
 
 			string name = Path.GetFileNameWithoutExtension(title);
-			
-			if (id == 0)
-				id = GetId(type, name);
+
+			id = GetId(type, name);
+
+			if (id > 0)
+				return id;
 
 			if (_resourceTypeNames.TryGetValue(type, out string value))
-				id = context.Resources.GetIdentifier(name, value, context.PackageName);
+				id = resource.GetIdentifier(name, value, packageName);
 
-			if (id == 0)
-				id = context.Resources.GetIdentifier(name, value, null);
+			if (id > 0)
+				return id;
+
+			id = resource.GetIdentifier(name, value, null);
 
 			return id;
 		}

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -134,7 +134,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static void Init(Assembly masterAssembly)
 		{
-			DrawableClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == _drawableDefType || x.Name == "Resource_Drawable");
+			DrawableClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == "Drawable" || x.Name == "Resource_Drawable");
 			ResourceClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == "Id" || x.Name == "Resource_Id");
 			StyleClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == "Style" || x.Name == "Resource_Style");
 			LayoutClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == "Layout" || x.Name == "Resource_Layout");

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -90,7 +90,7 @@ namespace Xamarin.Forms.Platform.Android
 			return AndroidAppCompat.GetDrawable(Forms.Context, id);
 		}
 
-		public static void LogInfo(string message)
+		static void LogInfoToPreviewer(string message)
 		{
 			Java.Lang.Class designerHost = Java.Lang.Class.FromType(typeof(ImageRenderer)).ClassLoader.LoadClass("mono.android.HostProcessConnection");
 			Java.Lang.Reflect.Method reportMethod = designerHost.GetMethod("logInfo", Java.Lang.Class.FromType(typeof(Java.Lang.String)));

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -170,10 +170,13 @@ namespace Xamarin.Forms.Platform.Android
 
 			id = GetId(resourceType, name);
 
-			if (id > 0)
-				return id;
+			if (packageName != null)
+			{
+				if (id > 0)
+					return id;
 
-			id = resource.GetIdentifier(name, defType, packageName);
+				id = resource.GetIdentifier(name, defType, packageName);
+			}
 
 			if (id > 0)
 				return id;

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -142,6 +142,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		static int IdFromTitle(string title, Type type)
 		{
+			if (title == null)
+				return 0;
+
 			string name = Path.GetFileNameWithoutExtension(title);
 			int id = GetId(type, name);
 			return id;
@@ -150,6 +153,10 @@ namespace Xamarin.Forms.Platform.Android
 		static int IdFromTitle(string title, Type type, Resources resource)
 		{
 			int id = 0;
+
+			if (title == null)
+				return id;
+
 			string name = Path.GetFileNameWithoutExtension(title);
 
 			if (id == 0)
@@ -168,6 +175,9 @@ namespace Xamarin.Forms.Platform.Android
 		static int IdFromTitle(string title, Type type, Context context)
 		{
 			int id = 0;
+			if (title == null)
+				return id;
+
 			string name = Path.GetFileNameWithoutExtension(title);
 			
 			if (id == 0)

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Forms.Platform.Android
 			+ "Please use GetDrawable(this Context, string) instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static Drawable GetDrawable(this Resources resource, string name)
-		{			
+		{
 			int id = IdFromTitle(name, DrawableClass, resource);
 			if (id == 0)
 			{

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -90,6 +90,7 @@ namespace Xamarin.Forms.Platform.Android
 			return AndroidAppCompat.GetDrawable(Forms.Context, id);
 		}
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		static void LogInfoToPreviewer(string message)
 		{
 			Java.Lang.Class designerHost = Java.Lang.Class.FromType(typeof(ImageRenderer)).ClassLoader.LoadClass("mono.android.HostProcessConnection");

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -168,16 +168,16 @@ namespace Xamarin.Forms.Platform.Android
 
 			id = GetId(resourceType, name);
 
-			if (packageName != null)
-			{
-				if (id > 0)
-					return id;
-
-				id = resource.GetIdentifier(name, defType, packageName);
-			}
-
 			if (id > 0)
 				return id;
+
+			if (packageName != null)
+			{
+				id = resource.GetIdentifier(name, defType, packageName);
+
+				if (id > 0)
+					return id;
+			}
 
 			id = resource.GetIdentifier(name, defType, null);
 

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -11,6 +11,7 @@ using Xamarin.Forms.Internals;
 using AndroidAppCompat = Android.Support.V7.Content.Res.AppCompatResources;
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -150,26 +151,35 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			int id = 0;
 			string name = Path.GetFileNameWithoutExtension(title);
-			if(_resourceTypeNames.TryGetValue(type, out string value))
+
+			if (id == 0)
+				id = GetId(type, name);
+
+			if (_resourceTypeNames.TryGetValue(type, out string value))
 				id = resource.GetIdentifier(name, value, Platform.PackageName);
 
-			if (id > 0)
-				return id;
+			if (id == 0)
+				id = resource.GetIdentifier(name, value, null);
 
-			return GetId(type, name);
+			return id;
+
 		}
 
 		static int IdFromTitle(string title, Type type, Context context)
 		{
 			int id = 0;
 			string name = Path.GetFileNameWithoutExtension(title);
+			
+			if (id == 0)
+				id = GetId(type, name);
+
 			if (_resourceTypeNames.TryGetValue(type, out string value))
 				id = context.Resources.GetIdentifier(name, value, context.PackageName);
 
-			if (id > 0)
-				return id;
+			if (id == 0)
+				id = context.Resources.GetIdentifier(name, value, null);
 
-			return GetId(type, name);
+			return id;
 		}
 
 		static int GetId(Type type, string memberName)

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public static class ResourceManager
 	{
-		static Dictionary<Type, string> _resourceTypeNames = new Dictionary<Type, string>();
+		static Dictionary<object, string> _resourceTypeNames = new Dictionary<object, string>();
 
 		public static Type DrawableClass { get; set; }
 
@@ -131,10 +131,12 @@ namespace Xamarin.Forms.Platform.Android
 			StyleClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == "Style" || x.Name == "Resource_Style");
 			LayoutClass = masterAssembly.GetTypes().FirstOrDefault(x => x.Name == "Layout" || x.Name == "Resource_Layout");
 
-			_resourceTypeNames.Add(DrawableClass, "drawable");
-			_resourceTypeNames.Add(ResourceClass, "id");
-			_resourceTypeNames.Add(StyleClass, "style");
-			_resourceTypeNames.Add(LayoutClass, "layout");
+			// If the above are null then these are just used for mapping types to names
+			// This mainly applies for the case of the designer
+			_resourceTypeNames.Add(DrawableClass ?? new object(), "drawable");
+			_resourceTypeNames.Add(ResourceClass ?? new object(), "id");
+			_resourceTypeNames.Add(StyleClass ?? new object(), "style");
+			_resourceTypeNames.Add(LayoutClass ?? new object(), "layout");
 		}
 
 		static int IdFromTitle(string title, Type type)


### PR DESCRIPTION
### Description of Change ###

This will try to retrieve a resource id by using the native GetIdentifier instead of reflection

### Platforms Affected ### 
- Android

### Testing Procedure ###
- Test any image code to make sure there are no breaking changes
- Install nuget into android project that references an image that's part of the Android project and test that it loads inside the previewer without a build

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
