### PR TITLE
remove left over sealed on Material Entry Renderer

### DIFF
--- a/Xamarin.Forms.Material.Android/MaterialEntryRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEntryRenderer.cs
@@ -10,7 +10,7 @@ using Xamarin.Forms.Platform.Android;
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Entry), typeof(MaterialEntryRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 namespace Xamarin.Forms.Material.Android
 {
-	public sealed class MaterialEntryRenderer : EntryRendererBase<MaterialFormsTextInputLayout>
+	public class MaterialEntryRenderer : EntryRendererBase<MaterialFormsTextInputLayout>
 	{
 		MaterialFormsEditText _textInputEditText;
 		MaterialFormsTextInputLayout _textInputLayout;


### PR DESCRIPTION
### Description of Change ###
Left over sealed on Material Entry Renderer

### API Changes ###
- MaterialEntryRenderer is no longer sealed on android

### Platforms Affected ### 
- Android
