### PR TITLE
[MacOS] Move ImageRenderer to use NSImageView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5204.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5204.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5204, "[MacOS] Image size issue (not rendered if skip setting WidthRequest and HeightRequest", PlatformAffected.macOS)]
+	public class Issue5204 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "You should see image";
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				Children = {
+					new Image
+					{
+						BackgroundColor = Color.Black,
+						Source = "https://user-images.githubusercontent.com/10124814/53306353-27302b80-389d-11e9-98ce-690db32f1ee3.jpg"
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -894,6 +894,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3318.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4493.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5172.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5204.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.MacOS/Controls/FormsImageView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Controls/FormsImageView.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AppKit;
 using CoreAnimation;
+using CoreGraphics;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
@@ -20,5 +21,21 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 		public override bool IsOpaque => _isOpaque;
+
+		public override CGSize FittingSize
+		{
+			get
+			{
+				var contents = Layer?.Contents;
+				if(contents == null)
+				{
+					return base.FittingSize;
+				}
+				var scale = (float)NSScreen.MainScreen.BackingScaleFactor;
+				var width = contents.Width / scale;
+				var height = contents.Height / scale;
+				return new CGSize(width, height);
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Controls/FormsImageView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Controls/FormsImageView.cs
@@ -5,15 +5,9 @@ using CoreGraphics;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
-	internal class FormsNSImageView : NSView
+	internal class FormsNSImageView : NSImageView
 	{
 		bool _isOpaque;
-
-		public FormsNSImageView()
-		{
-			Layer = new CALayer();
-			WantsLayer = true;
-		}
 
 		public void SetIsOpaque(bool isOpaque)
 		{
@@ -21,21 +15,5 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 		public override bool IsOpaque => _isOpaque;
-
-		public override CGSize FittingSize
-		{
-			get
-			{
-				var contents = Layer?.Contents;
-				if(contents == null)
-				{
-					return base.FittingSize;
-				}
-				var scale = (float)NSScreen.MainScreen.BackingScaleFactor;
-				var width = contents.Width / scale;
-				var height = contents.Height / scale;
-				return new CGSize(width, height);
-			}
-		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Extensions/ImageExtensions.cs
+++ b/Xamarin.Forms.Platform.MacOS/Extensions/ImageExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using CoreAnimation;
+using Foundation;
+
+namespace Xamarin.Forms.Platform.MacOS
+{
+	public static class ImageExtensions
+	{
+		public static NSString ToNSViewContentMode(this Aspect aspect)
+		{
+			switch (aspect)
+			{
+				case Aspect.AspectFill:
+					return CALayer.GravityResizeAspectFill;
+				case Aspect.Fill:
+					return CALayer.GravityResize;
+				case Aspect.AspectFit:
+				default:
+					return CALayer.GravityResizeAspect;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -241,6 +241,13 @@
     <Compile Include="..\Xamarin.Forms.Platform.iOS\DisposeHelpers.cs">
       <Link>DisposeHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\Xamarin.Forms.Platform.iOS\Renderers\ImageElementManager.cs">
+      <Link>Renderers\ImageElementManager.cs</Link>
+    </Compile>
+    <Compile Include="..\Xamarin.Forms.Platform.iOS\Renderers\IImageVisualElementRenderer.cs">
+      <Link>Renderers\IImageVisualElementRenderer.cs</Link>
+    </Compile>
+    <Compile Include="Extensions\ImageExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj">

--- a/Xamarin.Forms.Platform.iOS/Renderers/IImageVisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IImageVisualElementRenderer.cs
@@ -1,9 +1,9 @@
 ﻿#if __MOBILE__
-using ImageNativeView = UIKit.UIImageView;
-sing NativeImage = UIKit.UIImage;
+using NativeImageView = UIKit.UIImageView;
+using NativeImage = UIKit.UIImage;
 namespace Xamarin.Forms.Platform.iOS
 #else
-using ImageNativeView = AppKit.NSImageView;
+using NativeImageView = AppKit.NSImageView;
 using NativeImage = AppKit.NSImage;
 namespace Xamarin.Forms.Platform.MacOS
 #endif
@@ -12,6 +12,6 @@ namespace Xamarin.Forms.Platform.MacOS
 	{
 		void SetImage(NativeImage image);
 		bool IsDisposed { get; }
-		ImageNativeView GetImage();
+		NativeImageView GetImage();
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/IImageVisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IImageVisualElementRenderer.cs
@@ -1,11 +1,17 @@
-﻿using UIKit;
-
+﻿#if __MOBILE__
+using ImageNativeView = UIKit.UIImageView;
+sing NativeImage = UIKit.UIImage;
 namespace Xamarin.Forms.Platform.iOS
+#else
+using ImageNativeView = AppKit.NSImageView;
+using NativeImage = AppKit.NSImage;
+namespace Xamarin.Forms.Platform.MacOS
+#endif
 {
 	public interface IImageVisualElementRenderer : IVisualNativeElementRenderer
 	{
-		void SetImage(UIImage image);
+		void SetImage(NativeImage image);
 		bool IsDisposed { get; }
-		UIImageView GetImage();
+		ImageNativeView GetImage();
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
@@ -1,14 +1,18 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Foundation;
-using UIKit;
 
+#if __MOBILE__
+using UIKit;
+using NativeImage = UIKit.UIImage;
 namespace Xamarin.Forms.Platform.iOS
+#else
+using AppKit;
+using CoreAnimation;
+using NativeImage = AppKit.NSImage;
+namespace Xamarin.Forms.Platform.MacOS
+#endif
 {
 	public static class ImageElementManager
 	{
@@ -70,8 +74,11 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				return;
 			}
-
+#if __MOBILE__
 			Control.ContentMode = imageElement.Aspect.ToUIViewContentMode();
+#else
+			Control.Layer.ContentsGravity = imageElement.Aspect.ToNSViewContentMode();
+#endif
 		}
 
 		public static void SetOpacity(IImageVisualElementRenderer renderer, IImageElement imageElement)
@@ -83,8 +90,11 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				return;
 			}
-
+#if __MOBILE__
 			Control.Opaque = imageElement.IsOpaque;
+#else
+			(Control as FormsNSImageView)?.SetIsOpaque(imageElement.IsOpaque);
+#endif
 		}
 
 		public static async Task SetImage(IImageVisualElementRenderer renderer, IImageElement imageElement, Image oldElement = null)
@@ -133,14 +143,19 @@ namespace Xamarin.Forms.Platform.iOS
 			(imageElement as IViewController)?.NativeSizeChanged();
 		}
 
-		internal static async Task<UIImage> GetNativeImageAsync(this ImageSource source, CancellationToken cancellationToken = default(CancellationToken))
+		internal static async Task<NSImage> GetNativeImageAsync(this ImageSource source, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			IImageSourceHandler handler;
 			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				try
 				{
-					return await handler.LoadImageAsync(source, scale: (float)UIScreen.MainScreen.Scale, cancelationToken: cancellationToken);
+#if __MOBILE__
+					float scale = (float)UIScreen.MainScreen.Scale;
+#else
+					float scale = (float)NSScreen.MainScreen.BackingScaleFactor;
+#endif
+					return await handler.LoadImageAsync(source, scale: scale, cancelationToken: cancellationToken);
 				}
 				catch (OperationCanceledException ex)
 				{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
@@ -143,7 +143,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			(imageElement as IViewController)?.NativeSizeChanged();
 		}
 
-		internal static async Task<NSImage> GetNativeImageAsync(this ImageSource source, CancellationToken cancellationToken = default(CancellationToken))
+		internal static async Task<NativeImage> GetNativeImageAsync(this ImageSource source, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			IImageSourceHandler handler;
 			if (source != null && (handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -8,7 +8,6 @@ using Foundation;
 using UIKit;
 using Xamarin.Forms.Internals;
 using RectangleF = CoreGraphics.CGRect;
-using System.Linq;
 
 namespace Xamarin.Forms.Platform.iOS
 {


### PR DESCRIPTION
### Description of Change ###

Refactor the ImageRenderer to use a NSImageView and use the iOS load image helpers

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5204 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- macOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Can test issue 5204 and existing ImageGallery 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
