### PR TITLE
Re-enable "Treat warnings as errors"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
     <__XFBuildTasksLocation>$(_XFBuildTasksLocation)</__XFBuildTasksLocation>
     <__XFBuildTasksLocation Condition="'$(__XFBuildTasksLocation)' == '' AND '$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory).nuspec\netstandard2.0\</__XFBuildTasksLocation>
     <__XFBuildTasksLocation Condition="'$(__XFBuildTasksLocation)' == ''">$(MSBuildThisFileDirectory).nuspec\net46\</__XFBuildTasksLocation>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
  </Project> 

--- a/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
+++ b/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
@@ -32,7 +32,6 @@
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>

--- a/EmbeddingTestBeds/Embedding.UWP/Embedding.UWP.csproj
+++ b/EmbeddingTestBeds/Embedding.UWP/Embedding.UWP.csproj
@@ -30,7 +30,6 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>

--- a/EmbeddingTestBeds/Embedding.iOS/Embedding.iOS.csproj
+++ b/EmbeddingTestBeds/Embedding.iOS/Embedding.iOS.csproj
@@ -46,7 +46,6 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -32,7 +32,6 @@
     <DefineConstants>TRACE;DEBUG;__ANDROID__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -42,7 +41,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
@@ -24,7 +24,6 @@
     <ConsolePause>false</ConsolePause>
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -34,7 +33,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Platform.cs">

--- a/XFCorePostProcessor.Tasks/XFCorePostProcessor.Tasks.csproj
+++ b/XFCorePostProcessor.Tasks/XFCorePostProcessor.Tasks.csproj
@@ -6,11 +6,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>

--- a/XFCorePostProcessor.Tasks/XFCorePostProcessor.Tasks.csproj
+++ b/XFCorePostProcessor.Tasks/XFCorePostProcessor.Tasks.csproj
@@ -5,6 +5,11 @@
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="15.8.166" />
     <PackageReference Include="Microsoft.Build.Framework" Version="15.8.166" />

--- a/XFCorePostProcessor.Tasks/XFCorePostProcessor.Tasks.csproj
+++ b/XFCorePostProcessor.Tasks/XFCorePostProcessor.Tasks.csproj
@@ -6,7 +6,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -45,10 +45,6 @@
 		<SnExe>sn</SnExe>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
-	  <WarningsAsErrors />
-	</PropertyGroup>
-
 	<Target Name="_SetSnExe" Condition="'$(SnExe)' == '' And '$(OS)' == 'Windows_NT'">
 		<GetFrameworkSdkPath>
 			<Output TaskParameter="Path" PropertyName="WindowsSdkPath" />
@@ -62,7 +58,7 @@
 	</Target>
 
   <Target Name="_StrongName" AfterTargets="Build" DependsOnTargets="_SetSnExe" Condition="'$(TargetPath)' != ''" Inputs="$(TargetPath)" Outputs="$(IntermediateOutputPath)Sn.stamp">
-  	<Exec Command="&quot;$(SnExe)&quot; -R $(TargetPath) ..\xamarin.forms.snk" Condition=" '$(SignAssembly)' == 'true' " />
+  	<Exec Command='"$(SnExe)" -R $(TargetPath) ..\xamarin.forms.snk' Condition=" '$(SignAssembly)' == 'true' " />
   </Target>
 
   <Target Name="_CopyToNuspecDir" AfterTargets="_StrongName;Build">

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -46,7 +46,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
-	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	  <WarningsAsErrors />
 	</PropertyGroup>
 

--- a/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+++ b/Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
@@ -45,6 +45,11 @@
 		<SnExe>sn</SnExe>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
+	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	  <WarningsAsErrors />
+	</PropertyGroup>
+
 	<Target Name="_SetSnExe" Condition="'$(SnExe)' == '' And '$(OS)' == 'Windows_NT'">
 		<GetFrameworkSdkPath>
 			<Output TaskParameter="Path" PropertyName="WindowsSdkPath" />
@@ -58,7 +63,7 @@
 	</Target>
 
   <Target Name="_StrongName" AfterTargets="Build" DependsOnTargets="_SetSnExe" Condition="'$(TargetPath)' != ''" Inputs="$(TargetPath)" Outputs="$(IntermediateOutputPath)Sn.stamp">
-  	<Exec Command='"$(SnExe)" -R $(TargetPath) ..\xamarin.forms.snk' Condition=" '$(SignAssembly)' == 'true' " />
+  	<Exec Command="&quot;$(SnExe)&quot; -R $(TargetPath) ..\xamarin.forms.snk" Condition=" '$(SignAssembly)' == 'true' " />
   </Target>
 
   <Target Name="_CopyToNuspecDir" AfterTargets="_StrongName;Build">

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -54,7 +54,6 @@
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -72,7 +71,6 @@
     <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
     <MandroidI18n />
     <MonoDroidExtraArgs />
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Xamarin.Forms.ControlGallery.MacOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.MacOS/AppDelegate.cs
@@ -197,7 +197,7 @@ namespace Xamarin.Forms.ControlGallery.MacOS
 				StartPressed40911();
 			};
 
-			page.Layout.Children.Add(button);
+			page._40911Layout.Children.Add(button);
 		}
 
 		public void StartPressed40911()

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -35,7 +35,6 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
     <OutputPath>bin\ARM\Release\</OutputPath>
@@ -48,7 +47,6 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -60,7 +58,6 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -73,7 +70,6 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -85,7 +81,6 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -98,7 +93,6 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -351,7 +351,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				StartPressed40911();
 			};
 
-			page.Layout.Children.Add(button);
+			page._40911Layout.Children.Add(button);
 		}
 
 		public void StartPressed40911()

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -30,7 +30,6 @@
     <MtouchUseLlvm>False</MtouchUseLlvm>
     <MtouchUseThumb>False</MtouchUseThumb>
     <MtouchOptimizePNGs>False</MtouchOptimizePNGs>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <MtouchEnableBitcode>False</MtouchEnableBitcode>
     <OptimizePNGs>True</OptimizePNGs>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
@@ -50,7 +49,6 @@
     <MtouchLink>None</MtouchLink>
     <MtouchArch>i386, x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
@@ -82,7 +80,6 @@
     <CodesignProvision>Automatic</CodesignProvision>
     <CodesignResourceRules />
     <CodesignExtraArgs />
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -97,7 +94,6 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26501.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26501.cs
@@ -132,8 +132,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		ListView _familyListView;
 
-		List<FamilyViewModel> _itemSource;
-
 		void UpdateData ()
 		{
 			Device.BeginInvokeOnMainThread (() => _familyListView.ItemsSource = _demoDataSource);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28498.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla28498.cs
@@ -77,9 +77,11 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[TearDown]
-		public void TearDown()
+		public override void TearDown()
 		{
 			RunningApp.SetOrientationPortrait ();
+
+			base.TearDown();
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
@@ -113,9 +113,11 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[TearDown]
-		public void TearDown() 
+		public override void TearDown() 
 		{
 			RunningApp.SetOrientationPortrait ();
+
+			base.TearDown();
 		}
 
 		void Back()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31114.cs
@@ -377,7 +377,7 @@ namespace Xamarin.Forms.Controls.Issues
 						}
 					}
 				}
-				catch (Exception ex)
+				catch 
 				{
 				}
 			}
@@ -396,7 +396,7 @@ namespace Xamarin.Forms.Controls.Issues
 							RefreshFromQuickComplete(this, new ListItemEventArgs(item));
 					}
 				}
-				catch (Exception ex)
+				catch
 				{
 
 				}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31602.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31602.cs
@@ -131,9 +131,11 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[TearDown]
-		public void TearDown() 
+		public override void TearDown() 
 		{
 			RunningApp.SetOrientationPortrait ();
+
+			base.TearDown();
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32148.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32148.cs
@@ -31,7 +31,10 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			Title = "Contacts";
 			Content = CreateContent();
+
+#pragma warning disable 4014
 			LoadContactsAsync();
+#pragma warning restore 4014
 		}
 
 		Layout CreateContent()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32871.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32871.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 	public class Bugzilla32871 : TestContentPage
 	{
 
-		public static class Id
+		public static class Ids
 		{
 			public const string ValueEntry = nameof(ValueEntry);
 			public const string ValueLabel = nameof(ValueLabel);
@@ -56,23 +56,23 @@ namespace Xamarin.Forms.Controls.Issues
 			var stack = new StackLayout();
 
 			// text to be coerced
-			var entryValue = new Entry() { AutomationId = Id.ValueEntry };
+			var entryValue = new Entry() { AutomationId = Ids.ValueEntry };
 			stack.Children.Add(entryValue);
 
 			// feedback of the value coerced from text
-			s_labelValue = new Label() { Text = "value: [none]", AutomationId = Id.ValueLabel };
+			s_labelValue = new Label() { Text = "value: [none]", AutomationId = Ids.ValueLabel };
 			stack.Children.Add(s_labelValue);
 
 			// the type being coerced from text
-			var entryType = new Entry() { AutomationId = Id.TypeEntry };
+			var entryType = new Entry() { AutomationId = Ids.TypeEntry };
 			stack.Children.Add(entryType);
 
 			// feedback of the type being coerced from text
-			var labelType = new Label() { Text = "type: [none]", AutomationId = Id.TypeLabel };
+			var labelType = new Label() { Text = "type: [none]", AutomationId = Ids.TypeLabel };
 			stack.Children.Add(labelType);
 
 			// create view model of the type being coerced; clear text
-			var bindButton = new Button() { Text = "Bind", AutomationId = Id.BindButton };
+			var bindButton = new Button() { Text = "Bind", AutomationId = Ids.BindButton };
 			stack.Children.Add(bindButton);
 			bindButton.Clicked += (o, e) =>
 			{
@@ -99,7 +99,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue32871Test()
 		{
-			RunningApp.WaitForElement(q => q.Marked(Id.BindButton));
+			RunningApp.WaitForElement(q => q.Marked(Ids.BindButton));
 
 			var types = new Type[] {
 				typeof(double),
@@ -143,9 +143,9 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 		public void Theory(Type type, string[] values)
 		{
-			RunningApp.ClearText(Id.TypeEntry);
-			RunningApp.EnterText(Id.TypeEntry, type.FullName);
-			RunningApp.Tap(Id.BindButton);
+			RunningApp.ClearText(Ids.TypeEntry);
+			RunningApp.EnterText(Ids.TypeEntry, type.FullName);
+			RunningApp.Tap(Ids.BindButton);
 			RunningApp.WaitForElement(q => q.Marked($"type: {type.FullName}"));
 
 			foreach (var value in values)
@@ -157,14 +157,14 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Console.WriteLine($"TEST CASE: type={type.FullName}, value={value}");
 
-			RunningApp.ClearText(Id.ValueEntry);
+			RunningApp.ClearText(Ids.ValueEntry);
 
 			var input = string.Empty;
 			var output = string.Empty;
 			foreach (var c in value)
 			{
 				input += c;
-				RunningApp.EnterText(Id.ValueEntry, $"{c}");
+				RunningApp.EnterText(Ids.ValueEntry, $"{c}");
 
 				if (TryParse(type, input, ref output))
 					input = output;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
@@ -77,9 +77,11 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[TearDown]
-		public void TearDown() 
+		public override void TearDown() 
 		{
 			RunningApp.SetOrientationPortrait ();
+
+			base.TearDown();
 		}
 		#endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35132.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35132.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			PushAsync(new RootPage());
+			PushAsync(new _35132RootPage());
 		}
 
 		[Preserve(AllMembers = true)]
@@ -51,9 +51,9 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Preserve(AllMembers = true)]
-		public class RootPage : ContentPage
+		public class _35132RootPage : ContentPage
 		{
-			public RootPage()
+			public _35132RootPage()
 			{
 				var button = new Button { Text = "Open" };
 				button.Clicked += Button_Clicked;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35472.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35472.cs
@@ -63,8 +63,10 @@ namespace Xamarin.Forms.Controls.Issues
 
 			scrollToButton.Clicked += async (sender, args) => {
 				try {
-					// Deliberately not awaited so we can simulate a user navigating back
+#pragma warning disable 4014
+					// Deliberately not awaited so we can simulate a user navigating back before the scroll is finished
 					scrollView.ScrollToAsync (0, 1500, true);
+#pragma warning restore 4014
 					await Navigation.PopAsync ();
 					successLabel.IsVisible = true;
 				} catch (Exception ex) {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38658.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38658.cs
@@ -71,9 +71,11 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[TearDown]
-		public void TearDown() 
+		public override void TearDown() 
 		{
 			RunningApp.SetOrientationPortrait ();
+
+			base.TearDown();
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39963.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla39963.cs
@@ -27,10 +27,12 @@ namespace Xamarin.Forms.Controls.Issues
 						<p>This only happens when a local image is loaded.</p>
 						</body></html>";
 
+#pragma warning disable 0219
 			var workingHtml = @"<html><body>
 						<p></p>
 						<p>Without local image, everything works fine.</p>
 						</body></html>";
+#pragma warning restore 0219
 
 			WebView webView = new WebView {
 				Source = new HtmlWebViewSource() {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40911.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla40911.cs
@@ -11,17 +11,17 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue (IssueTracker.Bugzilla, 40911, "NRE with Facebook Login", PlatformAffected.iOS)]
 	public class Bugzilla40911 : TestContentPage 
 	{
-		public StackLayout Layout { get; private set; }
+		public StackLayout _40911Layout { get; private set; }
 
 		public const string ReadyToSetUp40911Test = "ReadyToSetUp40911Test";
 
 		protected override void Init ()
 		{
-			Layout = new StackLayout();
+			_40911Layout = new StackLayout();
 
-			Layout.Children.Add(new Label{Text = "This is an iOS-specific issue. If you're on another platform, you can ignore this." });
+			_40911Layout.Children.Add(new Label{Text = "This is an iOS-specific issue. If you're on another platform, you can ignore this." });
 
-			Content = Layout;
+			Content = _40911Layout;
 
 			MessagingCenter.Send(this, ReadyToSetUp40911Test);
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41415.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 	public class Bugzilla41415 : TestContentPage
 	{
 		const string ButtonText = "Click Me";
-		float _x, _y;
+		float _x;
 		bool _didXChange, _didYChange;
 
 		protected override void Init()
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Controls.Issues
 				_didXChange = false;
 				_didYChange = false;
 
-				await scrollView.ScrollToAsync(_x + 100, _y + 100, true);
+				await scrollView.ScrollToAsync(_x + 100, 100, true);
 				_x = 100;
 			};
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42620.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42620.cs
@@ -193,7 +193,7 @@ namespace Xamarin.Forms.Controls.Issues
 			rhs = temp;
 		}
 
-		public static class Id
+		public static class Ids
 		{
 			public const string AddRow = "R";
 			public const string AddColumn = "C";
@@ -224,7 +224,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.EnterText("batch", string.Join("", _buttons));
 			RunningApp.DismissKeyboard();
-			RunningApp.Tap(Id.Batch);
+			RunningApp.Tap(Ids.Batch);
 
 			foreach (var result in _result)
 				RunningApp.WaitForElement(q => q.Marked($"{result}"));
@@ -233,7 +233,7 @@ namespace Xamarin.Forms.Controls.Issues
 			_result.Clear();
 		}
 
-		public void AddHoizontal()
+		public void AddHorizontal()
 		{
 			// new block gets new id
 			var id = _id++;
@@ -253,9 +253,10 @@ namespace Xamarin.Forms.Controls.Issues
 			var column = _totalWidth - 1;
 			var width = 1;
 
-			Tap(Id.AddHorizontal);
+			Tap(Ids.AddHorizontal);
 			WaitForElement($"{id}: {column}x{row} {width}x{height}");
 		}
+
 		public void AddVertical()
 		{
 			// new block gets new id
@@ -276,21 +277,24 @@ namespace Xamarin.Forms.Controls.Issues
 			var row = _totalHeight - 1;
 			var height = 1;
 
-			Tap(Id.AddVertical);
+			Tap(Ids.AddVertical);
 			WaitForElement($"{id}: {column}x{row} {width}x{height}");
 		}
+
 		public void AddRowDef()
 		{
-			Tap(Id.AddRow);
+			Tap(Ids.AddRow);
 			_rowDef++;
 			_totalHeight = Math.Max(_rowDef, _totalHeight);
 		}
+
 		public void AddColumnDef()
 		{
-			Tap(Id.AddColumn);
+			Tap(Ids.AddColumn);
 			_colDef++;
 			_totalWidth = Math.Max(_colDef, _totalWidth);
 		}
+
 		[Test]
 		public void Issue42620Test()
 		{
@@ -318,7 +322,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 		public void Issue42620Test(string command)
 		{
-			RunningApp.WaitForElement(q => q.Marked(Id.Clear));
+			RunningApp.WaitForElement(q => q.Marked(Ids.Clear));
 
 			_totalWidth = 0;
 			_totalHeight = 0;
@@ -327,7 +331,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			foreach (var c in command)
 			{
-				if (c == 'H') AddHoizontal();
+				if (c == 'H') AddHorizontal();
 				if (c == 'V') AddVertical();
 				if (c == 'R') AddRowDef();
 				if (c == 'C') AddColumnDef();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51503.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51503.cs
@@ -15,13 +15,13 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			PushAsync(new RootPage());
+			PushAsync(new _51503RootPage());
 		}
 
 		[Preserve(AllMembers = true)]
-		class RootPage : ContentPage
+		class _51503RootPage : ContentPage
 		{
-			public RootPage()
+			public _51503RootPage()
 			{
 				Button button = new Button
 				{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57114.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57114.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		const string Testing = "Testing...";
 		const string Success = "Success";
-		const string AutomationId = "_57114View";
+		const string ViewAutomationId = "_57114View";
 
 		protected override void Init()
 		{
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var view = new _57114View
 			{
-				AutomationId = AutomationId,
+				AutomationId = ViewAutomationId,
 				HeightRequest = 200, WidthRequest = 200,
 				BackgroundColor = Color.Aqua,
 				HorizontalOptions = LayoutOptions.Fill,
@@ -103,7 +103,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public void _57114BothTypesOfGesturesFire()
 		{
 			RunningApp.WaitForElement(Testing);
-			RunningApp.Tap(AutomationId);
+			RunningApp.Tap(ViewAutomationId);
 			RunningApp.WaitForElement(Success);
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
@@ -73,14 +73,11 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				// These controls show a pop-up which we have to cancel/done out of before we can continue
 #if __ANDROID__
-				var cancelButtonText = "Cancel";
 				RunningApp.Back();
 #elif __IOS__
 				var cancelButtonText = "Done";
 				RunningApp.WaitForElement(q => q.Marked(cancelButtonText));
 				RunningApp.Tap(q => q.Marked(cancelButtonText));
-#else
-				var cancelButtonText = "DismissButton";
 #endif
 
 			}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
@@ -30,7 +30,6 @@ namespace Xamarin.Forms.Controls.Issues
 		const string TargetAutomationId = "controlinsideofframe";
 		const string NoTaps = "No taps yet";
 		const string Tapped = "Frame was tapped";
-		ContentPage _menu;
 
 #if UITEST
 		[Test, TestCaseSource(nameof(TestCases))]
@@ -175,11 +174,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		ContentPage BuildMenu()
 		{
-			if (_menu != null)
-			{
-				return _menu;
-			}
-
 			var layout = new Grid
 			{
 				VerticalOptions = LayoutOptions.Fill,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
@@ -64,15 +64,12 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				// These controls show a pop-up which we have to cancel/done out of before we can continue
 #if __ANDROID__
-				var cancelButtonText = "Cancel";
 				System.Threading.Tasks.Task.Delay(1000).Wait();
 				RunningApp.Back();
 #elif __IOS__
 				var cancelButtonText = "Done";
 				RunningApp.WaitForElement(q => q.Marked(cancelButtonText));
 				RunningApp.Tap(q => q.Marked(cancelButtonText));
-#else
-				var cancelButtonText = "Cancel";
 #endif
 			}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
@@ -23,7 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 	public class InputTransparentTests : TestNavigationPage
 	{
 		const string TargetAutomationId = "inputtransparenttarget";
-		ContentPage _menu;
 
 #if UITEST
 		[Test, TestCaseSource(nameof(TestCases))]
@@ -158,11 +157,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		ContentPage BuildMenu()
 		{
-			if (_menu != null)
-			{
-				return _menu;
-			}
-
 			var layout = new Grid
 			{
 				VerticalOptions = LayoutOptions.Fill, HorizontalOptions = LayoutOptions.Fill,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1483.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1483.cs
@@ -9,10 +9,10 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			PushAsync(RootPage());
+			PushAsync(CreateRootPage());
 		}
 
-		ContentPage RootPage()
+		ContentPage CreateRootPage()
 		{
 			var activityIndicator = new ActivityIndicator {VerticalOptions = LayoutOptions.Center, 
 				IsRunning = true, IsVisible = true, WidthRequest = 200, HeightRequest = 100 };

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1760.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1760.cs
@@ -80,7 +80,10 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				_scrollEnabled = scrollEnabled;
 				CreateHeaderPage();
+#pragma warning disable 4014
+				// The lack of `await` here is from the original repro code and is intentional
 				DisplayPage();
+#pragma warning restore 4014
 			}
 
 			void CreateHeaderPage()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1931.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1931.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Controls.Issues
 		Label _result;
 		Label _instructions2;
 
-		ContentPage RootPage()
+		ContentPage CreateRootPage()
 		{
 			var page = new ContentPage();
 			page.Title = "GH1931 Root";
@@ -168,7 +168,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			PushAsync(RootPage());
+			PushAsync(CreateRootPage());
 		}
 
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2247.cs
@@ -13,7 +13,6 @@ namespace Xamarin.Forms.Controls.Issues
 	public class Issue2247 : TestContentPage
 	{
 		ListView _listView;
-		bool _isRefreshing;
 
 		protected override void Init()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
@@ -293,13 +293,17 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					base.OnAppearing();
 					await Task.Delay(500);
+#pragma warning disable 4014
 					Detail.Navigation.PushAsync(new ContentPage());
 					Detail.Navigation.PushModalAsync(new NavigationPage(new ContentPage() { Title = "Details 2" }));
+#pragma warning restore 4014
 
 					var navPage = new NavigationPage(new ContentPage() { Title = "Details" });
 					Detail = navPage;
 					Application.Current.MainPage = Issue2338TestHelper.CreateSuccessPage(nameof(Issue2338_MasterDetailsPage));
+#pragma warning disable 4014
 					navPage.PushAsync(new ContentPage() { Title = "Details 2" });
+#pragma warning restore 4014
 				}
 			}
 		}
@@ -331,7 +335,10 @@ namespace Xamarin.Forms.Controls.Issues
 					base.OnAppearing();
 					await Task.Delay(500);
 					var contentPage = new ContentPage();
+
+#pragma warning disable 4014
 					Detail.Navigation.PushAsync(contentPage);
+#pragma warning restore 4014
 
 					contentPage.Appearing += (_, __) =>
 					{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue264.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue264.cs
@@ -18,8 +18,6 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue (IssueTracker.Github, 264, "PopModal NRE", PlatformAffected.Android | PlatformAffected.iOS)]
 	public class Issue264 : TestContentPage
 	{
-		Page _current;
-
 		protected override void Init ()
 		{
 			var aboutBtn = new Button {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2927.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2927.cs
@@ -19,21 +19,12 @@ namespace Xamarin.Forms.Controls.Issues
 		public class Issue2927Cell : TextCell, INotifyPropertyChanged
 		{
 			int _numberOfTimesTapped;
-			string _text;
 			string _cellId;
 
 			public Issue2927Cell (string id)
 			{
 				_cellId = id;
 				NumberOfTimesTapped = 0;
-			}
-
-			void OnPropertyChanged (string prop)
-			{
-				var handler = PropertyChanged;
-				if (handler != null) {
-					handler(this, new PropertyChangedEventArgs(prop));
-				}
 			}
 
 			public int NumberOfTimesTapped
@@ -44,17 +35,6 @@ namespace Xamarin.Forms.Controls.Issues
 					Text = _cellId + " " + _numberOfTimesTapped.ToString ();
 				}
 			}
-
-			public string Text {
-				get { return _text; }
-				set { 
-					_text = value;
-					OnPropertyChanged ("Text");
-				}
-			}
-
-			public event PropertyChangedEventHandler PropertyChanged;
-
 		}
 
 		protected override void Init ()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3319.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3319.xaml.cs
@@ -67,8 +67,13 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var articlelistingitem = mi.CommandParameter;
 
+#pragma warning disable 4014
+			// For some reason, Jason seemed to think we deliberately should _not_ add an await here.
+			// So leaving it out unless someone comes up with a really good reason to add it.
+			// (see https://github.com/xamarin/Xamarin.Forms/pull/65#discussion-diff-59305011) 
 			if (articlelistingitem != null)
 				DisplayAlert ("Alert", "I'm not deleting just refreshing...", "Ok");
+#pragma warning restore 4014
 			ViewModel.LoadFavoritesCommand.Execute (null);
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3408.cs
@@ -90,14 +90,14 @@ namespace Xamarin.Forms.Controls.Issues
 		[Preserve(AllMembers = true)]
 		public class RecommendationsBaseViewModel : ViewModelBase
 		{
-			public string AccountName => $"";
+			public virtual string AccountName => $"";
 			public List<Recommendation> Recommendations { get; set; }
 		}
 
 		[Preserve(AllMembers = true)]
 		public class RecommendationsViewModel : RecommendationsBaseViewModel
 		{
-			public string AccountName => $"Recommendations";
+			public override string AccountName => $"Recommendations";
 
 			public RecommendationsViewModel()
 			{
@@ -113,7 +113,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Preserve(AllMembers = true)]
 		public class RecommendationsViewModel2 : RecommendationsBaseViewModel
 		{
-			public string AccountName => $"Recommendations 2";
+			public override string AccountName => $"Recommendations 2";
 			public RecommendationsViewModel2()
 			{
 				Recommendations = new List<Recommendation>()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4356.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4356.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var articlelistingitem = mi.CommandParameter;
 
 			if (articlelistingitem != null)
-				DisplayAlert("Alert", "I'm not deleting just refreshing...", "Ok");
+				await DisplayAlert("Alert", "I'm not deleting just refreshing...", "Ok");
 			ViewModel.LoadFavoritesCommand.Execute(null);
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue774.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue774.cs
@@ -56,9 +56,11 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[TearDown]
-		public void TearDown()
+		public override void TearDown()
 		{
 			RunningApp.SetOrientationPortrait();
+
+			base.TearDown();
 		}
 #endif
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
@@ -148,6 +148,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var result = DisplayResults();
 
+#pragma warning disable 4014
 			PerformanceDataManager.PostScenarioResults(ViewModel.Scenario,
 				result,
 				ViewModel.TestRunReferenceId,
@@ -158,6 +159,7 @@ namespace Xamarin.Forms.Controls.Issues
 				_BuildInfo,
 				ViewModel.ActualRenderTime,
 				_PerformanceProvider.Statistics);
+#pragma warning restore 4014
 		}
 
 		void NextButton_Clicked(object sender, EventArgs e)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -368,7 +368,7 @@ namespace Xamarin.Forms.Controls
 		}
 
 		[TearDown]
-		public void TearDown()
+		public virtual void TearDown()
 		{
 			if (Isolate)
 			{
@@ -461,7 +461,7 @@ namespace Xamarin.Forms.Controls
 		}
 
 		[TearDown]
-		public void TearDown()
+		public virtual void TearDown()
 		{
 			if (Isolate)
 			{
@@ -551,7 +551,7 @@ namespace Xamarin.Forms.Controls
 		}
 
 		[TearDown]
-		public void TearDown()
+		public virtual void TearDown()
 		{
 			if (Isolate)
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -241,7 +241,7 @@ namespace Xamarin.Forms.Controls
 					RunningApp.TestServer.Get("version");
 					return;
 				}
-				catch (Exception ex)
+				catch 
 				{
 				}
 

--- a/Xamarin.Forms.Controls/GalleryPages/OpenGLGalleries/AdvancedOpenGLGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/OpenGLGalleries/AdvancedOpenGLGallery.cs
@@ -182,7 +182,9 @@ namespace Xamarin.Forms.Controls
 
             UniformMatrix4(_mMVPMatrixHandle, _mModelViewProjectionMatrix);
 
+#pragma warning disable 0618
             GL.DrawArrays(BeginMode.Triangles, 0, 3);
+#pragma warning restore 0618
             GL.Finish();
             GL.DisableVertexAttribArray(_mPositionHandle);
             GL.DisableVertexAttribArray(_mColorHandle);

--- a/Xamarin.Forms.Controls/GalleryPages/OpenGLGalleries/BasicOpenGLGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/OpenGLGalleries/BasicOpenGLGallery.cs
@@ -73,6 +73,7 @@ namespace Xamarin.Forms.Controls
 
         void Render()
         {
+#pragma warning disable 0618
             GL.ClearColor(0, 0, 0, 0);
             GL.Clear(ClearBufferMask.ColorBufferBit);
 
@@ -82,6 +83,7 @@ namespace Xamarin.Forms.Controls
             GL.Vertex3(0.0, 0.6, 0.0);
             GL.Vertex3(-0.2, -0.3, 0.0);
             GL.Vertex3(0.2, -0.3, 0.0);
+#pragma warning restore 0618
 
             GL.End();
 

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -11,7 +11,6 @@
     <DefineConstants>TRACE;DEBUG;PERF;APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429</NoWarn>
     <DebugType>full</DebugType>
   </PropertyGroup>
@@ -19,7 +18,6 @@
     <DefineConstants>TRACE;APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -23,7 +23,6 @@
     <DefineConstants>TRACE;DEBUG;__ANDROID__;UITEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0108;4014;0649;0168;0169;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -33,7 +32,6 @@
     <DefineConstants>TRACE;__ANDROID__;UITEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0108;4014;0649;0168;0169;0219</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
+++ b/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
@@ -23,7 +23,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +31,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup Condition=" '$(OS)' != 'Unix' ">
     <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ActionSheetUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ActionSheetUITests.cs
@@ -26,7 +26,11 @@ namespace Xamarin.Forms.Core.UITests
 			base.TestSetup();
 #if !__MACOS__
 			screenSize = App.Query(q => q.Marked("ActionSheetPage"))[0].Rect;
+#else
+			screenSize = new AppRect();
 #endif
+
+
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -14,7 +14,10 @@ namespace Xamarin.Forms.Core.UITests
 		string btn1Id = "tb1";
 		string btn2Id = "tb2";
 		string btn4Id = "tb4";
+#if !__MACOS__
 		string btn3Id = "tb3";
+#endif 
+
 #if __ANDROID__
 		static bool isSecondaryMenuOpen = false;
 #endif

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/UITestCustomExceptions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/UITestCustomExceptions.cs
@@ -80,16 +80,16 @@ namespace Xamarin.Forms.Core.UITests
 
 	internal class UITestErrorException : Exception
 	{
-		readonly string message;
+		readonly string _message;
 
 		public UITestErrorException (string message, [CallerMemberName] string caller = null)
 		{
-			message = string.Format ("Test error: {0}, {1}", caller, message);
+			_message = string.Format ("Test error: {0}, {1}", caller, message);
 		}
 
 		public override string Message
 		{
-			get { return message; }
+			get { return _message; }
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -23,7 +23,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0672;0108;0067;0168;0169;0219;0612;0618;1998;4014</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -33,7 +32,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0672;0108;0067;0168;0169;0219;0612;0618;1998;4014</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -21,7 +21,6 @@
     <DefineConstants>TRACE;DEBUG;__WINDOWS__;UITEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -31,7 +30,6 @@
     <DefineConstants>TRACE;__WINDOWS__;UITEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -23,7 +23,6 @@
     <DefineConstants>TRACE;DEBUG;__IOS__;UITEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0108;4014;0649;0169;0168;0219;NU1201</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -33,7 +32,6 @@
     <DefineConstants>TRACE;__IOS__;UITEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core/BindableLayout.cs
+++ b/Xamarin.Forms.Core/BindableLayout.cs
@@ -173,7 +173,6 @@ namespace Xamarin.Forms
 				return;
 			}
 
-			int i = 0;
 			foreach (object item in _itemsSource)
 			{
 				layout.Children.Add(CreateItemView(item, layout));

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -322,10 +322,10 @@ namespace Xamarin.Forms
 				{
 					ParameterInfo parameter = null;
 					ParameterInfo[] array = property.GetIndexParameters();
-					for (int i = 0; i < array.Length; i++)
+
+					if (array.Length > 0)
 					{
-						parameter = array[i];
-						break;
+						parameter = array[0];
 					}
 
 					if (parameter != null)

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -392,12 +392,6 @@ namespace Xamarin.Forms
 			set => SetValue(ScaleYProperty, value);
 		}
 
-		public Style Style
-		{
-			get { return (Style)GetValue(StyleProperty); }
-			set { SetValue(StyleProperty, value); }
-		}
-
 		public int TabIndex
 		{
 			get => (int)GetValue(TabIndexProperty);
@@ -417,20 +411,6 @@ namespace Xamarin.Forms
 		protected virtual void OnTabStopPropertyChanged(bool oldValue, bool newValue) { }
 
 		protected virtual bool TabStopDefaultValueCreator() => true;
-
-		[TypeConverter(typeof(ListStringTypeConverter))]
-		public IList<string> StyleClass
-		{
-			get { return @class; }
-			set { @class = value; }
-		}
-
-		[TypeConverter(typeof(ListStringTypeConverter))]
-		public IList<string> @class
-		{
-			get { return _mergedStyle.StyleClass; }
-			set { _mergedStyle.StyleClass = value; }
-		}
 
 		public double TranslationX
 		{

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -7,7 +7,9 @@
 		<DebugType>full</DebugType>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	  <WarningsAsErrors />
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
 	  <WarningsAsErrors />
 	</PropertyGroup>
 	<ItemGroup>

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -7,10 +7,8 @@
 		<DebugType>full</DebugType>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-	  <WarningsAsErrors />
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-	  <WarningsAsErrors />
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj" />

--- a/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
+++ b/Xamarin.Forms.Core/Xamarin.Forms.Core.csproj
@@ -6,6 +6,10 @@
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<DebugType>full</DebugType>
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	  <WarningsAsErrors />
+	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj" />
 	</ItemGroup>

--- a/Xamarin.Forms.CustomAttributes/Xamarin.Forms.CustomAttributes.csproj
+++ b/Xamarin.Forms.CustomAttributes/Xamarin.Forms.CustomAttributes.csproj
@@ -7,7 +7,6 @@
   <PropertyGroup>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>0169</NoWarn>
   </PropertyGroup>
 </Project>

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -243,7 +243,7 @@ namespace Xamarin.Forms.Maps.Android
 				pin.PropertyChanged += PinOnPropertyChanged;
 
 				// associate pin with marker for later lookup in event handlers
-				pin.Id = marker.Id;
+				pin.MarkerId = marker.Id;
 				return marker;
 			}));
 		}
@@ -274,7 +274,7 @@ namespace Xamarin.Forms.Maps.Android
 
 		protected Marker GetMarkerForPin(Pin pin)
 		{
-			return _markers?.Find(m => m.Id == (string)pin.Id);
+			return _markers?.Find(m => m.Id == (string)pin.MarkerId);
 		}
 
 		void MapOnMarkerClick(object sender, GoogleMap.InfoWindowClickEventArgs eventArgs)
@@ -287,7 +287,7 @@ namespace Xamarin.Forms.Maps.Android
 			for (var i = 0; i < Map.Pins.Count; i++)
 			{
 				Pin pin = Map.Pins[i];
-				if ((string)pin.Id != marker.Id)
+				if ((string)pin.MarkerId != marker.Id)
 				{
 					continue;
 				}

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -30,7 +30,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>
@@ -42,7 +41,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>

--- a/Xamarin.Forms.Maps.MacOS/Xamarin.Forms.Maps.macOS.csproj
+++ b/Xamarin.Forms.Maps.MacOS/Xamarin.Forms.Maps.macOS.csproj
@@ -33,6 +33,7 @@
     </LinkMode>
     <XamMacArch>
     </XamMacArch>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/Xamarin.Forms.Maps.MacOS/Xamarin.Forms.Maps.macOS.csproj
+++ b/Xamarin.Forms.Maps.MacOS/Xamarin.Forms.Maps.macOS.csproj
@@ -33,7 +33,6 @@
     </LinkMode>
     <XamMacArch>
     </XamMacArch>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/Xamarin.Forms.Maps.Tizen/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Tizen/MapRenderer.cs
@@ -204,7 +204,7 @@ namespace Xamarin.Forms.Maps.Tizen
 				pin.PropertyChanged += PinOnPropertyChanged;
 				var coordinates = new Geocoordinates(pin.Position.Latitude, pin.Position.Longitude);
 				var nativePin = new TPin(coordinates);
-				pin.Id = nativePin;
+				pin.MarkerId = nativePin;
 				nativePin.Clicked += (s, e) =>
 				{
 					pin.SendTap();
@@ -219,7 +219,7 @@ namespace Xamarin.Forms.Maps.Tizen
 			foreach (Pin pin in pins)
 			{
 				pin.PropertyChanged -= PinOnPropertyChanged;
-				Control.Remove((TPin)pin.Id);
+				Control.Remove((TPin)pin.MarkerId);
 				_pins.Remove(pin);
 			}
 		}
@@ -347,7 +347,7 @@ namespace Xamarin.Forms.Maps.Tizen
 		void PinOnPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			Pin pin = (Pin)sender;
-			var nativePin = pin.Id as TPin;
+			var nativePin = pin.MarkerId as TPin;
 
 			if (nativePin == null)
 			{

--- a/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
+++ b/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
@@ -27,7 +27,6 @@
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>
@@ -39,7 +38,6 @@
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>

--- a/Xamarin.Forms.Maps.WPF/GeocoderBackend.cs
+++ b/Xamarin.Forms.Maps.WPF/GeocoderBackend.cs
@@ -15,14 +15,14 @@ namespace Xamarin.Forms.Maps.WPF
 			Geocoder.GetAddressesForPositionFuncAsync = GetAddressesForPositionAsync;
 		}
 
-		static async Task<IEnumerable<string>> GetAddressesForPositionAsync(Position position)
+		static Task<IEnumerable<string>> GetAddressesForPositionAsync(Position position)
 		{
-			return new List<string>();
+			return Task.FromResult<IEnumerable<string>>(new List<string>());
 		}
 
-		static async Task<IEnumerable<Position>> GetPositionsForAddress(string address)
+		static Task<IEnumerable<Position>> GetPositionsForAddress(string address)
 		{
-			return new List<Position>();
+			return Task.FromResult<IEnumerable<Position>>(new List<Position>());
 		}
 	}
 }

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -260,7 +260,7 @@ namespace Xamarin.Forms.Maps.MacOS
 			Pin targetPin = null;
 			foreach (Pin pin in ((Map)Element).Pins)
 			{
-				object target = pin.Id;
+				object target = pin.MarkerId;
 				if (target != annotation)
 					continue;
 
@@ -296,7 +296,7 @@ namespace Xamarin.Forms.Maps.MacOS
 				pin.PropertyChanged += PinOnPropertyChanged;
 
 				var annotation = CreateAnnotation(pin);
-				pin.Id = annotation;
+				pin.MarkerId = annotation;
 				((MKMapView)Control).AddAnnotation(annotation);
 			}
 		}
@@ -304,7 +304,7 @@ namespace Xamarin.Forms.Maps.MacOS
 		void PinOnPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			Pin pin = (Pin)sender;
-			var annotation = pin.Id as MKPointAnnotation;
+			var annotation = pin.MarkerId as MKPointAnnotation;
 
 			if (annotation == null)
 			{
@@ -375,7 +375,7 @@ namespace Xamarin.Forms.Maps.MacOS
 			foreach (Pin pin in pins)
 			{
 				pin.PropertyChanged -= PinOnPropertyChanged;
-				((MKMapView)Control).RemoveAnnotation((IMKAnnotation)pin.Id);
+				((MKMapView)Control).RemoveAnnotation((IMKAnnotation)pin.MarkerId);
 			}
 		}
 

--- a/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
+++ b/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
@@ -23,7 +23,6 @@
     <ConsolePause>false</ConsolePause>
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>

--- a/Xamarin.Forms.Maps/Pin.cs
+++ b/Xamarin.Forms.Maps/Pin.cs
@@ -12,6 +12,8 @@ namespace Xamarin.Forms.Maps
 		public static readonly BindableProperty AddressProperty = BindableProperty.Create("Address", typeof(string), typeof(Pin), default(string));
 
 		public static readonly BindableProperty LabelProperty = BindableProperty.Create("Label", typeof(string), typeof(Pin), default(string));
+		private object _markerId;
+		private object _id;
 
 		public string Address
 		{
@@ -37,9 +39,31 @@ namespace Xamarin.Forms.Maps
 			set { SetValue(TypeProperty, value); }
 		}
 
+
 		// introduced to store the unique id for Android markers
+		[Obsolete("This property is obsolete as of 4.0.0. Please use MarkerId instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public object Id { get; set; }
+		public new object Id
+		{
+			get => _id;
+			set
+			{
+				_id = value;
+				_markerId = value;
+			}
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public object MarkerId
+		{
+			get => _markerId;
+			set
+			{
+				_markerId = value;
+				// Keep Id working just in case someone has taken a dependency on it
+				_id = value;
+			}
+		}
 
 		public event EventHandler Clicked;
 

--- a/Xamarin.Forms.Maps/Xamarin.Forms.Maps.csproj
+++ b/Xamarin.Forms.Maps/Xamarin.Forms.Maps.csproj
@@ -7,7 +7,9 @@
 		<DebugType>full</DebugType>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	  <WarningsAsErrors />
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
 	  <WarningsAsErrors />
 	</PropertyGroup>
 	<ItemGroup>

--- a/Xamarin.Forms.Maps/Xamarin.Forms.Maps.csproj
+++ b/Xamarin.Forms.Maps/Xamarin.Forms.Maps.csproj
@@ -6,6 +6,10 @@
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<DebugType>full</DebugType>
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	  <WarningsAsErrors />
+	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs" Link="Properties\GlobalAssemblyInfo.cs" />
 	</ItemGroup>

--- a/Xamarin.Forms.Maps/Xamarin.Forms.Maps.csproj
+++ b/Xamarin.Forms.Maps/Xamarin.Forms.Maps.csproj
@@ -7,10 +7,8 @@
 		<DebugType>full</DebugType>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-	  <WarningsAsErrors />
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-	  <WarningsAsErrors />
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs" Link="Properties\GlobalAssemblyInfo.cs" />

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -27,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -27,7 +27,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
+++ b/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
@@ -31,6 +31,7 @@
     </MtouchVerbosity>
     <MtouchLink>
     </MtouchLink>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
+++ b/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
@@ -31,7 +31,6 @@
     </MtouchVerbosity>
     <MtouchLink>
     </MtouchLink>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
+++ b/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
@@ -3,7 +3,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
+++ b/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.3</Version>

--- a/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
+++ b/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
@@ -3,10 +3,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -28,6 +28,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -28,7 +28,6 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/Xamarin.Forms.Platform.Android.FormsViewGroup/Xamarin.Forms.Platform.Android.FormsViewGroup.csproj
+++ b/Xamarin.Forms.Platform.Android.FormsViewGroup/Xamarin.Forms.Platform.Android.FormsViewGroup.csproj
@@ -25,7 +25,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS0109</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -35,7 +34,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS0109</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -32,7 +32,6 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS0109</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -43,7 +42,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS0109</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -20,7 +20,6 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ConsolePause>false</ConsolePause>
     <EnableCodeSigning>false</EnableCodeSigning>
     <CreatePackage>false</CreatePackage>

--- a/Xamarin.Forms.Platform.Tizen/Platform.cs
+++ b/Xamarin.Forms.Platform.Tizen/Platform.cs
@@ -104,7 +104,9 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		readonly HashSet<EvasObject> _alerts = new HashSet<EvasObject>();
 
+#pragma warning disable 0067
 		public event EventHandler<RootNativeViewChangedEventArgs> RootNativeViewChanged;
+#pragma warning restore 0067
 
 		internal DefaultPlatform(EvasObject parent)
 		{

--- a/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
+++ b/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
@@ -5,6 +5,11 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors>NU1605</WarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -26,7 +26,6 @@
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>
@@ -38,7 +37,6 @@
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>

--- a/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
+++ b/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>default</LangVersion>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>default</LangVersion>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -19,7 +19,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>
@@ -30,7 +29,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
     </NoWarn>
   </PropertyGroup>

--- a/Xamarin.Forms.Platform/Xamarin.Forms.Platform.csproj
+++ b/Xamarin.Forms.Platform/Xamarin.Forms.Platform.csproj
@@ -3,9 +3,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
 </Project>

--- a/Xamarin.Forms.Platform/Xamarin.Forms.Platform.csproj
+++ b/Xamarin.Forms.Platform/Xamarin.Forms.Platform.csproj
@@ -3,7 +3,9 @@
     <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 </Project>

--- a/Xamarin.Forms.Platform/Xamarin.Forms.Platform.csproj
+++ b/Xamarin.Forms.Platform/Xamarin.Forms.Platform.csproj
@@ -2,4 +2,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
 </Project>

--- a/Xamarin.Forms.Xaml.Design/Xamarin.Forms.Xaml.Design.csproj
+++ b/Xamarin.Forms.Xaml.Design/Xamarin.Forms.Xaml.Design.csproj
@@ -22,7 +22,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,7 +30,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup Condition=" '$(OS)' != 'Unix' ">
     <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -21,11 +21,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -21,6 +21,10 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsAsErrors />
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj" />
     <ProjectReference Include="..\Xamarin.Forms.Build.Tasks\Xamarin.Forms.Build.Tasks.csproj" />

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -9,7 +9,6 @@
   <Import Project="..\.nuspec\Xamarin.Forms.DefaultItems.targets" />
 	
   <PropertyGroup>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
     <NoWarn>0672;0219;0414</NoWarn>
   </PropertyGroup>
@@ -22,6 +21,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
 

--- a/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
+++ b/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
@@ -4,7 +4,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
+++ b/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
@@ -3,6 +3,10 @@
     <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs" Link="Properties\GlobalAssemblyInfo.cs" />
   </ItemGroup>

--- a/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
+++ b/Xamarin.Forms.Xaml/Xamarin.Forms.Xaml.csproj
@@ -4,10 +4,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core\Properties\GlobalAssemblyInfo.cs" Link="Properties\GlobalAssemblyInfo.cs" />

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -332,7 +332,9 @@ namespace Xamarin.Forms.Xaml
 		public static Type GetElementType(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly,
 			out XamlParseException exception)
 		{
+#if NETSTANDARD2_0
 			bool hasRetriedNsSearch = false;
+#endif
 			IList<XamlLoader.FallbackTypeInfo> potentialTypes;
 
 #if NETSTANDARD2_0


### PR DESCRIPTION
### Description of Change ###

Re-enable the "Treat warnings as errors" property for most projects.

### API Changes ###

Obsolete Maps.Pin.Id
Maps.Pin.Id -> Maps.Pin.MarkerId

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

