### PR TITLE
[iOS] Fixes memory leak when SwitchCell is used

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateOnColor(realCell, boolCell);
 		}
 
-		void OnSwitchValueChanged(object sender, EventArgs eventArgs)
+		static void OnSwitchValueChanged(object sender, EventArgs eventArgs)
 		{
 			var view = (UIView)sender;
 			var sw = (UISwitch)view;


### PR DESCRIPTION
### Description of Change ###

Fixes leak when SwitchCell is used.
The handler was keeping the renderer alive.

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Testing Procedure ###

create a page with a switchcell, close the page - it wont be garbage collected.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
