### PR TITLE
[UITest] Disable old 1461 test

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1461.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1461.cs
@@ -20,8 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public static bool ShouldRunTest (IApp app)
 		{
-			var appAs = app as iOSApp;
-			return (appAs != null && appAs.Device.IsTablet);
+			return (app is iOSApp appAs && appAs.Device.IsTablet);
 		}
 	}
 #endif
@@ -35,27 +34,27 @@ namespace Xamarin.Forms.Controls.Issues
 			await Navigation.PushModalAsync (new Issue1461Page (MasterBehavior.Popover, false));
 		}
 
-#if UITEST
-		[Test]
-		[UiTest (typeof (MasterDetailPage), "IsPresented")]
-		[UiTest (typeof (MasterDetailPage), "Master")]
-		public void Test1 ()
-		{
-			if (Issue1461Helpers.ShouldRunTest (RunningApp)) {
-				RunningApp.SetOrientationLandscape ();
-				var query = RunningApp.Query (q => q.Marked ("Master_Label"));
-				Assert.IsTrue (!query.Any (), "Master should not present");
-				RunningApp.Screenshot ("Master should not present");
-				RunningApp.SetOrientationPortrait ();
-				query = RunningApp.Query (q => q.Marked ("Master_Label"));
-				Assert.IsTrue (!query.Any (), "Master should not present");
-				RunningApp.Screenshot ("Master should not present");
-				RunningApp.Tap (q => q.Marked ("Go Back"));
-			} else {
-				Assert.Inconclusive ("Only run on iOS Tablet");
-			}
-		}
-#endif
+//#if UITEST
+//		[Test]
+//		[UiTest (typeof (MasterDetailPage), "IsPresented")]
+//		[UiTest (typeof (MasterDetailPage), "Master")]
+//		public void Test1 ()
+//		{
+//			if (Issue1461Helpers.ShouldRunTest (RunningApp)) {
+//				RunningApp.SetOrientationLandscape ();
+//				var query = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				Assert.IsTrue (!query.Any (), "Master should not present");
+//				RunningApp.Screenshot ("Master should not present");
+//				RunningApp.SetOrientationPortrait ();
+//				query = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				Assert.IsTrue (!query.Any (), "Master should not present");
+//				RunningApp.Screenshot ("Master should not present");
+//				RunningApp.Tap (q => q.Marked ("Go Back"));
+//			} else {
+//				Assert.Inconclusive ("Only run on iOS Tablet");
+//			}
+//		}
+//#endif
 	}
 
 	[Preserve (AllMembers = true)]
@@ -67,43 +66,43 @@ namespace Xamarin.Forms.Controls.Issues
 			await Navigation.PushModalAsync (new Issue1461Page (MasterBehavior.Default, null));
 		}
 
-#if UITEST
-		[Test]
-		[UiTest (typeof (MasterDetailPage), "IsPresented")]
-		[UiTest (typeof (MasterDetailPage), "Master")]
-		public void Test2 ()
-		{
-			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
-				RunningApp.SetOrientationLandscape ();
-				var query = RunningApp.Query (q => q.Marked ("Master_Label"));
-				Assert.IsTrue (query.Any (), "Master should be present");
-				RunningApp.Screenshot ("Master should not present");
-				RunningApp.SetOrientationPortrait ();
-				query = RunningApp.Query (q => q.Marked ("Master_Label"));
-				Assert.IsTrue (!query.Any (), "Master should not present");
-				RunningApp.Screenshot ("Master should not present");
-				RunningApp.Tap (q => q.Marked ("Go Back"));
-			} else {
-				Assert.Inconclusive ("Only run on iOS Tablet");
-			}
-		}
+//#if UITEST
+//		[Test]
+//		[UiTest (typeof (MasterDetailPage), "IsPresented")]
+//		[UiTest (typeof (MasterDetailPage), "Master")]
+//		public void Test2 ()
+//		{
+//			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
+//				RunningApp.SetOrientationLandscape ();
+//				var query = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				Assert.IsTrue (query.Any (), "Master should be present");
+//				RunningApp.Screenshot ("Master should not present");
+//				RunningApp.SetOrientationPortrait ();
+//				query = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				Assert.IsTrue (!query.Any (), "Master should not present");
+//				RunningApp.Screenshot ("Master should not present");
+//				RunningApp.Tap (q => q.Marked ("Go Back"));
+//			} else {
+//				Assert.Inconclusive ("Only run on iOS Tablet");
+//			}
+//		}
 
-		#if UITEST
-		[Test]
-		[UiTest (typeof (MasterDetailPage), "Button")]
-		public void TestButton ()
-		{
-			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
-				RunningApp.SetOrientationLandscape ();
-				RunningApp.WaitForNoElement (q => q.Marked ("bank"));
-				RunningApp.SetOrientationPortrait ();
-				RunningApp.WaitForElement (q => q.Marked ("bank"));
-			} else {
-				Assert.Inconclusive ("Only run on iOS Tablet");
-			}
-		}
-		#endif
-#endif
+//		#if UITEST
+//		[Test]
+//		[UiTest (typeof (MasterDetailPage), "Button")]
+//		public void TestButton ()
+//		{
+//			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
+//				RunningApp.SetOrientationLandscape ();
+//				RunningApp.WaitForNoElement (q => q.Marked ("bank"));
+//				RunningApp.SetOrientationPortrait ();
+//				RunningApp.WaitForElement (q => q.Marked ("bank"));
+//			} else {
+//				Assert.Inconclusive ("Only run on iOS Tablet");
+//			}
+//		}
+//		#endif
+//#endif
 	}
 
 	[Preserve (AllMembers = true)]
@@ -115,27 +114,27 @@ namespace Xamarin.Forms.Controls.Issues
 			await Navigation.PushModalAsync (new Issue1461Page (MasterBehavior.SplitOnLandscape, null));
 		}
 
-#if UITEST
-		[Test]
-		[UiTest (typeof (MasterDetailPage), "IsPresented")]
-		[UiTest (typeof (MasterDetailPage), "Master")]
-		public void Test3 ()
-		{
-			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
-				RunningApp.SetOrientationLandscape ();
-				var query = RunningApp.Query (q => q.Marked ("Master_Label"));
-				Assert.IsTrue (query.Any (), "Master should be present");
-				RunningApp.Screenshot ("Master should not present");
-				RunningApp.SetOrientationPortrait ();
-				query = RunningApp.Query (q => q.Marked ("Master_Label"));
-				Assert.IsTrue (!query.Any (), "Master should not present");
-				RunningApp.Screenshot ("Master should not present");
-				RunningApp.Tap (q => q.Marked ("Go Back"));
-			} else {
-				Assert.Inconclusive ("Only run on iOS Tablet");
-			}
-		}
-#endif
+//#if UITEST
+//		[Test]
+//		[UiTest (typeof (MasterDetailPage), "IsPresented")]
+//		[UiTest (typeof (MasterDetailPage), "Master")]
+//		public void Test3 ()
+//		{
+//			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
+//				RunningApp.SetOrientationLandscape ();
+//				var query = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				Assert.IsTrue (query.Any (), "Master should be present");
+//				RunningApp.Screenshot ("Master should not present");
+//				RunningApp.SetOrientationPortrait ();
+//				query = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				Assert.IsTrue (!query.Any (), "Master should not present");
+//				RunningApp.Screenshot ("Master should not present");
+//				RunningApp.Tap (q => q.Marked ("Go Back"));
+//			} else {
+//				Assert.Inconclusive ("Only run on iOS Tablet");
+//			}
+//		}
+//#endif
 	}
 
 	[Preserve (AllMembers = true)]
@@ -147,28 +146,28 @@ namespace Xamarin.Forms.Controls.Issues
 			await Navigation.PushModalAsync (new Issue1461Page (MasterBehavior.SplitOnPortrait, null));
 		}
 
-#if UITEST
-		[Test]
-		[UiTest (typeof (MasterDetailPage), "IsPresented")]
-		[UiTest (typeof (MasterDetailPage), "Master")]
-		public void Test4 ()
-		{
-			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
-				RunningApp.SetOrientationPortrait ();
-				var s = RunningApp.Query (q => q.Marked ("Master_Label"));
-				Assert.IsTrue (s.Any (), "Master should be present");
-				RunningApp.Screenshot ("Master should  present");
+//#if UITEST
+//		[Test]
+//		[UiTest (typeof (MasterDetailPage), "IsPresented")]
+//		[UiTest (typeof (MasterDetailPage), "Master")]
+//		public void Test4 ()
+//		{
+//			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
+//				RunningApp.SetOrientationPortrait ();
+//				var s = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				Assert.IsTrue (s.Any (), "Master should be present");
+//				RunningApp.Screenshot ("Master should  present");
 
-				RunningApp.SetOrientationLandscape ();
-				s = RunningApp.Query (q => q.Marked ("Master_Label"));
-				Assert.IsTrue (!s.Any (), "Master should not present on landscape");
-				RunningApp.Screenshot ("Master should not present");
-				RunningApp.Tap (q => q.Marked ("Go Back"));
-			} else {
-				Assert.Inconclusive ("Only run on iOS Tablet");
-			}
-		}
-#endif
+//				RunningApp.SetOrientationLandscape ();
+//				s = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				Assert.IsTrue (!s.Any (), "Master should not present on landscape");
+//				RunningApp.Screenshot ("Master should not present");
+//				RunningApp.Tap (q => q.Marked ("Go Back"));
+//			} else {
+//				Assert.Inconclusive ("Only run on iOS Tablet");
+//			}
+//		}
+//#endif
 	}
 
 	[Preserve (AllMembers = true)]
@@ -180,29 +179,29 @@ namespace Xamarin.Forms.Controls.Issues
 			await Navigation.PushModalAsync (new Issue1461Page (MasterBehavior.Split, null));
 		}
 
-#if UITEST
-		[Test]
-		[UiTest (typeof (MasterDetailPage), "IsPresented")]
-		[UiTest (typeof (MasterDetailPage), "Master")]
-		public void Test5 ()
-		{
-			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
-				RunningApp.SetOrientationPortrait ();
-				var s = RunningApp.Query (q => q.Marked ("Master_Label"));
-				Assert.IsTrue (s.Any (), "Master should be present");
-				RunningApp.Screenshot ("Master should be present");
+//#if UITEST
+//		[Test]
+//		[UiTest (typeof (MasterDetailPage), "IsPresented")]
+//		[UiTest (typeof (MasterDetailPage), "Master")]
+//		public void Test5 ()
+//		{
+//			if (Issue1461Helpers.ShouldRunTest(RunningApp)) {
+//				RunningApp.SetOrientationPortrait ();
+//				var s = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				Assert.IsTrue (s.Any (), "Master should be present");
+//				RunningApp.Screenshot ("Master should be present");
 
-				RunningApp.SetOrientationLandscape ();
-				s = RunningApp.Query (q => q.Marked ("Master_Label"));
+//				RunningApp.SetOrientationLandscape ();
+//				s = RunningApp.Query (q => q.Marked ("Master_Label"));
 
-				Assert.IsTrue (s.Any (), "Master should  be present");
-				RunningApp.Screenshot ("Master should be present");
-				RunningApp.Tap (q => q.Marked ("Go Back"));
-			} else {
-				Assert.Inconclusive ("Only run on iOS Tablet");
-			}
-		}
-#endif
+//				Assert.IsTrue (s.Any (), "Master should  be present");
+//				RunningApp.Screenshot ("Master should be present");
+//				RunningApp.Tap (q => q.Marked ("Go Back"));
+//			} else {
+//				Assert.Inconclusive ("Only run on iOS Tablet");
+//			}
+//		}
+//#endif
 	}
 
 	internal sealed class Issue1461Page : MasterDetailPage


### PR DESCRIPTION
### Description of Change ###

The UI tests on 1461 are only supposed to run for iOS Tablets, but there's no good way to enforce that without actually loading up the test and checking what context it's running in. That's what this test is doing, which is great, except that it's now flaky on iOS 10 and causes the next test in line (1469) to randomly fail because the 1461 page doesn't go away.

Also, since we don't currently run tests on any iOS tablets anyway, as far as I can tell, we're just spinning up 10 tests on every platform for no good whatsoever.

I declare it useless as an automated test right now.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Tests

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Tests should not fail. 🤞 

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
