### PR TITLE
[mac] fix build

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -98,8 +98,13 @@ namespace Xamarin.Forms
 			Device.SetIdiom(TargetIdiom.Desktop);
 			Device.SetFlowDirection(NSApplication.SharedApplication.UserInterfaceLayoutDirection.ToFlowDirection());
 			var mojave = new NSOperatingSystemVersion(10, 14, 0);
-			if (NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(mojave))
-				NSApplication.SharedApplication.Appearance = NSAppearance.GetAppearance(NSAppearance.NameAqua);
+			if (NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(mojave) && 
+				typeof(NSApplication).GetProperty("Appearance") is PropertyInfo appearance &&
+				appearance != null)
+			{
+				var aquaAppearance = NSAppearance.GetAppearance(NSAppearance.NameAqua);
+				appearance.SetValue(NSApplication.SharedApplication, aquaAppearance);
+			}
 #endif
 			Device.SetFlags(s_flags);
 			Device.PlatformServices = new IOSPlatformServices();


### PR DESCRIPTION
### Description of Change ###

fixes build exception `error CS1061: 'NSApplication' does not contain a definition for 'Appearance'`

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Mac

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
