### PR TITLE
Suppress warning for CharacterRangeForGlyphRange is obsolete

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
@@ -108,7 +108,9 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __MOBILE__
 			layoutManager.CharacterRangeForGlyphRange(characterRange, ref glyphRange);
 #else
-			layoutManager.GetCharacterRange(characterRange, out glyphRange);
+#pragma warning disable CS0618 // Type or member is obsolete
+			layoutManager.CharacterRangeForGlyphRange(characterRange, out glyphRange);
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
 			return layoutManager.BoundingRectForGlyphRange(glyphRange, textContainer);
 		}

--- a/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
@@ -108,7 +108,7 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __MOBILE__
 			layoutManager.CharacterRangeForGlyphRange(characterRange, ref glyphRange);
 #else
-			layoutManager.CharacterRangeForGlyphRange(characterRange, out glyphRange);
+			layoutManager.GetCharacterRange(characterRange, out glyphRange);
 #endif
 			return layoutManager.BoundingRectForGlyphRange(glyphRange, textContainer);
 		}


### PR DESCRIPTION
### Description of Change ###
Suppress warning that CharacterRangeForGlyphRange is obsolete. We can't change this to GetCharacterRange because that method doesn't exist on the current stable Mac SDK Apis

### Issues Resolved ### 
- fixes #5246

### Platforms Affected ### 
- macOS

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard