### PR TITLE
Dispose FrameRenderer's FrameDrawable

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.Platform.Android
 	public class FrameRenderer : VisualElementRenderer<Frame>
 	{
 		bool _disposed;
+		FrameDrawable _drawable;
 		readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
 
 		public FrameRenderer(Context context) : base(context)
@@ -32,7 +33,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (disposing && !_disposed)
 			{
-				Background.Dispose();
+				_drawable?.Dispose();
 				_disposed = true;
 			}
 		}
@@ -67,7 +68,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateBackground()
 		{
-			this.SetBackground(new FrameDrawable(Element, Context.ToPixels));
+			_drawable?.Dispose();
+			this.SetBackground(_drawable = new FrameDrawable(Element, Context.ToPixels));
 		}
 
 		class FrameDrawable : Drawable


### PR DESCRIPTION
### Description of Change ###

Dispose `FrameRenderer`'s `FrameDrawable`.

### Issues Resolved ### 

- fixes #5446

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None; Doesn't crash due to OOM.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run reproduction in fixed issue.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
