### PR TITLE
Make the 3.5 ABI compatible with 3.3 and 3.4

### DIFF
--- a/Xamarin.Forms.Core/HandlerAttribute.cs
+++ b/Xamarin.Forms.Core/HandlerAttribute.cs
@@ -5,7 +5,11 @@ namespace Xamarin.Forms
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
 	public abstract class HandlerAttribute : Attribute
 	{
-		protected HandlerAttribute(Type handler, Type target, Type[] supportedVisuals = null)
+		protected HandlerAttribute(Type handler, Type target) : this(handler, target, null)
+		{
+		}
+
+		protected HandlerAttribute(Type handler, Type target, Type[] supportedVisuals)
 		{
 			SupportedVisuals = supportedVisuals ?? new[] { typeof(VisualRendererMarker.Default) };
 			TargetType = target;

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -8,6 +8,10 @@ namespace Xamarin.Forms
 {
 	public partial class VisualElement : NavigableElement, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController, IPropertyPropagationController, IVisualController
 	{
+		public new static readonly BindableProperty NavigationProperty = NavigableElement.NavigationProperty;
+
+		public new static readonly BindableProperty StyleProperty = NavigableElement.StyleProperty;
+
 		public static readonly BindableProperty InputTransparentProperty = BindableProperty.Create("InputTransparent", typeof(bool), typeof(VisualElement), default(bool));
 
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool),

--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -21,7 +21,8 @@ namespace Xamarin.Forms.Platform.Android
 		IImageRendererController,
 		AView.IOnFocusChangeListener,
 		AView.IOnClickListener,
-		AView.IOnTouchListener
+		AView.IOnTouchListener,
+		ILayoutChanges
 	{
 		bool _inputTransparent;
 		bool _disposed;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
@@ -15,7 +15,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			renderer.ElementPropertyChanged += OnElementPropertyChanged;
 			renderer.ElementChanged += OnElementChanged;
-			renderer.LayoutChange += OnLayoutChange;
+
+			if(renderer is ILayoutChanges layoutChanges)
+				layoutChanges.LayoutChange += OnLayoutChange;
 		}
 
 		static void OnLayoutChange(object sender, global::Android.Views.View.LayoutChangeEventArgs e)
@@ -28,7 +30,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			renderer.ElementPropertyChanged -= OnElementPropertyChanged;
 			renderer.ElementChanged -= OnElementChanged;
-			renderer.LayoutChange -= OnLayoutChange;
+			if (renderer is ILayoutChanges layoutChanges)
+				layoutChanges.LayoutChange -= OnLayoutChange;
 
 			if (renderer.View is ImageView imageView)
 				imageView.SetImageDrawable(null);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -11,7 +11,8 @@ using Android.Support.V4.View;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
-	internal sealed class ImageRenderer : AImageView, IVisualElementRenderer, IImageRendererController, IViewRenderer, ITabStop
+	internal sealed class ImageRenderer : AImageView, IVisualElementRenderer, IImageRendererController, IViewRenderer, ITabStop,
+		ILayoutChanges
 	{
 		bool _disposed;
 		Image _element;

--- a/Xamarin.Forms.Platform.Android/ILayoutChanges.cs
+++ b/Xamarin.Forms.Platform.Android/ILayoutChanges.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using ALayoutChangeEventArgs = Android.Views.View.LayoutChangeEventArgs;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal interface ILayoutChanges
+	{
+		event EventHandler<ALayoutChangeEventArgs> LayoutChange;
+	}
+}

--- a/Xamarin.Forms.Platform.Android/IVisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/IVisualElementRenderer.cs
@@ -29,7 +29,5 @@ namespace Xamarin.Forms.Platform.Android
 		void SetLabelFor(int? id);
 
 		void UpdateLayout();
-
-		event EventHandler<ALayoutChangeEventArgs> LayoutChange;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
@@ -31,12 +31,6 @@ namespace Xamarin.Forms.Platform.Android
 			remove { _elementPropertyChanged -= value; }
 		}
 
-		event EventHandler<AView.LayoutChangeEventArgs> IVisualElementRenderer.LayoutChange
-		{
-			add =>_flyoutRenderer.AndroidView.LayoutChange += value;
-			remove => _flyoutRenderer.AndroidView.LayoutChange -= value;
-		}
-
 		VisualElement IVisualElementRenderer.Element => Element;
 
 		VisualElementTracker IVisualElementRenderer.Tracker => null;

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -143,6 +143,7 @@
     <Compile Include="GetDesiredSizeDelegate.cs" />
     <Compile Include="IBorderVisualElementRenderer.cs" />
     <Compile Include="IDeviceInfoProvider.cs" />
+    <Compile Include="ILayoutChanges.cs" />
     <Compile Include="ITabStop.cs" />
     <Compile Include="Material\MaterialContextThemeWrapper.cs" />
     <Compile Include="Material\MaterialFrameRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###
Cherry picks the IVisualElementRenderer ABI fix into 3.5
Cherry picks the ABI fixes for VisualElement

### Issues Resolved ### 
- fixes #5288 (Release from Sync Fusion still needed in order to fix completely) 

### API Changes ###
Added:
 - public new static readonly BindableProperty NavigationPropert
- public new static readonly BindableProperty StyleProperty
- added back protected HandlerAttribute(Type handler, Type target)  ctor

Removed:
- Removed LayoutChange from IVisualElementRenderer

### Platforms Affected ### 
- Android

### Testing ###
- Recommend if we should fix any of the additional ABI changes https://gist.github.com/PureWeen/d6b652955e3240bab260713c25c95a68

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
