### PR TITLE
[UWP] fix throw exception when update switch color

### DIFF
--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -74,7 +74,10 @@ namespace Xamarin.Forms.Platform.UWP
 			if (Control == null)
 				return;
 
-			var grid = Control.GetChildren<Windows.UI.Xaml.Controls.Grid>().FirstOrDefault();
+			var grid = Control.GetFirstDescendant<Windows.UI.Xaml.Controls.Grid>();
+			if (grid == null)
+				return;
+
 			var groups = Windows.UI.Xaml.VisualStateManager.GetVisualStateGroups(grid);
 			foreach (var group in groups)
 			{


### PR DESCRIPTION
### Description of Change ###

see comment  https://github.com/xamarin/Xamarin.Forms/pull/4883/files#r267342643

fixes #5517

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
