### PR TITLE
Set ImeOptions to Done on Android Editor

### DIFF
--- a/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
@@ -2,6 +2,7 @@
 using Android.Content;
 using Android.Util;
 using Android.Views;
+using Android.Views.InputMethods;
 using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
@@ -26,6 +27,7 @@ namespace Xamarin.Forms.Material.Android
 			var view = inflater.Inflate(Resource.Layout.TextInputLayoutFilledBox, null);
 			_textInputLayout = (MaterialFormsTextInputLayout)view;
 			_textInputEditText = _textInputLayout.FindViewById<MaterialFormsEditText>(Resource.Id.materialformsedittext);
+			_textInputEditText.ImeOptions = ImeAction.Done;
 			UpdatePlaceholderText();
 
 			return _textInputLayout;

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -10,6 +10,7 @@ using Android.Util;
 using Android.Views;
 using Java.Lang;
 using Android.Widget;
+using Android.Views.InputMethods;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -31,7 +32,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override FormsEditText CreateNativeControl()
 		{
-			return new FormsEditText(Context);
+			return new FormsEditText(Context)
+			{
+				ImeOptions = ImeAction.Done
+			};
 		}
 
 		protected override EditText EditText => Control;


### PR DESCRIPTION
### Description of Change ###

Set `ImeOptions = ImeAction.Done` in `CreateNativeControl()` in Android EditorRenderer.

Alternative to #5320, only fixing the bug without making any API changes.

### Issues Resolved ### 

- fixes #4832
- fixes #5030

### API Changes ### 

 None

### Platforms Affected ###
 
- Android

### Behavioral/Visual Changes ###

Editor will have Done button instead of Next when focused and the phone is in landscape orientation on Android.

### Before/After Screenshots ### 
Before:

![Screenshot_1553182621](https://user-images.githubusercontent.com/6132629/54764177-459bf500-4bc5-11e9-992c-fef829ac53ed.png)

After:
![Screenshot_1553182525](https://user-images.githubusercontent.com/6132629/54764089-19807400-4bc5-11e9-9a0d-4e8efa555ce8.png)

### Testing Procedure ###
1. Run Control Gallery app.
2. Go to Editor Gallery page.
3.  Focus the Editor.
4. Rotate the device to landscape.
5. Press the Done button.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
