### PR TITLE
[UWP] Allow embedding Forms page in secondary window

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/SecondaryWindowService.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/SecondaryWindowService.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.UI.Core;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Controls;
+using Xamarin.Forms.Platform.UWP;
+
+[assembly: Dependency(typeof(SecondaryWindowService))]
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	class SecondaryWindowService : ISecondaryWindowService
+	{
+		public async Task OpenSecondaryWindow(Type pageType)
+		{
+			CoreApplicationView newView = CoreApplication.CreateNewView();
+			int newViewId = 0;
+			await newView.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+			{
+				var frame = new Windows.UI.Xaml.Controls.Frame();
+				frame.Navigate(pageType);
+				Window.Current.Content = frame;
+				Window.Current.Activate();
+
+				newViewId = ApplicationView.GetForCurrentView().Id;
+			});
+			bool viewShown = await ApplicationViewSwitcher.TryShowAsStandaloneAsync(newViewId);
+		}
+
+		public async Task OpenSecondaryWindow(ContentPage page)
+		{
+			CoreApplicationView newView = CoreApplication.CreateNewView();
+			int newViewId = 0;
+			await newView.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+			{
+				var frame = new Windows.UI.Xaml.Controls.Frame();
+				frame.Navigate(page);
+				Window.Current.Content = frame;
+				Window.Current.Activate();
+
+				newViewId = ApplicationView.GetForCurrentView().Id;
+			});
+			bool viewShown = await ApplicationViewSwitcher.TryShowAsStandaloneAsync(newViewId);
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -130,6 +130,7 @@
     <Compile Include="PlatformSpecificCoreGalleryFactory.cs" />
     <Compile Include="RegistrarValidationService.cs" />
     <Compile Include="SampleNativeControl.cs" />
+    <Compile Include="SecondaryWindowService.cs" />
     <Compile Include="_2489CustomRenderer.cs" />
     <Compile Include="_57114Renderer.cs" />
     <Compile Include="_58406EffectRenderer.cs" />

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -10,6 +10,8 @@ using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries;
+using Xamarin.Forms.Controls.Issues;
+
 namespace Xamarin.Forms.Controls
 {
 	[Preserve(AllMembers = true)]
@@ -556,6 +558,14 @@ namespace Xamarin.Forms.Controls
 
 				}
 			};
+
+			var secondaryWindowService = DependencyService.Get<ISecondaryWindowService>();
+			if (secondaryWindowService != null)
+			{
+				var openSecondWindowButton = new Button() { Text = "Open Secondary Window" };
+				openSecondWindowButton.Clicked += (obj, args) => { secondaryWindowService.OpenSecondaryWindow(new Issue2482()); };
+				stackLayout.Children.Add(openSecondWindowButton);
+			}
 
 			this.SetAutomationPropertiesName("Gallery");
 			this.SetAutomationPropertiesHelpText("Lists all gallery pages");

--- a/Xamarin.Forms.Controls/ISecondaryWindowService.cs
+++ b/Xamarin.Forms.Controls/ISecondaryWindowService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Controls
+{
+	public interface ISecondaryWindowService
+	{
+		Task OpenSecondaryWindow(Type pageType);
+		Task OpenSecondaryWindow(ContentPage page);
+	}
+}

--- a/Xamarin.Forms.Core/Internals/Ticker.cs
+++ b/Xamarin.Forms.Core/Internals/Ticker.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Internals
 			{
 				if (s_ticker == null)
 				{
-					s_ticker = s_ticker = Device.PlatformServices.CreateTicker();
+					s_ticker = Device.PlatformServices.CreateTicker();
 				}
 
 				return s_ticker.GetTickerInstance(); 

--- a/Xamarin.Forms.Core/Internals/Ticker.cs
+++ b/Xamarin.Forms.Core/Internals/Ticker.cs
@@ -42,7 +42,22 @@ namespace Xamarin.Forms.Internals
 		public static Ticker Default
 		{
 			internal set { s_ticker = value; }
-			get { return s_ticker ?? (s_ticker =  Device.PlatformServices.CreateTicker()); }
+			get
+			{
+				if (s_ticker == null)
+				{
+					s_ticker = s_ticker = Device.PlatformServices.CreateTicker();
+				}
+
+				return s_ticker.GetTickerInstance(); 
+			}
+		}
+
+		protected virtual Ticker GetTickerInstance()
+		{
+			// This method is provided so platforms can override it and return something other than
+			// the normal Ticker singleton
+			return s_ticker;
 		}
 
 		public virtual int Insert(Func<long, bool> timeout)

--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Forms
 			return FlowDirection.MatchParent;
 		}
 
-		static Windows.UI.Xaml.ResourceDictionary GetTabletResources()
+		internal static Windows.UI.Xaml.ResourceDictionary GetTabletResources()
 		{
 			return new Windows.UI.Xaml.ResourceDictionary {
 				Source = new Uri("ms-appx:///Xamarin.Forms.Platform.UAP/Resources.xbf")

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -67,9 +67,16 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_page = page;
 
+			var current = Windows.UI.Xaml.Application.Current;
+
+			if (!current.Resources.ContainsKey("RootContainerStyle"))
+			{
+				Windows.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(Forms.GetTabletResources());
+			}
+
 			_container = new Canvas
 			{
-				Style = (Windows.UI.Xaml.Style)Windows.UI.Xaml.Application.Current.Resources["RootContainerStyle"]
+				Style = (Windows.UI.Xaml.Style)current.Resources["RootContainerStyle"]
 			};
 
 			_page.Content = _container;

--- a/Xamarin.Forms.Platform.UAP/WindowsTicker.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsTicker.cs
@@ -1,10 +1,15 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using Windows.ApplicationModel.Core;
+using System;
+using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.UWP
 {
 	internal class WindowsTicker : Ticker
 	{
+		[ThreadStatic]
+		static Ticker s_ticker;
+
 		protected override void DisableTimer()
 		{
 			CompositionTarget.Rendering -= RenderingFrameEventHandler;
@@ -18,6 +23,23 @@ namespace Xamarin.Forms.Platform.UWP
 		void RenderingFrameEventHandler(object sender, object args)
 		{
 			SendSignals();
+		}
+
+		protected override Ticker GetTickerInstance()
+		{
+			if (CoreApplication.Views.Count > 1)
+			{
+				// We've got multiple windows open, we'll need to use the local ThreadStatic Ticker instead of the 
+				// singleton in the base class 
+				if (s_ticker == null)
+				{
+					s_ticker = new WindowsTicker();
+				}
+
+				return s_ticker;
+			}
+
+			return base.GetTickerInstance();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Adds a check for the existence of the Forms resources when opening a secondary window and loads them if necessary.

Adds a workaround for using the correct dispatcher from Device.BeginInvokeOnMainThread when there are multiple windows present. Also adds a workaround for using multiple Tickers when multiple windows are present.

### Issues Resolved ### 

- fixes #2229
- closes #2432

### API Changes ###
 
Added `protected virtual Ticker GetTickerInstance()` to `Ticker` to allow platforms to modify the number of instances of Tickers available.

### Platforms Affected ### 

- Core
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

On UWP, Control Gallery now includes a button to open a secondary window; it will be populated by the test page for issue 2842.

We do not currently have a mechanism for automating tests in a secondary window.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
