### PR TITLE
Implemented ImageButtonRenderer for WPF

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.WPF/Properties/AssemblyInfo.cs
@@ -80,6 +80,7 @@ using Xamarin.Forms.Platform.WPF;
 [assembly: ExportRenderer(typeof(Frame), typeof(FrameRenderer))]
 [assembly: ExportRenderer(typeof(ListView), typeof(ListViewRenderer))]
 [assembly: ExportRenderer(typeof(OpenGLView), typeof(OpenGLViewRenderer))]
+[assembly: ExportRenderer(typeof(ImageButton), typeof(ImageButtonRenderer))]
 
 // Control don't exist natively in WPF Platform
 [assembly: ExportRenderer(typeof(TableView), typeof(TableViewRenderer))]

--- a/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Xamarin.Forms.Internals;
+using WButton = System.Windows.Controls.Button;
+using WImage = System.Windows.Controls.Image;
+using WThickness = System.Windows.Thickness;
+
+namespace Xamarin.Forms.Platform.WPF
+{
+	public class ImageButtonRenderer : ViewRenderer<ImageButton, WButton>, IVisualElementRenderer
+	{
+		bool _disposed;
+		WButton _button;
+		WImage _image;
+
+		public ImageButtonRenderer() : base() { }
+
+		protected async override void OnElementChanged(ElementChangedEventArgs<ImageButton> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+			{
+				if (Control == null)
+				{
+					_image = new WImage
+					{
+						VerticalAlignment = System.Windows.VerticalAlignment.Center,
+						HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+						Stretch = System.Windows.Media.Stretch.Uniform
+					};
+
+					_image.ImageFailed += OnImageFailed;
+
+					_button = new WButton
+					{
+						Padding = new WThickness(0),
+						BorderThickness = new WThickness(0),
+						Background = null,
+
+						Content = _image
+					};
+
+					_button.Click += OnButtonClick;
+
+					SetNativeControl(_button);
+				}
+
+				if (Element.BorderColor != Color.Default)
+					UpdateBorderColor();
+
+				if (Element.BorderWidth != 0)
+					UpdateBorderWidth();
+
+				await TryUpdateSource().ConfigureAwait(false);
+				UpdateAspect();
+			}
+		}
+
+		protected async override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == ImageButton.SourceProperty.PropertyName)
+				await TryUpdateSource().ConfigureAwait(false);
+			else if (e.PropertyName == ImageButton.BorderColorProperty.PropertyName)
+				UpdateBorderColor();
+			else if (e.PropertyName == ImageButton.BorderWidthProperty.PropertyName)
+				UpdateBorderWidth();
+			else if (e.PropertyName == ImageButton.AspectProperty.PropertyName)
+				UpdateAspect();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			if (disposing)
+			{
+				if (_image != null)
+				{
+					_image.ImageFailed -= OnImageFailed;
+				}
+
+				if (_button != null)
+				{
+					_button.Click -= OnButtonClick;
+				}
+			}
+
+			_disposed = true;
+			base.Dispose(disposing);
+		}
+
+		protected virtual async Task TryUpdateSource()
+		{
+			try
+			{
+				await UpdateSource().ConfigureAwait(false);
+			}
+			catch (Exception ex)
+			{
+				Log.Warning(nameof(ImageButtonRenderer), "Error loading image: {0}", ex);
+			}
+			finally
+			{
+				Element.SetIsLoading(false);
+			}
+		}
+
+		protected async Task UpdateSource()
+		{
+			if (Element == null || Control == null)
+				return;
+
+			Element.SetIsLoading(true);
+
+			ImageSource source = Element.Source;
+			IImageSourceHandler handler;
+			if (source != null && (handler = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
+			{
+				System.Windows.Media.ImageSource imageSource;
+
+				try
+				{
+					imageSource = await handler.LoadImageAsync(source);
+				}
+				catch (OperationCanceledException)
+				{
+					imageSource = null;
+				}
+
+				// In the time it takes to await the imagesource, some zippy little app
+				// might have disposed of this Image already.
+				if (_image != null)
+					_image.Source = imageSource;
+
+				RefreshImage();
+			}
+			else
+			{
+				_image.Source = null;
+				Element.SetIsLoading(false);
+			}
+		}
+
+		private void RefreshImage()
+		{
+			((IVisualElementController)Element)?.InvalidateMeasure(InvalidationTrigger.RendererReady);
+		}
+
+		private void OnButtonClick(object sender, System.Windows.RoutedEventArgs e)
+		{
+			((IButtonController)Element)?.SendReleased();
+			((IButtonController)Element)?.SendClicked();
+		}
+
+		private void OnImageFailed(object sender, System.Windows.ExceptionRoutedEventArgs e)
+		{
+			Log.Warning("Image loading", $"Image failed to load: {e.ErrorException.Message}");
+			Element?.SetIsLoading(false);
+		}
+
+		private void UpdateBorderColor()
+		{
+			Control.UpdateDependencyColor(WButton.BorderBrushProperty, Element.BorderColor);
+		}
+
+		private void UpdateBorderWidth()
+		{
+			Control.BorderThickness =
+				Element.BorderWidth <= 0d
+					? new WThickness(1)
+					: new WThickness(Element.BorderWidth);
+		}
+
+		private void UpdateAspect()
+		{
+			_image.Stretch = Element.Aspect.ToStretch();
+			if (Element.Aspect == Aspect.Fill)
+			{
+				Control.HorizontalAlignment = System.Windows.HorizontalAlignment.Center;
+				Control.VerticalAlignment = System.Windows.VerticalAlignment.Center;
+			}
+			else
+			{
+				Control.HorizontalAlignment = System.Windows.HorizontalAlignment.Left;
+				Control.VerticalAlignment = System.Windows.VerticalAlignment.Top;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
@@ -146,29 +146,29 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 		}
 
-		private void RefreshImage()
+		void RefreshImage()
 		{
 			((IVisualElementController)Element)?.InvalidateMeasure(InvalidationTrigger.RendererReady);
 		}
 
-		private void OnButtonClick(object sender, System.Windows.RoutedEventArgs e)
+		void OnButtonClick(object sender, System.Windows.RoutedEventArgs e)
 		{
 			((IButtonController)Element)?.SendReleased();
 			((IButtonController)Element)?.SendClicked();
 		}
 
-		private void OnImageFailed(object sender, System.Windows.ExceptionRoutedEventArgs e)
+		void OnImageFailed(object sender, System.Windows.ExceptionRoutedEventArgs e)
 		{
 			Log.Warning("Image loading", $"Image failed to load: {e.ErrorException.Message}");
 			Element?.SetIsLoading(false);
 		}
 
-		private void UpdateBorderColor()
+		void UpdateBorderColor()
 		{
 			Control.UpdateDependencyColor(WButton.BorderBrushProperty, Element.BorderColor);
 		}
 
-		private void UpdateBorderWidth()
+		void UpdateBorderWidth()
 		{
 			Control.BorderThickness =
 				Element.BorderWidth <= 0d
@@ -176,7 +176,7 @@ namespace Xamarin.Forms.Platform.WPF
 					: new WThickness(Element.BorderWidth);
 		}
 
-		private void UpdateAspect()
+		void UpdateAspect()
 		{
 			_image.Stretch = Element.Aspect.ToStretch();
 			if (Element.Aspect == Aspect.Fill)

--- a/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
+++ b/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Renderers\EditorRenderer.cs" />
     <Compile Include="Renderers\EntryRenderer.cs" />
     <Compile Include="Renderers\FrameRenderer.cs" />
+    <Compile Include="Renderers\ImageButtonRenderer.cs" />
     <Compile Include="Renderers\ImageRenderer.cs" />
     <Compile Include="Renderers\LabelRenderer.cs" />
     <Compile Include="Renderers\LayoutRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###
Implemented ImageButtonRenderer for WPF

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4991

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- WPF

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

To test the ImageButton, the image file oasissmall.jpg must be included in the WPF ControlGallery.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
