### PR TITLE
[Android] Fixes ObjectDisposedException when call Unfocus of Entry

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5376.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5376.cs
@@ -1,0 +1,81 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+using System.Threading;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.LifeCycle)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5376, "Call unfocus entry crashes app", PlatformAffected.Android)]
+	public class Issue5376 : TestMasterDetailPage
+	{
+		protected async override void Init()
+		{
+			MasterBehavior = MasterBehavior.Popover;
+			IsPresented = false;
+			Master = new ContentPage { Title = "test 5376" };
+			var testPage = new NavigationPage(new EntryPage() { Title = $"Test page" });
+			Detail = testPage;
+			await Task.Delay(100);
+			Detail = new ContentPage();
+			await Task.Delay(100);
+			Detail = testPage;
+			Detail = new ContentPage { Content = new Label { Text = "Success" } };
+		}
+
+		[Preserve(AllMembers = true)]
+		class EntryPage : ContentPage
+		{
+			Entry entry;
+
+			public EntryPage()
+			{
+				entry = new Entry { Text = Title };
+				Content = new StackLayout { Children = { entry } };
+			}
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+
+				new Thread(() =>
+				{
+					var success = false;
+					while (!success)
+					{
+						Thread.Sleep(1000);
+						Device.BeginInvokeOnMainThread(() =>
+						{
+							if (entry.IsFocused)
+							{
+								entry.Unfocus();
+								success = true;
+							}
+							else
+							{
+								entry.Focus();
+							}
+						});
+					}
+				}).Start();
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Issue5376Test() 
+		{
+			RunningApp.WaitForElement ("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5376.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5376.cs
@@ -23,12 +23,22 @@ namespace Xamarin.Forms.Controls.Issues
 			MasterBehavior = MasterBehavior.Popover;
 			IsPresented = false;
 			Master = new ContentPage { Title = "test 5376" };
-			var testPage = new NavigationPage(new EntryPage() { Title = $"Test page" });
+			var entryPage = new EntryPage() { Title = $"Test page" };
+			var testPage = new NavigationPage(entryPage);
 			Detail = testPage;
-			await Task.Delay(100);
+			while (!entryPage.IsTested)
+				await Task.Delay(100);
+
+			// dispose testPage renderers
 			Detail = new ContentPage();
 			await Task.Delay(100);
+
+			// create testPage renderers
+			entryPage.IsTested = false;
 			Detail = testPage;
+			while (!entryPage.IsTested)
+				await Task.Delay(100);
+
 			Detail = new ContentPage { Content = new Label { Text = "Success" } };
 		}
 
@@ -36,6 +46,8 @@ namespace Xamarin.Forms.Controls.Issues
 		class EntryPage : ContentPage
 		{
 			Entry entry;
+
+			public volatile bool IsTested = false;
 
 			public EntryPage()
 			{
@@ -45,20 +57,22 @@ namespace Xamarin.Forms.Controls.Issues
 
 			protected override void OnAppearing()
 			{
+				IsTested = false;
+
 				base.OnAppearing();
 
+				entry.Focus();
 				new Thread(() =>
 				{
-					var success = false;
-					while (!success)
+					while (!IsTested)
 					{
-						Thread.Sleep(1000);
+						Thread.Sleep(100);
 						Device.BeginInvokeOnMainThread(() =>
 						{
 							if (entry.IsFocused)
 							{
 								entry.Unfocus();
-								success = true;
+								IsTested = true;
 							}
 							else
 							{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5376.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml.cs">
       <DependentUpon>Bugzilla60787.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -117,6 +117,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
 		{
+			if (Element == null)
+				return;
+
 			if (!e.Focus)
 			{
 				EditText.HideKeyboard();

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -117,9 +117,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
 		{
-			if (Element == null)
-				return;
-
 			if (!e.Focus)
 			{
 				EditText.HideKeyboard();

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -147,7 +147,6 @@ namespace Xamarin.Forms.Platform.Android
 				if (Element != null && _focusChangeHandler != null)
 				{
 					Element.FocusChangeRequested -= _focusChangeHandler;
-
 				}
 				_focusChangeHandler = null;
 			}

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -143,6 +143,13 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					Control.OnFocusChangeListener = null;
 				}
+
+				if (Element != null && _focusChangeHandler != null)
+				{
+					Element.FocusChangeRequested -= _focusChangeHandler;
+
+				}
+				_focusChangeHandler = null;
 			}
 
 			base.Dispose(disposing);
@@ -158,17 +165,8 @@ namespace Xamarin.Forms.Platform.Android
 					}
 					_container = null;
 				}
-
-				if (Element != null && _focusChangeHandler != null)
-				{
-					Element.FocusChangeRequested -= _focusChangeHandler;
-				
-				}
-				_focusChangeHandler = null;
 				_disposed = true;
 			}
-
-			
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<TView> e)


### PR DESCRIPTION
### Description of Change ###

Fixes disposing of View.
`Dispose` of VisualElementRenderer sets Element to `null`. Because of this, the event of a response to focus was not removed from the Element.

### Issues Resolved ### 

- fixes #5376

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

- run UItest 5376

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
