### PR TITLE
[Android] don't clear shell content because native page isn't visible

### DIFF
--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -74,11 +74,6 @@ namespace Xamarin.Forms
 
 		void IShellContentController.RecyclePage(Page page)
 		{
-			if (ContentCache == page)
-			{
-				OnChildRemoved(page);
-				ContentCache = null;
-			}
 		}
 
 		Page _contentCache;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -48,7 +48,11 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				ShellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);
 
-				_toolbarTracker.Page = ((IShellContentController)shellContent).Page;
+				var page = ((IShellContentController)shellContent).Page;
+				if(page == null)
+					throw new ArgumentNullException(nameof(page), "Shell Content Page is Null");
+
+				_toolbarTracker.Page = page;
 			}
 			else
 			{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -41,16 +41,16 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			var stack = shellSection.Stack.ToList();
-			bool result = ((IShellController)_shellContext.Shell).ProposeNavigation(ShellNavigationSource.ShellContentChanged, 
+			bool result = ((IShellController)_shellContext.Shell).ProposeNavigation(ShellNavigationSource.ShellContentChanged,
 				(ShellItem)shellSection.Parent, shellSection, shellContent, stack, true);
 
 			if (result)
 			{
-				ShellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);
-
 				var page = ((IShellContentController)shellContent).Page;
-				if(page == null)
+				if (page == null)
 					throw new ArgumentNullException(nameof(page), "Shell Content Page is Null");
+
+				ShellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);
 
 				_toolbarTracker.Page = page;
 			}


### PR DESCRIPTION
### Description of Change ###

On android when you navigated away from a page it calls recycle on Shell Content but there's not really a reason to remove the shells internal content page is there?

iOS doesn't have this behavior when navigating away from pages. 

When shell starts up it instantiates all of the content pages that are part of the shell contents so it doesn't seem like this value should ever get set to null 

### Issues Resolved ### 

- fixes #4684

### Platforms Affected ### 
- Android


### Testing Procedure ###
- if you have a shell with two shell items
- toggle between them
- and now click on one of the tabs in a shell item

HEre's the xaml that I used to test
```
<ShellItem Title="Home" Route="Home">
        <ShellSection>
            <ShellContent>
                <ContentPage />
            </ShellContent>
        </ShellSection>
    </ShellItem>
    <ShellItem Title="Connect" Route="connect">
        <ShellSection>
            <ShellContent Title="Connect">
                <ContentPage  Title="Connect"/>
            </ShellContent>
            <ShellContent Title="Control">
                <ContentPage Title="Control" />
            </ShellContent>
        </ShellSection>
    </ShellItem>
```

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
