### PR TITLE
Add translated Intellisense files to NuGet package

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -104,11 +104,12 @@
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*mdb" target="lib\netstandard2.0" />
     <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\netstandard2.0" />
+    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\netstandard2.0" />
     <file src="..\docs\**\Xamarin.Forms.Core.xml" target="lib\netstandard2.0" />
+    <file src="..\docs\**\Xamarin.Forms.Xaml.xml" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*mdb" target="lib\netstandard2.0" />
-    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Platform.dll" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Platform.*pdb" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Platform.*mdb" target="lib\netstandard2.0" />
@@ -140,7 +141,6 @@
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\netstandard2.0\Design" />
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\netstandard1.0\Design" />
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\netstandard1.0\Design" />
-
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\MonoAndroid90\Design" /> 
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\MonoAndroid90\Design" />
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\MonoAndroid81\Design" />
@@ -166,9 +166,11 @@
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\MonoAndroid81" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\MonoAndroid81" />
     <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\MonoAndroid81" />
+    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid81" />
+    <file src="..\docs\**\Xamarin.Forms.Core.xml" target="lib\MonoAndroid81" />
+    <file src="..\docs\**\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid81" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\MonoAndroid81" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\MonoAndroid81" />
-    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid81" />
     <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid81\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid81" />
     
     <!--Android 90-->
@@ -179,9 +181,11 @@
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\MonoAndroid90" />
     <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\MonoAndroid90" />
+    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid90" />
+    <file src="..\docs\**\Xamarin.Forms.Core.xml" target="lib\MonoAndroid90" />
+    <file src="..\docs\**\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\MonoAndroid90" />
-    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid90" />
     <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid90" />
 
     <!--iPhone Unified-->
@@ -192,10 +196,12 @@
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*mdb" target="lib\Xamarin.iOS10" />
     <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\Xamarin.iOS10" />
+    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\Xamarin.iOS10" />
+    <file src="..\docs\**\Xamarin.Forms.Core.xml" target="lib\Xamarin.iOS10" />
+    <file src="..\docs\**\Xamarin.Forms.Xaml.xml" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*mdb" target="lib\Xamarin.iOS10" />
-    <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\Xamarin.iOS10" />
     <file src="..\Stubs\Xamarin.Forms.Platform.iOS\bin\iPhone\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\Xamarin.iOS10" />
 
     <!--UWP-->

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -104,6 +104,7 @@
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*mdb" target="lib\netstandard2.0" />
     <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\netstandard2.0" />
+    <file src="..\docs\**\Xamarin.Forms.Core.xml" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\netstandard2.0" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*mdb" target="lib\netstandard2.0" />

--- a/build/scripts/generate-docs.ps1
+++ b/build/scripts/generate-docs.ps1
@@ -1,51 +1,127 @@
 param(
-    [string]$branch = "master",
+    [string]$branch = "live",
     [string]$token
 )
 
+# Yes, this is ignoring the parameter passed in by VSTS; we don't need the 
+# parameter, but we can't remove it until all the active branches don't need it
+$branch = "live"
+
+$mdoc = '..\..\tools\mdoc\mdoc.exe'
 $docsUri = "https://$token@github.com/xamarin/Xamarin.Forms-api-docs.git"
 
-if($branch.StartsWith("refs/pull")) {
-    $branch = "master"
-} else {
+function StripNodes {
+    Param($file, $xpaths)
 
-    $docBranches = git ls-remote --heads $docsUri
-    $matched = $false
-    foreach ($db in $docBranches) {
+    [xml]$xml = Get-Content $file -Encoding UTF8
 
-        if($db.EndsWith($branch)) {
-            # $branch corresponds to an actual branch in docs, so use it
-            $matched = $true
-            break;
+    $xpaths | % {
+
+        $node = $xml.SelectSingleNode($_)
+
+        while ($node -ne $null) {
+         $x = $node.ParentNode.RemoveChild($node) 
+         $node = $xml.SelectSingleNode($_)
         }
+
     }
 
-    if(-not $matched) {
-        $branch = "master"
-    }
-
-    $branch = $branch.Replace("refs/heads/", "")
+    $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+    $streamWriter = New-Object System.IO.StreamWriter($file, $false, $utf8WithoutBom)
+    
+    $xml.Save($streamWriter)
+    $streamWriter.Close()
 }
-
-# API docs maintains its copy of master in `eng-master`
-if ($branch -eq "master") {$branch = "eng-master"}
 
 pushd ..\..
 
 mkdir docstemp
 pushd docstemp
 
-git clone -b $branch --single-branch $docsUri
+# Default Language Stuff
+# Clone Xamarin.Forms-api-docs in docstemp\Xamarin.Forms-api-docs
+git clone -b $branch --single-branch $docsUri 
 
 pushd .\Xamarin.Forms-api-docs
 
-$mdoc = '..\..\tools\mdoc\mdoc.exe'
-
+# Run mdoc
 & $mdoc export-msxdoc .\docs
 
+# Put the results in the docs folder (where NuGet will find it)
 mv Xamarin.Forms.*.xml ..\..\docs -Force
 
+# Return from the default language folder
 popd
+
+# Translations stuff
+
+$translations = 
+@{"lang" = "de-de"; "target" = "de"},
+@{"lang" = "es-es"; "target" = "es"},
+@{"lang" = "fr-fr"; "target" = "fr"},
+@{"lang" = "it-it"; "target" = "it"},
+@{"lang" = "ja-jp"; "target" = "ja"},
+@{"lang" = "ko-kr"; "target" = "ko"},
+@{"lang" = "pt-br"; "target" = "pt-br"},
+@{"lang" = "ru-ru"; "target" = "ru"},
+@{"lang" = "zh-cn"; "target" = "zh-Hans"},
+@{"lang" = "zh-tw"; "target" = "zh-Hant"}
+#@{"lang" = "cs-cz"; "target" = "cs"},
+#@{"lang" = "pl-pl"; "target" = "pl"},
+#@{"lang" = "tr-tr"; "target" = "tr"},
+
+
+$branch = "live"
+
+$translations | % {
+    # Generate the URI for each translated version
+    $translationUri = "https://$token@github.com/xamarin/Xamarin.Forms-api-docs.$($_.lang).git"
+    $translationFolder = ".\Xamarin.Forms-api-docs.$($_.lang)"
+    
+    # Clone the translation repo
+    git clone -b $branch --single-branch $translationUri
+
+    # Go into the language-specific folder
+    pushd $translationFolder\docs
+
+    # Copy everything over the stuff in the default language folder 
+    # (So untranslated bits still remain in the default language)
+    copy-item -Path . -Destination ..\..\Xamarin.Forms-api-docs -Recurse -Force    
+
+    # Return from the language-specific folder
+    popd
+
+    # Go into the default language folder
+    pushd .\Xamarin.Forms-api-docs
+
+    Write-Host "Stripping out unused XML for $($_.lang)"
+
+    dir .\docs -R *.xml | Select -ExpandProperty FullName | % {
+    
+        $xpaths = "//remarks",
+            "//summary[text()='To be added.']",
+            "//param[text()='To be added.']",
+            "//returns[text()='To be added.']",
+            "//typeparam[text()='To be added.']",
+            "//value[text()='To be added.']",
+            "//related",
+            "//example"
+
+        StripNodes $_ $xpaths 
+    }
+
+    # Run mdoc
+    & $mdoc export-msxdoc .\docs
+
+    # And put the results in the language specific folder under docs
+    $dest = "..\..\docs\$($_.target)"
+    mkdir $dest
+    mv Xamarin.Forms.*.xml $dest -Force
+
+    # Return from the default language folder
+    popd
+}
+
 popd
 
 del docstemp -R -Force


### PR DESCRIPTION
### Description of Change ###

When creating the NuGet package for Forms, include all of the translated Intellisense API docs from the various language-specific subfolders.
