### PR TITLE
[Android] Fix various issues with material found by a full run of the UI Tests with Material active

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -195,7 +195,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 #pragma warning disable 618
 				// Disabled the warning so we have a test that this obsolete stuff still works
-				Control.Adapter = new NativeListViewAdapter(Forms.Context as Activity, e.NewElement);
+				Control.Adapter = new NativeListViewAdapter(Forms.Context.GetActivity(), e.NewElement);
 #pragma warning restore 618
 				Control.ItemClick += Clicked;
 			}
@@ -215,7 +215,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 #pragma warning disable 618
 				// Disabled the warning so we have a test that this obsolete stuff still works
-				Control.Adapter = new NativeListViewAdapter(Forms.Context as Activity, Element);
+				Control.Adapter = new NativeListViewAdapter(Forms.Context.GetActivity(), Element);
 #pragma warning restore 618
 			}
 		}
@@ -293,7 +293,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			if (view == null)
 			{// no view to re-use, create new
-				view = (context as Activity).LayoutInflater.Inflate(Resource.Layout.NativeAndroidCell, null);
+				view = (context.GetActivity()).LayoutInflater.Inflate(Resource.Layout.NativeAndroidCell, null);
 			}
 			else
 			{ // re-use, clear image
@@ -382,7 +382,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 				// subscribe
 #pragma warning disable 618
 				// Disabled the warning so we have a test that this obsolete stuff still works
-				Control.Adapter = new NativeAndroidListViewAdapter(Forms.Context as Activity, e.NewElement);
+				Control.Adapter = new NativeAndroidListViewAdapter(Forms.Context.GetActivity(), e.NewElement);
 #pragma warning restore 618
 				Control.ItemClick += Clicked;
 			}
@@ -407,7 +407,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 #pragma warning disable 618
 				// Disabled the warning so we have a test that this obsolete stuff still works
-				Control.Adapter = new NativeAndroidListViewAdapter(Forms.Context as Activity, Element);
+				Control.Adapter = new NativeAndroidListViewAdapter(Forms.Context.GetActivity(), Element);
 #pragma warning restore 618
 			}
 		}

--- a/Xamarin.Forms.ControlGallery.Android/_38989CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_38989CustomRenderer.cs
@@ -12,6 +12,7 @@ using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.ControlGallery.Android;
 using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.Android;
 using AView = Android.Views.View;
 
 [assembly: ExportRenderer(typeof(Bugzilla38989._38989CustomViewCell), typeof(_38989CustomViewCellRenderer))]
@@ -25,7 +26,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 			var nativeView = convertView;
 
 			if (nativeView == null)
-				nativeView = (context as Activity).LayoutInflater.Inflate(Resource.Layout.Layout38989, null);
+				nativeView = (context.GetActivity()).LayoutInflater.Inflate(Resource.Layout.Layout38989, null);
 
 			return nativeView;
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
@@ -51,15 +51,17 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// Tap the control
 			var y = target.CenterY;
+			var x = target.CenterX;
 
 			// In theory we want to tap the center of the control. But Stepper lays out differently than the other controls,
 			// (it doesn't center vertically within its layout), so we need to adjust for it until someone fixes it
 			if (menuItem == "Stepper")
 			{
 				y = target.Y;
+				x = target.X;
 			}
 
-			RunningApp.TapCoordinates(target.CenterX, y);
+			RunningApp.TapCoordinates(x, y);
 
 			if(menuItem == nameof(DatePicker) || menuItem == nameof(TimePicker))
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System.Linq;
 
 #if UITEST
 using NUnit.Framework;
@@ -124,7 +125,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		Picker GenerateNewPicker()
 		{
-			var picker = new Picker();
+			var picker = new Picker() { ClassId = "PickerEditText" };
 			for (int i = 1; i < 100; i++)
 				picker.Items.Add($"item {i}");
 			return picker;
@@ -140,11 +141,17 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 #if UITEST && __ANDROID__
+
+		UITest.Queries.AppResult[] GetPickerEditText(UITest.IApp RunningApp) =>
+			RunningApp.Query(q => q.TextField()).Where(x => x.Class.Contains("PickerEditText")).ToArray();
+
 		[Test]
 		public void Issue4187Test()
 		{
 			RunningApp.WaitForElement("Text 1");
-			Assert.AreEqual(7, RunningApp.Query(q => q.TextField().Class("PickerEditText")).Length, "picker count");
+			UITest.Queries.AppResult[] fields = RunningApp.Query(q => q.TextField());
+
+			Assert.AreEqual(7, GetPickerEditText(RunningApp).Length, "picker count");
 			TapOnPicker(1);
 			Assert.IsTrue(DialogIsOpened(), "#1");
 			RunningApp.Tap("Text 2");
@@ -175,7 +182,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		void TapOnPicker(int index)
 		{
-			var picker = RunningApp.Query(q => q.TextField().Class("PickerEditText"))[index];
+			var picker = GetPickerEditText(RunningApp)[index];
 			var location = picker.Rect;
 			RunningApp.TapCoordinates(location.X + 10, location.Y + location.Height / 2);
 		}

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -573,6 +573,7 @@ namespace Xamarin.Forms.Controls
 
 			foreach (var page in Issues.Helpers.ViewHelper.GetAllPages())
 			{
+				page.Visual = VisualMarker.Default;
 				if (!DependencyService.Get<IRegistrarValidationService>().Validate(page, out string message))
 					throw new InvalidOperationException(message);
 			}

--- a/Xamarin.Forms.Core.Android.UITests/BaseViewContainerRemoteAndroid.cs
+++ b/Xamarin.Forms.Core.Android.UITests/BaseViewContainerRemoteAndroid.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Core.UITests
@@ -36,10 +37,15 @@ namespace Xamarin.Forms.Core.UITests
 			// renderer, then we *do* need to check the parent control for the property
 			// So we query the control's parent and see if it's a Container (legacy); if so, 
 			// we adjust the query to look at the parent of the current control
-			var parent = App.Query(appQuery => appQuery.Raw(ViewQuery + " parent * index:0"));
-			if (parent.Length > 0 && parent[0].Label.EndsWith(ContainerLabel))
+			//var text = Regex.Match(query, "'(?<text>[^']*)'").Groups["text"].Value;
+			//var parent = App.Query(appQuery => appQuery.Raw(ViewQuery + " parent * index:0"));
+			var parent = App.Query(appQuery => appQuery.Raw(ViewQuery).Parent());
+			//parent = App.Query(appQuery => appQuery.Raw(ViewQuery).Parent().Parent());
+
+			var parentElement = parent.FirstOrDefault(x => x.Label?.EndsWith(ContainerLabel) == true);
+			if (parentElement != null)
 			{
-				query = query + " parent * index:0";
+				query = query + $" parent * index:{Array.IndexOf(parent, parentElement)}";
 			}
 
 			return query;

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/AutomationIDUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/AutomationIDUITests.cs
@@ -30,13 +30,13 @@ namespace Xamarin.Forms.Core.UITests
 			App.WaitForElement (c => c.Marked ("tPicker"));
 	
 			var label = App.Query ("lblHello") [0];
-			Assert.AreEqual (label.Text, "Hello Label");
+			Assert.AreEqual ("Hello Label", label.Text);
 
 			var editor = App.Query ("editorHello") [0];
-			Assert.AreEqual (editor.Text, "Hello Editor");
+			Assert.AreEqual ("Hello Editor", editor.Text);
 
 			var entry = App.Query ("entryHello") [0];
-			Assert.AreEqual (entry.Text, "Hello Entry");
+			Assert.AreEqual ("Hello Entry", entry.Text);
 				
 			App.Tap (c => c.Marked ("popModal"));
 		}

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Core.UITests
 		[Test]
 		[UiTest(typeof(Entry), "Completed")]
 		[Category(UITestCategories.UwpIgnore)]
-		public void Completed()
+		public virtual void Completed()
 		{
 			var remote = new EventViewContainerRemote(App, Test.Entry.Completed, PlatformViewType);
 			remote.GoTo();

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/MaterialEntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/MaterialEntryUITests.cs
@@ -22,6 +22,41 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			base._Focus();
 		}
+
+		[Test]
+		[UiTest(typeof(Entry), "Rotation")]
+		public override void _Rotation()
+		{
+			base._Rotation();
+		}
+
+		[Test]
+		[UiTest(typeof(Entry), "RotationX")]
+		public override void _RotationX()
+		{
+			base._RotationX();
+		}
+
+		[Test]
+		[UiTest(typeof(Entry), "RotationY")]
+		public override void _RotationY()
+		{
+			base._RotationY();
+		}
+
+		[Test]
+		[UiTest(typeof(Entry), "Opacity")]
+		public override void _Opacity()
+		{
+			base._Opacity();
+		}
+
+		[Test]
+		[UiTest(typeof(Entry), "Scale")]
+		public override void _Scale()
+		{
+			base._Scale();
+		}
 	}
 #endif
 }

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/MaterialEntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/MaterialEntryUITests.cs
@@ -57,6 +57,41 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			base._Scale();
 		}
+
+		[Test]
+		[UiTest(typeof(Entry), "IsEnabled")]
+		public override void _IsEnabled()
+		{
+			base._IsEnabled();
+		}
+
+		[Test]
+		[UiTest(typeof(Entry), "IsVisible")]
+		public override void _IsVisible()
+		{
+			base._IsVisible();
+		}
+
+		[Test]
+		[UiTest(typeof(Entry), "TranslationX")]
+		public override void _TranslationX()
+		{
+			base._TranslationX();
+		}
+
+		[Test]
+		[UiTest(typeof(Entry), "TranslationY")]
+		public override void _TranslationY()
+		{
+			base._TranslationY();
+		}
+
+		[Test]
+		[UiTest(typeof(Entry), "Completed")]
+		public override void Completed()
+		{
+			base.Completed();
+		}
 	}
 #endif
 }

--- a/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RegistrarUnitTests.cs
@@ -180,6 +180,13 @@ namespace Xamarin.Forms.Core.UnitTests
 			}
 		}
 
+
+		[SetUp]
+		public void Setup()
+		{
+			VisualElement.SetDefaultVisual(VisualMarker.Default);
+		}
+
 		[Test]
 		public void TestConstructor ()
 		{

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -183,7 +183,9 @@ namespace Xamarin.Forms.Internals
 				// Only go through this process if we have not registered something for this type;
 				// we don't want RenderWith renderers to override ExportRenderers that are already registered.
 				// Plus, there's no need to do this again if we already have a renderer registered.
-				if (!_handlers.TryGetValue(viewType, out Dictionary<Type, Type> visualRenderers) || !visualRenderers.ContainsKey(visualType))
+				if (!_handlers.TryGetValue(viewType, out Dictionary<Type, Type> visualRenderers) || 
+					!(visualRenderers.ContainsKey(visualType) ||
+					  visualRenderers.ContainsKey(_defaultVisualType)))
 				{
 					// get RenderWith attribute for just this type, do not inherit attributes from base types
 					var attribute = viewType.GetTypeInfo().GetCustomAttributes<RenderWithAttribute>(false).FirstOrDefault();

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Forms
 			_defaultVisual = visual;
 		}
 
-		static IVisual _defaultVisual = Xamarin.Forms.VisualMarker.Default;
+		static IVisual _defaultVisual = Xamarin.Forms.VisualMarker.Material;
 		IVisual _effectiveVisual = _defaultVisual;
 		IVisual IVisualController.EffectiveVisual
 		{

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms
 			set { SetValue(VisualProperty, value); }
 		}
 
-		IVisual _effectiveVisual = Xamarin.Forms.VisualMarker.Default;
+		IVisual _effectiveVisual = Xamarin.Forms.VisualMarker.Material;
 		IVisual IVisualController.EffectiveVisual
 		{
 			get { return _effectiveVisual; }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -61,6 +61,9 @@ namespace Xamarin.Forms
 			BindableProperty.Create(nameof(Visual), typeof(IVisual), typeof(VisualElement), Forms.VisualMarker.MatchParent,
 									validateValue: (b, v) => v != null, propertyChanged: OnVisualChanged);
 
+		static IVisual _defaultVisual = Xamarin.Forms.VisualMarker.Default;
+		IVisual _effectiveVisual = _defaultVisual;
+
 		public IVisual Visual
 		{
 			get { return (IVisual)GetValue(VisualProperty); }
@@ -72,8 +75,6 @@ namespace Xamarin.Forms
 			_defaultVisual = visual;
 		}
 
-		static IVisual _defaultVisual = Xamarin.Forms.VisualMarker.Material;
-		IVisual _effectiveVisual = _defaultVisual;
 		IVisual IVisualController.EffectiveVisual
 		{
 			get { return _effectiveVisual; }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -67,7 +67,13 @@ namespace Xamarin.Forms
 			set { SetValue(VisualProperty, value); }
 		}
 
-		IVisual _effectiveVisual = Xamarin.Forms.VisualMarker.Material;
+		internal static void SetDefaultVisual(IVisual visual)
+		{
+			_defaultVisual = visual;
+		}
+
+		static IVisual _defaultVisual = Xamarin.Forms.VisualMarker.Default;
+		IVisual _effectiveVisual = _defaultVisual;
 		IVisual IVisualController.EffectiveVisual
 		{
 			get { return _effectiveVisual; }

--- a/Xamarin.Forms.Material.Android/MaterialDatePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialDatePickerRenderer.cs
@@ -5,6 +5,7 @@ using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
+using AView = Android.Views.View;
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.DatePicker), typeof(MaterialDatePickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
@@ -19,6 +20,7 @@ namespace Xamarin.Forms.Material.Android
 		{
 		}
 
+		protected override AView ControlUsedForAutomation => EditText;
 		protected override EditText EditText => _textInputEditText;
 
 		protected override MaterialPickerTextInputLayout CreateNativeControl()

--- a/Xamarin.Forms.Material.Android/MaterialDatePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialDatePickerRenderer.cs
@@ -37,6 +37,7 @@ namespace Xamarin.Forms.Material.Android
 		{
 			base.OnElementChanged(e);
 			_textInputLayout.SetHint(string.Empty, Element);
+			UpdateBackgroundColor();
 		}
 
 		protected override void UpdateBackgroundColor()

--- a/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
@@ -6,6 +6,7 @@ using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
+using AView = Android.Views.View;
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Editor), typeof(MaterialEditorRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 namespace Xamarin.Forms.Material.Android
@@ -58,7 +59,7 @@ namespace Xamarin.Forms.Material.Android
 		protected virtual void ApplyTheme() => _textInputLayout?.ApplyTheme(Element.TextColor, Element.PlaceholderColor);
 		protected override void UpdateTextColor() => ApplyTheme();
 		protected override EditText EditText => _textInputEditText;
-
+		protected override AView ControlUsedForAutomation => EditText; 
 		protected override void UpdateFont()
 		{
 			if (_disposed || _textInputLayout == null)

--- a/Xamarin.Forms.Material.Android/MaterialEntryRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEntryRenderer.cs
@@ -6,6 +6,7 @@ using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
+using AView = Android.Views.View;
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Entry), typeof(MaterialEntryRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 namespace Xamarin.Forms.Material.Android
@@ -19,6 +20,8 @@ namespace Xamarin.Forms.Material.Android
 			base(MaterialContextThemeWrapper.Create(context))
 		{
 		}
+
+		protected override AView ControlUsedForAutomation => EditText;
 
 		protected override MaterialFormsTextInputLayout CreateNativeControl()
 		{

--- a/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
@@ -8,6 +8,8 @@ using Android.Support.V4.View;
 using Android.Content.Res;
 using AView = Android.Views.View;
 using Xamarin.Forms.Platform.Android.AppCompat;
+using Xamarin.Forms.Platform.Android;
+using Android.Widget;
 
 namespace Xamarin.Forms.Material.Android
 {
@@ -98,6 +100,9 @@ namespace Xamarin.Forms.Material.Android
 		 * */
 		void OnFocusChange(object sender, FocusChangeEventArgs e)
 		{
+			if (EditText == null)
+				return;
+
 			Device.BeginInvokeOnMainThread(() => ApplyTheme());
 
 			// propagate the focus changed event to the View Renderer base class
@@ -121,12 +126,23 @@ namespace Xamarin.Forms.Material.Android
 			}
 		}
 
+		public override EditText EditText
+		{
+			get
+			{
+				if (this.IsDisposed())
+					return null;
+
+				return base.EditText;
+			}
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (!_isDisposed)
 			{
 				_isDisposed = true;
-				if (EditText != null)
+				if (EditText != null && !EditText.IsDisposed())
 					EditText.FocusChange -= OnFocusChange;
 			}
 

--- a/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
@@ -142,7 +142,7 @@ namespace Xamarin.Forms.Material.Android
 			if (!_isDisposed)
 			{
 				_isDisposed = true;
-				if (EditText != null &&)
+				if (EditText != null)
 					EditText.FocusChange -= OnFocusChange;
 			}
 

--- a/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
@@ -142,7 +142,7 @@ namespace Xamarin.Forms.Material.Android
 			if (!_isDisposed)
 			{
 				_isDisposed = true;
-				if (EditText != null && !EditText.IsDisposed())
+				if (EditText != null &&)
 					EditText.FocusChange -= OnFocusChange;
 			}
 

--- a/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
@@ -5,6 +5,7 @@ using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
+using AView = Android.Views.View;
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Picker), typeof(MaterialPickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
@@ -20,6 +21,7 @@ namespace Xamarin.Forms.Material.Android
 		}
 
 		protected override EditText EditText => _textInputEditText;
+		protected override AView ControlUsedForAutomation => EditText;
 
 		protected override MaterialPickerTextInputLayout CreateNativeControl()
 		{

--- a/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
@@ -33,6 +33,12 @@ namespace Xamarin.Forms.Material.Android
 			return _textInputLayout;
 		}
 
+		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
+		{
+			base.OnElementChanged(e);
+			UpdateBackgroundColor();
+		}
+
 		protected override void UpdateBackgroundColor()
 		{
 			if (_textInputLayout == null)

--- a/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Material.Android
 		MotionEventHelper _motionEventHelper;
 		double _max = 0.0;
 		double _min = 0.0;
+		private bool _inputTransparent;
 
 		public MaterialSliderRenderer(Context context)
 			: base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialSlider), null, Resource.Style.XamarinFormsMaterialSlider)
@@ -45,6 +46,9 @@ namespace Xamarin.Forms.Material.Android
 
 		public override bool OnTouchEvent(MotionEvent e)
 		{
+			if (!Enabled || (_inputTransparent && Enabled))
+				return false;
+
 			if (_visualElementRenderer.OnTouchEvent(e) || base.OnTouchEvent(e))
 				return true;
 
@@ -119,6 +123,7 @@ namespace Xamarin.Forms.Material.Android
 
 				UpdateValue();
 				UpdateColors();
+				UpdateInputTransparent();
 
 				ElevationHelper.SetElevation(this, e.NewElement);
 			}
@@ -132,6 +137,17 @@ namespace Xamarin.Forms.Material.Android
 				UpdateValue();
 			else if (e.IsOneOf(VisualElement.BackgroundColorProperty, Slider.MaximumTrackColorProperty, Slider.MinimumTrackColorProperty, Slider.ThumbColorProperty))
 				UpdateColors();
+			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
+				UpdateInputTransparent();
+		}
+
+
+		void UpdateInputTransparent()
+		{
+			if (Element == null)
+				return;
+
+			_inputTransparent = Element.InputTransparent;
 		}
 
 		void UpdateColors()
@@ -202,6 +218,8 @@ namespace Xamarin.Forms.Material.Android
 
 		// ITabStop
 		AView ITabStop.TabStop => this;
+
+
 	}
 }
 #endif

--- a/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Material.Android
 		MotionEventHelper _motionEventHelper;
 		double _max = 0.0;
 		double _min = 0.0;
-		private bool _inputTransparent;
+		bool _inputTransparent;
 
 		public MaterialSliderRenderer(Context context)
 			: base(new ContextThemeWrapper(context, Resource.Style.XamarinFormsMaterialSlider), null, Resource.Style.XamarinFormsMaterialSlider)

--- a/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialSliderRenderer.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Material.Android
 
 		public override bool OnTouchEvent(MotionEvent e)
 		{
-			if (!Enabled || (_inputTransparent && Enabled))
+			if (!Enabled || _inputTransparent)
 				return false;
 
 			if (_visualElementRenderer.OnTouchEvent(e) || base.OnTouchEvent(e))

--- a/Xamarin.Forms.Material.Android/MaterialStepperRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialStepperRenderer.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Material.Android
 
 		MButton _downButton;
 		MButton _upButton;
+		private bool _inputTransparent;
 
 		public MaterialStepperRenderer(Context context) : base(context)
 		{
@@ -61,6 +62,7 @@ namespace Xamarin.Forms.Material.Android
 			}
 
 			StepperRendererManager.UpdateButtons(this, _downButton, _upButton);
+			UpdateInputTransparent();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -68,6 +70,25 @@ namespace Xamarin.Forms.Material.Android
 			base.OnElementPropertyChanged(sender, e);
 
 			StepperRendererManager.UpdateButtons(this, _downButton, _upButton, e);
+
+			if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
+				UpdateInputTransparent();
+		}
+
+		void UpdateInputTransparent()
+		{
+			if (Element == null)
+				return;
+
+			_inputTransparent = Element.InputTransparent;
+		}
+
+		public override bool OnTouchEvent(MotionEvent e)
+		{
+			if (!Enabled || (_inputTransparent && Enabled))
+				return false;
+
+			return base.OnTouchEvent(e);
 		}
 
 		protected override void UpdateBackgroundColor()

--- a/Xamarin.Forms.Material.Android/MaterialStepperRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialStepperRenderer.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Forms.Material.Android
 
 		public override bool OnTouchEvent(MotionEvent e)
 		{
-			if (!Enabled || (_inputTransparent && Enabled))
+			if (!Enabled || _inputTransparent)
 				return false;
 
 			return base.OnTouchEvent(e);

--- a/Xamarin.Forms.Material.Android/MaterialStepperRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialStepperRenderer.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Material.Android
 
 		MButton _downButton;
 		MButton _upButton;
-		private bool _inputTransparent;
+		bool _inputTransparent;
 
 		public MaterialStepperRenderer(Context context) : base(context)
 		{

--- a/Xamarin.Forms.Material.Android/MaterialTimePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialTimePickerRenderer.cs
@@ -5,6 +5,7 @@ using Android.Widget;
 using Xamarin.Forms;
 using Xamarin.Forms.Material.Android;
 using Xamarin.Forms.Platform.Android;
+using AView = Android.Views.View;
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.TimePicker), typeof(MaterialTimePickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) })]
 
@@ -20,6 +21,7 @@ namespace Xamarin.Forms.Material.Android
 		}
 
 		protected override EditText EditText => _textInputEditText;
+		protected override AView ControlUsedForAutomation => EditText;
 
 		protected override MaterialPickerTextInputLayout CreateNativeControl()
 		{

--- a/Xamarin.Forms.Material.Android/MaterialTimePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialTimePickerRenderer.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Material.Android
 		{
 			base.OnElementChanged(e);
 			_textInputLayout.SetHint(string.Empty, Element);
+			UpdateBackgroundColor();
 		}
 
 		protected override void UpdateBackgroundColor()

--- a/Xamarin.Forms.Platform.Android.AppLinks/AndroidAppLinks.cs
+++ b/Xamarin.Forms.Platform.Android.AppLinks/AndroidAppLinks.cs
@@ -76,9 +76,9 @@ namespace Xamarin.Forms.Platform.Android.AppLinks
 			FirebaseAppIndex.Instance.Update(indexable);
 			GMSTask gmsTask = FirebaseUserActions.Instance
 												 .Start(indexAction)
-												 .AddOnSuccessListener(Context as Activity,
+												 .AddOnSuccessListener(Context.GetActivity(),
 																	   new AndroidActionSuccessListener(appLink as AppLinkEntry, indexAction))
-												 .AddOnFailureListener(Context as Activity,
+												 .AddOnFailureListener(Context.GetActivity(),
 																	   new AndroidActionFailureListener(appLink as AppLinkEntry, indexAction));
 		}
 

--- a/Xamarin.Forms.Platform.Android.AppLinks/ContextExtensions.cs
+++ b/Xamarin.Forms.Platform.Android.AppLinks/ContextExtensions.cs
@@ -1,0 +1,22 @@
+using Android.Content;
+using AActivity = Android.App.Activity;
+
+namespace Xamarin.Forms.Platform.Android.AppLinks
+{
+	internal static class ContextExtensions
+	{
+		public static AActivity GetActivity(this Context context)
+		{
+			if (context == null)
+				return null;
+
+			if (context is AActivity activity)
+				return activity;
+
+			if (context is ContextWrapper contextWrapper)
+				return contextWrapper.BaseContext.GetActivity();
+
+			return null;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -46,6 +46,7 @@
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContextExtensions.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AndroidAppLinks.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -469,7 +469,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (actionBarHeight <= 0)
 				return Device.Info.CurrentOrientation.IsPortrait() ? (int)Context.ToPixels(56) : (int)Context.ToPixels(48);
 
-			if (((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentStatus) || ((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentNavigation))
+			if (Context.GetActivity().Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentStatus) || Context.GetActivity().Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentNavigation))
 			{
 				if (_toolbar.PaddingTop == 0)
 					_toolbar.SetPadding(0, GetStatusBarHeight(), 0, 0);
@@ -642,7 +642,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			FastRenderers.AutomationPropertiesProvider.GetDrawerAccessibilityResources(context, _masterDetailPage, out int resourceIdOpen, out int resourceIdClose);
 
-			_drawerToggle = new ActionBarDrawerToggle((Activity)context, _drawerLayout, bar,
+			_drawerToggle = new ActionBarDrawerToggle(context.GetActivity(), _drawerLayout, bar,
 													  resourceIdOpen == 0 ? global::Android.Resource.String.Ok : resourceIdOpen,
 													  resourceIdClose == 0 ? global::Android.Resource.String.Ok : resourceIdClose)
 			{

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -244,7 +244,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				var appCompatActivity = view.Context as AppCompatActivity;
 				if (appCompatActivity == null)
-					_actionMode = ((Activity)view.Context).StartActionMode(this);
+					_actionMode = view.Context.GetActivity().StartActionMode(this);
 				else
 					_supportActionMode = appCompatActivity.StartSupportActionMode(this);
 			}

--- a/Xamarin.Forms.Platform.Android/Cells/EntryCellEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/EntryCellEditText.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnFocusChanged(bool gainFocus, FocusSearchDirection direction, Rect previouslyFocusedRect)
 		{
-			Window window = ((Activity)Context).Window;
+			Window window = Context.GetActivity().Window;
 			if (gainFocus)
 			{
 				_startingMode = window.Attributes.SoftInputMode;

--- a/Xamarin.Forms.Platform.Android/ContextExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ContextExtensions.cs
@@ -4,6 +4,7 @@ using Android.Content;
 using Android.Util;
 using Android.Views.InputMethods;
 using AApplicationInfoFlags = Android.Content.PM.ApplicationInfoFlags;
+using AActivity = Android.App.Activity;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -80,6 +81,20 @@ namespace Xamarin.Forms.Platform.Android
 
 			using (DisplayMetrics metrics = context.Resources.DisplayMetrics)
 				s_displayDensity = metrics.Density;
+		}
+
+		public static AActivity GetActivity(this Context context)
+		{
+			if (context == null)
+				return null;
+
+			if (context is AActivity activity)
+				return activity;
+
+			if (context is ContextWrapper contextWrapper)
+				return contextWrapper.BaseContext.GetActivity();
+
+			return null;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -88,18 +88,18 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetTitleBarVisibility(AndroidTitleBarVisibility visibility)
 		{
-			if ((Activity)Context == null)
+			if (Context.GetActivity() == null)
 				throw new NullReferenceException("Must be called after Xamarin.Forms.Forms.Init() method");
 
 			if (visibility == AndroidTitleBarVisibility.Never)
 			{
-				if (!((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen))
-					((Activity)Context).Window.AddFlags(WindowManagerFlags.Fullscreen);
+				if (!Context.GetActivity().Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen))
+					Context.GetActivity().Window.AddFlags(WindowManagerFlags.Fullscreen);
 			}
 			else
 			{
-				if (((Activity)Context).Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen))
-					((Activity)Context).Window.ClearFlags(WindowManagerFlags.Fullscreen);
+				if (Context.GetActivity().Window.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen))
+					Context.GetActivity().Window.ClearFlags(WindowManagerFlags.Fullscreen);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.Android
 			_embedded = embedded;
 			_context = context ?? throw new ArgumentNullException(nameof(context), "Somehow we're getting a null context passed in");
 			PackageName = context.PackageName;
-			_activity = context as Activity;
+			_activity = context.GetActivity();
 
 			if (!embedded)
 			{

--- a/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (e.Action != MotionEventActions.Up)
 				return base.DispatchTouchEvent(e);
 
-			global::Android.Views.View currentView = ((Activity)Context).CurrentFocus;
+			global::Android.Views.View currentView = Context.GetActivity().CurrentFocus;
 			bool result = base.DispatchTouchEvent(e);
 
 			do
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (!(currentView is EditText))
 					break;
 
-				global::Android.Views.View newCurrentView = ((Activity)Context).CurrentFocus;
+				global::Android.Views.View newCurrentView = Context.GetActivity().CurrentFocus;
 
 				if (currentView != newCurrentView)
 					break;
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Platform.Android
 					break;
 
 				Context.HideKeyboard(currentView);
-				((Activity)Context).Window.DecorView.ClearFocus();
+				Context.GetActivity().Window.DecorView.ClearFocus();
 			} while (false);
 
 			return result;

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			AddView(_masterLayout);
 
-			var activity = Context as Activity;
+			var activity = Context.GetActivity();
 			activity?.ActionBar?.SetDisplayShowHomeEnabled(true);
 			activity?.ActionBar?.SetHomeButtonEnabled(true);
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -249,7 +249,7 @@ namespace Xamarin.Forms.Platform.Android
 				var activity = (FormsAppCompatActivity)context;
 				if (_drawerToggle == null)
 				{
-					_drawerToggle = new ActionBarDrawerToggle((Activity)context, drawerLayout, toolbar,
+					_drawerToggle = new ActionBarDrawerToggle(context.GetActivity(), drawerLayout, toolbar,
 						R.String.Ok, R.String.Ok)
 					{
 						ToolbarNavigationClickListener = this,

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -57,6 +57,7 @@ namespace Xamarin.Forms.Platform.Android
 		SoftInput _startingInputMode;
 
 		public TNativeView Control { get; private set; }
+		protected virtual AView ControlUsedForAutomation => Control;
 
 		AView ITabStop.TabStop => Control;
 
@@ -224,7 +225,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			ContentDescription = id + "_Container";
-			AutomationPropertiesProvider.SetAutomationId(Control, Element, id);
+			AutomationPropertiesProvider.SetAutomationId(ControlUsedForAutomation, Element, id);
 		}
 
 		protected override void SetContentDescription()
@@ -236,7 +237,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			AutomationPropertiesProvider.SetContentDescription(
-				Control, Element, ref _defaultContentDescription, ref _defaultHint);
+				ControlUsedForAutomation, Element, ref _defaultContentDescription, ref _defaultHint);
 		}
 
 		protected override void SetFocusable()
@@ -247,7 +248,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			AutomationPropertiesProvider.SetFocusable(Control, Element, ref _defaultFocusable);
+			AutomationPropertiesProvider.SetFocusable(ControlUsedForAutomation, Element, ref _defaultFocusable);
 		}
 
 		protected void SetNativeControl(TNativeView control)

--- a/Xamarin.Forms.Platform.Android/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/ViewRenderer.cs
@@ -108,7 +108,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (isInViewCell)
 				{
-					Window window = ((Activity)Context).Window;
+					Window window = Context.GetActivity().Window;
 					if (hasFocus)
 					{
 						_startingInputMode = window.Attributes.SoftInputMode;

--- a/Xamarin.Forms.Sandbox/App.StartHere.cs
+++ b/Xamarin.Forms.Sandbox/App.StartHere.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Xamarin.Forms.Sandbox
 {
-	public partial class App 
+	public partial class App
 	{
 		// This code is called from the App Constructor so just initialize the main page of the application here
 		void InitializeMainPage()

--- a/Xamarin.Forms.Sandbox/MainPage.xaml
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml
@@ -6,17 +6,7 @@
              ios:Page.UseSafeArea="true">
     <ContentPage.Content>
         <StackLayout>
-            <ListView x:Name="tests">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <ViewCell>
-                            <StackLayout>
-                                <Entry></Entry>
-                            </StackLayout>
-                        </ViewCell>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView> 
+            <Button Text="I am a Button"  />
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Sandbox/MainPage.xaml
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml
@@ -6,7 +6,17 @@
              ios:Page.UseSafeArea="true">
     <ContentPage.Content>
         <StackLayout>
-            <Button Text="I am a Button"  />
+            <ListView x:Name="tests">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <ViewCell>
+                            <StackLayout>
+                                <Entry></Entry>
+                            </StackLayout>
+                        </ViewCell>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView> 
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Sandbox/MainPage.xaml.cs
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Sandbox
 		public MainPage()
 		{
 			InitializeComponent();
-			tests.ItemsSource = new[] { 1,2,3,4,5};
 		}
 	}
 }

--- a/Xamarin.Forms.Sandbox/MainPage.xaml.cs
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Sandbox
 		public MainPage()
 		{
 			InitializeComponent();
+			tests.ItemsSource = new[] { 1,2,3,4,5};
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
This PR contains a collection of fixes that make the material renderers run with all the UI Tests. 

- Material themes wrap the Context object with a Context Wrapper. This causes code that assumes Context is an Activity to not work. This PR moves that code to an extension method and ascends the wrapper until it finds the activity
-  tweak the stepper and picker tests to be compatible with material versions of the controls. 
- fix registrar to properly fall back to app compat tabbed renderer
- fixed all the controls based on Entry to set the Automation Id on the internal Edit Text control instead of the surrounding layout (picker, timepicker, editor, entry, datepicker)
- fixed disposed access error in the dispose of TextInputLayout. If the internal EditText was already disposed by the GC then just don't access it
- fixed material slider and stepper to work with Input Transparent


### Issues Resolved ### 
- fixes #5699
- fixes #5641

### API Changes ###


Added:
// overriding this allows you to specify a different control to associate the Automation Id features with
 - Android.ViewRenderer.ControlUsedForAutomation

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

None


### Testing Procedure ###
- At some point soon we'll get the material renderers running through the CI so a lot of this is already tested automatically by the UI tests

Here are the specifics of what was fixed
- Put a material entry inside a Listview and then click on it. App should not crash
- set input transparent on a material slider and stepper and then you should be able to click through it (you can run the input transparent ui test to verify)
- Run Automation ID UI tests

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
