### PR TITLE
[UWP] Fixes crash ImageButton with FontImageSource

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/FontImageSourceGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/FontImageSourceGallery.cs
@@ -31,7 +31,17 @@ namespace Xamarin.Forms.Controls
 					break;
 			}
 
-			var i = 0;
+			grid.Children.Add(new ImageButton
+			{
+				Source = new FontImageSource
+				{
+					Glyph = Ionicons[Ionicons.Length - 1].ToString(),
+					FontFamily = fontFamily,
+					Size = 20
+				},
+			});
+
+			var i = 1;
 			foreach (char c in Ionicons)
 			{
 				grid.Children.Add(new Image

--- a/Xamarin.Forms.Platform.UAP/Extensions/ImageExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/Extensions/ImageExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.Graphics.Canvas.UI.Xaml;
+using Windows.UI.Xaml.Media.Imaging;
+using WinImageSource = Windows.UI.Xaml.Media.ImageSource;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	internal static class ImageExtensions
+	{
+		public static SizeRequest GetDesiredSize(this WinImageSource source)
+		{
+			if (source is BitmapSource bitmap)
+			{
+				return new SizeRequest(
+					new Size
+					{
+						Width = bitmap.PixelWidth,
+						Height = bitmap.PixelHeight
+					});
+			}
+			else if (source is CanvasImageSource canvas)
+			{
+				return new SizeRequest(
+					new Size
+					{
+						Width = canvas.SizeInPixels.Width,
+						Height = canvas.SizeInPixels.Height
+					});
+			}
+			else
+			{
+				throw new InvalidCastException($"\"{source.GetType().FullName}\" is not supported.");
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
@@ -54,14 +54,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_measured = true;
 
-
-			var result = new Size
-			{
-				Width = ((BitmapSource)_image.Source).PixelWidth,
-				Height = ((BitmapSource)_image.Source).PixelHeight
-			};
-
-			return new SizeRequest(result);
+			return _image.Source.GetDesiredSize();
 		}
 
 

--- a/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
@@ -29,28 +29,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			_measured = true;
 
-			if (Control.Source is BitmapSource bitmap)
-			{
-				return new SizeRequest(
-					new Size
-					{
-						Width = bitmap.PixelWidth,
-						Height = bitmap.PixelHeight
-					});
-			}
-			else if (Control.Source is CanvasImageSource canvas)
-			{
-				return new SizeRequest(
-					new Size
-					{
-						Width = canvas.SizeInPixels.Width,
-						Height = canvas.SizeInPixels.Height
-					});
-			}
-			else
-			{
-				throw new InvalidCastException($"\"{Control.Source.GetType().FullName}\" is not supported.");
-			}
+			return Control.Source.GetDesiredSize();
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AccessibilityExtensions.cs" />
+    <Compile Include="Extensions\ImageExtensions.cs" />
     <Compile Include="IImageVisualElementRenderer.cs" />
     <Compile Include="ImageButtonRenderer.cs" />
     <Compile Include="CollectionViewRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###

ImageButton was not designed to work with FontImageSource

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5666

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Testing Procedure ###

- run Font ImageSorce Gallery

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
