### PR TITLE
[iOS] Don't crash if no Thumbnail specified for AppLink

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5470.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5470.cs
@@ -1,0 +1,64 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.AppLinks)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5470, "ApplinkEntry Thumbnail required after upgrading to 3.5/3.6", PlatformAffected.iOS)]
+	public class Issue5470 : TestContentPage 
+	{
+		protected override void Init()
+		{
+			Application.Current.AppLinks.RegisterLink(GetEntry());
+
+			// Initialize ui here instead of ctor
+			Content = new Label
+			{
+				AutomationId = "IssuePageLabel",
+				Text = "I just tried to register an applink without a Thumbnail. If this did not crash, this test has succeeded."
+			};
+		}
+
+		AppLinkEntry GetEntry()
+		{
+			if (string.IsNullOrEmpty(Title))
+				Title = "ApplinkEntry Thumbnail required after upgrading to 3.5/3.6";
+
+			var type = GetType().ToString();
+			var entry = new AppLinkEntry
+			{
+				Title = Title,
+				Description = $"ApplinkEntry Thumbnail required after upgrading to 3.5/3.6",
+				AppLinkUri = new Uri($"http://blah/gallery/{type}", UriKind.RelativeOrAbsolute),
+				IsLinkActive = true,
+				Thumbnail = null
+			};
+
+			entry.KeyValues.Add("contentType", "GalleryPage");
+			entry.KeyValues.Add("appName", "blah");
+			entry.KeyValues.Add("companyName", "Xamarin");
+
+			return entry;
+		}
+
+#if UITEST
+		[Test]
+		public async void Issue5470Test() 
+		{
+			await Task.Delay(500); // give it time to crash
+			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5470.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5470.cs
@@ -20,13 +20,15 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			Application.Current.AppLinks.RegisterLink(GetEntry());
+			// android needs firebase for this to work, so skip it unless iOS
+			if (Device.RuntimePlatform == Device.iOS)
+				Application.Current.AppLinks.RegisterLink(GetEntry());
 
 			// Initialize ui here instead of ctor
 			Content = new Label
 			{
 				AutomationId = "IssuePageLabel",
-				Text = "I just tried to register an applink without a Thumbnail. If this did not crash, this test has succeeded."
+				Text = "If this is iOS, I just tried to register an applink without a Thumbnail. If this did not crash, this test has succeeded."
 			};
 		}
 
@@ -52,7 +54,7 @@ namespace Xamarin.Forms.Controls.Issues
 			return entry;
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		public async void Issue5470Test() 
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -566,6 +566,7 @@
       <SubType>Code</SubType>
       <DependentUpon>%(Filename)</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5470.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />
@@ -1007,7 +1008,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)VisualControlsPage.xaml">
       <SubType>Designer</SubType>
-       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4356.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -46,5 +46,6 @@
 		public const string ManualReview = "ManualReview";
 		public const string Performance = "Performance";
 		public const string Visual = "Visual";
+		public const string AppLinks = "AppLinks";
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
+++ b/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
@@ -108,6 +108,7 @@ namespace Xamarin.Forms.Platform.iOS
 			};
 
 			if (deepLinkUri.Thumbnail != null)
+			{
 				using (var uiimage = await deepLinkUri.Thumbnail.GetNativeImageAsync())
 				{
 					if (uiimage == null)
@@ -115,6 +116,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					searchableAttributeSet.ThumbnailData = uiimage.AsPNG();
 				}
+			}
 
 			return searchableAttributeSet;
 		}

--- a/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
+++ b/Xamarin.Forms.Platform.iOS/iOSAppLinks.cs
@@ -107,13 +107,14 @@ namespace Xamarin.Forms.Platform.iOS
 				Url = new NSUrl(deepLinkUri.AppLinkUri.ToString())
 			};
 
-			using (var uiimage = await deepLinkUri.Thumbnail.GetNativeImageAsync())
-			{
-				if (uiimage == null)
-					throw new InvalidOperationException("AppLinkEntry Thumbnail must be set to a valid source");
+			if (deepLinkUri.Thumbnail != null)
+				using (var uiimage = await deepLinkUri.Thumbnail.GetNativeImageAsync())
+				{
+					if (uiimage == null)
+						throw new InvalidOperationException("AppLinkEntry Thumbnail must be set to a valid source");
 
-				searchableAttributeSet.ThumbnailData = uiimage.AsPNG();
-			}
+					searchableAttributeSet.ThumbnailData = uiimage.AsPNG();
+				}
 
 			return searchableAttributeSet;
 		}


### PR DESCRIPTION
### Description of Change ###

#4733 unified the image loading code but failed to preserve the check to see if an AppLink.Thumbnail was actually specified before throwing an exception. This restores that check.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5470 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

- Run Issue5470 in Control Gallery. If it doesn't crash, this works!
- Also run AppLinksGallery to make sure that an app link with a thumbnail still works.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
