### PR TITLE
Templated view GetTemplateChild(string)

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void TemplatedView_should_have_Templated_Root_set()
+		public void ShouldHaveTemplatedRootSet()
 		{
 			var tv = new TemplatedView();
 			var ct = (IControlTemplated)tv;
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void TemplatedView_GetTemplateChild_should_work()
+		public void GetTemplateChildShouldWork()
 		{
 			var xaml = @"<ContentView
 					xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -53,12 +53,12 @@ namespace Xamarin.Forms.Core.UnitTests
 			contentView.LoadFromXaml(xaml);
 
 			IList<Element> internalChildren = contentView.InternalChildren;
-			BindableObject tc = contentView.GetTemplateChild("label0");
+			var tc = (BindableObject)contentView.GetTemplateChild("label0");
 			Assert.AreEqual(tc, internalChildren[0]);
 		}
 
 		[Test]
-		public void TemplatedView_OnApplyTemplate_should_be_called()
+		public void OnApplyTemplateShouldBeCalled()
 		{
 			var xaml = @"<ContentView
 					xmlns=""http://xamarin.com/schemas/2014/forms""

--- a/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TemplatedViewUnitTests.cs
@@ -1,32 +1,87 @@
 ﻿using System.Collections.Generic;
 using NUnit.Framework;
+using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
-    [TestFixture]
-	public class TemplatedViewUnitTests : BaseTestFixture 
+	[TestFixture]
+	public class TemplatedViewUnitTests : BaseTestFixture
 	{
-        [Test]
-        public void TemplatedView_should_have_the_InternalChildren_correctly_when_ControlTemplate_changed()
-        {
-            var sut = new TemplatedView();
-            IList<Element> internalChildren = ((IControlTemplated)sut).InternalChildren;
-            internalChildren.Add(new VisualElement());
-            internalChildren.Add(new VisualElement());
-            internalChildren.Add(new VisualElement());
+		[Test]
+		public void TemplatedView_should_have_the_InternalChildren_correctly_when_ControlTemplate_changed()
+		{
+			var sut = new TemplatedView();
+			IList<Element> internalChildren = ((IControlTemplated)sut).InternalChildren;
+			internalChildren.Add(new VisualElement());
+			internalChildren.Add(new VisualElement());
+			internalChildren.Add(new VisualElement());
 
-            sut.ControlTemplate = new ControlTemplate(typeof(ExpectedView));
+			sut.ControlTemplate = new ControlTemplate(typeof(ExpectedView));
 
-            Assert.AreEqual(1, internalChildren.Count);
-            Assert.IsInstanceOf<ExpectedView>(internalChildren[0]);
-        }
+			Assert.AreEqual(1, internalChildren.Count);
+			Assert.IsInstanceOf<ExpectedView>(internalChildren[0]);
+		}
 
-        private class ExpectedView : View
-        {
-            public ExpectedView()
-            {
-            }
-        }
+		[Test]
+		public void TemplatedView_should_have_Templated_Root_set()
+		{
+			var tv = new TemplatedView();
+			var ct = (IControlTemplated)tv;
+			Assert.AreEqual(ct.TemplateRoot, null);
+
+			tv.ControlTemplate = new ControlTemplate(typeof(ExpectedView));
+
+			IList<Element> internalChildren = ct.InternalChildren;
+			Assert.AreEqual(ct.TemplateRoot, internalChildren[0]);
+		}
+
+		[Test]
+		public void TemplatedView_GetTemplateChild_should_work()
+		{
+			var xaml = @"<ContentView
+					xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					x:Class=""Xamarin.Forms.Core.UnitTests.MyTestContentView"">
+                       <ContentView.ControlTemplate>
+                         <ControlTemplate>
+                           <Label x:Name=""label0""/>
+                         </ControlTemplate>
+						</ContentView.ControlTemplate>
+					</ContentView>";
+
+			var contentView = new MyTestContentView();
+			contentView.LoadFromXaml(xaml);
+
+			IList<Element> internalChildren = contentView.InternalChildren;
+			BindableObject tc = contentView.GetTemplateChild("label0");
+			Assert.AreEqual(tc, internalChildren[0]);
+		}
+
+		[Test]
+		public void TemplatedView_OnApplyTemplate_should_be_called()
+		{
+			var xaml = @"<ContentView
+					xmlns=""http://xamarin.com/schemas/2014/forms""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					x:Class=""Xamarin.Forms.Core.UnitTests.MyTestContentView"">
+                       <ContentView.ControlTemplate>
+                         <ControlTemplate>
+                           <Label x:Name=""label0""/>
+                         </ControlTemplate>
+						</ContentView.ControlTemplate>
+					</ContentView>";
+
+			var contentView = new MyTestContentView();
+			contentView.LoadFromXaml(xaml);
+			Assert.IsTrue(contentView.WasOnApplyTemplateCalled);
+		}
+
+		private class ExpectedView : View
+		{
+			public ExpectedView()
+			{
+			}
+		}
 
 		public class MyTemplate : StackLayout
 		{
@@ -43,7 +98,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			var template1 = new ControlTemplate(typeof(MyTemplate));
 			var label = new Label();
 			label.SetBinding(Label.TextProperty, ".");
-			var cv = new ContentView {
+			var cv = new ContentView
+			{
 				ControlTemplate = template0,
 				Content = label
 			};
@@ -52,6 +108,16 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assume.That(label.Text, Is.EqualTo("Foo"));
 			cv.ControlTemplate = template1;
 			Assert.That(label.Text, Is.EqualTo("Foo"));
+		}
+	}
+
+	class MyTestContentView : ContentView
+	{
+		public bool WasOnApplyTemplateCalled { get; private set; }
+
+		protected override void OnApplyTemplate()
+		{
+			WasOnApplyTemplateCalled = true;
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -219,6 +219,10 @@
       <Project>{67f9d3a8-f71e-4428-913f-c37ae82cdb24}</Project>
       <Name>Xamarin.Forms.Platform</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj">
+      <Project>{9db2f292-8034-4e06-89ad-98bbda4306b9}</Project>
+      <Name>Xamarin.Forms.Xaml</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Xamarin.Forms.Core/IControlTemplated.cs
+++ b/Xamarin.Forms.Core/IControlTemplated.cs
@@ -8,6 +8,10 @@ namespace Xamarin.Forms
 
 		IList<Element> InternalChildren { get; }
 
+		Element TemplateRoot { get; set; }
+
 		void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue);
+
+		void OnApplyTemplate();
 	}
 }

--- a/Xamarin.Forms.Core/TemplateUtilities.cs
+++ b/Xamarin.Forms.Core/TemplateUtilities.cs
@@ -130,12 +130,12 @@ namespace Xamarin.Forms
 			}
 		}
 
-		public static BindableObject GetTemplateChild(this IControlTemplated controlTemplated, string name)
+		public static object GetTemplateChild(this IControlTemplated controlTemplated, string name)
 		{
-			return (BindableObject)controlTemplated.TemplateRoot?.FindByName(name);
+			return controlTemplated.TemplateRoot?.FindByName(name);
 		}
 
-		internal static void OnChildRemoved(this IControlTemplated controlTemplated, Element removedChild)
+		internal static void OnChildRemoved(IControlTemplated controlTemplated, Element removedChild)
 		{
 			if (removedChild == controlTemplated.TemplateRoot)
 				controlTemplated.TemplateRoot = null;

--- a/Xamarin.Forms.Core/TemplateUtilities.cs
+++ b/Xamarin.Forms.Core/TemplateUtilities.cs
@@ -123,8 +123,22 @@ namespace Xamarin.Forms
 				}
 
 				self.InternalChildren.Add(content);
-				((IControlTemplated)bindable).OnControlTemplateChanged((ControlTemplate)oldValue, (ControlTemplate)newValue);
+				var controlTemplated = (IControlTemplated)bindable;
+				controlTemplated.OnControlTemplateChanged((ControlTemplate)oldValue, (ControlTemplate)newValue);
+				controlTemplated.TemplateRoot = content;
+				controlTemplated.OnApplyTemplate();
 			}
+		}
+
+		public static BindableObject GetTemplateChild(this IControlTemplated controlTemplated, string name)
+		{
+			return (BindableObject)controlTemplated.TemplateRoot?.FindByName(name);
+		}
+
+		internal static void OnChildRemoved(this IControlTemplated controlTemplated, Element removedChild)
+		{
+			if (removedChild == controlTemplated.TemplateRoot)
+				controlTemplated.TemplateRoot = null;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/TemplatedPage.cs
+++ b/Xamarin.Forms.Core/TemplatedPage.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Forms
 		protected override void OnChildRemoved(Element child)
 		{
 			base.OnChildRemoved(child);
-			((IControlTemplated)this).OnChildRemoved(child);
+			TemplateUtilities.OnChildRemoved(this, child);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/TemplatedPage.cs
+++ b/Xamarin.Forms.Core/TemplatedPage.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Forms
 
 		IList<Element> IControlTemplated.InternalChildren => InternalChildren;
 
+		Element IControlTemplated.TemplateRoot { get; set; }
+
 		internal override void ComputeConstraintForView(View view)
 		{
 			LayoutOptions vOptions = view.VerticalOptions;
@@ -43,6 +45,21 @@ namespace Xamarin.Forms
 
 		internal virtual void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
 		{
+		}
+
+		void IControlTemplated.OnApplyTemplate()
+		{
+			OnApplyTemplate();
+		}
+
+		protected virtual void OnApplyTemplate()
+		{
+		}
+
+		protected override void OnChildRemoved(Element child)
+		{
+			base.OnChildRemoved(child);
+			((IControlTemplated)this).OnChildRemoved(child);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/TemplatedView.cs
+++ b/Xamarin.Forms.Core/TemplatedView.cs
@@ -17,6 +17,8 @@ namespace Xamarin.Forms
 
 		IList<Element> IControlTemplated.InternalChildren => InternalChildren;
 
+		Element IControlTemplated.TemplateRoot { get; set; }
+
 		protected override void LayoutChildren(double x, double y, double width, double height)
 		{
 			for (var i = 0; i < LogicalChildrenInternal.Count; i++)
@@ -74,6 +76,21 @@ namespace Xamarin.Forms
 
 		internal virtual void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
 		{
+		}
+
+		void IControlTemplated.OnApplyTemplate()
+		{
+			OnApplyTemplate();
+		}
+
+		protected virtual void OnApplyTemplate()
+		{
+		}
+
+		protected override void OnChildRemoved(Element child)
+		{
+			base.OnChildRemoved(child);
+			((IControlTemplated)this).OnChildRemoved(child);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/TemplatedView.cs
+++ b/Xamarin.Forms.Core/TemplatedView.cs
@@ -90,7 +90,7 @@ namespace Xamarin.Forms
 		protected override void OnChildRemoved(Element child)
 		{
 			base.OnChildRemoved(child);
-			((IControlTemplated)this).OnChildRemoved(child);
+			TemplateUtilities.OnChildRemoved(this, child);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Adds a way for templated views (i.e. ContentView, ContentPage) to get template child by name.

When creating custom controls, especially more complex ones, there's the need to get an instance of an element in the template. This is because not everything can be done in the template XAML or it could be harder to achieve some UI logic in XAML than doing it in code:

```
<controls:MyCustomControl... >
    <controls:MyCustomControl.ControlTemplate>
         <ControlTemplate>
              <Label x:Name="myLabel"/>
         </ControlTemplate>
    <controls:MyCustomControl.ControlTemplate>
</controls:MyCustomControl>
```

```
class MyCustomControl : TemplatedView
{
      Label _myLabel;

       protected override OnApplyTemplate()
       {  
               _myLabel = GetTemplateChild("myLabel");
       }
}
```

This is a **very** simple example which only shows how the new OnApplyTemplate/GetTemplateChild mechanism works. In an actual app, you have different elements of the template which need to be updated (size, etc.) based on gestures, etc. Also, obviously, I usually have an implicit `Style` for the custom control with the `ControlTemplate`,  such that the control is reusable across the app.

As you can see above, part of this change is also adding a virtual `OnApplyTemplate()` which `ContentView`/`ContentPage` derived classes should use when calling `GetTemplateChild()`. The `GetTemplateChild()` should be called only **after** `OnApplyTemplate()` was called. 

Here's my reasoning for adding `OnApplyTemplate()`:

Currently, creating the control hierarchy from the `ControlTemplate` property is synchronous, it's done as soon as `ControlTemplate` is set. Which means OnApplyTemplate is not needed.
However, in the future, I wonder if this behavior could change. If you look to WPF/UWP, they follow this pattern. In WPF/UWP, the template visual tree is not created when you set `ControlTemplate` property, the tree is created asynchronously (I assume it's when the control actually start taking part of layout process).  See [this](https://docs.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.onapplytemplate?view=netframework-4.7.2) and [this](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.frameworkelement.onapplytemplate).

Even if currently XF doesn't look like it needs `OnApplyTemplate()` today, if tomorrow creating the visual tree when setting the ControlTemplate is not synchronous anymore, then all apps using `GetTemplateChild()` at that point will break.
But if you really think `OnApplyTemplate()` is really not necessary, I can remove it, and just keep `GetTemplateChild()`

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

fixes #1620 
fixes #5674
closes #5343

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - static BindableObject GetTemplateChild(this IControlTemplated controlTemplated, string name)
- protected virtual TemplatedView.OnApplyTemplate()
- protected virtual TemplatedPage.OnApplyTemplate()

 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Please check-out the unit tests I added.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
