### PR TITLE
[Shell] nested routing

### DIFF
--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Controls.XamStore
 
 			CurrentItem =  _storeItem;
 			Routing.RegisterRoute("demo", typeof(DemoShellPage));
-			Routing.RegisterRoute("demo/demo", typeof(DemoShellPage));
+			Routing.RegisterRoute("d", typeof(StoreShell));
 		}
 
 		//bool allow = false;

--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -224,7 +224,7 @@ namespace Xamarin.Forms.Controls.XamStore
 				Text = "Navigate to",
 				VerticalOptions = LayoutOptions.CenterAndExpand
 			}, 0, 16);
-			var navEntry = new Entry { Text = "demo/demo" };
+			var navEntry = new Entry { Text = "d/store/games" };
 			grid.Children.Add(navEntry, 1, 16);
 			grid.Children.Add(MakeButton("GO!",
 				async () => await Shell.CurrentShell.GoToAsync(navEntry.Text, true)),

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -18,7 +18,12 @@ namespace Xamarin.Forms
 			return ImplicitPrefix + source;
 		}
 
-		internal static bool CompareWithRegisteredRoutes(string compare) => s_routes.ContainsKey(compare);
+		internal static bool CompareWithRegisteredRoutes(string compare)
+		{
+			// check only first part of uri
+			var c = Regex.Match(compare, @"(\/?)(?<u>[^\/]+)").Groups["u"].Value;
+			return s_routes.ContainsKey(c);
+		}
 
 		internal static bool CompareRoutes(string route, string compare, out bool isImplicit)
 		{
@@ -92,7 +97,7 @@ namespace Xamarin.Forms
 			// Honestly this could probably be expanded to allow any URI allowable character
 			// I just dont want to figure out what that validation looks like.
 			// It does however need to be lowercase since uri case sensitivity is a bit touchy
-			Regex r = new Regex(@"^[a-z|\/]*$");
+			Regex r = new Regex("^[a-z]*$");
 			return r.IsMatch(route);
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -127,14 +127,23 @@ namespace Xamarin.Forms
 			return result;
 		}
 
-		internal static ShellItem GetShellItemFromRouteName(string route)
+		internal static ShellItem GetOrCreateShellItemFromRouteName(string route, string parentRoute)
 		{
-			var shellContent = new ShellContent { Route = route, Content = Routing.GetOrCreateContent(route) };
-			var result = new ShellItem();
-			var shellSection = new ShellSection();
-			shellSection.Items.Add(shellContent);
-			result.Route = Routing.GenerateImplicitRoute(shellSection.Route);
-			result.Items.Add(shellSection);
+			var content = Routing.GetOrCreateContent(route);
+			var shellSection = new ShellSection
+			{
+				Items = {
+					new ShellContent {
+						Route = route,
+						Content = content
+					}
+				}
+			};
+			var result = new ShellItem
+			{
+				Route = parentRoute,
+				Items = { shellSection }
+			};
 			result.SetBinding(TitleProperty, new Binding(nameof(Title), BindingMode.OneWay, source: shellSection));
 			result.SetBinding(IconProperty, new Binding(nameof(Icon), BindingMode.OneWay, source: shellSection));
 			result.SetBinding(FlyoutDisplayOptionsProperty, new Binding(nameof(FlyoutDisplayOptions), BindingMode.OneTime, source: shellSection));


### PR DESCRIPTION
### Description of Change ###

Implemented nested routing for `Shell` with support nested pages inside.

### API Changes ###
 
 None

### Platforms Affected ### 

- Core

### After Screenshots ### 

Shell inside Shell
![image](https://user-images.githubusercontent.com/27482193/55077337-8c4b8c80-50a8-11e9-8c08-0fe3740411ca.png)

### Testing Procedure ###

- run Shell Store ControlGallery
- Navigate to "d/store/games"

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
