### PR TITLE
[X] Fail on element in nested namespaces

### DIFF
--- a/Xamarin.Forms.Core/XamlParseException.cs
+++ b/Xamarin.Forms.Core/XamlParseException.cs
@@ -8,6 +8,9 @@ namespace Xamarin.Forms.Xaml
 #endif
 	public class XamlParseException : Exception
 	{
+#if NETSTANDARD2_0
+		[NonSerialized]
+#endif
 		readonly string _unformattedMessage;
 
 		public XamlParseException()

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_2.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5378_2.xaml.cs
@@ -9,10 +9,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 	[XamlCompilation(XamlCompilationOptions.Skip)]
 	public partial class Gh5378_2 : ContentPage
 	{
-		public Gh5378_2()
-		{
-			InitializeComponent();
-		}
+		public Gh5378_2() => InitializeComponent();
 
 		public Gh5378_2(bool useCompiledXaml)
 		{

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5704.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5704.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5704">
+    <ContentPage.Content>
+        <local:Gh5704NS.MyLabel Text="Bar" />
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5704.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5704.xaml.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests.Gh5704NS
+{
+	public class MyLabel : Label
+	{
+	}
+}
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh5704 : ContentPage
+	{
+		public Gh5704() => InitializeComponent();
+		public Gh5704(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture] class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void Throws([Values(false, true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<XamlParseException>(() => MockCompiler.Compile(typeof(Gh5704)));
+				else
+					Assert.Throws<XamlParseException>(() => new Gh5704(useCompiledXaml));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -139,7 +139,7 @@ namespace Xamarin.Forms.Xaml
 			var skipFirstRead = nested;
 			Debug.Assert(reader.NodeType == XmlNodeType.Element);
 			var name = reader.Name;
-			List<INode> nodes = new List<INode>();
+			var nodes = new List<INode>();
 			INode node = null;
 
 			while (skipFirstRead || reader.Read())
@@ -161,6 +161,8 @@ namespace Xamarin.Forms.Xaml
 						var elementName = reader.Name;
 						var elementNsUri = reader.NamespaceURI;
 						var elementXmlInfo = (IXmlLineInfo)reader;
+						if (elementName.Contains("."))
+							throw new XamlParseException($"Invalid element name: '{elementName}'. Element names shouldn't contain a '.'");
 						IList<KeyValuePair<string, string>> xmlns;
 
 						var attributes = ParseXamlAttributes(reader, out xmlns);


### PR DESCRIPTION
### Description of Change ###

Nested namespaces are invalid Xaml constructs, as they could be confused
with property accessing in some contexts.

In case of an element directly set as a property, the parser used to support
dot-names, because it was un-ambiguous, but that's wrong.

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5704

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

> VS bug [#830045](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/830045)