### PR TITLE
[iOS] Add Platform Specific features for PrefersHomeIndicatorAutoHidden

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/HomeIndicatorPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/HomeIndicatorPageiOS.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Input;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
+{
+	public class HomeIndicatorPageiOS : ContentPage
+	{
+		public HomeIndicatorPageiOS(ICommand restore)
+		{
+			Title = "Large Titles";
+
+			var offscreenPageLimit = new Label();
+			var content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Fill,
+				HorizontalOptions = LayoutOptions.Fill,
+				Children =
+				{
+					new Button
+					{
+						Text = "Show Home indicator",
+						Command = new Command(() => On<iOS>().SetPrefersHomeIndicatorAutoHidden(false))
+					},
+					new Button
+					{
+						Text = "Hide Home indicator",
+						Command = new Command(() => On<iOS>().SetPrefersHomeIndicatorAutoHidden(true))
+					},
+					offscreenPageLimit
+				}
+			};
+
+			var restoreButton = new Button { Text = "Back To Gallery" };
+			restoreButton.Clicked += async (sender, args) => await Navigation.PopAsync();
+			content.Children.Add(restoreButton);
+
+			Content = content;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/MasterDetailPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/MasterDetailPageiOS.cs
@@ -143,6 +143,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 			{
 				Text = "Toggle PreferredStatusBarUpdateAnimation"
 			};
+			
+			var togglePrefersHomeIndicatorAutoHiddenButton = new Button
+			{
+				Text = "Toggle PrefersHomeIndicatorAutoHidden"
+			};
 
 			togglePrefersStatusBarHiddenButtonForPageButton.Command = new Command(() =>
 			{
@@ -165,10 +170,17 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 				else
 					page.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Fade);
 			});
+
+			togglePrefersHomeIndicatorAutoHiddenButton.Command = new Command(() =>
+			{
+				var isIndicatorAutoHidden = page.On<iOS>().PrefersHomeIndicatorAutoHidden();
+				page.On<iOS>().SetPrefersHomeIndicatorAutoHidden(!isIndicatorAutoHidden);
+			});
 			
 			content.Children.Add(navigateButton);
 			content.Children.Add(togglePrefersStatusBarHiddenButtonForPageButton);
 			content.Children.Add(togglePreferredStatusBarUpdateAnimationButton);
+			content.Children.Add(togglePrefersHomeIndicatorAutoHiddenButton);
 
 			page.Content = content;
 

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/TabbedPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/TabbedPageiOS.cs
@@ -44,6 +44,16 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 				Text = "Toggle PreferredStatusBarUpdateAnimation"
 			};
 
+			var togglePrefersHomeIndicatorAutoHiddenButton = new Button
+			{
+				Text = "Toggle PrefersHomeIndicatorAutoHidden for TabbedPage"
+			};
+
+			var togglePrefersHomeIndicatorAutoHiddenForPageButton = new Button
+			{
+				Text = "Toggle PrefersHomeIndicatorAutoHidden for Page"
+			};
+
 			togglePrefersStatusBarHiddenButton.Command = new Command(() =>
 			{
 				var mode = On<iOS>().PrefersStatusBarHidden();
@@ -77,12 +87,26 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 					page.On<iOS>().SetPreferredStatusBarUpdateAnimation(UIStatusBarAnimation.Fade);
 			});
 
+			togglePrefersHomeIndicatorAutoHiddenButton.Command = new Command(() =>
+			{
+				var isIndicatorAutoHidden = On<iOS>().PrefersHomeIndicatorAutoHidden();
+				On<iOS>().SetPrefersHomeIndicatorAutoHidden(!isIndicatorAutoHidden);
+			});
+
+			togglePrefersHomeIndicatorAutoHiddenForPageButton.Command = new Command(() =>
+			{
+				var isIndicatorAutoHidden = page.On<iOS>().PrefersHomeIndicatorAutoHidden();
+				page.On<iOS>().SetPrefersHomeIndicatorAutoHidden(!isIndicatorAutoHidden);
+			});
+
 			var restoreButton = new Button { Text = "Back To Gallery" };
 			restoreButton.Clicked += (sender, args) => restore.Execute(null);
 			content.Children.Add(restoreButton);
 			content.Children.Add(togglePrefersStatusBarHiddenButton);
 			content.Children.Add(togglePrefersStatusBarHiddenForPageButton);
 			content.Children.Add(togglePreferredStatusBarUpdateAnimationButton);
+			content.Children.Add(togglePrefersHomeIndicatorAutoHiddenButton);
+			content.Children.Add(togglePrefersHomeIndicatorAutoHiddenForPageButton);
 			content.Children.Add(new Label
 			{
 				HorizontalOptions = LayoutOptions.Center,

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Controls
 
 		public PlatformSpecificsGallery()
 		{
-			
+
 			Title = "PlatformSpecificsGallery";
 			var mdpiOSButton = new Button { Text = "MasterDetailPage (iOS)" };
 			var mdpWindowsButton = new Button { Text = "MasterDetailPage (Windows)" };
@@ -26,6 +26,7 @@ namespace Xamarin.Forms.Controls
 			var largeTitlesiOSButton = new Button() { Text = "Large Title (iOS)" };
 			var safeareaiOSButton = new Button() { Text = "SafeArea (iOS)" };
 			var modalformsheetiOSButton = new Button() { Text = "Modal FormSheet (iOS)" };
+			var homeIndicatoriOSButton = new Button() { Text = "Home indicator (iOS)" };
 
 			mdpiOSButton.Clicked += (sender, args) => { SetRoot(new MasterDetailPageiOS(new Command(RestoreOriginal))); };
 			mdpWindowsButton.Clicked += (sender, args) => { SetRoot(new MasterDetailPageWindows(new Command(RestoreOriginal))); };
@@ -41,13 +42,15 @@ namespace Xamarin.Forms.Controls
 			largeTitlesiOSButton.Clicked += (sender, args) => { Navigation.PushAsync(new LargeTitlesPageiOS(new Command(RestoreOriginal))); };
 			safeareaiOSButton.Clicked += (sender, args) => { SetRoot(new SafeAreaPageiOS(new Command(RestoreOriginal), new Command<Page>(p => SetRoot(p)))); };
 			modalformsheetiOSButton.Clicked += async (sender, args) => { await Navigation.PushModalAsync(new ModalFormSheetPageiOS()); };
+			homeIndicatoriOSButton.Clicked += (sender, args) => { Navigation.PushAsync(new HomeIndicatorPageiOS(new Command(RestoreOriginal))); };
 
 			Content = new ScrollView
 			{
 				Content = new StackLayout
 				{
 					Children = { mdpiOSButton, mdpWindowsButton, npWindowsButton, tbiOSButton, tbWindowsButton, viselemiOSButton,
-						appAndroidButton, tbAndroidButton, entryiOSButton, entryAndroidButton, largeTitlesiOSButton, safeareaiOSButton, modalformsheetiOSButton }
+						appAndroidButton, tbAndroidButton, entryiOSButton, entryAndroidButton, largeTitlesiOSButton, safeareaiOSButton, 
+						modalformsheetiOSButton, homeIndicatoriOSButton }
 				}
 			};
 		}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -153,5 +153,29 @@
 		{
 			element.SetValue(ModalPresentationStyleProperty, value);
 		}
+
+		public static readonly BindableProperty PrefersHomeIndicatorAutoHiddenProperty = 
+			BindableProperty.Create(nameof(PrefersHomeIndicatorAutoHidden), typeof(bool), typeof(Page), false);
+
+		public static bool GetPrefersHomeIndicatorAutoHidden(BindableObject element)
+		{
+			return (bool)element.GetValue(PrefersHomeIndicatorAutoHiddenProperty);
+		}
+
+		public static void SetPrefersHomeIndicatorAutoHidden(BindableObject element, bool value)
+		{
+			element.SetValue(PrefersHomeIndicatorAutoHiddenProperty, value);
+		}
+
+		public static bool PrefersHomeIndicatorAutoHidden(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetPrefersHomeIndicatorAutoHidden(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersHomeIndicatorAutoHidden(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		{
+			SetPrefersHomeIndicatorAutoHidden(config.Element, value);
+			return config;
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -104,6 +104,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidLoad();
 			SetNeedsStatusBarAppearanceUpdate();
+			SetNeedsUpdateOfHomeIndicatorAutoHidden();
 		}
 
 		public override UIViewController ChildViewControllerForStatusBarStyle()
@@ -149,6 +150,11 @@ namespace Xamarin.Forms.Platform.iOS
 			return ChildViewControllers?.LastOrDefault();
 		}
 
+		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden
+		{
+			get => (UIViewController)Platform.GetRenderer(this.Platform.Page);
+		}
+
 		public override bool ShouldAutorotate()
 		{
 			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
@@ -192,6 +198,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidLoad();
 			SetNeedsStatusBarAppearanceUpdate();
+			SetNeedsUpdateOfHomeIndicatorAutoHidden();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -231,6 +231,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateBarTextColor();
 			UpdateUseLargeTitles();
 			UpdateHideNavigationBarSeparator();
+			SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
 			// If there is already stuff on the stack we need to push it
 			navPage.Pages.ForEach(async p => await PushPageAsync(p, false));
@@ -1296,6 +1297,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			return (UIViewController)Platform.GetRenderer(Current);
 		}
+
+		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden => (UIViewController)Platform.GetRenderer(Current);
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -104,6 +104,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_appeared = true;
 			UpdateStatusBarPrefersHidden();
+			SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
 			if (Element.Parent is CarouselPage)
 				return;
@@ -220,6 +221,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateUseSafeArea();
 			else if (Forms.IsiOS11OrNewer && e.PropertyName == PlatformConfiguration.iOSSpecific.Page.SafeAreaInsetsProperty.PropertyName)
 				UpdateUseSafeArea();
+			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty.PropertyName)
+				UpdateHomeIndicatorAutoHidden();
 		}
 
 		public override UIKit.UIStatusBarAnimation PreferredStatusBarUpdateAnimation
@@ -354,5 +357,15 @@ namespace Xamarin.Forms.Platform.iOS
 				view = view.Superview;
 			}
 		}
+
+		void UpdateHomeIndicatorAutoHidden()
+		{
+			if (Element == null)
+				return;
+
+			SetNeedsUpdateOfHomeIndicatorAutoHidden();
+		}
+
+		public override bool PrefersHomeIndicatorAutoHidden => ((Page)Element).OnThisPlatform().PrefersHomeIndicatorAutoHidden();
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -332,6 +332,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_detailController.AddChildViewController(detailRenderer.ViewController);
 
 			SetNeedsStatusBarAppearanceUpdate();
+			SetNeedsUpdateOfHomeIndicatorAutoHidden();
 		}
 
 		void UpdateLeftBarButton()
@@ -353,6 +354,17 @@ namespace Xamarin.Forms.Platform.iOS
 				return (UIViewController)Platform.GetRenderer(((MasterDetailPage)Element).Detail);
 			else
 				return base.ChildViewControllerForStatusBarHidden();
+		}
+
+		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden
+		{
+			get
+			{
+				if (((MasterDetailPage)Element).Detail != null)
+					return (UIViewController)Platform.GetRenderer(((MasterDetailPage)Element).Detail);
+				else
+					return base.ChildViewControllerForStatusBarHidden();
+			}
 		}
 
 		void UpdatePanGesture()

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -238,6 +238,9 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateCurrentPagePreferredStatusBarUpdateAnimation();
 			else if (e.PropertyName == TabbedPage.SelectedTabColorProperty.PropertyName || e.PropertyName == TabbedPage.UnselectedTabColorProperty.PropertyName)
 				UpdateSelectedTabColors();
+			else if (e.PropertyName == PrefersHomeIndicatorAutoHiddenProperty.PropertyName)
+				UpdatePrefersHomeIndicatorAutoHiddenOnPages();
+
 		}
 
 		public override UIViewController ChildViewControllerForStatusBarHidden()
@@ -260,6 +263,27 @@ namespace Xamarin.Forms.Platform.iOS
 			for (var i = 0; i < ViewControllers.Length; i++)
 			{
 				Tabbed.GetPageByIndex(i).OnThisPlatform().SetPrefersStatusBarHidden(Tabbed.OnThisPlatform().PrefersStatusBarHidden());
+			}
+		}
+
+		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden
+		{
+			get
+			{
+				var current = Tabbed.CurrentPage;
+				if (current == null)
+					return null;
+
+				return GetViewController(current);
+			}
+		}
+
+		void UpdatePrefersHomeIndicatorAutoHiddenOnPages()
+		{
+			bool isHomeIndicatorHidden = Tabbed.OnThisPlatform().PrefersHomeIndicatorAutoHidden();
+			for (var i = 0; i < ViewControllers.Length; i++)
+			{
+				Tabbed.GetPageByIndex(i).OnThisPlatform().SetPrefersHomeIndicatorAutoHidden(isHomeIndicatorHidden);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -237,6 +237,17 @@ namespace Xamarin.Forms.Platform.iOS
 				return base.ChildViewControllerForStatusBarHidden();
 		}
 
+		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden
+		{
+			get
+			{
+				if (((MasterDetailPage)Element).Detail != null)
+					return (UIViewController)Platform.GetRenderer(((MasterDetailPage)Element).Detail);
+				else
+					return base.ChildViewControllerForHomeIndicatorAutoHidden;
+			}
+		}
+
 		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
 		{
 			if (e.OldElement != null)


### PR DESCRIPTION
### Description of Change ###
This is a Platform Specific feature which enables setting the visibility of the iOS Home Indicator on a per-view basis.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5310 

### API Changes ###

Added in Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page:
 - public static readonly BindableProperty PrefersHomeIndicatorAutoHiddenProperty;
 - public static bool GetPrefersHomeIndicatorAutoHidden(BindableObject element);
 - public static void SetPrefersHomeIndicatorAutoHidden(BindableObject element, bool value);
 - public static bool PrefersHomeIndicatorAutoHidden(this IPlatformElementConfiguration<iOS, FormsElement> config);
- public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersHomeIndicatorAutoHidden(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value);

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Before/After Screenshots ### 

NavigationPage:
![NavigationPage](https://user-images.githubusercontent.com/23615059/55087079-c79a8b00-50a9-11e9-8cbe-01cad7c8cae5.gif)

TabbedPage:
![TabbedPage](https://user-images.githubusercontent.com/23615059/55087076-c79a8b00-50a9-11e9-9727-f946093defbc.gif)

MasterDetailPage:
![MasterDetailPage](https://user-images.githubusercontent.com/23615059/55087078-c79a8b00-50a9-11e9-9fad-8e6fdccb6e86.gif)


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
