### PR TITLE
Allow EmptyView swapping in Android CollectionView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5535.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5535.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5535, "CollectionView: Swapping EmptyViews has no effect",
+		PlatformAffected.iOS | PlatformAffected.Android)]
+	public class Issue5535 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			Device.SetFlags(new List<string>(Device.Flags) { "CollectionView_Experimental" });
+
+			PushAsync(new GalleryPages.CollectionViewGalleries.EmptyViewGalleries.EmptyViewSwapGallery());
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public void SwappingEmptyViews()
+		{
+			RunningApp.WaitForElement("FilterItems");
+			RunningApp.Tap("FilterItems");	
+			RunningApp.EnterText("abcdef");
+			RunningApp.PressEnter();
+		
+			// Default empty view
+			RunningApp.WaitForElement("Nothing to see here.");
+
+			RunningApp.Tap("ToggleEmptyView");	
+
+			// Other empty view
+			RunningApp.WaitForElement("No results matched your filter.");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5535.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5535.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			Device.SetFlags(new List<string>(Device.Flags) { "CollectionView_Experimental" });
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
 
 			PushAsync(new GalleryPages.CollectionViewGalleries.EmptyViewGalleries.EmptyViewSwapGallery());
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -448,6 +448,7 @@
       <DependentUpon>Issue5003.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5535.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewSwapGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewSwapGallery.xaml
@@ -34,11 +34,11 @@
                 <RowDefinition Height="*"></RowDefinition>
             </Grid.RowDefinitions>
 
-            <SearchBar x:Name="SearchBar" Placeholder="Filter" />
+            <SearchBar x:Name="SearchBar" Placeholder="Filter" AutomationId="FilterItems" />
 
             <StackLayout Orientation="Horizontal" Grid.Row="1">
                 <Label Text="Toggle Between EmptyViews"/>
-                <Switch x:Name="EmptyViewSwitch"/>
+                <Switch x:Name="EmptyViewSwitch" AutomationId="ToggleEmptyView"/>
             </StackLayout> 
 
             <CollectionView x:Name="CollectionView" Grid.Row="2">

--- a/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+		protected readonly ItemsView ItemsView;
 		public override int ItemCount => 1;
 
 		public EmptyViewAdapter(ItemsView itemsView)
@@ -102,19 +103,6 @@ namespace Xamarin.Forms.Platform.Android
 		public override int GetItemViewType(int position)
 		{
 			return _itemViewType;
-		}
-
-		IVisualElementRenderer CreateRenderer(View view, Context context)
-		{
-			if (view == null)
-			{
-				throw new ArgumentNullException(nameof(view));
-			}
-
-			var renderer = Platform.CreateRenderer(view, context);
-			Platform.SetRenderer(view, renderer);
-
-			return renderer;
 		}
 
 		static TextView CreateTextView(string text, Context context)

--- a/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
@@ -10,9 +10,33 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public class EmptyViewAdapter : RecyclerView.Adapter
 	{
-		public object EmptyView { get; set; }
-		public DataTemplate EmptyViewTemplate { get; set; }
-		protected readonly ItemsView ItemsView;
+		int _itemViewType;
+		private object _emptyView;
+		private DataTemplate _emptyViewTemplate;
+
+		public object EmptyView
+		{
+			get => _emptyView;
+			set
+			{
+				_emptyView = value;
+
+				// Change _itemViewType to force OnCreateViewHolder to run again and use this new EmptyView
+				_itemViewType += 1;
+			}
+		}
+		
+		public DataTemplate EmptyViewTemplate
+		{
+			get => _emptyViewTemplate;
+			set
+			{
+				_emptyViewTemplate = value;
+				
+				// Change _itemViewType to force OnCreateViewHolder to run again and use this new template
+				_itemViewType += 1;
+			}
+		}
 
 		public override int ItemCount => 1;
 
@@ -73,6 +97,24 @@ namespace Xamarin.Forms.Platform.Android
 
 			var itemContentView = new SizedItemContentView(parent.Context, () => parent.Width, () => parent.Height);
 			return new TemplatedItemViewHolder(itemContentView, template);
+		}
+
+		public override int GetItemViewType(int position)
+		{
+			return _itemViewType;
+		}
+
+		IVisualElementRenderer CreateRenderer(View view, Context context)
+		{
+			if (view == null)
+			{
+				throw new ArgumentNullException(nameof(view));
+			}
+
+			var renderer = Platform.CreateRenderer(view, context);
+			Platform.SetRenderer(view, renderer);
+
+			return renderer;
 		}
 
 		static TextView CreateTextView(string text, Context context)

--- a/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
@@ -11,8 +11,8 @@ namespace Xamarin.Forms.Platform.Android
 	public class EmptyViewAdapter : RecyclerView.Adapter
 	{
 		int _itemViewType;
-		private object _emptyView;
-		private DataTemplate _emptyViewTemplate;
+		object _emptyView;
+		DataTemplate _emptyViewTemplate;
 
 		public object EmptyView
 		{


### PR DESCRIPTION
### Description of Change ###

Prevent crash when displaying EmptyView on Android.
Update EmptyViewAdapter to create a new ViewHolder when the EmptyView or EmptyViewTemplate properties change.

Also adds an automated test for this behavior.

### Issues Resolved ### 

- fixes #5535 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
