### PR TITLE
Make UI test 4600 run on Android/iOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4600.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4600.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms.CustomAttributes;
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
 #if UITEST
@@ -10,8 +11,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
-	[Category(UITestCategories.ManualReview)]
-	[Ignore("Ignoring until we have a lane to run CollectionView test (or CV is not behind a flag")] 
+	[Category(UITestCategories.CollectionView)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 4600, "[iOS] CollectionView crash with empty ObservableCollection", PlatformAffected.iOS)]
@@ -20,8 +20,9 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			PushAsync(
-				new GalleryPages.CollectionViewGalleries.ObservableCodeCollectionViewGallery(initialItems: 0));
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
+
+			PushAsync(new GalleryPages.CollectionViewGalleries.ObservableCodeCollectionViewGallery(initialItems: 0));
 #endif
 		}
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemInsert.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemInsert.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 		{
 			var index = indexes[0];
 
-			if (index > -1 && index < observableCollection.Count)
+			if (index > -1 && index <= observableCollection.Count)
 			{
 				var item = new CollectionViewGalleryTestItem(DateTime.Now, "Inserted", "oasis.jpg", index);
 				observableCollection.Insert(index, item);


### PR DESCRIPTION
### Description of Change ###

Remove `Ignore` attribute, fix broken test input, and add flag to allow test to run.

Test will _not_ run on UWP, as the underlying CollectionView features have not yet been implemented.

### Issues Resolved ### 

- fixes #4943

### API Changes ###

 None

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
