### PR TITLE
FIX: Navigation.InsertBefore() didn't update toolbar back button when inserting before the first page

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -555,14 +555,14 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (!_isAttachedToWindow)
 				PushCurrentPages();
 
-			UpdateToolbar();
-
 			int index = PageController.InternalChildren.IndexOf(before);
 			if (index == -1)
 				throw new InvalidOperationException("This should never happen, please file a bug");
 
 			Fragment fragment = FragmentContainer.CreateInstance(page);
 			_fragmentStack.Insert(index, fragment);
+
+			UpdateToolbar();
 		}
 
 		void OnInsertPageBeforeRequested(object sender, NavigationRequestedEventArgs e)
@@ -947,11 +947,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (bar == null)
 				return;
 
-			bool isNavigated = NavigationPageController.StackDepth > 1;
 			bar.NavigationIcon = null;
 			Page currentPage = Element.CurrentPage;
+			bool isFirstPage = _fragmentStack.IndexOf(GetPageFragment(currentPage)) == 0;
 
-			if (isNavigated)
+			if (!isFirstPage)
 			{
 				if (toggle != null)
 				{

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -523,8 +523,14 @@ namespace Xamarin.Forms.Platform.iOS
 				throw new ArgumentNullException("page");
 
 			var pageContainer = CreateViewControllerForPage(page);
-			var target = Platform.GetRenderer(before).ViewController.ParentViewController;
-			ViewControllers = ViewControllers.Insert(ViewControllers.IndexOf(target), pageContainer);
+			var target = Platform.GetRenderer(before).ViewController.ParentViewController as ParentingViewController;
+			var index = ViewControllers.IndexOf(target);
+			ViewControllers = ViewControllers.Insert(index, pageContainer);
+			if (index == 0)
+			{
+				target.NavigationItem.LeftBarButtonItem = null;
+				pageContainer.UpdateLeftBarButtonItem(before);
+			}
 		}
 
 		void OnInsertPageBeforeRequested(object sender, NavigationRequestedEventArgs e)
@@ -585,6 +591,7 @@ namespace Xamarin.Forms.Platform.iOS
 				_removeControllers = _removeControllers.Remove(target);
 				ViewControllers = _removeControllers;
 			}
+			target.Dispose();
 			var parentingViewController = ViewControllers.Last() as ParentingViewController;
 			parentingViewController?.UpdateLeftBarButtonItem(page);
 		}


### PR DESCRIPTION
### Description of Change ###

Navigation.InsertBefore() didn't update toolbar "back"/"menu" button if inserting before the first page (index 0)

### Issues Resolved ### 

Both Android & iOS renderers are affected (in a different way). The fix addresses both.

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Testing Procedure ###

[FormsTest.zip](https://github.com/xamarin/Xamarin.Forms/files/3019490/FormsTest.zip)

Press Insert, and the Menu button should change to a back button as a new page has been inserted before the current one. Once inserted, press Remove to remove the previous page and the back button should change back to Menu button.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
