### PR TITLE
Extend Control Gallery to allow for Shell UI Tests

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml
@@ -24,10 +24,12 @@
             </ShellContent>
             <ShellContent Title="Control">
                 <ContentPage Title="Control">
-                    <StackLayout>
-                        <Label Text="Success">
-                        </Label>
-                    </StackLayout>
+                    <ScrollView>
+                        <StackLayout>
+                            <Label Text="Success">
+                            </Label>
+                        </StackLayout>
+                    </ScrollView>
                 </ContentPage>
             </ShellContent>
         </ShellSection>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml
@@ -11,11 +11,16 @@
         </ContentView>
     </Shell.FlyoutHeader>
     <ShellItem Title="Home" Route="Home">
-        <ShellSection>
-            <ShellContent>
-                <ContentPage />
-            </ShellContent>
-        </ShellSection>
+        <ShellContent Title="Control">
+            <ContentPage Title="Control">
+                <ScrollView>
+                    <StackLayout>
+                        <Label Text="Select Connect in Flyout Menu. Click between tabs. Select Home in Flyout Menu. Select Connect in Flyout Menu. Click between tabs. If the app has not crashed then test has passed">
+                        </Label>
+                    </StackLayout>
+                </ScrollView>
+            </ContentPage>
+        </ShellContent>
     </ShellItem>
     <ShellItem Title="Connect" Route="connect">
         <ShellSection>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml
@@ -1,9 +1,15 @@
-﻿<local:TestShell
-    xmlns="http://xamarin.com/schemas/2014/forms" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-	x:Class="Xamarin.Forms.Controls.Issues.Issue4684"
-    Title="Test Page"
-    xmlns:local="using:Xamarin.Forms.Controls">
+<?xml version="1.0" encoding="UTF-8"?>
+<local:TestShell xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Controls.Issues.Issue4684" Title="Test Page" xmlns:local="using:Xamarin.Forms.Controls">
+    <Shell.FlyoutHeader>
+        <ContentView HeightRequest="200">
+            <ContentView.Content>
+                <Grid BackgroundColor="Black">
+                    <Image Aspect="AspectFill" Source="coffee.png" Opacity="0.6" />
+                    <Label Margin="0, 40, 0, 0" Text="I create an offset for ios" TextColor="White" FontAttributes="Bold" VerticalTextAlignment="Center" />
+                </Grid>
+            </ContentView.Content>
+        </ContentView>
+    </Shell.FlyoutHeader>
     <ShellItem Title="Home" Route="Home">
         <ShellSection>
             <ShellContent>
@@ -14,10 +20,15 @@
     <ShellItem Title="Connect" Route="connect">
         <ShellSection>
             <ShellContent Title="Connect">
-                <ContentPage  Title="Connect"/>
+                <ContentPage Title="Connect" />
             </ShellContent>
             <ShellContent Title="Control">
-                <ContentPage Title="Control" />
+                <ContentPage Title="Control">
+                    <StackLayout>
+                        <Label Text="Success">
+                        </Label>
+                    </StackLayout>
+                </ContentPage>
             </ShellContent>
         </ShellSection>
     </ShellItem>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml
@@ -1,0 +1,24 @@
+﻿<local:TestShell
+    xmlns="http://xamarin.com/schemas/2014/forms" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Xamarin.Forms.Controls.Issues.Issue4684"
+    Title="Test Page"
+    xmlns:local="using:Xamarin.Forms.Controls">
+    <ShellItem Title="Home" Route="Home">
+        <ShellSection>
+            <ShellContent>
+                <ContentPage />
+            </ShellContent>
+        </ShellSection>
+    </ShellItem>
+    <ShellItem Title="Connect" Route="connect">
+        <ShellSection>
+            <ShellContent Title="Connect">
+                <ContentPage  Title="Connect"/>
+            </ShellContent>
+            <ShellContent Title="Control">
+                <ContentPage Title="Control" />
+            </ShellContent>
+        </ShellSection>
+    </ShellItem>
+</local:TestShell>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 4684, "[Android] don't clear shell content because native page isn't visible",
 		PlatformAffected.Android)]
 #if UITEST
-	[NUnit.Framework.Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
 #endif
 	public sealed partial class Issue4684 : TestShell
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4684, "[Android] don't clear shell content because native page isn't visible",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public sealed partial class Issue4684 : TestShell
+	{
+		public Issue4684()
+		{
+#if APP
+			this.InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void NavigatingBackAndForthDoesNotCrash()
+		{
+			RunningApp.Tap("OK");
+			RunningApp.Tap("Connect");
+			RunningApp.Tap("Control");
+			RunningApp.Tap("OK");
+			RunningApp.Tap("Home");
+			RunningApp.Tap("OK");
+			RunningApp.Tap("Connect");
+			RunningApp.Tap("Connect");
+			RunningApp.Tap("Control");
+		}
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4684.xaml.cs
@@ -29,19 +29,20 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 		}
 
-#if UITEST && __ANDROID__
+#if UITEST
 		[Test]
 		public void NavigatingBackAndForthDoesNotCrash()
 		{
-			RunningApp.Tap("OK");
+			TapInFlyout("Connect");
+			RunningApp.Tap("Control");
+
+			TapInFlyout("Home");
+			TapInFlyout("Connect");
+
 			RunningApp.Tap("Connect");
 			RunningApp.Tap("Control");
-			RunningApp.Tap("OK");
-			RunningApp.Tap("Home");
-			RunningApp.Tap("OK");
-			RunningApp.Tap("Connect");
-			RunningApp.Tap("Connect");
-			RunningApp.Tap("Control");
+
+			RunningApp.WaitForElement("Success");
 		}
 
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -562,6 +562,55 @@ namespace Xamarin.Forms.Controls
 
 		protected abstract void Init();
 	}
+
+
+
+
+	public abstract class TestShell : Shell
+	{
+#if UITEST
+		public IApp RunningApp => AppSetup.RunningApp;
+
+		protected virtual bool Isolate => true;
+#endif
+
+		protected TestShell() : base(false)
+		{
+#if APP
+			Init();
+#endif
+		}
+
+#if UITEST
+		[SetUp]
+		public void Setup()
+		{
+			if (Isolate)
+			{
+				AppSetup.BeginIsolate();
+			}
+			else
+			{
+				AppSetup.EnsureMemory();
+				AppSetup.EnsureConnection();
+			}
+
+			AppSetup.NavigateToIssue(GetType(), RunningApp);
+		}
+
+		[TearDown]
+		public virtual void TearDown()
+		{
+			if (Isolate)
+			{
+				AppSetup.EndIsolate();
+			}
+		}
+#endif
+
+		protected abstract void Init();
+
+	}
 }
 
 #if UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -606,6 +606,22 @@ namespace Xamarin.Forms.Controls
 				AppSetup.EndIsolate();
 			}
 		}
+
+		public void ShowFlyout()
+		{
+			RunningApp.WaitForElement("OK");
+			RunningApp.Tap("OK");
+		}
+
+
+		public void TapInFlyout(string text)
+		{
+			ShowFlyout();
+			RunningApp.WaitForElement(text);
+			RunningApp.Tap(text);
+		}
+
+
 #endif
 
 		protected abstract void Init();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5376.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml.cs">
       <DependentUpon>Bugzilla60787.xaml</DependentUpon>
@@ -1145,5 +1146,16 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4684.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="H:\github\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue4684.xaml.cs">
+      <DependentUpon>Issue4684.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1132,7 +1132,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5057.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
@@ -1144,7 +1144,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)CollectionViewBindingErrors.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -124,7 +124,6 @@ namespace Xamarin.Forms.Controls
 			mdp.Master.Icon.SetAutomationPropertiesName("MDPICON");
 			return mdp;
 
-			//Device.SetFlags(new[] { "Shell_Experimental" });
             //return new XamStore.StoreShell();
         }
 

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -217,6 +217,7 @@ namespace Xamarin.Forms.Controls
 				new CoreViewContainer ("SwapRoot - NavigationPage", typeof(CoreNavigationPage)),
 				new CoreViewContainer ("SwapRoot - TabbedPage", typeof(CoreTabbedPage)),
 				new CoreViewContainer ("SwapRoot - BottomNavigation TabbedPage", typeof(CoreTabbedPageAsBottomNavigation)),
+				new CoreViewContainer ("SwapRoot - Store Shell", typeof(XamStore.StoreShell)),
 			};
 
 			var template = new DataTemplate(typeof(TextCell));

--- a/Xamarin.Forms.Controls/TestCases.cs
+++ b/Xamarin.Forms.Controls/TestCases.cs
@@ -56,7 +56,12 @@ namespace Xamarin.Forms.Controls
 							
 							await Navigation.PushAsync (page);
 
-						} else {
+						}
+						else if (page is Shell)
+						{
+							Application.Current.MainPage = page;
+						}
+						else {
 							await Navigation.PushModalAsync (page);
 						}
 					}; 

--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Shell xmlns="http://xamarin.com/schemas/2014/forms"
+<localTest:TestShell xmlns="http://xamarin.com/schemas/2014/forms"
 			xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			xmlns:local="clr-namespace:Xamarin.Forms.Controls.XamStore"
+			xmlns:localTest="clr-namespace:Xamarin.Forms.Controls"
 			Route="xamstore"
 			RouteHost="www.xamarin.com"
 			RouteScheme="http"
@@ -100,4 +101,4 @@
 		<MenuItem Text="Parent Guide" />
 		<MenuItem Text="About Xam Store" />
 	</Shell.MenuItems>
-</Shell>
+</localTest:TestShell>

--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
@@ -5,16 +5,22 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.XamStore
 {
+	[Preserve(AllMembers = true)]
 	[XamlCompilation(XamlCompilationOptions.Compile)]
-	public partial class StoreShell : Shell
+	public partial class StoreShell : TestShell
 	{
-		public StoreShell()
+		public StoreShell() 
 		{
 			InitializeComponent();
+		}
+
+		protected override void Init()
+		{
 			var fontFamily = "";
 			switch (Device.RuntimePlatform)
 			{
@@ -39,6 +45,8 @@ namespace Xamarin.Forms.Controls.XamStore
 			Routing.RegisterRoute("demo", typeof(DemoShellPage));
 			Routing.RegisterRoute("demo/demo", typeof(DemoShellPage));
 		}
+
+
 
 		//bool allow = false;
 

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -42,10 +42,10 @@
 		public const string Navigation = "Navigation";
 		public const string Effects = "Effects";
 		public const string Focus = "Focus";
-
 		public const string ManualReview = "ManualReview";
 		public const string Performance = "Performance";
 		public const string Visual = "Visual";
 		public const string AppLinks = "AppLinks";
+		public const string Shell = "Shell";
 	}
 }

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -572,9 +572,15 @@ namespace Xamarin.Forms
 		ShellNavigatedEventArgs _accumulatedEvent;
 		bool _accumulateNavigatedEvents;
 		View _flyoutHeaderView;
+		bool _checkExperimentalFlag = true;
 
-		public Shell()
+		public Shell() : this(true)
 		{
+		}
+
+		internal Shell(bool checkFlag)
+		{
+			_checkExperimentalFlag = checkFlag;
 			VerifyShellFlagEnabled(constructorHint: nameof(Shell));
 			((INotifyCollectionChanged)Items).CollectionChanged += (s, e) => SendStructureChanged();
 		}
@@ -582,9 +588,10 @@ namespace Xamarin.Forms
 		internal const string ShellExperimental = ExperimentalFlags.ShellExperimental;
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		internal static void VerifyShellFlagEnabled(string constructorHint = null, [CallerMemberName] string memberName = "")
+		internal void VerifyShellFlagEnabled(string constructorHint = null, [CallerMemberName] string memberName = "")
 		{
-			ExperimentalFlags.VerifyFlagEnabled("Shell", ShellExperimental, constructorHint, memberName);
+			if(_checkExperimentalFlag)
+				ExperimentalFlags.VerifyFlagEnabled("Shell", ShellExperimental, constructorHint, memberName);
 		}
 
 		public event EventHandler<ShellNavigatedEventArgs> Navigated;

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -15,7 +15,6 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <PackageId>Xamarin.Forms.Material.Android</PackageId>
   </PropertyGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -250,7 +250,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (image == null)
 				image = "3bar.png";
 			var icon = await image.GetNativeImageAsync();
-			NavigationItem.LeftBarButtonItem = new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, OnMenuButtonPressed);
+			var barButtonItem = new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, OnMenuButtonPressed);
+			barButtonItem.AccessibilityIdentifier = "OK";
+			NavigationItem.LeftBarButtonItem = barButtonItem;
 		}
 
 		void OnMenuButtonPressed(object sender, EventArgs e)

--- a/Xamarin.Forms.Sandbox.Android/Xamarin.Forms.Sandbox.Android.csproj
+++ b/Xamarin.Forms.Sandbox.Android/Xamarin.Forms.Sandbox.Android.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>


### PR DESCRIPTION
### Description of Change ###

- added UI test for Issue4684 to demonstrate UI tests
- Added an internal constructor to shell that lets us disable the flag check. Since all our UI tests have internals visible this makes it easy to circumvent the flag check without changing the flags
- added a TestShell base class to mimic other Test<Pages>. Added some helper methods here for opening flyout and clicking on menus
- Added Store shell to top list of gallery so it can be swapped in for main page
- Changed the base class on store shell to test shell. In theory this should make it so you can create an Issue that just inherits from StoreShell and then write a UI test against StoreShell
- Changed the AccessibilityIdentifier on the app bar button on iOS to be OK like it is on android which is probably wrong in both cases but now it's at least consistently wrong. This will need to be updated to a more correct AccessibilityIdentifier
- 


### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - internal Shell(bool checkFlags)

### Platforms Affected ### 
- iOS
- Android

### Testing Procedure ###
- run store shell from gallery home page
- click into Issue4684 and see that it opens to shell

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
