### PR TITLE
[iOS] Fix when we render the font icon image as original

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -191,6 +191,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 	public sealed class FontImageSourceHandler : IImageSourceHandler
 	{
+		//should this be the default color on the BP for iOS? 
+		readonly Color _defaultColor = Color.White;
+
 		public Task<UIImage> LoadImageAsync(
 			ImageSource imagesource, 
 			CancellationToken cancelationToken = default(CancellationToken), 
@@ -200,7 +203,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var fontsource = imagesource as FontImageSource;
 			if (fontsource != null)
 			{
-				var iconcolor = fontsource.Color != Color.Default ? fontsource.Color : Color.White;
+				var iconcolor = fontsource.Color.IsDefault ? _defaultColor : fontsource.Color;
 				var imagesize = new SizeF((float)fontsource.Size, (float)fontsource.Size);
 				var font = UIFont.FromName(fontsource.FontFamily ?? string.Empty, (float)fontsource.Size) ??
 					UIFont.SystemFontOfSize((float)fontsource.Size);
@@ -217,7 +220,7 @@ namespace Xamarin.Forms.Platform.iOS
 				image = UIGraphics.GetImageFromCurrentImageContext();
 				UIGraphics.EndImageContext();
 
-				if (iconcolor != Color.Default)
+				if (iconcolor != _defaultColor)
 					image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 			}
 			return Task.FromResult(image);


### PR DESCRIPTION
### Description of Change ###

We were changing the default color to White, then when comparing if we should render as origin (with color) we were comparing with the initial color but not with the Color.White we set as default on the platform side. 

This was preventing Shell to tin the FontIcon.

If the user want's to override and provide the color he can use the `Color` on FontImageSource.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5071

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS
### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Allows to tint `FontImageSource`

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
