### PR TITLE
Check if Element parent is null before getting the padding insets

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -258,7 +258,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateShellInsetPadding()
 		{
-			var setInsets = Shell.GetSetPaddingInsets(Element) || Shell.GetSetPaddingInsets(Element?.Parent);
+			var setInsets = false;
+
+			if (Element != null)
+			{
+				setInsets = Shell.GetSetPaddingInsets(Element);
+				if (Element.Parent != null)
+					setInsets = Shell.GetSetPaddingInsets(Element.Parent);
+			}
+
 			if (setInsets)
 			{
 				nfloat topPadding = 0;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -242,7 +242,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateUseSafeArea()
 		{
-			if (!Forms.IsiOS11OrNewer) return;
+			if (!Forms.IsiOS11OrNewer)
+				return;
 
 			if (!UsingSafeArea)
 			{
@@ -258,14 +259,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateShellInsetPadding()
 		{
-			var setInsets = false;
+			if (Element == null)
+				return;
 
-			if (Element != null)
-			{
-				setInsets = Shell.GetSetPaddingInsets(Element);
-				if (Element.Parent != null)
-					setInsets = Shell.GetSetPaddingInsets(Element.Parent);
-			}
+			var setInsets = Shell.GetSetPaddingInsets(Element);
+
+			if (!setInsets && Element.Parent != null)
+				setInsets = Shell.GetSetPaddingInsets(Element.Parent);
 
 			if (setInsets)
 			{


### PR DESCRIPTION
### Description of Change ###
This checks if the parent element is null before checking if the bindable property wants the safe area inset set. 

### Platforms Affected ### 
- iOS


### Testing Procedure ###
Make sure basic previewer functionality works

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
