### PR TITLE
[Android] Make type for SetElevation explicit

### DIFF
--- a/Xamarin.Forms.Platform.Android/Elevation.cs
+++ b/Xamarin.Forms.Platform.Android/Elevation.cs
@@ -4,14 +4,15 @@ namespace Xamarin.Forms.Platform.Android
 {
 	internal static class ElevationHelper
 	{
-		internal static void SetElevation(global::Android.Views.View view, VisualElement element)
+		internal static void SetElevation<T>(global::Android.Views.View view, T element) where T : VisualElement
 		{
 			if (view == null || element == null || !Forms.IsLollipopOrNewer)
 			{
 				return;
 			}
 
-			var iec = element as IElementConfiguration<VisualElement>;
+			var iec = element as IElementConfiguration<T>;
+
 			var elevation = iec?.On<PlatformConfiguration.Android>().GetElevation();
 
 			if (!elevation.HasValue)


### PR DESCRIPTION
### Description of Change ###

`SetElevation` helper method on Android relies on covariance in `IElementConfiguration<T>`, which was removed for performance reasons. Because of the change, `SetElevation` was no longer actually setting the `Elevation` property on Android.

This change makes `SetElevation` use a specific `VisualElement` type so that `Elevation` is correctly set.

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
