### PR TITLE
Increase API level check for setting Android ripple effect on selection

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
@@ -58,9 +58,10 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			if (Forms.IsLollipopOrNewer)
+			if (Forms.IsMarshmallowOrNewer)
 			{
 				// We're looking for the foreground ripple effect, which is not available on older APIs
+				// Limiting this to Marshmallow and newer, because View.setForeground() is not available on lower APIs
 				_selectableItemDrawable = GetSelectableItemDrawable();
 				ItemView.Foreground = _selectableItemDrawable;
 			}


### PR DESCRIPTION
### Description of Change ###

`SelectableViewHolder` is using `View.ForeGround` (`setForeground()`) to set the ripple effect on selection; the ripple effect is available on API 21+, but the `setForeground()` method is not available on `View` until API 23. 

This change increases the API check from 21 to 23 for attempting to set the ripple effect.

### Issues Resolved ### 

- fixes #5693 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run the Control Gallery on an Android device with API 22 or lower; navigate to CollectionView Gallery -> Selection Galleries -> Selection Modes, selection "Single", and select an item.

If the application crashes, this fix has failed.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
