### PR TITLE
Rename currentshell

### DIFF
--- a/Xamarin.Forms.Controls/XamStore/Views/DemoShellPage.xaml.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/DemoShellPage.xaml.cs
@@ -185,7 +185,7 @@ namespace Xamarin.Forms.Controls.XamStore
 		{
 			try
 			{
-				await Shell.CurrentShell.GoToAsync("app:///base/details?id=new");
+				await Shell.Current.GoToAsync("app:///base/details?id=new");
 			}
 			catch (Exception ex)
 			{
@@ -205,7 +205,7 @@ namespace Xamarin.Forms.Controls.XamStore
 
 			//Navigation.PushAsync(page);
 			Console.WriteLine("GoToMenu");
-			await Shell.CurrentShell.GoToAsync($"app:///home/vocab?id={id}");
+			await Shell.Current.GoToAsync($"app:///home/vocab?id={id}");
 		}
 
 		void Toggle(string destination)
@@ -232,7 +232,7 @@ namespace Xamarin.Forms.Controls.XamStore
 
 			//Navigation.PushAsync(page);
 
-			await Shell.CurrentShell.GoToAsync($"app:///base/details?id={entry.Id}");
+			await Shell.Current.GoToAsync($"app:///base/details?id={entry.Id}");
 		}
 
 		void DeleteEntry(VocabEntry entry)

--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -217,7 +217,7 @@ namespace Xamarin.Forms.Controls.XamStore
 				}), 0, 15);
 
 			grid.Children.Add(MakeButton("Navigate to 'demo' route",
-				async () => await Shell.CurrentShell.GoToAsync("demo", true)),
+				async () => await Shell.Current.GoToAsync("demo", true)),
 			1, 15);
 
 			grid.Children.Add(MakeButton("Go Back with Text",
@@ -240,7 +240,7 @@ namespace Xamarin.Forms.Controls.XamStore
 			var navEntry = new Entry { Text = "demo/demo" };
 			grid.Children.Add(navEntry, 1, 16);
 			grid.Children.Add(MakeButton("GO!",
-				async () => await Shell.CurrentShell.GoToAsync(navEntry.Text, true)),
+				async () => await Shell.Current.GoToAsync(navEntry.Text, true)),
 			2, 16);
 
 			Content = new ScrollView { Content = grid };

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -323,7 +323,7 @@ namespace Xamarin.Forms
 			OnNavigated(new ShellNavigatedEventArgs(oldState, CurrentState, source));
 		}
 
-		public static Shell CurrentShell => Application.Current?.MainPage as Shell;
+		public static Shell Current => Application.Current?.MainPage as Shell;
 
 		Uri GetAbsoluteUri(Uri relativeUri)
 		{


### PR DESCRIPTION
### Description of Change ###
- Rename Shell.CurrentShell to Current

### API Changes ###
Changed:
 - Shell.CurrentShell => Shell.Current
 
### Platforms Affected ### 
- Core/XAML (all platforms)
