### PR TITLE
[GTK] Fix Padding/Margin properties of Frame element (#5533)

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/FrameRenderer.cs
@@ -64,8 +64,9 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				return;
 
 			IVisualElementRenderer renderer = Element.Content.GetOrCreateRenderer();
-			Control.Child = renderer.Container;
-			renderer.Container.ShowAll();
+			var wrappingFixed = new Gtk.Fixed { renderer.Container };
+			Control.Child = wrappingFixed;
+			wrappingFixed.ShowAll();
 		}
 	}
 }


### PR DESCRIPTION
Frame's content wrapped into a Gtk.Fixed container since Gtk.Frame itself can't position it's content.

### Description of Change ###

In FrameRenderer.cs Frame's native content wrapped into a Gtk.Fixed container since Gtk.Frame itself can't position it's content. So content view will be positioned by wrapping Gtk.Fixed.

### Issues Resolved ### 

- fixes #5533 

### API Changes ###
None

### Platforms Affected ### 

- GTK

### Behavioral/Visual Changes ###

Padding and margin properties will work when view is a Content of a Frame.

### Before/After Screenshots ### 

Before
![before_fix](https://user-images.githubusercontent.com/3056222/55277583-0717e000-5313-11e9-95f2-96cab11e5c4e.png)

After
![after_fix](https://user-images.githubusercontent.com/3056222/55277582-04b58600-5313-11e9-9ef8-3a13d8ecdbef.png)

### Testing Procedure ###

Described in the issue #5533 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
