### PR TITLE
Add covariance back to IElementConfiguration

### DIFF
--- a/Xamarin.Forms.Core/IElementConfiguration.cs
+++ b/Xamarin.Forms.Core/IElementConfiguration.cs
@@ -2,7 +2,7 @@
 namespace Xamarin.Forms
 {
 	// Don't make this generic covariant as it causes UWP performance to tank
-	public interface IElementConfiguration<TElement> where TElement : Element
+	public interface IElementConfiguration<out TElement> where TElement : Element
 	{
 		IPlatformElementConfiguration<T, TElement> On<T>() where T : IConfigPlatform;
 	}

--- a/Xamarin.Forms.Core/IElementConfiguration.cs
+++ b/Xamarin.Forms.Core/IElementConfiguration.cs
@@ -1,7 +1,6 @@
 
 namespace Xamarin.Forms
 {
-	// Don't make this generic covariant as it causes UWP performance to tank
 	public interface IElementConfiguration<out TElement> where TElement : Element
 	{
 		IPlatformElementConfiguration<T, TElement> On<T>() where T : IConfigPlatform;


### PR DESCRIPTION
### Description of Change ###
Fast Renderer UI tests broke because IElementConfiguration<T> can no longer be covariantly cast which makes us realize that removing the out parameter will be too breaking. It'll also be breaking in such a way that's not obvious. 

Reverts #5449

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
