### PR TITLE
[C] change searchHandler bindingMode

### DIFF
--- a/Xamarin.Forms.Core/SearchHandler.cs
+++ b/Xamarin.Forms.Core/SearchHandler.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Forms
 							BindableProperty.Create(nameof(ClearIcon), typeof(ImageSource), typeof(SearchHandler), null, BindingMode.OneTime);
 
 		public static readonly BindableProperty ClearPlaceholderCommandParameterProperty =
-			BindableProperty.Create(nameof(ClearPlaceholderCommandParameter), typeof(object), typeof(SearchHandler), null, BindingMode.OneTime,
+			BindableProperty.Create(nameof(ClearPlaceholderCommandParameter), typeof(object), typeof(SearchHandler), null,
 				propertyChanged: OnClearPlaceholderCommandParameterChanged);
 
 		public static readonly BindableProperty ClearPlaceholderCommandProperty =
@@ -69,7 +69,7 @@ namespace Xamarin.Forms
 				propertyChanged: OnClearPlaceholderCommandChanged);
 
 		public static readonly BindableProperty ClearPlaceholderEnabledProperty =
-			BindableProperty.Create(nameof(ClearPlaceholderEnabled), typeof(bool), typeof(SearchHandler), false, BindingMode.OneWay);
+			BindableProperty.Create(nameof(ClearPlaceholderEnabled), typeof(bool), typeof(SearchHandler), false);
 
 		public static readonly BindableProperty ClearPlaceholderHelpTextProperty =
 			BindableProperty.Create(nameof(ClearPlaceholderHelpText), typeof(string), typeof(SearchHandler), null, BindingMode.OneTime,
@@ -84,7 +84,7 @@ namespace Xamarin.Forms
 				propertyChanged: (b, o, n) => ((SearchHandler)b).UpdateAutomationProperties());
 
 		public static readonly BindableProperty CommandParameterProperty =
-					BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SearchHandler), null, BindingMode.OneTime,
+					BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SearchHandler), null,
 				propertyChanged: OnCommandParameterChanged);
 
 		public static readonly BindableProperty CommandProperty =

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5706.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5706.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Shell  xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5706">
+    <Shell.SearchHandler>
+        <SearchHandler
+            x:Name="searchHandler"
+            Command="{Binding FilterCommand}"
+            CommandParameter="{Binding Source={x:Reference searchHandler}, Path=Query}" />
+    </Shell.SearchHandler>
+</Shell>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5706.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5706.xaml.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh5706 : Shell
+	{
+		class VM
+		{
+			public VM()
+			{
+				FilterCommand = new Command((p) => Param = p);
+			}
+
+			public Command FilterCommand { get; set; }
+
+			public object Param { get; set; }
+		}
+
+		public Gh5706() => InitializeComponent();
+		public Gh5706(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture] class Tests
+		{
+			IReadOnlyList<string> _flags;
+
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+				_flags = Device.Flags;
+				Device.SetFlags(new List<string>() { ExperimentalFlags.ShellExperimental });
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+				Device.SetFlags(_flags);
+			}
+
+			[Test]
+			public void ReportSyntaxError([Values(false, true)]bool useCompiledXaml)
+			{
+				var layout = new Gh5706(useCompiledXaml);
+				layout.searchHandler.BindingContext = new VM();
+
+				Assert.That(layout.searchHandler.CommandParameter, Is.Null);
+				layout.searchHandler.Query = "Foo";
+				Assert.That(layout.searchHandler.CommandParameter, Is.EqualTo("Foo"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Change the default BindingMode for some properties
<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5706

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
