### PR TITLE
XamlLoader should not ignore x:TypeArguments on root node

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -607,7 +607,6 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			string clrNamespace = null;
 			string typeName = null;
 
-
 			XamlLoader.FallbackTypeResolver = (fallbackTypeInfos, type) =>
 			{
 				assemblyName = fallbackTypeInfos?[1].AssemblyName;
@@ -681,6 +680,24 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Xamarin.Forms.Internals.ResourceLoader.ExceptionHandler = exceptions.Add;
 			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
 			Assert.That(exceptions.Count, Is.GreaterThanOrEqualTo(1));
+		}
+
+		[Test]
+		public void MissingGenericRootTypeProvidesCorrectTypeName()
+		{
+			var xaml = @"
+					<local:GenericContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+						xmlns:local=""clr-namespace:MissingNamespace""
+						x:TypeArguments=""x:Object"" />";
+
+			XamlLoader.FallbackTypeResolver = (p, type) =>
+			{
+				Assert.That(p.Select(i => i.TypeName), Has.Some.EqualTo("GenericContentPage`1"));
+				return typeof(ContentPage);
+			};
+
+			Assert.DoesNotThrow(() => XamlLoader.Create(xaml, true));
 		}
 	}
 

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -119,7 +119,8 @@ namespace Xamarin.Forms.Xaml
 						continue;
 					}
 
-					var rootnode = new RuntimeRootNode(new XmlType(reader.NamespaceURI, reader.Name, null), null, (IXmlNamespaceResolver)reader);
+					var typeArguments = XamlParser.GetTypeArguments(reader);
+					var rootnode = new RuntimeRootNode(new XmlType(reader.NamespaceURI, reader.Name, typeArguments), null, (IXmlNamespaceResolver)reader);
 					XamlParser.ParseXaml(rootnode, reader);
 					var visitorContext = new HydrationContext {
 						ExceptionHandler = exceptionHandler,

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -155,10 +155,7 @@ namespace Xamarin.Forms.Xaml
 
 						var attributes = ParseXamlAttributes(reader, out xmlns);
 						var prefixes = PrefixesToIgnore(xmlns);
-
-						IList<XmlType> typeArguments = null;
-						if (attributes.Any(kvp => kvp.Key == XmlName.xTypeArguments))
-							typeArguments = ((ValueNode)attributes.First(kvp => kvp.Key == XmlName.xTypeArguments).Value).Value as IList<XmlType>;
+						var typeArguments = GetTypeArguments(attributes);
 
 						node = new ElementNode(new XmlType(elementNsUri, elementName, typeArguments), elementNsUri,
 							reader as IXmlNamespaceResolver, elementXmlInfo.LineNumber, elementXmlInfo.LinePosition);
@@ -183,6 +180,15 @@ namespace Xamarin.Forms.Xaml
 				}
 			}
 			throw new XamlParseException("Closing PropertyElement expected", (IXmlLineInfo)reader);
+		}
+
+		internal static IList<XmlType> GetTypeArguments(XmlReader reader) => GetTypeArguments(ParseXamlAttributes(reader, out _));
+
+		static IList<XmlType> GetTypeArguments(IList<KeyValuePair<XmlName, INode>> attributes)
+		{
+			return attributes.Any(kvp => kvp.Key == XmlName.xTypeArguments)
+				? ((ValueNode)attributes.First(kvp => kvp.Key == XmlName.xTypeArguments).Value).Value as IList<XmlType>
+				: null;
 		}
 
 		static IList<KeyValuePair<XmlName, INode>> ParseXamlAttributes(XmlReader reader, out IList<KeyValuePair<string,string>> xmlns)


### PR DESCRIPTION
### Description of Change ###

`XamlLoader.Create()` does not resolve root type if it is a generic. Also, it provides the wrong type name to `FallbackTypeResolver` (it provides the base type name, rather than, for example, ``TypeName`1``). This is because it ignores the `x:TypeArguments` attribute when determining the type name.

### Issues Resolved ### 

- fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/815082

### API Changes ###

None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Manually tested in previewer. Added test to `DesignTimeLoaderTests`.

### PR Checklist ###

- [x] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
