### PR TITLE
[Android] fixes material placeholder

### DIFF
--- a/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
@@ -27,7 +27,6 @@ namespace Xamarin.Forms.Material.Android
 			var view = inflater.Inflate(Resource.Layout.TextInputLayoutFilledBox, null);
 			_textInputLayout = (MaterialFormsTextInputLayout)view;
 			_textInputEditText = _textInputLayout.FindViewById<MaterialFormsEditText>(Resource.Id.materialformsedittext);
-			UpdatePlaceholderText();
 
 			return _textInputLayout;
 		}

--- a/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFormsTextInputLayoutBase.cs
@@ -113,16 +113,14 @@ namespace Xamarin.Forms.Material.Android
 
 		internal void SetHint(string hint, VisualElement element)
 		{
-			if (HintEnabled != !String.IsNullOrWhiteSpace(hint))
+			HintEnabled = !string.IsNullOrWhiteSpace(hint);
+			if (HintEnabled)
 			{
-				HintEnabled = !String.IsNullOrWhiteSpace(hint);
-				Hint = hint ?? String.Empty;
-				EditText.Hint = String.Empty;
 				element?.InvalidateMeasureNonVirtual(Internals.InvalidationTrigger.VerticalOptionsChanged);
-			}
-			else
-			{
-				Hint = hint ?? String.Empty;
+				Hint = hint;
+				// EditText.Hint => Hint
+				// It is impossible to reset it but you can make it invisible.
+				EditText.SetHintTextColor(global::Android.Graphics.Color.Transparent);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Removed duplicate material editor placeholder.

### Issues Resolved ### 

- fixes #5822

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 

Before
![](http://g.recordit.co/I7RY2HltPL.gif)

After
![](http://g.recordit.co/aSbX5wLjXa.gif)


### Testing Procedure ###

- check VisualGallery
- check Editor Gallery

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
