### PR TITLE
Add automated test for Bugzilla41205

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41205.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla41205.cs
@@ -4,17 +4,29 @@ using System.Text;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 41205, "UWP CreateDefault passes string instead of object")]
-	public class Bugzilla41205 : ContentPage
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Bugzilla41205 : TestContentPage
 	{
+		const string _success = "Pass";
+
+		[Preserve(AllMembers = true)]
 		public class ViewModel
 		{
-			public string Text { get { return "Pass"; } }
+			public string Text { get { return _success; } }
 		}
 
+		[Preserve(AllMembers = true)]
 		public class CustomListView : ListView
 		{
 			protected override Cell CreateDefault(object item)
@@ -29,19 +41,27 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-		public Bugzilla41205()
+		protected override void Init()
 		{
 			var listView = new CustomListView
 			{
-				ItemsSource = new []
+				ItemsSource = new[]
 				{
-					new ViewModel(), 
+					new ViewModel(),
 					new ViewModel(),
 				}
 			};
 
 			Content = listView;
 		}
+
+#if UITEST
+		[Test]
+		public void CreateDefaultPassesStringInsteadOfObject()
+		{
+			RunningApp.WaitForElement(_success);
+		}
+#endif
 
 	}
 }


### PR DESCRIPTION
### Description of Change ###
Add preserve attributes and automated test for House Keeping Item

### Issues Resolved ### 
- fixes #2353 

### Testing Procedure ###
Run Bugzilla41205 and make sure the text shows up. This adds UI tests so make sure all UI Tests pass

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
