### PR TITLE
Move IElementConfiguration to an internal structure on Cell

### DIFF
--- a/Xamarin.Forms.Core/Cells/Cell.cs
+++ b/Xamarin.Forms.Core/Cells/Cell.cs
@@ -268,7 +268,7 @@ namespace Xamarin.Forms
 			return _elementConfiguration.Value;
 		}
 
-		public class ElementConfiguration : IElementConfiguration<Cell>
+		class ElementConfiguration : IElementConfiguration<Cell>
 		{
 			readonly Lazy<PlatformConfigurationRegistry<Cell>> _platformConfigurationRegistry;
 			public ElementConfiguration(Cell cell)

--- a/Xamarin.Forms.Core/Cells/Cell.cs
+++ b/Xamarin.Forms.Core/Cells/Cell.cs
@@ -254,9 +254,9 @@ namespace Xamarin.Forms
 		}
 
 
-		#region internal element configuration
-		// This creates an internal class to keep track of IElementConfiguration because adding 
-		// IElementConfiguration<T> to the Cell itself kills performance on UWP
+		#region Nested IElementConfiguration<Cell> Implementation
+		// This creates a nested class to keep track of IElementConfiguration<Cell> because adding 
+		// IElementConfiguration<Cell> to the Cell itself tanks performance on UWP ListViews
 		// Issue has been logged with UWP
 		public IPlatformElementConfiguration<T, Cell> On<T>() where T : IConfigPlatform
 		{

--- a/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
@@ -59,8 +59,11 @@ namespace Xamarin.Forms.Platform.iOS
 		protected void UpdateBackground(UITableViewCell tableViewCell, Cell cell)
 		{
 			var uiBgColor = UIColor.White; // Must be set to a solid color or blending issues will occur
-
-			var  defaultBgColor = cell.OnThisPlatform().DefaultBackgroundColor();
+#if __MOBILE__
+			var defaultBgColor = cell.On<PlatformConfiguration.iOS>().DefaultBackgroundColor();
+#else
+			var defaultBgColor = cell.On<PlatformConfiguration.macOS>().DefaultBackgroundColor();
+#endif
 			if (defaultBgColor != Color.Default)
 			{
 				uiBgColor = defaultBgColor.ToUIColor();


### PR DESCRIPTION
### Description of Change ###
Another attempt to resolve the issue with UWP covariance performance. Another option we could go for would be to just convert the UI Test list in control gallery to a collectionview

Though right now it's a TableView

Basically I just move the PlatformConfiguration to an internal class on Cell to proxy the On calls to


### Testing Procedure ###
- make sure UI Tests work on UWP
- make sure you can change the default background color of a cell on iOS using the platform specific

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
