### PR TITLE
[Android] Null check on Switch TrackDrawable

### DIFF
--- a/Xamarin.Forms.Core/Switch.cs
+++ b/Xamarin.Forms.Core/Switch.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms
 				eh(bindable, new ToggledEventArgs((bool)newValue));
 		}, defaultBindingMode: BindingMode.TwoWay);
 
-		public static readonly BindableProperty OnColorProperty = BindableProperty.Create(nameof(OnColor), typeof(Color), typeof(Slider), Color.Default);
+		public static readonly BindableProperty OnColorProperty = BindableProperty.Create(nameof(OnColor), typeof(Color), typeof(Switch), Color.Default);
 
 		public Color OnColor
 		{

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -66,9 +66,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (Element != null)
 					Element.Toggled -= HandleToggled;
 
-				Control.SetOnCheckedChangeListener(null);
+				Control?.SetOnCheckedChangeListener(null);
 
-				_defaultTrackDrawable.Dispose();
+				_defaultTrackDrawable?.Dispose();
 				_defaultTrackDrawable = null;
 			}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -118,12 +118,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 				else
 				{
-					Control.TrackDrawable.SetColorFilter(Element.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
+					Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
 				}
 			}
 			else
 			{
-				Control.TrackDrawable.ClearColorFilter();
+				Control.TrackDrawable?.ClearColorFilter();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -67,6 +67,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					Element.Toggled -= HandleToggled;
 
 				Control.SetOnCheckedChangeListener(null);
+
+				_defaultTrackDrawable.Dispose();
+				_defaultTrackDrawable = null;
 			}
 
 			base.Dispose(disposing);

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -55,6 +55,9 @@ namespace Xamarin.Forms.Platform.Android
 					Element.Toggled -= HandleToggled;
 
 				Control.SetOnCheckedChangeListener(null);
+
+				_defaultTrackDrawable.Dispose();
+				_defaultTrackDrawable = null;
 			}
 
 			base.Dispose(disposing);
@@ -114,13 +117,13 @@ namespace Xamarin.Forms.Platform.Android
 					{
 						if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBean)
 						{
-							Control.TrackDrawable.SetColorFilter(Element.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
+							Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
 						}
 					}
 				}
 				else
 				{
-					Control.TrackDrawable.ClearColorFilter();
+					Control.TrackDrawable?.ClearColorFilter();
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Add a null check to `TrackDrawable`, which may not be set and thus may be null.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5553

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->


- Android


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
See if the project attached to #5456 crashes. Spoiler alert: It will, but for a different and totally unrelated reason (https://github.com/xamarin/Xamarin.Forms/issues/5456#issuecomment-481486341).

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
