### PR TITLE
Port fix from 4794 to handle clip bounds on sub-API-19 Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -10,6 +10,7 @@ using Android.Widget;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.Android.FastRenderers;
 using AView = Android.Views.View;
+using AViewCompat = Android.Support.V4.View.ViewCompat;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -48,7 +49,7 @@ namespace Xamarin.Forms.Platform.Android
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			base.OnLayout(changed, l, t, r, b);
-			ClipBounds = new Rect(0,0, Width, Height);
+			AViewCompat.SetClipBounds(this, new Rect(0, 0, Width, Height));
 
 			// After a direct (non-animated) scroll operation, we may need to make adjustments
 			// to align the target item; if an adjustment is pending, execute it here.


### PR DESCRIPTION
### Description of Change ###

Using ViewCompat.SetClipBounds to set clipping bounds for ItemsViewRenderer. 

### Issues Resolved ### 

- fixes #4790

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
