### PR TITLE
[Android] fixes z-index of material button

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5642.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5642.cs
@@ -1,0 +1,56 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 5642, "[Material] Button Overlay Issue", PlatformAffected.Android)]
+	public class Issue5642 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var button = new Button
+			{
+				Visual = VisualMarker.Material,
+				Text = "Button",
+				BackgroundColor = Color.DarkBlue
+			};			
+			AbsoluteLayout.SetLayoutFlags(button, AbsoluteLayoutFlags.All);
+			AbsoluteLayout.SetLayoutBounds(button, new Rectangle(0, 0, 1, 1));
+
+			var label1 = new Label
+			{
+				Text = "Left",
+				TextColor = Color.Red,
+				BackgroundColor = Color.Transparent,
+				Margin = new Thickness(10, 0)
+			};
+			AbsoluteLayout.SetLayoutFlags(label1, AbsoluteLayoutFlags.PositionProportional);
+			AbsoluteLayout.SetLayoutBounds(label1, new Rectangle(0, 0.5, AbsoluteLayout.AutoSize, AbsoluteLayout.AutoSize));
+
+			var label2 = new Label
+			{
+				Text = "Right",
+				TextColor = Color.Red,
+				BackgroundColor = Color.Transparent,
+				Margin = new Thickness(10, 0)
+			};
+			AbsoluteLayout.SetLayoutFlags(label2, AbsoluteLayoutFlags.PositionProportional);
+			AbsoluteLayout.SetLayoutBounds(label2, new Rectangle(1, 0.5, AbsoluteLayout.AutoSize, AbsoluteLayout.AutoSize));
+
+			Content = new AbsoluteLayout
+			{
+				Padding = 0,
+				BackgroundColor = Color.Transparent,
+				MinimumHeightRequest = 50,
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					button,
+					label1,
+					label2
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4684.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5642.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5376.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla60787.xaml.cs">
       <DependentUpon>Bugzilla60787.xaml</DependentUpon>

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -103,6 +103,8 @@ namespace Xamarin.Forms.Material.Android
 			}
 		}
 
+		public override float Elevation { get; set; }
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -103,7 +103,11 @@ namespace Xamarin.Forms.Material.Android
 			}
 		}
 
-		public override float Elevation { get; set; }
+		public override void Draw(Canvas canvas)
+		{
+			ElevationHelper.SetElevation(this, Element, 0);
+			base.Draw(canvas);
+		}
 
 		protected override void Dispose(bool disposing)
 		{

--- a/Xamarin.Forms.Platform.Android/Elevation.cs
+++ b/Xamarin.Forms.Platform.Android/Elevation.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Forms.Platform.Android
 {
 	internal static class ElevationHelper
 	{
-		internal static void SetElevation(global::Android.Views.View view, VisualElement element)
+		internal static void SetElevation(global::Android.Views.View view, VisualElement element, float? defautValue = null)
 		{
 			if (view == null || element == null || !Forms.IsLollipopOrNewer)
 			{
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			var iec = element as IElementConfiguration<VisualElement>;
-			var elevation = iec?.On<PlatformConfiguration.Android>().GetElevation();
+			var elevation = iec?.On<PlatformConfiguration.Android>().GetElevation() ?? defautValue;
 
 			if (!elevation.HasValue)
 			{


### PR DESCRIPTION
### Description of Change ###

Fixes elevation of Material button 

### Issues Resolved ### 

- fixes #5642

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Before
![image](https://user-images.githubusercontent.com/27482193/55970064-8d271580-5c87-11e9-88c0-b1f61a1a6c69.png)

After
![image](https://user-images.githubusercontent.com/27482193/55969875-34577d00-5c87-11e9-85f2-bce7344fb405.png)


### Testing Procedure ###

- run ui test 5642
- `Left` and `Right` labels should be visible

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
