### PR TITLE
[Android, shell] fixes visibility of tabs after their changes

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -327,7 +327,7 @@ namespace Xamarin.Forms.Platform.Android
 					menuItem.SetChecked(true);
 			}
 
-			_bottomView.Visibility = end == 1 ? ViewStates.Gone : ViewStates.Visible;
+			UpdateTabBarVisibility();
 
 			_bottomView.SetShiftMode(false, false);
 
@@ -383,7 +383,7 @@ namespace Xamarin.Forms.Platform.Android
 					visible = false;
 			}
 
-			_bottomView.Visibility = (visible) ? ViewStates.Visible : ViewStates.Gone;
+			_bottomView.Visibility = visible ? ViewStates.Visible : ViewStates.Gone;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 

- fixes #4758

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

- run Shell control gallery
- select page with tabs. ex: `GamesPage`
- click `Hide tabs` > `Add tab` > `Remove tab`
- tabs should be hidden

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
