### PR TITLE
remove unused Group Header Template

### DIFF
--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -574,9 +574,6 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty FlyoutIsPresentedProperty =
 			BindableProperty.Create(nameof(FlyoutIsPresented), typeof(bool), typeof(Shell), false, BindingMode.TwoWay);
 
-		public static readonly BindableProperty GroupHeaderTemplateProperty =
-			BindableProperty.Create(nameof(GroupHeaderTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
-
 		public static readonly BindableProperty ItemsProperty = ItemsPropertyKey.BindableProperty;
 
 		public static readonly BindableProperty ItemTemplateProperty =
@@ -669,12 +666,6 @@ namespace Xamarin.Forms
 		{
 			get => (bool)GetValue(FlyoutIsPresentedProperty);
 			set => SetValue(FlyoutIsPresentedProperty, value);
-		}
-
-		public DataTemplate GroupHeaderTemplate
-		{
-			get => (DataTemplate)GetValue(GroupHeaderTemplateProperty);
-			set => SetValue(GroupHeaderTemplateProperty, value);
 		}
 
 		public ShellItemCollection Items => (ShellItemCollection)GetValue(ItemsProperty);


### PR DESCRIPTION
### Description of Change ###
Removed GroupHeaderTemplate as it has not been implemented yet and we can add it back once the work is done to create it

### Issues Resolved ### 
- fixes #5870

### API Changes ###

 Removed:
 - Shell.GroupHeaderTemplate as it has not been implemented.
 

### Platforms Affected ### 
- Core/XAML (all platforms)


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
