### PR TITLE
[macOs] Fixed NRE during EntryRenderer disposing

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -93,13 +93,12 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			base.OnElementChanged(e);
 
-			if (Control == null)
-			{
-				CreateControl();
-			}
-
 			if (e.NewElement != null)
 			{
+				if (Control == null)
+				{
+					CreateControl();
+				}
 				UpdateControl();
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Create native entry control only if there is corresponding XF control.

Similar changes with https://github.com/xamarin/Xamarin.Forms/pull/5363

### Issues Resolved ### 

fixes #5881

### API Changes ###
None

### Platforms Affected ### 
macOS

### Behavioral/Visual Changes ###

No crash

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
See sample attached to original issue
