### PR TITLE
[Shell] Hide Shell types from being browsable

### DIFF
--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -13,6 +13,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
+	[EditorBrowsable(EditorBrowsableState.Always)]
 	public class TabContent : ShellContent
 	{
 	}

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -13,13 +13,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	[EditorBrowsable(EditorBrowsableState.Always)]
-	public class TabContent : ShellContent
-	{
-	}
-
 	[ContentProperty(nameof(Content))]
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ShellContent : BaseShellItem, IShellContentController
 	{
 		static readonly BindablePropertyKey MenuItemsPropertyKey =

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 
 #if NETSTANDARD1_0
 using System.Linq;
@@ -17,6 +18,7 @@ namespace Xamarin.Forms
 	}
 
 	[ContentProperty(nameof(Content))]
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ShellContent : BaseShellItem, IShellContentController
 	{
 		static readonly BindablePropertyKey MenuItemsPropertyKey =

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
+using System.ComponentModel;
 
 namespace Xamarin.Forms
 {
@@ -13,6 +14,7 @@ namespace Xamarin.Forms
 	}
 
 	[ContentProperty(nameof(Items))]
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ShellItem : ShellGroupItem, IShellItemController, IElementConfiguration<ShellItem>, IPropertyPropagationController
 	{
 		#region PropertyKeys

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms
 {
+	[EditorBrowsable(EditorBrowsableState.Always)]
 	public class FlyoutItem : ShellItem
 	{
 		public ShellSectionCollection Tabs => Items;

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms
 {
+	[EditorBrowsable(EditorBrowsableState.Always)]
 	public class Tab : ShellSection
 	{
 		public ShellContentCollection Content => Items;

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
+using System.ComponentModel;
 
 namespace Xamarin.Forms
 {
@@ -15,6 +16,7 @@ namespace Xamarin.Forms
 	}
 
 	[ContentProperty(nameof(Items))]
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ShellSection : ShellGroupItem, IShellSectionController, IPropertyPropagationController
 	{
 		#region PropertyKeys


### PR DESCRIPTION
### Description of Change ###
This hides Shell<things> and just shows the Tab aliases for intellisense.

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
Set ShellItem, ShellContent, and ShellSection  to EditorBrowsable(false) so that FlyoutItem, TabContent, and Tab are all that show up but won't cause compile exceptions. 

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
