### PR TITLE
WpfHelper.FindChildren: Pass forceUsingTheVisualTreeHelper to recursive calls.

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Helpers/TreeHelper.cs
+++ b/Xamarin.Forms.Platform.WPF/Helpers/TreeHelper.cs
@@ -146,7 +146,7 @@ namespace Xamarin.Forms.Platform.WPF.Helpers
 					}
 
 					//recurse tree
-					foreach (T descendant in FindChildren<T>(child))
+					foreach (T descendant in FindChildren<T>(child, forceUsingTheVisualTreeHelper))
 					{
 						yield return descendant;
 					}


### PR DESCRIPTION
### Description of Change ###

`WpfHelper.FindChildren`: Pass `forceUsingTheVisualTreeHelper` to recursive calls.

### Issues Resolved ### 

- fixes #5921 

### API Changes ###

 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- WPF

### Behavioral/Visual Changes ###

If using the visual tree helper, `TreeHelper.FindChildren` now uses the visual tree helper all the way down to the leaf nodes.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

As described in #5921 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
