### PR TITLE
s/SearchBoxVisiblity/SearchBoxVisibility/

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ButtonGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ButtonGallery.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Controls
 		public ButtonGallery ()
 		{
 			//ShellAppearance.SetNavBarVisible(this, false);
-			Shell.SetSearchHandler(this, new SearchHandler() { SearchBoxVisibility = SearchBoxVisiblity.Collapsable });
+			Shell.SetSearchHandler(this, new SearchHandler() { SearchBoxVisibility = SearchBoxVisibility.Collapsable });
 			BackgroundColor = new Color (0.9);
 
 			var normal = new Button { Text = "Normal Button" };

--- a/Xamarin.Forms.Controls/GalleryPages/ButtonGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ButtonGallery.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Controls
 		public ButtonGallery ()
 		{
 			//ShellAppearance.SetNavBarVisible(this, false);
-			Shell.SetSearchHandler(this, new SearchHandler() { SearchBoxVisibility = SearchBoxVisibility.Collapsable });
+			Shell.SetSearchHandler(this, new SearchHandler() { SearchBoxVisibility = SearchBoxVisibility.Collapsible });
 			BackgroundColor = new Color (0.9);
 
 			var normal = new Button { Text = "Normal Button" };

--- a/Xamarin.Forms.Controls/XamStore/Views/DemoShellPage.xaml.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/DemoShellPage.xaml.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Controls.XamStore
 			InitializeComponent();
 			ViewModel = new HomeViewModel();
 			NavigationPage.SetBackButtonTitle(this, "");
-			//AddSearchHandler("Search", SearchBoxVisiblity.Expanded);
+			//AddSearchHandler("Search", SearchBoxVisibility.Expanded);
 		}
 
 		protected override void OnAppearing()
@@ -49,7 +49,7 @@ namespace Xamarin.Forms.Controls.XamStore
 			(sender as ListView).SelectedItem = null;
 		}
 
-		protected void AddSearchHandler(string placeholder, SearchBoxVisiblity visibility)
+		protected void AddSearchHandler(string placeholder, SearchBoxVisibility visibility)
 		{
 			var searchHandler = new BasePage.CustomSearchHandler();
 

--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -104,7 +104,7 @@ namespace Xamarin.Forms.Controls.XamStore
 				0, 6);
 
 			grid.Children.Add(MakeButton("Collapse Search",
-					() => Shell.GetSearchHandler(this).SearchBoxVisibility = SearchBoxVisibility.Collapsable),
+					() => Shell.GetSearchHandler(this).SearchBoxVisibility = SearchBoxVisibility.Collapsible),
 				1, 6);
 
 			grid.Children.Add(MakeButton("Show Search",
@@ -374,7 +374,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public UpdatesPage() : base("Available Updates", Color.Default)
 		{
-			AddSearchHandler("Search Updates", SearchBoxVisibility.Collapsable);
+			AddSearchHandler("Search Updates", SearchBoxVisibility.Collapsible);
 		}
 	}
 
@@ -383,7 +383,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public InstalledPage() : base("Installed Items", Color.Default)
 		{
-			AddSearchHandler("Search Installed", SearchBoxVisibility.Collapsable);
+			AddSearchHandler("Search Installed", SearchBoxVisibility.Collapsible);
 		}
 	}
 
@@ -392,7 +392,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public LibraryPage() : base("My Library", Color.Default)
 		{
-			AddSearchHandler("Search Apps", SearchBoxVisibility.Collapsable);
+			AddSearchHandler("Search Apps", SearchBoxVisibility.Collapsible);
 		}
 	}
 

--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Controls.XamStore
 				1, 2);
 
 			grid.Children.Add(MakeButton("Add Search",
-					() => AddSearchHandler("Added Search", SearchBoxVisiblity.Expanded)),
+					() => AddSearchHandler("Added Search", SearchBoxVisibility.Expanded)),
 				2, 2);
 
 			grid.Children.Add(MakeButton("Add Toolbar",
@@ -100,15 +100,15 @@ namespace Xamarin.Forms.Controls.XamStore
 				2, 5);
 
 			grid.Children.Add(MakeButton("Hide Search",
-					() => Shell.GetSearchHandler(this).SearchBoxVisibility = SearchBoxVisiblity.Hidden),
+					() => Shell.GetSearchHandler(this).SearchBoxVisibility = SearchBoxVisibility.Hidden),
 				0, 6);
 
 			grid.Children.Add(MakeButton("Collapse Search",
-					() => Shell.GetSearchHandler(this).SearchBoxVisibility = SearchBoxVisiblity.Collapsable),
+					() => Shell.GetSearchHandler(this).SearchBoxVisibility = SearchBoxVisibility.Collapsable),
 				1, 6);
 
 			grid.Children.Add(MakeButton("Show Search",
-					() => Shell.GetSearchHandler(this).SearchBoxVisibility = SearchBoxVisiblity.Expanded),
+					() => Shell.GetSearchHandler(this).SearchBoxVisibility = SearchBoxVisibility.Expanded),
 				2, 6);
 
 			grid.Children.Add(MakeButton("Set Back",
@@ -339,7 +339,7 @@ namespace Xamarin.Forms.Controls.XamStore
 			}
 		}
 
-		protected void AddSearchHandler(string placeholder, SearchBoxVisiblity visibility)
+		protected void AddSearchHandler(string placeholder, SearchBoxVisibility visibility)
 		{
 			var searchHandler = new CustomSearchHandler();
 
@@ -374,7 +374,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public UpdatesPage() : base("Available Updates", Color.Default)
 		{
-			AddSearchHandler("Search Updates", SearchBoxVisiblity.Collapsable);
+			AddSearchHandler("Search Updates", SearchBoxVisibility.Collapsable);
 		}
 	}
 
@@ -383,7 +383,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public InstalledPage() : base("Installed Items", Color.Default)
 		{
-			AddSearchHandler("Search Installed", SearchBoxVisiblity.Collapsable);
+			AddSearchHandler("Search Installed", SearchBoxVisibility.Collapsable);
 		}
 	}
 
@@ -392,7 +392,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public LibraryPage() : base("My Library", Color.Default)
 		{
-			AddSearchHandler("Search Apps", SearchBoxVisiblity.Collapsable);
+			AddSearchHandler("Search Apps", SearchBoxVisibility.Collapsable);
 		}
 	}
 
@@ -413,7 +413,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public HomePage() : base("Store Home", Color.Default)
 		{
-			AddSearchHandler("Search Apps", SearchBoxVisiblity.Expanded);
+			AddSearchHandler("Search Apps", SearchBoxVisibility.Expanded);
 		}
 	}
 
@@ -422,7 +422,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public GamesPage() : base("Games", Color.Default)
 		{
-			AddSearchHandler("Search Games", SearchBoxVisiblity.Expanded);
+			AddSearchHandler("Search Games", SearchBoxVisibility.Expanded);
 		}
 	}
 
@@ -431,7 +431,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public MoviesPage() : base("Hot Movies", Color.Default)
 		{
-			AddSearchHandler("Search Movies", SearchBoxVisiblity.Expanded);
+			AddSearchHandler("Search Movies", SearchBoxVisibility.Expanded);
 		}
 	}
 
@@ -440,7 +440,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public BooksPage() : base("Bookstore", Color.Default)
 		{
-			AddSearchHandler("Search Books", SearchBoxVisiblity.Expanded);
+			AddSearchHandler("Search Books", SearchBoxVisibility.Expanded);
 		}
 	}
 
@@ -449,7 +449,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public MusicPage() : base("Music", Color.Default)
 		{
-			AddSearchHandler("Search Music", SearchBoxVisiblity.Expanded);
+			AddSearchHandler("Search Music", SearchBoxVisibility.Expanded);
 		}
 	}
 
@@ -458,7 +458,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	{
 		public NewsPage() : base("Newspapers", Color.Default)
 		{
-			AddSearchHandler("Search Papers", SearchBoxVisiblity.Expanded);
+			AddSearchHandler("Search Papers", SearchBoxVisibility.Expanded);
 		}
 	}
 

--- a/Xamarin.Forms.Core/SearchBoxVisiblity.cs
+++ b/Xamarin.Forms.Core/SearchBoxVisiblity.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms
 {
-	public enum SearchBoxVisiblity
+	public enum SearchBoxVisibility
 	{
 		Hidden,
 		Collapsable,

--- a/Xamarin.Forms.Core/SearchBoxVisiblity.cs
+++ b/Xamarin.Forms.Core/SearchBoxVisiblity.cs
@@ -3,7 +3,7 @@
 	public enum SearchBoxVisibility
 	{
 		Hidden,
-		Collapsable,
+		Collapsible,
 		Expanded
 	}
 }

--- a/Xamarin.Forms.Core/Shell/SearchHandler.cs
+++ b/Xamarin.Forms.Core/Shell/SearchHandler.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Forms
 				propertyChanged: OnQueryChanged);
 
 		public static readonly BindableProperty SearchBoxVisibilityProperty =
-			BindableProperty.Create(nameof(SearchBoxVisibility), typeof(SearchBoxVisiblity), typeof(SearchHandler), SearchBoxVisiblity.Expanded, BindingMode.OneWay);
+			BindableProperty.Create(nameof(SearchBoxVisibility), typeof(SearchBoxVisibility), typeof(SearchHandler), SearchBoxVisibility.Expanded, BindingMode.OneWay);
 
 		static readonly BindablePropertyKey SelectedItemPropertyKey =
 			BindableProperty.CreateReadOnly (nameof(SelectedItem), typeof(object), typeof(SearchHandler), null, BindingMode.OneWayToSource);
@@ -253,9 +253,9 @@ namespace Xamarin.Forms
 			set { SetValue(QueryIconNameProperty, value); }
 		}
 
-		public SearchBoxVisiblity SearchBoxVisibility
+		public SearchBoxVisibility SearchBoxVisibility
 		{
-			get { return (SearchBoxVisiblity)GetValue(SearchBoxVisibilityProperty); }
+			get { return (SearchBoxVisibility)GetValue(SearchBoxVisibilityProperty); }
 			set { SetValue(SearchBoxVisibilityProperty, value); }
 		}
 

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -574,9 +574,6 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty FlyoutIsPresentedProperty =
 			BindableProperty.Create(nameof(FlyoutIsPresented), typeof(bool), typeof(Shell), false, BindingMode.TwoWay);
 
-		public static readonly BindableProperty GroupHeaderTemplateProperty =
-			BindableProperty.Create(nameof(GroupHeaderTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
-
 		public static readonly BindableProperty ItemsProperty = ItemsPropertyKey.BindableProperty;
 
 		public static readonly BindableProperty ItemTemplateProperty =
@@ -669,12 +666,6 @@ namespace Xamarin.Forms
 		{
 			get => (bool)GetValue(FlyoutIsPresentedProperty);
 			set => SetValue(FlyoutIsPresentedProperty, value);
-		}
-
-		public DataTemplate GroupHeaderTemplate
-		{
-			get => (DataTemplate)GetValue(GroupHeaderTemplateProperty);
-			set => SetValue(GroupHeaderTemplateProperty, value);
 		}
 
 		public ShellItemCollection Items => (ShellItemCollection)GetValue(ItemsProperty);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -438,7 +438,7 @@ namespace Xamarin.Forms.Platform.Android
 					_searchView.SearchConfirmed += OnSearchConfirmed;
 				}
 
-				if (SearchHandler.SearchBoxVisibility == SearchBoxVisibility.Collapsable)
+				if (SearchHandler.SearchBoxVisibility == SearchBoxVisibility.Collapsible)
 				{
 					var placeholder = new Java.Lang.String(SearchHandler.Placeholder);
 					var item = menu.Add(placeholder);
@@ -482,7 +482,7 @@ namespace Xamarin.Forms.Platform.Android
 		void OnSearchViewAttachedToWindow(object sender, AView.ViewAttachedToWindowEventArgs e)
 		{
 			// We only need to do this tint hack when using collapsed search handlers
-			if (SearchHandler.SearchBoxVisibility != SearchBoxVisibility.Collapsable)
+			if (SearchHandler.SearchBoxVisibility != SearchBoxVisibility.Collapsible)
 				return;
 
 			for (int i = 0; i < _toolbar.ChildCount; i++)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -421,7 +421,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			SearchHandler = Shell.GetSearchHandler(page);
-			if (SearchHandler != null && SearchHandler.SearchBoxVisibility != SearchBoxVisiblity.Hidden)
+			if (SearchHandler != null && SearchHandler.SearchBoxVisibility != SearchBoxVisibility.Hidden)
 			{
 				var context = _shellContext.AndroidContext;
 				if (_searchView == null)
@@ -438,7 +438,7 @@ namespace Xamarin.Forms.Platform.Android
 					_searchView.SearchConfirmed += OnSearchConfirmed;
 				}
 
-				if (SearchHandler.SearchBoxVisibility == SearchBoxVisiblity.Collapsable)
+				if (SearchHandler.SearchBoxVisibility == SearchBoxVisibility.Collapsable)
 				{
 					var placeholder = new Java.Lang.String(SearchHandler.Placeholder);
 					var item = menu.Add(placeholder);
@@ -457,7 +457,7 @@ namespace Xamarin.Forms.Platform.Android
 					item.SetActionView(_searchView.View);
 					item.Dispose();
 				}
-				else if (SearchHandler.SearchBoxVisibility == SearchBoxVisiblity.Expanded)
+				else if (SearchHandler.SearchBoxVisibility == SearchBoxVisibility.Expanded)
 				{
 					_searchView.ShowKeyboardOnAttached = false;
 					if (_searchView.View.Parent != _toolbar)
@@ -482,7 +482,7 @@ namespace Xamarin.Forms.Platform.Android
 		void OnSearchViewAttachedToWindow(object sender, AView.ViewAttachedToWindowEventArgs e)
 		{
 			// We only need to do this tint hack when using collapsed search handlers
-			if (SearchHandler.SearchBoxVisibility != SearchBoxVisiblity.Collapsable)
+			if (SearchHandler.SearchBoxVisibility != SearchBoxVisibility.Collapsable)
 				return;
 
 			for (int i = 0; i < _toolbar.ChildCount; i++)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -391,12 +391,12 @@ namespace Xamarin.Forms.Platform.iOS
 						NavigationItem.TitleView = null;
 				}
 			}
-			else if (visibility == SearchBoxVisibility.Collapsable || visibility == SearchBoxVisibility.Expanded)
+			else if (visibility == SearchBoxVisibility.Collapsible || visibility == SearchBoxVisibility.Expanded)
 			{
 				if (Forms.IsiOS11OrNewer)
 				{
 					NavigationItem.SearchController = _searchController;
-					NavigationItem.HidesSearchBarWhenScrolling = visibility == SearchBoxVisibility.Collapsable;
+					NavigationItem.HidesSearchBarWhenScrolling = visibility == SearchBoxVisibility.Collapsible;
 				}
 				else
 				{
@@ -438,7 +438,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateSearchIsEnabled(_searchController);
 			searchBar.SearchButtonClicked += SearchButtonClicked;
 			if (Forms.IsiOS11OrNewer)
-				NavigationItem.HidesSearchBarWhenScrolling = visibility == SearchBoxVisibility.Collapsable;
+				NavigationItem.HidesSearchBarWhenScrolling = visibility == SearchBoxVisibility.Collapsible;
 
 			var icon = SearchHandler.QueryIcon;
 			if (icon != null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -381,7 +381,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected virtual void UpdateSearchVisibility(UISearchController searchController)
 		{
 			var visibility = SearchHandler.SearchBoxVisibility;
-			if (visibility == SearchBoxVisiblity.Hidden)
+			if (visibility == SearchBoxVisibility.Hidden)
 			{
 				if (searchController != null)
 				{
@@ -391,12 +391,12 @@ namespace Xamarin.Forms.Platform.iOS
 						NavigationItem.TitleView = null;
 				}
 			}
-			else if (visibility == SearchBoxVisiblity.Collapsable || visibility == SearchBoxVisiblity.Expanded)
+			else if (visibility == SearchBoxVisibility.Collapsable || visibility == SearchBoxVisibility.Expanded)
 			{
 				if (Forms.IsiOS11OrNewer)
 				{
 					NavigationItem.SearchController = _searchController;
-					NavigationItem.HidesSearchBarWhenScrolling = visibility == SearchBoxVisiblity.Collapsable;
+					NavigationItem.HidesSearchBarWhenScrolling = visibility == SearchBoxVisibility.Collapsable;
 				}
 				else
 				{
@@ -417,7 +417,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_searchController = new UISearchController(_resultsRenderer?.ViewController);
 			var visibility = SearchHandler.SearchBoxVisibility;
-			if (visibility != SearchBoxVisiblity.Hidden)
+			if (visibility != SearchBoxVisibility.Hidden)
 			{
 				if (Forms.IsiOS11OrNewer)
 					NavigationItem.SearchController = _searchController;
@@ -438,7 +438,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateSearchIsEnabled(_searchController);
 			searchBar.SearchButtonClicked += SearchButtonClicked;
 			if (Forms.IsiOS11OrNewer)
-				NavigationItem.HidesSearchBarWhenScrolling = visibility == SearchBoxVisiblity.Collapsable;
+				NavigationItem.HidesSearchBarWhenScrolling = visibility == SearchBoxVisibility.Collapsable;
 
 			var icon = SearchHandler.QueryIcon;
 			if (icon != null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateVerticalBounce()
 		{
 			// Normally we dont want to do this unless this scrollview is vertical and its
-			// element is the child of a Page with a SearchHandler that is collapsable.
+			// element is the child of a Page with a SearchHandler that is Collapsible.
 			// If we can't bounce in that case you may not be able to expose the handler.
 			// Also the hiding behavior only depends on scroll on iOS 11. In 10 and below
 			// the search goes in the TitleView so there is nothing to collapse/expand.
@@ -116,7 +116,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (parent is Page)
 				{
 					var searchHandler = Shell.GetSearchHandler(parent);
-					if (searchHandler?.SearchBoxVisibility == SearchBoxVisibility.Collapsable)
+					if (searchHandler?.SearchBoxVisibility == SearchBoxVisibility.Collapsible)
 						_scrollView.AlwaysBounceVertical = true;
 					return;
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (parent is Page)
 				{
 					var searchHandler = Shell.GetSearchHandler(parent);
-					if (searchHandler?.SearchBoxVisibility == SearchBoxVisiblity.Collapsable)
+					if (searchHandler?.SearchBoxVisibility == SearchBoxVisibility.Collapsable)
 						_scrollView.AlwaysBounceVertical = true;
 					return;
 				}


### PR DESCRIPTION
Fix typo in type name.

### Description of Change ###

I searched for the string `SearchBoxVisiblity` and changed it to `SearchBoxVisibility`. 

### Issues Resolved ### 


- fixes #5924

### API Changes ###
Xamarin.Forms.Controls.XamStore.AddSearchHandler(string,SearchBoxVisiblty) -> changed arg type
enum SearchBoxVisiblity -> SearchBoxVisibility


### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Build
Build Xamarin.Forms.Core.UnitTests
Run Unit Tests. 

4 unit tests fail: 
ListProxyTests.WeakToWeak
MapTests.ElementIsGarbageCollectedAfterItsRemoved
MessagingCenterTests.SubscriberCollectableAfterUnsubscribeEvenIfHeldByClosure
ShellUriHandlerTests.SubscriberCollectableAfterUnsubscribeEvenIfHeldByClosure

I don't think any of those failures plausibly relate to this change

### PR Checklist ###

- [ ] Has automated tests 

No additional tests because renaming enum. If old symbol used, should not compile. Even if reflection, "Replace in files..." should have caught string 

- [ x ] Rebased on top of the target branch at time of PR
- [  x ] Changes adhere to coding standard
