### PR TITLE
Avoid LINQ exception

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -254,6 +254,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 		internal bool BackButtonPressed()
 		{
+			if (!_navModel.Roots.Any())
+				return false;
+
 			Page lastRoot = _navModel.Roots.Last();
 
 			bool handled = lastRoot.SendBackButtonPressed();

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -254,10 +254,10 @@ namespace Xamarin.Forms.Platform.UWP
 
 		internal bool BackButtonPressed()
 		{
-			if (!_navModel.Roots.Any())
-				return false;
+			Page lastRoot = _navModel.Roots.LastOrDefault();
 
-			Page lastRoot = _navModel.Roots.Last();
+			if (lastRoot == null)
+				return false;
 
 			bool handled = lastRoot.SendBackButtonPressed();
 


### PR DESCRIPTION
### Description of Change ###

If the back button in UWP is pressed, but there's nothing in the backstack, the `Last()` LINQ query will throw `System.InvalidOperationException: 'Sequence contains no elements`
This change avoids that, and just returns false that Forms didn't handle the event.


### Issues Resolved ### 
Exception thrown when turning the backbutton on, but not having anything put in the backstack.

### API Changes ###
None
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
