### PR TITLE
Remove Xamarin.Android.Support.v7.MediaRouter

### DIFF
--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -19,7 +19,6 @@
       <group targetFramework="MonoAndroid81">
         <dependency id="Xamarin.GooglePlayServices.Maps" version="60.1142.1"/>
         <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0.1"/>
-        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0.1"/>
         <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
       <group targetFramework="tizen40">

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -18,7 +18,6 @@
         <dependency id="Xamarin.Android.Support.Design" version="28.0.0.1"/>
         <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0.1"/>
         <dependency id="Xamarin.Android.Support.v7.CardView" version="28.0.0.1"/>
-        <dependency id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0.1"/>
         <dependency id="Xamarin.Android.Support.CustomTabs" version="28.0.0.1"/>
       </group>
       <group targetFramework="uap10.0">

--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -282,12 +282,10 @@
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Fragment" Version="28.0.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.Media.Compat" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Transition" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.Palette" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="28.0.0.1" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -351,12 +351,10 @@
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Fragment" Version="28.0.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.Media.Compat" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Transition" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.Palette" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="28.0.0.1" />

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -84,7 +84,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.1" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Xamarin.Forms.Sandbox.Android/Xamarin.Forms.Sandbox.Android.csproj
+++ b/Xamarin.Forms.Sandbox.Android/Xamarin.Forms.Sandbox.Android.csproj
@@ -57,7 +57,6 @@
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/xamarin/xamarin-android/issues/2982

The Blank Xamarin.Forms app template in VS 2019 takes longer to build
than in VS 2017. A little research is showing that this is due to use
of the 28.x support libraries... For example, the build includes ~20
*more* jar files in the template from 2019 than 2017. The
`_CompileDex` step alone goes from ~15.2s to ~18.2s.

This lead me down the road of investigating if we can remove any
support libraries by default in Xamarin.Forms apps. I am also seeing
if there is more we can do in Xamarin.Android for this problem, in
general.

It looks like we can remove:

* Xamarin.Android.Support.v7.MediaRouter
* Xamarin.Android.Support.Media.Compat

Neither of these appear to be used, but have been listed as
dependencies of Xamarin.Forms for a long time.

## Results ##

I made these changes, then did a `Debug` build of
`Xamarin.Forms.ControlGallery.Android.csproj` for comparison.

Comparing dex file sizes (in bytes):

    Before:
    3428092 classes.dex
    3265616 classes2.dex
    6693708 total
    After:
    4938000 classes.dex
    1098772 classes2.dex
    6036772 total

This looks like it could potentially save ~600KB of compiled dex code
on every Xamarin.Forms app.

Comparing methods:

    Before:
    classes.dex  11,492 methods
    classes2.dex 19,451 methods
    total        30,943 methods
    After:
    classes.dex  22,171 methods
    classes2.dex  7,635 methods
    total        29,806 methods

~1,137 methods removed, which should help with the dex limit.

Comparing APK sizes (in bytes):

    Before:
    26442597 AndroidControlGallery.AndroidControlGallery-Signed.apk
    After:
    25741701 AndroidControlGallery.AndroidControlGallery-Signed.apk

~700KB smaller APK, due to less .NET assemblies & dex code.

Comparing build time (this was using dx):

    Before:
    19785 ms  CompileToDalvik                            1 calls
    After:
    18532 ms  CompileToDalvik                            1 calls

Looks like it saved over a second of build time for this project.

Seems like an "easy win", let's do this!

### Issues Resolved ### 

none

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Only known behavior, is a user might have to add `<PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.1" />` if they are using it directly.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

If Xamarin.Forms apps build with this change, things should work.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
