### PR TITLE
Change error message when Map.ItemTemplate is set to a DataTemplateSelector

### DIFF
--- a/Xamarin.Forms.Maps/Map.cs
+++ b/Xamarin.Forms.Maps/Map.cs
@@ -155,7 +155,9 @@ namespace Xamarin.Forms.Maps
 		{
 			if (newItemTemplate is DataTemplateSelector)
 			{
-				throw new NotSupportedException($"You are using an instance of {nameof(DataTemplateSelector)} to set the {nameof(Map)}.{ItemTemplateProperty.PropertyName} property. Use an instance of a {nameof(DataTemplate)} property instead to set an item template.");
+				throw new NotSupportedException(
+					$"The {nameof(Map)}.{ItemTemplateProperty.PropertyName} property only supports {nameof(DataTemplate)}." +
+					$" Set the {nameof(Map)}.{ItemTemplateSelectorProperty.PropertyName} property instead to use a {nameof(DataTemplateSelector)}");
 			}
 
 			_pins.Clear();


### PR DESCRIPTION
### Description of Change ###

Changed the message of the `NotSupportedException` thrown when the `Map.ItemTemplate` property is set to a `DataTemplateSelector`. Instead of telling the user to just use a single `DataTemplate` it directs them to use the `ItemTemplateSelector` property.

### Issues Resolved ### 

None

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Not applicable

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
